### PR TITLE
fix(anthropic): bound streaming success-body SSE reads at 16 MiB

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -22,7 +22,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
-import { streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
+import { iterateSseMessagesForTest, streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
 
 function createSseResponse(events: Record<string, unknown>[] = []): Response {
   const body = events
@@ -2371,5 +2371,31 @@ describe("Anthropic provider", () => {
     } else {
       expect(capturedPayload).not.toHaveProperty("output_config");
     }
+  });
+
+  it("rejects oversized Anthropic SSE bodies", async () => {
+    const bigPayload = "x".repeat(16 * 1024 * 1024 + 1);
+
+    // Build an SSE response body whose content_block_delta text payload alone
+    // exceeds the 16 MiB guard, so the byte guard fires before the stream ends.
+    const body = new TextEncoder().encode(
+      `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", model: "claude", usage: { input_tokens: 0, output_tokens: 0 } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", content_block: { type: "text", index: 0 } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", delta: { type: "text_delta", text: bigPayload } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 1, output_tokens: 1 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    );
+
+    // Collect all yielded events; the byte guard overflows on the first
+    // oversized chunk and the async generator throws.
+    await expect(
+      (async () => {
+        const events: unknown[] = [];
+        for await (const event of iterateSseMessagesForTest(new Response(body).body!)) {
+          events.push(event);
+        }
+      })(),
+    ).rejects.toThrow(/exceeds 16777216 bytes/);
   });
 });

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -37,6 +37,7 @@ import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -93,6 +94,7 @@ import {
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
+const ANTHROPIC_SSE_STREAM_MAX_BYTES = 16 * 1024 * 1024;
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
 const EMPTY_ERROR_TOOL_RESULT_TEXT = "[tool error with no output]";
 
@@ -400,7 +402,8 @@ async function* iterateSseMessages(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncGenerator<ServerSentEvent> {
-  const reader = body.getReader();
+  const rawReader = body.getReader();
+  const reader = createSseByteGuard(rawReader, { maxBytes: ANTHROPIC_SSE_STREAM_MAX_BYTES });
   const decoder = new TextDecoder();
   const state: SseDecoderState = { event: null, data: [], raw: [] };
   let buffer = "";
@@ -451,8 +454,16 @@ async function* iterateSseMessages(
       yield trailingEvent;
     }
   } finally {
-    reader.releaseLock();
+    rawReader.releaseLock();
   }
+}
+
+// Exported for testing only.
+export async function* iterateSseMessagesForTest(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncGenerator<ServerSentEvent> {
+  yield* iterateSseMessages(body, signal);
 }
 
 async function* iterateAnthropicEvents(


### PR DESCRIPTION
## What Problem This Solves

The refactored `iterateSseMessages` in `packages/ai/src/providers/anthropic.ts` reads SSE chunks into an unbounded `buffer` string with no byte cap. A hanging or adversarial Anthropic endpoint that streams oversized success-body data (or never sends `message_stop`) could cause unbounded buffer growth and OOM.

## Why This Change Was Made

The OpenClaw codebase already applies 16 MiB byte caps to SSE/NDJSON streams in Mistral (#97648), OpenAI Chat/Responses (#96762), Ollama (#99585), Google (#102879), and the proxy streams (#97235 / #100686). The Anthropic `iterateSseMessages` was the last major bundled SSE parser in the core AI runtime that lacked this boundary — a gap introduced when the provider was refactored from `src/llm/providers/anthropic.ts` to `packages/ai/src/providers/anthropic.ts`.

This change applies the same `createSseByteGuard` helper already used by Mistral and OpenAI Chat/Responses, with a matching 16 MiB fail-closed threshold.

## User Impact

An Anthropic API endpoint that returns an oversized SSE body (or an unbounded event stream) no longer causes unbounded memory growth. The stream errors cleanly with a descriptive message once the 16 MiB limit is exceeded.

## Evidence

- **Prod code change:** 15 lines added, 2 deleted across 1 file
- **Test:** 28 lines added — new `rejects oversized Anthropic SSE bodies` test via `iterateSseMessagesForTest` export
- **Test run:** `pnpm test packages/ai/src/providers/anthropic.test.ts` — 69 passed (all existing + 1 new)
  ```
  ✓ rejects oversized Anthropic SSE bodies 926ms
  Test Files  1 passed (1)
       Tests  69 passed (69)
  ```
- **Format:** `oxfmt --check` — passed
- **git diff --check origin/main..HEAD** — clean

Co-Authored-By: Claude <noreply@anthropic.com>


## Real behavior proof (added 2026-07-10)

Behavior addressed: Anthropic SSE success-body streams are capped at 16 MiB.

Real environment tested: local Linux Node source checkout; real `node:http` loopback servers.

**Three layers of proof:**

### 1. Real HTTP loopback — oversized stream rejection
A real `node:http` server on `127.0.0.1:0` sends a 16 MiB + 1 byte SSE body. The production `iterateSseMessages` consumes the response over a real TCP connection and rejects:
```
PASS: SSE stream exceeds 16777216 bytes (received 16777225)
```

### 2. Real HTTP loopback — normal-size stream success
Same setup with a 400-byte valid Anthropic SSE conversation:
```
PASS: consumed 6 SSE events
```

### 3. Mutation test
Changing `ANTHROPIC_SSE_STREAM_MAX_BYTES` to `1` causes 18 test failures — the guard is wired and active:
```
Test Files  1 failed (1)
    Tests  18 failed | 51 passed (69)
```

All existing unit tests pass (69/69) with no regressions.
