### PR TITLE
fix(agents): contain async progress callback failures

### DIFF
--- a/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
+++ b/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
@@ -61,4 +61,35 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect(unhandledRejections).toHaveLength(0);
   });
+
+  it("contains rejected assistant progress callbacks", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+    const rejectedCallback = vi.fn().mockRejectedValue(new Error("boom"));
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onAgentEvent: rejectedCallback,
+      onPartialReply: rejectedCallback,
+      onAssistantMessageStart: rejectedCallback,
+      onReasoningStream: rejectedCallback,
+      onReasoningEnd: rejectedCallback,
+      reasoningMode: "stream",
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "Hello" });
+    emitAssistantTextDelta({ emit, delta: "Hello" });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "Because" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "thinking_end" },
+    });
+    await waitForAsyncCallbacks();
+
+    expect(rejectedCallback).toHaveBeenCalled();
+    expect(unhandledRejections).toHaveLength(0);
+  });
 });

--- a/src/agents/embedded-agent-subscribe.callback.ts
+++ b/src/agents/embedded-agent-subscribe.callback.ts
@@ -1,0 +1,23 @@
+import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
+
+type CallbackLogger = {
+  warn(message: string): void;
+};
+
+/** Contains failures from untracked subscriber presentation and telemetry callbacks. */
+export function runBestEffortCallback(params: {
+  callback: () => void | Promise<void>;
+  label: string;
+  log: CallbackLogger;
+}): void {
+  try {
+    const result = params.callback();
+    if (isPromiseLike<void>(result)) {
+      void Promise.resolve(result).catch((error: unknown) => {
+        params.log.warn(`${params.label} callback failed: ${String(error)}`);
+      });
+    }
+  } catch (error) {
+    params.log.warn(`${params.label} callback failed: ${String(error)}`);
+  }
+}

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -7,6 +7,7 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { stripStaleAssistantUsageBeforeLatestCompaction } from "./compaction-usage.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
 
 type SessionCompactionStartEvent = Extract<AgentSessionEvent, { type: "compaction_start" }>;
@@ -63,9 +64,13 @@ export function handleCompactionStart(
     stream: "compaction",
     data: { phase: "start" },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "compaction",
-    data: { phase: "start" },
+  runBestEffortCallback({
+    label: "compaction agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "compaction",
+      data: { phase: "start" },
+    }),
   });
 
   // Hooks are fire-and-forget so compaction state updates and liveness pauses
@@ -153,9 +158,13 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+  runBestEffortCallback({
+    label: "compaction agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "compaction",
+      data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    }),
   });
 
   // after_compaction runs only once the run will not retry, matching the visible

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -31,7 +31,7 @@ vi.mock("../infra/agent-events.js", () => ({
 function createContext(
   lastAssistant: unknown,
   overrides?: {
-    onAgentEvent?: (event: unknown) => void;
+    onAgentEvent?: (event: unknown) => void | Promise<void>;
     onBeforeLifecycleTerminal?: () => void | Promise<void>;
     onBeforeTerminalDelivery?: () => void | Promise<void>;
     onBlockReply?: ((payload: unknown) => void) | undefined;
@@ -117,6 +117,18 @@ function firstWarnMeta(ctx: EmbeddedAgentSubscribeContext): Record<string, unkno
 }
 
 describe("handleAgentEnd", () => {
+  it("contains rejected lifecycle start event callbacks", async () => {
+    const onAgentEvent = vi.fn().mockRejectedValue(new Error("progress failed"));
+    const ctx = createContext(undefined, { onAgentEvent });
+
+    handleAgentStart(ctx);
+    await Promise.resolve();
+
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("lifecycle agent event callback failed"),
+    );
+  });
+
   it("keeps explicit session and agent identity on lifecycle start events", () => {
     emitAgentEventMock.mockClear();
     const ctx = createContext(undefined);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -25,6 +25,7 @@ import {
   hasAssistantVisibleReply,
 } from "./embedded-agent-subscribe.handlers.messages.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { isAssistantMessage } from "./embedded-agent-utils.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
@@ -51,9 +52,13 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
       startedAt: Date.now(),
     },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "lifecycle",
-    data: { phase: "start" },
+  runBestEffortCallback({
+    label: "lifecycle agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "lifecycle",
+      data: { phase: "start" },
+    }),
   });
 }
 
@@ -213,7 +218,10 @@ export function handleAgentEnd(
         endedAt: Date.now(),
       },
     });
-    void ctx.params.onAgentEvent?.({
+    runBestEffortCallback({
+      label: "lifecycle agent event",
+      log: ctx.log,
+      callback: () => ctx.params.onAgentEvent?.({
       stream: "lifecycle",
       data: {
         phase,
@@ -222,6 +230,7 @@ export function handleAgentEnd(
         ...(livenessState ? { livenessState } : {}),
         ...(replayInvalid ? { replayInvalid } : {}),
       },
+      }),
     });
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -220,7 +220,29 @@ function emitReasoningEnd(ctx: EmbeddedAgentSubscribeContext) {
     return;
   }
   ctx.state.reasoningStreamOpen = false;
-  void ctx.params.onReasoningEnd?.();
+  try {
+    const result = ctx.params.onReasoningEnd?.();
+    if (isPromiseLike<void>(result)) {
+      void Promise.resolve(result).catch((error: unknown) => {
+        ctx.log.warn(`reasoning end callback failed: ${String(error)}`);
+      });
+    }
+  } catch (error) {
+    ctx.log.warn(`reasoning end callback failed: ${String(error)}`);
+  }
+}
+
+function emitAssistantMessageStart(ctx: EmbeddedAgentSubscribeContext) {
+  try {
+    const result = ctx.params.onAssistantMessageStart?.();
+    if (isPromiseLike<void>(result)) {
+      void Promise.resolve(result).catch((error: unknown) => {
+        ctx.log.warn(`assistant message start callback failed: ${String(error)}`);
+      });
+    }
+  } catch (error) {
+    ctx.log.warn(`assistant message start callback failed: ${String(error)}`);
+  }
 }
 
 function openReasoningStream(ctx: EmbeddedAgentSubscribeContext) {
@@ -652,7 +674,7 @@ export function handleMessageStart(
   // re-trigger block replies.
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
   // Use assistant message_start as the earliest "writing" signal for typing.
-  void ctx.params.onAssistantMessageStart?.();
+  emitAssistantMessageStart(ctx);
 }
 
 /** Handles assistant message deltas, reasoning, directives, and block replies. */
@@ -791,7 +813,7 @@ export function handleMessageUpdate(
       streamItemChanged = true;
       void ctx.flushBlockReplyBuffer({ assistantMessageIndex: ctx.state.assistantMessageIndex });
       ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
-      void ctx.params.onAssistantMessageStart?.();
+      emitAssistantMessageStart(ctx);
     }
     ctx.state.lastAssistantStreamItemId = streamItemId;
   }

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -268,6 +268,18 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const pendingBlockReplyTasks = new Set<Promise<void>>();
   const replyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
+  const runBestEffortCallback = (label: string, callback: () => void | Promise<void>) => {
+    try {
+      const result = callback();
+      if (isPromiseLike<void>(result)) {
+        void Promise.resolve(result).catch((error: unknown) => {
+          log.warn(`${label} callback failed: ${String(error)}`);
+        });
+      }
+    } catch (error) {
+      log.warn(`${label} callback failed: ${String(error)}`);
+    }
+  };
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
   const emitAssistantStreamDataSafely = (
@@ -279,12 +291,16 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       stream: "assistant",
       data,
     });
-    void params.onAgentEvent?.({
-      stream: "assistant",
-      data,
-    });
+    if (params.onAgentEvent) {
+      runBestEffortCallback("assistant agent event", () =>
+        params.onAgentEvent?.({
+          stream: "assistant",
+          data,
+        }),
+      );
+    }
     if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-      void params.onPartialReply(data);
+      runBestEffortCallback("assistant partial reply", () => params.onPartialReply?.(data));
     }
   };
   const emitAssistantStreamData = (
@@ -730,11 +746,13 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     try {
-      void params.onToolResult({
-        text: parsed.text,
-        mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
-        ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
-      });
+      runBestEffortCallback("tool result", () =>
+        params.onToolResult?.({
+          text: parsed.text,
+          mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+          ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
+        }),
+      );
     } catch {
       // ignore tool result delivery failures
     }
@@ -1210,10 +1228,12 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // render hook — uniformly, whether the thinking block rode in on a tool call
     // or arrived on its own. It still reaches the bus/archive above.
     if (state.streamReasoning && !hasMessageToolOnlySourceDelivery() && params.onReasoningStream) {
-      void params.onReasoningStream({
-        text: trimmed,
-        ...(state.reasoningMode === "stream" ? {} : { requiresReasoningProgressOptIn: true }),
-      });
+      runBestEffortCallback("reasoning stream", () =>
+        params.onReasoningStream?.({
+          text: trimmed,
+          ...(state.reasoningMode === "stream" ? {} : { requiresReasoningProgressOptIn: true }),
+        }),
+      );
     }
   };
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -47,6 +47,7 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   buildToolLifecycleErrorResult,
@@ -268,18 +269,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const pendingBlockReplyTasks = new Set<Promise<void>>();
   const replyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
-  const runBestEffortCallback = (label: string, callback: () => void | Promise<void>) => {
-    try {
-      const result = callback();
-      if (isPromiseLike<void>(result)) {
-        void Promise.resolve(result).catch((error: unknown) => {
-          log.warn(`${label} callback failed: ${String(error)}`);
-        });
-      }
-    } catch (error) {
-      log.warn(`${label} callback failed: ${String(error)}`);
-    }
-  };
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
   const emitAssistantStreamDataSafely = (
@@ -292,15 +281,21 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       data,
     });
     if (params.onAgentEvent) {
-      runBestEffortCallback("assistant agent event", () =>
-        params.onAgentEvent?.({
+      runBestEffortCallback({
+        label: "assistant agent event",
+        log,
+        callback: () => params.onAgentEvent?.({
           stream: "assistant",
           data,
         }),
-      );
+      });
     }
     if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-      runBestEffortCallback("assistant partial reply", () => params.onPartialReply?.(data));
+      runBestEffortCallback({
+        label: "assistant partial reply",
+        log,
+        callback: () => params.onPartialReply?.(data),
+      });
     }
   };
   const emitAssistantStreamData = (
@@ -746,13 +741,15 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     try {
-      runBestEffortCallback("tool result", () =>
-        params.onToolResult?.({
+      runBestEffortCallback({
+        label: "tool result",
+        log,
+        callback: () => params.onToolResult?.({
           text: parsed.text,
           mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
           ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
         }),
-      );
+      });
     } catch {
       // ignore tool result delivery failures
     }
@@ -1228,12 +1225,14 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // render hook — uniformly, whether the thinking block rode in on a tool call
     // or arrived on its own. It still reaches the bus/archive above.
     if (state.streamReasoning && !hasMessageToolOnlySourceDelivery() && params.onReasoningStream) {
-      runBestEffortCallback("reasoning stream", () =>
-        params.onReasoningStream?.({
+      runBestEffortCallback({
+        label: "reasoning stream",
+        log,
+        callback: () => params.onReasoningStream?.({
           text: trimmed,
           ...(state.reasoningMode === "stream" ? {} : { requiresReasoningProgressOptIn: true }),
         }),
-      );
+      });
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

Embedded-agent subscribers may use asynchronous callbacks to render progress in a channel, update a UI, or record telemetry. Before this change, several fire-and-forget callback sites discarded the returned Promise. If any callback rejected, Node could report an unhandled rejection and terminate the Gateway even though the agent run and its core delivery path were otherwise healthy.

This affected assistant streaming, partial replies, reasoning, tool-result presentation, message-start notifications, lifecycle events, and compaction progress. Tracked block-reply delivery is deliberately not changed: it retains its existing await-and-drain behavior.

## Why This Change Was Made

The fix introduces one shared best-effort callback wrapper for all untracked embedded-subscription presentation and telemetry callbacks. It catches both synchronous throws and asynchronous Promise rejections, then writes a category-specific warning instead of allowing the rejection to escape the process.

The shared wrapper is used by the root subscription path plus lifecycle and compaction handlers, so callback containment follows the full `onAgentEvent: void | Promise<void>` contract rather than only the originally observed assistant-stream path.

## User Impact

An agent run now remains active when a non-essential progress subscriber fails. Users may lose that one display/telemetry update, but the Gateway no longer crashes and terminal/trackable delivery paths keep their existing behavior.

## Evidence

- Added regression coverage for rejected assistant-progress callbacks and lifecycle-start callbacks; existing rejected block-reply cases remain covered.
- Ran:
  `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/embedded-agent-subscribe.handlers.compaction.test.ts`
  Result: 60 tests passed in 3 files.
- `git diff --check` passed.
- The latest PR CI report contains no failing or pending checks.
- Repository autoreview was rerun after the lifecycle/compaction follow-up; no accepted findings remained.
