### PR TITLE
fix(cli): keep session key tables Unicode-safe

### DIFF
--- a/src/commands/sessions-table.test.ts
+++ b/src/commands/sessions-table.test.ts
@@ -1,0 +1,14 @@
+// Sessions table tests cover shared fixed-width cell formatting.
+import { describe, expect, it } from "vitest";
+import { formatSessionKeyCell, SESSION_KEY_PAD } from "./sessions-table.js";
+
+describe("formatSessionKeyCell", () => {
+  it("keeps both truncation boundaries UTF-16 safe", () => {
+    const key = `${"a".repeat(15)}😀middle😀${"z".repeat(5)}`;
+
+    const rendered = formatSessionKeyCell(key, false);
+
+    expect(rendered).toBe(`${"a".repeat(15)}...${"z".repeat(5)}`.padEnd(SESSION_KEY_PAD));
+    expect(rendered).toHaveLength(SESSION_KEY_PAD);
+  });
+});

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -4,6 +4,7 @@
  * Cleanup and listing commands use the same row shape and fixed-width cells so
  * terminal output stays aligned across commands.
  */
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -108,7 +109,7 @@ function truncateSessionKey(key: string): string {
   // Keep both the stable prefix and suffix; the tail often contains direct
   // recipient or runtime identifiers that distinguish otherwise similar keys.
   const head = Math.max(4, SESSION_KEY_PAD - 10);
-  return `${key.slice(0, head)}...${key.slice(-6)}`;
+  return `${truncateUtf16Safe(key, head)}...${sliceUtf16Safe(key, -6)}`;
 }
 
 /** Formats a session key cell for table output. */


### PR DESCRIPTION
Closes #103001

AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where operators listing sessions, or previewing session cleanup, could see replacement characters in a long session key when an emoji or other supplementary-plane character crossed either truncation boundary.

## Why This Change Was Made

The shared session-table formatter now uses the canonical UTF-16-safe prefix and suffix helpers while preserving its existing 16-unit prefix, ellipsis, 6-unit suffix, and 26-unit cell budget. A focused regression test places emoji across both retained boundaries so the old raw slicing fails deterministically.

This stays at the shared formatter owner boundary: normal session listing and cleanup dry-run both benefit, while JSON output and persisted keys remain unchanged.

## User Impact

Long Unicode session keys remain recognizable in terminal tables instead of displaying `�` characters. ASCII keys, short keys, output width, and the meaningful prefix/suffix layout keep their existing behavior.

## Evidence

Blacksmith Testbox lease: `tbx_01kx3w5bfyc64dwp5g3rj4cr7y` (`brisk-crayfish`).

- `pnpm test src/commands/sessions-table.test.ts`: 1/1 passed.
- `pnpm test src/commands/sessions-table.test.ts src/commands/sessions.test.ts src/commands/sessions-cleanup.test.ts`: 26/26 passed across three files.
- `pnpm check:changed`: passed (core + coreTests; typecheck, lint, and guards clean).
- Real CLI fixture: `openclaw sessions --store /tmp/openclaw-sessions-utf16.json --limit all` rendered `aaaaaaaaaaaaaaa...zzzzz` without replacement characters.
- Old-slice control on the same Testbox reproduced dangling surrogate indices 15 and 19 and terminal text `aaaaaaaaaaaaaaa�...�zzzzz`.
- Source-blind behavior validation passed 7/7 clauses and probes: normal and cleanup tables, full-key JSON preservation, short/varied/ASCII keys, forbidden-surrogate scan, and a byte-identical retry.
- Fresh autoreview: clean, no accepted/actionable findings; correctness confidence 0.99.
- Exact-head CI at `f4fa56da1449596c9f23a6aacf47f06fff7c5737`: [CI run](https://github.com/openclaw/openclaw/actions/runs/29035127950) and [real behavior proof](https://github.com/openclaw/openclaw/actions/runs/29035755629) passed. Verification snapshot: 65 successful checks, 36 skipped, zero failures or pending checks.
- `git diff --check`: passed.
