### PR TITLE
fix(feishu): transcribe audio messages with mixed-case content types

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2577,14 +2577,14 @@ describe("handleFeishuMessage command authorization", () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
       buffer: Buffer.from("voice"),
-      contentType: "audio/ogg",
+      contentType: "Audio/Ogg",
       fileName: "voice.ogg",
     });
     mockSaveMediaBuffer.mockResolvedValueOnce({
       id: "inbound-voice.ogg",
       path: "/tmp/inbound-voice.ogg",
       size: Buffer.byteLength("voice"),
-      contentType: "audio/ogg",
+      contentType: "Audio/Ogg",
     });
     mockTranscribeFirstAudio.mockResolvedValueOnce("voice transcript");
 
@@ -2629,7 +2629,7 @@ describe("handleFeishuMessage command authorization", () => {
       ctx?: { ChatType?: string; MediaPaths?: string[]; MediaTypes?: string[] };
     }>(mockTranscribeFirstAudio, 0, 0);
     expect(transcribeRequest.ctx?.MediaPaths).toEqual(["/tmp/inbound-voice.ogg"]);
-    expect(transcribeRequest.ctx?.MediaTypes).toEqual(["audio/ogg"]);
+    expect(transcribeRequest.ctx?.MediaTypes).toEqual(["Audio/Ogg"]);
     expect(transcribeRequest.ctx?.ChatType).toBe("direct");
     expect(transcribeRequest.cfg?.channels?.feishu?.dmPolicy).toBe("open");
     const finalized = mockCallArg<{
@@ -2648,7 +2648,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(finalized.CommandBody).toBe("voice transcript");
     expect(finalized.Transcript).toBe("voice transcript");
     expect(finalized.MediaPaths).toEqual(["/tmp/inbound-voice.ogg"]);
-    expect(finalized.MediaTypes).toEqual(["audio/ogg"]);
+    expect(finalized.MediaTypes).toEqual(["Audio/Ogg"]);
     expect(finalized.MediaTranscribedIndexes).toEqual([0]);
     expect(finalized.BodyForAgent).not.toContain("file_audio_payload");
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -198,6 +198,10 @@ export async function resolveGroupName(params: {
   return resolvedName;
 }
 
+function isFeishuAudioContentType(contentType: string | undefined): boolean {
+  return contentType?.toLowerCase().startsWith("audio/") === true;
+}
+
 async function resolveFeishuAudioPreflightTranscript(params: {
   cfg: ClawdbotConfig;
   mediaList: FeishuMediaInfo[];
@@ -208,7 +212,9 @@ async function resolveFeishuAudioPreflightTranscript(params: {
   if (params.content.trim() !== "<media:audio>") {
     return undefined;
   }
-  const audioMedia = params.mediaList.filter((media) => media.contentType?.startsWith("audio/"));
+  const audioMedia = params.mediaList.filter((media) =>
+    isFeishuAudioContentType(media.contentType),
+  );
   if (audioMedia.length === 0) {
     return undefined;
   }
@@ -1090,7 +1096,7 @@ export async function handleFeishuMessage(params: {
     const preflightAudioIndex =
       audioTranscript === undefined
         ? -1
-        : mediaList.findIndex((media) => media.contentType?.startsWith("audio/"));
+        : mediaList.findIndex((media) => isFeishuAudioContentType(media.contentType));
     const inboundMedia = toInboundMediaFacts(mediaList, {
       transcribed: (_media, index) => index === preflightAudioIndex,
     });

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -1,16 +1,21 @@
 // Feishu tests cover monitor.webhook e2e plugin behavior.
 import crypto from "node:crypto";
 import type { Server } from "node:http";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { createFeishuRuntimeMockModule } from "./monitor.test-mocks.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import {
   buildWebhookConfig,
   getFreePort,
   waitUntilServerReady,
   withRunningWebhookMonitor,
 } from "./monitor.webhook.test-helpers.js";
+import type { FeishuMessageContext } from "./types.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
+const mockDownloadMessageResourceFeishu = vi.hoisted(() => vi.fn());
+const mockTranscribeFirstAudio = vi.hoisted(() => vi.fn());
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const mockCreateFeishuReplyDispatcher = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
@@ -20,17 +25,68 @@ vi.mock("./client.js", async () => {
   const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
   return {
     ...actual,
+    createEventDispatcher: createEventDispatcherMock,
     createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
   };
 });
 
-vi.mock("./runtime.js", () => createFeishuRuntimeMockModule());
+vi.mock("./media.js", () => ({
+  saveMessageResourceFeishu: mockDownloadMessageResourceFeishu,
+}));
+
+vi.mock("./audio-preflight.runtime.js", () => ({
+  transcribeFirstAudio: mockTranscribeFirstAudio,
+}));
+
+vi.mock("./reply-dispatcher.js", () => ({
+  createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
 
 import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 import { httpServers } from "./monitor.state.js";
+import { setFeishuRuntime } from "./runtime.js";
 
 beforeAll(async () => {
   await import("./monitor.account.js");
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createEventDispatcherMock.mockImplementation(() => createWebhookEventDispatcher());
+  mockCreateFeishuReplyDispatcher.mockReset().mockReturnValue({
+    dispatcher: {
+      sendToolResult: vi.fn(),
+      sendBlockReply: vi.fn(),
+      sendFinalReply: vi.fn(),
+      waitForIdle: vi.fn(),
+      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      markComplete: vi.fn(),
+    },
+    replyOptions: {},
+    markDispatchIdle: vi.fn(),
+    ensureNoVisibleReplyFallback: vi.fn(),
+  });
+  mockDownloadMessageResourceFeishu.mockReset();
+  mockTranscribeFirstAudio.mockReset();
+  setFeishuRuntime({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+          cancelKey: () => false,
+        }),
+      },
+      commands: {
+        isControlCommandMessage: () => false,
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  } as unknown as PluginRuntime);
 });
 
 function signFeishuPayload(params: {
@@ -69,6 +125,156 @@ async function postSignedPayload(url: string, payload: Record<string, unknown>) 
     headers: signFeishuPayload({ encryptKey: "encrypt_key", rawBody }),
     body: rawBody,
   });
+}
+
+type ObservedInboundContext = Record<string, unknown> & {
+  BodyForAgent?: string;
+  CommandBody?: string;
+  MediaPaths?: string[];
+  MediaTranscribedIndexes?: number[];
+  MediaTypes?: string[];
+  RawBody?: string;
+  Transcript?: string;
+};
+
+type FeishuWebhookHandler = (event: unknown) => Promise<void> | void;
+
+function createWebhookEventDispatcher() {
+  const handlers = new Map<string, FeishuWebhookHandler>();
+  return {
+    register: (registered: Record<string, FeishuWebhookHandler>) => {
+      for (const [eventType, handler] of Object.entries(registered)) {
+        handlers.set(eventType, handler);
+      }
+    },
+    invoke: async (payload: Record<string, unknown>) => {
+      const eventType = (payload.header as { event_type?: string } | undefined)?.event_type;
+      const handler = eventType ? handlers.get(eventType) : undefined;
+      if (!handler) {
+        return `no ${eventType ?? "unknown"} event handle`;
+      }
+      await handler(payload.event);
+      return {};
+    },
+  };
+}
+
+function createWebhookProofRuntime(params: {
+  cfg: ClawdbotConfig;
+  observedContexts: ObservedInboundContext[];
+}): PluginRuntime {
+  const recordInboundSession = vi.fn(async ({ ctx }: { ctx: ObservedInboundContext }) => {
+    params.observedContexts.push(ctx);
+  });
+  const dispatcher = {
+    sendToolResult: vi.fn(),
+    sendBlockReply: vi.fn(),
+    sendFinalReply: vi.fn(),
+    waitForIdle: vi.fn(),
+    getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    markComplete: vi.fn(),
+  };
+  return {
+    config: { current: vi.fn(() => params.cfg) },
+    channel: {
+      routing: {
+        resolveAgentRoute: vi.fn(() => ({
+          agentId: "main",
+          channel: "feishu",
+          accountId: "webhook-audio-proof",
+          sessionKey: "agent:main:feishu:direct:ou_audio_sender",
+          mainSessionKey: "agent:main:main",
+          lastRoutePolicy: "session",
+          matchedBy: "binding.peer",
+        })),
+      },
+      session: {
+        readSessionUpdatedAt: vi.fn(),
+        resolveStorePath: vi.fn(() => "/tmp/feishu-webhook-proof-sessions.json"),
+        recordInboundSession,
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+        formatAgentEnvelope: vi.fn((envelope: { body: string }) => envelope.body),
+        finalizeInboundContext: vi.fn((ctx: ObservedInboundContext) => ctx),
+        dispatchReplyFromConfig: vi
+          .fn()
+          .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } }),
+        withReplyDispatcher: vi.fn(async ({ run, onSettled }) => {
+          try {
+            return await run();
+          } finally {
+            await onSettled?.();
+          }
+        }),
+        settleReplyDispatcher: vi.fn(async ({ onSettled }) => {
+          await onSettled?.();
+        }),
+        resolveHumanDelayConfig: vi.fn(() => undefined),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+        isControlCommandMessage: vi.fn(() => false),
+      },
+      text: {
+        resolveTextChunkLimit: vi.fn(() => 4000),
+        resolveChunkMode: vi.fn(() => "hard"),
+        resolveMarkdownTableMode: vi.fn(() => "preserve"),
+        chunkTextWithMode: vi.fn((text: string) => [text]),
+        chunkText: vi.fn((text: string) => [text]),
+      },
+      pairing: {
+        readAllowFromStore: vi.fn().mockResolvedValue([]),
+        upsertPairingRequest: vi.fn(),
+        buildPairingReply: vi.fn(),
+      },
+      media: {
+        saveMediaBuffer: vi.fn(async (buffer, contentType) => ({
+          id: "inbound-voice.ogg",
+          path: "/tmp/inbound-voice.ogg",
+          size: Buffer.isBuffer(buffer) ? buffer.byteLength : 0,
+          contentType,
+        })),
+      },
+      debounce: {
+        resolveInboundDebounceMs: vi.fn(() => 0),
+        createInboundDebouncer: vi.fn((options) => ({
+          enqueue: async (event: unknown) => {
+            await options.onFlush([event as never]);
+          },
+          flushKey: vi.fn(),
+          cancelKey: vi.fn(() => false),
+        })),
+      },
+      inbound: {
+        run: vi.fn(async ({ raw, adapter }) => {
+          const input = await adapter.ingest(raw as FeishuMessageContext);
+          const turn = await adapter.resolveTurn(input, {
+            kind: "message",
+            canStartAgentTurn: true,
+          });
+          await turn.recordInboundSession({
+            storePath: turn.storePath,
+            sessionKey: turn.ctxPayload.SessionKey ?? turn.routeSessionKey,
+            ctx: turn.ctxPayload,
+            groupResolution: turn.record?.groupResolution,
+            createIfMissing: turn.record?.createIfMissing,
+            updateLastRoute: turn.record?.updateLastRoute,
+            onRecordError: turn.record?.onRecordError ?? (() => undefined),
+          });
+          return {
+            dispatched: true,
+            dispatchResult: await turn.runDispatch(),
+          };
+        }),
+      },
+    },
+    media: {
+      detectMime: vi.fn(async () => "application/octet-stream"),
+    },
+  } as unknown as PluginRuntime;
 }
 
 afterEach(async () => {
@@ -361,6 +567,100 @@ describe("Feishu webhook signed-request e2e", () => {
         expect(await response.text()).toContain("no unknown.event event handle");
       },
     );
+  });
+
+  it("routes uppercase audio MIME webhook events through audio preflight", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    mockDownloadMessageResourceFeishu.mockResolvedValue({
+      buffer: Buffer.from("voice"),
+      contentType: "AUDIO/OGG",
+      fileName: "voice.ogg",
+    });
+    mockTranscribeFirstAudio.mockResolvedValue("live webhook transcript");
+
+    const accountId = "webhook-audio-proof";
+    const cfg = buildWebhookConfig({
+      accountId,
+      path: "/hook-e2e-audio-uppercase-mime",
+      port: await getFreePort(),
+      verificationToken: "verify_token",
+      encryptKey: "encrypt_key",
+    });
+    const feishuAccount = cfg.channels?.feishu?.accounts?.[accountId] as Record<string, unknown>;
+    feishuAccount.dmPolicy = "open";
+    feishuAccount.allowFrom = ["*"];
+    feishuAccount.resolveSenderNames = false;
+    const observedContexts: ObservedInboundContext[] = [];
+    setFeishuRuntime(createWebhookProofRuntime({ cfg, observedContexts }));
+
+    const abortController = new AbortController();
+    const runtimeError = vi.fn();
+    const monitorPromise = monitorFeishuProvider({
+      config: cfg,
+      runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+      abortSignal: abortController.signal,
+      accountId,
+    });
+    const url = `http://127.0.0.1:${feishuAccount.webhookPort}${feishuAccount.webhookPath}`;
+
+    try {
+      await waitUntilServerReady(url);
+      const response = await postSignedPayload(url, {
+        schema: "2.0",
+        header: { event_type: "im.message.receive_v1" },
+        event: {
+          sender: {
+            sender_id: { open_id: "ou_audio_sender" },
+            sender_type: "user",
+          },
+          message: {
+            message_id: "msg-webhook-audio-uppercase-mime",
+            chat_id: "oc_audio_dm",
+            chat_type: "p2p",
+            message_type: "audio",
+            content: JSON.stringify({ file_key: "file_audio_payload", duration: 1200 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await vi.waitFor(() => {
+        if (runtimeError.mock.calls.length > 0) {
+          throw new Error(JSON.stringify(runtimeError.mock.calls));
+        }
+        expect(observedContexts).toHaveLength(1);
+      });
+      expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId,
+          fileKey: "file_audio_payload",
+          messageId: "msg-webhook-audio-uppercase-mime",
+          type: "file",
+        }),
+      );
+      expect(mockTranscribeFirstAudio).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            ChatType: "direct",
+            MediaPaths: ["/tmp/inbound-voice.ogg"],
+            MediaTypes: ["AUDIO/OGG"],
+          }),
+        }),
+      );
+      expect(observedContexts[0]).toEqual(
+        expect.objectContaining({
+          CommandBody: "live webhook transcript",
+          MediaPaths: ["/tmp/inbound-voice.ogg"],
+          MediaTranscribedIndexes: [0],
+          MediaTypes: ["AUDIO/OGG"],
+          RawBody: "live webhook transcript",
+          Transcript: "live webhook transcript",
+        }),
+      );
+    } finally {
+      abortController.abort();
+      await monitorPromise.catch(() => undefined);
+    }
   });
 
   it("does not emit unhandled-event warning for bot_p2p_chat_entered_v1", async () => {

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -166,15 +166,6 @@ function createWebhookProofRuntime(params: {
   const recordInboundSession = vi.fn(async ({ ctx }: { ctx: ObservedInboundContext }) => {
     params.observedContexts.push(ctx);
   });
-  const dispatcher = {
-    sendToolResult: vi.fn(),
-    sendBlockReply: vi.fn(),
-    sendFinalReply: vi.fn(),
-    waitForIdle: vi.fn(),
-    getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-    getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-    markComplete: vi.fn(),
-  };
   return {
     config: { current: vi.fn(() => params.cfg) },
     channel: {
@@ -601,7 +592,7 @@ describe("Feishu webhook signed-request e2e", () => {
       abortSignal: abortController.signal,
       accountId,
     });
-    const url = `http://127.0.0.1:${feishuAccount.webhookPort}${feishuAccount.webhookPath}`;
+    const url = `http://127.0.0.1:${String(feishuAccount.webhookPort)}${String(feishuAccount.webhookPath)}`;
 
     try {
       await waitUntilServerReady(url);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu users sending audio messages could have those messages handled as ordinary media instead of transcribed when Feishu returns the media MIME type with uppercase or mixed-case letters, such as `Audio/Ogg` or `AUDIO/OGG`.

## Why This Change Was Made

Feishu audio detection now treats MIME content types case-insensitively when deciding whether inbound media should enter the audio preflight path. The original `contentType` value is still preserved in the inbound media context, and this stays limited to the Feishu audio media classification path without changing config, schema, or persisted formats.

## User Impact

Feishu audio messages with valid uppercase or mixed-case audio MIME types now go through audio transcription and are recorded with the correct transcribed media index instead of falling through as untranscribed media.

## Evidence

- Signed local Feishu webhook runtime proof passed: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/monitor.webhook-e2e.test.ts -t "routes uppercase audio MIME webhook events through audio preflight"`
  - Starts the Feishu webhook monitor on a real local HTTP server.
  - Sends a signed `im.message.receive_v1` audio webhook request with media `contentType: "AUDIO/OGG"`.
  - Observes the message flow through webhook handling, Feishu message handling, media resolution, audio preflight, and channel inbound recording with `MediaTranscribedIndexes: [0]` while preserving `MediaTypes: ["AUDIO/OGG"]`.
- Focused Feishu audio regression passed: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/bot.test.ts -t "transcribes inbound audio before building the agent turn"`
- Full Feishu webhook e2e file passed: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/monitor.webhook-e2e.test.ts`
- Bundled extension lint passed: `pnpm lint:extensions:bundled`
- Extension lint passed: `pnpm lint:extensions`
- Requested `pnpm check:changed -- extensions/feishu/src/monitor.webhook-e2e.test.ts extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts` was attempted locally, but this environment failed before running changed-file checks because the Crabbox/Testbox binary failed its basic sanity check. The two CI lint failures were reproduced from CI logs and covered by the passing extension lint commands above.
