### PR TITLE
fix(memory): keep QMD search hits on the matching file

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6298,6 +6298,89 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("keeps duplicate qmd docid lookups scoped by file hint", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const duplicateDocid = "dup123";
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              docid: duplicateDocid,
+              file: "qmd://workspace-main/a.md",
+              score: 0.9,
+              snippet: "@@ -1,1\nfirst",
+            },
+            {
+              docid: duplicateDocid,
+              file: "qmd://workspace-main/b.md",
+              score: 0.8,
+              snippet: "@@ -2,1\nsecond",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) => {
+          if (arg === duplicateDocid) {
+            return [
+              { collection: "workspace-main", path: "a.md" },
+              { collection: "workspace-main", path: "b.md" },
+            ];
+          }
+          return [];
+        },
+      }),
+      close: () => {},
+    };
+
+    const results = await manager.search("duplicate content", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    expect(results).toEqual([
+      {
+        path: "a.md",
+        startLine: 1,
+        endLine: 1,
+        score: 0.9,
+        snippet: "@@ -1,1\nfirst",
+        source: "memory",
+      },
+      {
+        path: "b.md",
+        startLine: 2,
+        endLine: 2,
+        score: 0.8,
+        snippet: "@@ -2,1\nsecond",
+        source: "memory",
+      },
+    ]);
+    await manager.close();
+  });
+
   it("resolves search hits when qmd returns qmd:// file URIs without docid", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -3010,7 +3010,15 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!normalized) {
       return null;
     }
-    const cacheKey = `${normalizedHints.preferredCollection ?? "*"}:${normalized}`;
+    // QMD docids are content hashes, so multiple paths can legitimately share one id.
+    // Keep the file hint in the cache key or a later hit can inherit the first path.
+    const cacheKey = [
+      normalizedHints.preferredCollection ?? "*",
+      normalized,
+      normalizedHints.preferredFile
+        ? path.normalize(normalizedHints.preferredFile).replace(/\\/g, "/")
+        : "*",
+    ].join(":");
     const cached = this.docPathCache.get(cacheKey);
     if (cached) {
       return cached;
@@ -3174,6 +3182,20 @@ export class QmdMemoryManager implements MemorySearchManager {
     rows: Array<{ collection: string; path: string }>,
     hints?: { preferredCollection?: string; preferredFile?: string },
   ): DocLocation | null {
+    if (hints?.preferredCollection && hints?.preferredFile) {
+      for (const row of rows) {
+        if (
+          row.collection !== hints.preferredCollection ||
+          !this.matchesPreferredFileHint(row.path, hints.preferredFile)
+        ) {
+          continue;
+        }
+        const location = this.toDocLocation(row.collection, row.path);
+        if (location) {
+          return location;
+        }
+      }
+    }
     if (hints?.preferredCollection) {
       for (const row of rows) {
         if (row.collection !== hints.preferredCollection) {

--- a/extensions/memory-core/src/qmd-session-artifacts.ts
+++ b/extensions/memory-core/src/qmd-session-artifacts.ts
@@ -243,18 +243,19 @@ function findQmdSessionArtifactByDocId(
   db: DatabaseSync,
   lookup: QmdSessionArtifactLookup,
 ): QmdSessionArtifactRow | null {
-  const docid = lookup.docid?.trim();
+  const docid = lookup.docid?.trim().replace(/^#/, "");
   if (!docid) {
     return null;
   }
+  const canPrefixMatch = /^[a-f0-9]+$/i.test(docid) ? 1 : 0;
   const rows = db
     .prepare(
       `SELECT collection, artifact_path, search_path, docid, archived, memory_key AS memoryKey,
               agent_id AS agentId, session_id AS sessionId
        FROM ${QMD_SESSION_ARTIFACT_TABLE}
-       WHERE docid = ?`,
+       WHERE docid = ? OR (? = 1 AND docid LIKE ?)`,
     )
-    .all(docid) as QmdSessionArtifactRow[];
+    .all(docid, canPrefixMatch, `${docid}%`) as QmdSessionArtifactRow[];
   return pickQmdSessionArtifactRow(rows, lookup);
 }
 
@@ -297,5 +298,5 @@ function pickQmdSessionArtifactRow(
   if (exact) {
     return exact;
   }
-  return rows.length === 1 ? (rows[0] ?? null) : null;
+  return null;
 }

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -2,12 +2,14 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { requireNodeSqlite } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   attachQmdSessionArtifactHit,
   copyQmdSessionArtifactHit,
+  refreshQmdSessionArtifactDocIds,
   replaceQmdSessionArtifactMappings,
   resolveQmdSessionArtifactIdentity,
 } from "./qmd-session-artifacts.js";
@@ -84,6 +86,36 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
       ],
     });
     return indexPath;
+  }
+
+  function seedQmdDocumentHash(params: {
+    artifactPath: string;
+    collection: string;
+    docid: string;
+    indexPath: string;
+  }): void {
+    const { DatabaseSync: SqliteDatabase } = requireNodeSqlite();
+    const db = new SqliteDatabase(params.indexPath);
+    try {
+      db.exec(
+        `CREATE TABLE IF NOT EXISTS documents (
+          collection TEXT NOT NULL,
+          path TEXT NOT NULL,
+          hash TEXT NOT NULL,
+          active INTEGER NOT NULL
+        )`,
+      );
+      db.prepare(
+        `INSERT INTO documents (collection, path, hash, active)
+         VALUES (?, ?, ?, 1)`,
+      ).run(params.collection, params.artifactPath, params.docid);
+    } finally {
+      db.close();
+    }
+    refreshQmdSessionArtifactDocIds({
+      collection: params.collection,
+      indexPath: params.indexPath,
+    });
   }
 
   function attachMappedQmdHit(
@@ -649,6 +681,45 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     });
 
     expect(filtered).toEqual([hit]);
+  });
+
+  it("requires path match before attaching short-docid QMD session artifact identity", async () => {
+    const searchPath = "qmd/sessions-main/visible.md";
+    const indexPath = await createQmdArtifactIndex({
+      agentId: "main",
+      artifactPath: "visible.md",
+      collection: "sessions-main",
+      searchPath,
+      sessionId: "visible",
+    });
+    seedQmdDocumentHash({
+      artifactPath: "visible.md",
+      collection: "sessions-main",
+      docid: "abc123def456",
+      indexPath,
+    });
+
+    expect(
+      resolveQmdSessionArtifactIdentity({
+        artifactPath: "visible.md",
+        collection: "sessions-main",
+        docid: "#abc123",
+        indexPath,
+        searchPath,
+      }),
+    ).toMatchObject({
+      agentId: "main",
+      sessionId: "visible",
+    });
+    expect(
+      resolveQmdSessionArtifactIdentity({
+        artifactPath: "other.md",
+        collection: "sessions-main",
+        docid: "#abc123",
+        indexPath,
+        searchPath: "qmd/sessions-main/other.md",
+      }),
+    ).toBeNull();
   });
 
   it("denies mapped QMD session hits before deprecated filename fallback", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching QMD-backed memory could see a result attached to the wrong file when multiple indexed documents share the same QMD docid/content hash.

Resolves a related problem where a short QMD session artifact docid could attach session identity even when the requested artifact path did not match the stored artifact row.

## Why This Change Was Made

QMD docids are content hashes, so duplicate docids across files are valid. The docid-to-path resolver now scopes its cache by the preferred file hint and prefers rows that match both collection and file when both hints are available.

Session artifact docid lookup now accepts leading-`#` short hex docids while still requiring the resolved row to match the requested artifact path or search path before attaching identity.

## User Impact

QMD memory search and session artifact results keep their original file/session identity instead of inheriting another file that happens to share the same content hash. This should make Memory search output more reliable for duplicated or copied content.

## Evidence

- `git diff --check`
- `node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/qmd-manager.ts extensions/memory-core/src/qmd-session-artifacts.ts extensions/memory-core/src/memory/qmd-manager.test.ts extensions/memory-core/src/session-search-visibility.test.ts`
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/qmd-manager.test.ts extensions/memory-core/src/session-search-visibility.test.ts` — 2 files passed, 170 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` — no accepted/actionable findings

AI-assisted: yes, using Codex. A redacted agent transcript was not included because transcript logs require explicit user approval before insertion.