### PR TITLE
fix(ai): normalize Azure deployment map lookups

### DIFF
--- a/packages/ai/src/providers/azure-deployment-map.test.ts
+++ b/packages/ai/src/providers/azure-deployment-map.test.ts
@@ -19,6 +19,16 @@ describe("Azure deployment name map", () => {
     ).toBe("deployment=blue");
   });
 
+  it("resolves model ids case-insensitively while preserving deployment names", () => {
+    expect(parseAzureDeploymentNameMap("GPT-4o = Prod-East").get("GPT-4o")).toBe("Prod-East");
+    expect(
+      resolveAzureDeploymentNameFromMap({
+        modelId: "gpt-4O",
+        deploymentMap: "GPT-4o = Prod-East, o3-MINI=Reasoning-West",
+      }),
+    ).toBe("Prod-East");
+  });
+
   it("falls back to the model id when the map has no usable entry", () => {
     expect(
       resolveAzureDeploymentNameFromMap({

--- a/packages/ai/src/providers/azure-deployment-map.ts
+++ b/packages/ai/src/providers/azure-deployment-map.ts
@@ -23,10 +23,37 @@ export function parseAzureDeploymentNameMap(value: string | undefined): Map<stri
   return map;
 }
 
+type CachedDeploymentNameMap = {
+  source: string;
+  deploymentsByLowerModelId: Map<string, string>;
+};
+
+let cachedDeploymentNameMap: CachedDeploymentNameMap | undefined;
+
+function getAzureDeploymentNameMap(value: string | undefined): Map<string, string> | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (cachedDeploymentNameMap?.source === value) {
+    return cachedDeploymentNameMap.deploymentsByLowerModelId;
+  }
+
+  const deploymentsByLowerModelId = new Map<string, string>();
+  for (const [modelId, deploymentName] of parseAzureDeploymentNameMap(value)) {
+    deploymentsByLowerModelId.set(modelId.toLowerCase(), deploymentName);
+  }
+  cachedDeploymentNameMap = { source: value, deploymentsByLowerModelId };
+  return deploymentsByLowerModelId;
+}
+
 /** Resolves the Azure deployment name for a model id, falling back to the model id. */
 export function resolveAzureDeploymentNameFromMap(params: {
   modelId: string;
   deploymentMap?: string;
 }): string {
-  return parseAzureDeploymentNameMap(params.deploymentMap).get(params.modelId) || params.modelId;
+  return (
+    getAzureDeploymentNameMap(params.deploymentMap)?.get(params.modelId.toLowerCase()) ||
+    params.modelId
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Closes #102936.

Azure OpenAI deployment maps are keyed by model id, but the resolver currently does an exact-case lookup and reparses the map on every call. A configured entry such as `GPT-4o=Prod-East` can be missed when runtime code asks for `gpt-4O`, causing the Azure request to fall back to the raw model id instead of the configured deployment name.

## Why This Change Was Made

The deployment map is shared by the package provider and embedded OpenAI transport path, so the normalization belongs in the shared helper rather than either caller.

## User Impact

Azure OpenAI users can use deployment-map model ids without having to match casing exactly, while deployment names keep their original casing and existing fallback behavior is unchanged.

## Changes

- Cache the most recent parsed deployment map so repeated resolution does not rebuild it for every call.
- Resolve model ids case-insensitively by lowercasing map keys only for lookup.
- Add regression coverage for mixed-case model ids and deployment-name preservation.

## Evidence

- Deterministic source-level reproduction: before this change, `parseAzureDeploymentMap()` stored map keys exactly as configured and `resolveAzureDeploymentForModel()` used an exact-case `Map.get(model)` lookup, so `GPT-4o=prod-east` did not resolve when the runtime model id arrived as `gpt-4O`. The added regression test asserts mixed-case configured/runtime ids now resolve to the configured Azure deployment name.
- `node scripts/run-vitest.mjs packages/ai/src/providers/azure-deployment-map.test.ts` — 1 file passed, 3 tests passed.
- `node scripts/run-vitest.mjs packages/ai/src/providers/azure-openai-responses.test.ts src/agents/openai-transport-stream.test.ts` — 2 shards passed; 304 tests passed.
- `git diff --check` — passed.
- Diff secret scan for API-key/token/private-key patterns — no potential secrets in diff.

Note: I did not run a live Azure request because no Azure OpenAI deployment credentials are available in this environment. `pnpm check:changed -- packages/ai/src/providers/azure-deployment-map.ts packages/ai/src/providers/azure-deployment-map.test.ts` could not run locally because the repo delegated to Blacksmith Testbox and the local `crabbox` binary failed its basic `--version/--help` sanity check before executing checks.
