### PR TITLE
fix: count multi-failure tool summaries accurately

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -941,6 +941,35 @@ describe("CodexAppServerEventProjector", () => {
     ]);
   });
 
+  it("marks every failed tool in a multi-call turn", async () => {
+    const projector = await createProjector();
+    const commandItem = (id: string, status: "completed" | "failed", exitCode: number) => ({
+      type: "commandExecution",
+      id,
+      command: `/bin/bash -lc 'exit ${exitCode}'`,
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status,
+      commandActions: [],
+      aggregatedOutput: "",
+      exitCode,
+      durationMs: 10,
+    });
+
+    await projector.handleNotification(
+      turnCompleted([
+        commandItem("cmd-failed-1", "failed", 1),
+        commandItem("cmd-failed-2", "failed", 2),
+        commandItem("cmd-success", "completed", 0),
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.toolMetas).toHaveLength(3);
+    expect(result.toolMetas.filter((meta) => meta.isError === true)).toHaveLength(2);
+  });
+
   it("keeps explicit cancellation marked aborted for interrupted tool-only turns", async () => {
     const projector = await createProjector();
     projector.markAborted();

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -521,10 +521,7 @@ export class CodexAppServerEventProjector {
   // Once an output delta crosses the transcript cap, later deltas must not fill
   // UTF-16 capacity recovered by backing up over a split surrogate pair.
   private readonly toolResultOutputTruncatedItemIds = new Set<string>();
-  private readonly toolMetas = new Map<
-    string,
-    { toolName: string; meta?: string; asyncStarted?: boolean }
-  >();
+  private readonly toolMetas = new Map<string, EmbeddedRunAttemptResult["toolMetas"][number]>();
   private readonly terminalPresentationClearedItemIds = new Set<string>();
   private readonly nativeToolOutcomeOrdinals = new Map<string, number>();
   private readonly sideEffectingToolItemIds = new Set<string>();
@@ -882,14 +879,13 @@ export class CodexAppServerEventProjector {
     contentItems: CodexDynamicToolCallOutputContentItem[];
   }): void {
     const resultText = collectDynamicToolContentText(params.contentItems);
-    if (params.asyncStarted === true) {
-      const existing = this.toolMetas.get(params.callId);
-      this.toolMetas.set(params.callId, {
-        toolName: existing?.toolName ?? params.tool,
-        ...(existing?.meta ? { meta: existing.meta } : {}),
-        asyncStarted: true,
-      });
-    }
+    const existing = this.toolMetas.get(params.callId);
+    this.toolMetas.set(params.callId, {
+      toolName: existing?.toolName ?? params.tool,
+      ...(existing?.meta ? { meta: existing.meta } : {}),
+      ...(params.asyncStarted === true ? { asyncStarted: true } : {}),
+      ...(!params.success ? { isError: true } : {}),
+    });
     this.recordToolTranscriptResult({
       id: params.callId,
       name: params.tool,
@@ -2010,11 +2006,13 @@ export class CodexAppServerEventProjector {
       return;
     }
     const meta = itemMeta(item, this.toolProgressDetailMode());
+    const status = itemStatus(item);
     const existing = this.toolMetas.get(item.id);
     this.toolMetas.set(item.id, {
       toolName,
       ...(meta ? { meta } : {}),
       ...(existing?.asyncStarted ? { asyncStarted: true } : {}),
+      ...(status !== "running" && isNonSuccessItemStatus(status) ? { isError: true } : {}),
     });
   }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3465,6 +3465,58 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
+  it("preserves every command failure from official app-server events", async () => {
+    const sessionFile = path.join(tempDir, "session-multi-command-failure.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-multi-command-failure");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+
+    for (const [id, status, exitCode] of [
+      ["command-failed-1", "failed", 1],
+      ["command-succeeded", "completed", 0],
+      ["command-failed-2", "failed", 2],
+    ] as const) {
+      await harness.notify({
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "commandExecution",
+            id,
+            command: `/bin/bash -lc 'exit ${exitCode}'`,
+            cwd: workspaceDir,
+            status: "inProgress",
+          },
+        },
+      });
+      await harness.notify({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "commandExecution",
+            id,
+            command: `/bin/bash -lc 'exit ${exitCode}'`,
+            cwd: workspaceDir,
+            status,
+            aggregatedOutput: "",
+            exitCode,
+            durationMs: 1,
+          },
+        },
+      });
+    }
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    const result = await run;
+    expect(result.toolMetas).toHaveLength(3);
+    expect(result.toolMetas.filter((meta) => meta.isError === true)).toHaveLength(2);
+  });
+
   it("promotes implicit Codex yolo approval policy when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -1234,7 +1234,7 @@ function createResult(
     sessionIdUsed?: string;
     timedOut?: boolean;
     timedOutDuringCompaction?: boolean;
-    toolMetas?: Array<{ meta?: string; toolName: string }>;
+    toolMetas?: AgentHarnessAttemptResult["toolMetas"];
     usage?: AssistantUsageSnapshot;
     yieldDetected?: boolean;
   },

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -186,10 +186,7 @@ describe("attachEventBridge", () => {
 
     expect(bridge.snapshot().assistantTexts).toEqual(["root"]);
     expect(bridge.snapshot().startedCount).toBe(0);
-    expect(bridge.snapshot().toolMetas).toEqual([
-      { toolName: "write" },
-      { meta: "child write", toolName: "write" },
-    ]);
+    expect(bridge.snapshot().toolMetas).toEqual([{ meta: "child write", toolName: "write" }]);
     await bridge.awaitDeltaChain();
     expect(onAssistantDelta).toHaveBeenCalledTimes(1);
   });
@@ -689,7 +686,7 @@ describe("attachEventBridge", () => {
     });
   });
 
-  it("tool.execution_complete uses detailedContent or content on success and error.message on failure", () => {
+  it("tool.execution_complete updates one tool meta per call and marks failures", () => {
     const session = createFakeSession();
     const bridge = attachEventBridge(session, {
       getSdkSessionId: () => "sdk-session-id",
@@ -722,10 +719,8 @@ describe("attachEventBridge", () => {
     );
 
     expect(bridge.snapshot().toolMetas).toEqual([
-      { toolName: "bash" },
       { meta: "details", toolName: "bash" },
-      { toolName: "read" },
-      { meta: "failed", toolName: "read" },
+      { meta: "failed", toolName: "read", isError: true },
     ]);
   });
 

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -1,6 +1,9 @@
 // Copilot plugin module implements event bridge behavior.
 import type { MessageOptions, SessionEvent, SessionEventType } from "@github/copilot-sdk";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type {
+  AgentHarnessAttemptResult,
+  AgentMessage,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   buildCopilotAssistantUsage,
   normalizeCopilotUsage,
@@ -66,7 +69,7 @@ interface EventBridgeSnapshot {
   readonly lastAssistantEvent: Extract<SessionEvent, { type: "assistant.message" }> | undefined;
   readonly startedCount: number;
   readonly streamError: Error | undefined;
-  readonly toolMetas: ReadonlyArray<{ meta?: string; toolName: string }>;
+  readonly toolMetas: ReadonlyArray<AgentHarnessAttemptResult["toolMetas"][number]>;
   readonly usage: AssistantUsageSnapshot | undefined;
 }
 
@@ -106,8 +109,8 @@ export function attachEventBridge(
   let lastAssistantEvent: Extract<SessionEvent, { type: "assistant.message" }> | undefined;
   let usage: AssistantUsageSnapshot | undefined;
   let streamError: Error | undefined;
-  const toolMetas: Array<{ meta?: string; toolName: string }> = [];
-  const toolNamesByCallId = new Map<string, string>();
+  const toolMetas: AgentHarnessAttemptResult["toolMetas"] = [];
+  const toolMetaIndexByCallId = new Map<string, number>();
   let startedCount = 0;
   let completedCount = 0;
   let activeCompactionCount = 0;
@@ -202,7 +205,7 @@ export function attachEventBridge(
     if (isRootSessionEvent(event)) {
       startedCount += 1;
     }
-    toolNamesByCallId.set(event.data.toolCallId, event.data.toolName);
+    toolMetaIndexByCallId.set(event.data.toolCallId, toolMetas.length);
     toolMetas.push({ toolName: event.data.toolName });
   });
 
@@ -210,12 +213,17 @@ export function attachEventBridge(
     if (isRootSessionEvent(event)) {
       completedCount += 1;
     }
-    const toolName = toolNamesByCallId.get(event.data.toolCallId);
+    const toolMetaIndex = toolMetaIndexByCallId.get(event.data.toolCallId);
+    const toolName = toolMetaIndex === undefined ? undefined : toolMetas[toolMetaIndex]?.toolName;
     const meta = event.data.success
       ? (event.data.result?.detailedContent ?? event.data.result?.content)
       : event.data.error?.message;
-    if (toolName) {
-      toolMetas.push({ meta, toolName });
+    if (toolName && toolMetaIndex !== undefined) {
+      toolMetas[toolMetaIndex] = {
+        ...(meta ? { meta } : {}),
+        toolName,
+        ...(event.data.success ? {} : { isError: true }),
+      };
     }
   });
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -85,6 +85,31 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     return call[0] as { prompt?: string };
   }
 
+  it("counts failed tool results in trace tool summaries", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Done."],
+        toolMetas: [
+          { toolName: "bash", meta: "exit=1", isError: true },
+          { toolName: "bash", meta: "exit=2", isError: true },
+          { toolName: "bash", meta: "exit=0" },
+        ],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-tool-summary-failure-count",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta?.toolSummary).toEqual({
+      calls: 3,
+      tools: ["bash"],
+      failures: 2,
+    });
+  });
+
   it("emits the before_agent_run hook block message as the agent payload", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -496,7 +496,12 @@ function createScopedAuthProfileStore(
 }
 
 function buildTraceToolSummary(params: {
-  toolMetas?: Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>;
+  toolMetas?: Array<{
+    toolName: string;
+    meta?: string;
+    isError?: boolean;
+    asyncStarted?: boolean;
+  }>;
   hadFailure: boolean;
 }): ToolSummaryTrace | undefined {
   if (!params.toolMetas?.length) {
@@ -512,10 +517,11 @@ function buildTraceToolSummary(params: {
     seen.add(toolName);
     tools.push(toolName);
   }
+  const failedToolCalls = params.toolMetas.filter((entry) => entry.isError === true).length;
   return {
     calls: params.toolMetas?.length ?? 0,
     tools,
-    failures: params.hadFailure ? 1 : 0,
+    failures: failedToolCalls > 0 || !params.hadFailure ? failedToolCalls : 1,
   };
 }
 

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -496,13 +496,8 @@ function createScopedAuthProfileStore(
 }
 
 function buildTraceToolSummary(params: {
-  toolMetas?: Array<{
-    toolName: string;
-    meta?: string;
-    isError?: boolean;
-    asyncStarted?: boolean;
-  }>;
-  hadFailure: boolean;
+  toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"];
+  fallbackHadFailure: boolean;
 }): ToolSummaryTrace | undefined {
   if (!params.toolMetas?.length) {
     return undefined;
@@ -521,7 +516,9 @@ function buildTraceToolSummary(params: {
   return {
     calls: params.toolMetas?.length ?? 0,
     tools,
-    failures: failedToolCalls > 0 || !params.hadFailure ? failedToolCalls : 1,
+    // Per-call error metadata is additive to the shipped harness result contract.
+    // Keep the prior any-failure signal for external harnesses that do not emit it yet.
+    failures: failedToolCalls || Number(params.fallbackHadFailure),
   };
 }
 
@@ -3756,7 +3753,7 @@ async function runEmbeddedAgentInternal(
             (attempt.toolMetas?.length ?? 0) === 0;
           const attemptToolSummary = buildTraceToolSummary({
             toolMetas: attempt.toolMetas,
-            hadFailure: Boolean(attempt.lastToolError),
+            fallbackHadFailure: Boolean(attempt.lastToolError),
           });
           const failureSignal = resolveEmbeddedRunFailureSignal({
             trigger: params.trigger,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5613,6 +5613,7 @@ export async function runEmbeddedAttempt(
             toolName: string;
             meta?: string;
             replaySafe?: boolean;
+            isError?: boolean;
             asyncStarted?: boolean;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
@@ -5623,6 +5624,7 @@ export async function runEmbeddedAttempt(
             toolName: string;
             meta?: string;
             replaySafe: boolean;
+            isError?: true;
             asyncStarted?: true;
             asyncTaskRunId?: string;
             asyncTaskId?: string;
@@ -5631,6 +5633,9 @@ export async function runEmbeddedAttempt(
             meta: entry.meta,
             replaySafe: entry.replaySafe === true,
           };
+          if (entry.isError === true) {
+            normalized.isError = true;
+          }
           if (entry.asyncStarted === true) {
             normalized.asyncStarted = true;
           }

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5613,7 +5613,7 @@ export async function runEmbeddedAttempt(
             toolName: string;
             meta?: string;
             replaySafe?: boolean;
-            isError?: boolean;
+            isError?: true;
             asyncStarted?: boolean;
             asyncTaskRunId?: string;
             asyncTaskId?: string;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -209,6 +209,7 @@ export type EmbeddedRunAttemptResult = {
     toolName: string;
     meta?: string;
     replaySafe?: boolean;
+    isError?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1674,6 +1674,33 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
 });
 
 describe("handleToolExecutionEnd timeout metadata", () => {
+  it("retains every failed call after later successes change the last-error slot", async () => {
+    const { ctx } = createTestContext();
+
+    for (const [toolCallId, isError] of [
+      ["tool-read-failed", true],
+      ["tool-read-succeeded", false],
+      ["tool-exec-failed", true],
+    ] as const) {
+      await handleToolExecutionEnd(
+        ctx as never,
+        {
+          type: "tool_execution_end",
+          toolName: toolCallId.includes("read") ? "read" : "exec",
+          toolCallId,
+          isError,
+          result: isError ? { error: `${toolCallId} failed` } : { content: "ok" },
+        } as never,
+      );
+    }
+
+    expect(ctx.state.toolMetas.map(({ toolName, isError }) => ({ toolName, isError }))).toEqual([
+      { toolName: "read", isError: true },
+      { toolName: "read", isError: undefined },
+      { toolName: "exec", isError: true },
+    ]);
+  });
+
   it("records timeout metadata for failed exec results", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1706,6 +1706,9 @@ describe("handleToolExecutionEnd timeout metadata", () => {
       toolName: "exec",
       timedOut: true,
     });
+    expect(ctx.state.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "exec", isError: true }),
+    ]);
   });
 
   it("uses raw exec metadata for failed tool payload warnings", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1328,6 +1328,7 @@ export async function handleToolExecutionEnd(
     toolName,
     meta,
     replaySafe: callSummary.replaySafe,
+    ...(isToolError ? { isError: true } : {}),
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -72,7 +72,7 @@ export type EmbeddedAgentSubscribeState = {
     toolName?: string;
     meta?: string;
     replaySafe?: boolean;
-    isError?: boolean;
+    isError?: true;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -72,6 +72,7 @@ export type EmbeddedAgentSubscribeState = {
     toolName?: string;
     meta?: string;
     replaySafe?: boolean;
+    isError?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;


### PR DESCRIPTION
Closes #102960

## What Problem This Solves

Embedded agent traces exposed numeric `toolSummary.failures`, but a turn with many failed tool calls was summarized as at most `1`. Issue #102960 captured a real 12-call turn with 10 failures reported as one.

## Why This Change Was Made

The repaired implementation carries each call's terminal error status through the existing canonical `toolMetas` path and counts those entries when building the trace summary. It covers the core embedded runner and both official sibling harnesses:

- Codex app-server terminal item status marks each native and dynamic tool failure.
- Copilot `tool.execution_complete.data.success` updates the matching start entry by `toolCallId`, so one call is no longer represented by separate start and completion metadata entries.
- External harness implementations that have not adopted the additive per-call flag retain the prior minimum one-failure fallback.

The existing public `failures?: number` trace shape is unchanged. A parallel counter was rejected because the shared per-call metadata is already the owner of call count, names, and terminal outcome.

## User Impact

Dashboards, QA gates, retry logic, and plugins consuming raw run traces can distinguish one failed tool call from multiple failures in the same turn. Copilot traces also report one `calls` entry per actual tool invocation rather than counting start and completion separately.

Release-note context: agent tool failure summaries now count every failed call across embedded, Codex, and Copilot runners. Thanks @NianJiuZst for the original fix and report follow-through.

## Evidence

- Final reviewed head: `0d4ac1325ed0f06ed5ce08a166a6efbed587291d`, rebased onto `991262e2e72bedd109abe74cb6e00b715c8c8ce7`.
- Provenance: the zero-or-one population of the numeric trace field was introduced by #66089 / `7c09ba70efb0b542a387bf5b3df362b350d64c55`; current source and the v2026.6.5 tag retain that behavior.
- Direct Codex contract inspection at `8347b8de2144133f49fd18a20f4ca176deef1d3c`: `codex-rs/app-server-protocol/src/protocol/v2/item.rs` defines completed/failed terminal item statuses and carries the authoritative `ThreadItem` in `ItemCompletedNotification`.
- Direct Copilot SDK contract inspection: `@github/copilot-sdk@1.0.5` declares `tool.execution_complete.data.success: boolean` and the matching `toolCallId` in its generated event types.
- Blacksmith Testbox `tbx_01kx4hzh0n1nybffv053rjddbs`: 517/517 focused tests passed on the final tree — core 236, Codex projector plus full controlled app-server attempt 246, Copilot bridge 35.
- Full controlled Codex attempt proof emits official fail/success/fail item events and returns three call metadata entries with two failures.
- Exact-head `pnpm check:changed`: passed all selected guards, four tsgo typecheck lanes, core and extension lint, and runtime boundary checks in 11m40s.
- Fresh exact-base Codex autoreview: clean, zero findings, confidence 0.86.
- Targeted `oxfmt`, `git diff --check`, and staged diff checks passed.
- A real external-provider CLI probe reached the runtime but could not authenticate before tool execution. The credential-free official-event integration provides deterministic production-lifecycle proof without relying on provider availability.

The normal sweep PR intentionally omits root `CHANGELOG.md`; release notes own the changelog entry.
