### PR TITLE
fix(google): stream Gemini batch JSONL output instead of res.text()

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -243,4 +243,82 @@ describe("Google embedding-batch bounded JSON reads", () => {
 
     expect(result.get("r0")).toEqual([1, 0, 0]);
   });
+
+  it("streams multi-line JSONL batch output across delayed chunks", async () => {
+    // Genuinely chunked delivery: body is emitted as overlapping mid-line
+    // chunks with an await between writes, so the readline path cannot rely on
+    // a single buffered string from `new Response(fullText)`.
+    const requests: Parameters<typeof runGeminiEmbeddingBatches>[0]["requests"] = [
+      {
+        custom_id: "r0",
+        request: {
+          model: "models/text-embedding-004",
+          content: { parts: [{ text: "hello" }] },
+          taskType: "RETRIEVAL_DOCUMENT",
+        },
+      },
+      {
+        custom_id: "r1",
+        request: {
+          model: "models/text-embedding-004",
+          content: { parts: [{ text: "world" }] },
+          taskType: "RETRIEVAL_DOCUMENT",
+        },
+      },
+    ];
+    const line0 = JSON.stringify({ key: "r0", embedding: { values: [1, 0, 0] } });
+    const line1 = JSON.stringify({ custom_id: "r1", embedding: { values: [0, 1, 0] } });
+    const jsonlBody = `${line0}\n${line1}\n`;
+    const mid = Math.floor(line0.length / 2);
+    const chunks = [
+      jsonlBody.slice(0, mid),
+      jsonlBody.slice(mid, line0.length + 1 + Math.floor(line1.length / 3)),
+      jsonlBody.slice(line0.length + 1 + Math.floor(line1.length / 3)),
+    ];
+    expect(chunks.join("")).toBe(jsonlBody);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+              const encoder = new TextEncoder();
+              for (const chunk of chunks) {
+                controller.enqueue(encoder.encode(chunk));
+                await new Promise((resolve) => setTimeout(resolve, 5));
+              }
+              controller.close();
+            },
+          });
+          return new Response(stream, { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    const result = await runGeminiEmbeddingBatches({
+      gemini: makeGeminiClient(),
+      agentId: "main",
+      requests,
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: 50,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.get("r0")).toEqual([1, 0, 0]);
+    expect(result.get("r1")).toEqual([0, 1, 0]);
+  });
 });

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -297,7 +297,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
               const encoder = new TextEncoder();
               for (const chunk of chunks) {
                 controller.enqueue(encoder.encode(chunk));
-                await new Promise((resolve) => setTimeout(resolve, 5));
+                await new Promise((resolve) => {
+                  setTimeout(resolve, 5);
+                });
               }
               controller.close();
             },

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -1,5 +1,7 @@
 // Google plugin module implements embedding batch behavior.
 import crypto from "node:crypto";
+import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
 import {
   buildEmbeddingBatchGroupOptions,
   runEmbeddingBatchGroups,
@@ -13,7 +15,6 @@ import {
   createProviderHttpError,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
-import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
 
 type EmbeddingBatchExecutionParams = {
@@ -202,15 +203,74 @@ async function fetchGeminiBatchStatus(params: {
   });
 }
 
-async function fetchGeminiFileContent(params: {
+/**
+ * Streams the JSONL batch output body line by line, parsing each embedding
+ * directly into the result maps. Avoids holding the full raw text and all
+ * parsed objects in memory simultaneously — batch outputs can reach hundreds
+ * of MB for large embedding jobs.
+ *
+ * Mirrors the pattern in extensions/voyage/embedding-batch.ts.
+ */
+async function readGeminiBatchOutputContent(
+  contentRes: Response,
+  remaining: Set<string>,
+  errors: string[],
+  byCustomId: Map<string, number[]>,
+): Promise<void> {
+  if (!contentRes.body) {
+    return;
+  }
+  const inputStream = Readable.fromWeb(
+    contentRes.body as unknown as import("stream/web").ReadableStream,
+  );
+  const reader = createInterface({ input: inputStream, terminal: false });
+  try {
+    for await (const rawLine of reader) {
+      const trimmed = rawLine.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const line = JSON.parse(trimmed) as GeminiBatchOutputLine;
+      const customId = line.key ?? line.custom_id ?? line.request_id;
+      if (!customId) {
+        continue;
+      }
+      remaining.delete(customId);
+      if (line.error?.message) {
+        errors.push(`${customId}: ${line.error.message}`);
+        continue;
+      }
+      if (line.response?.error?.message) {
+        errors.push(`${customId}: ${line.response.error.message}`);
+        continue;
+      }
+      const embedding = sanitizeAndNormalizeEmbedding(
+        line.embedding?.values ?? line.response?.embedding?.values ?? [],
+      );
+      if (embedding.length === 0) {
+        errors.push(`${customId}: empty embedding`);
+        continue;
+      }
+      byCustomId.set(customId, embedding);
+    }
+  } finally {
+    reader.close();
+    inputStream.destroy();
+  }
+}
+
+async function fetchGeminiBatchOutput(params: {
   gemini: GeminiEmbeddingClient;
   fileId: string;
-}): Promise<string> {
+  remaining: Set<string>;
+  errors: string[];
+  byCustomId: Map<string, number[]>;
+}): Promise<void> {
   const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const file = params.fileId.startsWith("files/") ? params.fileId : `files/${params.fileId}`;
   const downloadUrl = `${baseUrl}/${file}:download`;
   debugEmbeddingsLog("memory embeddings: gemini batch download", { downloadUrl });
-  return await withRemoteHttpResponse({
+  await withRemoteHttpResponse({
     url: downloadUrl,
     ssrfPolicy: params.gemini.ssrfPolicy,
     init: {
@@ -220,18 +280,9 @@ async function fetchGeminiFileContent(params: {
       if (!res.ok) {
         throw await createProviderHttpError(res, "gemini batch file content failed");
       }
-      return await res.text();
+      await readGeminiBatchOutputContent(res, params.remaining, params.errors, params.byCustomId);
     },
   });
-}
-
-function parseGeminiBatchOutput(text: string): GeminiBatchOutputLine[] {
-  if (!text.trim()) {
-    return [];
-  }
-  return normalizeStringEntries(text.split("\n")).map(
-    (line) => JSON.parse(line) as GeminiBatchOutputLine,
-  );
 }
 
 async function waitForGeminiBatch(params: {
@@ -344,37 +395,15 @@ export async function runGeminiEmbeddingBatches(
         throw new Error(`gemini batch ${batchName} completed without output file`);
       }
 
-      const content = await fetchGeminiFileContent({
-        gemini: params.gemini,
-        fileId: completed.outputFileId,
-      });
-      const outputLines = parseGeminiBatchOutput(content);
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
-
-      for (const line of outputLines) {
-        const customId = line.key ?? line.custom_id ?? line.request_id;
-        if (!customId) {
-          continue;
-        }
-        remaining.delete(customId);
-        if (line.error?.message) {
-          errors.push(`${customId}: ${line.error.message}`);
-          continue;
-        }
-        if (line.response?.error?.message) {
-          errors.push(`${customId}: ${line.response.error.message}`);
-          continue;
-        }
-        const embedding = sanitizeAndNormalizeEmbedding(
-          line.embedding?.values ?? line.response?.embedding?.values ?? [],
-        );
-        if (embedding.length === 0) {
-          errors.push(`${customId}: empty embedding`);
-          continue;
-        }
-        byCustomId.set(customId, embedding);
-      }
+      await fetchGeminiBatchOutput({
+        gemini: params.gemini,
+        fileId: completed.outputFileId,
+        remaining,
+        errors,
+        byCustomId,
+      });
 
       if (errors.length > 0) {
         throw new Error(`gemini batch ${batchName} failed: ${errors.join("; ")}`);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes a memory spike in the Gemini embedding batch download step where large batch output files are fully buffered in memory before any embedding is written to the result map.

`fetchGeminiFileContent` called `res.text()` to download the JSONL output file as a single string, then `parseGeminiBatchOutput` called `text.split("\n")` to produce a full `GeminiBatchOutputLine[]` array. Both the raw text buffer and the parsed object array exist simultaneously at peak — for a large embedding batch this roughly doubles peak heap on top of the result map.

## Why This Change Was Made

Replace the two-step buffer-then-parse approach with a streaming readline reader that consumes one JSONL line at a time and writes each embedding directly into `byCustomId`, matching the pattern already established in `extensions/voyage/embedding-batch.ts`.

Structural changes:

- **Deleted** `fetchGeminiFileContent` — returned the full JSONL body as a `string`.
- **Deleted** `parseGeminiBatchOutput` — split the string and mapped it to `GeminiBatchOutputLine[]`.
- **Added** `readGeminiBatchOutputContent` — wraps `Response.body` with `Readable.fromWeb` + `readline.Interface`, applies each line inline, and always closes/destroys reader resources in `finally`.
- **Added** `fetchGeminiBatchOutput` — thin wrapper that builds the `:download` URL and delegates body reading to the streamed reader.

Identifier precedence (`key` / `custom_id` / `request_id`) and both error paths are preserved.

## User Impact

Peak memory for large Gemini embedding batch jobs drops from roughly `2× output file size` (raw text + parsed lines + result map) toward approximately the embedding result map size. Successful batches, partial-error batches, and empty-output error paths keep the same user-visible behavior.

## Evidence

- Pattern parity with `extensions/voyage/embedding-batch.ts` streamed JSONL reader
- Focused regression: delayed mid-line chunked `ReadableStream` body through production `runGeminiEmbeddingBatches`
- Real `node:http` Transfer-Encoding chunked download against production caller with peak-heap before/after

## Real behavior proof

- **Behavior or issue addressed:** Gemini embedding batch download no longer holds the full JSONL text and a full parsed-line array in memory at the same time while populating `byCustomId`.
- **Canonical reachability path:** `runGeminiEmbeddingBatches` → `fetchGeminiBatchOutput` → `withRemoteHttpResponse` → `readGeminiBatchOutputContent` (`Readable.fromWeb` + `readline`) → per-line `byCustomId.set`.
- **Boundary crossed:** local-runtime; real Node `http.createServer` on `127.0.0.1` serving a ~22 MiB JSONL body with 22,823 on-wire chunks (no `Content-Length`), fetched through production SSRF-guarded `withRemoteHttpResponse` with `allowPrivateNetwork`.
- **Shared helper / provider constraint check:** Mirrors Voyage's provider-local streamed JSONL reader; no new config/env. Google Batch API output remains JSONL with per-line `key`/`response`/`error`.
- **Real environment tested:** macOS (darwin 24.3.0), Node 22 (`--expose-gc --import tsx`), branch `fix/gemini-batch-streaming-jsonl-reader`.
- **Exact steps or command run after this patch:**

```text
$ node --expose-gc --import tsx /tmp/gemini-batch-stream-proof.mjs
$ node scripts/run-vitest.mjs extensions/google/embedding-batch.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
payload_lines= 12000
payload_bytes= 23370184
payload_mib= 22.29 MiB
chunk_bytes= 1024
gc_available= true
BEFORE_mode=res.text()+split+parse_all
BEFORE_buffered_count= 12000
BEFORE_buffered_text_bytes= 23370184
BEFORE_buffered_parsed_lines= 12000
BEFORE_peak_heap_delta= 61.84 MiB
BEFORE_peak_heap= 166.04 MiB
BEFORE_download_chunks= 22823
AFTER_mode=production_runGeminiEmbeddingBatches_readline_stream
AFTER_streamed_count= 12000
AFTER_streamed_sample_dims= 96
AFTER_peak_heap_delta= 24.32 MiB
AFTER_peak_heap= 132.46 MiB
AFTER_download_chunks= 22823
AFTER_download_bytes= 23370184
peak_delta_ratio_streamed_over_buffered= 0.393
peak_delta_saved= 37.52 MiB
proof_ok= true

$ node scripts/run-vitest.mjs extensions/google/embedding-batch.test.ts --reporter=verbose
 ✓ bounds oversized file-upload JSON response and cancels the stream
 ✓ bounds oversized batch-create JSON response and cancels the stream
 ✓ bounds oversized batch-status poll JSON response and cancels the stream
 ✓ parses small responses on all three JSON paths correctly
 ✓ streams multi-line JSONL batch output across delayed chunks

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

- **Observed result after fix:** Same ~22.29 MiB JSONL payload was served in 22,823 delayed HTTP chunks. The old `res.text()` + split + parse-all path peaked at +61.84 MiB heap delta while retaining text + parsed lines + result map. Production `runGeminiEmbeddingBatches` on this branch resolved all 12,000 embeddings with +24.32 MiB peak delta (~39% of the buffered delta; ~37.5 MiB saved on this workload). Supplemental Vitest proves mid-line chunk boundaries across an async `ReadableStream`.
- **What was not tested:** Live Google Gemini Batch API credentials / real Files API download against Google infrastructure; process RSS via `/usr/bin/time` outside V8 heapUsed sampling.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
