### PR TITLE
fix(channels): stop sends after delivery cancellation

### DIFF
--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -39,8 +39,6 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
-  /** Cancellation owned by the current outbound delivery attempt. */
-  abortSignal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   /** @internal Opaque durable intent id for exact provider-side send reconciliation. */
   deliveryQueueId?: string;
@@ -140,7 +138,10 @@ export type ChannelOutboundTargetRef = {
   threadId?: string | number | null;
 };
 
-export type ChannelOutboundFormattedContext = ChannelOutboundContext;
+/** Context for channel-native formatting sends that can observe delivery cancellation. */
+export type ChannelOutboundFormattedContext = ChannelOutboundContext & {
+  abortSignal?: AbortSignal;
+};
 
 export type ChannelOutboundChunkContext = {
   formatting?: OutboundDeliveryFormattingOptions;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -39,6 +39,8 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  /** Cancellation owned by the current outbound delivery attempt. */
+  abortSignal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   /** @internal Opaque durable intent id for exact provider-side send reconciliation. */
   deliveryQueueId?: string;
@@ -138,9 +140,7 @@ export type ChannelOutboundTargetRef = {
   threadId?: string | number | null;
 };
 
-export type ChannelOutboundFormattedContext = ChannelOutboundContext & {
-  abortSignal?: AbortSignal;
-};
+export type ChannelOutboundFormattedContext = ChannelOutboundContext;
 
 export type ChannelOutboundChunkContext = {
   formatting?: OutboundDeliveryFormattingOptions;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4299,6 +4299,36 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMatrix).not.toHaveBeenCalled();
   });
 
+  it("stops before the platform send when a reply hook aborts delivery", async () => {
+    const abortController = new AbortController();
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "reply_payload_sending",
+    );
+    hookMocks.runner.runReplyPayloadSending.mockImplementationOnce(async (event) => {
+      abortController.abort();
+      return { payload: (event as { payload: unknown }).payload };
+    });
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "a" }],
+        deps: { matrix: sendMatrix },
+        abortSignal: abortController.signal,
+        replyPayloadSendingHook: {
+          kind: "final",
+          channel: "matrix",
+          context: { channelId: "matrix", conversationId: "!room:example" },
+        },
+      }),
+    ).rejects.toThrow("Operation aborted");
+
+    expect(sendMatrix).not.toHaveBeenCalled();
+  });
+
   it("passes normalized payload to onError", async () => {
     const sendMatrix = vi.fn().mockRejectedValue(new Error("boom"));
     const onError = vi.fn();

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -18,6 +18,7 @@ import type {
   ChannelDeliveryCapabilities,
   ChannelOutboundAdapter,
   ChannelOutboundContext,
+  ChannelOutboundFormattedContext,
   ChannelOutboundPayloadContext,
   ChannelOutboundTargetRef,
 } from "../../channels/plugins/types.adapters.js";
@@ -405,8 +406,9 @@ function createPluginHandler(
     threadId?: string | number | null;
     audioAsVoice?: boolean;
     formatting?: OutboundDeliveryFormattingOptions;
-  }): Omit<ChannelOutboundContext, "text" | "mediaUrl"> => ({
+  }): Omit<ChannelOutboundFormattedContext, "text" | "mediaUrl"> => ({
     ...baseCtx,
+    abortSignal: params.abortSignal,
     replyToId: overrides && "replyToId" in overrides ? overrides.replyToId : baseCtx.replyToId,
     replyToIdSource:
       overrides && "replyToIdSource" in overrides
@@ -652,7 +654,6 @@ function createChannelOutboundContextBase(
     forceDocument: params.forceDocument,
     deps: params.deps,
     silent: params.silent,
-    abortSignal: params.abortSignal,
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -210,6 +210,7 @@ type ChannelHandlerParams = {
   gifPlayback?: boolean;
   forceDocument?: boolean;
   silent?: boolean;
+  abortSignal?: AbortSignal;
   mediaAccess?: OutboundMediaAccess;
   gatewayClientScopes?: readonly string[];
   deliveryQueueId?: string;
@@ -508,6 +509,7 @@ function createPluginHandler(
             if (messagePayload) {
               const messagePayloadCtx = {
                 ...payloadCtx,
+                signal: params.abortSignal,
                 onDeliveryResult: onMessageDeliveryResult,
               };
               const sent = await runChannelMessageSendWithLifecycle({
@@ -558,7 +560,11 @@ function createPluginHandler(
       };
       assertUnknownSendReconciliationKind("text");
       if (messageText) {
-        const messageTextCtx = { ...textCtx, onDeliveryResult: onMessageDeliveryResult };
+        const messageTextCtx = {
+          ...textCtx,
+          signal: params.abortSignal,
+          onDeliveryResult: onMessageDeliveryResult,
+        };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
           ctx: messageTextCtx,
@@ -585,7 +591,11 @@ function createPluginHandler(
       };
       assertUnknownSendReconciliationKind("media");
       if (messageMedia) {
-        const messageMediaCtx = { ...mediaCtx, onDeliveryResult: onMessageDeliveryResult };
+        const messageMediaCtx = {
+          ...mediaCtx,
+          signal: params.abortSignal,
+          onDeliveryResult: onMessageDeliveryResult,
+        };
         const sent = await runChannelMessageSendWithLifecycle({
           lifecycle: messageLifecycle,
           ctx: messageMediaCtx,
@@ -642,6 +652,7 @@ function createChannelOutboundContextBase(
     forceDocument: params.forceDocument,
     deps: params.deps,
     silent: params.silent,
+    abortSignal: params.abortSignal,
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,
@@ -1854,6 +1865,7 @@ async function deliverOutboundPayloadsCore(
       gifPlayback: params.gifPlayback,
       forceDocument: params.forceDocument,
       silent: params.silent,
+      abortSignal,
       mediaAccess: resolveMediaAccess(mediaSources),
       gatewayClientScopes: params.gatewayClientScopes,
       deliveryQueueId: params.deliveryQueueId,
@@ -2028,6 +2040,7 @@ async function deliverOutboundPayloadsCore(
         hook: params.replyPayloadSendingHook,
         payload,
       });
+      throwIfAborted(abortSignal);
       if (replyHookResult.cancelled) {
         recordPayloadOutcome(
           suppressedPayloadOutcome({
@@ -2053,6 +2066,7 @@ async function deliverOutboundPayloadsCore(
         threadId: params.threadId,
         sessionKey: sessionKeyForInternalHooks,
       });
+      throwIfAborted(abortSignal);
       if (hookResult.cancelled) {
         const hookEffect =
           hookResult.cancelReason || hookResult.hookMetadata
@@ -2077,6 +2091,7 @@ async function deliverOutboundPayloadsCore(
       const renderedPayload = stripInternalRuntimeScaffoldingFromPayload(
         await renderPresentationForDelivery(presentationHandler, deliveryPayload),
       );
+      throwIfAborted(abortSignal);
       const renderedHandler = await getDeliveryHandler(
         buildPayloadSummary(renderedPayload).mediaUrls,
       );
@@ -2103,6 +2118,7 @@ async function deliverOutboundPayloadsCore(
       }
       payloadSummary = buildPayloadSummary(effectivePayload);
       const deliveryHandler = await getDeliveryHandler(payloadSummary.mediaUrls);
+      throwIfAborted(abortSignal);
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
 
       params.onPayload?.(payloadSummary);
@@ -2133,6 +2149,7 @@ async function deliverOutboundPayloadsCore(
           effectivePayload.audioAsVoice === true)
       ) {
         const beforeCount = results.length;
+        throwIfAborted(abortSignal);
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,
           applySendReplyToConsumption(sendOverrides),
@@ -2174,6 +2191,7 @@ async function deliverOutboundPayloadsCore(
       }
       if (payloadSummary.mediaUrls.length === 0) {
         const beforeCount = results.length;
+        throwIfAborted(abortSignal);
         if (deliveryHandler.sendFormattedText) {
           await recordIdentifiedDeliveryResults(
             await deliveryHandler.sendFormattedText(
@@ -2240,6 +2258,7 @@ async function deliverOutboundPayloadsCore(
           );
         }
         const beforeCount = results.length;
+        throwIfAborted(abortSignal);
         await sendTextChunks(deliveryHandler, fallbackText, sendOverrides);
         const deliveredResults = results.slice(beforeCount);
         if (deliveredResults.length > 0) {


### PR DESCRIPTION
## What Problem This Solves

An outbound delivery can be cancelled while a reply-payload hook, message-sending hook, or presentation renderer is still awaiting. Previously the delivery loop checked cancellation only before those stages, so it could resume afterward and send a late channel message even though the agent run had already been cancelled.

The Signal formatter also had per-chunk abort checks but was not receiving the delivery attempt's signal, making those checks ineffective for durable outbound sends.

## Why This Change Was Made

The delivery loop now rechecks the existing abort signal after every fallible pre-send stage and immediately before each platform send. The signal is forwarded to message adapters as `signal` and to channel-native formatted sends through the existing narrow `ChannelOutboundFormattedContext` contract. The broader `ChannelOutboundContext` remains unchanged, avoiding an unnecessary plugin API expansion.

This preserves existing delivery queue semantics: cancellation occurs before platform I/O, so the normal abort queue cleanup path remains authoritative.

## User Impact

Cancelled runs no longer produce late outbound messages after hook or rendering work finishes. Channels that support cooperative cancellation, including Signal's chunked formatted sender, receive the same delivery attempt signal.

## Evidence

- Added a regression test that aborts inside `reply_payload_sending` and asserts the Matrix platform sender is never invoked.
- Ran:
  `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts`
  Result: 138 tests passed.
- `git diff --check` passed.
- The initial full CI matrix passed; the latest narrow contract refinement is currently running with no failed checks reported.
- Repository autoreview was rerun after narrowing the plugin-facing contract; no accepted findings remained.
