### PR TITLE
perf(sessions): reuse parsed transcripts for successor rotation

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -293,6 +293,7 @@ export const rotateTranscriptAfterCompactionMock: Mock<
 > = vi.fn(async () => ({
   rotated: false,
 }));
+export const rotateTranscriptFileAfterCompactionMock = vi.fn((_params?: unknown) => undefined);
 export const enqueueCommandInLaneMock = vi.fn((_lane: unknown, task: () => unknown) => task());
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
@@ -494,6 +495,7 @@ export function resetCompactSessionStateMocks(): void {
   resolveContextWindowInfoMock.mockReturnValue({ tokens: 128_000 });
   rotateTranscriptAfterCompactionMock.mockReset();
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
+  rotateTranscriptFileAfterCompactionMock.mockReset();
   enqueueCommandInLaneMock.mockReset();
   enqueueCommandInLaneMock.mockImplementation((_lane: unknown, task: () => unknown) => task());
   listRegisteredPluginAgentPromptGuidanceMock.mockReset();
@@ -590,6 +592,7 @@ export async function loadCompactHooksHarness(): Promise<{
   testing: typeof import("./compact.js").testing;
   onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
   onInternalSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onInternalSessionTranscriptUpdate;
+  SessionManager: typeof import("../sessions/session-manager.js").SessionManager;
 }> {
   resetCompactHooksHarnessMocks();
   vi.resetModules();
@@ -741,6 +744,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-file-repair.js", () => ({
+    invalidateSessionFileRepairCache: vi.fn(),
     repairSessionFileIfNeeded: vi.fn(async () => {}),
   }));
 
@@ -902,6 +906,12 @@ export async function loadCompactHooksHarness(): Promise<{
     return {
       ...actual,
       rotateTranscriptAfterCompaction: rotateTranscriptAfterCompactionMock,
+      rotateTranscriptFileAfterCompaction: async (
+        params: Parameters<typeof actual.rotateTranscriptFileAfterCompaction>[0],
+      ) => {
+        rotateTranscriptFileAfterCompactionMock(params);
+        return await actual.rotateTranscriptFileAfterCompaction(params);
+      },
     };
   });
 
@@ -1050,16 +1060,19 @@ export async function loadCompactHooksHarness(): Promise<{
     };
   });
 
-  const [compactModule, compactQueuedModule, transcriptEvents] = await Promise.all([
-    import("./compact.js"),
-    import("./compact.queued.js"),
-    import("../../sessions/transcript-events.js"),
-  ]);
+  const [compactModule, compactQueuedModule, transcriptEvents, sessionManagerModule] =
+    await Promise.all([
+      import("./compact.js"),
+      import("./compact.queued.js"),
+      import("../../sessions/transcript-events.js"),
+      import("../sessions/session-manager.js"),
+    ]);
 
   return {
     ...compactModule,
     compactEmbeddedAgentSession: compactQueuedModule.compactEmbeddedAgentSession,
     onSessionTranscriptUpdate: transcriptEvents.onSessionTranscriptUpdate,
     onInternalSessionTranscriptUpdate: transcriptEvents.onInternalSessionTranscriptUpdate,
+    SessionManager: sessionManagerModule.SessionManager,
   };
 }

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1,9 +1,12 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 // Hook integration coverage for direct and queued embedded compaction.
-
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
@@ -41,6 +44,7 @@ import {
   selectAgentHarnessForPreparedModelProvidersMock,
   selectAgentHarnessMock,
   shouldPreferExplicitConfigApiKeyAuthMock,
+  rotateTranscriptFileAfterCompactionMock,
   resetCompactHooksHarnessMocks,
   resetCompactSessionStateMocks,
   sessionAbortCompactionMock,
@@ -61,6 +65,7 @@ let compactEmbeddedAgentSession: typeof import("./compact.queued.js").compactEmb
 let compactTesting: typeof import("./compact.js").testing;
 let onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
 let onInternalSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onInternalSessionTranscriptUpdate;
+let HarnessSessionManager: typeof import("../sessions/session-manager.js").SessionManager;
 
 const TEST_SESSION_ID = "session-1";
 const TEST_SESSION_KEY = "agent:main:session-1";
@@ -307,6 +312,7 @@ beforeAll(async () => {
   compactTesting = loaded.testing;
   onSessionTranscriptUpdate = loaded.onSessionTranscriptUpdate;
   onInternalSessionTranscriptUpdate = loaded.onInternalSessionTranscriptUpdate;
+  HarnessSessionManager = loaded.SessionManager;
 });
 
 beforeEach(() => {
@@ -3845,6 +3851,74 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         active.activeSessionKey,
         active.activeSessionFile,
       );
+    }
+  });
+
+  it("keeps the session cache warm through queued successor rotation", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "compact-cache-caller-test-"));
+    const manager = HarnessSessionManager.create(dir, dir);
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept user",
+      timestamp: 1,
+    });
+    manager.appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "kept assistant" }],
+        timestamp: 2,
+      }),
+    );
+    manager.appendCompaction("Summary of old work.", firstKeptId, 5000);
+    const sessionFile = manager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("expected compact caller session file");
+    }
+    // The normal embedded-run lifecycle opens the manager before queued
+    // compaction. Rotation must consume that retained canonical snapshot.
+    HarnessSessionManager.open(sessionFile);
+
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    contextEngineCompactMock.mockImplementationOnce(async () => {
+      // Checkpoint capture reads before engine compaction. Measure only the
+      // post-engine interval that owns successor rotation.
+      readFileSpy.mockClear();
+      return {
+        ok: true,
+        compacted: true,
+        reason: undefined,
+        result: { summary: "engine-summary", tokensAfter: 50 },
+      };
+    });
+    try {
+      const result = await compactEmbeddedAgentSession(
+        wrappedCompactionArgs({
+          sessionId: manager.getSessionId(),
+          sessionKey: undefined,
+          sessionFile,
+          workspaceDir: dir,
+          config: {
+            agents: {
+              defaults: {
+                compaction: {
+                  truncateAfterCompaction: true,
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(rotateTranscriptFileAfterCompactionMock).toHaveBeenCalledWith({ sessionFile });
+      expect(
+        readFileSpy.mock.calls.some(
+          ([file]) => typeof file === "string" && path.resolve(file) === path.resolve(sessionFile),
+        ),
+      ).toBe(false);
+    } finally {
+      readFileSpy.mockRestore();
+      await fs.rm(dir, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CURRENT_SESSION_VERSION, SessionManager } from "../sessions/session-manager.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   rotateTranscriptAfterCompaction,
@@ -116,10 +116,186 @@ function createCompactedSession(sessionDir: string): {
   };
 }
 
+type DifferentialFixture =
+  | "malformed rows"
+  | "duplicate IDs"
+  | "invalid leaf controls"
+  | "opaque parent rows";
+
+function buildDifferentialFixture(kind: DifferentialFixture, cwd: string): string {
+  const timestamp = (second: number) => `2026-04-27T12:00:${String(second).padStart(2, "0")}.000Z`;
+  const rows: unknown[] = [
+    {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: "source-session",
+      timestamp: timestamp(0),
+      cwd,
+    },
+    {
+      type: "message",
+      id: "old-user",
+      parentId: null,
+      timestamp: timestamp(1),
+      message: { role: "user", content: "old user", timestamp: 1 },
+    },
+    {
+      type: "message",
+      id: "old-assistant",
+      parentId: "old-user",
+      timestamp: timestamp(2),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "old assistant" }],
+        timestamp: 2,
+      },
+    },
+    {
+      type: "message",
+      id: "kept-user",
+      parentId: "old-assistant",
+      timestamp: timestamp(3),
+      message: { role: "user", content: "kept user", timestamp: 3 },
+    },
+    {
+      type: "message",
+      id: "kept-assistant",
+      parentId: "kept-user",
+      timestamp: timestamp(4),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "kept assistant" }],
+        timestamp: 4,
+      },
+    },
+  ];
+
+  let compactionParentId = "kept-assistant";
+  if (kind === "malformed rows") {
+    rows.push("not valid json {{{");
+    rows.push({
+      type: "message",
+      id: "malformed-parent",
+      parentId: "kept-assistant",
+      timestamp: timestamp(5),
+      message: { role: "assistant", content: 42, timestamp: 5 },
+    });
+    compactionParentId = "malformed-parent";
+  } else if (kind === "duplicate IDs") {
+    rows.push({
+      type: "message",
+      id: "kept-assistant",
+      parentId: "kept-user",
+      timestamp: timestamp(5),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "duplicate should be ignored" }],
+        timestamp: 5,
+      },
+    });
+  } else if (kind === "invalid leaf controls") {
+    rows.push({
+      type: "leaf",
+      id: "invalid-leaf",
+      parentId: "kept-assistant",
+      timestamp: timestamp(5),
+      targetId: "missing-target",
+      appendParentId: "missing-parent",
+      appendMode: "side",
+    });
+    compactionParentId = "invalid-leaf";
+  } else {
+    rows.push({
+      type: "plugin-owned-state",
+      id: "opaque-parent",
+      parentId: "kept-assistant",
+      timestamp: timestamp(5),
+      payload: { cursor: 1 },
+    });
+    compactionParentId = "opaque-parent";
+  }
+
+  rows.push(
+    {
+      type: "compaction",
+      id: "compaction",
+      parentId: compactionParentId,
+      timestamp: timestamp(6),
+      summary: "Summary of old work.",
+      firstKeptEntryId: "kept-user",
+      tokensBefore: 5000,
+    },
+    {
+      type: "message",
+      id: "post-user",
+      parentId: "compaction",
+      timestamp: timestamp(7),
+      message: { role: "user", content: "post user", timestamp: 7 },
+    },
+    {
+      type: "message",
+      id: "post-assistant",
+      parentId: "post-user",
+      timestamp: timestamp(8),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "post assistant" }],
+        timestamp: 8,
+      },
+    },
+  );
+  return `${rows.map((row) => (typeof row === "string" ? row : JSON.stringify(row))).join("\n")}\n`;
+}
+
+async function rotateDifferentialFixture(params: {
+  dir: string;
+  kind: DifferentialFixture;
+  warm: boolean;
+}): Promise<unknown> {
+  const sessionFile = path.join(
+    params.dir,
+    `${params.kind.replaceAll(" ", "-")}-${params.warm ? "warm" : "cold"}.jsonl`,
+  );
+  await fs.writeFile(sessionFile, buildDifferentialFixture(params.kind, params.dir));
+  if (params.warm) {
+    SessionManager.open(sessionFile, params.dir, params.dir);
+  }
+
+  const result = await rotateTranscriptFileAfterCompaction({
+    sessionFile,
+    now: () => new Date("2026-04-27T13:00:00.000Z"),
+  });
+  const successorFile = requireString(result.sessionFile, "differential successor file");
+  const persisted = (await fs.readFile(successorFile, "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  const header = persisted[0];
+  const context = SessionManager.open(successorFile).buildSessionContext();
+  return {
+    result: {
+      rotated: result.rotated,
+      compactionEntryId: result.compactionEntryId,
+      leafId: result.leafId,
+      entriesWritten: result.entriesWritten,
+    },
+    header: {
+      type: header?.type,
+      version: header?.version,
+      timestamp: header?.timestamp,
+      cwd: header?.cwd,
+    },
+    entries: persisted.slice(1),
+    messages: context.messages,
+  };
+}
+
 describe("rotateTranscriptAfterCompaction", () => {
   it("can rotate a persisted transcript without opening a manager", async () => {
     const dir = await createTmpDir();
-    const { sessionFile } = createCompactedSession(dir);
+    const { sessionFile: cachedSessionFile } = createCompactedSession(dir);
+    const sessionFile = path.join(dir, "cold-session.jsonl");
+    await fs.copyFile(cachedSessionFile, sessionFile);
 
     // File-only rotation is used after the active manager has moved on; opening
     // a new manager here would hide bugs in the direct persistence path.
@@ -184,6 +360,94 @@ describe("rotateTranscriptAfterCompaction", () => {
         timestamp: 6,
       },
     ]);
+  });
+
+  it("reuses a complete cached transcript without reading the source file", async () => {
+    const dir = await createTmpDir();
+    const { sessionFile } = createCompactedSession(dir);
+    SessionManager.open(sessionFile);
+
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    try {
+      const result = await rotateTranscriptFileAfterCompaction({
+        sessionFile,
+        now: () => new Date("2026-04-27T12:00:00.000Z"),
+      });
+
+      expect(result.rotated).toBe(true);
+      expect(
+        readFileSpy.mock.calls.some(
+          ([file]) => typeof file === "string" && path.resolve(file) === path.resolve(sessionFile),
+        ),
+      ).toBe(false);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  it("falls back to the canonical reader when the cached transcript changed", async () => {
+    const dir = await createTmpDir();
+    const { sessionFile } = createCompactedSession(dir);
+    SessionManager.open(sessionFile);
+    await fs.appendFile(sessionFile, "\n");
+
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    try {
+      const result = await rotateTranscriptFileAfterCompaction({ sessionFile });
+
+      expect(result.rotated).toBe(true);
+      expect(
+        readFileSpy.mock.calls.some(
+          ([file]) => typeof file === "string" && path.resolve(file) === path.resolve(sessionFile),
+        ),
+      ).toBe(true);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  it("falls back after a same-size source file replacement", async () => {
+    const dir = await createTmpDir();
+    const { sessionFile } = createCompactedSession(dir);
+    SessionManager.open(sessionFile);
+    const original = await fs.readFile(sessionFile, "utf8");
+    const replacement = original.replace("post assistant", "evil assistant");
+    expect(replacement).not.toBe(original);
+    expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+    const replacementFile = path.join(dir, "replacement.jsonl");
+    await fs.writeFile(replacementFile, replacement, "utf8");
+    await fs.rename(replacementFile, sessionFile);
+
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    try {
+      const result = await rotateTranscriptFileAfterCompaction({ sessionFile });
+      const successorFile = requireString(result.sessionFile, "successor session file");
+
+      expect(result.rotated).toBe(true);
+      expect(
+        readFileSpy.mock.calls.some(
+          ([file]) => typeof file === "string" && path.resolve(file) === path.resolve(sessionFile),
+        ),
+      ).toBe(true);
+      expect(await fs.readFile(successorFile, "utf8")).toContain("evil assistant");
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    "malformed rows",
+    "duplicate IDs",
+    "invalid leaf controls",
+    "opaque parent rows",
+  ] as const)("matches canonical cold rotation for %s", async (kind) => {
+    const dir = await createTmpDir();
+    const cold = await rotateDifferentialFixture({ dir, kind, warm: false });
+    const warm = await rotateDifferentialFixture({ dir, kind, warm: true });
+
+    expect(warm).toEqual(cold);
+    expect(JSON.stringify(warm)).toContain("post assistant");
+    expect(JSON.stringify(warm)).not.toContain("duplicate should be ignored");
   });
 
   it("keeps the paired tool result without replaying summarized custom context", async () => {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -10,6 +10,7 @@ import type { CompactionEntry, SessionEntry, SessionHeader } from "../sessions/i
 import { collectDuplicateUserMessageEntryIdsForCompaction } from "./compaction-duplicate-user-messages.js";
 import { stripThinkingSignaturesFromMessage } from "./thinking.js";
 import {
+  readCachedTranscriptFileState,
   readTranscriptFileState,
   TranscriptFileState,
   writeTranscriptFileAtomic,
@@ -91,7 +92,9 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   sessionFile: string;
   now?: () => Date;
 }): Promise<CompactionTranscriptRotation> {
-  const state = await readTranscriptFileState(params.sessionFile);
+  const state =
+    readCachedTranscriptFileState(params.sessionFile) ??
+    (await readTranscriptFileState(params.sessionFile));
   return rotateTranscriptAfterCompaction({
     sessionManager: state,
     sessionFile: params.sessionFile,

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -18,6 +18,7 @@ import {
   type SessionEntry,
   type SessionHeader,
 } from "../sessions/index.js";
+import { tryReadCachedSessionEntries } from "../sessions/session-manager-cache-internal.js";
 
 // Mutable view over a session JSONL transcript. The runner uses this layer to
 // tolerate old or partially malformed rows before appending new canonical rows.
@@ -960,10 +961,8 @@ export class TranscriptFileState {
   }
 }
 
-/** Read a transcript file, migrate old rows, and drop only unrecoverable entries. */
-export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
-  const raw = await fs.readFile(sessionFile, "utf-8");
-  const fileEntries = (parseSessionEntries(raw) as unknown[]).map(fileEntryOrMigrationSlot);
+function createTranscriptFileState(parsedEntries: readonly unknown[]): TranscriptFileState {
+  const fileEntries = parsedEntries.map(fileEntryOrMigrationSlot);
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);
@@ -972,6 +971,20 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   return createReadableTranscriptFileState({ fileEntries, header, migrated });
+}
+
+/** Reuse parsed rows while applying the same validation and repair as a cold read. */
+export function readCachedTranscriptFileState(
+  sessionFile: string,
+): TranscriptFileState | undefined {
+  const cachedEntries = tryReadCachedSessionEntries(sessionFile);
+  return cachedEntries ? createTranscriptFileState(cachedEntries) : undefined;
+}
+
+/** Read a transcript file, migrate old rows, and drop only unrecoverable entries. */
+export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return createTranscriptFileState(parseSessionEntries(raw) as unknown[]);
 }
 
 /** Rewrite the full transcript through the private-file store. */

--- a/src/agents/sessions/session-manager-cache-internal.test.ts
+++ b/src/agents/sessions/session-manager-cache-internal.test.ts
@@ -1,0 +1,77 @@
+import { resolve } from "node:path";
+import { beforeEach, expect, it, vi } from "vitest";
+import type { FileEntry } from "./session-manager.js";
+
+const { statSyncMock } = vi.hoisted(() => ({
+  statSyncMock: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  statSync: statSyncMock,
+}));
+
+import {
+  sessionEntriesCache,
+  tryReadCachedSessionEntries,
+} from "./session-manager-cache-internal.js";
+
+beforeEach(() => {
+  sessionEntriesCache.clear();
+  statSyncMock.mockReset();
+});
+
+it("returns cache misses without synchronously stating the file", () => {
+  expect(tryReadCachedSessionEntries("/tmp/not-cached.jsonl")).toBeUndefined();
+  expect(statSyncMock).not.toHaveBeenCalled();
+});
+
+const snapshot = {
+  dev: 1n,
+  ino: 2n,
+  size: 100n,
+  mtimeNs: 3n,
+  ctimeNs: 4n,
+};
+
+function seedCache(filePath: string): FileEntry[] {
+  const entries: FileEntry[] = [
+    {
+      type: "session",
+      version: 3,
+      id: "session-1",
+      timestamp: "2026-07-10T00:00:00.000Z",
+      cwd: "/tmp",
+    },
+  ];
+  sessionEntriesCache.set(resolve(filePath), {
+    snapshot,
+    entries,
+    endsWithNewline: true,
+  });
+  return entries;
+}
+
+it("returns a detached entry-list snapshot", () => {
+  const filePath = "/tmp/cached.jsonl";
+  const cachedEntries = seedCache(filePath);
+  statSyncMock.mockReturnValue(snapshot);
+
+  const firstRead = tryReadCachedSessionEntries(filePath);
+  expect(firstRead).toEqual(cachedEntries);
+  expect(firstRead).not.toBe(cachedEntries);
+
+  (firstRead as FileEntry[]).length = 0;
+  expect(tryReadCachedSessionEntries(filePath)).toEqual(cachedEntries);
+});
+
+it("invalidates a same-size cache hit changed between snapshot checks", () => {
+  const filePath = "/tmp/concurrently-replaced.jsonl";
+  seedCache(filePath);
+  statSyncMock
+    .mockReturnValueOnce(snapshot)
+    .mockReturnValueOnce({ ...snapshot, mtimeNs: 5n, ctimeNs: 6n });
+
+  expect(tryReadCachedSessionEntries(filePath)).toBeUndefined();
+  expect(sessionEntriesCache.has(resolve(filePath))).toBe(false);
+});

--- a/src/agents/sessions/session-manager-cache-internal.ts
+++ b/src/agents/sessions/session-manager-cache-internal.ts
@@ -1,7 +1,6 @@
 /** Internal metadata-keyed cache shared by session loading and transcript rotation. */
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
-import type { FileEntry } from "./session-manager.js";
 
 export interface SessionFileSnapshot {
   dev: bigint;
@@ -13,7 +12,7 @@ export interface SessionFileSnapshot {
 
 export interface CachedSessionEntries {
   snapshot: SessionFileSnapshot;
-  entries: FileEntry[];
+  entries: unknown[];
   endsWithNewline: boolean;
 }
 
@@ -52,7 +51,7 @@ export function isSameSessionFileSnapshot(
 }
 
 /** Return parsed rows only when a complete cache entry still matches the file. */
-export function tryReadCachedSessionEntries(filePath: string): readonly FileEntry[] | undefined {
+export function tryReadCachedSessionEntries(filePath: string): readonly unknown[] | undefined {
   const resolvedPath = resolve(filePath);
   const cached = sessionEntriesCache.get(resolvedPath);
   // Misses are common for external context engines. Avoid filesystem polling

--- a/src/agents/sessions/session-manager-cache-internal.ts
+++ b/src/agents/sessions/session-manager-cache-internal.ts
@@ -1,0 +1,77 @@
+/** Internal metadata-keyed cache shared by session loading and transcript rotation. */
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+import type { FileEntry } from "./session-manager.js";
+
+export interface SessionFileSnapshot {
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+}
+
+export interface CachedSessionEntries {
+  snapshot: SessionFileSnapshot;
+  entries: FileEntry[];
+  endsWithNewline: boolean;
+}
+
+export const sessionEntriesCache = new Map<string, CachedSessionEntries>();
+
+export function readSessionFileSnapshot(filePath: string): SessionFileSnapshot {
+  const fileStat = statSync(filePath, { bigint: true });
+  return {
+    dev: fileStat.dev,
+    ino: fileStat.ino,
+    size: fileStat.size,
+    mtimeNs: fileStat.mtimeNs,
+    ctimeNs: fileStat.ctimeNs,
+  };
+}
+
+export function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot | undefined {
+  try {
+    return readSessionFileSnapshot(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+export function isSameSessionFileSnapshot(
+  left: SessionFileSnapshot,
+  right: SessionFileSnapshot,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs
+  );
+}
+
+/** Return parsed rows only when a complete cache entry still matches the file. */
+export function tryReadCachedSessionEntries(filePath: string): readonly FileEntry[] | undefined {
+  const resolvedPath = resolve(filePath);
+  const cached = sessionEntriesCache.get(resolvedPath);
+  // Misses are common for external context engines. Avoid filesystem polling
+  // unless this process already owns a complete parsed snapshot for the path.
+  if (!cached) {
+    return undefined;
+  }
+
+  const beforeSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
+  if (!beforeSnapshot || !isSameSessionFileSnapshot(cached.snapshot, beforeSnapshot)) {
+    sessionEntriesCache.delete(resolvedPath);
+    return undefined;
+  }
+  const afterSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
+  if (!afterSnapshot || !isSameSessionFileSnapshot(beforeSnapshot, afterSnapshot)) {
+    sessionEntriesCache.delete(resolvedPath);
+    return undefined;
+  }
+  // Cache producers deep-freeze each entry, but retain a mutable list so owned
+  // appends can advance it. Do not expose that list's ownership to consumers.
+  return cached.entries.slice();
+}

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -489,7 +489,12 @@ function loadEntriesFromFileWithSnapshot(filePath: string): {
     if (cached && isSameSessionFileSnapshot(cached.snapshot, beforeReadSnapshot)) {
       const afterCacheSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
       if (afterCacheSnapshot && isSameSessionFileSnapshot(beforeReadSnapshot, afterCacheSnapshot)) {
-        return { entries: copyFileEntries(cached.entries), snapshot: afterCacheSnapshot };
+        // SessionManager is the cache's sole producer. Keep the cache module a
+        // leaf by storing opaque rows, then recover the owned type at this boundary.
+        return {
+          entries: copyFileEntries(cached.entries as readonly FileEntry[]),
+          snapshot: afterCacheSnapshot,
+        };
       }
       continue;
     }

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -63,6 +63,14 @@ import {
 } from "../runtime/index.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
+import {
+  type CachedSessionEntries,
+  isSameSessionFileSnapshot,
+  readSessionFileSnapshot,
+  readSessionFileSnapshotIfExists,
+  type SessionFileSnapshot,
+  sessionEntriesCache,
+} from "./session-manager-cache-internal.js";
 
 export { CURRENT_SESSION_VERSION };
 
@@ -506,46 +514,10 @@ function loadEntriesFromFileWithSnapshot(filePath: string): {
   throw new Error(`session file changed repeatedly while loading: ${resolvedPath}`);
 }
 
-interface SessionFileSnapshot {
-  dev: bigint;
-  ino: bigint;
-  size: bigint;
-  mtimeNs: bigint;
-  ctimeNs: bigint;
-}
-
-interface CachedSessionEntries {
-  snapshot: SessionFileSnapshot;
-  entries: FileEntry[];
-  endsWithNewline: boolean;
-}
-
 const MAX_CACHED_SESSION_FILES = 8;
 // Bound approximate retained payload bytes as well as file count; parsed JSON
 // has higher overhead than the transcript bytes used for this conservative cap.
 const MAX_CACHED_SESSION_BYTES = 32n * 1024n * 1024n;
-const sessionEntriesCache = new Map<string, CachedSessionEntries>();
-
-function readSessionFileSnapshot(filePath: string): SessionFileSnapshot {
-  const fileStat = statSync(filePath, { bigint: true });
-  return {
-    dev: fileStat.dev,
-    ino: fileStat.ino,
-    size: fileStat.size,
-    mtimeNs: fileStat.mtimeNs,
-    ctimeNs: fileStat.ctimeNs,
-  };
-}
-
-function isSameSessionFileSnapshot(left: SessionFileSnapshot, right: SessionFileSnapshot): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
-  );
-}
 
 function rememberSessionEntries(
   filePath: string,
@@ -855,14 +827,6 @@ function messageSerializesOwnedValues(
     return hasOwnProperty(message, "details");
   }
   return false;
-}
-
-function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot | undefined {
-  try {
-    return readSessionFileSnapshot(filePath);
-  } catch {
-    return undefined;
-  }
 }
 
 function sessionFileNeedsAppendSeparator(


### PR DESCRIPTION
## What Problem This Solves

Post-compaction successor rotation rereads and reparses the complete transcript even when `SessionManager` already owns a complete parsed snapshot of the same file. Large long-lived sessions therefore pay the full transcript cost again on this hot path.

This change reuses those complete parsed entries when the source is unchanged.

This replaces the draft sampled-prefix reader. That approach still scanned historical rows, read more than the source transcript on the measured fixture, and was slower than the canonical reader. The new warm path reuses a complete process-local snapshot, then applies the same migration, validation, and repair logic as the cold path.

Related to #99190.

## Correctness

- Cache misses go directly to the canonical reader without adding a synchronous `stat`.
- Cache hits validate `dev`, `ino`, size, `mtime`, and `ctime` before and after access; any mismatch or read failure falls back to the canonical reader.
- Cached entries are deep-frozen by `SessionManager`, and the accessor returns a detached array so consumers cannot mutate cache membership.
- The helper remains internal to the session implementation and is not exported through the plugin SDK.
- Differential tests cover malformed rows, duplicate IDs, invalid leaf controls, opaque parent rows, same-size metadata changes, and same-byte-count file replacement.

## Evidence

The final head was tested against current main with a large synthetic transcript, differential correctness fixtures, focused repository tests, typechecks, lint, and boundary checks.

### Performance

Fixture: 11,023,351 bytes, 24,005 entries, and 12,000 history pairs. Results use 3 warmups and 15 alternating measured samples on current `main` (`57af2bbff0`).

| Path | Median |
| --- | ---: |
| Canonical cold read | 98.284 ms |
| Validated cache path | 60.685 ms |

Median successor-rotation latency falls by **38.25%** on current main.

Absolute timings are hardware-sensitive, so the claim is based on alternating samples on the same host and CPU configuration.

### Memory

RSS was measured in fresh Node processes so allocator and cache state could not carry between samples. Seven cold/warm pairs used the same 11.0 MB fixture.

| Path | Rotation median | Retained RSS after rotation | Peak operation RSS delta |
| --- | ---: | ---: | ---: |
| Canonical cold read | 115.274 ms | 0.97 MiB | 16.94 MiB |
| Validated cache path | 75.434 ms | 18.94 MiB | 13.16 MiB |

The cache retains about **17.97 MiB** more than the cold path after rotation for this fixture, while reducing the operation's incremental peak by about **3.78 MiB**. Retention is bounded by the existing cache limits of 8 files and 32 MiB of source transcript bytes; parsed objects can occupy more memory than their source bytes.

### Autoresearch Progress

[Public autoresearch trajectory](https://dashboard.weco.ai/share/JQpnh-YQ-WoekxgGAisEifv6Fv4TWHMJ)

- Step 0: measured the canonical full read, migration, validation, and repair path at 111.190 ms.
- Step 1: measured the final cache-backed path at 56.743 ms after ownership, source-change fallback, and differential correctness gates passed.

### Validation

- 196 focused and adjacent Vitest tests
- Core source and test typechecks
- Targeted type-aware lint
- Session transcript reader boundary guard
- Import-cycle architecture check (0 cycles)
- Touched-file format check
- `git diff --check`
