### PR TITLE
feat(agent-cli): accept message input from files and stdin

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -16,8 +16,8 @@ Related: [Agent send tool](/tools/agent-send)
 ## Options
 
 - `-m, --message <text>`: message body
-- `--message-file <path>`: read the message body from a UTF-8 file
-- `--message-stdin`: read the message body from stdin
+- `--message-file <path>`: read the message body from a regular UTF-8 text file
+- `--message-stdin`: read the message body from UTF-8 text stdin
 - `-t, --to <dest>`: recipient used to derive the session key
 - `--session-key <key>`: explicit session key to use for routing
 - `--session-id <id>`: explicit session id
@@ -53,7 +53,7 @@ openclaw agent --agent ops --message "Run locally" --local
 ## Notes
 
 - Pass exactly one of `--message`, `--message-file`, or `--message-stdin`.
-  File and stdin messages strip a leading UTF-8 BOM and preserve multiline content; they reject input that is not valid UTF-8.
+  File and stdin messages strip a leading UTF-8 BOM and preserve multiline content. File/stdin input is capped at 4 MiB and rejects symlink or non-regular files, invalid UTF-8, NUL bytes, and binary-looking data before dispatch.
 - Slash commands (for example `/compact`) cannot run through `--message`. The CLI rejects them and points you at the first-class command instead (`openclaw sessions compact <key>` for compaction).
 - `--local` and embedded fallback runs are one-shot: bundled MCP loopback resources and warm Claude stdio sessions opened for the run are retired after the reply, so scripted invocations do not leave local child processes running. Gateway-backed runs keep Gateway-owned MCP loopback resources under the running Gateway process instead.
 - With `--agent`, `--channel` and `--to` together, session routing follows the channel's canonical recipient and `session.dmScope`. Channels with a stable outbound-only recipient identity use a provider-owned session isolated from the agent's main session. `--reply-channel` and `--reply-account` affect delivery only.

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -17,6 +17,7 @@ Related: [Agent send tool](/tools/agent-send)
 
 - `-m, --message <text>`: message body
 - `--message-file <path>`: read the message body from a UTF-8 file
+- `--message-stdin`: read the message body from stdin
 - `-t, --to <dest>`: recipient used to derive the session key
 - `--session-key <key>`: explicit session key to use for routing
 - `--session-id <id>`: explicit session id
@@ -39,6 +40,7 @@ Related: [Agent send tool](/tools/agent-send)
 openclaw agent --to +15555550123 --message "status update" --deliver
 openclaw agent --agent ops --message "Summarize logs"
 openclaw agent --agent ops --message-file ./task.md
+printf 'Summarize logs' | openclaw agent --agent ops --message-stdin
 openclaw agent --agent ops --model openai/gpt-5.4 --message "Summarize logs"
 openclaw agent --session-key agent:ops:incident-42 --message "Summarize status"
 openclaw agent --agent ops --session-key incident-42 --message "Summarize status"
@@ -50,7 +52,8 @@ openclaw agent --agent ops --message "Run locally" --local
 
 ## Notes
 
-- Pass exactly one of `--message` or `--message-file`. `--message-file` strips a leading UTF-8 BOM and preserves multiline content; it rejects files that are not valid UTF-8.
+- Pass exactly one of `--message`, `--message-file`, or `--message-stdin`.
+  File and stdin messages strip a leading UTF-8 BOM and preserve multiline content; they reject input that is not valid UTF-8.
 - Slash commands (for example `/compact`) cannot run through `--message`. The CLI rejects them and points you at the first-class command instead (`openclaw sessions compact <key>` for compaction).
 - `--local` and embedded fallback runs are one-shot: bundled MCP loopback resources and warm Claude stdio sessions opened for the run are retired after the reply, so scripted invocations do not leave local child processes running. Gateway-backed runs keep Gateway-owned MCP loopback resources under the running Gateway process instead.
 - With `--agent`, `--channel` and `--to` together, session routing follows the channel's canonical recipient and `session.dmScope`. Channels with a stable outbound-only recipient identity use a provider-owned session isolated from the agent's main session. `--reply-channel` and `--reply-account` affect delivery only.

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -32,6 +32,15 @@ programmatic delivery. Full flag and behavior reference:
 
   </Step>
 
+  <Step title="Pipe a prompt from another command">
+    ```bash
+    printf 'Summarize this build log' | openclaw agent --agent ops --message-stdin
+    ```
+
+    Reads valid UTF-8 stdin as the agent message body.
+
+  </Step>
+
   <Step title="Target a specific agent or session">
     ```bash
     # Target a specific agent
@@ -68,6 +77,7 @@ programmatic delivery. Full flag and behavior reference:
 | --------------------------- | -------------------------------------------------------------------- |
 | `--message <text>`          | Inline message to send                                               |
 | `--message-file <path>`     | Read the message from a valid UTF-8 file                             |
+| `--message-stdin`           | Read the message from valid UTF-8 stdin                              |
 | `--to <dest>`               | Derive session key from a target (phone, chat id)                    |
 | `--session-key <key>`       | Use an explicit session key                                          |
 | `--agent <id>`              | Target a configured agent (uses its `main` session)                  |
@@ -88,8 +98,9 @@ programmatic delivery. Full flag and behavior reference:
 
 - By default, the CLI goes **through the Gateway**. Add `--local` to force the
   embedded runtime on the current machine.
-- Pass exactly one of `--message` or `--message-file`. File messages preserve
-  multiline content after removing an optional UTF-8 BOM.
+- Pass exactly one of `--message`, `--message-file`, or `--message-stdin`.
+  File and stdin messages preserve multiline content after removing an
+  optional UTF-8 BOM.
 - If the Gateway request fails, the CLI **falls back** to the local embedded
   run; a Gateway timeout falls back with a fresh session instead of racing the
   original transcript.
@@ -127,6 +138,9 @@ openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium
 
 # Multiline prompt from a file
 openclaw agent --agent ops --message-file ./task.md
+
+# Prompt from stdin
+printf 'Summarize logs' | openclaw agent --agent ops --message-stdin
 
 # Exact session key
 openclaw agent --session-key agent:ops:incident-42 --message "Summarize status"

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -76,8 +76,8 @@ programmatic delivery. Full flag and behavior reference:
 | Flag                        | Description                                                          |
 | --------------------------- | -------------------------------------------------------------------- |
 | `--message <text>`          | Inline message to send                                               |
-| `--message-file <path>`     | Read the message from a valid UTF-8 file                             |
-| `--message-stdin`           | Read the message from valid UTF-8 stdin                              |
+| `--message-file <path>`     | Read the message from a regular UTF-8 text file                      |
+| `--message-stdin`           | Read the message from valid UTF-8 text stdin                         |
 | `--to <dest>`               | Derive session key from a target (phone, chat id)                    |
 | `--session-key <key>`       | Use an explicit session key                                          |
 | `--agent <id>`              | Target a configured agent (uses its `main` session)                  |
@@ -100,7 +100,9 @@ programmatic delivery. Full flag and behavior reference:
   embedded runtime on the current machine.
 - Pass exactly one of `--message`, `--message-file`, or `--message-stdin`.
   File and stdin messages preserve multiline content after removing an
-  optional UTF-8 BOM.
+  optional UTF-8 BOM. File/stdin input is capped at 4 MiB and rejects symlink
+  or non-regular files, invalid UTF-8, NUL bytes, and binary-looking data
+  before dispatch.
 - If the Gateway request fails, the CLI **falls back** to the local embedded
   run; a Gateway timeout falls back with a fresh session instead of racing the
   original transcript.

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -36,6 +36,7 @@ export function registerAgentTurnCommand(
     .description("Run an agent turn via the Gateway (use --local for embedded)")
     .option("-m, --message <text>", "Message body for the agent")
     .option("--message-file <path>", "Read the agent message body from a UTF-8 file")
+    .option("--message-stdin", "Read the agent message body from stdin", false)
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-key <key>", "Explicit session key (agent:<id>:<key>, or scoped to --agent)")
     .option("--session-id <id>", "Use an explicit session id")
@@ -73,6 +74,7 @@ ${formatHelpExamples([
   ['openclaw agent --to +15555550123 --message "status update"', "Start a new session."],
   ['openclaw agent --agent ops --message "Summarize logs"', "Use a specific agent."],
   ["openclaw agent --agent ops --message-file ./task.md", "Read a multiline message file."],
+  ["printf 'Summarize logs' | openclaw agent --agent ops --message-stdin", "Read from stdin."],
   [
     'openclaw agent --session-key agent:ops:incident-42 --message "Summarize status"',
     "Target an exact session key.",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -1,8 +1,8 @@
 // Register agent tests cover agent command registration and option wiring.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { registerAgentsCommands } from "./register.agent.js";
 import { registerAgentTurnCommand } from "./register.agent-turn.js";
+import { registerAgentsCommands } from "./register.agent.js";
 
 const mocks = vi.hoisted(() => ({
   agentCliCommandMock: vi.fn(),
@@ -124,6 +124,17 @@ describe("agent command registration", () => {
     const [options, callRuntime, deps] = commandCall(agentCliCommandMock);
     expect((options as { message?: string }).message).toBeUndefined();
     expect((options as { messageFile?: string }).messageFile).toBe("task.md");
+    expect((options as { agent?: string }).agent).toBe("ops");
+    expect(callRuntime).toBe(runtime);
+    expect(deps).toBeUndefined();
+  });
+
+  it("forwards message stdin to the agent command", async () => {
+    await runCli(["agent", "--message-stdin", "--agent", "ops"]);
+
+    const [options, callRuntime, deps] = commandCall(agentCliCommandMock);
+    expect((options as { message?: string }).message).toBeUndefined();
+    expect((options as { messageStdin?: boolean }).messageStdin).toBe(true);
     expect((options as { agent?: string }).agent).toBe("ops");
     expect(callRuntime).toBe(runtime);
     expect(deps).toBeUndefined();

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -445,6 +445,57 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("rejects symlink message files before dispatch", async () => {
+    await withTempStore(async ({ dir }) => {
+      const targetFile = path.join(dir, "target.md");
+      const messageFile = path.join(dir, "linked.md");
+      fs.writeFileSync(targetFile, "secret from symlink", "utf8");
+      fs.symlinkSync(targetFile, messageFile);
+
+      await expect(
+        agentCliCommand({ messageFile, sessionKey: "agent:main:incident-42" }, runtime),
+      ).rejects.toThrow("Message file must be a regular file, not a symlink");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects non-regular message files before dispatch", async () => {
+    await withTempStore(async ({ dir }) => {
+      await expect(
+        agentCliCommand({ messageFile: dir, sessionKey: "agent:main:incident-42" }, runtime),
+      ).rejects.toThrow("Message file must be a regular file");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects oversized message files before dispatch", async () => {
+    await withTempStore(async ({ dir }) => {
+      const messageFile = path.join(dir, "large.md");
+      fs.writeFileSync(messageFile, Buffer.alloc(4 * 1024 * 1024 + 1, 0x61));
+
+      await expect(
+        agentCliCommand({ messageFile, sessionKey: "agent:main:incident-42" }, runtime),
+      ).rejects.toThrow("exceeds the maximum size of 4194304 bytes");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects NUL bytes in message files before dispatch", async () => {
+    await withTempStore(async ({ dir }) => {
+      const messageFile = path.join(dir, "task.md");
+      fs.writeFileSync(messageFile, Buffer.from("hello\0there", "utf8"));
+
+      await expect(
+        agentCliCommand({ messageFile, sessionKey: "agent:main:incident-42" }, runtime),
+      ).rejects.toThrow("NUL bytes are not allowed");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects message files that are not valid UTF-8", async () => {
     await withTempStore(async ({ dir }) => {
       const messageFile = path.join(dir, "task.bin");
@@ -452,8 +503,44 @@ describe("agentCliCommand", () => {
 
       await expect(
         agentCliCommand({ messageFile, sessionKey: "agent:main:incident-42" }, runtime),
-      ).rejects.toThrow("Message file must be valid UTF-8");
+      ).rejects.toThrow("must be valid UTF-8");
       expect(callGateway).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects oversized stdin before dispatch", async () => {
+    await withTempStore(async () => {
+      await expect(
+        agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+          stdin: Readable.from([Buffer.alloc(4 * 1024 * 1024, 0x61), Buffer.from("x")]),
+        }),
+      ).rejects.toThrow("exceeds the maximum size of 4194304 bytes");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects NUL bytes in stdin before dispatch", async () => {
+    await withTempStore(async () => {
+      await expect(
+        agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+          stdin: Readable.from([Buffer.from("hello\0there", "utf8")]),
+        }),
+      ).rejects.toThrow("NUL bytes are not allowed");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects binary-looking stdin before dispatch", async () => {
+    await withTempStore(async () => {
+      await expect(
+        agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+          stdin: Readable.from([Buffer.alloc(512, 0x01)]),
+        }),
+      ).rejects.toThrow("looks like binary data");
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -347,14 +348,90 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("reads UTF-8 stdin for gateway dispatch", async () => {
+    await withTempStore(async () => {
+      const messageBody = 'first line\n```json\n{"ok":true}\n```\nsecond line\n';
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+        stdin: Readable.from([Buffer.from(`\uFEFF${messageBody}`, "utf8")]),
+      });
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      const params = requireRecord(request.params, "gateway request params");
+      expect(params.message).toBe(messageBody);
+    });
+  });
+
+  it("reads UTF-8 stdin for local embedded dispatch", async () => {
+    await withTempStore(async () => {
+      const messageBody = 'first line\n```json\n{"ok":true}\n```\nsecond line\n';
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        { messageStdin: true, sessionKey: "agent:main:incident-42", local: true },
+        runtime,
+        { stdin: Readable.from([Buffer.from(`\uFEFF${messageBody}`, "utf8")]) },
+      );
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      const opts = requireRecord(
+        requireFirstCallArg(agentCommand, "embedded agent"),
+        "embedded agent options",
+      );
+      expect(opts.message).toBe(messageBody);
+      expect(opts).not.toHaveProperty("messageStdin");
+    });
+  });
+
   it("rejects inline and file messages together", async () => {
     await expect(
       agentCliCommand(
         { message: "inline", messageFile: "task.md", sessionKey: "agent:main:incident-42" },
         runtime,
       ),
-    ).rejects.toThrow("Use either --message or --message-file, not both");
+    ).rejects.toThrow("Use only one of --message, --message-file, or --message-stdin");
     expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects inline and stdin messages together", async () => {
+    await expect(
+      agentCliCommand(
+        { message: "inline", messageStdin: true, sessionKey: "agent:main:incident-42" },
+        runtime,
+        { stdin: Readable.from(["stdin"]) },
+      ),
+    ).rejects.toThrow("Use only one of --message, --message-file, or --message-stdin");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects file and stdin messages together", async () => {
+    await withTempStore(async ({ dir }) => {
+      const messageFile = path.join(dir, "message.md");
+      fs.writeFileSync(messageFile, "file message", "utf8");
+
+      await expect(
+        agentCliCommand(
+          { messageFile, messageStdin: true, sessionKey: "agent:main:incident-42" },
+          runtime,
+          { stdin: Readable.from(["stdin"]) },
+        ),
+      ).rejects.toThrow("Use only one of --message, --message-file, or --message-stdin");
+      expect(callGateway).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects empty stdin input", async () => {
+    await withTempStore(async () => {
+      await expect(
+        agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+          stdin: Readable.from([" \n\t"]),
+        }),
+      ).rejects.toThrow("--message-stdin input is empty");
+      expect(callGateway).not.toHaveBeenCalled();
+    });
   });
 
   it("reports missing message files before dispatch", async () => {
@@ -376,6 +453,17 @@ describe("agentCliCommand", () => {
       await expect(
         agentCliCommand({ messageFile, sessionKey: "agent:main:incident-42" }, runtime),
       ).rejects.toThrow("Message file must be valid UTF-8");
+      expect(callGateway).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects stdin input that is not valid UTF-8", async () => {
+    await withTempStore(async () => {
+      await expect(
+        agentCliCommand({ messageStdin: true, sessionKey: "agent:main:incident-42" }, runtime, {
+          stdin: Readable.from([Buffer.from([0xff])]),
+        }),
+      ).rejects.toThrow("--message-stdin input must be valid UTF-8");
       expect(callGateway).not.toHaveBeenCalled();
     });
   });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -70,6 +70,7 @@ const GATEWAY_TRANSIENT_CONNECT_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 
 type AgentCliOpts = {
   message?: string;
   messageFile?: string;
+  messageStdin?: boolean;
   agent?: string;
   model?: string;
   to?: string;
@@ -90,7 +91,7 @@ type AgentCliOpts = {
   extraSystemPrompt?: string;
   local?: boolean;
 };
-type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile"> & {
+type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile" | "messageStdin"> & {
   message: string;
 };
 
@@ -101,6 +102,7 @@ type AgentCliProcessLike = {
 };
 type AgentCliDeps = CliDeps & {
   process?: AgentCliProcessLike;
+  stdin?: NodeJS.ReadableStream;
 };
 type AgentGatewayCallIdentity = Pick<
   Parameters<typeof callGateway>[0],
@@ -178,7 +180,7 @@ function protectJsonStdout(opts: Pick<AgentCliOpts, "json">): void {
 
 function missingAgentMessageError(): Error {
   return new Error(
-    `Missing message. Use ${formatCliCommand('openclaw agent --message "..." --agent <id>')} or ${formatCliCommand("openclaw agent --message-file <path> --agent <id>")}.`,
+    `Missing message. Use ${formatCliCommand('openclaw agent --message "..." --agent <id>')}, ${formatCliCommand("openclaw agent --message-file <path> --agent <id>")}, or ${formatCliCommand("openclaw agent --message-stdin --agent <id>")}.`,
   );
 }
 
@@ -209,15 +211,54 @@ async function readAgentMessageFile(messageFile: string): Promise<string> {
   }
 }
 
-async function resolveAgentMessageOpts(opts: AgentCliOpts): Promise<AgentDispatchOpts> {
-  const { messageFile: rawMessageFile, ...rest } = opts;
+async function readAgentMessageStdin(
+  stream: NodeJS.ReadableStream = process.stdin,
+): Promise<string> {
+  if ((stream as { isTTY?: unknown }).isTTY === true) {
+    throw new Error(
+      "--message-stdin refuses to read from an interactive terminal; pipe input instead.",
+    );
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    if (typeof chunk === "string") {
+      chunks.push(Buffer.from(chunk, "utf8"));
+    } else if (chunk instanceof Uint8Array) {
+      chunks.push(Buffer.from(chunk));
+    } else {
+      chunks.push(Buffer.from(String(chunk), "utf8"));
+    }
+  }
+  try {
+    return MESSAGE_FILE_DECODER.decode(Buffer.concat(chunks)).replace(/^\uFEFF/, "");
+  } catch {
+    throw new Error("--message-stdin input must be valid UTF-8.");
+  }
+}
+
+async function resolveAgentMessageOpts(
+  opts: AgentCliOpts,
+  deps?: Pick<AgentCliDeps, "stdin">,
+): Promise<AgentDispatchOpts> {
+  const { messageFile: rawMessageFile, messageStdin: rawMessageStdin, ...rest } = opts;
   const messageFile = rawMessageFile?.trim();
   const hasInlineMessage = opts.message !== undefined;
-  if (hasInlineMessage && messageFile) {
-    throw new Error("Use either --message or --message-file, not both.");
+  const hasStdinMessage = rawMessageStdin === true;
+  const selectedSources = [hasInlineMessage, Boolean(messageFile), hasStdinMessage].filter(
+    Boolean,
+  ).length;
+  if (selectedSources > 1) {
+    throw new Error("Use only one of --message, --message-file, or --message-stdin.");
   }
   if (rawMessageFile !== undefined && !messageFile) {
     throw new Error("--message-file must not be empty.");
+  }
+  if (hasStdinMessage) {
+    const message = await readAgentMessageStdin(deps?.stdin);
+    if (!message.trim()) {
+      throw new Error("--message-stdin input is empty.");
+    }
+    return { ...rest, message };
   }
   if (messageFile) {
     const message = await readAgentMessageFile(messageFile);
@@ -910,7 +951,7 @@ export async function agentCliCommand(
   deps?: AgentCliDeps,
 ) {
   protectJsonStdout(opts);
-  const messageOpts = await resolveAgentMessageOpts(opts);
+  const messageOpts = await resolveAgentMessageOpts(opts, deps);
   // `/compact` cannot run as a plain CLI agent turn: the slash-command handler
   // rejects CLI-originated senders, so the message would fall through to a
   // normal turn and exit 0 without compacting anything (issue #90640 Gap B).

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,6 +1,6 @@
 // Gateway-first agent CLI implementation with embedded fallback for local/runtime failures.
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { lstat, open } from "node:fs/promises";
 import { TextDecoder } from "node:util";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -114,6 +114,8 @@ type AgentSessionModuleLoader = () => Promise<AgentSessionModule>;
 const AGENT_CLI_SIGNALS: readonly AgentCliSignal[] = ["SIGINT", "SIGTERM"];
 const GATEWAY_ABORT_RETRY_DELAYS_MS = [50, 150, 300, 600] as const;
 const GATEWAY_ABORT_REQUEST_TIMEOUT_MS = 2_000;
+const MAX_AGENT_MESSAGE_INPUT_BYTES = 4 * 1024 * 1024;
+const AGENT_MESSAGE_INPUT_READ_CHUNK_BYTES = 64 * 1024;
 const AGENT_CLI_SIGNAL_EXIT_CODES: Record<AgentCliSignal, number> = {
   SIGINT: 130,
   SIGTERM: 143,
@@ -184,6 +186,10 @@ function missingAgentMessageError(): Error {
   );
 }
 
+function formatMessageInputByteLimit(source: string): string {
+  return `${source} exceeds the maximum size of ${MAX_AGENT_MESSAGE_INPUT_BYTES} bytes.`;
+}
+
 function formatMessageFileReadFailure(messageFile: string, err: unknown): string {
   const code =
     typeof (err as { code?: unknown })?.code === "string" ? (err as { code: string }).code : "";
@@ -197,18 +203,79 @@ function formatMessageFileReadFailure(messageFile: string, err: unknown): string
   return `Unable to read message file ${messageFile}: ${message}`;
 }
 
-async function readAgentMessageFile(messageFile: string): Promise<string> {
-  let buffer: Buffer;
+function assertAgentMessageInputLooksText(buffer: Buffer, source: string): void {
+  const scanLength = Math.min(buffer.length, 4096);
+  let binaryControlBytes = 0;
+  for (let index = 0; index < scanLength; index += 1) {
+    const byte = buffer[index];
+    if (byte === 0) {
+      throw new Error(`${source} must be text; NUL bytes are not allowed.`);
+    }
+    if (byte < 32 && byte !== 9 && byte !== 10 && byte !== 12 && byte !== 13) {
+      binaryControlBytes += 1;
+    }
+  }
+  if (scanLength > 0 && binaryControlBytes / scanLength > 0.3) {
+    throw new Error(`${source} looks like binary data; provide UTF-8 text input.`);
+  }
+}
+
+function decodeAgentMessageInput(buffer: Buffer, source: string): string {
+  assertAgentMessageInputLooksText(buffer, source);
   try {
-    buffer = await readFile(messageFile);
+    return MESSAGE_FILE_DECODER.decode(buffer).replace(/^\uFEFF/, "");
+  } catch {
+    throw new Error(`${source} must be valid UTF-8.`);
+  }
+}
+
+async function readBoundedAgentMessageFileBuffer(messageFile: string): Promise<Buffer> {
+  let fileStat: Awaited<ReturnType<typeof lstat>>;
+  try {
+    fileStat = await lstat(messageFile);
+  } catch (err) {
+    throw new Error(formatMessageFileReadFailure(messageFile, err), { cause: err });
+  }
+  if (fileStat.isSymbolicLink()) {
+    throw new Error(`Message file must be a regular file, not a symlink: ${messageFile}`);
+  }
+  if (!fileStat.isFile()) {
+    throw new Error(`Message file must be a regular file: ${messageFile}`);
+  }
+  if (fileStat.size > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+    throw new Error(formatMessageInputByteLimit(`Message file ${messageFile}`));
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(messageFile, "r");
   } catch (err) {
     throw new Error(formatMessageFileReadFailure(messageFile, err), { cause: err });
   }
   try {
-    return MESSAGE_FILE_DECODER.decode(buffer).replace(/^\uFEFF/, "");
-  } catch {
-    throw new Error(`Message file must be valid UTF-8: ${messageFile}`);
+    const readBuffer = Buffer.allocUnsafe(AGENT_MESSAGE_INPUT_READ_CHUNK_BYTES);
+    for (;;) {
+      const { bytesRead } = await handle.read(readBuffer, 0, readBuffer.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytes += bytesRead;
+      if (totalBytes > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+        throw new Error(formatMessageInputByteLimit(`Message file ${messageFile}`));
+      }
+      chunks.push(Buffer.from(readBuffer.subarray(0, bytesRead)));
+    }
+  } finally {
+    await handle.close();
   }
+  return Buffer.concat(chunks, totalBytes);
+}
+
+async function readAgentMessageFile(messageFile: string): Promise<string> {
+  const buffer = await readBoundedAgentMessageFileBuffer(messageFile);
+  return decodeAgentMessageInput(buffer, `Message file ${messageFile}`);
 }
 
 async function readAgentMessageStdin(
@@ -220,20 +287,23 @@ async function readAgentMessageStdin(
     );
   }
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of stream) {
+    let buffer: Buffer;
     if (typeof chunk === "string") {
-      chunks.push(Buffer.from(chunk, "utf8"));
+      buffer = Buffer.from(chunk, "utf8");
     } else if (chunk instanceof Uint8Array) {
-      chunks.push(Buffer.from(chunk));
+      buffer = Buffer.from(chunk);
     } else {
-      chunks.push(Buffer.from(String(chunk), "utf8"));
+      buffer = Buffer.from(String(chunk), "utf8");
     }
+    totalBytes += buffer.length;
+    if (totalBytes > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+      throw new Error(formatMessageInputByteLimit("--message-stdin input"));
+    }
+    chunks.push(buffer);
   }
-  try {
-    return MESSAGE_FILE_DECODER.decode(Buffer.concat(chunks)).replace(/^\uFEFF/, "");
-  } catch {
-    throw new Error("--message-stdin input must be valid UTF-8.");
-  }
+  return decodeAgentMessageInput(Buffer.concat(chunks, totalBytes), "--message-stdin input");
 }
 
 async function resolveAgentMessageOpts(


### PR DESCRIPTION
## What Problem This Solves

`openclaw agent --message <text>` requires callers to put the entire agent prompt in process argv. In dogfood runs this made even short review prompts visible through `ps`, and private or long prompts would have the same input-boundary problem. This PR adds file-backed and stdin-backed message input so callers can pass private or long prompt bodies without placing the body in argv.

This is a command/input-boundary hygiene change only. It does not add session control, transcript retention authority, provider routing, dashboard authority, auth handling, secret custody, or installed wrapper/runtime mutation.

## What Changed

- Added `openclaw agent --message-file <path>`.
- Added `openclaw agent --message-stdin`.
- Enforced exactly one of `--message`, `--message-file`, and `--message-stdin`.
- Preserved existing `--message` compatibility for short non-secret text.
- Added bounded file/stdin reads with a 4 MiB cap.
- Rejected symlink/non-regular message files before dispatch.
- Rejected empty input, invalid UTF-8, NUL bytes, and binary-looking input before dispatch.
- Updated CLI/tool docs to steer private or long prompt bodies to file/stdin.

## Evidence

Local proof from packet `OPENCLAW-AGENT-MESSAGE-FILE-INPUT-BOUNDARY-SOURCE-PACKAGING-1`:

```text
node scripts/test-projects.mjs src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts
```

Result:

```text
2 Vitest shards passed
CLI shard: 17 tests passed
Commands shard: 83 tests passed
```

Formatting and diff hygiene:

```text
./node_modules/.bin/oxfmt --check --threads=1 src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts src/cli/program/register.agent-turn.ts src/cli/program/register.agent.test.ts docs/cli/agent.md docs/tools/agent-send.md
git diff --check
git diff --name-only origin/main...HEAD
git diff --stat origin/main...HEAD
```

Boundary proof:

- changed files are limited to CLI agent command registration, gateway command handling/tests, and CLI/tool docs;
- no `/opt/openclaw` installed package or wrapper mutation;
- no release-channel or promotion mutation;
- no session-control or retention behavior added.

Process-list body-absence proof, using the repo-local source entry only:

```text
node --import tsx src/entry.ts agent --agent main --message-file <temp-file> --timeout 0
node --import tsx src/entry.ts agent --agent main --message-stdin --timeout 0
```

Result:

```text
message-file argv: contained --message-file and temp path only; file body absent
message-stdin argv: contained --message-stdin only; stdin body absent
```

Raw-body scan proof:

```text
rg -n "raw-body|getRawBody|rawBody|req\\.body|request\\.body" src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts src/cli/program/register.agent-turn.ts src/cli/program/register.agent.test.ts docs/cli/agent.md docs/tools/agent-send.md
```

Result: no matches.

Packet lint/plan:

```text
/opt/fcore/bin/ei packet lint /srv/openclaw/shared/packets/OPENCLAW-AGENT-MESSAGE-FILE-INPUT-BOUNDARY-SOURCE-PACKAGING-1/README.md --json
/opt/fcore/bin/ei packet plan /srv/openclaw/shared/packets/OPENCLAW-AGENT-MESSAGE-FILE-INPUT-BOUNDARY-SOURCE-PACKAGING-1/README.md --json
```

Result: both `ok: true`; plan `ready: true`.

## Packet

Packet closeout:

```text
/srv/openclaw/shared/packets/OPENCLAW-AGENT-MESSAGE-FILE-INPUT-BOUNDARY-SOURCE-PACKAGING-1/receipts/gus-implementation-closeout-20260709.md
```

No issue closed: packet work `OPENCLAW-AGENT-MESSAGE-FILE-INPUT-BOUNDARY-SOURCE-PACKAGING-1`.