### PR TITLE
fix: recover Android permission request timeouts

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 277,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -275,7 +275,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 213,
+      "line": 198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Permission required",
       "surface": "android",
@@ -283,7 +283,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 215,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Continue",
       "surface": "android",
@@ -291,7 +291,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 216,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Not now",
       "surface": "android",
@@ -299,7 +299,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 243,
+      "line": 228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Enable permission in Settings",
       "surface": "android",
@@ -307,7 +307,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 245,
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -315,7 +315,7 @@
     },
     {
       "kind": "ui-dialog",
-      "line": 253,
+      "line": 238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Cancel",
       "surface": "android",
@@ -323,7 +323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 260,
+      "line": 245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "OpenClaw needs ${labels.joinToString(\", \")} permissions to continue.",
       "surface": "android",
@@ -331,7 +331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 265,
+      "line": 250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Please enable ${labels.joinToString(\", \")} in Android Settings to continue.",
       "surface": "android",
@@ -339,7 +339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 270,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Camera",
       "surface": "android",
@@ -347,7 +347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 271,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Microphone",
       "surface": "android",
@@ -355,7 +355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 272,
+      "line": 257,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Send SMS",
       "surface": "android",
@@ -363,7 +363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 273,
+      "line": 258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read SMS",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 274,
+      "line": 259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Contacts",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 275,
+      "line": 260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Contacts",
       "surface": "android",
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 276,
+      "line": 261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Calendar",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 277,
+      "line": 262,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Calendar",
       "surface": "android",
@@ -403,7 +403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 278,
+      "line": 263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Call Log",
       "surface": "android",
@@ -411,7 +411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 279,
+      "line": 264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Motion Activity",
       "surface": "android",
@@ -419,7 +419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 282,
+      "line": 267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Photos",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Shows the localized app version, Git commit, and build date together on the About screen, with real provenance in repository-backed debug builds.
 
+Recovers Android permission prompts after timeouts or cancellation without exhausting future requests. Thanks @NianJiuZst.
+
 ## 2026.7.1 - 2026-07-08
 
 Adds multi-gateway switching with isolated credentials, history, queues, and notification routing.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -117,6 +117,18 @@ class MainActivity : AppCompatActivity() {
     }
   }
 
+  override fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<String>,
+    grantResults: IntArray,
+  ) {
+    // AppCompatActivity marks this callback @CallSuper; it preserves Fragment and ActivityResult dispatch.
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    if (::permissionRequester.isInitialized) {
+      permissionRequester.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+  }
+
   /**
    * Wires MainViewModel only after Activity first draw and background prefs warm-up.
    */

--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -8,8 +8,6 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import androidx.activity.ComponentActivity
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -17,7 +15,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,31 +28,26 @@ import kotlin.coroutines.resume
  */
 class PermissionRequester internal constructor(
   private val activity: ComponentActivity,
-  launcherFactory: ((Map<String, Boolean>) -> Unit) -> ActivityResultLauncher<Array<String>>,
+  private val permissionRequestLauncher: (Array<String>, Int) -> Unit,
+  private val requestCodeAllocator: PermissionRequestCodeAllocator = PermissionRequestCodeAllocator(),
 ) {
   private data class PendingPermissionRequest(
+    val requestCode: Int,
+    val permissions: List<String>,
     val deferred: CompletableDeferred<Map<String, Boolean>>,
-    var timedOut: Boolean = false,
-  )
-
-  private class PermissionRequestSlot(
-    val launcher: ActivityResultLauncher<Array<String>>,
-    var request: PendingPermissionRequest? = null,
   )
 
   constructor(activity: ComponentActivity) : this(
     activity = activity,
-    launcherFactory = { callback ->
-      activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions(), callback)
+    permissionRequestLauncher = { permissions, requestCode ->
+      ActivityCompat.requestPermissions(activity, permissions, requestCode)
     },
   )
 
   private val mutex = Mutex()
-  private val requestSlotsLock = Any()
+  private val permissionRequestsLock = Any()
   private val mainHandler = Handler(Looper.getMainLooper())
-
-  // ActivityResult launchers cannot be registered after start; pre-register a small pool for nested UI flows.
-  private val launchers = List(4) { createPermissionRequestSlot(launcherFactory) }
+  private val pendingPermissionRequests = mutableMapOf<Int, PendingPermissionRequest>()
 
   /**
    * Request missing Android runtime permissions and return the final grant state for every requested permission.
@@ -86,24 +78,22 @@ class PermissionRequester internal constructor(
         }
 
         val deferred = CompletableDeferred<Map<String, Boolean>>()
-        val request = PendingPermissionRequest(deferred)
-        val slot = reservePermissionRequestSlot(request)
+        val request = reservePermissionRequest(missing, deferred)
         try {
           withContext(Dispatchers.Main) {
-            slot.launcher.launch(missing.toTypedArray())
+            permissionRequestLauncher(missing.toTypedArray(), request.requestCode)
           }
         } catch (err: Throwable) {
-          clearPermissionRequestSlot(slot, request)
+          clearPermissionRequest(request)
           throw err
         }
 
         val result =
           try {
             withTimeout(timeoutMs) { deferred.await() }
-          } catch (err: TimeoutCancellationException) {
-            // Late ActivityResult callbacks are ignored by completePermissionRequest.
-            request.timedOut = true
-            throw err
+          } finally {
+            // Timeout and caller cancellation both retire the request code before the mutex admits another prompt.
+            clearPermissionRequest(request)
           }
 
         val merged =
@@ -127,46 +117,41 @@ class PermissionRequester internal constructor(
     }
   }
 
-  private fun createPermissionRequestSlot(
-    launcherFactory: ((Map<String, Boolean>) -> Unit) -> ActivityResultLauncher<Array<String>>,
-  ): PermissionRequestSlot {
-    var slot: PermissionRequestSlot? = null
-    val launcher = launcherFactory { result -> completePermissionRequest(checkNotNull(slot), result) }
-    val created = PermissionRequestSlot(launcher)
-    slot = created
-    return created
+  internal fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<String>,
+    grantResults: IntArray,
+  ): Boolean {
+    val request =
+      synchronized(permissionRequestsLock) {
+        pendingPermissionRequests.remove(requestCode)
+      } ?: return false
+    val grants =
+      permissions
+        .mapIndexed { index, permission ->
+          permission to (grantResults.getOrNull(index) == PackageManager.PERMISSION_GRANTED)
+        }.toMap()
+    request.deferred.complete(request.permissions.associateWith { permission -> grants[permission] == true })
+    return true
   }
 
-  private fun reservePermissionRequestSlot(request: PendingPermissionRequest): PermissionRequestSlot =
-    synchronized(requestSlotsLock) {
-      // The outer mutex serializes normal callers; this guard catches accidental concurrent launchers in tests.
-      val slot = launchers.firstOrNull { it.request == null } ?: error("permission request launcher busy")
-      slot.request = request
-      slot
+  private fun reservePermissionRequest(
+    permissions: List<String>,
+    deferred: CompletableDeferred<Map<String, Boolean>>,
+  ): PendingPermissionRequest =
+    synchronized(permissionRequestsLock) {
+      val requestCode = requestCodeAllocator.allocate(pendingPermissionRequests::containsKey)
+      val request = PendingPermissionRequest(requestCode, permissions, deferred)
+      pendingPermissionRequests[requestCode] = request
+      request
     }
 
-  private fun completePermissionRequest(
-    slot: PermissionRequestSlot,
-    result: Map<String, Boolean>,
-  ) {
-    val request =
-      synchronized(requestSlotsLock) {
-        slot.request.also {
-          slot.request = null
-        }
-      } ?: return
-    // Timed-out requests have already resumed callers with failure; ignore any late platform callback.
-    if (request.timedOut) return
-    request.deferred.complete(result)
-  }
-
-  private fun clearPermissionRequestSlot(
-    slot: PermissionRequestSlot,
+  private fun clearPermissionRequest(
     request: PendingPermissionRequest,
   ) {
-    synchronized(requestSlotsLock) {
-      if (slot.request === request) {
-        slot.request = null
+    synchronized(permissionRequestsLock) {
+      if (pendingPermissionRequests[request.requestCode] === request) {
+        pendingPermissionRequests.remove(request.requestCode)
       }
     }
   }
@@ -282,4 +267,37 @@ class PermissionRequester internal constructor(
       Manifest.permission.READ_EXTERNAL_STORAGE -> "Photos"
       else -> permission
     }
+}
+
+internal class PermissionRequestCodeAllocator(
+  initialRequestCode: Int = FIRST_PERMISSION_REQUEST_CODE,
+) {
+  private var nextRequestCode = initialRequestCode
+
+  init {
+    require(initialRequestCode in FIRST_PERMISSION_REQUEST_CODE..LAST_PERMISSION_REQUEST_CODE)
+  }
+
+  fun allocate(isInUse: (Int) -> Boolean): Int {
+    repeat(PERMISSION_REQUEST_CODE_COUNT) {
+      val requestCode = nextRequestCode
+      nextRequestCode =
+        if (requestCode == LAST_PERMISSION_REQUEST_CODE) {
+          FIRST_PERMISSION_REQUEST_CODE
+        } else {
+          requestCode + 1
+        }
+      if (!isInUse(requestCode)) return requestCode
+    }
+    error("permission request codes exhausted")
+  }
+
+  internal companion object {
+    // AndroidX ActivityResultRegistry reserves request codes >= 0x10000. Direct ActivityCompat
+    // requests stay in a disjoint 16-bit range and skip live codes when the counter wraps.
+    const val FIRST_PERMISSION_REQUEST_CODE = 0x4C00
+    const val LAST_PERMISSION_REQUEST_CODE = 0xFFFF
+    private const val PERMISSION_REQUEST_CODE_COUNT =
+      LAST_PERMISSION_REQUEST_CODE - FIRST_PERMISSION_REQUEST_CODE + 1
+  }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -124,9 +124,9 @@ class CameraCaptureManager(
     lifecycleOwner = owner
   }
 
-  /** Supplies the Activity-owned permission launcher used by camera and microphone commands. */
+  /** Supplies the Activity-owned permission requester used by camera and microphone commands. */
   fun attachPermissionRequester(requester: PermissionRequester) {
-    // Permission prompts must be launched by the Activity that owns the ActivityResult registry.
+    // Runtime permission callbacks belong to the foreground Activity, not the background node service.
     permissionRequester = requester
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/PermissionRequesterTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/PermissionRequesterTest.kt
@@ -1,15 +1,13 @@
 package ai.openclaw.app
 
 import android.Manifest
+import android.content.pm.PackageManager
 import androidx.activity.ComponentActivity
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContract
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityOptionsCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
@@ -33,11 +31,8 @@ class PermissionRequesterTest {
   fun timedOutRequestCallbackDoesNotCompleteNextRequest() =
     runTest {
       Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-      val launchers = mutableListOf<FakePermissionLauncher>()
-      val requester =
-        PermissionRequester(activity()) { callback ->
-          FakePermissionLauncher(callback).also { launchers += it }
-        }
+      val requests = FakePermissionRequests()
+      val requester = PermissionRequester(activity(), requests::request)
 
       try {
         val first = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 10) }
@@ -47,18 +42,18 @@ class PermissionRequesterTest {
 
         assertTrue(first.isCompleted)
         assertTrue(first.getCompletionExceptionOrNull() is TimeoutCancellationException)
-        assertEquals(listOf(listOf(Manifest.permission.CAMERA)), launchers[0].launches)
+        assertEquals(listOf(Manifest.permission.CAMERA), requests[0].permissions)
 
         val second = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
         runCurrent()
-        assertEquals(listOf(listOf(Manifest.permission.CAMERA)), launchers[1].launches)
+        assertEquals(listOf(Manifest.permission.CAMERA), requests[1].permissions)
 
-        launchers[0].deliver(mapOf(Manifest.permission.CAMERA to false))
+        assertFalse(requests.deliver(requester, 0, mapOf(Manifest.permission.CAMERA to false)))
         runCurrent()
 
         assertFalse(second.isCompleted)
 
-        launchers[1].deliver(mapOf(Manifest.permission.CAMERA to true))
+        assertTrue(requests.deliver(requester, 1, mapOf(Manifest.permission.CAMERA to true)))
         runCurrent()
 
         assertEquals(mapOf(Manifest.permission.CAMERA to true), second.await())
@@ -69,37 +64,108 @@ class PermissionRequesterTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
-  fun timedOutRequestWithoutCallbackDoesNotBlockNextRequest() =
+  fun repeatedTimedOutRequestsWithoutCallbacksDoNotBlockNextRequest() =
     runTest {
       Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-      val launchers = mutableListOf<FakePermissionLauncher>()
-      val requester =
-        PermissionRequester(activity()) { callback ->
-          FakePermissionLauncher(callback).also { launchers += it }
-        }
+      val requests = FakePermissionRequests()
+      val requester = PermissionRequester(activity(), requests::request)
 
       try {
-        val first = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 10) }
-        runCurrent()
-        advanceTimeBy(11)
-        runCurrent()
+        repeat(4) { index ->
+          val timedOut = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 10) }
+          runCurrent()
+          advanceTimeBy(11)
+          runCurrent()
 
-        assertTrue(first.isCompleted)
-        assertTrue(first.getCompletionExceptionOrNull() is TimeoutCancellationException)
+          assertTrue(timedOut.isCompleted)
+          assertTrue(timedOut.getCompletionExceptionOrNull() is TimeoutCancellationException)
+          assertEquals(listOf(Manifest.permission.CAMERA), requests[index].permissions)
+        }
 
-        val second = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
-        runCurrent()
-
-        assertEquals(listOf(listOf(Manifest.permission.CAMERA)), launchers[1].launches)
-
-        launchers[1].deliver(mapOf(Manifest.permission.CAMERA to true))
+        val recovered = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
         runCurrent()
 
-        assertEquals(mapOf(Manifest.permission.CAMERA to true), second.await())
+        assertEquals(5, requests.size)
+        assertEquals(listOf(Manifest.permission.CAMERA), requests[4].permissions)
+
+        assertTrue(requests.deliver(requester, 4, mapOf(Manifest.permission.CAMERA to true)))
+        runCurrent()
+
+        assertEquals(mapOf(Manifest.permission.CAMERA to true), recovered.await())
       } finally {
         Dispatchers.resetMain()
       }
     }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun cancelledRequestCallbackDoesNotCompleteNextRequest() =
+    runTest {
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      val requests = FakePermissionRequests()
+      val requester = PermissionRequester(activity(), requests::request)
+
+      try {
+        val cancelled = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
+        runCurrent()
+        cancelled.cancelAndJoin()
+
+        val recovered = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
+        runCurrent()
+
+        assertEquals(2, requests.size)
+        assertFalse(requests.deliver(requester, 0, mapOf(Manifest.permission.CAMERA to false)))
+        runCurrent()
+        assertFalse(recovered.isCompleted)
+
+        assertTrue(requests.deliver(requester, 1, mapOf(Manifest.permission.CAMERA to true)))
+        runCurrent()
+        assertEquals(mapOf(Manifest.permission.CAMERA to true), recovered.await())
+      } finally {
+        Dispatchers.resetMain()
+      }
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun emptyPlatformCallbackTreatsRequestedPermissionsAsDenied() =
+    runTest {
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      val requests = FakePermissionRequests()
+      val requester = PermissionRequester(activity(), requests::request)
+
+      try {
+        val pending = async { requester.requestIfMissing(listOf(Manifest.permission.CAMERA), timeoutMs = 1_000) }
+        runCurrent()
+
+        assertTrue(
+          requester.onRequestPermissionsResult(
+            requests[0].requestCode,
+            emptyArray(),
+            intArrayOf(),
+          ),
+        )
+        runCurrent()
+
+        assertEquals(mapOf(Manifest.permission.CAMERA to false), pending.await())
+      } finally {
+        Dispatchers.resetMain()
+      }
+    }
+
+  @Test
+  fun requestCodeAllocatorWrapsWithinLegacyRangeAndSkipsLiveCodes() {
+    val allocator =
+      PermissionRequestCodeAllocator(PermissionRequestCodeAllocator.LAST_PERMISSION_REQUEST_CODE)
+
+    assertEquals(PermissionRequestCodeAllocator.LAST_PERMISSION_REQUEST_CODE, allocator.allocate { false })
+    assertEquals(
+      PermissionRequestCodeAllocator.FIRST_PERMISSION_REQUEST_CODE + 1,
+      allocator.allocate { requestCode ->
+        requestCode == PermissionRequestCodeAllocator.FIRST_PERMISSION_REQUEST_CODE
+      },
+    )
+  }
 
   private fun activity(): ComponentActivity =
     Robolectric
@@ -108,22 +174,41 @@ class PermissionRequesterTest {
       .get()
 }
 
-private class FakePermissionLauncher(
-  private val callback: (Map<String, Boolean>) -> Unit,
-) : ActivityResultLauncher<Array<String>>() {
-  val launches = mutableListOf<List<String>>()
-  override val contract: ActivityResultContract<Array<String>, *> = ActivityResultContracts.RequestMultiplePermissions()
+private class FakePermissionRequest(
+  val permissions: List<String>,
+  val requestCode: Int,
+)
 
-  override fun launch(
-    input: Array<String>,
-    options: ActivityOptionsCompat?,
+private class FakePermissionRequests {
+  private val requests = mutableListOf<FakePermissionRequest>()
+
+  val size: Int
+    get() = requests.size
+
+  operator fun get(index: Int): FakePermissionRequest = requests[index]
+
+  fun request(
+    permissions: Array<String>,
+    requestCode: Int,
   ) {
-    launches += input.toList()
+    requests += FakePermissionRequest(permissions.toList(), requestCode)
   }
 
-  override fun unregister() {}
-
-  fun deliver(result: Map<String, Boolean>) {
-    callback(result)
+  fun deliver(
+    requester: PermissionRequester,
+    index: Int,
+    result: Map<String, Boolean>,
+  ): Boolean {
+    val request = requests[index]
+    val grantResults =
+      request.permissions
+        .map { permission ->
+          if (result[permission] == true) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
+        }.toIntArray()
+    return requester.onRequestPermissionsResult(
+      request.requestCode,
+      request.permissions.toTypedArray(),
+      grantResults,
+    )
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an Android permission-request failure where repeated runtime permission timeouts could strand the pre-registered launcher pool. After enough requests timed out without platform callbacks, later camera, microphone, or SMS permission flows could fail immediately with `permission request launcher busy` instead of recovering.

## Why This Change Was Made

`PermissionRequester` now keys each permission request by the platform `requestCode` and `MainActivity` forwards `onRequestPermissionsResult` back into the requester. Timed-out or cancelled requests are removed from the pending table, so a late callback for an old request is ignored by request code instead of completing a newer request. This replaces the finite ActivityResult launcher pool and avoids unsafe slot reuse.

## User Impact

Android permission prompts can recover after repeated timeout/no-callback cases. Late platform callbacks from old prompts no longer complete a later request with stale grant results.

## Evidence

- `JAVA_HOME=/Users/nianjiu/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home ./gradlew :app:ktlintFormat` from `apps/android`
- `JAVA_HOME=/Users/nianjiu/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home ./gradlew -Dorg.gradle.java.home=/Users/nianjiu/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home :app:testPlayDebugUnitTest --tests ai.openclaw.app.PermissionRequesterTest --rerun-tasks` from `apps/android`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after the request-code rewrite
- Remote proof gap: Blacksmith Testbox warmup failed because the account is not authenticated to the `openclaw` org; AWS Crabbox warmup failed because the local Crabbox broker is not logged in. GitHub CI will provide the remote signal.

AI-assisted: yes.
