### PR TITLE
fix(ci): back off OCM release asset retries

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -227,7 +227,8 @@ jobs:
           mkdir -p "$HOME/.local/bin" "$(dirname "$KOVA_SRC")" "${RUNNER_TEMP}/ocm-install"
 
           ocm_archive="${RUNNER_TEMP}/ocm-${OCM_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 --retry-connrefused \
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
             -o "$ocm_archive" \
             "https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"
           echo "${OCM_LINUX_X64_SHA256}  ${ocm_archive}" | sha256sum -c -


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release performance validation could fail before exercising OpenClaw because the pinned OCM release asset returned a transient HTTP 504. The workflow retried only three times at fixed one-second intervals, so every attempt could hit the same unhealthy CDN/egress window.

This happened twice in [performance run 29032864140](https://github.com/openclaw/openclaw/actions/runs/29032864140): each attempt received four 504 responses and produced no Kova metrics or artifacts. A third attempt later downloaded the same asset successfully, and concurrent Blacksmith runners also split between success and 504 for the identical URL.

## Why This Change Was Made

The checksum-pinned, idempotent download now gets eight retries over a bounded 180-second retry window, uses curl's default backoff instead of a fixed one-second retry storm, and retries all transport errors including refused connections. The existing SHA-256 verification remains mandatory before extraction.

No mirrors, cache-busters, unpinned versions, or alternate binaries are introduced.

## User Impact

No product runtime change. Release performance checks are more resilient to short GitHub release-asset CDN or runner-egress outages without weakening supply-chain verification.

## Evidence

- Exact asset metadata still reports version `v0.2.15`, asset id `410473079`, size `2617319`, and digest `sha256:b849b8de5d77e97e0df9319703254ae95e29d7f26a7552ea79bf173ff110ea0a`, matching the workflow pin.
- An independent authenticated asset download produced the same SHA-256.
- `git diff --check` passed.
- `node scripts/check-workflows.mjs` passed zizmor and the repository workflow interpolation guard.
- Final `autoreview --mode local` reported no accepted/actionable findings (`patch is correct`, confidence 0.98).
