### PR TITLE
fix(ci): honor Kova performance report contracts

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -83,14 +83,14 @@ jobs:
             repeat: input
             deep_profile: "false"
             live: "false"
-            include_filters: "scenario:fresh-install scenario:gateway-performance scenario:bundled-plugin-startup scenario:bundled-runtime-deps scenario:agent-cold-warm-message"
+            include_filters: "scenario:fresh-install,scenario:gateway-performance,scenario:bundled-plugin-startup,scenario:bundled-runtime-deps,scenario:agent-cold-warm-message"
           - lane: mock-deep-profile
             title: Kova mock provider deep profile
             auth: mock
             repeat: "1"
             deep_profile: "true"
             live: "false"
-            include_filters: "scenario:fresh-install scenario:gateway-performance scenario:agent-cold-warm-message"
+            include_filters: "scenario:fresh-install,scenario:gateway-performance,scenario:agent-cold-warm-message"
           - lane: live-openai-candidate
             title: Kova live OpenAI GPT 5.5 agent turn
             auth: live
@@ -344,9 +344,7 @@ jobs:
             --json
           )
 
-          for filter in $INCLUDE_FILTERS; do
-            args+=(--include "$filter")
-          done
+          args+=(--include "$INCLUDE_FILTERS")
 
           if [[ "$MATRIX_DEEP_PROFILE" == "true" ]]; then
             args+=(--deep-profile)

--- a/scripts/lib/kova-report-gate.mjs
+++ b/scripts/lib/kova-report-gate.mjs
@@ -134,6 +134,10 @@ function validateRecord(recordValue) {
   return record;
 }
 
+function recordViolations(record) {
+  return record.violations === undefined ? [] : array(record.violations, "record violations");
+}
+
 function validateTargetCleanup(report) {
   if (!text(report.target, "report target").startsWith("local-build:")) {
     check(report.targetCleanup === null, "non-local target had cleanup metadata");
@@ -428,7 +432,7 @@ function validateProfiledFailure(record, card, group) {
     group.resourceInterpretation === "instrumented",
     "failed record group was not instrumented",
   );
-  const violations = array(record.violations, "record violations");
+  const violations = recordViolations(record);
   check(violations.length > 0, "failed record had no violations");
   for (const violationValue of violations) {
     const violation = object(violationValue, "violation");
@@ -488,7 +492,7 @@ export function evaluateToleratedPartialKovaReport(report) {
       "PARTIAL report had a non-PASS record",
     );
     check(
-      records.every((record) => array(record.violations, "record violations").length === 0),
+      records.every((record) => recordViolations(record).length === 0),
       "PARTIAL report had violations",
     );
   });
@@ -505,7 +509,7 @@ export function evaluateToleratedProfiledKovaReport(report) {
     check(
       records
         .filter((record) => record.status === "PASS")
-        .every((record) => array(record.violations, "record violations").length === 0),
+        .every((record) => recordViolations(record).length === 0),
       "PASS record had violations",
     );
     const failed = records.filter((record) => record.status === "FAIL");

--- a/test/scripts/kova-report-gate.test.ts
+++ b/test/scripts/kova-report-gate.test.ts
@@ -207,7 +207,6 @@ function partialReport(): JsonObject {
         state: { id: STATE },
         status: "PASS",
         surface: SURFACE,
-        violations: [],
       },
     ],
     schemaVersion: "kova.report.v1",
@@ -805,6 +804,10 @@ describe("scripts/lib/kova-report-gate.mjs", () => {
     [
       "rejects PARTIAL records with violations",
       (report) => setAt(report, ["records", 0, "violations"], [{}]),
+    ],
+    [
+      "rejects PARTIAL records with null violations",
+      (report) => setAt(report, ["records", 0, "violations"], null),
     ],
     [
       "rejects PARTIAL reports without sampled RSS",

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -16,6 +16,11 @@ type WorkflowStep = {
 
 type WorkflowJob = {
   steps?: WorkflowStep[];
+  strategy?: {
+    matrix?: {
+      include?: Array<{ include_filters?: string }>;
+    };
+  };
 };
 
 type Workflow = {
@@ -105,6 +110,22 @@ describe("OpenClaw performance workflow", () => {
     expect(runKova.run).toContain(
       "profiling-affected resource thresholds with no baseline regression",
     );
+  });
+
+  it("passes every configured scenario through one Kova include flag", () => {
+    const workflow = readWorkflow();
+    const includeFilters = workflow.jobs?.kova?.strategy?.matrix?.include?.map(
+      (lane) => lane.include_filters,
+    );
+    const runKova = findStep("Run Kova");
+
+    expect(includeFilters).toEqual([
+      "scenario:fresh-install,scenario:gateway-performance,scenario:bundled-plugin-startup,scenario:bundled-runtime-deps,scenario:agent-cold-warm-message",
+      "scenario:fresh-install,scenario:gateway-performance,scenario:agent-cold-warm-message",
+      "scenario:agent-cold-warm-message",
+    ]);
+    expect(runKova.run).toContain('args+=(--include "$INCLUDE_FILTERS")');
+    expect(runKova.run).not.toContain("for filter in $INCLUDE_FILTERS");
   });
 
   it("installs local workspace packages beside the OCM root tarball", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves release-performance failures where Kova reported all selected scenarios as passing, but OpenClaw's trusted adapter rejected clean records because their optional `violations` field was omitted. It also restores four intended scenario filters that were silently discarded by repeated scalar `--include` flags.

## Why This Change Was Made

The adapter now treats only an absent `violations` field as the canonical empty list emitted by pinned Kova; explicit null, malformed values, hidden PASS violations, and failed records without evidence remain rejected. The workflow passes one comma-separated include value, matching Kova's parser and preserving every configured scenario.

## User Impact

No product runtime behavior changes. Release performance validation can correctly evaluate clean Kova reports and now runs all configured install, gateway, plugin, runtime-dependency, and agent scenarios instead of only the final filter.

## Evidence

- Failed runs `29036241466` and `29036409792`: Kova 3/3 PASS, zero blocking cards; adapter failed on omitted `record.violations`.
- Pinned Kova `4f146016583018bad9e24f8e64a6af5f963bb7ee` explicitly deletes empty `record.violations` and parses comma-separated filters.
- Updated adapter accepts both the failed 5013 report and prior known-green report `29033038636`.
- Exact Kova matrix plan now preserves all five filters and selects six expected scenario/state entries; previous reports selected only `agent-cold-warm-message`.
- Blacksmith Testbox `tbx_01kx3ye9b155846xyrn0m36nw5`: focused tooling tests passed 93/93.
- Same Testbox: workflow validation, path-scoped `check:changed`, and `oxfmt --check` passed.
- Fresh structured autoreview: no findings, 0.98 confidence.
