### PR TITLE
fix: coalesce iOS location requests safely

### DIFF
--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -5,16 +5,25 @@ import UIKit
 
 @MainActor
 final class LocationService: NSObject, CLLocationManagerDelegate, LocationServiceCommon {
+    typealias LocationRequestFactory = @MainActor (
+        _ desiredAccuracy: CLLocationAccuracy,
+        _ allowsBackgroundLocationUpdates: Bool,
+        _ onFinish: @escaping @MainActor (LocationOneShotRequest) -> Void) -> LocationOneShotRequest
+
     enum Error: Swift.Error {
         case timeout
         case unavailable
     }
 
     private let manager = CLLocationManager()
+    private let locationRequestFactory: LocationRequestFactory
     private var authWaitID: UUID?
     private var authWaitRequiresDeterminedStatus = false
     private var authContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
     private var locationContinuation: CheckedContinuation<CLLocation, Swift.Error>?
+    private var activeLocationRequests: [CLLocationAccuracy: LocationOneShotRequest] = [:]
+    private var cachedOneShotLocation: CLLocation?
+    private var backgroundLocationUpdatesEnabled = false
     private var authorizationChangeHandler: (@MainActor @Sendable (CLAuthorizationStatus) -> Void)?
     private var significantLocationCallback: (@Sendable (CLLocation) -> Void)?
     private var isMonitoringSignificantChanges = false
@@ -28,7 +37,17 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
         set { self.locationContinuation = newValue }
     }
 
-    override init() {
+    override convenience init() {
+        self.init { desiredAccuracy, allowsBackgroundLocationUpdates, onFinish in
+            LocationOneShotRequest(
+                desiredAccuracy: desiredAccuracy,
+                allowsBackgroundLocationUpdates: allowsBackgroundLocationUpdates,
+                onFinish: onFinish)
+        }
+    }
+
+    init(locationRequestFactory: @escaping LocationRequestFactory) {
+        self.locationRequestFactory = locationRequestFactory
         super.init()
         self.configureLocationManager()
     }
@@ -64,15 +83,53 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
         timeoutMs: Int?) async throws -> CLLocation
     {
         _ = params
-        return try await LocationCurrentRequest.resolve(
+        if let cached = self.cachedOneShotLocation(maxAgeMs: maxAgeMs) {
+            return cached
+        }
+        let requestedAccuracy = LocationCurrentRequest.accuracyValue(desiredAccuracy)
+        let location = try await LocationCurrentRequest.resolve(
             manager: self.manager,
             desiredAccuracy: desiredAccuracy,
             maxAgeMs: maxAgeMs,
             timeoutMs: timeoutMs,
-            request: { try await self.requestLocationOnce() },
+            request: { try await self.requestLocationOnce(desiredAccuracy: requestedAccuracy) },
             withTimeout: { timeoutMs, operation in
                 try await self.withTimeout(timeoutMs: timeoutMs, operation: operation)
             })
+        self.cachedOneShotLocation = location
+        return location
+    }
+
+    func requestLocationOnce() async throws -> CLLocation {
+        try await self.requestLocationOnce(desiredAccuracy: self.manager.desiredAccuracy)
+    }
+
+    private func requestLocationOnce(desiredAccuracy: CLLocationAccuracy) async throws -> CLLocation {
+        let request =
+            self.activeLocationRequests[desiredAccuracy] ?? self.makeLocationOneShotRequest(
+                desiredAccuracy: desiredAccuracy)
+        return try await request.location()
+    }
+
+    private func makeLocationOneShotRequest(desiredAccuracy: CLLocationAccuracy) -> LocationOneShotRequest {
+        let request = self
+            .locationRequestFactory(desiredAccuracy, self.backgroundLocationUpdatesEnabled) { [weak self] request in
+                if self?.activeLocationRequests[desiredAccuracy] === request {
+                    self?.activeLocationRequests[desiredAccuracy] = nil
+                }
+            }
+        self.activeLocationRequests[desiredAccuracy] = request
+        return request
+    }
+
+    private func cachedOneShotLocation(maxAgeMs: Int?) -> CLLocation? {
+        guard let maxAgeMs,
+              let cached = self.cachedOneShotLocation,
+              Date().timeIntervalSince(cached.timestamp) * 1000 <= Double(maxAgeMs)
+        else {
+            return nil
+        }
+        return cached
     }
 
     private func requestAuthorization(
@@ -164,7 +221,11 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
     }
 
     func setBackgroundLocationUpdatesEnabled(_ enabled: Bool) {
+        self.backgroundLocationUpdatesEnabled = enabled
         self.manager.allowsBackgroundLocationUpdates = enabled
+        for request in self.activeLocationRequests.values {
+            request.setBackgroundLocationUpdatesEnabled(enabled)
+        }
     }
 
     func setAuthorizationChangeHandler(
@@ -214,6 +275,149 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
             guard let cont = self.locationContinuation else { return }
             self.locationContinuation = nil
             cont.resume(throwing: err)
+        }
+    }
+}
+
+@MainActor
+final class LocationOneShotRequest: NSObject, CLLocationManagerDelegate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<CLLocation, Swift.Error>
+    }
+
+    private let manager: CLLocationManager?
+    private let startRequest: @MainActor () -> Void
+    private let stopRequest: @MainActor () -> Void
+    private let onFinish: @MainActor (LocationOneShotRequest) -> Void
+    private var waiters: [Waiter] = []
+    private var didStart = false
+    private var didFinish = false
+
+    init(
+        desiredAccuracy: CLLocationAccuracy,
+        allowsBackgroundLocationUpdates: Bool,
+        onFinish: @escaping @MainActor (LocationOneShotRequest) -> Void)
+    {
+        let manager = CLLocationManager()
+        self.manager = manager
+        self.startRequest = {
+            manager.requestLocation()
+        }
+        self.stopRequest = {
+            manager.stopUpdatingLocation()
+            manager.delegate = nil
+        }
+        self.onFinish = onFinish
+        super.init()
+        manager.desiredAccuracy = desiredAccuracy
+        manager.allowsBackgroundLocationUpdates = allowsBackgroundLocationUpdates
+        manager.delegate = self
+    }
+
+    init(
+        startRequest: @escaping @MainActor () -> Void,
+        stopRequest: @escaping @MainActor () -> Void,
+        onFinish: @escaping @MainActor (LocationOneShotRequest) -> Void)
+    {
+        self.manager = nil
+        self.startRequest = startRequest
+        self.stopRequest = stopRequest
+        self.onFinish = onFinish
+        super.init()
+    }
+
+    func location() async throws -> CLLocation {
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.addWaiter(id: waiterID, continuation: continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelWaiter(id: waiterID)
+            }
+        }
+    }
+
+    func complete(with locations: [CLLocation]) {
+        if let latest = locations.last {
+            self.finish(.success(latest))
+        } else {
+            self.finish(.failure(LocationService.Error.unavailable))
+        }
+    }
+
+    func fail(with error: Swift.Error) {
+        self.finish(.failure(error))
+    }
+
+    func setBackgroundLocationUpdatesEnabled(_ enabled: Bool) {
+        self.manager?.allowsBackgroundLocationUpdates = enabled
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        let locs = locations
+        Task { @MainActor in
+            self.complete(with: locs)
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Swift.Error) {
+        let err = error
+        Task { @MainActor in
+            self.fail(with: err)
+        }
+    }
+
+    private func addWaiter(
+        id: UUID,
+        continuation: CheckedContinuation<CLLocation, Swift.Error>)
+    {
+        guard !self.didFinish else {
+            continuation.resume(throwing: LocationService.Error.unavailable)
+            return
+        }
+        self.waiters.append(Waiter(id: id, continuation: continuation))
+        guard !self.didStart else { return }
+        self.didStart = true
+        self.startRequest()
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = self.waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = self.waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+        if self.waiters.isEmpty {
+            self.finishWithoutWaiters()
+        }
+    }
+
+    private func finishWithoutWaiters() {
+        guard !self.didFinish else { return }
+        self.didFinish = true
+        self.stopRequest()
+        self.onFinish(self)
+    }
+
+    private func finish(_ result: Result<CLLocation, Swift.Error>) {
+        guard !self.didFinish else { return }
+        self.didFinish = true
+        let waiters = self.waiters
+        self.waiters.removeAll()
+        self.stopRequest()
+        self.onFinish(self)
+        for waiter in waiters {
+            switch result {
+            case let .success(location):
+                waiter.continuation.resume(returning: location)
+            case let .failure(error):
+                waiter.continuation.resume(throwing: error)
+            }
         }
     }
 }

--- a/apps/ios/Tests/LocationOneShotRequestTests.swift
+++ b/apps/ios/Tests/LocationOneShotRequestTests.swift
@@ -1,0 +1,175 @@
+import CoreLocation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+@MainActor
+struct LocationOneShotRequestTests {
+    @Test func `location service keeps incompatible accuracies separate`() async throws {
+        var startedAccuracies: [CLLocationAccuracy] = []
+        var requests: [LocationOneShotRequest] = []
+        let service = LocationService { desiredAccuracy, _, onFinish in
+            let request = LocationOneShotRequest(
+                startRequest: {
+                    startedAccuracies.append(desiredAccuracy)
+                },
+                stopRequest: {},
+                onFinish: onFinish)
+            requests.append(request)
+            return request
+        }
+
+        let coarse = Task {
+            @MainActor in
+            try await service.currentLocation(
+                params: OpenClawLocationGetParams(desiredAccuracy: .coarse),
+                desiredAccuracy: .coarse,
+                maxAgeMs: nil,
+                timeoutMs: 10000)
+        }
+        await Task.yield()
+
+        let precise = Task {
+            @MainActor in
+            try await service.currentLocation(
+                params: OpenClawLocationGetParams(desiredAccuracy: .precise),
+                desiredAccuracy: .precise,
+                maxAgeMs: nil,
+                timeoutMs: 10000)
+        }
+        await Task.yield()
+
+        #expect(startedAccuracies == [kCLLocationAccuracyKilometer, kCLLocationAccuracyBest])
+        #expect(requests.count == 2)
+
+        let coarseLocation = CLLocation(latitude: 37.0, longitude: -122.0)
+        let preciseLocation = CLLocation(latitude: 37.3349, longitude: -122.0090)
+        requests[0].complete(with: [coarseLocation])
+        requests[1].complete(with: [preciseLocation])
+
+        let resolvedCoarse = try await coarse.value
+        let resolvedPrecise = try await precise.value
+        #expect(resolvedCoarse.coordinate.latitude == coarseLocation.coordinate.latitude)
+        #expect(resolvedPrecise.coordinate.latitude == preciseLocation.coordinate.latitude)
+    }
+
+    @Test func `current location reuses one shot cache within max age`() async throws {
+        var startCount = 0
+        var requests: [LocationOneShotRequest] = []
+        let service = LocationService { _, _, onFinish in
+            let request = LocationOneShotRequest(
+                startRequest: {
+                    startCount += 1
+                },
+                stopRequest: {},
+                onFinish: onFinish)
+            requests.append(request)
+            return request
+        }
+
+        let first = Task {
+            @MainActor in
+            try await service.currentLocation(
+                params: OpenClawLocationGetParams(),
+                desiredAccuracy: .balanced,
+                maxAgeMs: nil,
+                timeoutMs: 10000)
+        }
+        await Task.yield()
+
+        #expect(startCount == 1)
+        #expect(requests.count == 1)
+
+        let location = CLLocation(latitude: 37.3349, longitude: -122.0090)
+        requests[0].complete(with: [location])
+        let firstLocation = try await first.value
+        #expect(firstLocation.coordinate.latitude == location.coordinate.latitude)
+
+        let cached = try await service.currentLocation(
+            params: OpenClawLocationGetParams(maxAgeMs: 60000),
+            desiredAccuracy: .balanced,
+            maxAgeMs: 60000,
+            timeoutMs: 10000)
+
+        #expect(startCount == 1)
+        #expect(cached.coordinate.longitude == location.coordinate.longitude)
+    }
+
+    @Test func `one shot request inherits background location setting`() async throws {
+        var inheritedBackgroundFlags: [Bool] = []
+        let service = LocationService { _, allowsBackgroundLocationUpdates, onFinish in
+            inheritedBackgroundFlags.append(allowsBackgroundLocationUpdates)
+            return LocationOneShotRequest(
+                startRequest: {},
+                stopRequest: {},
+                onFinish: onFinish)
+        }
+        service.setBackgroundLocationUpdatesEnabled(true)
+
+        let task = Task { @MainActor in try await service.requestLocationOnce() }
+        await Task.yield()
+
+        #expect(inheritedBackgroundFlags == [true])
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test func `concurrent waiters share one location request`() async throws {
+        var startCount = 0
+        var finishCount = 0
+        let request = LocationOneShotRequest(
+            startRequest: {
+                startCount += 1
+            },
+            stopRequest: {},
+            onFinish: { _ in
+                finishCount += 1
+            })
+
+        let first = Task { @MainActor in try await request.location() }
+        let second = Task { @MainActor in try await request.location() }
+        await Task.yield()
+
+        #expect(startCount == 1)
+
+        let location = CLLocation(latitude: 37.3349, longitude: -122.0090)
+        request.complete(with: [location])
+
+        let firstLocation = try await first.value
+        let secondLocation = try await second.value
+        #expect(firstLocation.coordinate.latitude == location.coordinate.latitude)
+        #expect(secondLocation.coordinate.longitude == location.coordinate.longitude)
+        #expect(finishCount == 1)
+    }
+
+    @Test func `last cancelled waiter stops and finishes request`() async {
+        var startCount = 0
+        var stopCount = 0
+        var finishCount = 0
+        let request = LocationOneShotRequest(
+            startRequest: {
+                startCount += 1
+            },
+            stopRequest: {
+                stopCount += 1
+            },
+            onFinish: { _ in
+                finishCount += 1
+            })
+
+        let task = Task { @MainActor in try await request.location() }
+        await Task.yield()
+
+        #expect(startCount == 1)
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(stopCount == 1)
+        #expect(finishCount == 1)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an iOS one-shot location bug where concurrent `location.get` calls could overwrite the single stored continuation. One caller could be left suspended or timed out when another request arrived before CoreLocation delivered its callback.

## Why This Change Was Made

`LocationService` now uses a `LocationOneShotRequest` helper that fans out one CoreLocation result to all compatible waiters. Requests are separated by requested accuracy, preserve max-age cache behavior, inherit background-location settings, and clean up on completion or cancellation so late callbacks cannot write into a newer request object.

## User Impact

Concurrent iOS location reads are more reliable: matching requests share one CoreLocation request, incompatible accuracy requests remain isolated, and cached fresh locations are reused for `maxAgeMs` calls.

## Evidence

- `swiftformat --config config/swiftformat apps/ios/Sources/Location/LocationService.swift apps/ios/Tests/LocationOneShotRequestTests.swift`
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/Location/LocationService.swift apps/ios/Tests/LocationOneShotRequestTests.swift`
- `swiftc -parse apps/ios/Sources/Location/LocationService.swift apps/ios/Tests/LocationOneShotRequestTests.swift -I apps/shared/OpenClawKit/Sources`
- `swiftc -typecheck -parse-as-library -strict-concurrency=complete -warn-concurrency -` scratch check for the one-shot helper's actor/cancellation shape
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after follow-up fixes
- Local Xcode proof gap: `xcodebuild`/`simctl` are unavailable because `xcode-select` points at `/Library/Developer/CommandLineTools`, and `xcodegen` is not installed in PATH. GitHub CI will provide the full iOS test/build signal.
- Remote proof gap: Blacksmith Testbox warmup failed because the account is not authenticated to the `openclaw` org; AWS Crabbox warmup failed because the local Crabbox broker is not logged in.

AI-assisted: yes.
