### PR TITLE
fix(ci): run Kova managed-service release scenarios

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -83,21 +83,27 @@ jobs:
             repeat: input
             deep_profile: "false"
             live: "false"
+            managed_service: "true"
             include_filters: "scenario:fresh-install,scenario:gateway-performance,scenario:bundled-plugin-startup,scenario:bundled-runtime-deps,scenario:agent-cold-warm-message"
+            expected_release_entries: "fresh-install:fresh,fresh-install:onboarded-user,bundled-runtime-deps:missing-plugin-index,bundled-plugin-startup:fresh,agent-cold-warm-message:mock-openai-provider,gateway-performance:many-bundled-plugins"
           - lane: mock-deep-profile
             title: Kova mock provider deep profile
             auth: mock
             repeat: "1"
             deep_profile: "true"
             live: "false"
+            managed_service: "true"
             include_filters: "scenario:fresh-install,scenario:gateway-performance,scenario:agent-cold-warm-message"
+            expected_release_entries: "fresh-install:fresh,fresh-install:onboarded-user,agent-cold-warm-message:mock-openai-provider,gateway-performance:many-bundled-plugins"
           - lane: live-openai-candidate
             title: Kova live OpenAI GPT 5.5 agent turn
             auth: live
             repeat: "1"
             deep_profile: "false"
             live: "true"
+            managed_service: "false"
             include_filters: "scenario:agent-cold-warm-message"
+            expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
       KOVA_REF: ${{ inputs.kova_ref || '4f146016583018bad9e24f8e64a6af5f963bb7ee' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
@@ -112,6 +118,7 @@ jobs:
       REQUESTED_REPEAT: ${{ inputs.repeat || '3' }}
       FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression || 'false' }}
       INCLUDE_FILTERS: ${{ matrix.include_filters }}
+      EXPECTED_RELEASE_ENTRIES: ${{ matrix.expected_release_entries }}
       AUTH_MODE: ${{ matrix.auth }}
       MATRIX_REPEAT: ${{ matrix.repeat }}
       MATRIX_DEEP_PROFILE: ${{ matrix.deep_profile }}
@@ -216,6 +223,35 @@ jobs:
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
+
+      - name: Prepare systemd user session
+        if: ${{ steps.lane.outputs.run == 'true' && matrix.managed_service == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          user="$(id -un)"
+          uid="$(id -u)"
+
+          test "$(ps -p 1 -o comm= | xargs)" = systemd
+          sudo systemctl is-active --quiet systemd-logind.service
+          sudo loginctl enable-linger "$user"
+          sudo systemctl start "user@${uid}.service"
+
+          runtime_dir="$(loginctl show-user "$user" --property=RuntimePath --value)"
+          test -n "$runtime_dir"
+          test -d "$runtime_dir"
+          test -O "$runtime_dir"
+
+          export XDG_RUNTIME_DIR="$runtime_dir"
+          test -S "$XDG_RUNTIME_DIR/systemd/private"
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
+
+          if [[ -S "$runtime_dir/bus" ]]; then
+            export DBUS_SESSION_BUS_ADDRESS="unix:path=${runtime_dir}/bus"
+            echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
+          fi
+
+          systemctl --user show-environment >/dev/null
 
       - name: Install OCM and Kova
         if: steps.lane.outputs.run == 'true'
@@ -329,6 +365,41 @@ jobs:
             --parallel 1 \
             --repeat "$repeat" \
             --json >"$plan_json"
+          node --input-type=module - "$plan_json" <<'NODE'
+          import fs from "node:fs";
+
+          const plan = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const expectedFilters = process.env.INCLUDE_FILTERS.split(",");
+          const actualFilters = plan.controls?.include;
+          if (
+            !Array.isArray(actualFilters) ||
+            actualFilters.length !== expectedFilters.length ||
+            actualFilters.some((filter, index) => filter !== expectedFilters[index])
+          ) {
+            throw new Error("Kova plan did not preserve the requested include filters");
+          }
+
+          if (process.env.PROFILE === "release") {
+            const expectedEntries = process.env.EXPECTED_RELEASE_ENTRIES.split(",").sort();
+            if (!Array.isArray(plan.entries)) {
+              throw new Error("Kova release plan did not contain entries");
+            }
+            const actualEntries = plan.entries
+              .map((entry) => {
+                if (entry.status !== "SELECTED" || !entry.scenario?.id || !entry.state?.id) {
+                  throw new Error("Kova release plan contained an invalid selected entry");
+                }
+                return `${entry.scenario.id}:${entry.state.id}`;
+              })
+              .sort();
+            if (
+              actualEntries.length !== expectedEntries.length ||
+              actualEntries.some((entry, index) => entry !== expectedEntries[index])
+            ) {
+              throw new Error("Kova release plan entries did not match the required lane coverage");
+            }
+          }
+          NODE
           echo "KOVA_PLAN_JSON=$plan_json" >> "$GITHUB_ENV"
           echo "KOVA_LANE_REPEAT=$repeat" >> "$GITHUB_ENV"
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -119,7 +119,9 @@ describe("OpenClaw performance workflow", () => {
   it("passes one comma-delimited include set to the lane plan and run", () => {
     const plan = findStep("Kova version and plan sanity");
     const runKova = findStep("Run Kova");
-    const includeFilters = kovaMatrixEntries().map((entry) => entry.include_filters);
+    const matrixEntries = kovaMatrixEntries();
+    const includeFilters = matrixEntries.map((entry) => entry.include_filters);
+    const expectedReleaseEntries = matrixEntries.map((entry) => entry.expected_release_entries);
 
     expect(includeFilters).toEqual([
       "scenario:fresh-install,scenario:gateway-performance,scenario:bundled-plugin-startup,scenario:bundled-runtime-deps,scenario:agent-cold-warm-message",
@@ -134,6 +136,56 @@ describe("OpenClaw performance workflow", () => {
     expect(plan.run).not.toContain("$REPORT_DIR");
     expect(runKova.run).toContain('--include "$INCLUDE_FILTERS"');
     expect(runKova.run).not.toContain("for filter in $INCLUDE_FILTERS");
+    expect(expectedReleaseEntries).toEqual([
+      "fresh-install:fresh,fresh-install:onboarded-user,bundled-runtime-deps:missing-plugin-index,bundled-plugin-startup:fresh,agent-cold-warm-message:mock-openai-provider,gateway-performance:many-bundled-plugins",
+      "fresh-install:fresh,fresh-install:onboarded-user,agent-cold-warm-message:mock-openai-provider,gateway-performance:many-bundled-plugins",
+      "agent-cold-warm-message:mock-openai-provider",
+    ]);
+  });
+
+  it("prepares a fail-closed systemd user session for OCM", () => {
+    const workflow = readWorkflow();
+    const steps = workflow.jobs?.kova?.steps ?? [];
+    const managedServiceLanes = workflow.jobs?.kova?.strategy?.matrix?.include?.map(
+      (lane) => lane.managed_service,
+    );
+    const prepare = findStep("Prepare systemd user session");
+    const stepNames = steps.map((step) => step.name);
+
+    expect(managedServiceLanes).toEqual(["true", "true", "false"]);
+    expect(prepare.if).toBe(
+      "${{ steps.lane.outputs.run == 'true' && matrix.managed_service == 'true' }}",
+    );
+    expect(prepare.run).toContain("set -euo pipefail");
+    expect(prepare.run).toContain('test "$(ps -p 1 -o comm= | xargs)" = systemd');
+    expect(prepare.run).toContain("sudo systemctl is-active --quiet systemd-logind.service");
+    expect(prepare.run).toContain('sudo loginctl enable-linger "$user"');
+    expect(prepare.run).toContain('sudo systemctl start "user@${uid}.service"');
+    expect(prepare.run).toContain(
+      'runtime_dir="$(loginctl show-user "$user" --property=RuntimePath --value)"',
+    );
+    expect(prepare.run).toContain('test -S "$XDG_RUNTIME_DIR/systemd/private"');
+    expect(prepare.run).toContain('echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"');
+    expect(prepare.run).toContain('if [[ -S "$runtime_dir/bus" ]]; then');
+    expect(prepare.run).toContain(
+      'echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"',
+    );
+    expect(prepare.run).toContain("systemctl --user show-environment >/dev/null");
+    expect(prepare.run).not.toContain("|| true");
+    expect(stepNames.indexOf("Prepare systemd user session")).toBeLessThan(
+      stepNames.indexOf("Install OCM and Kova"),
+    );
+  });
+
+  it("validates exact Kova release-plan coverage before execution", () => {
+    const sanity = findStep("Kova version and plan sanity");
+
+    expect(sanity.run).toContain('--include "$INCLUDE_FILTERS"');
+    expect(sanity.run).toContain("plan.controls?.include");
+    expect(sanity.run).toContain("process.env.EXPECTED_RELEASE_ENTRIES.split");
+    expect(sanity.run).toContain('entry.status !== "SELECTED"');
+    expect(sanity.run).toContain("Kova release plan entries did not match");
+    expect(sanity.run).not.toContain("--include scenario:fresh-install");
   });
 
   it("makes the live lane honor explicit live auth in the ephemeral Kova checkout", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Kova release performance validation blocked every managed-service scenario because Blacksmith runners had no usable systemd user session. The prior filter bug had hidden this by executing only the service-free agent scenario.

## Why This Change Was Made

The workflow now provisions a real logind-owned systemd user manager only for lanes that require managed services, exports its runtime environment, and verifies OCM's exact `systemctl --user show-environment` availability contract before downloading or running Kova. The Kova plan sanity step also validates the requested filter list and exact release entry identities, preventing truncated coverage from being tolerated as a filtered report.

## User Impact

Release performance validation once again exercises cold start, status, logs, readiness, warm restart, PID/RSS, and dependency-reuse scenarios instead of blocking before product startup or silently running only one scenario. Product runtime behavior is unchanged.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29037275814 produced 3 passing service-free records and 15 blocked managed-service records with OCM's unusable `systemctl --user` error.
- Pinned OCM v0.2.15 source requires successful `systemctl --user show-environment` and then uses real user-unit reload/enable/restart/start operations.
- Pinned Kova release plan verified exact 6/4/1 entries for the three configured lanes.
- Blacksmith Testbox `tbx_01kx460gcahft17f6k0j706z79`: the exact systemd preflight passed against a real runner.
- Same Testbox: `pnpm test test/scripts/openclaw-performance-workflow.test.ts` passed 12/12; `pnpm check:changed` passed.
- `actionlint .github/workflows/openclaw-performance.yml`, targeted oxfmt, and `git diff --check` passed.
- Autoreview: clean, patch correct (0.84 confidence).
