### PR TITLE
fix(ci): sync Nodes raw-copy baseline

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -4051,15 +4051,106 @@
       "count": 1,
       "kind": "html-text",
       "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Any node"
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "approval needed"
+    },
+    {
+      "count": 2,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Approve"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "auto-paired"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "No paired nodes or devices."
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Nodes & devices"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "One entry per paired client: roles, tokens, live links."
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Paired"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Pending approval"
+    },
+    {
+      "count": 2,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Reject"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Remove"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Revoke"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Rotate"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Tokens"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-inventory.ts",
+      "text": "Tokens & capabilities"
     },
     {
       "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view.ts",
-      "text": "Approve"
+      "text": "Any node"
     },
     {
       "count": 1,
@@ -4073,13 +4164,6 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view.ts",
-      "text": "Devices"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
       "text": "No agents found."
     },
     {
@@ -4087,91 +4171,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view.ts",
-      "text": "No nodes found."
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
       "text": "No nodes with system.run available."
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "No paired devices."
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Nodes"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Paired"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Paired devices and live links."
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Pairing requests + role tokens."
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Pending"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Reject"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Revoke"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Rotate"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Tokens"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/nodes/view.ts",
-      "text": "Tokens: none"
     },
     {
       "count": 1,


### PR DESCRIPTION
## What Problem This Solves

Resolves a deterministic full-CI failure where the Control UI raw-copy drift gate still expected the pre-redesign Nodes page strings and file paths.

## Why This Change Was Made

The Nodes redesign intentionally keeps this inventory copy on the existing raw-copy surface. This change regenerates only the canonical raw-copy baseline, removing stale `view.ts` entries and recording the current `view-inventory.ts` strings and duplicate counts; it does not broaden into a partial localization refactor.

## User Impact

No runtime or user-facing behavior changes. Full CI and release validation can build artifacts again while continuing to detect future unintended Control UI copy drift.

## Evidence

- Exact release CI failure: [run 29029211559, build-artifacts job 86157251482](https://github.com/openclaw/openclaw/actions/runs/29029211559/job/86157251482), target `14558dee87683f197ffcf1ee5ba1196aec57f7d9`.
- Root provenance: Nodes redesign PR #102810 / merge `898559830291d3fb8ce70e68902ec22359a6974b` moved/replaced the inventory copy without regenerating the baseline.
- Blacksmith Testbox `tbx_01kx3qvqenxz5h2p6t8bsm8htj`: `pnpm ui:i18n:sync` generated this exact file; local and generated SHA-256 both `6e786cdb056e576937381027cfa7f7ba6b3736be94e5e7810b48e7cbdc86fcda`.
- Same Testbox: `pnpm ui:i18n:check` passed the raw-copy gate and all 20 locales with zero fallbacks/drift.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no actionable findings, confidence 0.99.
