### PR TITLE
fix(microsoft-foundry): remove shell:true from Azure CLI invocations

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -8,6 +8,30 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AzAccessToken, AzAccount } from "./shared.js";
 import { COGNITIVE_SERVICES_RESOURCE } from "./shared.js";
 
+// On Windows the Azure CLI ships as az.cmd, which execFile/execFileSync cannot
+// resolve without shell:true. shell:true passes args through cmd.exe, enabling
+// command injection. Resolve the full .cmd path so we can drop shell:true.
+let _resolvedAzCommand: string | undefined;
+function resolveAzCommand(): string {
+  if (_resolvedAzCommand === undefined) {
+    if (process.platform === "win32") {
+      try {
+        const result = execFileSync("where", ["az"], {
+          encoding: "utf-8",
+          timeout: 5_000,
+        });
+        const first = result.trim().split(/\r?\n/)[0];
+        _resolvedAzCommand = first?.trim() || "az.cmd";
+      } catch {
+        _resolvedAzCommand = "az.cmd";
+      }
+    } else {
+      _resolvedAzCommand = "az";
+    }
+  }
+  return _resolvedAzCommand;
+}
+
 function summarizeAzErrorMessage(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -46,10 +70,9 @@ function buildAzCommandError(error: Error, stderr: string, stdout: string): Erro
 export function execAz(args: string[]): string {
   return (
     normalizeOptionalString(
-      execFileSync("az", args, {
+      execFileSync(resolveAzCommand(), args, {
         encoding: "utf-8",
         timeout: 30_000,
-        shell: process.platform === "win32",
       }),
     ) ?? ""
   );
@@ -58,12 +81,11 @@ export function execAz(args: string[]): string {
 async function execAzAsync(args: string[]): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     execFile(
-      "az",
+      resolveAzCommand(),
       args,
       {
         encoding: "utf-8",
         timeout: 30_000,
-        shell: process.platform === "win32",
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -164,9 +186,8 @@ export async function azLoginDeviceCodeWithOptions(params: {
       ...(params.tenantId ? ["--tenant", params.tenantId] : []),
       ...(params.allowNoSubscriptions ? ["--allow-no-subscriptions"] : []),
     ];
-    const child = spawn("az", args, {
+    const child = spawn(resolveAzCommand(), args, {
       stdio: ["inherit", "pipe", "pipe"],
-      shell: process.platform === "win32",
     });
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];


### PR DESCRIPTION
## Summary

Remove `shell: true` from all `execFileSync`, `execFile`, and `spawn`
calls for the Azure CLI executable. On Windows, `shell: true` passes
arguments through `cmd.exe` which interprets shell metacharacters,
enabling command injection through user-controllable parameters like
`scope`, `subscriptionId`, and `tenantId`.

Replace with `where az` resolution on Windows to find the full `az.cmd`
path so `execFile`/`spawn` can invoke it directly without a shell.

## Real behavior proof

**Behavior addressed**: Azure CLI commands invoked with `shell: true` on Windows enabled command injection.

**Real environment tested**: Linux 4.19.112, Node 22.19.0, pnpm 11.2.2

**Exact steps or command run after this patch**:
```bash
pnpm test -- extensions/microsoft-foundry/
```

**After-fix evidence**:
```
Test Files  3 passed (3)
     Tests  111 passed (111)
```

**Observed result after the fix**: All 111 microsoft-foundry tests pass.

**What was not tested**: Windows-specific `where az` resolution was not tested on a Windows host. The Linux path (`resolveAzCommand()` returns `"az"`) is unchanged.

## Tests and validation

```
pnpm test -- extensions/microsoft-foundry/ — 111 passed
```

## Risk checklist

- [x] This change is backwards compatible — behavior on Linux/macOS unchanged
- [x] This change has been tested with existing configurations — 111 tests pass
- [x] I have updated relevant documentation — no docs changes needed
- [x] Breaking changes (if any) are documented in Summary — none on non-Windows
