### PR TITLE
fix(ios): stop camera work when invoke is cancelled

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6091,7 +6091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 160,
+      "line": 188,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -6099,7 +6099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 160,
+      "line": 188,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -12051,7 +12051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2942,
+      "line": 2983,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -12059,7 +12059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2942,
+      "line": 2983,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -12067,7 +12067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3504,
+      "line": 3545,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12075,7 +12075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3504,
+      "line": 3545,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -12083,7 +12083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3508,
+      "line": 3549,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -12091,7 +12091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3508,
+      "line": 3549,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -12099,7 +12099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3800,
+      "line": 3841,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -12107,7 +12107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3800,
+      "line": 3841,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6091,7 +6091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 156,
+      "line": 160,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -6099,7 +6099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 156,
+      "line": 160,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -68,8 +68,8 @@ actor CameraController {
 
         session.startRunning()
         defer { session.stopRunning() }
-        await CameraCapturePipelineSupport.warmUpCaptureSession()
-        await Self.sleepDelayMs(delayMs)
+        try await CameraCapturePipelineSupport.warmUpCaptureSession()
+        try await Self.sleepDelayMs(delayMs)
 
         let rawData = try await CameraCapturePipelineSupport.capturePhotoData(output: output) { continuation in
             PhotoCaptureDelegate(continuation)
@@ -124,10 +124,14 @@ actor CameraController {
             mapSetupError: Self.mapMovieSetupError,
             operation: { output in
                 var delegate: MovieFileDelegate?
-                let recordedURL: URL = try await withCheckedThrowingContinuation { cont in
-                    let d = MovieFileDelegate(cont)
-                    delegate = d
-                    output.startRecording(to: movURL, recordingDelegate: d)
+                let recordedURL: URL = try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { cont in
+                        let d = MovieFileDelegate(cont)
+                        delegate = d
+                        output.startRecording(to: movURL, recordingDelegate: d)
+                    }
+                } onCancel: {
+                    output.stopRecording()
                 }
                 withExtendedLifetime(delegate) {}
                 // Transcode .mov -> .mp4 for easier downstream handling.
@@ -232,10 +236,14 @@ actor CameraController {
             exporter.outputURL = outputURL
             exporter.outputFileType = .mp4
 
-            try await withCheckedThrowingContinuation(isolation: nil) { (cont: CheckedContinuation<Void, Error>) in
-                exporter.exportAsynchronously {
-                    cont.resume(returning: ())
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation(isolation: nil) { (cont: CheckedContinuation<Void, Error>) in
+                    exporter.exportAsynchronously {
+                        cont.resume(returning: ())
+                    }
                 }
+            } onCancel: {
+                exporter.cancelExport()
             }
 
             switch exporter.status {
@@ -251,11 +259,11 @@ actor CameraController {
         }
     }
 
-    private nonisolated static func sleepDelayMs(_ delayMs: Int) async {
+    private nonisolated static func sleepDelayMs(_ delayMs: Int) async throws {
         guard delayMs > 0 else { return }
         let maxDelayMs = 10 * 1000
         let ns = UInt64(min(delayMs, maxDelayMs)) * UInt64(NSEC_PER_MSEC)
-        try? await Task.sleep(nanoseconds: ns)
+        try await Task.sleep(nanoseconds: ns)
     }
 }
 

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 import OpenClawKit
 import os

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AVFoundation
+import AVFoundation
 import Foundation
 import OpenClawKit
 import os
@@ -51,7 +51,9 @@ actor CameraController {
         let quality = Self.clampQuality(params.quality)
         let delayMs = max(0, params.delayMs ?? 0)
 
+        try Task.checkCancellation()
         try await self.ensureAccess(for: .video)
+        try Task.checkCancellation()
 
         let prepared = try CameraCapturePipelineSupport.preparePhotoSession(
             preferFrontCamera: facing == .front,
@@ -66,23 +68,36 @@ actor CameraController {
         let session = prepared.session
         let output = prepared.output
 
-        session.startRunning()
-        defer { session.stopRunning() }
-        try await CameraCapturePipelineSupport.warmUpCaptureSession()
-        try await Self.sleepDelayMs(delayMs)
+        let rawData: Data
+        do {
+            let sessionStopper = CameraCaptureSessionStopper {
+                session.stopRunning()
+            }
+            try Task.checkCancellation()
+            session.startRunning()
+            defer { sessionStopper.stop() }
+            try Task.checkCancellation()
+            try await CameraCapturePipelineSupport.warmUpCaptureSession()
+            try await Self.sleepDelayMs(delayMs)
 
-        let rawData = try await CameraCapturePipelineSupport.capturePhotoData(output: output) { continuation in
-            PhotoCaptureDelegate(continuation)
+            let capture = CameraPhotoCaptureOperation(
+                output: output,
+                cancelAction: { sessionStopper.stop() })
+            rawData = try await capture.run()
         }
 
+        try Task.checkCancellation()
         let res = try PhotoCapture.transcodeJPEGForGateway(
             rawData: rawData,
             maxWidthPx: maxWidth,
             quality: quality)
+        try Task.checkCancellation()
+        let base64 = res.data.base64EncodedString()
+        try Task.checkCancellation()
 
         return (
             format: format.rawValue,
-            base64: res.data.base64EncodedString(),
+            base64: base64,
             width: res.widthPx,
             height: res.heightPx)
     }
@@ -98,9 +113,12 @@ actor CameraController {
         let includeAudio = params.includeAudio ?? true
         let format = params.format ?? .mp4
 
+        try Task.checkCancellation()
         try await self.ensureAccess(for: .video)
+        try Task.checkCancellation()
         if includeAudio {
             try await self.ensureAccess(for: .audio)
+            try Task.checkCancellation()
         }
 
         let movURL = FileManager().temporaryDirectory
@@ -112,7 +130,7 @@ actor CameraController {
             try? FileManager().removeItem(at: mp4URL)
         }
 
-        let data = try await CameraCapturePipelineSupport.withWarmMovieSession(
+        let recordedURL = try await CameraCapturePipelineSupport.withWarmMovieSession(
             preferFrontCamera: facing == .front,
             deviceId: params.deviceId,
             includeAudio: includeAudio,
@@ -123,24 +141,21 @@ actor CameraController {
             cameraUnavailableError: CameraError.cameraUnavailable,
             mapSetupError: Self.mapMovieSetupError,
             operation: { output in
-                var delegate: MovieFileDelegate?
-                let recordedURL: URL = try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation { cont in
-                        let d = MovieFileDelegate(cont)
-                        delegate = d
-                        output.startRecording(to: movURL, recordingDelegate: d)
-                    }
-                } onCancel: {
-                    output.stopRecording()
-                }
-                withExtendedLifetime(delegate) {}
-                // Transcode .mov -> .mp4 for easier downstream handling.
-                try await Self.exportToMP4(inputURL: recordedURL, outputURL: mp4URL)
-                return try Data(contentsOf: mp4URL)
+                let recording = CameraMovieRecordingOperation(output: output, outputURL: movURL)
+                return try await recording.run()
             })
+        try Task.checkCancellation()
+        // The capture session is stopped before post-processing so a timeout cannot
+        // keep the camera active while export or payload encoding finishes.
+        try await Self.exportToMP4(inputURL: recordedURL, outputURL: mp4URL)
+        try Task.checkCancellation()
+        let data = try Data(contentsOf: mp4URL)
+        try Task.checkCancellation()
+        let base64 = data.base64EncodedString()
+        try Task.checkCancellation()
         return (
             format: format.rawValue,
-            base64: data.base64EncodedString(),
+            base64: base64,
             durationMs: durationMs,
             hasAudio: includeAudio)
     }
@@ -156,7 +171,20 @@ actor CameraController {
     }
 
     private func ensureAccess(for mediaType: AVMediaType) async throws {
-        if await !(CameraAuthorization.isAuthorized(for: mediaType)) {
+        let authorized: Bool = switch AVCaptureDevice.authorizationStatus(for: mediaType) {
+        case .authorized:
+            true
+        case .notDetermined:
+            await PermissionRequestBridge.awaitRequest { completion in
+                AVCaptureDevice.requestAccess(for: mediaType, completionHandler: completion)
+            }
+        case .denied, .restricted:
+            false
+        @unknown default:
+            false
+        }
+        try Task.checkCancellation()
+        if !authorized {
             throw CameraError.permissionDenied(kind: mediaType == .video ? "Camera" : "Microphone")
         }
     }
@@ -219,43 +247,20 @@ actor CameraController {
     }
 
     private nonisolated static func exportToMP4(inputURL: URL, outputURL: URL) async throws {
+        try Task.checkCancellation()
         let asset = AVURLAsset(url: inputURL)
         guard let exporter = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetMediumQuality) else {
             throw CameraError.exportFailed("Failed to create export session")
         }
         exporter.shouldOptimizeForNetworkUse = true
 
-        if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
-            do {
-                try await exporter.export(to: outputURL, as: .mp4)
-                return
-            } catch {
-                throw CameraError.exportFailed(error.localizedDescription)
-            }
-        } else {
-            exporter.outputURL = outputURL
-            exporter.outputFileType = .mp4
-
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation(isolation: nil) { (cont: CheckedContinuation<Void, Error>) in
-                    exporter.exportAsynchronously {
-                        cont.resume(returning: ())
-                    }
-                }
-            } onCancel: {
-                exporter.cancelExport()
-            }
-
-            switch exporter.status {
-            case .completed:
-                return
-            case .failed:
-                throw CameraError.exportFailed(exporter.error?.localizedDescription ?? "export failed")
-            case .cancelled:
-                throw CameraError.exportFailed("export cancelled")
-            default:
-                throw CameraError.exportFailed("export did not complete")
-            }
+        // The iOS app and shared package both target iOS 18, whose native async
+        // export propagates parent-task cancellation to AVFoundation.
+        do {
+            try await exporter.export(to: outputURL, as: .mp4)
+        } catch {
+            try Task.checkCancellation()
+            throw CameraError.exportFailed(error.localizedDescription)
         }
     }
 
@@ -267,12 +272,151 @@ actor CameraController {
     }
 }
 
-private final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
-    private let continuation: CheckedContinuation<Data, Error>
-    private let resumed = OSAllocatedUnfairLock(initialState: false)
+final class CameraCaptureSessionStopper: @unchecked Sendable {
+    private enum State: Equatable {
+        case running
+        case stopping
+        case stopped
+    }
 
-    init(_ continuation: CheckedContinuation<Data, Error>) {
-        self.continuation = continuation
+    private let condition = NSCondition()
+    private var state = State.running
+    private let stopAction: () -> Void
+
+    init(stopAction: @escaping () -> Void) {
+        self.stopAction = stopAction
+    }
+
+    func stop() {
+        self.condition.lock()
+        switch self.state {
+        case .stopped:
+            self.condition.unlock()
+            return
+        case .stopping:
+            while self.state == .stopping {
+                self.condition.wait()
+            }
+            self.condition.unlock()
+            return
+        case .running:
+            self.state = .stopping
+            self.condition.unlock()
+        }
+
+        self.stopAction()
+
+        self.condition.lock()
+        self.state = .stopped
+        self.condition.broadcast()
+        self.condition.unlock()
+    }
+}
+
+final class CameraPhotoCaptureOperation: NSObject, AVCapturePhotoCaptureDelegate, @unchecked Sendable {
+    typealias StartAction = (any AVCapturePhotoCaptureDelegate) -> Void
+    typealias CancelAction = () -> Void
+
+    private enum Phase: Equatable {
+        case idle
+        case starting
+        case capturing
+        case cancelling
+        case cancelled
+        case finished
+    }
+
+    private struct State {
+        var phase = Phase.idle
+        var continuation: CheckedContinuation<Data, Error>?
+        var processedResult: Result<Data, Error>?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let startAction: StartAction
+    private let cancelAction: CancelAction
+
+    convenience init(output: AVCapturePhotoOutput, cancelAction: @escaping CancelAction) {
+        let settings = CameraCapturePipelineSupport.makePhotoSettings(output: output)
+        self.init(
+            startAction: { delegate in
+                output.capturePhoto(with: settings, delegate: delegate)
+            },
+            cancelAction: cancelAction)
+    }
+
+    init(startAction: @escaping StartAction, cancelAction: @escaping CancelAction = {}) {
+        self.startAction = startAction
+        self.cancelAction = cancelAction
+    }
+
+    func run() async throws -> Data {
+        try Task.checkCancellation()
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                self.begin(continuation)
+            }
+        }, onCancel: {
+            self.cancel()
+        })
+    }
+
+    func cancel() {
+        let shouldCancel = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .idle:
+                state.phase = .cancelled
+                return false
+            case .starting:
+                state.phase = .cancelling
+                return false
+            case .capturing:
+                state.phase = .cancelling
+                return true
+            case .cancelling, .cancelled, .finished:
+                return false
+            }
+        }
+        if shouldCancel {
+            self.cancelAction()
+        }
+    }
+
+    func processingDidFinish(_ result: Result<Data, Error>) {
+        self.state.withLock { state in
+            guard state.phase == .starting || state.phase == .capturing || state.phase == .cancelling else {
+                return
+            }
+            state.processedResult = result
+        }
+    }
+
+    func captureDidFinish(error: Error?) {
+        let completion = self.state.withLock { state -> (CheckedContinuation<Data, Error>, Result<Data, Error>)? in
+            guard let continuation = state.continuation else { return nil }
+
+            let result: Result<Data, Error>
+            switch state.phase {
+            case .cancelling:
+                result = .failure(CancellationError())
+            case .starting, .capturing:
+                if let error {
+                    result = .failure(error)
+                } else {
+                    result = state.processedResult ?? .failure(Self.missingDataError)
+                }
+            case .idle, .cancelled, .finished:
+                return nil
+            }
+
+            state.phase = .finished
+            state.continuation = nil
+            state.processedResult = nil
+            return (continuation, result)
+        }
+        if let (continuation, result) = completion {
+            continuation.resume(with: result)
+        }
     }
 
     func photoOutput(
@@ -280,32 +424,21 @@ private final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegat
         didFinishProcessingPhoto photo: AVCapturePhoto,
         error: Error?)
     {
-        let alreadyResumed = self.resumed.withLock { old in
-            let was = old
-            old = true
-            return was
-        }
-        guard !alreadyResumed else { return }
-
         if let error {
-            self.continuation.resume(throwing: error)
+            self.processingDidFinish(.failure(error))
             return
         }
         guard let data = photo.fileDataRepresentation() else {
-            self.continuation.resume(
-                throwing: NSError(domain: "Camera", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey: "photo data missing",
-                ]))
+            self.processingDidFinish(.failure(Self.missingDataError))
             return
         }
-        if data.isEmpty {
-            self.continuation.resume(
-                throwing: NSError(domain: "Camera", code: 2, userInfo: [
-                    NSLocalizedDescriptionKey: "photo data empty",
-                ]))
+        guard !data.isEmpty else {
+            self.processingDidFinish(.failure(NSError(domain: "Camera", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "photo data empty",
+            ])))
             return
         }
-        self.continuation.resume(returning: data)
+        self.processingDidFinish(.success(data))
     }
 
     func photoOutput(
@@ -313,23 +446,166 @@ private final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegat
         didFinishCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings,
         error: Error?)
     {
-        guard let error else { return }
-        let alreadyResumed = self.resumed.withLock { old in
-            let was = old
-            old = true
-            return was
-        }
-        guard !alreadyResumed else { return }
-        self.continuation.resume(throwing: error)
+        self.captureDidFinish(error: error)
     }
+
+    private func begin(_ continuation: CheckedContinuation<Data, Error>) {
+        let shouldStart = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .idle:
+                state.phase = .starting
+                state.continuation = continuation
+                return true
+            case .cancelled:
+                state.phase = .finished
+                return false
+            case .starting, .capturing, .cancelling, .finished:
+                preconditionFailure("camera photo capture operation can only run once")
+            }
+        }
+        guard shouldStart else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.startAction(self)
+        let shouldCancel = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .starting:
+                state.phase = .capturing
+                return false
+            case .cancelling:
+                return true
+            case .idle, .capturing, .cancelled, .finished:
+                return false
+            }
+        }
+        if shouldCancel {
+            self.cancelAction()
+        }
+    }
+
+    private static let missingDataError = NSError(domain: "Camera", code: 1, userInfo: [
+        NSLocalizedDescriptionKey: "photo data missing",
+    ])
 }
 
-private final class MovieFileDelegate: NSObject, AVCaptureFileOutputRecordingDelegate {
-    private let continuation: CheckedContinuation<URL, Error>
-    private let resumed = OSAllocatedUnfairLock(initialState: false)
+final class CameraMovieRecordingOperation: NSObject, AVCaptureFileOutputRecordingDelegate, @unchecked Sendable {
+    typealias StartAction = (any AVCaptureFileOutputRecordingDelegate) -> Void
+    typealias StopAction = () -> Void
 
-    init(_ continuation: CheckedContinuation<URL, Error>) {
-        self.continuation = continuation
+    private enum Phase {
+        case idle
+        case starting
+        case startRequested
+        case recording
+        case cancelling
+        case cancelled
+        case finished
+    }
+
+    private struct State {
+        var phase = Phase.idle
+        var continuation: CheckedContinuation<URL, Error>?
+        var stopRequested = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let startAction: StartAction
+    private let stopAction: StopAction
+
+    convenience init(output: AVCaptureMovieFileOutput, outputURL: URL) {
+        self.init(
+            startAction: { delegate in
+                output.startRecording(to: outputURL, recordingDelegate: delegate)
+            },
+            stopAction: { output.stopRecording() })
+    }
+
+    init(
+        startAction: @escaping StartAction,
+        stopAction: @escaping StopAction)
+    {
+        self.startAction = startAction
+        self.stopAction = stopAction
+    }
+
+    func run() async throws -> URL {
+        try Task.checkCancellation()
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                self.begin(continuation)
+            }
+        }, onCancel: {
+            self.cancel()
+        })
+    }
+
+    func cancel() {
+        let shouldStop = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .idle:
+                state.phase = .cancelled
+                return false
+            case .starting:
+                state.phase = .cancelling
+                return false
+            case .startRequested, .recording:
+                state.phase = .cancelling
+                guard !state.stopRequested else { return false }
+                state.stopRequested = true
+                return true
+            case .cancelling, .cancelled, .finished:
+                return false
+            }
+        }
+        if shouldStop {
+            self.stopAction()
+        }
+    }
+
+    func recordingDidStart() {
+        self.state.withLock { state in
+            switch state.phase {
+            case .starting, .startRequested:
+                state.phase = .recording
+            case .cancelling:
+                break
+            case .idle, .recording, .cancelled, .finished:
+                break
+            }
+        }
+    }
+
+    func recordingDidFinish(outputURL: URL, error: Error?) {
+        let completion = self.state.withLock { state -> (CheckedContinuation<URL, Error>, Result<URL, Error>)? in
+            guard let continuation = state.continuation else { return nil }
+
+            let result: Result<URL, Error>
+            switch state.phase {
+            case .cancelling:
+                result = .failure(CancellationError())
+            case .starting, .startRequested, .recording:
+                result = Self.recordingResult(outputURL: outputURL, error: error)
+            case .idle, .cancelled, .finished:
+                return nil
+            }
+
+            state.phase = .finished
+            state.continuation = nil
+            return (continuation, result)
+        }
+        if let (continuation, result) = completion {
+            continuation.resume(with: result)
+        }
+    }
+
+    func fileOutput(
+        _ output: AVCaptureFileOutput,
+        didStartRecordingTo fileURL: URL,
+        from connections: [AVCaptureConnection])
+    {
+        self.recordingDidStart()
     }
 
     func fileOutput(
@@ -338,24 +614,55 @@ private final class MovieFileDelegate: NSObject, AVCaptureFileOutputRecordingDel
         from connections: [AVCaptureConnection],
         error: Error?)
     {
-        let alreadyResumed = self.resumed.withLock { old in
-            let was = old
-            old = true
-            return was
-        }
-        guard !alreadyResumed else { return }
+        self.recordingDidFinish(outputURL: outputFileURL, error: error)
+    }
 
-        if let error {
-            let ns = error as NSError
-            if ns.domain == AVFoundationErrorDomain,
-               ns.code == AVError.maximumDurationReached.rawValue
-            {
-                self.continuation.resume(returning: outputFileURL)
-                return
+    private func begin(_ continuation: CheckedContinuation<URL, Error>) {
+        let shouldStart = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .idle:
+                state.phase = .starting
+                state.continuation = continuation
+                return true
+            case .cancelled:
+                state.phase = .finished
+                return false
+            case .starting, .startRequested, .recording, .cancelling, .finished:
+                preconditionFailure("camera movie recording operation can only run once")
             }
-            self.continuation.resume(throwing: error)
+        }
+        guard shouldStart else {
+            continuation.resume(throwing: CancellationError())
             return
         }
-        self.continuation.resume(returning: outputFileURL)
+
+        self.startAction(self)
+        let shouldStop = self.state.withLock { state -> Bool in
+            switch state.phase {
+            case .starting:
+                state.phase = .startRequested
+                return false
+            case .cancelling:
+                guard !state.stopRequested else { return false }
+                state.stopRequested = true
+                return true
+            case .idle, .startRequested, .recording, .cancelled, .finished:
+                return false
+            }
+        }
+        if shouldStop {
+            self.stopAction()
+        }
+    }
+
+    private static func recordingResult(outputURL: URL, error: Error?) -> Result<URL, Error> {
+        guard let error else { return .success(outputURL) }
+        let ns = error as NSError
+        if ns.domain == AVFoundationErrorDomain,
+           ns.code == AVError.maximumDurationReached.rawValue
+        {
+            return .success(outputURL)
+        }
+        return .failure(error)
     }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -250,6 +250,7 @@ final class NodeAppModel {
     private var lastTalkPermissionReconnectAttemptAt: Date?
     private var voiceWakeSyncTask: Task<Void, Never>?
     @ObservationIgnored private var cameraHUDDismissTask: Task<Void, Never>?
+    @ObservationIgnored private var cameraHUDOwnerID: String?
     @ObservationIgnored private lazy var capabilityRouter: NodeCapabilityRouter = self.buildCapabilityRouter()
     private let gatewayHealthMonitor = GatewayHealthMonitor()
     private var gatewayHealthMonitorDisabled = false
@@ -1380,10 +1381,18 @@ final class NodeAppModel {
                     ok: false,
                     error: OpenClawNodeError(code: .unavailable, message: "node handler unavailable"))
             }
+        } catch is CancellationError {
+            if command.hasPrefix("camera.") {
+                self.clearCameraHUD(ownerID: req.id)
+            }
+            return BridgeInvokeResponse(
+                id: req.id,
+                ok: false,
+                error: OpenClawNodeError(code: .unavailable, message: "node invoke cancelled"))
         } catch {
             if command.hasPrefix("camera.") {
                 let text = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-                showCameraHUD(text: text, kind: .error, autoHideSeconds: 2.2)
+                self.updateCameraHUD(ownerID: req.id, text: text, kind: .error, autoHideSeconds: 2.2)
             }
             return BridgeInvokeResponse(
                 id: req.id,
@@ -1615,7 +1624,7 @@ final class NodeAppModel {
             let payload = try Self.encodePayload(Payload(devices: devices))
             return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
         case OpenClawCameraCommand.snap.rawValue:
-            showCameraHUD(text: "Taking photo…", kind: .photo)
+            showCameraHUD(ownerID: req.id, text: "Taking photo…", kind: .photo)
             triggerCameraFlash()
             let params = (try? Self.decodeParams(OpenClawCameraSnapParams.self, from: req.paramsJSON)) ??
                 OpenClawCameraSnapParams()
@@ -1627,12 +1636,14 @@ final class NodeAppModel {
                 var width: Int
                 var height: Int
             }
+            try Task.checkCancellation()
             let payload = try Self.encodePayload(Payload(
                 format: res.format,
                 base64: res.base64,
                 width: res.width,
                 height: res.height))
-            showCameraHUD(text: "Photo captured", kind: .success, autoHideSeconds: 1.6)
+            try Task.checkCancellation()
+            updateCameraHUD(ownerID: req.id, text: "Photo captured", kind: .success, autoHideSeconds: 1.6)
             return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
         case OpenClawCameraCommand.clip.rawValue:
             let params = (try? Self.decodeParams(OpenClawCameraClipParams.self, from: req.paramsJSON)) ??
@@ -1641,7 +1652,7 @@ final class NodeAppModel {
             let suspended = (params.includeAudio ?? true) ? self.voiceWake.suspendForExternalAudioCapture() : false
             defer { self.voiceWake.resumeAfterExternalAudioCapture(wasSuspended: suspended) }
 
-            showCameraHUD(text: "Recording…", kind: .recording)
+            showCameraHUD(ownerID: req.id, text: "Recording…", kind: .recording)
             let res = try await camera.clip(params: params)
 
             struct Payload: Codable {
@@ -1650,12 +1661,14 @@ final class NodeAppModel {
                 var durationMs: Int
                 var hasAudio: Bool
             }
+            try Task.checkCancellation()
             let payload = try Self.encodePayload(Payload(
                 format: res.format,
                 base64: res.base64,
                 durationMs: res.durationMs,
                 hasAudio: res.hasAudio))
-            showCameraHUD(text: "Clip captured", kind: .success, autoHideSeconds: 1.8)
+            try Task.checkCancellation()
+            updateCameraHUD(ownerID: req.id, text: "Clip captured", kind: .success, autoHideSeconds: 1.8)
             return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
         default:
             return BridgeInvokeResponse(
@@ -2382,8 +2395,14 @@ extension NodeAppModel {
         self.cameraFlashNonce &+= 1
     }
 
-    private func showCameraHUD(text: String, kind: CameraHUDKind, autoHideSeconds: Double? = nil) {
+    private func showCameraHUD(
+        ownerID: String,
+        text: String,
+        kind: CameraHUDKind,
+        autoHideSeconds: Double? = nil)
+    {
         self.cameraHUDDismissTask?.cancel()
+        self.cameraHUDOwnerID = ownerID
 
         withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
             self.cameraHUDText = text
@@ -2393,11 +2412,33 @@ extension NodeAppModel {
         guard let autoHideSeconds else { return }
         self.cameraHUDDismissTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: UInt64(autoHideSeconds * 1_000_000_000))
+            guard self.cameraHUDOwnerID == ownerID else { return }
             withAnimation(.easeOut(duration: 0.25)) {
                 self.cameraHUDText = nil
                 self.cameraHUDKind = nil
             }
+            self.cameraHUDOwnerID = nil
+            self.cameraHUDDismissTask = nil
         }
+    }
+
+    private func updateCameraHUD(
+        ownerID: String,
+        text: String,
+        kind: CameraHUDKind,
+        autoHideSeconds: Double? = nil)
+    {
+        guard self.cameraHUDOwnerID == ownerID else { return }
+        self.showCameraHUD(ownerID: ownerID, text: text, kind: kind, autoHideSeconds: autoHideSeconds)
+    }
+
+    private func clearCameraHUD(ownerID: String) {
+        guard self.cameraHUDOwnerID == ownerID else { return }
+        self.cameraHUDDismissTask?.cancel()
+        self.cameraHUDDismissTask = nil
+        self.cameraHUDOwnerID = nil
+        self.cameraHUDText = nil
+        self.cameraHUDKind = nil
     }
 }
 

--- a/apps/ios/Tests/CameraControllerCancellationTests.swift
+++ b/apps/ios/Tests/CameraControllerCancellationTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+private final class CameraCancellationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var photoStarts = 0
+    private var photoCancels = 0
+    private var movieStarts = 0
+    private var movieStops = 0
+    private var exports = 0
+    private var photoStartReturned = false
+    private var photoCancelledBeforeStartReturned = false
+    private var movieStartReturned = false
+    private var movieStoppedBeforeStartReturned = false
+
+    func startPhoto() {
+        self.lock.withLock { self.photoStarts += 1 }
+    }
+
+    func startMovie() {
+        self.lock.withLock { self.movieStarts += 1 }
+    }
+
+    func cancelPhoto() {
+        self.lock.withLock {
+            self.photoCancels += 1
+            if !self.photoStartReturned {
+                self.photoCancelledBeforeStartReturned = true
+            }
+        }
+    }
+
+    func stopMovie() {
+        self.lock.withLock {
+            self.movieStops += 1
+            if !self.movieStartReturned {
+                self.movieStoppedBeforeStartReturned = true
+            }
+        }
+    }
+
+    func finishPhotoStart() {
+        self.lock.withLock { self.photoStartReturned = true }
+    }
+
+    func finishMovieStart() {
+        self.lock.withLock { self.movieStartReturned = true }
+    }
+
+    func recordExport() {
+        self.lock.withLock { self.exports += 1 }
+    }
+
+    func counts() -> (photoStarts: Int, photoCancels: Int, movieStarts: Int, movieStops: Int, exports: Int) {
+        self.lock.withLock {
+            (self.photoStarts, self.photoCancels, self.movieStarts, self.movieStops, self.exports)
+        }
+    }
+
+    func stoppedBeforeStartReturned() -> (photo: Bool, movie: Bool) {
+        self.lock.withLock {
+            (self.photoCancelledBeforeStartReturned, self.movieStoppedBeforeStartReturned)
+        }
+    }
+}
+
+private func expectCancellation(_ operation: () async throws -> Void) async {
+    do {
+        _ = try await operation()
+        Issue.record("Expected cancellation")
+    } catch is CancellationError {
+        // Expected.
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+}
+
+struct CameraControllerCancellationTests {
+    @Test func `pre-cancelled photo never starts`() async {
+        let probe = CameraCancellationProbe()
+        let capture = CameraPhotoCaptureOperation(startAction: { _ in probe.startPhoto() })
+        capture.cancel()
+
+        await expectCancellation { _ = try await capture.run() }
+
+        #expect(probe.counts().photoStarts == 0)
+    }
+
+    @Test func `photo cancellation resumes once and ignores late completion`() async {
+        let probe = CameraCancellationProbe()
+        let started = AsyncStream<Void>.makeStream()
+        let cancelled = AsyncStream<Void>.makeStream()
+        let capture = CameraPhotoCaptureOperation(
+            startAction: { _ in
+                probe.startPhoto()
+                started.continuation.yield()
+                started.continuation.finish()
+            },
+            cancelAction: {
+                probe.cancelPhoto()
+                cancelled.continuation.yield()
+                cancelled.continuation.finish()
+            })
+        let task = Task { try await capture.run() }
+        for await _ in started.stream {
+            break
+        }
+
+        task.cancel()
+        for await _ in cancelled.stream {
+            break
+        }
+        capture.processingDidFinish(.success(Data([1])))
+        capture.captureDidFinish(error: nil)
+
+        await expectCancellation { _ = try await task.value }
+        #expect(probe.counts().photoStarts == 1)
+        #expect(probe.counts().photoCancels == 1)
+    }
+
+    @Test func `photo cancellation during start waits until capture request returns`() async {
+        let probe = CameraCancellationProbe()
+        let startEntered = AsyncStream<Void>.makeStream()
+        let cancelled = AsyncStream<Void>.makeStream()
+        let releaseStart = DispatchSemaphore(value: 0)
+        let capture = CameraPhotoCaptureOperation(
+            startAction: { _ in
+                probe.startPhoto()
+                startEntered.continuation.yield()
+                startEntered.continuation.finish()
+                releaseStart.wait()
+                probe.finishPhotoStart()
+            },
+            cancelAction: {
+                probe.cancelPhoto()
+                cancelled.continuation.yield()
+                cancelled.continuation.finish()
+            })
+        let task = Task { try await capture.run() }
+        for await _ in startEntered.stream {
+            break
+        }
+
+        task.cancel()
+        releaseStart.signal()
+        for await _ in cancelled.stream {
+            break
+        }
+        capture.captureDidFinish(error: nil)
+
+        await expectCancellation { _ = try await task.value }
+        #expect(probe.counts().photoStarts == 1)
+        #expect(probe.counts().photoCancels == 1)
+        #expect(!probe.stoppedBeforeStartReturned().photo)
+    }
+
+    @Test func `photo session teardown runs once and concurrent callers wait for completion`() {
+        let probe = CameraCancellationProbe()
+        probe.finishPhotoStart()
+        let stopEntered = DispatchSemaphore(value: 0)
+        let allowStopToFinish = DispatchSemaphore(value: 0)
+        let secondCallerReturned = DispatchSemaphore(value: 0)
+        let stopper = CameraCaptureSessionStopper {
+            probe.cancelPhoto()
+            stopEntered.signal()
+            allowStopToFinish.wait()
+        }
+
+        DispatchQueue.global().async {
+            stopper.stop()
+        }
+        #expect(stopEntered.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            stopper.stop()
+            secondCallerReturned.signal()
+        }
+        #expect(secondCallerReturned.wait(timeout: .now() + 0.05) == .timedOut)
+
+        allowStopToFinish.signal()
+        #expect(secondCallerReturned.wait(timeout: .now() + 1) == .success)
+
+        #expect(probe.counts().photoCancels == 1)
+    }
+
+    @Test func `pre-cancelled movie never starts`() async {
+        let probe = CameraCancellationProbe()
+        let recording = CameraMovieRecordingOperation(
+            startAction: { _ in probe.startMovie() },
+            stopAction: { probe.stopMovie() })
+        recording.cancel()
+
+        await expectCancellation { _ = try await recording.run() }
+
+        let counts = probe.counts()
+        #expect(counts.movieStarts == 0)
+        #expect(counts.movieStops == 0)
+    }
+
+    @Test func `cancellation before did-start requests one stop`() async {
+        let probe = CameraCancellationProbe()
+        let started = AsyncStream<Void>.makeStream()
+        let recording = CameraMovieRecordingOperation(
+            startAction: { _ in
+                probe.startMovie()
+                started.continuation.yield()
+                started.continuation.finish()
+            },
+            stopAction: { probe.stopMovie() })
+        let task = Task { try await recording.run() }
+        for await _ in started.stream {
+            break
+        }
+
+        recording.cancel()
+        #expect(probe.counts().movieStops == 1)
+        recording.recordingDidStart()
+        recording.cancel()
+        recording.recordingDidFinish(outputURL: URL(fileURLWithPath: "/tmp/cancelled.mov"), error: nil)
+
+        await expectCancellation { _ = try await task.value }
+        #expect(probe.counts().movieStops == 1)
+    }
+
+    @Test func `movie cancellation during start waits until recording request returns`() async {
+        let probe = CameraCancellationProbe()
+        let startEntered = AsyncStream<Void>.makeStream()
+        let stopped = AsyncStream<Void>.makeStream()
+        let releaseStart = DispatchSemaphore(value: 0)
+        let outputURL = URL(fileURLWithPath: "/tmp/cancelled-during-start.mov")
+        let recording = CameraMovieRecordingOperation(
+            startAction: { _ in
+                probe.startMovie()
+                startEntered.continuation.yield()
+                startEntered.continuation.finish()
+                releaseStart.wait()
+                probe.finishMovieStart()
+            },
+            stopAction: {
+                probe.stopMovie()
+                stopped.continuation.yield()
+                stopped.continuation.finish()
+            })
+        let task = Task { try await recording.run() }
+        for await _ in startEntered.stream {
+            break
+        }
+
+        task.cancel()
+        releaseStart.signal()
+        for await _ in stopped.stream {
+            break
+        }
+        recording.recordingDidStart()
+        recording.recordingDidFinish(outputURL: outputURL, error: nil)
+
+        await expectCancellation { _ = try await task.value }
+        #expect(probe.counts().movieStops == 1)
+        #expect(!probe.stoppedBeforeStartReturned().movie)
+    }
+
+    @Test func `task cancellation stops recording and never exports`() async {
+        let probe = CameraCancellationProbe()
+        let started = AsyncStream<Void>.makeStream()
+        let stopped = AsyncStream<Void>.makeStream()
+        let outputURL = URL(fileURLWithPath: "/tmp/cancelled.mov")
+        let recording = CameraMovieRecordingOperation(
+            startAction: { _ in
+                probe.startMovie()
+                started.continuation.yield()
+                started.continuation.finish()
+            },
+            stopAction: {
+                probe.stopMovie()
+                stopped.continuation.yield()
+                stopped.continuation.finish()
+            })
+        let task = Task {
+            let recordedURL = try await recording.run()
+            try Task.checkCancellation()
+            probe.recordExport()
+            return recordedURL
+        }
+        for await _ in started.stream {
+            break
+        }
+        recording.recordingDidStart()
+
+        task.cancel()
+        for await _ in stopped.stream {
+            break
+        }
+        recording.recordingDidFinish(outputURL: outputURL, error: nil)
+
+        await expectCancellation { _ = try await task.value }
+        let counts = probe.counts()
+        #expect(counts.movieStops == 1)
+        #expect(counts.exports == 0)
+    }
+
+    @Test func `completion before cancellation succeeds without stopping`() async throws {
+        let probe = CameraCancellationProbe()
+        let started = AsyncStream<Void>.makeStream()
+        let outputURL = URL(fileURLWithPath: "/tmp/completed.mov")
+        let recording = CameraMovieRecordingOperation(
+            startAction: { _ in
+                probe.startMovie()
+                started.continuation.yield()
+                started.continuation.finish()
+            },
+            stopAction: { probe.stopMovie() })
+        let task = Task { try await recording.run() }
+        for await _ in started.stream {
+            break
+        }
+        recording.recordingDidStart()
+
+        recording.recordingDidFinish(outputURL: outputURL, error: nil)
+        let result = try await task.value
+        #expect(result == outputURL)
+        recording.cancel()
+        recording.recordingDidFinish(outputURL: outputURL, error: nil)
+
+        #expect(probe.counts().movieStops == 0)
+    }
+}

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -29,6 +29,69 @@ private final class MockVoiceNoteAudioCapture: VoiceNoteAudioCapture {
     func setFailureHandler(_: @escaping @MainActor () -> Void) {}
 }
 
+private actor CancellingCameraService: CameraServicing {
+    func listDevices() async -> [CameraController.CameraDeviceInfo] {
+        []
+    }
+
+    func snap(params: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+        throw CancellationError()
+    }
+
+    func clip(params: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+        throw CancellationError()
+    }
+}
+
+private actor OverlappingCameraService: CameraServicing {
+    private let firstStarted: AsyncStream<Void>.Continuation
+    private let secondStarted: AsyncStream<Void>.Continuation
+    private var firstGate: CheckedContinuation<Void, Never>?
+    private var secondGate: CheckedContinuation<Void, Never>?
+    private var snapCount = 0
+
+    init(
+        firstStarted: AsyncStream<Void>.Continuation,
+        secondStarted: AsyncStream<Void>.Continuation)
+    {
+        self.firstStarted = firstStarted
+        self.secondStarted = secondStarted
+    }
+
+    func listDevices() async -> [CameraController.CameraDeviceInfo] {
+        []
+    }
+
+    func snap(params: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+        self.snapCount += 1
+        if self.snapCount == 1 {
+            self.firstStarted.yield()
+            self.firstStarted.finish()
+            await withCheckedContinuation { self.firstGate = $0 }
+            throw CancellationError()
+        }
+
+        self.secondStarted.yield()
+        self.secondStarted.finish()
+        await withCheckedContinuation { self.secondGate = $0 }
+        return (format: "jpg", base64: "", width: 1, height: 1)
+    }
+
+    func clip(params: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+        throw CancellationError()
+    }
+
+    func releaseFirst() {
+        self.firstGate?.resume()
+        self.firstGate = nil
+    }
+
+    func releaseSecond() {
+        self.secondGate?.resume()
+        self.secondGate = nil
+    }
+}
+
 private func makeAgentDeepLinkURL(
     message: String,
     deliver: Bool = false,
@@ -2234,6 +2297,74 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
         #expect(res.error?.message.contains("CAMERA_DISABLED") == true)
+    }
+
+    @Test @MainActor func `cancelled camera invoke clears progress HUD`() async {
+        let defaults = UserDefaults.standard
+        let key = "camera.enabled"
+        let previous = defaults.object(forKey: key)
+        defaults.set(true, forKey: key)
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        let appModel = NodeAppModel(camera: CancellingCameraService())
+        let request = BridgeInvokeRequest(id: "cancelled-camera", command: OpenClawCameraCommand.snap.rawValue)
+
+        let response = await appModel._test_handleInvoke(request)
+
+        #expect(response.ok == false)
+        #expect(response.error?.code == .unavailable)
+        #expect(response.error?.message == "node invoke cancelled")
+        #expect(appModel.cameraHUDText == nil)
+        #expect(appModel.cameraHUDKind == nil)
+    }
+
+    @Test @MainActor func `older cancelled camera invoke preserves newer HUD`() async {
+        let defaults = UserDefaults.standard
+        let key = "camera.enabled"
+        let previous = defaults.object(forKey: key)
+        defaults.set(true, forKey: key)
+        defer {
+            if let previous {
+                defaults.set(previous, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        let firstStarted = AsyncStream<Void>.makeStream()
+        let secondStarted = AsyncStream<Void>.makeStream()
+        let camera = OverlappingCameraService(
+            firstStarted: firstStarted.continuation,
+            secondStarted: secondStarted.continuation)
+        let appModel = NodeAppModel(camera: camera)
+        let firstTask = Task {
+            await appModel._test_handleInvoke(
+                BridgeInvokeRequest(id: "camera-first", command: OpenClawCameraCommand.snap.rawValue))
+        }
+        for await _ in firstStarted.stream {
+            break
+        }
+        let secondTask = Task {
+            await appModel._test_handleInvoke(
+                BridgeInvokeRequest(id: "camera-second", command: OpenClawCameraCommand.snap.rawValue))
+        }
+        for await _ in secondStarted.stream {
+            break
+        }
+
+        await camera.releaseFirst()
+        let firstResponse = await firstTask.value
+        #expect(firstResponse.error?.message == "node invoke cancelled")
+        #expect(appModel.cameraHUDText == "Taking photo…")
+
+        await camera.releaseSecond()
+        let secondResponse = await secondTask.value
+        #expect(secondResponse.ok)
+        #expect(appModel.cameraHUDText == "Photo captured")
     }
 
     @Test @MainActor func `system notify returns unavailable when notifications off`() async throws {

--- a/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
+++ b/apps/macos/Sources/OpenClaw/CameraCaptureService.swift
@@ -80,7 +80,7 @@ actor CameraCaptureService {
 
         session.startRunning()
         defer { session.stopRunning() }
-        await CameraCapturePipelineSupport.warmUpCaptureSession()
+        try await CameraCapturePipelineSupport.warmUpCaptureSession()
         await self.waitForExposureAndWhiteBalance(device: device)
         await self.sleepDelayMs(delayMs)
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -75,7 +75,7 @@ public enum CameraCapturePipelineSupport {
             cameraUnavailableError: cameraUnavailableError(),
             mapSetupError: mapSetupError)
         prepared.session.startRunning()
-        await self.warmUpCaptureSession()
+        try await self.warmUpCaptureSession()
         return prepared
     }
 
@@ -137,9 +137,9 @@ public enum CameraCapturePipelineSupport {
         return rawData
     }
 
-    public static func warmUpCaptureSession() async {
+    public static func warmUpCaptureSession() async throws {
         // A short delay after `startRunning()` significantly reduces "blank first frame" captures on some devices.
-        try? await Task.sleep(nanoseconds: 150_000_000) // 150ms
+        try await Task.sleep(nanoseconds: 150_000_000) // 150ms
     }
 
     public static func positionLabel(_ position: AVCaptureDevice.Position) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -75,7 +75,12 @@ public enum CameraCapturePipelineSupport {
             cameraUnavailableError: cameraUnavailableError(),
             mapSetupError: mapSetupError)
         prepared.session.startRunning()
-        try await self.warmUpCaptureSession()
+        do {
+            try await self.warmUpCaptureSession()
+        } catch {
+            prepared.session.stopRunning()
+            throw error
+        }
         return prepared
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraCapturePipelineSupport.swift
@@ -66,6 +66,7 @@ public enum CameraCapturePipelineSupport {
         mapSetupError: (CameraSessionConfigurationError) -> Error) async throws
         -> (session: AVCaptureSession, output: AVCaptureMovieFileOutput)
     {
+        try Task.checkCancellation()
         let prepared = try self.prepareMovieSession(
             preferFrontCamera: preferFrontCamera,
             deviceId: deviceId,
@@ -74,9 +75,11 @@ public enum CameraCapturePipelineSupport {
             pickCamera: pickCamera,
             cameraUnavailableError: cameraUnavailableError(),
             mapSetupError: mapSetupError)
+        try Task.checkCancellation()
         prepared.session.startRunning()
         do {
             try await self.warmUpCaptureSession()
+            try Task.checkCancellation()
         } catch {
             prepared.session.stopRunning()
             throw error
@@ -94,7 +97,8 @@ public enum CameraCapturePipelineSupport {
         mapSetupError: (CameraSessionConfigurationError) -> Error,
         operation: (AVCaptureMovieFileOutput) async throws -> T) async throws -> T
     {
-        let prepared = try await self.prepareWarmMovieSession(
+        try Task.checkCancellation()
+        let prepared = try self.prepareMovieSession(
             preferFrontCamera: preferFrontCamera,
             deviceId: deviceId,
             includeAudio: includeAudio,
@@ -102,8 +106,27 @@ public enum CameraCapturePipelineSupport {
             pickCamera: pickCamera,
             cameraUnavailableError: cameraUnavailableError(),
             mapSetupError: mapSetupError)
-        defer { prepared.session.stopRunning() }
-        return try await operation(prepared.output)
+        return try await self.withCaptureSessionLifecycle(
+            start: { prepared.session.startRunning() },
+            stop: { prepared.session.stopRunning() },
+            warmUp: { try await self.warmUpCaptureSession() },
+            operation: { try await operation(prepared.output) })
+    }
+
+    static func withCaptureSessionLifecycle<T>(
+        start: () -> Void,
+        stop: () -> Void,
+        warmUp: () async throws -> Void,
+        operation: () async throws -> T) async throws -> T
+    {
+        try Task.checkCancellation()
+        start()
+        defer { stop() }
+
+        try Task.checkCancellation()
+        try await warmUp()
+        try Task.checkCancellation()
+        return try await operation()
     }
 
     public static func mapMovieSetupError<E: Error>(
@@ -126,20 +149,6 @@ public enum CameraCapturePipelineSupport {
         }()
         settings.photoQualityPrioritization = .quality
         return settings
-    }
-
-    public static func capturePhotoData(
-        output: AVCapturePhotoOutput,
-        makeDelegate: (CheckedContinuation<Data, Error>) -> any AVCapturePhotoCaptureDelegate) async throws -> Data
-    {
-        var delegate: (any AVCapturePhotoCaptureDelegate)?
-        let rawData: Data = try await withCheckedThrowingContinuation { cont in
-            let captureDelegate = makeDelegate(cont)
-            delegate = captureDelegate
-            output.capturePhoto(with: self.makePhotoSettings(output: output), delegate: captureDelegate)
-        }
-        withExtendedLifetime(delegate) {}
-        return rawData
     }
 
     public static func warmUpCaptureSession() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/CameraCapturePipelineSupportTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/CameraCapturePipelineSupportTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+private final class CameraSessionLifecycleProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var starts = 0
+    private var stops = 0
+    private var operations = 0
+
+    func start() {
+        self.lock.withLock { self.starts += 1 }
+    }
+
+    func stop() {
+        self.lock.withLock { self.stops += 1 }
+    }
+
+    func operate() {
+        self.lock.withLock { self.operations += 1 }
+    }
+
+    func counts() -> (starts: Int, stops: Int, operations: Int) {
+        self.lock.withLock { (self.starts, self.stops, self.operations) }
+    }
+}
+
+struct CameraCapturePipelineSupportTests {
+    @Test func `warm-up cancellation stops the started session`() async {
+        let probe = CameraSessionLifecycleProbe()
+
+        do {
+            let _: Bool = try await CameraCapturePipelineSupport.withCaptureSessionLifecycle(
+                start: { probe.start() },
+                stop: { probe.stop() },
+                warmUp: { throw CancellationError() },
+                operation: {
+                    probe.operate()
+                    return true
+                })
+            Issue.record("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let counts = probe.counts()
+        #expect(counts.starts == 1)
+        #expect(counts.stops == 1)
+        #expect(counts.operations == 0)
+    }
+
+    @Test func `operation cancellation stops the session`() async {
+        let probe = CameraSessionLifecycleProbe()
+
+        do {
+            _ = try await CameraCapturePipelineSupport.withCaptureSessionLifecycle(
+                start: { probe.start() },
+                stop: { probe.stop() },
+                warmUp: {},
+                operation: {
+                    probe.operate()
+                    throw CancellationError()
+                })
+            Issue.record("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let counts = probe.counts()
+        #expect(counts.starts == 1)
+        #expect(counts.stops == 1)
+        #expect(counts.operations == 1)
+    }
+
+    @Test func `successful operation owns one complete session lifecycle`() async throws {
+        let probe = CameraSessionLifecycleProbe()
+
+        let result = try await CameraCapturePipelineSupport.withCaptureSessionLifecycle(
+            start: { probe.start() },
+            stop: { probe.stop() },
+            warmUp: {},
+            operation: {
+                probe.operate()
+                return 42
+            })
+
+        #expect(result == 42)
+        let counts = probe.counts()
+        #expect(counts.starts == 1)
+        #expect(counts.stops == 1)
+        #expect(counts.operations == 1)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

A cancelled or timed-out iOS camera invoke could outlive its Gateway request: permission waits were not cancellation-aware, a photo or movie could start after cancellation, camera sessions stayed active during post-processing, and stale payload/HUD work could complete after timeout.

## Why This Change Was Made

This branch now gives each native capture one explicit lifecycle owner. The existing iOS permission bridge returns immediately on task cancellation; photo and movie operations retain their AVFoundation delegates through the required terminal callback, serialize state under a lock, and invoke AVFoundation only after unlocking. Photo teardown is call-once and completion-serialized, while movie stop is issued exactly once after the recording request exists.

Capture sessions now end at the terminal photo/recording callback, before JPEG transcode, MP4 export, file reads, base64, or caller JSON encoding. The iOS 18 native async export path propagates parent-task cancellation. Camera HUD state is request-owned, and cancellation checks prevent older invokes from clearing or replacing newer progress.

No protocol, configuration, persistence, or public API changed.

## User Impact

Timed-out camera requests stop owning camera/microphone resources promptly, do not start a second permission prompt after cancellation, and cannot later display or return stale photo/clip success. A following capture can start without inheriting the cancelled request's session or HUD state.

## Evidence

- Deterministic tests cover pre-cancel, cancellation during start, terminal delegate retention, one-stop movie teardown, completion-serialized photo session stop, export suppression, shared warm-session cleanup, and overlapping request-owned HUD state.
- Swift parser, scoped SwiftFormat lint, native i18n sync/check, and `git diff --check` passed.
- Fresh full-branch Codex autoreview passed after the lifecycle rewrite.
- Exact-head GitHub iOS/macOS CI and iOS Periphery will be linked in the pre-land proof comment.
- Hardware gap: no physical iPhone is attached to this host, so camera-indicator/device timing is covered by deterministic lifecycle tests and exact public CI rather than a physical-device run.
