### PR TITLE
fix(sandbox): keep redacted session keys UTF-16 safe

### DIFF
--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -4,6 +4,7 @@
  * Resolves whether a session is sandboxed and explains policy blocks before tool execution.
  */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatCliCommand } from "../../cli/command-format.js";
 import {
   canonicalizeMainSessionAlias,
@@ -110,7 +111,7 @@ function redactSessionKey(value: string): string {
   if (trimmed.length <= 12) {
     return "(redacted)";
   }
-  return `${sanitizeForSingleLineDisplay(trimmed.slice(0, 6))}…${sanitizeForSingleLineDisplay(trimmed.slice(-6))}`;
+  return `${sanitizeForSingleLineDisplay(truncateUtf16Safe(trimmed, 6))}…${sanitizeForSingleLineDisplay(sliceUtf16Safe(trimmed, -6))}`;
 }
 
 function shellEscapeSingleArg(value: string): string {

--- a/src/agents/sandbox/tool-policy.test.ts
+++ b/src/agents/sandbox/tool-policy.test.ts
@@ -305,6 +305,34 @@ describe("sandbox/tool-policy", () => {
     );
   });
 
+  it("keeps redacted session keys UTF-16 safe", () => {
+    const sessionKey = `abcde\u{1F600}middle123456`;
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            deny: ["browser"],
+          },
+        },
+      },
+    };
+
+    const message = formatSandboxToolPolicyBlockedMessage({
+      cfg,
+      sessionKey,
+      toolName: "browser",
+    });
+
+    const sessionLine = message?.split("\n").find((line) => line.startsWith("Session: "));
+    expect(sessionLine).toBe("Session: abcde…123456");
+    expect(sessionLine).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+  });
+
   it("avoids terminal injection for control-character session keys", () => {
     const sessionKey = "agent:main:abcde\n12345";
     const cfg: OpenClawConfig = {

--- a/src/agents/sandbox/tool-policy.test.ts
+++ b/src/agents/sandbox/tool-policy.test.ts
@@ -305,8 +305,26 @@ describe("sandbox/tool-policy", () => {
     );
   });
 
-  it("keeps redacted session keys UTF-16 safe", () => {
-    const sessionKey = `abcde\u{1F600}middle123456`;
+  it.each([
+    {
+      boundary: "prefix",
+      sessionKey: `abcde\u{1f600}middle123456`,
+      expectedLabel: "abcde…123456",
+    },
+    {
+      boundary: "suffix",
+      sessionKey: `abcdefmiddle\u{1f600}12345`,
+      expectedLabel: "abcdef…12345",
+    },
+    {
+      boundary: "both",
+      sessionKey: `abcde\u{1f600}middle\u{1f600}12345`,
+      expectedLabel: "abcde…12345",
+    },
+  ])("keeps redacted session keys UTF-16 safe at the $boundary boundary", ({
+    sessionKey,
+    expectedLabel,
+  }) => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: {
@@ -329,8 +347,13 @@ describe("sandbox/tool-policy", () => {
     });
 
     const sessionLine = message?.split("\n").find((line) => line.startsWith("Session: "));
-    expect(sessionLine).toBe("Session: abcde…123456");
-    expect(sessionLine).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    const sessionLabel = sessionLine?.slice("Session: ".length);
+    expect(sessionLabel).toBe(expectedLabel);
+    expect(sessionLabel?.length).toBeLessThanOrEqual(13);
+    expect(sessionLabel).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+    );
+    expect(message).toContain(`openclaw sandbox explain --session '${sessionKey}'`);
   });
 
   it("avoids terminal injection for control-character session keys", () => {


### PR DESCRIPTION
## Summary
- Keep sandbox blocked-tool session key redaction UTF-16 safe for both the displayed prefix and suffix.
- Add a regression through `formatSandboxToolPolicyBlockedMessage` so the user-visible blocked-tool guidance path is covered.

## What Problem This Solves
Sandbox blocked-tool guidance redacts long session keys as `prefix…suffix`. The old formatter used `trimmed.slice(0, 6)` and `trimmed.slice(-6)`, so a session key with an emoji or other astral character at either redaction boundary could leave a lone UTF-16 surrogate in the displayed `Session:` line.

Reviewed `origin/main` still has the raw slices at `src/agents/sandbox/runtime-status.ts`:

```text
origin/main=cd50d4983b2f0fdfffe550449c40b2024d2991be
113:  return `${sanitizeForSingleLineDisplay(trimmed.slice(0, 6))}…${sanitizeForSingleLineDisplay(trimmed.slice(-6))}`;
```

## User Impact
- **Why it matters / User impact:** Users reading sandbox tool-policy denial messages should see a compact, terminal-safe, valid `Session:` value. Unicode session keys should not render replacement characters or malformed half-surrogates in the guidance that tells the user which sandboxed session was blocked.

## Origin / follow-up
Follows #102625.

- Follows: #102625 fixed the same UTF-16-safe truncation class in UI event payload display by moving raw slicing to a shared safe truncation helper.
- Gap: Sandbox blocked-tool guidance still used raw code-unit slicing for the redacted session key prefix and suffix.
- Consistency: This applies shared UTF-16-safe prefix/suffix truncation at the source formatter while preserving existing control-character escaping and command guidance.

## Competition / linked PR analysis
- Related open PR scan: checked open PRs for `sandbox redacted session key UTF-16` in `openclaw/openclaw` before submission.

```json
[]
```

No open same-point PR was found.

## Merge risk
- **Risk labels considered:** security-boundary, session-state, compatibility, automation, availability.
- **Risk explanation:** The relevant surfaces are sandbox session-state display and security-boundary guidance. The patch does not change whether sandboxing applies, which tool policy blocks a tool, audit behavior, allow/deny matching, or the shell command target. It only changes how an already-selected session key is shortened for display.
- **Why acceptable:** The diff is limited to the redaction helper and one exported blocked-message regression. Existing control-character escaping remains in place, and the full session key remains used for the shell-escaped explain command when safe.
- **Patch quality notes:** Focused source change plus a regression that calls the exported message formatter with a real sandbox config. No skip/only directives, no type escapes, no fallback/default strategy, and no unrelated cleanup.
- **Maintainer-ready confidence:** High: latest main still has the raw slices, no same-point open PR was found, the patch uses existing UTF-16-safe helpers, and the regression covers the user-visible blocked-tool message path.

## Real behavior proof
- **Behavior or issue addressed:** A sandboxed session key whose prefix or suffix redaction boundary lands inside an emoji should not surface a malformed half-surrogate in the redacted `Session:` line of blocked-tool guidance.
- **Canonical reachability path:** user/config/input → schema/type/ingestion/normalization → runtime object → request/effect: user/session input (`sessionKey`) plus sandbox config (`agents.defaults.sandbox.mode=all`, tool deny policy) enters `formatSandboxToolPolicyBlockedMessage`, is resolved by `resolveSandboxRuntimeStatus` and `resolveSandboxToolPolicyForAgent`, classified by `classifyToolAgainstSandboxToolPolicy`, then renders the user-visible blocked-tool guidance effect containing `Session: ...`.
- **Boundary crossed:** The regression calls the exported `formatSandboxToolPolicyBlockedMessage` path with a real sandbox config and denied tool, then observes the returned multiline guidance exactly as a caller would display it.
- **Shared helper / provider constraint check:** The fix uses existing shared UTF-16-safe helpers from `@openclaw/normalization-core/utf16-slice`: `truncateUtf16Safe` for the prefix and `sliceUtf16Safe` for the suffix. No external provider constraint is involved.
- **Real environment tested:** Sanitized direct AWS Crabbox (`provider=aws`, lease `cbx_e5d64f409c98`, public network, no Tailscale, no IAM instance profile, no credential hydration), Node 24.15.0, pnpm 11.2.2, exact PR head `a2ed154337cb729e2dc1b58ca1b0ba50cf8b844a`.
- **Exact steps or command run after this patch:**

```bash
pnpm test src/agents/sandbox/tool-policy.test.ts -- -t 'keeps redacted session keys UTF-16 safe'
pnpm test src/agents/sandbox/tool-policy.test.ts
```

- **Evidence after fix:**

```text
Focused boundary regression:
 Test Files  1 passed (1)
      Tests  3 passed | 10 skipped (13)

Full scoped file:
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

```text
Old-slice negative control:
 Test Files  1 failed (1)
      Tests  3 failed | 10 passed (13)
prefix: received abcde�…123456
suffix: received abcdef…�12345
both: received abcde�…�12345
```

- **Run artifacts:** [focused green](https://crabbox.openclaw.ai/portal/runs/run_f5c25f8cf932), [full scoped green](https://crabbox.openclaw.ai/portal/runs/run_4af38181cc8b), [old-slice red](https://crabbox.openclaw.ai/portal/runs/run_e5428cf38f76), [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29035351635).
- **Exact-head CI result:** completed successfully at `a2ed154337cb729e2dc1b58ca1b0ba50cf8b844a` with 44 passed jobs, 11 scoped skips, and no failures.
- **Observed result after fix:** Prefix-only, suffix-only, and simultaneous boundary splits produce exact compact labels with no unpaired high or low surrogate and remain within the existing 13-code-unit redaction budget. The copy-paste explain command still contains the intact full Unicode session key; only the display label is redacted.
- **What was not tested:** No browser or external service is involved in this path. The proof does not run an actual blocked tool invocation; it verifies the exported formatter that produces the blocked-tool guidance after policy classification.
- **Fix classification:** Root cause fix

## Review findings addressed
- Expanded the original prefix-only regression to cover suffix-only and simultaneous prefix+suffix splits.
- Asserted both kinds of unpaired surrogate, the existing 13-code-unit label budget, exact rendered labels, and preservation of the intact Unicode key in the `--session` explain command.
- Fresh Codex autoreview at exact head: clean, no accepted/actionable findings (`patch is correct`, confidence 0.91).

## Regression Test Plan
- **Target test file:** `src/agents/sandbox/tool-policy.test.ts`.
- **Scenario locked in:** Table cases place an emoji across the prefix boundary (`abcde\u{1F600}middle123456`), suffix boundary (`abcdefmiddle\u{1F600}12345`), and both boundaries (`abcde\u{1F600}middle\u{1F600}12345`) while a real sandbox config denies `browser` and forces `formatSandboxToolPolicyBlockedMessage` to render the user-visible guidance.
- **Why this is the smallest reliable guardrail:** It reaches the exact user-visible message formatter through the exported sandbox policy path while keeping the assertion focused on the redacted session key boundary.

```bash
pnpm test src/agents/sandbox/tool-policy.test.ts -- -t 'keeps redacted session keys UTF-16 safe'
pnpm test src/agents/sandbox/tool-policy.test.ts
```

## Risk / Compatibility
Existing redaction shape remains `prefix…suffix`, and existing control-character escaping is preserved. The only observable change is that redaction will not split a surrogate pair; the displayed prefix or suffix may be one UTF-16 code unit shorter when the boundary lands inside an astral character.

## What was not changed
- **What did NOT change:** Does not change sandbox mode resolution, agent/session resolution, tool allow/deny classification, audit behavior, shell escaping, unsafe control-character handling, command formatting, or full session-key use in safe explain commands.
- **Architecture / source-of-truth check:** Source-of-truth boundary: `redactSessionKey` is the canonical formatter used by `formatSandboxToolPolicyBlockedMessage` before the blocked-tool guidance is returned. This patch fixes that source formatter rather than post-processing a terminal mirror, log copy, or test-only representation.

## Root Cause
- **Root cause:** Root cause is the source formatter `redactSessionKey` shortening the session key prefix and suffix with raw JavaScript `slice`. Because JavaScript string indices are UTF-16 code units, slicing at fixed display boundaries can cut between the high and low surrogate of an emoji or another astral code point.
- **Why this is root-cause fix:** The patch replaces both raw code-unit slices at the redaction source with shared UTF-16-safe helpers. Every long session key displayed by sandbox blocked-tool guidance flows through `redactSessionKey`, so the invalid-surrogate source is removed before the message is assembled.
