### PR TITLE
fix(telegram): deliver content instead of throwing when tag overhead fills chunk

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -635,12 +635,12 @@ describe("markdownToTelegramHtml", () => {
     expect(containsLoneSurrogate(output)).toBe(false);
   });
 
-  it("delivers content instead of throwing when tag overhead fills the chunk", () => {
+  it("delivers content as plain text when tag overhead fills the chunk", () => {
     const chunks = splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10);
     expect(chunks).toHaveLength(1);
-    // Content is delivered even though the chunk exceeds the limit;
-    // throwing would cause complete message loss.
-    expect(chunks[0]).toContain("x");
+    // Rich formatting stripped; content delivered as bounded plain text.
+    // The existing send.ts plain-text fallback path is preserved.
+    expect(chunks[0]).toBe("x");
   });
 
   it("does not split an astral char across the chunk boundary", () => {

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -638,9 +638,16 @@ describe("markdownToTelegramHtml", () => {
   it("delivers content as plain text when tag overhead fills the chunk", () => {
     const chunks = splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10);
     expect(chunks).toHaveLength(1);
-    // Rich formatting stripped; content delivered as bounded plain text.
-    // The existing send.ts plain-text fallback path is preserved.
     expect(chunks[0]).toBe("x");
+  });
+
+  it("keeps later formatting balanced after dropping an oversized tag scope", () => {
+    const oversizedLink = `<a href="https://example.com/${"x".repeat(40)}">first</a>`;
+    const chunks = splitTelegramHtmlChunks(`${oversizedLink}<b>second</b>`, 20);
+
+    expect(chunks).toEqual(["first<b>second</b>"]);
+    expect(chunks.every((chunk) => chunk.length <= 20)).toBe(true);
+    expect(telegramHtmlToPlainTextFallback(chunks.join(""))).toBe("firstsecond");
   });
 
   it("does not split an astral char across the chunk boundary", () => {

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -635,8 +635,12 @@ describe("markdownToTelegramHtml", () => {
     expect(containsLoneSurrogate(output)).toBe(false);
   });
 
-  it("fails loudly when tag overhead leaves no room for text", () => {
-    expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
+  it("delivers content instead of throwing when tag overhead fills the chunk", () => {
+    const chunks = splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10);
+    expect(chunks).toHaveLength(1);
+    // Content is delivered even though the chunk exceeds the limit;
+    // throwing would cause complete message loss.
+    expect(chunks[0]).toContain("x");
   });
 
   it("does not split an astral char across the chunk boundary", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1496,13 +1496,11 @@ export function splitTelegramHtmlChunks(
 
   const chunks: string[] = [];
   const openTags: TelegramHtmlTag[] = [];
+  const suppressedTagNames: string[] = [];
   let current = "";
   let currentBlockCount = 0;
   let currentMediaCount = 0;
   let chunkHasPayload = false;
-  // Set when tag overhead fills an empty chunk and rich formatting is stripped.
-  // Close tags are skipped so the segment is delivered as bounded plain text.
-  let strippedTagsForPlainTextFallback = false;
 
   const resetCurrent = () => {
     current = buildTelegramHtmlOpenPrefix(openTags);
@@ -1526,11 +1524,11 @@ export function splitTelegramHtmlChunks(
         normalizedLimit - current.length - buildTelegramHtmlCloseSuffixLength(openTags);
       if (available <= 0) {
         if (!chunkHasPayload) {
-          // Tag overhead fills the entire chunk; strip rich formatting and
-          // retry as plain text so message content is still delivered within
-          // the chunk limit.
+          // Preserve the matching closes separately when tag overhead alone
+          // fills a chunk. Dropping only this active scope keeps later tags
+          // balanced while the affected text degrades to plain HTML content.
+          suppressedTagNames.push(...openTags.map((tag) => tag.name));
           openTags.length = 0;
-          strippedTagsForPlainTextFallback = true;
           resetCurrent();
           continue;
         }
@@ -1597,9 +1595,10 @@ export function splitTelegramHtmlChunks(
       }
     }
 
-    // Skip orphan close tags after stripping formatting for plain-text fallback.
-    // openTags was cleared so the close tag has no matching open tag.
-    if (!strippedTagsForPlainTextFallback || !isClosing || openTags.length > 0) {
+    const closesOpenTag = isClosing && openTags.some((tag) => tag.name === tagName);
+    const closesSuppressedTag =
+      isClosing && !closesOpenTag && popLastTagName(suppressedTagNames, tagName);
+    if (!closesSuppressedTag) {
       current += rawTag;
     }
     if (isSelfClosing) {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1500,6 +1500,9 @@ export function splitTelegramHtmlChunks(
   let currentBlockCount = 0;
   let currentMediaCount = 0;
   let chunkHasPayload = false;
+  // Set when tag overhead fills an empty chunk and rich formatting is stripped.
+  // Close tags are skipped so the segment is delivered as bounded plain text.
+  let strippedTagsForPlainTextFallback = false;
 
   const resetCurrent = () => {
     current = buildTelegramHtmlOpenPrefix(openTags);
@@ -1523,12 +1526,13 @@ export function splitTelegramHtmlChunks(
         normalizedLimit - current.length - buildTelegramHtmlCloseSuffixLength(openTags);
       if (available <= 0) {
         if (!chunkHasPayload) {
-          // Tag overhead fills the entire chunk with no room for text.
-          // Still deliver content to avoid complete message loss — Telegram
-          // accepts oversized chunks in practice.
-          chunkHasPayload = true;
-          current += remaining;
-          break;
+          // Tag overhead fills the entire chunk; strip rich formatting and
+          // retry as plain text so message content is still delivered within
+          // the chunk limit.
+          openTags.length = 0;
+          strippedTagsForPlainTextFallback = true;
+          resetCurrent();
+          continue;
         }
         flushCurrent();
         continue;
@@ -1593,7 +1597,11 @@ export function splitTelegramHtmlChunks(
       }
     }
 
-    current += rawTag;
+    // Skip orphan close tags after stripping formatting for plain-text fallback.
+    // openTags was cleared so the close tag has no matching open tag.
+    if (!strippedTagsForPlainTextFallback || !isClosing || openTags.length > 0) {
+      current += rawTag;
+    }
     if (isSelfClosing) {
       chunkHasPayload = true;
     }

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1523,9 +1523,12 @@ export function splitTelegramHtmlChunks(
         normalizedLimit - current.length - buildTelegramHtmlCloseSuffixLength(openTags);
       if (available <= 0) {
         if (!chunkHasPayload) {
-          throw new Error(
-            `Telegram HTML chunk limit exceeded by tag overhead (limit=${normalizedLimit})`,
-          );
+          // Tag overhead fills the entire chunk with no room for text.
+          // Still deliver content to avoid complete message loss — Telegram
+          // accepts oversized chunks in practice.
+          chunkHasPayload = true;
+          current += remaining;
+          break;
         }
         flushCurrent();
         continue;

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -1,6 +1,7 @@
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
+import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 // Telegram tests cover telegram outbound plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { splitTelegramHtmlChunks } from "./format.js";
 import { telegramOutbound } from "./outbound-adapter.js";
 import { clearTelegramRuntime } from "./runtime.js";
@@ -54,6 +55,33 @@ describe("telegramPlugin outbound", () => {
       splitTelegramHtmlChunks(text, 4000),
     );
     expect(telegramOutbound.chunker?.(text, 4000)).toEqual([text]);
+  });
+
+  it("delivers bounded HTML through the shared payload path when tag overhead overflows", async () => {
+    clearTelegramRuntime();
+    const oversizedLink = `<a href="https://example.com/${"x".repeat(4_000)}">first</a>`;
+    const text = `${oversizedLink}<b>second</b>`;
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-1", chatId: "12345" });
+
+    await sendTextMediaPayload({
+      channel: "telegram",
+      ctx: {
+        cfg: {},
+        to: "12345",
+        text: "",
+        payload: { text },
+        formatting: { parseMode: "HTML" },
+        deps: { sendTelegram },
+      },
+      adapter: telegramOutbound,
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "12345",
+      "first<b>second</b>",
+      expect.objectContaining({ textMode: "html" }),
+    );
   });
 
   it("keeps astral characters whole at positive configured chunk limits", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #102910. Telegram HTML chunk planning threw when an active tag prefix plus its required closing tags consumed an empty chunk. The normal durable send helper catches that exception, but outbound delivery invokes the adapter chunker before the send helper, so the exception could abort the entire visible payload.

## Why This Change Was Made

The splitter now suppresses only the active formatting scope that cannot fit, retries the same text without that scope, and records those tag names so their later closing tags are consumed instead of emitted as orphan HTML. Formatting that begins after the overflowing scope continues through the normal balanced chunking path.

This is the shared owner-boundary fix: a caller-only catch in the outbound adapter would leave the durable send and rich-message sibling paths divergent. The existing send-side plain-text recovery remains unchanged.

## User Impact

Before: pathological nested or attribute-heavy HTML could throw during outbound planning and drop the whole Telegram message.

After: the affected scope degrades to readable text; all content is delivered in bounded chunks, and later valid formatting remains balanced.

## Evidence

Exact reviewed head: `7ce58a9404491fb8d8fda4149daf1288a1e7cc42`

### Regression coverage

- Formatter proof: tag-only overhead returns visible text instead of throwing.
- Mixed follow-up proof: an oversized link scope is dropped while later bold text remains balanced and within the limit.
- Shared outbound production-path proof: an attribute-heavy HTML payload reaches the Telegram send dependency as bounded, parseable HTML instead of aborting during chunk planning.

### Blacksmith Testbox

Lease `tbx_01kx4hxv0jxz2p4fa5awbsbnr3`:

- 5 focused files, 209 tests passed:
  - `extensions/telegram/src/format.test.ts`
  - `extensions/telegram/src/format.wrap-md.test.ts`
  - `extensions/telegram/src/telegram-outbound.test.ts`
  - `extensions/telegram/src/outbound-adapter.test.ts`
  - `src/plugin-sdk/reply-payload.test.ts`
- `pnpm check:changed` passed: extension production/test typechecks, lint, guards, and import-cycle checks.

### Additional checks

- `oxfmt` on all changed files — passed
- `git diff --check` — passed
- Fresh final-head autoreview — clean, no actionable findings (0.82)
- Exact-head canonical CI run [29056542491](https://github.com/openclaw/openclaw/actions/runs/29056542491) — passed
- Exact-head native Telegram Desktop run [29056563223](https://github.com/openclaw/openclaw/actions/runs/29056563223) — baseline and candidate scenarios passed with screenshots, GIFs, MP4s, and a raw evidence manifest. The workflow's red conclusion is only its post-proof reaction-cleanup job.

## Contract checked

Telegram's current Bot API documents a 1–4096 character message limit after entity parsing, supports nested entities, and requires raw `<`, `>`, and `&` to be represented as tags or entities. The regression assertions retain readable content, balanced HTML, and conservative wire-length bounds.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
