### PR TITLE
fix(reply): log media drops at warn level instead of verbose

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -11,7 +11,9 @@ import {
 } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const replyMediaLog = createSubsystemLogger("reply-media");
 import { resolveChannelAccountMediaMaxMb } from "../../media/configured-max-bytes.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
@@ -223,7 +225,7 @@ export function createReplyMediaPathNormalizer(params: {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
         firstMediaDropError ??= err;
-        logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
+        replyMediaLog.warn(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;
       }
       if (!normalized || seen.has(normalized)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #103000: Reply media drops are logged only at verbose level, leaving zero trace in default logs. Users only see "⚠️ Media failed." with no reason anywhere.

## Why This Change Was Made

When a reply media attachment is rejected during normalization (policy block, disallowed root, missing file), the drop was logged via `logVerbose` which no-ops unless `--verbose` is set or file-log-level is `debug`. On a default install, the gateway log contains **zero trace** of the drop. Every occurrence is a user-visible data loss — the textbook case for warn-level logging.

The fix replaces `logVerbose` with `createSubsystemLogger("reply-media").warn()`, which always emits at the warn threshold. This follows the same subsystem logger pattern used throughout the auto-reply reply directory (session-init, silent-reply/dispatcher, mentions, etc.).

## User Impact

- Gateway logs now show the dropped media path and rejection reason at warn level (always visible, no verbose flag needed)
- No change to the user-facing `⚠️ Media failed.` suffix behavior
- No change to media normalization logic itself

## Evidence

- `src/auto-reply/reply/reply-media-paths.test.ts` — 22 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>