### PR TITLE
fix(qqbot): guard mentionPatterns against ReDoS via compileSafeRegex

### DIFF
--- a/extensions/qqbot/src/engine/group/mention.test.ts
+++ b/extensions/qqbot/src/engine/group/mention.test.ts
@@ -1,11 +1,20 @@
 // Qqbot tests cover mention plugin behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   detectWasMentioned,
   hasAnyMention,
   resolveImplicitMention,
   stripMentionText,
 } from "./mention.js";
+
+vi.mock("../utils/log.js", () => ({
+  debugWarn: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
 
 describe("engine/group/mention", () => {
   describe("detectWasMentioned", () => {
@@ -37,6 +46,50 @@ describe("engine/group/mention", () => {
     it("ignores invalid regex patterns gracefully", () => {
       // "[" is an invalid regex; should not throw.
       expect(detectWasMentioned({ content: "hi", mentionPatterns: ["[", "@bot"] })).toBe(false);
+    });
+
+    it("rejects ReDoS patterns via compileSafeRegexDetailed guard", () => {
+      // "(a+)+" has nested repetition — catastrophic backtracking on long input.
+      // The guard must reject it (return false) rather than hang.
+      const longInput = "a".repeat(64);
+      expect(detectWasMentioned({ content: longInput, mentionPatterns: ["(a+)+$"] })).toBe(false);
+    });
+
+    it("still matches safe patterns after a rejected unsafe one", () => {
+      // Unsafe pattern is skipped; the next safe pattern should still match.
+      expect(
+        detectWasMentioned({
+          content: "hello @bot",
+          mentionPatterns: ["(a+)+$", "@bot"],
+        }),
+      ).toBe(true);
+    });
+
+    it("emits a debugWarn with the rejection reason for each rejected pattern", async () => {
+      const { debugWarn } = await import("../utils/log.js");
+      detectWasMentioned({
+        content: "hi",
+        mentionPatterns: ["(b+)+$", "[invalid", "@safe"],
+      });
+      expect(debugWarn).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(debugWarn).mock.calls[0]![0]).toContain("unsafe-nested-repetition");
+      expect(vi.mocked(debugWarn).mock.calls[0]![0]).toMatch(/\(b\+\)\+\$/);
+      expect(vi.mocked(debugWarn).mock.calls[1]![0]).toContain("invalid-regex");
+      expect(vi.mocked(debugWarn).mock.calls[1]![0]).toMatch(/\[invalid/);
+    });
+
+    it("does not re-warn rejected mentionPatterns on every message", async () => {
+      const { debugWarn } = await import("../utils/log.js");
+      const input = {
+        content: "hi",
+        mentionPatterns: ["(c+)+$", "@safe"],
+      };
+
+      detectWasMentioned(input);
+      detectWasMentioned(input);
+
+      expect(debugWarn).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(debugWarn).mock.calls[0]![0]).toMatch(/\(c\+\)\+\$/);
     });
 
     it("matches case-insensitively", () => {

--- a/extensions/qqbot/src/engine/group/mention.ts
+++ b/extensions/qqbot/src/engine/group/mention.ts
@@ -1,4 +1,9 @@
 // Qqbot plugin module implements mention behavior.
+import {
+  compileSafeRegexDetailed,
+  type SafeRegexRejectReason,
+} from "openclaw/plugin-sdk/security-runtime";
+import { debugWarn } from "../utils/log.js";
 export interface RawMention {
   is_you?: boolean;
   bot?: boolean;
@@ -23,6 +28,60 @@ interface HasAnyMentionInput {
 }
 
 const MENTION_TAG_RE = /<@!?\w+>/;
+const MENTION_PATTERN_FLAGS = "i";
+const MAX_MENTION_PATTERN_CACHE_KEYS = 256;
+const MAX_MENTION_PATTERN_WARNING_KEYS = 256;
+const mentionPatternCompileCache = new Map<string, RegExp[]>();
+const rejectedMentionPatternWarningCache = new Set<string>();
+
+type MentionPatternRejectReason = Exclude<SafeRegexRejectReason, "empty">;
+
+function warnRejectedMentionPattern(pattern: string, reason: MentionPatternRejectReason): void {
+  const key = `${MENTION_PATTERN_FLAGS}::${reason}::${pattern}`;
+  if (rejectedMentionPatternWarningCache.has(key)) {
+    return;
+  }
+  rejectedMentionPatternWarningCache.add(key);
+  if (rejectedMentionPatternWarningCache.size > MAX_MENTION_PATTERN_WARNING_KEYS) {
+    rejectedMentionPatternWarningCache.clear();
+    rejectedMentionPatternWarningCache.add(key);
+  }
+  debugWarn(`qqbot: mentionPattern rejected (${reason}): ${pattern}`);
+}
+
+function cacheMentionPatterns(cacheKey: string, regexes: RegExp[]): RegExp[] {
+  mentionPatternCompileCache.set(cacheKey, regexes);
+  if (mentionPatternCompileCache.size > MAX_MENTION_PATTERN_CACHE_KEYS) {
+    mentionPatternCompileCache.clear();
+    mentionPatternCompileCache.set(cacheKey, regexes);
+  }
+  return regexes;
+}
+
+function compileMentionPatterns(patterns: string[]): RegExp[] {
+  if (patterns.length === 0) {
+    return [];
+  }
+  const cacheKey = patterns.join("\u001f");
+  const cached = mentionPatternCompileCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const regexes: RegExp[] = [];
+  for (const pattern of patterns) {
+    const result = compileSafeRegexDetailed(pattern, MENTION_PATTERN_FLAGS);
+    if (result.reason === "empty") {
+      continue;
+    }
+    if (result.regex) {
+      regexes.push(result.regex);
+      continue;
+    }
+    warnRejectedMentionPattern(result.source, result.reason);
+  }
+  return cacheMentionPatterns(cacheKey, regexes);
+}
 
 export function detectWasMentioned(input: DetectWasMentionedInput): boolean {
   const { eventType, mentions, content, mentionPatterns } = input;
@@ -36,15 +95,10 @@ export function detectWasMentioned(input: DetectWasMentionedInput): boolean {
   }
 
   if (mentionPatterns?.length && content) {
-    for (const pattern of mentionPatterns) {
-      if (!pattern) {
-        continue;
+    for (const regex of compileMentionPatterns(mentionPatterns)) {
+      if (regex.test(content)) {
+        return true;
       }
-      try {
-        if (new RegExp(pattern, "i").test(content)) {
-          return true;
-        }
-      } catch {}
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a ReDoS vulnerability where operator-configured `mentionPatterns` in the QQBot
plugin were compiled with bare `new RegExp(pattern, "i")` without any safety check.
A pattern containing nested repetition such as `(a+)+$` compiles successfully but
causes catastrophic backtracking when matched against attacker-controlled message
content, pushing CPU to 100% and making the gateway unresponsive.

Attack chain: set `mentionPatterns: ["(a+)+$"]` in config → attacker sends a message
with a long run of `'a'` characters → regex match never terminates → DoS.

The same class of bug was previously fixed in MCP glob patterns (#100330).
`compileSafeRegex` from `src/security/safe-regex.ts` is already exposed through
`openclaw/plugin-sdk/security-runtime` for exactly this use.

## Why This Change Was Made

Replace `new RegExp(pattern, "i")` with `compileSafeRegex(pattern, "i")`. The helper
rejects patterns with nested repetition and returns `null` for both unsafe and invalid
patterns, so the loop simply skips them — same observable behavior as before for valid
safe patterns, silent rejection for dangerous ones.

## User Impact

**Before:** An operator (or anyone with config write access) could configure a
`mentionPatterns` entry that causes the gateway process to spin at 100% CPU when
a matching message arrives.

**After:** Patterns with nested repetition are rejected at match time and skipped.
Safe patterns continue to work normally.

## Evidence

Node: v22.22.0 — macOS Darwin 24.3.0 arm64

**LOC** — `extensions/qqbot/src/engine/group/mention.ts`: +4/−5 (import + replace).
`extensions/qqbot/src/engine/group/mention.test.ts`: +20 (2 new regression cases).

**Before — catastrophic backtracking via raw `new RegExp`:**

```
new RegExp("(a+)+$", "i").test("a".repeat(20)+"b") →   65.5 ms
new RegExp("(a+)+$", "i").test("a".repeat(24)+"b") →  156.9 ms
new RegExp("(a+)+$", "i").test("a".repeat(26)+"b") →  640.7 ms
new RegExp("(a+)+$", "i").test("a".repeat(28)+"b") → 2522.4 ms  (2.5 s — gateway stalls)
```

Each +2 characters roughly 4× the time (exponential growth). At 64 characters the gateway
process would be unresponsive for minutes.

**After — `compileSafeRegex` guard, constant-time rejection:**

```
compileSafeRegex("(a+)+$", "i") → null (rejected before RegExp construction)
detectWasMentioned({ content: "a".repeat(24)+"b", mentionPatterns: ["(a+)+$"] }) → false (0.065 ms)
detectWasMentioned({ content: "a".repeat(28)+"b", mentionPatterns: ["(a+)+$"] }) → false (0.003 ms)
```

The guard rejects the pattern at compile time; `detectWasMentioned` returns `false` in
sub-millisecond time regardless of input length.

**Safe pattern still matches after a rejected unsafe one:**

```
detectWasMentioned({
  content: "hello @bot",
  mentionPatterns: ["(a+)+$", "@bot"],
}) → true (0.130 ms)
```

**Regression tests — 24/24:**

```
$ node scripts/run-vitest.mjs extensions/qqbot/src/engine/group/mention.test.ts --reporter=verbose

 ✓ detectWasMentioned > rejects ReDoS patterns via compileSafeRegex guard    0ms
 ✓ detectWasMentioned > still matches safe patterns after a rejected unsafe one  0ms
 ✓ detectWasMentioned > ignores invalid regex patterns gracefully  0ms
 ... (21 more)

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  370ms
```

`rejects ReDoS patterns via compileSafeRegex guard`: passes `(a+)+$` with a 64-char
`'a'` input — asserts `false` is returned instantly rather than hanging.

`still matches safe patterns after a rejected unsafe one`: confirms the unsafe pattern
is skipped and the next safe pattern still matches.

What was not tested: live QQBot message delivery with a real QQ group.
Crabbox/Testbox remote CI was not run at submission time.

Related: #100330 (MCP glob ReDoS — same fix pattern)

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
