### PR TITLE
fix: restore Apple builds under SwiftFormat 0.62.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1830,7 +1830,11 @@ jobs:
       - *platform_checkout_step
 
       - name: Install XcodeGen / SwiftLint / SwiftFormat
-        run: brew install xcodegen swiftlint swiftformat
+        run: |
+          brew update
+          brew install xcodegen swiftlint swiftformat
+          brew upgrade swiftformat
+          swiftformat --version
 
       - name: Detect Swift toolchain cache key
         id: swift-toolchain
@@ -1978,7 +1982,11 @@ jobs:
           install-bun: "false"
 
       - name: Install iOS Swift tooling
-        run: brew install xcodegen swiftlint swiftformat
+        run: |
+          brew update
+          brew install xcodegen swiftlint swiftformat
+          brew upgrade swiftformat
+          swiftformat --version
 
       - name: Build iOS app
         run: pnpm ios:build

--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -95,7 +95,11 @@ jobs:
           install-bun: "false"
 
       - name: Install iOS Swift tooling
-        run: brew install xcodegen swiftformat swiftlint periphery
+        run: |
+          brew update
+          brew install xcodegen swiftformat swiftlint periphery
+          brew upgrade swiftformat
+          swiftformat --version
 
       - name: Generate iOS project
         run: |

--- a/config/swiftformat
+++ b/config/swiftformat
@@ -1,6 +1,7 @@
 # SwiftFormat configuration adapted from Peekaboo defaults (Swift 6 friendly)
 
 --swiftversion 6.2
+--min-version 0.62.1
 
 # Self handling
 --self insert
@@ -33,6 +34,9 @@
 --wrapparameters before-first
 --wrapcollections before-first
 --closingparen same-line
+
+# Preserve the established compact conditionals and SwiftUI groups across SwiftFormat releases.
+--disable wrapIfStatementBodies,wrapIfExpressionBodies,redundantSwiftUIGroup
 
 # Organization
 --organizetypes class,struct,enum,extension

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -34,12 +34,13 @@ const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
 const SKILLS_PYTHON_SCOPE_RE = /^(skills\/|skills\/pyproject\.toml$)/;
 const INSTALL_SMOKE_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/install-smoke\.yml$/;
 const NATIVE_PROTOCOL_GEN_RE = /^apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\//;
+const APPLE_SWIFT_CONFIG_RE = /^config\/(?:swiftformat|swiftlint\.yml)$/;
 const MACOS_NATIVE_RE =
   /^(apps\/macos\/|apps\/macos-mlx-tts\/|apps\/ios\/|apps\/shared\/|apps\/swabble\/|Swabble\/)/;
 const MACOS_SCRIPT_SCOPE_RE =
   /^(?:scripts\/(?:codesign-mac-app|create-dmg|notarize-mac-artifact|package-mac-app|package-mac-dist)\.sh|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh|test\/scripts\/(?:codesign-mac-app|create-dmg|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts)$/;
 const IOS_BUILD_RE =
-  /^(apps\/ios\/|apps\/shared\/|apps\/swabble\/|Swabble\/|config\/(?:swiftformat|swiftlint\.yml)$|scripts\/ios-(?:configure-signing|team-id|write-version-xcconfig)\.sh$|scripts\/ios-version\.ts$|scripts\/lib\/(?:ios-version\.ts|npm-publish-plan\.mjs|version-script-args\.ts)$)/;
+  /^(apps\/ios\/|apps\/shared\/|apps\/swabble\/|Swabble\/|scripts\/ios-(?:configure-signing|team-id|write-version-xcconfig)\.sh$|scripts\/ios-version\.ts$|scripts\/lib\/(?:ios-version\.ts|npm-publish-plan\.mjs|version-script-args\.ts)$)/;
 const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 const NODE_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
@@ -100,6 +101,8 @@ export function detectChangedScope(changedPaths) {
       continue;
     }
 
+    const isAppleSwiftConfig = APPLE_SWIFT_CONFIG_RE.test(path);
+
     if (DOCS_PATH_RE.test(path)) {
       continue;
     }
@@ -116,12 +119,12 @@ export function detectChangedScope(changedPaths) {
 
     if (
       !NATIVE_PROTOCOL_GEN_RE.test(path) &&
-      (MACOS_NATIVE_RE.test(path) || MACOS_SCRIPT_SCOPE_RE.test(path))
+      (MACOS_NATIVE_RE.test(path) || MACOS_SCRIPT_SCOPE_RE.test(path) || isAppleSwiftConfig)
     ) {
       runMacos = true;
     }
 
-    if (IOS_BUILD_RE.test(path)) {
+    if (IOS_BUILD_RE.test(path) || isAppleSwiftConfig) {
       runIosBuild = true;
     }
 

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -223,6 +223,21 @@ describe("detectChangedScope", () => {
     });
   });
 
+  it("runs both Apple lanes for shared Swift lint configuration", () => {
+    for (const configPath of ["config/swiftformat", "config/swiftlint.yml"]) {
+      expect(detectChangedScope([configPath])).toEqual({
+        runNode: true,
+        runMacos: true,
+        runIosBuild: true,
+        runAndroid: false,
+        runWindows: false,
+        runSkillsPython: false,
+        runChangedSmoke: false,
+        runControlUiI18n: false,
+      });
+    }
+  });
+
   it("enables the iOS build lane for iOS build helper changes", () => {
     for (const helperPath of [
       "scripts/ios-team-id.sh",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running Apple builds with SwiftFormat 0.62.1 would hit hundreds of pre-existing lint failures and `pnpm ios:build` would abort. SwiftFormat 0.62 newly enabled rules that conflict with the repository's established compact conditional and SwiftUI `Group` style.

## Why This Change Was Made

The shared config now requires SwiftFormat 0.62.1 and explicitly disables `wrapIfStatementBodies`, `wrapIfExpressionBodies`, and `redundantSwiftUIGroup`. All three Apple CI consumers refresh and upgrade SwiftFormat before using that config, and shared Swift lint config changes now route through both macOS and iOS CI. This avoids a 172-file, 3,588-line formatting pass that would also make structural SwiftUI rewrites.

## User Impact

Apple contributors can run the repository's iOS build and macOS Swift lint with Homebrew SwiftFormat 0.62.1 without unrelated formatter drift. There is no runtime behavior change.

## Evidence

- Before: the exact macOS CI lint command reported 1,026 diagnostics across 113/264 files; the iOS build-phase list reported 954 diagnostics across 59/180 files.
- After: SwiftFormat 0.62.1 exact macOS CI lint command passes with `0/264 files require formatting, 2 files skipped`.
- `pnpm ios:build` — passed locally, including the always-run SwiftFormat phase; Xcode build succeeded in 226.984 seconds.
- `pnpm test src/scripts/ci-changed-scope.test.ts` — 30/30 passed on Blacksmith Testbox lease `tbx_01kx46qbdxwxt2x7zqy5ee8acv`.
- SwiftFormat 0.61.1 now exits early with the explicit `--min-version 0.62.1` requirement instead of failing on unknown rule names.
- Fresh autoreview: no accepted or actionable findings.
