### PR TITLE
fix(synology-chat): evict stale chat user cache entries

### DIFF
--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -442,7 +442,7 @@ describe("fetchChatUsers", () => {
     const firstCall = firstHttpsGetCall();
     expect(firstCall[1]?.rejectUnauthorized).toBe(true);
   });
-  it("evicts stale cache entries when inserting a fresh one", async () => {
+  it("evicts stale same-origin cache entries when inserting a fresh one", async () => {
     // The module-level chatUserCache only evicts stale entries on
     // successful insert. Verify that stale entries are removed from
     // the Map so a caller rotating through many webhook URLs cannot
@@ -475,6 +475,41 @@ describe("fetchChatUsers", () => {
     expect(chatUserCache.has(listUrlA)).toBe(false);
 
     // Verify fresh urlB is still present
+    expect(chatUserCache.has(listUrlB)).toBe(true);
+  });
+
+  it("preserves other-origin stale cache entries on cross-origin refresh", async () => {
+    // Regression: a successful refresh for endpoint B (nas2) must
+    // NOT evict endpoint A's stale entry (nas1).  If it did, A's
+    // last-known-good fallback would be lost and reply delivery
+    // would fall back to the incompatible webhook user ID.
+    const clientModule = await import("./client.js");
+    const { chatUserCache, CACHE_TTL_MS } = clientModule.testing;
+    const listUrlA =
+      "https://nas1.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22origin-a%22";
+    const listUrlB =
+      "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22origin-b%22";
+
+    // Seed cache with a stale entry for endpoint A (nas1 origin)
+    chatUserCache.set(listUrlA, {
+      users: [{ user_id: 1, username: "alice", nickname: "a" }],
+      cachedAt: fakeNowMs - CACHE_TTL_MS - 1,
+    });
+
+    // Refresh endpoint B (nas2, different origin) — must NOT
+    // evict A's stale entry
+    mockUserListResponse([{ user_id: 2, username: "bob", nickname: "b" }]);
+    await fetchChatUsers(
+      "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22origin-b%22",
+    );
+
+    // Verify A's stale entry is preserved (fallback for failed refresh)
+    expect(chatUserCache.has(listUrlA)).toBe(true);
+    expect(chatUserCache.get(listUrlA)?.users).toEqual([
+      { user_id: 1, username: "alice", nickname: "a" },
+    ]);
+
+    // Verify B's fresh entry is present
     expect(chatUserCache.has(listUrlB)).toBe(true);
   });
 });

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -442,74 +442,70 @@ describe("fetchChatUsers", () => {
     const firstCall = firstHttpsGetCall();
     expect(firstCall[1]?.rejectUnauthorized).toBe(true);
   });
-  it("evicts stale same-origin cache entries when inserting a fresh one", async () => {
-    // The module-level chatUserCache only evicts stale entries on
-    // successful insert. Verify that stale entries are removed from
-    // the Map so a caller rotating through many webhook URLs cannot
-    // grow the cache without bound.
+  it("bounds cache growth by removing the oldest entry when the cap is reached", async () => {
+    // Regression: a caller rotating through many webhook URLs must not
+    // grow the Map without bound. When the cache reaches its cap, the
+    // oldest entry (least-recently refreshed) is evicted and newer
+    // entries remain.
     const clientModule = await import("./client.js");
-    const { chatUserCache, CACHE_TTL_MS } = clientModule.testing;
-    const listUrlA =
-      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22regression-a%22";
-    const listUrlB =
-      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22regression-b%22";
+    const { chatUserCache } = clientModule.testing;
+    chatUserCache.clear();
 
-    // Populate cache with a fresh entry for urlA
-    chatUserCache.set(listUrlA, {
-      users: [{ user_id: 1, username: "alice", nickname: "a" }],
-      cachedAt: fakeNowMs,
-    });
+    // Fill the cache up to its cap (100). Each key is a distinct URL.
+    const base =
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22seed-";
+    for (let i = 0; i < 100; i++) {
+      chatUserCache.set(`${base}${i}%22`, {
+        users: [{ user_id: i, username: `user-${i}`, nickname: `nick-${i}` }],
+        cachedAt: fakeNowMs - i,
+      });
+    }
+    expect(chatUserCache.size).toBe(100);
 
-    // Advance past TTL so urlA entry is stale
-    fakeNowMs += CACHE_TTL_MS + 1;
-    vi.setSystemTime(fakeNowMs);
-
-    // Insert urlB via fetchChatUsers — the eviction pass must
-    // delete stale urlA from the Map
-    mockUserListResponse([{ user_id: 2, username: "bob", nickname: "b" }]);
+    // Refresh a new endpoint — the oldest entry must be evicted to
+    // make room, and the new entry must be present.
+    mockUserListResponse([{ user_id: 999, username: "new", nickname: "new" }]);
     await fetchChatUsers(
-      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22regression-b%22",
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22newest%22",
     );
 
-    // Verify stale urlA was evicted
-    expect(chatUserCache.has(listUrlA)).toBe(false);
-
-    // Verify fresh urlB is still present
-    expect(chatUserCache.has(listUrlB)).toBe(true);
+    expect(chatUserCache.size).toBe(100);
+    expect(chatUserCache.has(`${base}0%22`)).toBe(false); // oldest evicted
+    expect(
+      chatUserCache.has(
+        "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22newest%22",
+      ),
+    ).toBe(true);
   });
 
-  it("preserves other-origin stale cache entries on cross-origin refresh", async () => {
-    // Regression: a successful refresh for endpoint B (nas2) must
-    // NOT evict endpoint A's stale entry (nas1).  If it did, A's
-    // last-known-good fallback would be lost and reply delivery
-    // would fall back to the incompatible webhook user ID.
+  it("preserves other endpoints' fallback entries on same-origin refresh", async () => {
+    // Regression: a successful refresh for endpoint B must NOT evict
+    // endpoint A's stale entry, even on the same NAS origin. Both
+    // endpoints are active; A's stale fallback is still needed if A's
+    // next refresh fails.
     const clientModule = await import("./client.js");
     const { chatUserCache, CACHE_TTL_MS } = clientModule.testing;
     const listUrlA =
-      "https://nas1.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22origin-a%22";
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22same-origin-a%22";
     const listUrlB =
-      "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22origin-b%22";
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22same-origin-b%22";
 
-    // Seed cache with a stale entry for endpoint A (nas1 origin)
+    // Seed cache with a stale entry for endpoint A
     chatUserCache.set(listUrlA, {
       users: [{ user_id: 1, username: "alice", nickname: "a" }],
       cachedAt: fakeNowMs - CACHE_TTL_MS - 1,
     });
 
-    // Refresh endpoint B (nas2, different origin) — must NOT
-    // evict A's stale entry
+    // Refresh endpoint B on the same origin — must NOT evict A's entry
     mockUserListResponse([{ user_id: 2, username: "bob", nickname: "b" }]);
     await fetchChatUsers(
-      "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22origin-b%22",
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22same-origin-b%22",
     );
 
-    // Verify A's stale entry is preserved (fallback for failed refresh)
     expect(chatUserCache.has(listUrlA)).toBe(true);
     expect(chatUserCache.get(listUrlA)?.users).toEqual([
       { user_id: 1, username: "alice", nickname: "a" },
     ]);
-
-    // Verify B's fresh entry is present
     expect(chatUserCache.has(listUrlB)).toBe(true);
   });
 });

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -442,4 +442,39 @@ describe("fetchChatUsers", () => {
     const firstCall = firstHttpsGetCall();
     expect(firstCall[1]?.rejectUnauthorized).toBe(true);
   });
+  it("evicts stale cache entries when inserting a fresh one", async () => {
+    // The module-level chatUserCache only evicts stale entries on
+    // successful insert. Verify that stale entries are removed from
+    // the Map so a caller rotating through many webhook URLs cannot
+    // grow the cache without bound.
+    const clientModule = await import("./client.js");
+    const { chatUserCache, CACHE_TTL_MS } = clientModule.testing;
+    const listUrlA =
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22regression-a%22";
+    const listUrlB =
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=user_list&version=2&token=%22regression-b%22";
+
+    // Populate cache with a fresh entry for urlA
+    chatUserCache.set(listUrlA, {
+      users: [{ user_id: 1, username: "alice", nickname: "a" }],
+      cachedAt: fakeNowMs,
+    });
+
+    // Advance past TTL so urlA entry is stale
+    fakeNowMs += CACHE_TTL_MS + 1;
+    vi.setSystemTime(fakeNowMs);
+
+    // Insert urlB via fetchChatUsers — the eviction pass must
+    // delete stale urlA from the Map
+    mockUserListResponse([{ user_id: 2, username: "bob", nickname: "b" }]);
+    await fetchChatUsers(
+      "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22regression-b%22",
+    );
+
+    // Verify stale urlA was evicted
+    expect(chatUserCache.has(listUrlA)).toBe(false);
+
+    // Verify fresh urlB is still present
+    expect(chatUserCache.has(listUrlB)).toBe(true);
+  });
 });

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -196,6 +196,13 @@ export async function fetchChatUsers(
 
           if (result.success) {
             const users = result.data?.users ?? [];
+            // Evict stale entries so a hostile caller that rotates through
+            // many webhook URLs cannot grow the Map without bound.
+            for (const [key, entry] of chatUserCache) {
+              if (now - entry.cachedAt >= CACHE_TTL_MS) {
+                chatUserCache.delete(key);
+              }
+            }
             chatUserCache.set(listUrl, {
               users,
               cachedAt: now,

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -350,3 +350,9 @@ function doPost(url: string, body: string, allowInsecureSsl = false): Promise<bo
     req.end();
   });
 }
+
+export const testing = {
+  chatUserCache,
+  CACHE_TTL_MS,
+};
+export { testing as __testing };

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -196,25 +196,20 @@ export async function fetchChatUsers(
 
           if (result.success) {
             const users = result.data?.users ?? [];
-            // Evict stale entries for this origin so a hostile caller that
-            // rotates through many webhook URLs cannot grow the Map without
-            // bound. Preserve other origins' entries — a different endpoint's
-            // refresh must not delete another endpoint's last-known-good
-            // fallback (the stale-on-error contract in the failure branches).
-            const currentOrigin = parsedUrl.origin;
-            for (const [key, entry] of chatUserCache) {
-              let sameOrigin = false;
-              try {
-                sameOrigin = new URL(key).origin === currentOrigin;
-              } catch {
-                // Malformed cache key — skip, do not evict.
+            // Bound cache growth without deleting other endpoints' fallback
+            // data. Each key is its own listUrl, so a stale entry is replaced
+            // naturally when the same endpoint refreshes. A cap on total
+            // entries reclaims space only when the cache actually grows large,
+            // and the oldest (least-recently refreshed) entry is removed first.
+            // This preserves every active endpoint's stale-on-error fallback
+            // even when another endpoint on the same NAS refreshes.
+            const MAX_CHAT_USER_CACHE_ENTRIES = 100;
+            while (chatUserCache.size >= MAX_CHAT_USER_CACHE_ENTRIES) {
+              const oldestKey = chatUserCache.keys().next().value;
+              if (oldestKey === undefined) {
+                break;
               }
-              if (!sameOrigin) {
-                continue;
-              }
-              if (now - entry.cachedAt >= CACHE_TTL_MS) {
-                chatUserCache.delete(key);
-              }
+              chatUserCache.delete(oldestKey);
             }
             chatUserCache.set(listUrl, {
               users,

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -196,9 +196,22 @@ export async function fetchChatUsers(
 
           if (result.success) {
             const users = result.data?.users ?? [];
-            // Evict stale entries so a hostile caller that rotates through
-            // many webhook URLs cannot grow the Map without bound.
+            // Evict stale entries for this origin so a hostile caller that
+            // rotates through many webhook URLs cannot grow the Map without
+            // bound. Preserve other origins' entries — a different endpoint's
+            // refresh must not delete another endpoint's last-known-good
+            // fallback (the stale-on-error contract in the failure branches).
+            const currentOrigin = parsedUrl.origin;
             for (const [key, entry] of chatUserCache) {
+              let sameOrigin = false;
+              try {
+                sameOrigin = new URL(key).origin === currentOrigin;
+              } catch {
+                // Malformed cache key — skip, do not evict.
+              }
+              if (!sameOrigin) {
+                continue;
+              }
               if (now - entry.cachedAt >= CACHE_TTL_MS) {
                 chatUserCache.delete(key);
               }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `chatUserCache` Map in Synology Chat could leak memory when callers rotated through many webhook URLs. Previously the cache had no eviction at all; stale entries from old URLs accumulated for the lifetime of the process. Earlier attempts to evict stale entries used too broad a scope (origin-wide deletion), which could remove an active endpoint's last-known-good fallback when another endpoint on the same NAS refreshed successfully.

## Why This Change Was Made

This change uses a bounded per-key cache policy:

- Each `listUrl` is its own cache key, so refreshing one endpoint naturally overwrites only that endpoint's entry.
- A 100-entry cap reclaims space only when the cache actually grows large, evicting the least-recently refreshed entry first.
- No endpoint can delete another endpoint's fallback data, even on the same NAS origin.

The change reuses the existing `CACHE_TTL_MS` constant and `cachedAt` timestamp for read-path freshness; no config, schema, storage, or public API surface changes. The stale-on-error contract in the failure branches (parse failure, API error, HTTP error, timeout → return `cached?.users ?? []`) is preserved for every endpoint.

## User Impact

Synology Chat channels that reference many webhook URLs no longer leak memory from unbounded cache growth. Channels with multiple active webhooks on the same NAS retain each endpoint's fallback mapping even when other endpoints refresh successfully.

## Evidence

### Unit tests

```
✓ fetchChatUsers > bounds cache growth by removing the oldest entry when the cap is reached
✓ fetchChatUsers > preserves other endpoints' fallback entries on same-origin refresh

Test Files  1 passed (1)
     Tests  24 passed (24)
```

### Runtime reproduction (local fake Synology Chat server)

The script below imports `fetchChatUsers` directly and drives it against a local HTTP server that mimics the Synology Chat `user_list` API.

```
=== Synology Chat cache bounding runtime reproduction ===

Step 1: Refresh endpoint A (token=a) — success
  usersA1 = [{"user_id":1,"username":"user-\"a\"","nickname":"nick-\"a\""}]
  cache size = 1

Step 2: Refresh endpoint B (token=b) on same origin — success
  usersB = [{"user_id":2,"username":"user-\"b\"","nickname":"nick-\"b\""}]
  cache size = 2
  endpoint A still cached = true

Step 3: Simulate endpoint A user_list refresh failure
  usersA2 (fallback) = [{"user_id":1,"username":"user-\"a\"","nickname":"nick-\"a\""}]
  fallback preserved = true

Step 4: Rotate through 150 distinct tokens to trigger cache cap
  cache size after 150 rotations = 100 (cap = 100)
  oldest seeded entry evicted = true

=== Result ===
- Per-endpoint fallback is preserved across same-origin refreshes.
- Cache growth is bounded at 100 entries (oldest evicted first).
```

### Scoped checks

```
oxlint: pass
git diff --check: pass
```
