### PR TITLE
fix(ci): serialize real TUI PTY backends

### DIFF
--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -464,7 +464,9 @@ async function startGatewayModeTui(
   }
 }
 
-describe.concurrent("TUI PTY real backends", () => {
+// Each case spawns a real Gateway/PTY stack. Keep them serial so constrained
+// release runners do not turn host contention into test-level timeouts.
+describe("TUI PTY real backends", () => {
   it(
     "drives the real local backend with a mocked model endpoint",
     async ({ onTestFinished }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release CI could time out a real-Gateway TUI PTY scenario under host contention even though the same user path was healthy.

In [CI run 29033041664](https://github.com/openclaw/openclaw/actions/runs/29033041664/job/86170710566), the fresh-session scenario hit its 150-second test timeout while sibling real-backend tests took 18–67 seconds. The suite was launching several real Gateway/PTY stacks concurrently on the smaller manual-dispatch runner.

## Why This Change Was Made

The real-backend PTY suite is intentionally serial again. Per-test `onTestFinished` and idempotent cleanup remain unchanged; only resource-contending execution is removed.

This restores the proven stabilization from `0d86f64` after concurrency was re-enabled by `c20ce00`. It does not increase timeouts, add retries, weaken assertions, or change TUI/Gateway runtime behavior.

## User Impact

No product runtime change. Release CI keeps all eight real TUI backend scenarios while avoiding runner-load timeouts.

## Evidence

- Failed concurrent release run: fresh-session test timed out at 150 seconds; 26/27 shard tests passed.
- Same-code current-main rerun passed, confirming runner sensitivity rather than a deterministic runtime regression.
- Historical sequential CI passed all eight real-backend scenarios in 139.1 seconds; the fresh-session case took 14.6 seconds.
- Blacksmith Testbox `tbx_01kx3vqjpczaqa5qmv9cjdw92g`: full TUI PTY config passed 27/27 tests in 72.90 seconds. The serialized real-backend suite passed 8/8 in 63.48 seconds; fresh-session passed in 6.27 seconds.
- `git diff --check` passed.
- Final `autoreview --mode local` reported no accepted/actionable findings (`patch is correct`, confidence 0.99).
