### PR TITLE
fix(azure-speech): add timeout to voices list request

### DIFF
--- a/extensions/azure-speech/tts.ts
+++ b/extensions/azure-speech/tts.ts
@@ -25,6 +25,9 @@ export const DEFAULT_AZURE_SPEECH_VOICE_NOTE_FORMAT = "ogg-24khz-16bit-mono-opus
 /** Default telephony output format. */
 export const DEFAULT_AZURE_SPEECH_TELEPHONY_FORMAT = "raw-8khz-8bit-mono-mulaw";
 const DEFAULT_AZURE_SPEECH_MAX_BYTES = 16 * 1024 * 1024;
+// Voice discovery should fail boundedly instead of waiting forever when the
+// Azure Speech voices endpoint accepts the connection but never responds.
+const DEFAULT_AZURE_SPEECH_VOICE_LIST_TIMEOUT_MS = 30_000;
 
 type AzureSpeechVoiceEntry = {
   ShortName?: string;
@@ -156,7 +159,7 @@ export async function listAzureSpeechVoices(params: {
         "Ocp-Apim-Subscription-Key": params.apiKey,
       },
     },
-    timeoutMs: params.timeoutMs,
+    timeoutMs: params.timeoutMs ?? DEFAULT_AZURE_SPEECH_VOICE_LIST_TIMEOUT_MS,
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(url),
     auditContext: "azure-speech.voices",
   });

--- a/extensions/azure-speech/voices-timeout-default.test.ts
+++ b/extensions/azure-speech/voices-timeout-default.test.ts
@@ -1,0 +1,66 @@
+// Azure Speech voice list default timeout unit tests.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
+import { listAzureSpeechVoices } from "./tts.js";
+
+type GuardRequest = {
+  url: string;
+  init?: RequestInit;
+  timeoutMs?: number;
+  policy?: unknown;
+  auditContext?: string;
+};
+
+function queueGuardedResponse(response: Response): { release: ReturnType<typeof vi.fn> } {
+  const release = vi.fn(async () => {});
+  fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+  return { release };
+}
+
+function lastGuardRequest(): GuardRequest {
+  const calls = fetchWithSsrFGuardMock.mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) {
+    throw new Error("fetchWithSsrFGuard was not called");
+  }
+  return call[0] as GuardRequest;
+}
+
+afterEach(() => {
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("listAzureSpeechVoices default timeout", () => {
+  it("defaults to a bounded timeout for voice list requests", async () => {
+    queueGuardedResponse(new Response(JSON.stringify([]), { status: 200 }));
+
+    await listAzureSpeechVoices({ apiKey: "speech-key", region: "eastus" });
+
+    expect(lastGuardRequest().timeoutMs).toBe(30_000);
+  });
+
+  it("preserves an explicit timeout for voice list requests", async () => {
+    queueGuardedResponse(new Response(JSON.stringify([]), { status: 200 }));
+
+    await listAzureSpeechVoices({
+      apiKey: "speech-key",
+      region: "eastus",
+      timeoutMs: 5_000,
+    });
+
+    expect(lastGuardRequest().timeoutMs).toBe(5_000);
+  });
+});

--- a/extensions/azure-speech/voices-timeout-default.test.ts
+++ b/extensions/azure-speech/voices-timeout-default.test.ts
@@ -47,7 +47,7 @@ describe("listAzureSpeechVoices default timeout", () => {
   it("defaults to a bounded timeout for voice list requests", async () => {
     queueGuardedResponse(new Response(JSON.stringify([]), { status: 200 }));
 
-    await listAzureSpeechVoices({ apiKey: "speech-key", region: "eastus" });
+    await listAzureSpeechVoices({ apiKey: "not-a-real", region: "eastus" });
 
     expect(lastGuardRequest().timeoutMs).toBe(30_000);
   });
@@ -56,7 +56,7 @@ describe("listAzureSpeechVoices default timeout", () => {
     queueGuardedResponse(new Response(JSON.stringify([]), { status: 200 }));
 
     await listAzureSpeechVoices({
-      apiKey: "speech-key",
+      apiKey: "not-a-real",
       region: "eastus",
       timeoutMs: 5_000,
     });

--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -1,0 +1,80 @@
+// Azure Speech voice list live timeout proof.
+// Uses a local node:http server that accepts the connection but never responds,
+// proving that listAzureSpeechVoices aborts within the configured timeout.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listAzureSpeechVoices } from "./tts.js";
+
+async function listenLocal(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+describe("listAzureSpeechVoices live timeout", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts a hanging voice list request within the configured timeout", async () => {
+    const sockets = new Set<Socket>();
+    let requestCount = 0;
+    const server = createServer((_req, _res) => {
+      requestCount += 1;
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+
+    const port = await listenLocal(server);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, init);
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const startedAt = Date.now();
+
+    try {
+      await expect(
+        Promise.race([
+          listAzureSpeechVoices({
+            apiKey: "speech-key",
+            baseUrl: "https://custom.example.com",
+            timeoutMs: 250,
+          }),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
+          }),
+        ]),
+      ).rejects.toThrow(/aborted|timeout|timed out/i);
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(requestCount).toBe(1);
+    } finally {
+      await closeServer(server, sockets);
+    }
+  });
+});

--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -1,8 +1,8 @@
-// Azure Speech voice list live timeout proof.
-// Uses a local node:http server that accepts the connection but never responds,
-// proving that listAzureSpeechVoices aborts within the configured timeout.
+// Azure Speech voice list timeout integration proof.
+// A loopback server accepts the connection but never responds so this exercises
+// the real fetch abort path without depending on Azure latency.
 import { createServer, type Server } from "node:http";
-import type { AddressInfo, Socket } from "node:net";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listAzureSpeechVoices } from "./tts.js";
 
@@ -14,10 +14,8 @@ async function listenLocal(server: Server): Promise<number> {
   return (server.address() as AddressInfo).port;
 }
 
-async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
   await new Promise<void>((resolve, reject) => {
     server.close((error) => {
       if (error) {
@@ -29,7 +27,7 @@ async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> 
   });
 }
 
-describe("listAzureSpeechVoices live timeout", () => {
+describe("listAzureSpeechVoices timeout", () => {
   const originalFetch = globalThis.fetch;
 
   afterEach(() => {
@@ -37,14 +35,9 @@ describe("listAzureSpeechVoices live timeout", () => {
   });
 
   it("aborts a hanging voice list request within the configured timeout", async () => {
-    const sockets = new Set<Socket>();
     let requestCount = 0;
     const server = createServer((_req, _res) => {
       requestCount += 1;
-    });
-    server.on("connection", (socket) => {
-      sockets.add(socket);
-      socket.on("close", () => sockets.delete(socket));
     });
 
     const port = await listenLocal(server);
@@ -74,7 +67,7 @@ describe("listAzureSpeechVoices live timeout", () => {
       expect(Date.now() - startedAt).toBeLessThan(2_000);
       expect(requestCount).toBe(1);
     } finally {
-      await closeServer(server, sockets);
+      await closeServer(server);
     }
   });
 });

--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -55,7 +55,7 @@ describe("listAzureSpeechVoices timeout", () => {
       await expect(
         Promise.race([
           listAzureSpeechVoices({
-            apiKey: "speech-key",
+            apiKey: "not-a-real",
             baseUrl: "https://custom.example.com",
             timeoutMs: 250,
           }),


### PR DESCRIPTION
## What Problem This Solves

Azure Speech voice discovery could wait indefinitely when the regional voices endpoint accepted a connection but never returned a response.

## Why This Change Was Made

`listAzureSpeechVoices` already owns Azure's request timeout and accepts an explicit override. This change supplies a provider-local 30-second default only when that override is absent, preserving the existing configuration contract and keeping the fix at the Azure transport boundary.

This is intentionally Azure-scoped. A sibling audit found that other speech providers have separate voice-discovery implementations; they do not establish the contract for this helper and are not changed here.

## User Impact

Azure Speech voice listing now fails boundedly instead of hanging forever when the upstream stalls. Explicit Azure timeout configuration continues to win.

## Evidence

- Microsoft documents the regional `GET /cognitiveservices/voices/list` endpoint and subscription-key authentication: https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech#get-a-list-of-voices
- A live request to the documented `eastus` endpoint with an intentionally invalid key returned HTTP 401 in 0.59 seconds, confirming endpoint and authentication reachability without exposing credentials.
- Blacksmith Testbox `tbx_01kxd93zk2p1nprhdxafjx940n`: 9/9 focused tests passed across the Azure helper, timeout default/override seam, and hanging-server abort path.
- The loopback integration test accepts a real HTTP connection without responding, then verifies the guarded fetch aborts within the configured bound.
- The original PR head has 65 successful checks, 57 intentional skips, and no failures.
- `pnpm docs:list` passed; no documentation surface changes.

What was not tested: a successful production-key Azure voice listing. The live endpoint/authentication failure path and deterministic hanging-server fault injection cover the changed timeout behavior.
