### PR TITLE
fix(ui): restore device-token revoke release coverage

### DIFF
--- a/ui/src/e2e/device-token-reconnect.e2e.test.ts
+++ b/ui/src/e2e/device-token-reconnect.e2e.test.ts
@@ -240,12 +240,25 @@ describeControlUiE2e("Control UI device-token reconnect E2E", () => {
       route: "nodes",
     });
     expect(requireConnectAuth(wilfredNodes.connect).token).toBe(WILFRED_DEVICE_TOKEN);
-    const revokeButton = wilfredNodes.page.getByRole("button", { name: "Revoke" });
-    await revokeButton.waitFor();
+    await wilfredNodes.gateway.waitForRequest("device.pair.list");
+    const deviceEntry = wilfredNodes.page.locator(".nodes-entry").filter({
+      has: wilfredNodes.page.getByText("This browser", { exact: true }),
+    });
+    await deviceEntry.waitFor();
+    await deviceEntry.locator("details.nodes-entry__details > summary").click();
+    const revokeButton = deviceEntry.getByRole("button", { name: "Revoke", exact: true });
+    await revokeButton.waitFor({ state: "visible" });
     await revokeButton.scrollIntoViewIfNeeded();
     await captureProof(wilfredNodes.page, "wilfred-before-revoke.png");
-    wilfredNodes.page.once("dialog", (dialog) => void dialog.accept());
-    await revokeButton.click();
+    const dialogPromise = wilfredNodes.page.waitForEvent("dialog");
+    await Promise.all([
+      dialogPromise.then(async (dialog) => {
+        expect(dialog.type()).toBe("confirm");
+        expect(dialog.message()).toBe(`Revoke token for ${deviceId} (operator)?`);
+        await dialog.accept();
+      }),
+      revokeButton.click(),
+    ]);
     const revoke = await wilfredNodes.gateway.waitForRequest("device.token.revoke");
     expect(revoke.params).toEqual({ deviceId, role: "operator" });
     const wilfredStoreKey =

--- a/ui/src/pages/nodes/view.devices.test.ts
+++ b/ui/src/pages/nodes/view.devices.test.ts
@@ -292,6 +292,7 @@ describe("nodes inventory rendering", () => {
 
   it("shows token rows with rotate and revoke inside entry details", () => {
     const rotations: Array<{ deviceId: string; role: string }> = [];
+    const revocations: Array<{ deviceId: string; role: string }> = [];
     const container = renderNodesContainer({
       devicesList: {
         pending: [],
@@ -305,12 +306,15 @@ describe("nodes inventory rendering", () => {
         ],
       },
       onDeviceRotate: (deviceId, role) => rotations.push({ deviceId, role }),
+      onDeviceRevoke: (deviceId, role) => revocations.push({ deviceId, role }),
     });
     const card = getInventoryCard(container);
 
     expect(card.textContent).toContain("operator · active · scopes: operator.read");
     findButton(card, "Rotate").click();
     expect(rotations).toEqual([{ deviceId: "device-1", role: "operator" }]);
+    findButton(card, "Revoke").click();
+    expect(revocations).toEqual([{ deviceId: "device-1", role: "operator" }]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-check failure where the device-token reconnect E2E timed out waiting for Revoke after the Nodes UI moved token actions into a collapsed disclosure.

## Why This Change Was Made

The E2E now waits for the device inventory, scopes the action to the current browser, opens Tokens & capabilities, and verifies the exact confirmation dialog before revocation. The rendering test now covers both rotate and revoke callback wiring.

## User Impact

No production behavior changes. Release validation again exercises the current device-token revocation flow instead of waiting on a hidden control.

## Evidence

- Before: Release Checks run `29033038418`, job `86171505078`, timed out after 30s waiting for visible Revoke.
- Blacksmith Testbox `tbx_01kx3vqjpczaqa5qmv9cjdw92g`: focused device-token E2E passed in 4.57s.
- Same Testbox: full Control UI E2E passed 30 files / 94 tests.
- Same Testbox: Nodes rendering tests passed 9/9.
- Path-scoped `check:changed` and two-file `oxfmt --check`: pass.
- Fresh structured autoreview: no findings, 0.96 confidence.
