### PR TITLE
fix(fal): image generation hangs on slow generated-image downloads

### DIFF
--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -26,10 +26,10 @@ function expectFalJsonPost(params: { call: number; url: string; body: Record<str
   expect(JSON.parse(String(request.init?.body))).toEqual(params.body);
 }
 
-function expectFalDownload(params: { call: number; url: string }) {
+function expectFalDownload(params: { call: number; url: string; timeoutMs?: number }) {
   expect(fetchWithSsrFGuardMock.mock.calls[params.call - 1]?.[0]).toEqual({
     url: params.url,
-    timeoutMs: 30_000,
+    timeoutMs: params.timeoutMs ?? 30_000,
     policy: undefined,
     auditContext: "fal-image-download",
   });
@@ -42,6 +42,7 @@ describe("fal image-generation provider", () => {
 
   afterEach(() => {
     setFalFetchGuardForTesting(null);
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -145,6 +146,116 @@ describe("fal image-generation provider", () => {
       model: "fal-ai/flux/dev",
       metadata: { prompt: "draw a cat" },
     });
+  });
+
+  it("shares an explicit operation deadline across generated image downloads", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T00:00:00Z"));
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockImplementation(async () => {
+      vi.advanceTimersByTime(5_000);
+      return {
+        apiKey: "fal-test-key",
+        source: "env",
+        mode: "api-key",
+      };
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockImplementationOnce(async () => {
+        vi.advanceTimersByTime(10_000);
+        return {
+          response: new Response(
+            JSON.stringify({
+              images: [
+                { url: "https://v3.fal.media/files/example/first.png" },
+                { url: "https://v3.fal.media/files/example/second.png" },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+          release: vi.fn(async () => {}),
+        };
+      })
+      .mockImplementationOnce(async () => {
+        vi.advanceTimersByTime(20_000);
+        return {
+          response: new Response(Buffer.from("first"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+          release: vi.fn(async () => {}),
+        };
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("second"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const result = await buildFalImageGenerationProvider().generateImage({
+      provider: "fal",
+      model: "fal-ai/flux/dev",
+      prompt: "draw two cats",
+      cfg: {},
+      timeoutMs: 180_000,
+      count: 2,
+    });
+
+    expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.timeoutMs).toBe(175_000);
+    expectFalDownload({
+      call: 2,
+      url: "https://v3.fal.media/files/example/first.png",
+      timeoutMs: 165_000,
+    });
+    expectFalDownload({
+      call: 3,
+      url: "https://v3.fal.media/files/example/second.png",
+      timeoutMs: 145_000,
+    });
+    expect(result.images.map((image) => image.buffer.toString())).toEqual(["first", "second"]);
+  });
+
+  it("releases a timed-out generated image download", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    const releaseDownload = vi.fn(async () => {});
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/slow.png" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new DOMException("timed out", "TimeoutError"));
+            },
+          }),
+          { status: 200, headers: { "content-type": "image/png" } },
+        ),
+        release: releaseDownload,
+      });
+
+    await expect(
+      buildFalImageGenerationProvider().generateImage({
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(releaseDownload).toHaveBeenCalledTimes(1);
   });
 
   it("rejects generated image downloads that exceed the configured media cap", async () => {

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -29,6 +29,7 @@ function expectFalJsonPost(params: { call: number; url: string; body: Record<str
 function expectFalDownload(params: { call: number; url: string }) {
   expect(fetchWithSsrFGuardMock.mock.calls[params.call - 1]?.[0]).toEqual({
     url: params.url,
+    timeoutMs: 30_000,
     policy: undefined,
     auditContext: "fal-image-download",
   });

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -12,7 +12,10 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
   assertOkOrThrowProviderError,
+  createProviderOperationDeadline,
   readProviderJsonResponse,
+  resolveProviderOperationTimeoutMs,
+  type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
@@ -592,6 +595,7 @@ function resolveGeneratedImageMaxBytes(req: {
 
 async function fetchImageBuffer(
   url: string,
+  deadline: ProviderOperationDeadline,
   networkPolicy?: FalNetworkPolicy,
   maxBytes = DEFAULT_GENERATED_IMAGE_MAX_BYTES,
 ): Promise<{ buffer: Buffer; mimeType: string }> {
@@ -610,7 +614,10 @@ async function fetchImageBuffer(
   })();
   const { response, release } = await falFetchGuard({
     url,
-    timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
+    timeoutMs: resolveProviderOperationTimeoutMs({
+      deadline,
+      defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
+    }),
     policy: downloadPolicy,
     auditContext: "fal-image-download",
   });
@@ -707,6 +714,10 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       },
     },
     async generateImage(req) {
+      const deadline = createProviderOperationDeadline({
+        timeoutMs: req.timeoutMs,
+        label: "fal image generation",
+      });
       const inputImageCount = req.inputImages?.length ?? 0;
       const hasInputImages = inputImageCount > 0;
       const requestedModel = req.model?.trim() || DEFAULT_FAL_IMAGE_MODEL;
@@ -776,7 +787,13 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           headers,
           body: JSON.stringify(requestBody),
         },
-        timeoutMs: req.timeoutMs,
+        timeoutMs:
+          deadline.timeoutMs === undefined
+            ? undefined
+            : resolveProviderOperationTimeoutMs({
+                deadline,
+                defaultTimeoutMs: deadline.timeoutMs,
+              }),
         policy: networkPolicy.apiPolicy,
         dispatcherPolicy,
         auditContext: "fal-image-generate",
@@ -794,7 +811,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           if (!url) {
             throw new Error(FAL_IMAGE_MALFORMED_RESPONSE);
           }
-          const downloaded = await fetchImageBuffer(url, networkPolicy, maxImageBytes);
+          const downloaded = await fetchImageBuffer(url, deadline, networkPolicy, maxImageBytes);
           imageIndex += 1;
           images.push({
             buffer: downloaded.buffer,

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -125,6 +125,7 @@ const GROK_IMAGINE_SUPPORTED_RESOLUTIONS: readonly ("1K" | "2K" | "4K")[] = ["1K
 const KREA_CREATIVITY_LEVELS = ["raw", "low", "medium", "high"] as const;
 
 const FAL_IMAGE_MALFORMED_RESPONSE = "fal image generation response malformed";
+const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
 const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
 
 type FalImageSize = string | { width: number; height: number };
@@ -609,6 +610,7 @@ async function fetchImageBuffer(
   })();
   const { response, release } = await falFetchGuard({
     url,
+    timeoutMs: DEFAULT_HTTP_TIMEOUT_MS,
     policy: downloadPolicy,
     auditContext: "fal-image-download",
   });


### PR DESCRIPTION
## What Problem This Solves

fal image generation could finish the paid generation request and then hang indefinitely while reading a stalled generated-image URL. The download already had a byte cap, but no time bound.

## Why This Change Was Made

Generated-image downloads now use a 30-second fallback only when the image operation has no configured timeout. When the caller or `imageGenerationModel.timeoutMs` supplies a budget, one absolute deadline spans auth/setup, the generation POST, response parsing, and every sequential image download. This avoids both failure modes: an unbounded stalled body and an unconditional 30-second cap that would override a documented longer budget.

The guarded fetch signal remains active through body consumption, the existing SSRF and byte-limit policies are unchanged, and every request guard is released on success or failure.

## User Impact

- Stalled fal generated-image downloads fail instead of hanging forever.
- Explicit longer operation budgets continue to permit legitimately slow downloads.
- Multiple generated images consume one total configured budget rather than resetting it per asset.

## Evidence

- Exact rewritten head: `4ae8650df2025b6c0d1a3f9c7553d644314d0692`
- Blacksmith Testbox `tbx_01kx4zqmnafjmgtqt7zjzve36g` (`amber-hermit`), Linux Node 24:
  - `pnpm test extensions/fal/image-generation-provider.test.ts extensions/fal/video-generation-provider.test.ts` — 61/61 passed.
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed` — passed, including extension typechecks, lint, import-cycle, and repository guards.
  - Real slow-drip HTTP proof through `buildFalImageGenerationProvider` and `fetchWithSsrFGuard`:
    - explicit 500 ms operation budget: `TimeoutError` at 505 ms;
    - continuously progressing body: completed at 31,005 ms under a 40-second explicit budget, proving there is no hard 30-second cap;
    - no configured budget: `TimeoutError` at 30,007 ms.
- Fresh branch autoreview: clean; no accepted/actionable findings.
- Before comparison on current `main`: the same never-ending generated-image body remained pending until the 20-second observation process was stopped.

The Testbox did not have `FAL_KEY`, so a paid live fal generation was not available. The production provider, real loopback HTTP transport, SSRF guard, streamed response body, deadline, and cleanup path were exercised end to end. No screenshot is useful for this non-visual transport fix.
