### PR TITLE
fix(core): preserve target ID case when resolution is pure normalization

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -414,7 +414,12 @@ async function resolveActionTarget(params: {
       input: toRaw,
       accountId: params.accountId ?? undefined,
     });
-    params.args.to = resolved.to;
+    // Only overwrite arg when the resolved value is materially different from
+    // the raw input. Pure normalization (prefix + lowercase of same ID) is
+    // lossy for case-sensitive provider channel IDs (e.g. Slack C0XXX -> channel:c0xxx).
+    if (shouldApplyResolvedTargetArg(toRaw, resolved)) {
+      params.args.to = resolved.to;
+    }
     resolvedTarget = resolved;
   }
   const channelIdRaw = normalizeOptionalString(params.args.channelId) ?? "";
@@ -430,9 +435,31 @@ async function resolveActionTarget(params: {
           ? `Channel id "${channelIdRaw}" resolved to a user target.`
           : undefined,
     });
-    params.args.channelId = sanitizeGroupTargetId(resolved.to);
+    if (shouldApplyResolvedTargetArg(channelIdRaw, resolved)) {
+      params.args.channelId = sanitizeGroupTargetId(resolved.to);
+    }
   }
   return resolvedTarget;
+}
+
+/** Strips kind-prefixes from a raw target string. */
+function stripTargetKindPrefix(raw: string): string {
+  return raw.replace(/^(channel|group|user|telegram|slack|discord|signal):/i, "").trim();
+}
+
+/**
+ * Whether {@link resolved.to} (from the target resolver) should replace the
+ * raw argument value. Directory and plugin resolutions always apply. Pure
+ * normalization that only adds a kind prefix + lowercases is skipped so the
+ * original case is preserved for case-sensitive provider IDs.
+ */
+function shouldApplyResolvedTargetArg(raw: string, resolved: ResolvedMessagingTarget): boolean {
+  if (resolved.resolutionSource !== "normalized") {
+    return true;
+  }
+  const input = stripTargetKindPrefix(raw);
+  const resolvedId = stripTargetKindPrefix(resolved.to);
+  return !(resolvedId.toLowerCase() === input.toLowerCase() && resolvedId !== input);
 }
 
 function sanitizeGroupTargetId(target: string): string {


### PR DESCRIPTION
## What Problem This Solves

Slack message tool `delete`/`react`/`remove-reaction`/etc. actions fail with `channel_not_found` because the channel ID is lowercased during target resolution before being passed to the Slack Web API. Slack channel IDs are case-sensitive (C0BG72N6Z0V vs c0bg72n6z0v), and the lowercased form is rejected.

The root cause is in `resolveActionTarget`: after resolving `to`/`channelId` through the target resolver, the normalized result (which lowercases the entire `kind:id` string) always overwrites the original arg -- even when the resolution was just case normalization with no directory/plugin match. Both `to` and `channelId` paths are affected.

## Changes

| File | Change |
|------|--------|
| src/infra/outbound/message-action-runner.ts | Add `shouldApplyResolvedTargetArg()` helper that compares raw input vs resolved output (after stripping kind prefixes). When the only difference is character case, preserve the raw input. Directory and plugin resolutions always apply since they carry real canonical IDs. |

## Evidence

**Unit tests (946 tests, all passed):**
```
 Test Files  38 + 3 passed (41)
      Tests  833 + 113 passed (946)
```

**Real behavior proof (Slack API):**
```
Hostname: LIN-66D8BD4EA2C
PID: 2542625
Timestamp: 2026-07-10T07:16:58+08:00

to path: reactions.add original-case -> success
to path: reactions.add lowercased    -> failure (channel_not_found)
channelId path: chat.delete original-case -> success
```

## Review

- Manually reviewed and verified
- AI-assisted: Yes
- Fixes #102800
