### PR TITLE
feat(webchat): lobster pet shape variants (build, claw size, tail fan)

### DIFF
--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -71,14 +71,22 @@ describe("lobster pet look", () => {
   it("stays within the variant catalog for many seeds", () => {
     const palettes = new Set<string>();
     const personalities = new Set<string>();
+    const builds = new Set<string>();
+    const clawSizes = new Set<string>();
+    const tailFans = new Set<boolean>();
     for (let seed = 0; seed < 300; seed++) {
       const look = createLobsterPetLook(seed);
       palettes.add(look.palette.id);
       personalities.add(look.personality);
+      builds.add(look.build);
+      clawSizes.add(look.clawSize);
+      tailFans.add(look.tailFan);
       expect(LOBSTER_PET_PALETTE_IDS).toContain(look.palette.id);
       expect([1.7, 2, 2.5]).toContain(look.scale);
       expect(["none", "crown", "sprout", "patch"]).toContain(look.accessory);
       expect(["perky", "droopy"]).toContain(look.antennae);
+      expect(["round", "squat", "slender"]).toContain(look.build);
+      expect(["dainty", "regular", "mighty"]).toContain(look.clawSize);
       const zone = SPOT_ZONES[look.side];
       expect(look.spotPct).toBeGreaterThanOrEqual(zone[0]);
       expect(look.spotPct).toBeLessThanOrEqual(zone[1]);
@@ -86,6 +94,9 @@ describe("lobster pet look", () => {
     // Sessions should feel different: many seeds must not collapse onto one look.
     expect(palettes.size).toBeGreaterThan(2);
     expect(personalities.size).toBeGreaterThan(2);
+    expect(builds.size).toBe(3);
+    expect(clawSizes.size).toBe(3);
+    expect(tailFans.size).toBe(2);
   });
 
   it("hatches every rarity tier, with rares staying rare", () => {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -46,6 +46,10 @@ export type LobsterPetAccessory = "none" | "crown" | "sprout" | "patch";
 
 export type LobsterPetAntennae = "perky" | "droopy";
 
+export type LobsterPetBuild = "round" | "squat" | "slender";
+
+export type LobsterPetClawSize = "dainty" | "regular" | "mighty";
+
 export type LobsterPetLook = {
   palette: LobsterPetPalette;
   scale: number;
@@ -56,6 +60,9 @@ export type LobsterPetLook = {
   facing: 1 | -1;
   personality: LobsterPetPersonalityId;
   blinkDelayS: number;
+  build: LobsterPetBuild;
+  clawSize: LobsterPetClawSize;
+  tailFan: boolean;
 };
 
 type ActProfile = {
@@ -187,6 +194,33 @@ const SCALES: Array<[number, number]> = [
   [2.5, 20],
 ];
 
+const BUILDS: Array<[LobsterPetBuild, number]> = [
+  ["round", 40],
+  ["squat", 30],
+  ["slender", 30],
+];
+
+const CLAW_SIZES: Array<[LobsterPetClawSize, number]> = [
+  ["regular", 55],
+  ["dainty", 25],
+  ["mighty", 20],
+];
+
+// Builds reshape the whole sprite by stretching its aspect ratio (the svg
+// renders with preserveAspectRatio="none"), so eyes, claws, accessories, and
+// rare-variant geometry stay aligned for every silhouette.
+export const LOBSTER_PET_BUILD_MULS: Record<LobsterPetBuild, { w: number; h: number }> = {
+  round: { w: 1, h: 1 },
+  squat: { w: 1.14, h: 0.9 },
+  slender: { w: 0.88, h: 1.1 },
+};
+
+export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
+  dainty: 0.85,
+  regular: 1,
+  mighty: 1.18,
+};
+
 // Keep the perch off the footer center so tooltips and the theme toggle
 // never sit under the sprite.
 const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
@@ -247,7 +281,25 @@ export function createLobsterPetLook(seed: number): LobsterPetLook {
   const facing = rng() < 0.5 ? 1 : -1;
   const personality = pickWeighted(rng, PERSONALITY_IDS);
   const blinkDelayS = Math.round(randomBetween(rng, 0, 4) * 10) / 10;
-  return { palette, scale, accessory, antennae, side, spotPct, facing, personality, blinkDelayS };
+  // Shape traits roll after the original ones so pre-existing seeds keep
+  // their palette/personality and only gain a silhouette.
+  const build = pickWeighted(rng, BUILDS);
+  const clawSize = pickWeighted(rng, CLAW_SIZES);
+  const tailFan = rng() < 0.3;
+  return {
+    palette,
+    scale,
+    accessory,
+    antennae,
+    side,
+    spotPct,
+    facing,
+    personality,
+    blinkDelayS,
+    build,
+    clawSize,
+    tailFan,
+  };
 }
 
 export function resolveLobsterPetMode(
@@ -344,6 +396,15 @@ const RETRO_FACE = svg`
   </g>
 `;
 
+// Tail-fan lobes peek out diagonally behind the lower body (drawn before the
+// body path so they read as "behind"). Fill color lives in lobster-pet.css.
+const TAIL_FAN = svg`
+  <g class="lob-tail">
+    <ellipse cx="16" cy="84" rx="11" ry="7" transform="rotate(-32 16 84)" />
+    <ellipse cx="104" cy="84" rx="11" ry="7" transform="rotate(32 104 84)" />
+  </g>
+`;
+
 const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
   perky: svg`
     <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
@@ -366,10 +427,11 @@ function renderLobsterSvg(look: LobsterPetLook) {
     <svg
       class="lobster-pet__svg"
       viewBox="0 0 120 105"
-      preserveAspectRatio="xMidYMax meet"
+      preserveAspectRatio="none"
       aria-hidden="true"
     >
       ${look.palette.id === "retro" ? RETRO_ANTENNAE : ANTENNAE_SPRITES[look.antennae]}
+      ${look.tailFan ? TAIL_FAN : nothing}
       <g class="lob-claw lob-claw--l">
         <path
           d="M20 42 C5 37 0 47 5 57 C10 67 20 62 25 52 C28 45 25 42 20 42 Z"
@@ -600,6 +662,9 @@ export class LobsterPet extends LitElement {
       `--lob-x:${this.spotPct}%`,
       `--lob-face:${this.facing}`,
       `--lob-blink-delay:${look.blinkDelayS}s`,
+      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
+      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
+      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
     ].join(";");
     return html`
       <div class=${classes} style=${style} aria-hidden="true" @pointerdown=${this.handlePoke}>

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -31,8 +31,10 @@ openclaw-lobster-pet {
   position: absolute;
   bottom: 0;
   left: var(--lob-x, 80%);
-  width: calc(16px * var(--lob-scale, 2));
-  height: calc(14px * var(--lob-scale, 2));
+  /* Build multipliers stretch the sprite box; the svg renders with
+     preserveAspectRatio="none", so the silhouette follows the box. */
+  width: calc(16px * var(--lob-scale, 2) * var(--lob-w, 1));
+  height: calc(14px * var(--lob-scale, 2) * var(--lob-h, 1));
   transform: translateX(-50%);
   pointer-events: auto;
   cursor: pointer;
@@ -105,6 +107,9 @@ openclaw-lobster-pet {
   display: block;
   width: 100%;
   height: 100%;
+  /* Mighty claws scale past the 120x105 viewBox edges; let the svg paint
+     outside its viewport — the host strip still clips at the ledge. */
+  overflow: visible;
   transform: scaleX(var(--lob-face, 1));
   transform-origin: 50% 100%;
 }
@@ -123,6 +128,25 @@ openclaw-lobster-pet {
 
 .lob-claw--r {
   transform-origin: 95px 52px;
+}
+
+/* Claw size scales the paths inside the group: act animations own the group
+   transform, so scaling here composes instead of being overridden mid-wave. */
+.lob-claw > path {
+  transform: scale(var(--lob-claw-scale, 1));
+  transform-box: view-box;
+}
+
+.lob-claw--l > path {
+  transform-origin: 25px 52px;
+}
+
+.lob-claw--r > path {
+  transform-origin: 95px 52px;
+}
+
+.lob-tail {
+  fill: color-mix(in srgb, var(--lob-shell, #ff4f40) 78%, #10181f);
 }
 
 /* ---- Idle blinking: crossfade open pupils and closed-lid curves ---- */


### PR DESCRIPTION
Related: #102754 (follow-up to #102766, #102829)

## What Problem This Solves

The sidebar lobster pet varies by palette, size, accessory, and personality — but every lobster has the same silhouette. Shape is the strongest at-a-glance differentiator between individuals, and it's the axis the pet is missing.

## Why This Change Was Made

**Proposal:** three new seeded shape traits, composable with everything that exists:

| Trait | Options (weights) | How |
|---|---|---|
| Build | round (40%) · squat (30%) · slender (30%) | The sprite box stretches by per-build multipliers and the svg renders with `preserveAspectRatio="none"`, so the whole silhouette follows — eyes, claws, accessories, and rare-variant geometry (split halves, calico spots, retro parts) stay aligned for free. |
| Claw size | regular (55%) · dainty (25%) · mighty (20%) | Scaled on the paths *inside* the claw groups, so wave/snip act animations (which own the group transform) still compose — a mighty lobster stays mighty mid-wave. |
| Tail fan | ~30% | Two fan lobes peek out diagonally behind the lower body, drawn behind the body path in a darker shell mix. |

Shape traits roll **after** the existing traits in the RNG sequence, so any given seed keeps its palette/personality and only gains a silhouette. Combined with palettes, accessories, antennae, and personalities, the catalog now spans ~12k visual combinations with everyday commons and compounding rarities (a squat gold tail-fan lobster, a slender mighty-clawed retro...).

One review-cycle fix included: mighty claws scale past the 120×105 viewBox edges, so the sprite svg now sets `overflow: visible` (the host strip still owns the ledge clipping that sells duck/peek/enter moves).

## User Impact

Each session's lobster now has a body type: chunky wide ones, tall skinny ones, big-clawed bruisers, dainty pinchers, and the occasional tail-fan flourish. No behavior, mode, a11y, or config changes.

## Evidence

![shape variants](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/shape-variants.png)

Validation (delegated Blacksmith Testbox, `exit=0`):

- `pnpm test ui/src/components/lobster-pet.test.ts` — 11/11; the catalog test now asserts all three builds, all three claw sizes, and both tail-fan states appear across 300 seeds and stay within bounds.
- `pnpm tsgo:test:ui` and `pnpm --dir ui build`.
- Live verification against `pnpm dev:ui:mock`: side-by-side build comparison, claw-size composition probe during a wave act (group runs the `lobster-pet-wave` animation while the path keeps its 1.18 scale matrix), tail-fan lobes render behind the body, and post-fix confirmation that mighty claw geometry paints outside the svg viewport (`overflow: visible` computed, claw bounding box exceeds the viewport edge).
- Codex autoreview: one accepted finding (mighty-claw viewBox clipping) fixed as above; fresh review on the final diff clean.
