### PR TITLE
fix(cli): reject unsafe byte sizes

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -159,6 +159,17 @@ describe("parseByteSize", () => {
   it.each(["", "nope", "-5kb"] as const)("rejects invalid value %j", (input) => {
     expect(() => parseByteSize(input)).toThrow(/Invalid byte size/);
   });
+  it("keeps the largest safe integer exact", () => {
+    expect(parseByteSize(String(Number.MAX_SAFE_INTEGER))).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseByteSize(`${Number.MAX_SAFE_INTEGER}.1`)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it.each([String(Number.MAX_SAFE_INTEGER + 1), "9007199254740993", "9000000tb"] as const)(
+    "rejects finite-but-unsafe values that would round to a different number: %j",
+    (input) => {
+      expect(() => parseByteSize(input)).toThrow(/Invalid byte size/);
+    },
+  );
 });
 
 describe("parseDurationMs", () => {

--- a/src/cli/parse-bytes.ts
+++ b/src/cli/parse-bytes.ts
@@ -52,7 +52,8 @@ export function parseByteSize(raw: string, opts?: BytesParseOptions): number {
   }
 
   const bytes = Math.round(value * multiplier);
-  if (!Number.isFinite(bytes)) {
+  // Validate the rounded byte count; fractional inputs may safely round back into range.
+  if (!Number.isSafeInteger(bytes)) {
     throw invalidByteSize(raw);
   }
   return bytes;

--- a/src/config/byte-size.test.ts
+++ b/src/config/byte-size.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseNonNegativeByteSize } from "./byte-size.js";
+
+describe("parseNonNegativeByteSize", () => {
+  it("keeps safe-integer boundaries exact for numeric and string forms", () => {
+    expect(parseNonNegativeByteSize(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseNonNegativeByteSize(String(Number.MAX_SAFE_INTEGER))).toBe(Number.MAX_SAFE_INTEGER);
+    expect(parseNonNegativeByteSize("2mb")).toBe(2 * 1024 * 1024);
+  });
+
+  it.each([Number.MAX_SAFE_INTEGER + 1, String(Number.MAX_SAFE_INTEGER + 1), "9007199254740993"])(
+    "rejects unsafe byte size %j",
+    (value) => expect(parseNonNegativeByteSize(value)).toBeNull(),
+  );
+});

--- a/src/config/byte-size.ts
+++ b/src/config/byte-size.ts
@@ -6,9 +6,9 @@ import { parseByteSize } from "../cli/parse-bytes.js";
  * Accepts non-negative numbers or strings like "2mb".
  */
 export function parseNonNegativeByteSize(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
+  if (typeof value === "number") {
     const int = Math.floor(value);
-    return int >= 0 ? int : null;
+    return Number.isSafeInteger(int) && int >= 0 ? int : null;
   }
   if (typeof value === "string") {
     const trimmed = value.trim();

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -327,6 +327,20 @@ describe("agent defaults schema", () => {
     expect(result.compaction?.maxActiveTranscriptBytes).toBe("20mb");
   });
 
+  it("rejects unsafe byte-size strings in compaction defaults", () => {
+    const unsafe = String(Number.MAX_SAFE_INTEGER + 1);
+    expect(
+      AgentDefaultsSchema.safeParse({
+        compaction: { maxActiveTranscriptBytes: unsafe },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentDefaultsSchema.safeParse({
+        compaction: { memoryFlush: { forceFlushTranscriptBytes: unsafe } },
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts compaction.midTurnPrecheck.enabled", () => {
     const result = AgentDefaultsSchema.parse({
       compaction: {


### PR DESCRIPTION
Related: #96300

## What Problem This Solves

Fixes an issue where users supplying byte counts above JavaScript's safe-integer range could have CLI or config values silently rounded to a different number.

## Why This Change Was Made

The shared byte parser now rejects rounded results that are not safe integers, and the numeric config helper applies the same rule after its existing flooring step. The rewrite keeps one canonical parser path, removes the contributor branch's one-use helper, and relies on Zod 4.4.3's built-in safe-integer behavior for numeric schema values instead of adding a duplicate refinement.

This is an AI-assisted maintainer rewrite of #96300 because the stale fork could not accept a safe repo-native ancestry sync. It preserves @ly-wang19's authorship through `Co-authored-by` metadata and explicit PR credit.

## User Impact

Valid byte sizes, including fractional values that round into the safe range, continue to work. Integer values that JavaScript cannot represent exactly now fail validation instead of selecting a different threshold.

## Evidence

- Direct Zod 4.4.3 source and declaration inspection confirmed `z.number().int()` uses the `safeint` format and `Number.isSafeInteger`.
- Focused MAX_SAFE_INTEGER, unsafe string, numeric config, and compaction-schema regressions are included.
- Exact head: `f3eb3baab918c0b2a8ad2f901807e32d98ff824d`, one semantic commit atop its current-main parent, with exactly five intended files (`+44/-3`).
- Exact-head Codex autoreview: no findings, confidence 0.88; independent whole-path review: no actionable findings, best-fix READY.
- Blacksmith Testbox `tbx_01kx4dhp39ynxjcdkp0shzcxz1`: 84/84 focused tests passed; `pnpm check:changed` passed the core and coreTests lanes, including typechecks, lint, and guards.
- Source-blind real CLI validation used isolated HOME/state/config/XDG directories: unsafe string and numeric values failed, while `Number.MAX_SAFE_INTEGER` and `"2mb"` passed (4/4 cases).
- Exact-head hosted CI run [29052414586](https://github.com/openclaw/openclaw/actions/runs/29052414586) and Workflow Sanity run [29052414680](https://github.com/openclaw/openclaw/actions/runs/29052414680) passed.
- No OpenAI credential was used or needed: this validation path completes before provider selection or API activity.
