### PR TITLE
fix(discord): inherit forum default_auto_archive_duration for thread creation

### DIFF
--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -32,7 +32,7 @@ import {
   buildDiscordSendError,
   createDiscordClient,
   resolveChannelId,
-  resolveDiscordChannelType,
+  resolveDiscordChannel,
   toDiscordFileBlob,
   stripUndefinedFields,
   SUPPRESS_NOTIFICATIONS_FLAG,
@@ -299,9 +299,9 @@ export async function sendDiscordComponentMessage(
   const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
-  const channelType = await resolveDiscordChannelType(rest, channelId);
+  const channel = await resolveDiscordChannel(rest, channelId);
 
-  if (channelType && DISCORD_FORUM_LIKE_TYPES.has(channelType)) {
+  if (channel && DISCORD_FORUM_LIKE_TYPES.has(channel.type)) {
     throw new Error("Discord components are not supported in forum-style channels");
   }
 

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements send.outbound behavior.
+import type { APIChannel, APIGuildForumChannel, APIGuildMediaChannel } from "discord-api-types/v10";
 import { ChannelType } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -28,7 +29,7 @@ import {
   normalizeStickerIds,
   resolveDiscordMessageFlags,
   resolveChannelId,
-  resolveDiscordChannelType,
+  resolveDiscordChannel,
   resolveDiscordSendComponents,
   resolveDiscordSendEmbeds,
   sendDiscordMedia,
@@ -121,8 +122,10 @@ function deriveForumThreadName(text: string): string {
 }
 
 /** Forum/Media channels cannot receive regular messages; detect them here. */
-function isForumLikeType(channelType?: number): boolean {
-  return channelType === ChannelType.GuildForum || channelType === ChannelType.GuildMedia;
+function isForumLikeChannel(
+  channel?: APIChannel,
+): channel is APIGuildForumChannel | APIGuildMediaChannel {
+  return channel?.type === ChannelType.GuildForum || channel?.type === ChannelType.GuildMedia;
 }
 
 function toDiscordSendResult(
@@ -199,9 +202,9 @@ export async function sendMessageDiscord(
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.
-  const channelType = await resolveDiscordChannelType(rest, channelId);
+  const channel = await resolveDiscordChannel(rest, channelId);
 
-  if (isForumLikeType(channelType)) {
+  if (isForumLikeChannel(channel)) {
     const threadName = deriveForumThreadName(textWithTables);
     const chunks = buildDiscordTextChunks(textWithMentions, {
       maxLinesPerMessage,
@@ -236,6 +239,11 @@ export async function sendMessageDiscord(
             {
               body: {
                 name: threadName,
+                // Discord clients preselect the parent default; the REST endpoint otherwise
+                // falls back to 4320 minutes, so carry the fetched parent value explicitly.
+                ...(channel.default_auto_archive_duration === undefined
+                  ? {}
+                  : { auto_archive_duration: channel.default_auto_archive_duration }),
                 message: starterBody,
               },
             },

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -432,7 +432,10 @@ describe("sendMessageDiscord", () => {
   it("auto-creates a forum thread when target is a Forum channel", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     // Channel type lookup returns a Forum channel.
-    getMock.mockResolvedValueOnce({ type: ChannelType.GuildForum });
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildForum,
+      default_auto_archive_duration: 1440,
+    });
     postMock.mockResolvedValue({
       id: "thread1",
       message: { id: "starter1", channel_id: "thread1" },
@@ -453,6 +456,7 @@ describe("sendMessageDiscord", () => {
     expectRestRoute(postMock, 0, Routes.threads("forum1"));
     expect(requireRestBody(postMock)).toEqual({
       name: "Discussion topic",
+      auto_archive_duration: 1440,
       message: {
         content: "Discussion topic\nBody of the post",
         flags: MessageFlags.SuppressEmbeds,

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -278,13 +278,12 @@ async function resolveDiscordTargetChannelId(
   return await resolveChannelId(rest, recipient, request);
 }
 
-export async function resolveDiscordChannelType(
+export async function resolveDiscordChannel(
   rest: RequestClient,
   channelId: string,
-): Promise<number | undefined> {
+): Promise<APIChannel | undefined> {
   try {
-    const channel = (await getChannel(rest, channelId)) as APIChannel | undefined;
-    return channel?.type;
+    return await getChannel(rest, channelId);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #103021: Discord forum/media threads created by `message action=send` ignored the parent channel's `default_auto_archive_duration`. When the field was omitted from the thread-create request, Discord used 4320 minutes instead of the operator's configured value such as 1440 minutes.

## Why This Change Was Made

The reported send path does not call `createThreadDiscord`; it calls `sendMessageDiscord`, which fetched the target channel only to classify its numeric type and then built the forum thread request directly in `send.outbound.ts`.

The revised fix carries that existing lookup forward as a typed Discord channel. Once narrowed to a forum/media parent, the send path copies its `default_auto_archive_duration` into the same thread-create request. This avoids another API request, preserves the field-absent fallback, and leaves the explicit `thread-create` action and its `autoArchiveMinutes` override unchanged.

## User Impact

- Implicit forum/media posts now use the parent channel's configured archive duration.
- Non-forum sends and component handling retain their existing behavior.
- The explicit `thread-create` action remains unchanged.
- No new config, environment variable, or message-tool parameter is introduced.

## Evidence

- Exact reviewed head: `fcb7c056d7b8bd4489e6565eef3a8c83abd889d2`.
- Blacksmith Testbox through Crabbox `tbx_01kx4hyrjn05y5r8ttcn8sykfh`: 206/206 focused Discord tests passed across the production send, explicit thread-create, component, and action-runtime surfaces.
- `pnpm check:changed`: extension production/test typechecks, lint, dependency/architecture guards, and runtime import-cycle checks passed.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.87 confidence.
- Discord's [channel resource contract](https://docs.discord.com/developers/resources/channel) exposes `default_auto_archive_duration` and accepts `auto_archive_duration` on forum/media thread creation; the pinned `discord-api-types@0.38.49` types match that contract.
- Live create/read-back was not run because neither the dedicated Testbox nor the maintainer checkout exposed an authorized Discord smoke credential/account. The linked issue supplies the shipped live 4320-minute symptom; the regression test proves the corrected 1440-minute request body.

Thanks @tzy-17 for the report-linked fix and contribution.
