### PR TITLE
feat: session and link context menus support single-key keyboard shortcuts

### DIFF
--- a/ui/src/app/native-link-routing.test.ts
+++ b/ui/src/app/native-link-routing.test.ts
@@ -63,7 +63,7 @@ function contextMenu(anchor: HTMLAnchorElement) {
 
 function menuItem(label: string): HTMLButtonElement {
   const item = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find(
-    (candidate) => candidate.textContent?.trim() === label,
+    (candidate) => candidate.querySelector(".session-menu__text")?.textContent?.trim() === label,
   );
   if (!item) {
     throw new Error(`Expected menu item: ${label}`);
@@ -172,7 +172,9 @@ describe("native link routing", () => {
     const firstMenu = document.querySelector("openclaw-native-link-menu");
     await (firstMenu as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
     expect(
-      [...firstMenu!.querySelectorAll('[role="menuitem"]')].map((item) => item.textContent?.trim()),
+      [...firstMenu!.querySelectorAll('[role="menuitem"]')].map((item) =>
+        item.querySelector(".session-menu__text")?.textContent?.trim(),
+      ),
     ).toEqual(["Open in Sidebar", "Open in Default Browser", "Copy Link"]);
     menuItem("Open in Default Browser").click();
     expect(bridge.messages.at(-1)).toEqual({

--- a/ui/src/components/menu-shortcuts.ts
+++ b/ui/src/components/menu-shortcuts.ts
@@ -1,0 +1,28 @@
+import { html } from "lit";
+
+// Single-letter context-menu shortcuts. Items opt in via data-shortcut plus a
+// rendered hint; menu hosts route non-Escape keydowns here so a bare letter
+// clicks the matching enabled item and disabled items swallow nothing.
+export function menuShortcutHint(key: string) {
+  return html`<span class="session-menu__shortcut" aria-hidden="true">${key.toUpperCase()}</span>`;
+}
+
+export function activateMenuShortcut(root: ParentNode, event: KeyboardEvent): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return false;
+  }
+  const key = event.key.toLowerCase();
+  // Letters only: keeps the querySelector below safe and leaves navigation
+  // keys (arrows, Tab, Enter) to native menu focus handling.
+  if (!/^[a-z]$/.test(key)) {
+    return false;
+  }
+  const item = root.querySelector<HTMLButtonElement>(`button[data-shortcut="${key}"]`);
+  if (!item || item.disabled) {
+    return false;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  item.click();
+  return true;
+}

--- a/ui/src/components/native-link-menu.test.ts
+++ b/ui/src/components/native-link-menu.test.ts
@@ -57,11 +57,9 @@ describe("native link menu", () => {
     });
     const items = menuItems(menu);
 
-    expect(items.map((item) => item.textContent?.trim())).toEqual([
-      "Open in Sidebar",
-      "Open in Default Browser",
-      "Copy Link",
-    ]);
+    expect(
+      items.map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
+    ).toEqual(["Open in Sidebar", "Open in Default Browser", "Copy Link"]);
 
     items[0]?.click();
     expect(calls).toEqual(["close", "inline"]);
@@ -74,11 +72,27 @@ describe("native link menu", () => {
     await menu.updateComplete;
 
     expect(menu.querySelector('[role="menu"]')?.getAttribute("aria-label")).toBe("Link-Aktionen");
-    expect(menuItems(menu).map((item) => item.textContent?.trim())).toEqual([
-      "In der Seitenleiste öffnen",
-      "Im Standardbrowser öffnen",
-      "Link kopieren",
-    ]);
+    expect(
+      menuItems(menu).map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
+    ).toEqual(["In der Seitenleiste öffnen", "Im Standardbrowser öffnen", "Link kopieren"]);
+  });
+
+  it("renders shortcut hints and dispatches actions from bare letter keys", async () => {
+    const calls: string[] = [];
+    const menu = await mountMenu({
+      onClose: () => calls.push("close"),
+      onAction: (action) => calls.push(action),
+    });
+
+    const hints = menuItems(menu).map(
+      (item) => item.querySelector(".session-menu__shortcut")?.textContent,
+    );
+    expect(hints).toEqual(["S", "B", "C"]);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "c", bubbles: true, cancelable: true }),
+    );
+    expect(calls).toEqual(["close", "copy"]);
   });
 
   it("closes on Escape and outside pointerdown while preserving trigger clicks", async () => {

--- a/ui/src/components/native-link-menu.ts
+++ b/ui/src/components/native-link-menu.ts
@@ -3,6 +3,7 @@ import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
+import { activateMenuShortcut, menuShortcutHint } from "./menu-shortcuts.ts";
 
 export type NativeLinkMenuAction = "inline" | "external" | "copy";
 
@@ -39,13 +40,14 @@ export class NativeLinkMenu extends OpenClawLightDomElement {
   };
 
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape") {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.trigger?.focus();
+      this.onClose();
       return;
     }
-    event.preventDefault();
-    event.stopPropagation();
-    this.trigger?.focus();
-    this.onClose();
+    activateMenuShortcut(this, event);
   };
 
   private runAction(action: NativeLinkMenuAction) {
@@ -69,29 +71,38 @@ export class NativeLinkMenu extends OpenClawLightDomElement {
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="s"
+          aria-keyshortcuts="S"
           @click=${() => this.runAction("inline")}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.panelRightOpen}</span>
           <span class="session-menu__text">${t("nativeLinkMenu.openInline")}</span>
+          ${menuShortcutHint("s")}
         </button>
         <button
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="b"
+          aria-keyshortcuts="B"
           @click=${() => this.runAction("external")}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.externalLink}</span>
           <span class="session-menu__text">${t("nativeLinkMenu.openExternal")}</span>
+          ${menuShortcutHint("b")}
         </button>
         <div class="session-menu__separator" role="separator"></div>
         <button
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="c"
+          aria-keyshortcuts="C"
           @click=${() => this.runAction("copy")}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
           <span class="session-menu__text">${t("nativeLinkMenu.copy")}</span>
+          ${menuShortcutHint("c")}
         </button>
       </div>
     `;

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -66,15 +66,17 @@ async function mountMenu(
   return element;
 }
 
+function itemLabel(item: HTMLElement): string {
+  return item.querySelector(".session-menu__text")?.textContent?.trim() ?? "";
+}
+
 function menuItemLabels(menu: ParentNode): string[] {
-  return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]')).map(
-    (item) => item.textContent?.trim() ?? "",
-  );
+  return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]')).map(itemLabel);
 }
 
 function menuItem(menu: ParentNode, label: string): HTMLButtonElement {
   const item = Array.from(menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')).find(
-    (candidate) => candidate.textContent?.trim() === label,
+    (candidate) => itemLabel(candidate) === label,
   );
   if (!item) {
     throw new Error(`Expected menu item: ${label}`);
@@ -168,6 +170,41 @@ describe("session menu", () => {
     await menu.updateComplete;
 
     expect(menuItemLabels(menu)).not.toContain("Remove from group");
+  });
+
+  it("renders shortcut hints and dispatches actions from bare letter keys", async () => {
+    const calls: string[] = [];
+    const menu = await mountMenu({
+      onClose: () => calls.push("close"),
+      onAction: (action) => calls.push(action.kind),
+    });
+
+    const pin = menuItem(menu, "Pin session");
+    expect(pin.querySelector(".session-menu__shortcut")?.textContent).toBe("P");
+    expect(pin.getAttribute("aria-keyshortcuts")).toBe("P");
+    expect(menuItem(menu, "Move to group").querySelector(".session-menu__shortcut")).toBeNull();
+
+    const keydown = new KeyboardEvent("keydown", { key: "p", bubbles: true, cancelable: true });
+    document.dispatchEvent(keydown);
+    expect(calls).toEqual(["close", "toggle-pin"]);
+    expect(keydown.defaultPrevented).toBe(true);
+  });
+
+  it("ignores shortcut keys for disabled items and modified keystrokes", async () => {
+    const onAction = vi.fn();
+    await mountMenu({ archiveAllowed: false, onAction });
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "d", bubbles: true, cancelable: true }),
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "p", metaKey: true, bubbles: true, cancelable: true }),
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "x", bubbles: true, cancelable: true }),
+    );
+
+    expect(onAction).not.toHaveBeenCalled();
   });
 
   it("closes on Escape and outside pointerdown but ignores its trigger", async () => {

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -3,6 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
+import { activateMenuShortcut, menuShortcutHint } from "./menu-shortcuts.ts";
 
 export type SessionMenuData = {
   key: string;
@@ -92,12 +93,13 @@ class SessionMenu extends OpenClawLightDomElement {
   };
 
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
-    if (event.key !== "Escape") {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      this.trigger?.focus();
+      this.onClose();
       return;
     }
-    event.stopPropagation();
-    this.trigger?.focus();
-    this.onClose();
+    activateMenuShortcut(this, event);
   };
 
   private runAction(action: SessionMenuAction) {
@@ -125,11 +127,14 @@ class SessionMenu extends OpenClawLightDomElement {
                 type="button"
                 class="session-menu__item"
                 role="menuitem"
+                data-shortcut="o"
+                aria-keyshortcuts="O"
                 ?disabled=${this.disabled}
                 @click=${() => this.runAction({ kind: "open-chat" })}
               >
                 <span class="session-menu__icon" aria-hidden="true">${icons.messageSquare}</span>
                 <span class="session-menu__text">${t("sessionsView.openChat")}</span>
+                ${menuShortcutHint("o")}
               </button>
             `
           : nothing}
@@ -137,6 +142,8 @@ class SessionMenu extends OpenClawLightDomElement {
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="p"
+          aria-keyshortcuts="P"
           ?disabled=${this.disabled || session.archived}
           @click=${() => this.runAction({ kind: "toggle-pin" })}
         >
@@ -146,11 +153,14 @@ class SessionMenu extends OpenClawLightDomElement {
           <span class="session-menu__text"
             >${session.pinned ? t("sessionsView.unpinSession") : t("sessionsView.pinSession")}</span
           >
+          ${menuShortcutHint("p")}
         </button>
         <button
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="u"
+          aria-keyshortcuts="U"
           ?disabled=${this.disabled}
           @click=${() => this.runAction({ kind: "toggle-unread" })}
         >
@@ -160,26 +170,33 @@ class SessionMenu extends OpenClawLightDomElement {
           <span class="session-menu__text"
             >${session.unread ? t("sessionsView.markRead") : t("sessionsView.markUnread")}</span
           >
+          ${menuShortcutHint("u")}
         </button>
         <button
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="r"
+          aria-keyshortcuts="R"
           ?disabled=${this.disabled}
           @click=${() => this.runAction({ kind: "rename" })}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
           <span class="session-menu__text">${t("sessionsView.renameSessionMenu")}</span>
+          ${menuShortcutHint("r")}
         </button>
         <button
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="f"
+          aria-keyshortcuts="F"
           ?disabled=${this.disabled || this.forkDisabled}
           @click=${() => this.runAction({ kind: "fork" })}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
           <span class="session-menu__text">${t("sessionsView.forkSession")}</span>
+          ${menuShortcutHint("f")}
         </button>
         ${this.workboard
           ? html`
@@ -187,6 +204,8 @@ class SessionMenu extends OpenClawLightDomElement {
                 type="button"
                 class="session-menu__item"
                 role="menuitem"
+                data-shortcut="w"
+                aria-keyshortcuts="W"
                 ?disabled=${this.disabled || this.workboard.busy}
                 @click=${() => this.runAction({ kind: "workboard" })}
               >
@@ -198,6 +217,7 @@ class SessionMenu extends OpenClawLightDomElement {
                     ? t("sessionsView.openWorkboardCard")
                     : t("sessionsView.addToWorkboard")}</span
                 >
+                ${menuShortcutHint("w")}
               </button>
             `
           : nothing}
@@ -286,6 +306,8 @@ class SessionMenu extends OpenClawLightDomElement {
           type="button"
           class="session-menu__item"
           role="menuitem"
+          data-shortcut="a"
+          aria-keyshortcuts="A"
           ?disabled=${this.disabled || (!session.archived && !this.archiveAllowed)}
           @click=${() => this.runAction({ kind: "toggle-archived" })}
         >
@@ -297,16 +319,20 @@ class SessionMenu extends OpenClawLightDomElement {
               ? t("sessionsView.restoreSession")
               : t("sessionsView.archiveSession")}</span
           >
+          ${menuShortcutHint("a")}
         </button>
         <button
           type="button"
           class="session-menu__item session-menu__item--destructive"
           role="menuitem"
+          data-shortcut="d"
+          aria-keyshortcuts="D"
           ?disabled=${this.disabled || !(session.archived || this.archiveAllowed)}
           @click=${() => this.runAction({ kind: "delete" })}
         >
           <span class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
           <span class="session-menu__text">${t("sessionsView.deleteSessionMenu")}</span>
+          ${menuShortcutHint("d")}
         </button>
       </div>
     `;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1416,6 +1416,14 @@ openclaw-native-link-menu[popover] {
   color: var(--muted);
 }
 
+.session-menu__shortcut {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 550;
+  letter-spacing: 0.04em;
+}
+
 .session-menu__separator {
   margin: 6px 4px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);


### PR DESCRIPTION
Closes #103086

## What Problem This Solves

The Control UI session context menu (sidebar kebab / right-click: Open chat, Pin, Mark as unread, Rename, Fork, Workboard, Move to group, Archive, Delete) and the native link context menu are mouse-only. Keyboard-centric users have no fast path for common session operations, and the menus advertise no accelerators.

## Why This Change Was Made

While a context menu is open, a bare letter key now activates the matching enabled item, and each item shows a right-aligned uppercase hint. A small shared helper (`ui/src/components/menu-shortcuts.ts`) renders the hint and routes non-Escape keydowns: letters only, no Cmd/Ctrl/Alt-modified keys, disabled items ignored, and matched keys are consumed (preventDefault/stopPropagation) so nothing leaks to global handlers. Submenu rows ("Move to group") keep their chevron and get no letter. Accelerators are fixed Latin letters across locales, mirroring Gmail/Linear-style single-key menus; buttons expose `aria-keyshortcuts` and the visual hint is `aria-hidden` so accessible names are unchanged.

Session menu: O Open chat, P Pin/Unpin, U Mark as unread/read, R Rename, F Fork, W Workboard, A Archive/Restore, D Delete. Link menu: S Open in Sidebar, B Open in Default Browser, C Copy Link.

## User Impact

Control UI users can operate session and link context menus entirely from the keyboard: open the menu, press one letter. Existing mouse behavior, Escape handling, and focus restoration are unchanged.

## Evidence

- Blacksmith Testbox (delegated, exit 0): https://github.com/openclaw/openclaw/actions/runs/29045739583
  - `pnpm test ui/src/components/session-menu.test.ts ui/src/components/native-link-menu.test.ts ui/src/app/native-link-routing.test.ts ui/src/e2e/native-link-routing.e2e.test.ts` — 21 tests passed (10 + 3 + 8 unit, 2 e2e), including new coverage: hint rendering, `aria-keyshortcuts`, bare-letter dispatch closes menu then fires the action, disabled items and Cmd-modified keys ignored, submenu row has no hint.
  - `pnpm tsgo:test:ui` and scoped `scripts/run-oxlint.mjs ui/src/components ui/src/app` clean in the same run.
- Codex autoreview (gpt-5.5, high): clean, no actionable findings.
