### PR TITLE
fix: whatsapp replies before rich context is debounced

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -1043,9 +1043,41 @@ describe("web auto-reply connection", () => {
       reply,
     });
 
-    expect(capture.getLastOptions()?.shouldDebounce?.(msg)).toBe(true);
+    const shouldDebounce = capture.getLastOptions()?.shouldDebounce;
+    expect(shouldDebounce?.(msg)).toBe(true);
     expect(
-      capture.getLastOptions()?.shouldDebounce?.(
+      shouldDebounce?.(
+        createTestWebInboundMessage({
+          payload: {
+            body: "<media:image>",
+            media: { path: "/tmp/inbound.jpg", type: "image/jpeg" },
+          },
+          platform: { sendComposing, reply, sendMedia },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldDebounce?.(
+        createTestWebInboundMessage({
+          payload: {
+            body: "Location: -27.594870, -48.548219",
+            location: { latitude: -27.59487, longitude: -48.548219 },
+          },
+          platform: { sendComposing, reply, sendMedia },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldDebounce?.(
+        createTestWebInboundMessage({
+          payload: { body: "replying with more context" },
+          platform: { sendComposing, reply, sendMedia },
+          quote: { id: "quoted-1", body: "previous context" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldDebounce?.(
         createTestWebInboundMessage({
           payload: {
             body: "/stop\n\n[whatsapp attachment unavailable]",

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -263,15 +263,6 @@ export async function monitorWebChannel(
       });
       const shouldDebounce = (msg: WebInboundMessageInput) => {
         const normalized = normalizeWebInboundMessage(msg);
-        if (normalized.payload.media?.path || normalized.payload.media?.type) {
-          return false;
-        }
-        if (normalized.payload.location) {
-          return false;
-        }
-        if (normalized.quote?.id || normalized.quote?.body) {
-          return false;
-        }
         return !isControlCommandMessage(
           normalized.payload.commandBody ?? normalized.payload.body,
           cfg,

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -263,6 +263,9 @@ export async function monitorWebChannel(
       });
       const shouldDebounce = (msg: WebInboundMessageInput) => {
         const normalized = normalizeWebInboundMessage(msg);
+        if (normalized.payload.media?.type?.startsWith("audio/") === true) {
+          return false;
+        }
         return !isControlCommandMessage(
           normalized.payload.commandBody ?? normalized.payload.body,
           cfg,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -441,6 +441,42 @@ describe("whatsapp inbound dispatch", () => {
     });
   });
 
+  it("projects debounced media items into aligned context media lists", async () => {
+    const ctx = await buildWhatsAppInboundContext({
+      combinedBody: "<media:image>\n<media:image>",
+      msg: makeMsg({
+        payload: {
+          body: "<media:image>\n<media:image>",
+          media: {
+            path: "/tmp/first.jpg",
+            type: "image/jpeg",
+          },
+          mediaItems: [
+            {
+              path: "/tmp/first.jpg",
+              type: "image/jpeg",
+            },
+            {
+              path: "/tmp/second.png",
+              type: "image/png",
+            },
+          ],
+        },
+      }),
+      route: makeRoute(),
+      sender: {
+        e164: "+1000",
+      },
+    });
+
+    expectRecordFields(requireRecord(ctx, "multi media inbound context"), {
+      MediaPath: "/tmp/first.jpg",
+      MediaPaths: ["/tmp/first.jpg", "/tmp/second.png"],
+      MediaType: "image/jpeg",
+      MediaTypes: ["image/jpeg", "image/png"],
+    });
+  });
+
   it("marks authorized text slash commands as text command turns", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "/status",

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -329,16 +329,16 @@ export async function buildWhatsAppInboundContext(params: {
         })
       : undefined;
 
+  const mediaInputs =
+    params.msg.payload.mediaItems ?? (params.msg.payload.media ? [params.msg.payload.media] : []);
   const media = toInboundMediaFacts(
-    params.msg.payload.media?.path || params.msg.payload.media?.url
-      ? [
-          {
-            path: params.msg.payload.media?.path,
-            url: params.msg.payload.media?.url ?? params.msg.payload.media?.path,
-            contentType: params.msg.payload.media?.type,
-          },
-        ]
-      : undefined,
+    mediaInputs
+      .filter((entry) => entry.path || entry.url)
+      .map((entry) => ({
+        path: entry.path,
+        url: entry.url ?? entry.path,
+        contentType: entry.type,
+      })),
     { transcribed: (_entry, index) => params.mediaTranscribedIndexes?.includes(index) === true },
   );
   return buildChannelInboundEventContext({

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -15,6 +15,7 @@ import {
   formatLocationText,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import {
@@ -459,6 +460,7 @@ export async function attachWebInboxToSocket(
     admission: AdmittedWebInboundCallbackMessage["admission"];
     dedupeKey?: string;
     debounceKey?: string;
+    canonicalDebounceKey?: string;
     durableId?: string;
     readReceipt?: WhatsAppReadReceiptTarget;
     receiveOrder?: number;
@@ -468,7 +470,30 @@ export async function attachWebInboxToSocket(
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
   const activeInboundFlushes = new Set<Promise<void>>();
+  type ActiveInboundPreparationWindow = {
+    debounceKey: string;
+    expired: Promise<void>;
+    id: number;
+    lastReceivedAt: number;
+    releaseExpired: () => void;
+    task: Promise<void>;
+    cleanupTimeout: ReturnType<typeof setTimeout> | null;
+  };
+  type InboundPreparationReservation = {
+    key: string;
+    receivedAt: number;
+    debounceKey: string;
+    releaseDebounceHold?: () => void;
+    releaseTask: () => void;
+    previousTask?: Promise<void>;
+    window: ActiveInboundPreparationWindow;
+  };
+  const activeInboundPreparationWindows = new Map<string, ActiveInboundPreparationWindow>();
   const pendingMessageHandlers = new Set<Promise<void>>();
+  const pendingDebounceKeysByCanonical = new Map<string, Set<string>>();
+  let flushInboundDebounceKey: ((key: string) => Promise<void>) | undefined;
+  let holdInboundDebounceKey: ((key: string) => (() => void) | null) | undefined;
+  let nextInboundPreparationWindowId = 0;
   let nextReceiveOrder = 0;
   const publishPendingWorkState = (at = Date.now()) => {
     options.onPendingWorkChanged?.(
@@ -492,6 +517,150 @@ export async function attachWebInboxToSocket(
     }
     return `${admission.accountId}:${admission.conversation.id}:${senderKey}`;
   };
+  const buildNormalizedInboundDebounceKey = (inbound: NormalizedInboundMessage): string | null => {
+    const admission = inbound.access.admission;
+    const senderKey =
+      admission.conversation.kind === "group"
+        ? (inbound.senderE164 ?? inbound.participantJid ?? admission.sender.id)
+        : admission.conversation.id;
+    if (!senderKey) {
+      return null;
+    }
+    return `${admission.accountId}:${admission.conversation.id}:${senderKey}`;
+  };
+  const shouldSerializeInboundPreparation = (msg: WAMessage): boolean => {
+    if (inboundDebounceMs <= 0) {
+      return false;
+    }
+    const mediaPlaceholder = extractMediaPlaceholder(msg.message ?? undefined);
+    if (mediaPlaceholder === "<media:audio>") {
+      return false;
+    }
+    const body = extractText(msg.message ?? undefined) ?? mediaPlaceholder ?? "";
+    return !isControlCommandMessage(body, options.loadConfig?.() ?? options.cfg);
+  };
+  const scheduleInboundPreparationWindowCleanup = (
+    key: string,
+    state: ActiveInboundPreparationWindow,
+  ) => {
+    if (activeInboundPreparationWindows.get(key) !== state) {
+      return;
+    }
+    if (state.cleanupTimeout) {
+      clearTimeout(state.cleanupTimeout);
+    }
+    const cleanupDelayMs = Math.max(0, state.lastReceivedAt + inboundDebounceMs - Date.now());
+    state.cleanupTimeout = setTimeout(() => {
+      if (activeInboundPreparationWindows.get(key) !== state) {
+        return;
+      }
+      if (Date.now() - state.lastReceivedAt >= inboundDebounceMs) {
+        activeInboundPreparationWindows.delete(key);
+        state.releaseExpired();
+        return;
+      }
+      scheduleInboundPreparationWindowCleanup(key, state);
+    }, cleanupDelayMs);
+    state.cleanupTimeout.unref?.();
+  };
+  const reserveInboundPreparationWindow = (
+    key: string | null,
+    receivedAt: number,
+  ): InboundPreparationReservation | null => {
+    if (!key) {
+      return null;
+    }
+    const active = activeInboundPreparationWindows.get(key);
+    const withinActiveWindow =
+      active !== undefined && receivedAt - active.lastReceivedAt <= inboundDebounceMs;
+    if (active && !withinActiveWindow && active.cleanupTimeout) {
+      clearTimeout(active.cleanupTimeout);
+      active.cleanupTimeout = null;
+    }
+    if (active && !withinActiveWindow) {
+      active.releaseExpired();
+    }
+    let releaseTask!: () => void;
+    const task = new Promise<void>((resolve) => {
+      releaseTask = resolve;
+    });
+    const window =
+      withinActiveWindow && active
+        ? active
+        : (() => {
+            let releaseExpired!: () => void;
+            const expired = new Promise<void>((resolve) => {
+              releaseExpired = resolve;
+            });
+            const id = nextInboundPreparationWindowId++;
+            return {
+              debounceKey: `${key}:prepared:${id}`,
+              expired,
+              id,
+              lastReceivedAt: receivedAt,
+              releaseExpired,
+              task,
+              cleanupTimeout: null,
+            };
+          })();
+    const previousTask = withinActiveWindow ? window.task : undefined;
+    window.lastReceivedAt = receivedAt;
+    window.task = task;
+    activeInboundPreparationWindows.set(key, window);
+    return {
+      key,
+      receivedAt,
+      debounceKey: window.debounceKey,
+      releaseDebounceHold: withinActiveWindow
+        ? (holdInboundDebounceKey?.(window.debounceKey) ?? undefined)
+        : undefined,
+      releaseTask,
+      previousTask,
+      window,
+    };
+  };
+  const waitForLaterInboundPreparationWindows = async (
+    reservation: InboundPreparationReservation | null,
+  ) => {
+    if (!reservation) {
+      return;
+    }
+    while (true) {
+      const active = activeInboundPreparationWindows.get(reservation.key);
+      if (!active || active.lastReceivedAt <= reservation.receivedAt) {
+        return;
+      }
+      if (active === reservation.window) {
+        const latestTask = active.task;
+        await latestTask;
+        if (
+          activeInboundPreparationWindows.get(reservation.key) === active &&
+          active.task === latestTask
+        ) {
+          return;
+        }
+        continue;
+      }
+      return;
+    }
+  };
+  const runSerializedInboundPreparation = async <T>(
+    reservation: InboundPreparationReservation | null,
+    task: () => Promise<T>,
+  ): Promise<T> => {
+    if (!reservation) {
+      return await task();
+    }
+    try {
+      await reservation.previousTask?.catch(() => undefined);
+      return await task();
+    } finally {
+      reservation.releaseTask();
+      if (activeInboundPreparationWindows.get(reservation.key) === reservation.window) {
+        scheduleInboundPreparationWindowCleanup(reservation.key, reservation.window);
+      }
+    }
+  };
   const shouldDebounceInboundMessage = (msg: AdmittedWebInboundCallbackMessage): boolean =>
     options.shouldDebounce?.(msg) ?? true;
   const orderDebouncedInboundEntries = (entries: QueuedInboundMessage[]) =>
@@ -504,6 +673,38 @@ export async function attachWebInboxToSocket(
     });
   const firstDefined = <T>(values: Array<T | undefined>): T | undefined =>
     values.find((value): value is T => value !== undefined);
+  const collectMediaItems = (entries: QueuedInboundMessage[]) =>
+    entries.flatMap(
+      (entry) => entry.payload.mediaItems ?? (entry.payload.media ? [entry.payload.media] : []),
+    );
+  const rememberPendingDebounceKey = (canonicalKey: string, actualKey: string) => {
+    let keys = pendingDebounceKeysByCanonical.get(canonicalKey);
+    if (!keys) {
+      keys = new Set();
+      pendingDebounceKeysByCanonical.set(canonicalKey, keys);
+    }
+    keys.add(actualKey);
+  };
+  const forgetPendingDebounceKey = (canonicalKey: string | undefined, actualKey: string) => {
+    if (!canonicalKey) {
+      return;
+    }
+    const keys = pendingDebounceKeysByCanonical.get(canonicalKey);
+    if (!keys) {
+      return;
+    }
+    keys.delete(actualKey);
+    if (keys.size === 0) {
+      pendingDebounceKeysByCanonical.delete(canonicalKey);
+    }
+  };
+  const flushPendingDebounceKeysForCanonical = async (canonicalKey: string) => {
+    const keys = Array.from(pendingDebounceKeysByCanonical.get(canonicalKey) ?? []);
+    if (keys.length === 0) {
+      return;
+    }
+    await Promise.all(keys.map((key) => flushInboundDebounceKey?.(key) ?? Promise.resolve()));
+  };
 
   const finalizeInboundDelivery = async (
     entries: QueuedInboundMessage[],
@@ -584,6 +785,7 @@ export async function attachWebInboxToSocket(
           const combinedStructuredContext = orderedEntries.flatMap(
             (entry) => entry.payload.untrustedStructuredContext ?? [],
           );
+          const combinedMediaItems = collectMediaItems(orderedEntries);
           const combinedMentions =
             mentioned.size > 0
               ? {
@@ -604,7 +806,8 @@ export async function attachWebInboxToSocket(
               ...last.payload,
               body: combinedBody,
               commandBody: combinedCommandBody,
-              media: firstDefined(orderedEntries.map((entry) => entry.payload.media)),
+              media: combinedMediaItems[0],
+              mediaItems: combinedMediaItems.length > 0 ? combinedMediaItems : undefined,
               location: firstDefined(orderedEntries.map((entry) => entry.payload.location)),
               untrustedStructuredContext:
                 combinedStructuredContext.length > 0 ? combinedStructuredContext : undefined,
@@ -626,6 +829,7 @@ export async function attachWebInboxToSocket(
         for (const entry of entries) {
           if (entry.debounceKey) {
             pendingDebounceKeys.delete(entry.debounceKey);
+            forgetPendingDebounceKey(entry.canonicalDebounceKey, entry.debounceKey);
           }
         }
         activeInboundFlushes.delete(flushTask);
@@ -638,6 +842,8 @@ export async function attachWebInboxToSocket(
       inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
     },
   });
+  flushInboundDebounceKey = debouncer.flushKey;
+  holdInboundDebounceKey = debouncer.holdKey;
   const groupMetadataCache = options.groupMetadataCache ?? new Map();
   const groupMetaCache = new Map<string, LocalGroupMetadataCacheEntry>();
   const lidLookup = sock.signalRepository?.lidMapping;
@@ -1147,10 +1353,11 @@ export async function attachWebInboxToSocket(
   const buildDurableInboundPayload = (
     msg: WAMessage,
     upsertType: string | undefined,
+    receivedAt: number,
   ): WhatsAppDurableInboundPayload => ({
     message: serializeWhatsAppDurableInboundMessage(msg),
     ...(upsertType ? { upsertType } : {}),
-    receivedAt: Date.now(),
+    receivedAt,
   });
 
   const shouldSkipStaleAppend = (msg: WAMessage, upsertType: string | undefined): boolean => {
@@ -1174,6 +1381,7 @@ export async function attachWebInboxToSocket(
     msg: WAMessage,
     upsertType: string | undefined,
     receiveOrder: number | undefined,
+    receivedAt: number,
     stored?: {
       id: string;
       payload: WhatsAppDurableInboundPayload;
@@ -1212,10 +1420,10 @@ export async function attachWebInboxToSocket(
       try {
         const accepted = await durableInboundJournal.accept(
           durableId,
-          buildDurableInboundPayload(msg, upsertType),
+          buildDurableInboundPayload(msg, upsertType, receivedAt),
           {
             metadata: durableMetadata,
-            receivedAt: inbound.messageTimestampMs,
+            receivedAt,
           },
         );
         if (accepted.kind === "completed") {
@@ -1241,29 +1449,45 @@ export async function attachWebInboxToSocket(
       }
     }
 
-    const enriched = await enrichInboundMessage(msg);
-    if (!enriched) {
-      await completeUndeliverableDurableInbound(durableId, durableMetadata);
-      await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
-      return;
-    }
-
-    const dedupeKey = inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : "";
-    const dedupeClaim = dedupeKey ? await claimRecentInboundMessageDelivery(dedupeKey) : "claimed";
-    if (dedupeClaim !== "claimed") {
-      if (dedupeClaim === "duplicate") {
+    const preparationKey = shouldSerializeInboundPreparation(msg)
+      ? buildNormalizedInboundDebounceKey(inbound)
+      : null;
+    const preparationReservation = reserveInboundPreparationWindow(preparationKey, receivedAt);
+    const enriched = await runSerializedInboundPreparation(preparationReservation, async () => {
+      return await enrichInboundMessage(msg);
+    });
+    try {
+      if (!enriched) {
         await completeUndeliverableDurableInbound(durableId, durableMetadata);
         await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
+        return;
       }
-      return;
-    }
 
-    recordAcceptedInboundActivity(options.accountId);
-    await enqueueInboundMessage(msg, inbound, enriched, {
-      durableId,
-      readReceipt: deliveryReadReceipt,
-      receiveOrder,
-    });
+      const dedupeKey = inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : "";
+      const dedupeClaim = dedupeKey
+        ? await claimRecentInboundMessageDelivery(dedupeKey)
+        : "claimed";
+      if (dedupeClaim !== "claimed") {
+        if (dedupeClaim === "duplicate") {
+          await completeUndeliverableDurableInbound(durableId, durableMetadata);
+          await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
+        }
+        return;
+      }
+
+      await waitForLaterInboundPreparationWindows(preparationReservation);
+      recordAcceptedInboundActivity(options.accountId);
+      await enqueueInboundMessage(msg, inbound, enriched, {
+        durableId,
+        debounceKey: preparationReservation?.debounceKey,
+        canonicalDebounceKey: preparationReservation?.key,
+        releaseDebounceHold: preparationReservation?.releaseDebounceHold,
+        readReceipt: deliveryReadReceipt,
+        receiveOrder,
+      });
+    } finally {
+      preparationReservation?.releaseDebounceHold?.();
+    }
   };
 
   const replayPendingDurableInboundMessages = async () => {
@@ -1272,6 +1496,7 @@ export async function attachWebInboxToSocket(
       await processDurableInboundMessage(
         deserializeWhatsAppDurableInboundMessage(record.payload.message),
         record.payload.upsertType,
+        nextReceiveOrder++,
         record.payload.receivedAt,
         {
           id: record.id,
@@ -1373,6 +1598,9 @@ export async function attachWebInboxToSocket(
     enriched: EnrichedInboundMessage,
     durable: {
       durableId?: string;
+      debounceKey?: string;
+      canonicalDebounceKey?: string;
+      releaseDebounceHold?: () => void;
       readReceipt?: WhatsAppReadReceiptTarget;
       receiveOrder?: number;
     },
@@ -1519,12 +1747,23 @@ export async function attachWebInboxToSocket(
       readReceipt: durable.readReceipt,
       receiveOrder: durable.receiveOrder,
     });
-    const debounceKey = buildInboundDebounceKey(inboundMessage);
+    const canonicalDebounceKey =
+      durable.canonicalDebounceKey ?? buildInboundDebounceKey(inboundMessage);
+    const debounceKey = durable.debounceKey ?? canonicalDebounceKey;
     if (debounceKey) {
       inboundMessage.debounceKey = debounceKey;
-      if (inboundDebounceMs > 0 && shouldDebounceInboundMessage(inboundMessage)) {
+      inboundMessage.canonicalDebounceKey = canonicalDebounceKey ?? undefined;
+      const shouldDebounceMessage =
+        inboundDebounceMs > 0 && shouldDebounceInboundMessage(inboundMessage);
+      if (shouldDebounceMessage) {
         pendingDebounceKeys.add(debounceKey);
+        if (canonicalDebounceKey) {
+          rememberPendingDebounceKey(canonicalDebounceKey, debounceKey);
+        }
         publishPendingWorkState();
+      } else if (canonicalDebounceKey) {
+        durable.releaseDebounceHold?.();
+        await flushPendingDebounceKeysForCanonical(canonicalDebounceKey);
       }
     }
     if (inboundMessage.event.id) {
@@ -1556,7 +1795,10 @@ export async function attachWebInboxToSocket(
     }
   };
 
-  const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
+  const handleMessagesUpsert = async (
+    upsert: { type?: string; messages?: Array<WAMessage> },
+    receivedAt: number,
+  ) => {
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
@@ -1579,11 +1821,12 @@ export async function attachWebInboxToSocket(
         continue;
       }
 
-      await processDurableInboundMessage(msg, upsert.type, receiveOrder);
+      await processDurableInboundMessage(msg, upsert.type, receiveOrder, receivedAt);
     }
   };
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
-    const task = handleMessagesUpsert(upsert).catch((err: unknown) => {
+    const receivedAt = Date.now();
+    const task = handleMessagesUpsert(upsert, receivedAt).catch((err: unknown) => {
       inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
       inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
     });

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -502,6 +502,8 @@ export async function attachWebInboxToSocket(
       }
       return (a.receiveOrder ?? 0) - (b.receiveOrder ?? 0);
     });
+  const firstDefined = <T>(values: Array<T | undefined>): T | undefined =>
+    values.find((value): value is T => value !== undefined);
 
   const finalizeInboundDelivery = async (
     entries: QueuedInboundMessage[],
@@ -579,6 +581,9 @@ export async function attachWebInboxToSocket(
             .map((entry) => entry.payload.commandBody ?? entry.payload.body)
             .filter(Boolean)
             .join("\n");
+          const combinedStructuredContext = orderedEntries.flatMap(
+            (entry) => entry.payload.untrustedStructuredContext ?? [],
+          );
           const combinedMentions =
             mentioned.size > 0
               ? {
@@ -599,7 +604,12 @@ export async function attachWebInboxToSocket(
               ...last.payload,
               body: combinedBody,
               commandBody: combinedCommandBody,
+              media: firstDefined(orderedEntries.map((entry) => entry.payload.media)),
+              location: firstDefined(orderedEntries.map((entry) => entry.payload.location)),
+              untrustedStructuredContext:
+                combinedStructuredContext.length > 0 ? combinedStructuredContext : undefined,
             },
+            quote: firstDefined(orderedEntries.map((entry) => entry.quote)),
             group: combinedGroup,
             event: {
               ...last.event,

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -85,15 +85,18 @@ export type WhatsAppInboundGroupContext = {
   };
 };
 
+export type WhatsAppInboundMediaPayload = {
+  path?: string;
+  type?: string;
+  fileName?: string;
+  url?: string;
+};
+
 export type WhatsAppInboundPayload = {
   body: string;
   commandBody?: string;
-  media?: {
-    path?: string;
-    type?: string;
-    fileName?: string;
-    url?: string;
-  };
+  media?: WhatsAppInboundMediaPayload;
+  mediaItems?: WhatsAppInboundMediaPayload[];
   location?: NormalizedLocation;
   untrustedStructuredContext?: Array<{
     label: string;

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -958,6 +958,108 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("preserves media metadata when debounced with a follow-up text message", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: nextMessageId("debounce-image-1"),
+              fromMe: false,
+              remoteJid: "999@s.whatsapp.net",
+            },
+            message: { imageMessage: { mimetype: "image/jpeg" } },
+            messageTimestamp: 1_700_000_000,
+            pushName: "Tester",
+          },
+        ],
+      });
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-image-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "caption after image",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 1);
+      const inbound = inboundMessage(onMessage);
+      expect(inbound.payload.body).toBe("<media:image>\ncaption after image");
+      expect(inbound.payload.media).toMatchObject({
+        path: expect.any(String),
+        type: "image/jpeg",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves location metadata when debounced with a follow-up text message", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: nextMessageId("debounce-location-1"),
+              fromMe: false,
+              remoteJid: "999@s.whatsapp.net",
+            },
+            message: {
+              locationMessage: {
+                degreesLatitude: -27.59487,
+                degreesLongitude: -48.548219,
+                name: "test location",
+              },
+            },
+            messageTimestamp: 1_700_000_000,
+            pushName: "Tester",
+          },
+        ],
+      });
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-location-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "details after location",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 1);
+      const inbound = inboundMessage(onMessage);
+      expect(inbound.payload.body).toContain("-27.594870, -48.548219");
+      expect(inbound.payload.body).toContain("details after location");
+      expect(inbound.payload.location).toMatchObject({
+        latitude: -27.59487,
+        longitude: -48.548219,
+        name: "test location",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("lets a drained debounced inbound reply before closing the socket", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -958,6 +958,86 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("flushes pending debounced inbound before immediate control messages", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+        shouldDebounce: (msg) => msg.payload.commandBody !== "/stop",
+      });
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-before-command-1"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-before-command-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "/stop",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage).payload.body).toBe("first");
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("/stop");
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes pending debounced inbound before custom immediate messages", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+        shouldDebounce: (msg) => msg.payload.body !== "immediate",
+      });
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-before-custom-immediate-1"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-before-custom-immediate-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "immediate",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage).payload.body).toBe("first");
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("immediate");
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("preserves media metadata when debounced with a follow-up text message", async () => {
     vi.useFakeTimers();
     try {
@@ -1000,6 +1080,236 @@ describe("web monitor inbox", () => {
         path: expect.any(String),
         type: "image/jpeg",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for slow media enrichment before debouncing follow-up text", async () => {
+    vi.useFakeTimers();
+    try {
+      const { downloadMediaMessage } = await import("./inbound/runtime-api.js");
+      let releaseMedia!: () => void;
+      const mediaReady = new Promise<void>((resolve) => {
+        releaseMedia = resolve;
+      });
+      async function* delayedMediaStream() {
+        await mediaReady;
+        yield Buffer.from("delayed-media-data");
+      }
+      vi.mocked(downloadMediaMessage).mockImplementationOnce(() => delayedMediaStream() as never);
+
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      const firstReceivedAt = Date.now();
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: nextMessageId("debounce-slow-image-1"),
+              fromMe: false,
+              remoteJid: "999@s.whatsapp.net",
+            },
+            message: { imageMessage: { mimetype: "image/jpeg" } },
+            messageTimestamp: 1_700_000_000,
+            pushName: "Tester",
+          },
+        ],
+      });
+
+      await vi.waitFor(() => {
+        expect(downloadMediaMessage).toHaveBeenCalledTimes(1);
+      });
+      vi.setSystemTime(firstReceivedAt);
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-slow-image-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "caption after slow image",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(onMessage).not.toHaveBeenCalled();
+
+      releaseMedia();
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 1);
+      const inbound = inboundMessage(onMessage);
+      expect(inbound.payload.body).toBe("<media:image>\ncaption after slow image");
+      expect(inbound.payload.media).toMatchObject({
+        path: expect.any(String),
+        type: "image/jpeg",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not debounce slow media with follow-up text outside the window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { downloadMediaMessage } = await import("./inbound/runtime-api.js");
+      let releaseMedia!: () => void;
+      const mediaReady = new Promise<void>((resolve) => {
+        releaseMedia = resolve;
+      });
+      async function* delayedMediaStream() {
+        await mediaReady;
+        yield Buffer.from("delayed-media-data");
+      }
+      vi.mocked(downloadMediaMessage).mockImplementationOnce(() => delayedMediaStream() as never);
+
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      const firstReceivedAt = Date.now();
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: nextMessageId("debounce-slow-window-image-1"),
+              fromMe: false,
+              remoteJid: "999@s.whatsapp.net",
+            },
+            message: { imageMessage: { mimetype: "image/jpeg" } },
+            messageTimestamp: 1_700_000_000,
+            pushName: "Tester",
+          },
+        ],
+      });
+
+      await vi.waitFor(() => {
+        expect(downloadMediaMessage).toHaveBeenCalledTimes(1);
+      });
+      vi.setSystemTime(firstReceivedAt + 51);
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-slow-window-image-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "caption outside slow image window",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("caption outside slow image window");
+
+      releaseMedia();
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 2);
+      const delayedMedia = inboundMessage(onMessage, 1);
+      expect(delayedMedia.payload.body).toBe("<media:image>");
+      expect(delayedMedia.payload.media).toMatchObject({
+        path: expect.any(String),
+        type: "image/jpeg",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves all media metadata when debounced messages contain multiple attachments", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+      for (const id of ["debounce-image-a", "debounce-image-b"]) {
+        sock.ev.emit("messages.upsert", {
+          type: "notify",
+          messages: [
+            {
+              key: {
+                id: nextMessageId(id),
+                fromMe: false,
+                remoteJid: "999@s.whatsapp.net",
+              },
+              message: { imageMessage: { mimetype: "image/jpeg" } },
+              messageTimestamp: 1_700_000_000,
+              pushName: "Tester",
+            },
+          ],
+        });
+      }
+
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 1);
+      const inbound = inboundMessage(onMessage);
+      expect(inbound.payload.body).toBe("<media:image>\n<media:image>");
+      expect(inbound.payload.media).toMatchObject({
+        path: expect.any(String),
+        type: "image/jpeg",
+      });
+      expect(inbound.payload.mediaItems).toEqual([
+        expect.objectContaining({ path: expect.any(String), type: "image/jpeg" }),
+        expect.objectContaining({ path: expect.any(String), type: "image/jpeg" }),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps audio messages immediate when debounce predicate skips them", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+        shouldDebounce: (msg) => msg.payload.media?.type?.startsWith("audio/") !== true,
+      });
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: {
+              id: nextMessageId("debounce-audio-1"),
+              fromMe: false,
+              remoteJid: "999@s.whatsapp.net",
+            },
+            message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+            messageTimestamp: 1_700_000_000,
+            pushName: "Tester",
+          },
+        ],
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("<media:audio>");
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-audio-2"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "caption after audio",
+          timestamp: 1_700_000_001,
+          pushName: "Tester",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      await listener.close();
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("caption after audio");
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -39,6 +39,7 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  holds: Set<Promise<void>>;
   releaseReady: () => void;
   readyReleased: boolean;
   task: Promise<void>;
@@ -150,13 +151,31 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     buffer.releaseReady();
   };
 
-  const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
-    if (buffers.get(key) === buffer) {
-      buffers.delete(key);
+  const waitForHolds = async (buffer: DebounceBuffer<T>) => {
+    while (buffer.holds.size > 0) {
+      await Promise.allSettled(Array.from(buffer.holds));
     }
+  };
+
+  const flushBuffer = async (
+    key: string,
+    buffer: DebounceBuffer<T>,
+    options: { force?: boolean } = {},
+  ) => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
       buffer.timeout = null;
+    }
+    await waitForHolds(buffer);
+    if (buffer.timeout) {
+      if (!options.force) {
+        return;
+      }
+      clearTimeout(buffer.timeout);
+      buffer.timeout = null;
+    }
+    if (buffers.get(key) === buffer) {
+      buffers.delete(key);
     }
     // Reserve each key's execution slot as soon as the first buffered item
     // arrives, so later same-key work cannot overtake a timer-backed flush.
@@ -169,7 +188,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (!buffer) {
       return;
     }
-    await flushBuffer(key, buffer);
+    await flushBuffer(key, buffer, { force: true });
   };
 
   const cancelKey = (key: string): boolean => {
@@ -211,6 +230,32 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return true;
     }
     return new Set([...buffers.keys(), ...keyChains.keys()]).size < maxTrackedKeys;
+  };
+
+  const holdKey = (key: string): (() => void) | null => {
+    const buffer = buffers.get(key);
+    if (!buffer) {
+      return null;
+    }
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    buffer.holds.add(hold);
+    let released = false;
+    const releaseOnce = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      buffer.holds.delete(hold);
+      release();
+    };
+    hold.then(
+      () => buffer.holds.delete(hold),
+      () => buffer.holds.delete(hold),
+    );
+    return releaseOnce;
   };
 
   const enqueue = async (item: T) => {
@@ -278,6 +323,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       items: [item],
       timeout: null,
       debounceMs,
+      holds: new Set(),
       releaseReady: reservedTask.release,
       readyReleased: false,
       task: reservedTask.task,
@@ -286,5 +332,5 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey, cancelKey };
+  return { enqueue, flushKey, cancelKey, holdKey };
 }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -507,6 +507,62 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
+  it("holds buffered flushes until later same-key work joins", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 10,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    const release = debouncer.holdKey("a");
+    expect(release).toBeTypeOf("function");
+
+    await vi.advanceTimersByTimeAsync(10);
+    expect(calls).toEqual([]);
+
+    await debouncer.enqueue({ key: "a", id: "2" });
+    release?.();
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(calls).toEqual([["1", "2"]]);
+
+    vi.useRealTimers();
+  });
+
+  it("forces held buffered flushes after later same-key work joins", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 10,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    const release = debouncer.holdKey("a");
+    expect(release).toBeTypeOf("function");
+
+    const flush = debouncer.flushKey("a");
+    await debouncer.enqueue({ key: "a", id: "2" });
+    release?.();
+    await flush;
+
+    expect(calls).toEqual([["1", "2"]]);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(calls).toEqual([["1", "2"]]);
+
+    vi.useRealTimers();
+  });
+
   it("reports buffered items when cancelling a key", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -14,7 +14,9 @@ describe("createPluginRuntimeMock", () => {
     });
 
     expect(debouncer.cancelKey("key")).toBe(false);
+    expect(debouncer.holdKey("key")).toBeNull();
     expect(vi.isMockFunction(debouncer.cancelKey)).toBe(true);
+    expect(vi.isMockFunction(debouncer.holdKey)).toBe(true);
   });
 
   it("exposes channel inbound helpers without the removed turn aliases", async () => {

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -676,6 +676,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
             },
             flushKey: vi.fn(),
             cancelKey: vi.fn(() => false),
+            holdKey: vi.fn(() => null),
           }),
         ) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"],
         resolveInboundDebounceMs: vi.fn((params: unknown) => {


### PR DESCRIPTION
AI-assisted: yes (Codex)

No issue filed; this is a focused bug fix.

## What Problem This Solves

WhatsApp rich inbound messages could bypass the configured inbound debounce window. Images, locations, quoted replies, and slow media preparation could trigger an auto-reply before nearby context arrived, so the agent could answer with incomplete context.

## Why This Change Was Made

WhatsApp now only bypasses inbound debounce for control commands and audio voice notes. Rich inbound messages enter the configured debounce window, media preparation is coordinated by sender and receive window, and combined batches preserve media, location, quote, and structured context metadata.

## User Impact

Users who send an image, location, or quoted reply followed by more text should get one response based on the fuller message context. Stop/status/control commands and voice-note transcription behavior stay immediate.

## Evidence

- `pnpm --config.verify-deps-before-run=false test:extension whatsapp` — passed, 1040 tests
- `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/monitor-inbox.behavior.test.ts -t "preserves .* metadata|keeps audio messages immediate|slow media|immediate control messages|custom immediate messages"` — passed
- `node scripts/run-vitest.mjs --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/inbound.test.ts -t "holds buffered flushes|forces held buffered flushes|debounces and combines items|flushes buffered items before non-debounced item"` — passed
- `node scripts/run-vitest.mjs --config test/vitest/vitest.plugin-sdk.config.ts src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts -t "inbound debouncer mock"` — passed
- `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts -t "projects debounced media items|preserves remote-only inbound media URLs"` — passed
- `node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts -t "normalizes legacy flat listener messages and rejects partial nested input"` — passed
- `git diff --check origin/main...HEAD` — passed
- `codex review --base origin/main` — clean
