### PR TITLE
fix(ci): restore Kova release performance gate

### DIFF
--- a/scripts/lib/kova-report-gate.mjs
+++ b/scripts/lib/kova-report-gate.mjs
@@ -142,10 +142,6 @@ function validateRecord(recordValue) {
   return record;
 }
 
-function recordViolations(record) {
-  return record.violations === undefined ? [] : array(record.violations, "record violations");
-}
-
 function validateTargetCleanup(report) {
   if (!text(report.target, "report target").startsWith("local-build:")) {
     check(report.targetCleanup === null, "non-local target had cleanup metadata");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the release performance gate could not load after two concurrent Kova contract fixes landed with duplicate helper declarations.

## Why This Change Was Made

Removes the duplicate declaration while retaining the stricter existing helper that accepts omitted `violations` fields and rejects malformed present values.

## User Impact

Release performance validation can load and evaluate Kova reports again. There is no product runtime behavior change.

## Evidence

- Before: `node --check scripts/lib/kova-report-gate.mjs` failed with `Identifier 'recordViolations' has already been declared` on `main`.
- After: the module syntax check and dynamic import both pass.
- Blacksmith Testbox `tbx_01kx44qdbdhmay3gyhnk4b0x5r`: `pnpm test test/scripts/kova-report-gate.test.ts` passed 92/92 tests.
- `git diff --check` passed.
- Autoreview: clean, patch correct (0.89 confidence).
