### PR TITLE
fix(twitch): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/twitch/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/twitch/src/outbound-tool-trace-sanitize.test.ts
@@ -1,7 +1,6 @@
-// Twitch outbound must strip assistant internal tool-trace scaffolding, matching
-// the sibling channel fixes tracked under #90684 (Matrix #97372 / Slack #97367 /
-// IRC #97214 / Google Chat #95084). The hook runs in core delivery before chunk
-// planning, so the 500-char Twitch chunker only ever sees sanitized text.
+// Twitch outbound must strip assistant internal tool-trace scaffolding before
+// delivery (#90684). The hook runs in core delivery before chunk planning, so
+// the 500-char Twitch chunker only ever sees sanitized text.
 import { describe, expect, it } from "vitest";
 import { twitchPlugin } from "./plugin.js";
 

--- a/extensions/twitch/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/twitch/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,28 @@
+// Twitch outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Matrix #97372 / Slack #97367 /
+// IRC #97214 / Google Chat #95084). The hook runs in core delivery before chunk
+// planning, so the 500-char Twitch chunker only ever sees sanitized text.
+import { describe, expect, it } from "vitest";
+import { twitchPlugin } from "./plugin.js";
+
+describe("twitch outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(twitchPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("strips XML tool-call scaffolding leaked into assistant text", () => {
+    const text = '<tool_call>{"name":"exec"}</tool_call>Stream is live.';
+
+    expect(twitchPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(
+      "Stream is live.",
+    );
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(twitchPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -12,6 +12,7 @@ import {
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveTwitchAccountContext } from "./config.js";
 import { sendMessageTwitchInternal } from "./send.js";
 import type {
@@ -42,6 +43,9 @@ export const twitchOutbound: ChannelOutboundAdapter = {
 
   /** Twitch chat message limit is 500 characters */
   textChunkLimit: 500,
+
+  /** Strip internal assistant tool-trace scaffolding before delivery */
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
 
   /** Word-boundary chunker with markdown stripping */
   chunker: chunkTextForTwitch,


### PR DESCRIPTION
Related: #90684

## What Problem This Solves

Fixes an issue where assistant internal tool-trace scaffolding — `<tool_call>`-style XML blocks and `⚠️ 🛠️ … failed` tool banners, among the scaffolding forms `sanitizeAssistantVisibleText()` strips — leaks verbatim into Twitch chat when a model emits it as plain text (common with models that render tool calls as text, e.g. after a failed exec whose error output echoes the prompt's tool XML). Twitch chat is public: every viewer of the channel sees the internal scaffolding, not just the addressed user.

`sanitizeAssistantVisibleText()` exists for exactly this, but the Twitch outbound adapter never declares the `sanitizeText` hook, so core delivery sends the raw text through.

## Why This Change Was Made

This is the Twitch sibling of the per-channel fixes tracked under #90684: the same adapter hook pattern is already merged for Google Chat, IRC, Signal, Slack, Matrix, SMS, Mattermost, and Feishu (all linked from that issue). ClickClack, the only other bundled channel still missing the hook without an open PR, will follow separately, keeping the family's one-channel-per-PR shape.

The fix adds the family-standard hook to `twitchOutbound`:

```ts
sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
```

Core delivery wires this adapter hook once and applies it before chunk planning, so the 500-char word-boundary Twitch chunker only ever sees sanitized text. The markdown-stripping chunker itself, delivery mode, and all send paths are unchanged.

## User Impact

Twitch viewers no longer see internal tool-call XML or tool-failure banners in public chat when a model leaks scaffolding into its reply text. Ordinary assistant prose is delivered unchanged. No config, schema, or API changes.

## Evidence

Boundary capture drives the composed production plugin object (`twitchPlugin.outbound.sanitizeText`, exactly what core delivery reads) under `node --import tsx`; no sanitizer or plugin code is faked. A live Twitch chat send is not exercised (infeasible here).

```
                        input                                            before (no hook)                        after (hook)
tool banner             "Done.\n⚠️ 🛠️ `search repos (agent)` failed"     passes through verbatim                 "Done."
XML tool_call leak      "<tool_call>{...}</tool_call>Stream is live."    passes through verbatim                 "Stream is live."
ordinary prose          "The pipeline has 3 open deals."                 "The pipeline has 3 open deals."        unchanged
```

Focused regression tests (`extensions/twitch/src/outbound-tool-trace-sanitize.test.ts`, 3 cases): tool banner stripped, XML `<tool_call>` block stripped, ordinary prose preserved. All 3 fail without the production change (the adapter exposes no hook).

Local: targeted suite 3/3; full twitch extension suite 16 files / 188 tests green; `oxfmt` and `oxlint` clean; `tsgo:extensions` clean. `check:changed` lanes run on CI.
