### PR TITLE
fix(ai): match reasoning efforts case-insensitively without lowering provider values

### DIFF
--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -132,6 +132,18 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("HIGH");
   });
 
+  it("preserves unmapped canonical-looking provider-native compat values", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["LOW", "MEDIUM", "HIGH"],
+      },
+    };
+
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("HIGH");
+  });
+
   it("omits unsupported disabled reasoning instead of falling back to enabled effort", () => {
     const model = { provider: "groq", id: "openai/gpt-oss-120b" };
 

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -110,6 +110,27 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("ProviderDefault");
   });
 
+  it("matches canonical fallback map keys case-insensitively", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["ProviderLow", "ProviderHigh"],
+        reasoningEffortMap: {
+          HIGH: "ProviderHigh",
+        },
+      },
+    };
+
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "HIGH",
+        fallbackMap: model.compat.reasoningEffortMap,
+      }),
+    ).toBe("ProviderHigh");
+  });
+
   it("preserves canonical-looking provider-native compat values mapped from canonical efforts", () => {
     const model = {
       provider: "example",

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveOpenAIReasoningEffortForModel,
   resolveOpenAISupportedReasoningEfforts,
+  supportsOpenAIReasoningEffort,
 } from "./openai-reasoning-effort.js";
 
 describe("OpenAI reasoning effort support", () => {
@@ -153,16 +154,36 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("HIGH");
   });
 
-  it("preserves unmapped canonical-looking provider-native compat values", () => {
+  it("requires an explicit map for canonical-looking provider casing", () => {
     const model = {
       provider: "example",
       id: "custom-reasoning",
       compat: {
-        supportedReasoningEfforts: ["LOW", "MEDIUM", "HIGH"],
+        supportedReasoningEfforts: ["NONE", "HIGH"],
       },
     };
 
-    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("HIGH");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "none",
+        fallbackMap: { none: "NONE" },
+      }),
+    ).toBe("NONE");
+  });
+
+  it("does not fold provider-native compat values", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["ProviderDefault"],
+      },
+    };
+
+    expect(supportsOpenAIReasoningEffort(model, "ProviderDefault")).toBe(true);
+    expect(supportsOpenAIReasoningEffort(model, "providerdefault")).toBe(false);
   });
 
   it("omits unsupported disabled reasoning instead of falling back to enabled effort", () => {

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -110,6 +110,28 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("ProviderDefault");
   });
 
+  it("preserves canonical-looking provider-native compat values mapped from canonical efforts", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["LOW", "MEDIUM", "HIGH"],
+        reasoningEffortMap: {
+          high: "HIGH",
+        },
+      },
+    };
+
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toEqual(["LOW", "MEDIUM", "HIGH"]);
+    expect(
+      resolveOpenAIReasoningEffortForModel({
+        model,
+        effort: "HIGH",
+        fallbackMap: model.compat.reasoningEffortMap,
+      }),
+    ).toBe("HIGH");
+  });
+
   it("omits unsupported disabled reasoning instead of falling back to enabled effort", () => {
     const model = { provider: "groq", id: "openai/gpt-oss-120b" };
 

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -36,6 +36,14 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "medium" })).toBe("medium");
   });
 
+  it("matches canonical reasoning efforts case-insensitively", () => {
+    const model = { provider: "openai", id: "gpt-5.6-sol" };
+
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("high");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: " XHIGH " })).toBe("xhigh");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "MAX" })).toBe("max");
+  });
+
   it("does not downgrade xhigh when model compat metadata declares it explicitly", () => {
     const model = {
       provider: "openai",
@@ -81,13 +89,32 @@ describe("OpenAI reasoning effort support", () => {
     ).toBe("none");
   });
 
-  it("omits unsupported disabled reasoning instead of falling back to enabled effort", () => {
+  it("preserves provider-native compat values mapped from canonical efforts", () => {
+    const model = {
+      provider: "example",
+      id: "custom-reasoning",
+      compat: {
+        supportedReasoningEfforts: ["ProviderDefault"],
+        reasoningEffortMap: {
+          high: "ProviderDefault",
+        },
+      },
+    };
+
     expect(
       resolveOpenAIReasoningEffortForModel({
-        model: { provider: "groq", id: "openai/gpt-oss-120b" },
-        effort: "off",
+        model,
+        effort: "HIGH",
+        fallbackMap: model.compat.reasoningEffortMap,
       }),
-    ).toBeUndefined();
+    ).toBe("ProviderDefault");
+  });
+
+  it("omits unsupported disabled reasoning instead of falling back to enabled effort", () => {
+    const model = { provider: "groq", id: "openai/gpt-oss-120b" };
+
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "off" })).toBeUndefined();
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "OFF" })).toBeUndefined();
   });
 
   it("honors compat metadata that disables reasoning effort payloads", () => {

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -153,8 +153,9 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   fallbackMap?: Record<string, string>;
 }): OpenAIApiReasoningEffort | undefined {
   const requested = normalizeOpenAIReasoningEffort(params.effort);
-  const mapped = params.fallbackMap?.[requested] ?? requested;
-  const normalized = normalizeOpenAIReasoningEffort(mapped);
+  const mapped = params.fallbackMap?.[requested];
+  // Fallback maps emit provider-native payload labels; keep their case for exact compat lists.
+  const normalized = mapped === undefined ? requested : mapped.trim();
   const supported = resolveOpenAISupportedReasoningEfforts(params.model);
   if (supported.includes(normalized as OpenAIApiReasoningEffort)) {
     return normalized as OpenAIApiReasoningEffort;

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -160,6 +160,16 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   if (supported.includes(normalized as OpenAIApiReasoningEffort)) {
     return normalized as OpenAIApiReasoningEffort;
   }
+  if (mapped === undefined) {
+    // Unmapped canonical requests may match compat values case-insensitively, but
+    // return the configured value so provider payload casing remains intact.
+    const canonicalMatch = supported.find(
+      (effort) => normalizeOpenAIReasoningEffort(effort) === requested,
+    );
+    if (canonicalMatch !== undefined) {
+      return canonicalMatch;
+    }
+  }
   if (isDisabledReasoningEffort(requested) || isDisabledReasoningEffort(normalized)) {
     return undefined;
   }

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -153,7 +153,14 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   fallbackMap?: Record<string, string>;
 }): OpenAIApiReasoningEffort | undefined {
   const requested = normalizeOpenAIReasoningEffort(params.effort);
-  const mapped = params.fallbackMap?.[requested];
+  // Config preserves map-key casing, so compare canonical keys after exact lookup.
+  const mapped =
+    params.fallbackMap?.[requested] ??
+    (params.fallbackMap
+      ? Object.entries(params.fallbackMap).find(
+          ([effort]) => normalizeOpenAIReasoningEffort(effort) === requested,
+        )?.[1]
+      : undefined);
   // Fallback maps emit provider-native payload labels; keep their case for exact compat lists.
   const normalized = mapped === undefined ? requested : mapped.trim();
   const supported = resolveOpenAISupportedReasoningEfforts(params.model);

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -39,6 +39,16 @@ const GPT_5_PRO_REASONING_EFFORTS = ["high"] as const;
 const GPT_51_CODEX_MAX_REASONING_EFFORTS = ["none", "medium", "high", "xhigh"] as const;
 const GPT_51_CODEX_MINI_REASONING_EFFORTS = ["medium"] as const;
 const GENERIC_REASONING_EFFORTS = ["low", "medium", "high"] as const;
+const CANONICAL_REASONING_EFFORTS = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "off",
+]);
 
 function normalizeModelId(id: string | null | undefined): string {
   return normalizeLowercaseStringOrEmpty(id ?? "").replace(/-\d{4}-\d{2}-\d{2}$/u, "");
@@ -59,7 +69,10 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
-  return effort === "minimal" ? "minimal" : effort;
+  const trimmed = effort.trim();
+  const folded = trimmed.toLowerCase();
+  // Only fold OpenAI-owned names; provider-native compat values can be case-sensitive.
+  return CANONICAL_REASONING_EFFORTS.has(folded) ? folded : trimmed;
 }
 
 function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[] | undefined {

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -71,7 +71,7 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 export function normalizeOpenAIReasoningEffort(effort: string): string {
   const trimmed = effort.trim();
   const folded = trimmed.toLowerCase();
-  // Only fold OpenAI-owned names; provider-native compat values can be case-sensitive.
+  // Only fold canonical names; provider-native values can be case-sensitive.
   return CANONICAL_REASONING_EFFORTS.has(folded) ? folded : trimmed;
 }
 
@@ -153,10 +153,10 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   fallbackMap?: Record<string, string>;
 }): OpenAIApiReasoningEffort | undefined {
   const requested = normalizeOpenAIReasoningEffort(params.effort);
-  // Config preserves map-key casing, so compare canonical keys after exact lookup.
+  // Config preserves map-key casing, so only canonical keys get a folded lookup.
   const mapped =
     params.fallbackMap?.[requested] ??
-    (params.fallbackMap
+    (params.fallbackMap && CANONICAL_REASONING_EFFORTS.has(requested)
       ? Object.entries(params.fallbackMap).find(
           ([effort]) => normalizeOpenAIReasoningEffort(effort) === requested,
         )?.[1]
@@ -166,16 +166,6 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   const supported = resolveOpenAISupportedReasoningEfforts(params.model);
   if (supported.includes(normalized as OpenAIApiReasoningEffort)) {
     return normalized as OpenAIApiReasoningEffort;
-  }
-  if (mapped === undefined) {
-    // Unmapped canonical requests may match compat values case-insensitively, but
-    // return the configured value so provider payload casing remains intact.
-    const canonicalMatch = supported.find(
-      (effort) => normalizeOpenAIReasoningEffort(effort) === requested,
-    );
-    if (canonicalMatch !== undefined) {
-      return canonicalMatch;
-    }
   }
   if (isDisabledReasoningEffort(requested) || isDisabledReasoningEffort(normalized)) {
     return undefined;
@@ -192,5 +182,7 @@ export function resolveOpenAIReasoningEffortForModel(params: {
   if (requested === "max" && supported.includes("xhigh")) {
     return "xhigh";
   }
-  return supported.find((effort) => effort !== "none");
+  return supported.find(
+    (effort) => !isDisabledReasoningEffort(normalizeOpenAIReasoningEffort(effort)),
+  );
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5791,6 +5791,39 @@ describe("openai transport stream", () => {
     expect(params.reasoning).toEqual({ effort: "high", summary: "auto" });
   });
 
+  it("normalizes canonical reasoning casing in Responses and Chat Completions payloads", () => {
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+    const baseModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"] as Model["input"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    };
+
+    const responses = buildOpenAIResponsesParams(
+      { ...baseModel, api: "openai-responses" } satisfies Model<"openai-responses">,
+      context,
+      { reasoningEffort: " XHIGH " } as never,
+    ) as { reasoning?: unknown };
+    const completions = buildOpenAICompletionsParams(
+      { ...baseModel, api: "openai-completions" } satisfies Model<"openai-completions">,
+      context,
+      { reasoningEffort: " XHIGH " } as never,
+    ) as { reasoning_effort?: unknown };
+
+    expect(responses.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    expect(completions.reasoning_effort).toBe("xhigh");
+  });
+
   it("uses disabled OpenAI Responses reasoning when the model supports none", () => {
     const params = buildOpenAIResponsesParams(
       {


### PR DESCRIPTION
Related: #102908
Alternative to #102958
Supersedes #103169

## What Problem This Solves

Canonical OpenAI-compatible reasoning effort values such as `HIGH` or ` XHIGH ` could miss lowercase supported-effort lists and silently fall through to a different effort.

## Why This Change Was Made

The resolver now trims and folds only canonical reasoning effort names before lookup. Provider-native values remain case-sensitive and are emitted exactly as configured. Canonical-looking provider-native casing must be declared through `reasoningEffortMap`, which keeps provider output explicit and prevents values such as `NONE` from being mistaken for core control semantics.

The same normalization path is exercised by both OpenAI Responses and Chat Completions payload builders.

## User Impact

Users get the intended reasoning effort even when canonical values use mixed casing or surrounding whitespace. Custom OpenAI-compatible providers keep their exact mapped payload labels.

## Evidence

- Blacksmith Testbox `tbx_01kx4w5fxp81tfkw75hk0mjbk5`: 471 focused and sibling tests passed across the resolver, both transports, shared Responses logic, stream wrappers, plugin SDK, Groq, and LM Studio.
- Blacksmith Testbox: `pnpm check:changed` passed for the core and core-test lanes.
- Blacksmith Testbox: `pnpm build` passed.
- Real loopback HTTP/SSE proof exercised both transport stream implementations. Both requests returned HTTP 200 and captured canonical `xhigh` payloads:

```json
{"responses":"xhigh","chatCompletions":"xhigh","paths":["/v1/chat/completions","/v1/responses"]}
```

- Fresh Codex autoreview after the final fix reported no actionable findings.

Closes #102908
