### PR TITLE
fix(android): keep link preview metadata UTF-16 safe

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/Utf16Text.kt
@@ -1,0 +1,8 @@
+package ai.openclaw.app
+
+internal fun String.takeUtf16Safe(maxChars: Int): String {
+  if (length <= maxChars) return this
+  // Keep the code-unit cap without leaving a high surrogate at its boundary.
+  val endsOnHighSurrogate = maxChars > 0 && Character.isHighSurrogate(this[maxChars - 1])
+  return take(if (endsOnHighSurrogate) maxChars - 1 else maxChars)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceNotificationListenerService.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.NotificationBurstLimiter
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.allowsPackage
 import ai.openclaw.app.isWithinQuietHours
+import ai.openclaw.app.takeUtf16Safe
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.RemoteInput
@@ -28,17 +29,6 @@ internal fun sanitizeNotificationText(value: CharSequence?): String? {
   val normalized = value?.toString()?.trim().orEmpty()
   // Notification extras can include long previews; cap before sending over node events.
   return normalized.takeUtf16Safe(MAX_NOTIFICATION_TEXT_CHARS).ifEmpty { null }
-}
-
-private fun String.takeUtf16Safe(maxChars: Int): String {
-  if (length <= maxChars) return this
-  val end =
-    if (maxChars > 0 && Character.isHighSurrogate(this[maxChars - 1])) {
-      maxChars - 1
-    } else {
-      maxChars
-    }
-  return take(end)
 }
 
 /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -524,7 +524,18 @@ private fun sanitizeMetadataText(
       .filterNot(Character::isISOControl)
       .replace(Regex("\\s+"), " ")
       .trim()
-  return sanitized.take(maxChars).takeIf(String::isNotEmpty)
+  return sanitized.takeUtf16Safe(maxChars).takeIf(String::isNotEmpty)
+}
+
+private fun String.takeUtf16Safe(maxChars: Int): String {
+  if (length <= maxChars) return this
+  val end =
+    if (maxChars > 0 && Character.isHighSurrogate(this[maxChars - 1])) {
+      maxChars - 1
+    } else {
+      maxChars
+    }
+  return take(end)
 }
 
 private fun findTitle(html: String): String? =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.takeUtf16Safe
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.LruCache
@@ -525,17 +526,6 @@ private fun sanitizeMetadataText(
       .replace(Regex("\\s+"), " ")
       .trim()
   return sanitized.takeUtf16Safe(maxChars).takeIf(String::isNotEmpty)
-}
-
-private fun String.takeUtf16Safe(maxChars: Int): String {
-  if (length <= maxChars) return this
-  val end =
-    if (maxChars > 0 && Character.isHighSurrogate(this[maxChars - 1])) {
-      maxChars - 1
-    } else {
-      maxChars
-    }
-  return take(end)
 }
 
 private fun findTitle(html: String): String? =

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -165,6 +165,21 @@ class ChatLinkPreviewTest {
   }
 
   @Test
+  fun metadataTruncationPreservesUtf16Boundaries() {
+    val titlePrefix = "t".repeat(LINK_PREVIEW_TITLE_MAX_CHARS - 1)
+    val descriptionPrefix = "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_CHARS - 1)
+    val result =
+      parseOpenGraph(
+        "<meta property='og:title' content='$titlePrefix\uD83D\uDE80 trailing'>" +
+          "<meta property='og:description' content='$descriptionPrefix\uD83D\uDE80 trailing'>",
+        "https://example.com",
+      ) as LinkPreviewResult.Loaded
+
+    assertEquals(titlePrefix, result.metadata.title)
+    assertEquals(descriptionPrefix, result.metadata.description)
+  }
+
+  @Test
   fun fetchesHtmlWithoutAmbientHeaders() =
     withServer { server ->
       server.enqueue(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -167,7 +167,7 @@ class ChatLinkPreviewTest {
   @Test
   fun metadataTruncationPreservesUtf16Boundaries() {
     val titlePrefix = "t".repeat(LINK_PREVIEW_TITLE_MAX_CHARS - 1)
-    val descriptionPrefix = "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_CHARS - 1)
+    val descriptionPrefix = "d".repeat(LINK_PREVIEW_DESCRIPTION_MAX_CHARS - 2)
     val result =
       parseOpenGraph(
         "<meta property='og:title' content='$titlePrefix\uD83D\uDE80 trailing'>" +
@@ -176,7 +176,7 @@ class ChatLinkPreviewTest {
       ) as LinkPreviewResult.Loaded
 
     assertEquals(titlePrefix, result.metadata.title)
-    assertEquals(descriptionPrefix, result.metadata.description)
+    assertEquals("$descriptionPrefix\uD83D\uDE80", result.metadata.description)
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Android link previews cap Open Graph title and description metadata before rendering compact preview cards. Kotlin `take(maxChars)` counts UTF-16 code units, so it could leave an unpaired high surrogate when the cap landed between the two units of an emoji or another supplementary-plane character.

## Why This Change Was Made

The final implementation keeps the existing 120/200-unit metadata limits while backing up one unit only when the boundary would retain a lone high surrogate. Review also moved that invariant into one Android-owned `takeUtf16Safe` helper shared with notification snapshot sanitation, replacing the earlier duplicate private implementation. This leaves production code net -1 LOC and one canonical truncation path.

## User Impact

Long Android link-preview titles and descriptions no longer carry malformed UTF-16 at an emoji boundary. A split pair is omitted; a complete pair ending exactly at the cap remains intact. Notification snapshot truncation keeps its existing behavior through the shared helper.

## Evidence

- Exact reviewed head: `74386e4c7e566151934ca3debe6a82fd7e0bd9f9`
- Fresh autoreview: clean, 0 findings, overall confidence 0.86
- `git diff --check`: pass
- Exact-head GitHub CI run [29045458923](https://github.com/openclaw/openclaw/actions/runs/29045458923): pass
  - `android-test-play` job `86212977276`
  - `android-test-third-party` job `86212977364`
  - `android-build-play` job `86212977286`
  - `android-ktlint` job `86212977287`
  - `native-i18n` job `86212977192`
  - OpenGrep, security-fast, and preflight also passed
- Required native prepare gate: pass at `2026-07-09T19:57:11Z`, mode `hosted_exact_or_recent_rebase`, verified exact PR head/tree
- Regression coverage verifies both split-pair removal and complete-pair preservation at the cap; existing notification surrogate coverage remains green

Known proof gap: no exact-head Android APK was available for device/emulator rendering. Source-blind runtime validation therefore reported 0 pass, 0 fail, and 4 blocked clauses; no device-render claim is made. Sanitized AWS fallback runs `run_11199f6ce6ea` and `run_6565652416e0` were infrastructure-blocked before tests because the generic image lacked Java and then the Android SDK. The exact-head hosted Android matrix above is the runtime build/test proof.

Changelog is intentionally deferred: per contributor policy, this branch stays changelog-free; a maintainer-owned consolidated UTF-16 changelog follow-up will include #102988 and thank @ly85206559.
