### PR TITLE
feat: toggle the session workspace rail with Command-Shift-B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
+- **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -246,6 +246,7 @@ The terminal is also available as a full-screen, terminal-only document at `/?vi
     - In the macOS app, the OpenClaw mark uses the otherwise-empty native titlebar strip next to the window controls instead of consuming a sidebar row.
     - On desktop widths, chat controls stay on one compact row and collapse while scrolling down the transcript; scrolling up, returning to the top, or reaching the bottom restores the controls.
     - Consecutive duplicate text-only messages render as one bubble with a count badge. Messages that carry images, attachments, tool output, or canvas previews are left uncollapsed.
+    - The session workspace rail on the right side of each Chat pane lists session files, project files, and artifacts. Press ⇧⌘B to expand or collapse the active pane's rail; the separate file, tool, and Canvas detail panel is unaffected.
     - The chat header model and thinking pickers patch the active session immediately through `sessions.patch`; they are persistent session overrides, not one-turn-only send options.
     - **Split view:** open it from the bottom-right page action, then split the active pane right or down for as many panes as fit. Each pane has its own session, transcript, composer, and tool stream.
     - Drag a session from the sidebar into chat to open it in a pane. An animated drop preview glides between zones and labels the outcome — "Split" over the exact half a new pane will occupy, "Open here" over a whole pane — and drops also work from single-pane mode.

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -12,14 +12,18 @@ import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
 import type { ChatPageHost } from "./chat-state.ts";
+import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
+import type { SidebarContent } from "./components/chat-sidebar.ts";
 
 type TestChatPane = HTMLElement & {
+  active: boolean;
   context: ApplicationContext;
   state: ChatPageHost;
   connectedClient: GatewayBrowserClient | null;
   connectionGeneration: number;
   createSession: () => Promise<boolean>;
   acceptTaskSuggestion: (suggestion: TaskSuggestion) => Promise<void>;
+  handleDocumentKeydown: (event: KeyboardEvent) => void;
   handleTaskSuggestionEvent: (event: TaskSuggestionEvent) => void;
   refreshTaskSuggestions: () => Promise<void>;
   taskSuggestions: TaskSuggestion[];
@@ -43,6 +47,17 @@ function createDeferred<T>() {
     resolve = nextResolve;
   });
   return { promise, resolve };
+}
+
+function dispatchSidebarShortcut(pane: TestChatPane, shiftKey = true) {
+  const event = new KeyboardEvent("keydown", {
+    cancelable: true,
+    key: "b",
+    metaKey: true,
+    shiftKey,
+  });
+  pane.handleDocumentKeydown(event);
+  return event;
 }
 
 function createSessionContext(
@@ -88,6 +103,8 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
     sessions: params.sessions,
     sessionsError: null,
     sessionsLoading: false,
+    sidebarContent: null,
+    sidebarOpen: false,
   } as unknown as ChatPageHost;
   pane.context = createSessionContext(params.client, params.sessions);
   pane.state = state;
@@ -95,6 +112,47 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
   pane.connectionGeneration = 4;
   return { pane, requestUpdate, state };
 }
+
+describe("chat pane keyboard shortcuts", () => {
+  it("toggles only the active pane's session workspace", () => {
+    const client = {} as GatewayBrowserClient;
+    const sessions = {} as SessionCapability;
+    const { pane, state } = createTestChatPane({ client, sessions });
+    const canvasContent: SidebarContent = {
+      kind: "canvas",
+      docId: "canvas-1",
+      entryUrl: "/__openclaw__/canvas/canvas-1/index.html",
+    };
+    pane.active = true;
+    state.connected = false;
+    state.sidebarContent = canvasContent;
+    state.sidebarOpen = true;
+
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(true);
+
+    const expandEvent = dispatchSidebarShortcut(pane);
+
+    expect(expandEvent.defaultPrevented).toBe(true);
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(false);
+    expect(state.sidebarOpen).toBe(true);
+    expect(state.sidebarContent).toBe(canvasContent);
+
+    const collapseEvent = dispatchSidebarShortcut(pane);
+
+    expect(collapseEvent.defaultPrevented).toBe(true);
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(true);
+    expect(state.sidebarOpen).toBe(true);
+    expect(state.sidebarContent).toBe(canvasContent);
+
+    const mainSidebarEvent = dispatchSidebarShortcut(pane, false);
+    expect(mainSidebarEvent.defaultPrevented).toBe(false);
+
+    pane.active = false;
+    const inactivePaneEvent = dispatchSidebarShortcut(pane);
+    expect(inactivePaneEvent.defaultPrevented).toBe(false);
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(true);
+  });
+});
 
 describe("chat pane session creation lifecycle", () => {
   it("drops a created session after a same-client reconnect", async () => {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -74,6 +74,7 @@ import {
   createSessionWorkspaceProps,
   openSessionWorkspaceFile,
   revealSessionWorkspaceFile,
+  toggleSessionWorkspace,
 } from "./components/chat-session-workspace.ts";
 import {
   CHAT_DETAIL_FULL_MESSAGE_MAX_CHARS,
@@ -581,6 +582,24 @@ class ChatPane extends OpenClawLightDomElement {
   }
 
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
+    if (
+      this.active &&
+      !event.defaultPrevented &&
+      !event.altKey &&
+      event.shiftKey &&
+      event.metaKey &&
+      !event.ctrlKey &&
+      event.key.toLowerCase() === "b"
+    ) {
+      const state = this.state;
+      if (!state) {
+        return;
+      }
+      event.preventDefault();
+      toggleSessionWorkspace(state);
+      return;
+    }
+
     if (
       this.active &&
       !event.defaultPrevented &&

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1189,9 +1189,11 @@ describe("chat composer workbench", () => {
     );
     expect(browserFileButton?.disabled).toBe(false);
     browserFileButton?.click();
-    container
-      .querySelector<HTMLButtonElement>('button[aria-label="Collapse session workspace"]')
-      ?.click();
+    const collapseToggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse session workspace"]',
+    );
+    expect(collapseToggle?.getAttribute("aria-keyshortcuts")).toBe("Meta+Shift+B");
+    collapseToggle?.click();
 
     expect(onOpenFile).toHaveBeenCalledWith("/workspace/AGENTS.md", "session");
     expect(onOpenFile).toHaveBeenCalledWith("package.json", "workspace");
@@ -1227,6 +1229,7 @@ describe("chat composer workbench", () => {
       'button[aria-label="Expand session workspace"]',
     );
     expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle?.getAttribute("aria-keyshortcuts")).toBe("Meta+Shift+B");
 
     toggle?.click();
 

--- a/ui/src/pages/chat/components/chat-session-workspace.test.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, it } from "vitest";
-import { workspaceBrowserFilePath } from "./chat-session-workspace.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSessionWorkspaceProps,
+  toggleSessionWorkspace,
+  type SessionWorkspaceHost,
+  workspaceBrowserFilePath,
+} from "./chat-session-workspace.ts";
+
+describe("toggleSessionWorkspace", () => {
+  it("expands and collapses the session workspace rail", () => {
+    const requestUpdate = vi.fn();
+    const state = {
+      client: null,
+      connected: false,
+      handleOpenSidebar: vi.fn(),
+      hello: null,
+      requestUpdate,
+      sessionKey: "agent:main:current",
+      sessions: {},
+    } as unknown as SessionWorkspaceHost;
+
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(true);
+
+    toggleSessionWorkspace(state);
+
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(false);
+
+    toggleSessionWorkspace(state);
+
+    expect(createSessionWorkspaceProps(state).collapsed).toBe(true);
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe("workspaceBrowserFilePath", () => {
   it("resolves browser rows from the workspace root", () => {

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -569,11 +569,12 @@ export function renderSessionWorkspaceRail(
         class="chat-workspace-rail chat-workspace-rail--collapsed"
         aria-label=${t("chat.workspaceFiles.label")}
       >
-        <openclaw-tooltip .content=${t("chat.workspaceFiles.expand")}>
+        <openclaw-tooltip .content=${`${t("chat.workspaceFiles.expand")} (⇧⌘B)`}>
           <button
             type="button"
             class="nav-collapse-toggle chat-workspace-rail__collapse-toggle"
             aria-label=${t("chat.workspaceFiles.expand")}
+            aria-keyshortcuts="Meta+Shift+B"
             aria-expanded="false"
             @click=${sessionWorkspace.onToggleCollapsed}
           >
@@ -882,11 +883,12 @@ export function renderSessionWorkspaceRail(
               ${icons.refresh}
             </button>
           </openclaw-tooltip>
-          <openclaw-tooltip .content=${t("chat.workspaceFiles.collapse")}>
+          <openclaw-tooltip .content=${`${t("chat.workspaceFiles.collapse")} (⇧⌘B)`}>
             <button
               type="button"
               class="nav-collapse-toggle chat-workspace-rail__collapse-toggle"
               aria-label=${t("chat.workspaceFiles.collapse")}
+              aria-keyshortcuts="Meta+Shift+B"
               aria-expanded="true"
               @click=${sessionWorkspace.onToggleCollapsed}
             >

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -399,6 +399,15 @@ export function openSessionWorkspaceFile(
   openFile(state, getWorkspaceState(state), target.path, { line: target.line });
 }
 
+export function toggleSessionWorkspace(state: SessionWorkspaceHost) {
+  const workspace = getWorkspaceState(state);
+  workspace.collapsed = !workspace.collapsed;
+  if (!workspace.collapsed && workspace.list?.sessionKey !== state.sessionKey) {
+    loadWorkspace(state, workspace);
+  }
+  requestUpdate(state);
+}
+
 export function revealSessionWorkspaceFile(state: SessionWorkspaceHost, path: string) {
   const workspace = getWorkspaceState(state);
   clearWorkspaceSearchTimer(workspace);
@@ -460,13 +469,7 @@ export function createSessionWorkspaceProps(state: SessionWorkspaceHost): Sessio
     loading: workspace.loading,
     error: workspace.error,
     activeId: workspace.activeId,
-    onToggleCollapsed: () => {
-      workspace.collapsed = !workspace.collapsed;
-      if (!workspace.collapsed && workspace.list?.sessionKey !== state.sessionKey) {
-        loadWorkspace(state, workspace);
-      }
-      requestUpdate(state);
-    },
+    onToggleCollapsed: () => toggleSessionWorkspace(state),
     onRefresh: () => loadWorkspace(state, workspace, true),
     onBrowsePath: (path) => {
       clearWorkspaceSearchTimer(workspace);


### PR DESCRIPTION
## What Problem This Solves

Chat users currently need the mouse to expand or collapse the session workspace rail.

## Why This Change Was Made

Add ⇧⌘B as a keyboard toggle for the active Chat pane’s session workspace rail. It reuses the existing workspace toggle path and leaves the main app sidebar and separate detail/Canvas panel unchanged.

## User Impact

Users can quickly show or hide session files, project files, and artifacts without leaving the keyboard.

## Evidence

- Focused Control UI tests: 146 passed.
- `pnpm check:changed`: passed.
- Tested through Crabbox with Blacksmith Testbox `tbx_01kx40jhz5tezed3mbx7etbdwk`.
- Autoreview completed with no actionable findings.
