### PR TITLE
fix(state-migrations): skip default-profile approval migration for named --profile [AI-assisted]

### DIFF
--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -485,6 +485,32 @@ describe("state migrations", () => {
     expect(result.changes).toContain("Migrated fixture environment");
   });
 
+  it("does not migrate default-profile approval files into a named profile (#102846)", async () => {
+    const root = await createTempDir();
+    const customHome = path.join(root, "custom-home");
+    const defaultOpenclaw = path.join(customHome, ".openclaw");
+    fsSync.mkdirSync(defaultOpenclaw, { recursive: true });
+    fsSync.writeFileSync(path.join(defaultOpenclaw, "exec-approvals.json"), "{}", "utf-8");
+    fsSync.writeFileSync(
+      path.join(defaultOpenclaw, "plugin-binding-approvals.json"),
+      "{}",
+      "utf-8",
+    );
+    const stateDir = path.join(root, "profile-state");
+    const env = {
+      ...process.env,
+      HOME: customHome,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_PROFILE: "crestodian-e2e",
+    } as NodeJS.ProcessEnv;
+    const cfg = createConfig();
+    const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => customHome });
+    // Named profiles are isolated: the default profile's approval files must NOT
+    // be detected as legacy migration sources for the named profile's state dir.
+    expect(detected.execApprovals.hasLegacy).toBe(false);
+    expect(detected.pluginBindingApprovals.hasLegacy).toBe(false);
+  });
+
   it("detects legacy sessions, agent files, channel auth, and allowFrom copies", () => {
     expect(detectionCase.targetAgentId).toBe("worker-1");
     expect(detectionCase.targetMainKey).toBe("desk");

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -349,6 +349,7 @@ function detectLegacyExecApprovalsMigration(params: {
     targetPath,
     hasLegacy:
       Boolean(params.env.OPENCLAW_STATE_DIR?.trim()) &&
+      !params.env.OPENCLAW_PROFILE?.trim() &&
       path.resolve(sourcePath) !== path.resolve(targetPath) &&
       fileExists(sourcePath) &&
       !fileExists(targetPath),
@@ -4305,7 +4306,8 @@ export async function detectLegacyStateMigrations(params: {
   const pluginBindingApprovals = {
     sourcePath: resolveLegacyPluginBindingApprovalsPath(env, homedir),
   };
-  const hasPluginBindingApprovals = fileExists(pluginBindingApprovals.sourcePath);
+  const hasPluginBindingApprovals =
+    fileExists(pluginBindingApprovals.sourcePath) && !env.OPENCLAW_PROFILE?.trim();
   const currentConversationBindings = {
     sourcePath: resolveLegacyCurrentConversationBindingsPath(stateDir),
   };


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #102846

## What Problem This Solves

Starting OpenClaw with a named `--profile` can import and archive the default profile's `~/.openclaw/exec-approvals.json` (and `plugin-binding-approvals.json`) into the named profile's state directory. This crosses the profile-isolation boundary: a named profile should not inspect, import, archive, or mutate the default profile's approval state.

## Why This Change Was Made

The legacy exec-approvals migration detection (`detectLegacyExecApprovalsMigration`) and plugin-binding-approvals detection gate on `OPENCLAW_STATE_DIR` being set (which both named profiles and bare relocations set). They check the DEFAULT profile's `homedir/.openclaw/exec-approvals.json` as the migration source - without checking whether a NAMED profile is active (`OPENCLAW_PROFILE` env). The fix adds a `!OPENCLAW_PROFILE` guard to both detection paths: when `OPENCLAW_PROFILE` is set (named profile), skip the migration from the default; when only `OPENCLAW_STATE_DIR` is set (bare relocation, no profile), keep the existing compatibility migration.

## User Impact

Named profiles (`--profile <name>`) no longer mutate the default profile's approval files on startup. Bare `OPENCLAW_STATE_DIR` relocation behavior is unchanged.

## Evidence

Regression test added to `src/infra/state-migrations.test.ts`:

```
✓ does not migrate default-profile approval files into a named profile (#102846)
Tests  1 passed | 43 skipped (44)
```

The test sets up a default `~/.openclaw/exec-approvals.json` + `plugin-binding-approvals.json`, then starts with `OPENCLAW_STATE_DIR` + `OPENCLAW_PROFILE` (a named profile), and asserts both `detected.execApprovals.hasLegacy` and `detected.pluginBindingApprovals.hasLegacy` are `false` (no migration). Without the `!OPENCLAW_PROFILE` guard, `hasLegacy` would be `true` (the default's files would be detected as migration sources for the named profile).

`pnpm tsgo`, `oxlint`, and `oxfmt` are clean on the changed files.

## Human Verification

- Confirmed the bug on current `main`: `detectLegacyExecApprovalsMigration` checks `Boolean(OPENCLAW_STATE_DIR)` + the default's `homedir/.openclaw/exec-approvals.json` even for named profiles.
- Confirmed `--profile` sets `OPENCLAW_PROFILE` (`src/cli/profile.ts:95`).
- Verified the guard does not affect bare `OPENCLAW_STATE_DIR` relocation (no `OPENCLAW_PROFILE`): `!OPENCLAW_PROFILE` is `true` -> migration proceeds as before.
- Not verified: macOS/iOS not tested; Swift host-env-policy check skipped on Windows.

## Compatibility / Migration

No API, config, or CLI changes. The only behavioral change: named `--profile` startup no longer migrates the default profile's approval files. Bare `OPENCLAW_STATE_DIR` relocation is unchanged.

## Failure Recovery

Revert the single commit. No migration or state changes are involved.
