### PR TITLE
fix(auto-reply): log dropped reply media at warn level

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -498,6 +498,46 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(message).toContain("file not found");
   });
 
+  it("omits data: URL payloads from the dropped-media warn log", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const payload = `data:image/png;base64,${"secretbytes".repeat(20)}`;
+    const result = await normalize({
+      text: "hello",
+      mediaUrls: [payload],
+    });
+
+    expect(result.text).toBe("hello\n⚠️ Media failed.");
+    expect(subsystemWarnSpy).toHaveBeenCalledTimes(1);
+    const message = subsystemWarnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain("[data: URL omitted]");
+    expect(message).not.toContain("secretbytes");
+  });
+
+  it("truncates very long media sources in the dropped-media warn log", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const longSource = `./out/${"a".repeat(600)}.png`;
+    await normalize({
+      text: "hello",
+      mediaUrls: [longSource],
+    });
+
+    expect(subsystemWarnSpy).toHaveBeenCalledTimes(1);
+    const message = subsystemWarnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain(`… (${longSource.length} chars)`);
+    expect(message).not.toContain(longSource);
+  });
+
   it("keeps surviving media and appends a warning when some reply media is dropped", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -9,10 +9,23 @@ import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-paylo
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
 const resolveOutboundAttachmentFromUrl = vi.hoisted(() => vi.fn());
 const resolveAgentScopedOutboundMediaAccess = vi.hoisted(() => vi.fn());
+const subsystemWarnSpy = vi.hoisted(() => vi.fn());
 const stateDirEnvSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: subsystemWarnSpy,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+  }),
 }));
 
 vi.mock("../../media/outbound-attachment.js", () => ({
@@ -88,6 +101,7 @@ describe("createReplyMediaPathNormalizer", () => {
         localRoots: workspaceDir ? [workspaceDir] : undefined,
         readFile: async () => Buffer.from("image"),
       }));
+    subsystemWarnSpy.mockReset();
   });
 
   afterEach(() => {
@@ -463,6 +477,25 @@ describe("createReplyMediaPathNormalizer", () => {
 
     expect(result.text).toBe("WA_MEDIA_DM_07\n⚠️ Media failed.");
     expectNoMedia(result);
+  });
+
+  it("logs dropped reply media at warn level with the source and reason", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    await normalize({
+      text: "WA_MEDIA_DM_07",
+      mediaUrls: ["./out/missing.png"],
+    });
+
+    expect(subsystemWarnSpy).toHaveBeenCalledTimes(1);
+    const message = subsystemWarnSpy.mock.calls[0]?.[0] as string;
+    expect(message).toContain("./out/missing.png");
+    expect(message).toContain("file not found");
   });
 
   it("keeps surviving media and appends a warning when some reply media is dropped", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -11,12 +11,14 @@ import {
 } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { appendReplyMediaFailureWarning, copyReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+
+const replyMediaLog = createSubsystemLogger("auto-reply/reply-media");
 
 const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
@@ -210,7 +212,7 @@ export function createReplyMediaPathNormalizer(params: {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
         firstMediaDropError ??= err;
-        logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
+        replyMediaLog.warn(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;
       }
       if (!normalized || seen.has(normalized)) {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -20,6 +20,22 @@ import type { ReplyPayload } from "../types.js";
 
 const replyMediaLog = createSubsystemLogger("auto-reply/reply-media");
 
+const DROPPED_MEDIA_SOURCE_MAX_CHARS = 256;
+
+/**
+ * Bounded descriptor for dropped media sources: omits data: URL payloads and
+ * truncates long sources so warn-level logs never carry inline media bytes.
+ */
+function describeDroppedMediaSource(media: string): string {
+  if (/^\s*data:/i.test(media)) {
+    return "[data: URL omitted]";
+  }
+  if (media.length > DROPPED_MEDIA_SOURCE_MAX_CHARS) {
+    return `${media.slice(0, DROPPED_MEDIA_SOURCE_MAX_CHARS)}… (${media.length} chars)`;
+  }
+  return media;
+}
+
 const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
@@ -212,7 +228,9 @@ export function createReplyMediaPathNormalizer(params: {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
         firstMediaDropError ??= err;
-        replyMediaLog.warn(`dropping blocked reply media ${media}: ${String(err)}`);
+        replyMediaLog.warn(
+          `dropping blocked reply media ${describeDroppedMediaSource(media)}: ${String(err)}`,
+        );
         continue;
       }
       if (!normalized || seen.has(normalized)) {


### PR DESCRIPTION
Fixes #103000

## What Problem This Solves

When a reply `MEDIA:` attachment is rejected during normalization (policy block, missing file, size cap, …), the drop is logged only via `logVerbose`. On a default install (verbose off, file log level `info`) the gateway log contains **zero trace** of the drop — the only artifact is the `⚠️ Media failed.` suffix on the delivered message, with no reason anywhere.

This code path fires exactly when the user visibly loses data (the attachment is gone), so it warrants `warn`, not debug-gated verbose. Root-causing one of these in production currently requires enabling verbose logging and reproducing, or reading the bundled sources (see #103000 for the full incident writeup; related: the "clearer blocked-media diagnostics" half of #100292).

## Change

- `src/auto-reply/reply/reply-media-paths.ts`: replace the `logVerbose` call in the drop path with `createSubsystemLogger("auto-reply/reply-media").warn(...)` carrying the media source and the rejection reason — same idiom as sibling modules (`auto-reply/agent-turn-timing`, `silent-reply/dispatcher`).
- **Sanitization (added per review):** the warn message logs a bounded descriptor via `describeDroppedMediaSource()` instead of the raw source — `data:` URLs are replaced with a fixed `[data: URL omitted]` marker (this catch also handles `assertMediaNotDataUrl` rejections, so raw interpolation could have written inline payload bytes to default logs), and sources longer than 256 chars are truncated with an explicit `… (N chars)` suffix.
- No policy/behavior change: what gets dropped and the user-facing `⚠️ Media failed.` text are untouched. Only the log level/visibility changes.

## Tests

- Warn emission: dropping a media source emits one warn-level record containing the source path and the reason.
- Data URL omission: a rejected `data:image/png;base64,…` source emits a warn containing `[data: URL omitted]` and **not** the payload bytes.
- Long-source bounding: a 600+ char source is truncated with the `… (N chars)` suffix; the full raw string never reaches the log message.
- `node scripts/test-projects.mjs src/auto-reply/reply/reply-media-paths.test.ts` → 1 file, **25 tests passed**.
- `oxfmt` / `oxlint` clean on both touched files.

## Evidence

Driver: real `createReplyMediaPathNormalizer` + real subsystem logger, default settings (no `--verbose`, no debug file level), isolated `TMPDIR`. Two drops exercised — a missing local file and a `data:` URL carrying a `SECRETPAYLOAD…` marker string:

```text
[auto-reply/reply-media] dropping blocked reply media ./out/missing-proof.png: FsSafeError: file not found
case1 delivered text: "proof-1\n⚠️ Media failed."
[auto-reply/reply-media] dropping blocked reply media [data: URL omitted]: Error: data: URLs are not supported for media. Use buffer instead.
case2 delivered text: "proof-2\n⚠️ Media failed."
```

Leak check: `grep SECRETPAYLOAD` across every log file produced under the isolated `TMPDIR` → no matches. The payload marker appears nowhere; only the bounded descriptor does.
