### PR TITLE
fix(test): tolerate Docker heartbeat clock rollover

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3371,7 +3371,9 @@ printf "container output\\n" >"$run_log"
 docker_e2e_sample_stats_until_exit demo sampled-docker-pid "$stats_log" "$run_log" "Docker stats" 08 >"$sampler_log" 2>&1
 output="$(cat "$sampler_log")"
 
-[[ "$output" = *"Docker stats still running (8s elapsed,"* ]]
+[[ "$output" =~ Docker\\ stats\\ still\\ running\\ \\(([0-9]+)s\\ elapsed, ]]
+heartbeat_elapsed="\${BASH_REMATCH[1]}"
+(( heartbeat_elapsed >= 8 ))
 [[ "$output" != *"value too great for base"* ]]
 [[ -s "$stats_log" ]]
 `;


### PR DESCRIPTION
## What Problem This Solves

The Docker build helper test could fail intermittently when Bash's special `SECONDS` clock advanced by a real second during the synthetic heartbeat loop. The production helper remained correct, but the test required an exact `8s` timestamp and rejected the valid `9s` case.

## Why This Change Was Made

The test now parses the emitted heartbeat elapsed time and requires it to be at least the normalized eight-second interval. It retains the leading-zero/octal regression check and verifies Docker stats were captured. Production Docker helper behavior is unchanged.

## User Impact

No product behavior changes. CI no longer fails randomly when this heartbeat test crosses a wall-clock second boundary.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/29030021683/job/86160101884
- Exact failed job rerun passed: https://github.com/openclaw/openclaw/actions/runs/29030021683/job/86162319148
- Same unchanged test/helper blobs passed in unrelated CI: https://github.com/openclaw/openclaw/actions/runs/29030019068/job/86160146926
- Before the fix, a 5,000-iteration local reproduction emitted `9s` four times instead of the test's exact `8s` expectation.
- Blacksmith Testbox `tbx_01kx3saj6h9qdwmtm40p4yn30n`: `CI=true corepack pnpm test:serial test/scripts/docker-build-helper.test.ts` (163/163 passed)
- Blacksmith Testbox `tbx_01kx3saj6h9qdwmtm40p4yn30n`: `CI=true corepack pnpm check:changed -- test/scripts/docker-build-helper.test.ts` (passed, 0 warnings/errors)
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings
