### PR TITLE
fix(ui): keep hidden sessions out of configured-only lists

### DIFF
--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -1,0 +1,93 @@
+// Control UI E2E tests cover session-list event scope through the Gateway WebSocket.
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser | undefined;
+let page: Page | undefined;
+let server: ControlUiE2eServer | undefined;
+
+describeControlUiE2e("Control UI session-list event scope", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+  });
+
+  afterEach(async () => {
+    await page
+      ?.context()
+      .close()
+      .catch(() => {});
+    await browser?.close().catch(() => {});
+    page = undefined;
+    browser = undefined;
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("refetches instead of showing a row excluded by configured-agent filtering", async () => {
+    const visibleLabel = "Visible configured session";
+    const hiddenLabel = "Hidden unconfigured session";
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, {
+      sessionKey: "unknown",
+      methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: { contextTokens: null, model: null, modelProvider: null },
+          path: "",
+          sessions: [
+            {
+              key: "agent:main:visible",
+              kind: "direct",
+              label: visibleLabel,
+              updatedAt: 1,
+            },
+          ],
+          ts: 1,
+        },
+      },
+    });
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}overview`);
+    await currentPage.getByText(visibleLabel, { exact: true }).waitFor({ timeout: 10_000 });
+    const requestsBeforeEvent = await gateway.getRequests("sessions.list");
+    expect(
+      requestsBeforeEvent.some(
+        (request) =>
+          (request.params as { configuredAgentsOnly?: unknown } | undefined)
+            ?.configuredAgentsOnly === true,
+      ),
+    ).toBe(true);
+
+    await gateway.emitGatewayEvent("sessions.changed", {
+      session: {
+        key: "agent:local:hidden",
+        kind: "direct",
+        label: hiddenLabel,
+        updatedAt: 2,
+      },
+    });
+
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(requestsBeforeEvent.length);
+    expect(await currentPage.getByText(hiddenLabel, { exact: true }).count()).toBe(0);
+    await currentPage.getByText(visibleLabel, { exact: true }).waitFor();
+  });
+});

--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -65,7 +65,8 @@ describeControlUiE2e("Control UI session-list event scope", () => {
     });
 
     await currentPage.goto(`${server?.baseUrl ?? ""}overview`);
-    await currentPage.getByText(visibleLabel, { exact: true }).waitFor({ timeout: 10_000 });
+    const visibleOverviewRow = currentPage.getByRole("listitem").filter({ hasText: visibleLabel });
+    await visibleOverviewRow.waitFor({ timeout: 10_000 });
     const requestsBeforeEvent = await gateway.getRequests("sessions.list");
     expect(
       requestsBeforeEvent.some(
@@ -88,6 +89,6 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       .poll(async () => (await gateway.getRequests("sessions.list")).length)
       .toBeGreaterThan(requestsBeforeEvent.length);
     expect(await currentPage.getByText(hiddenLabel, { exact: true }).count()).toBe(0);
-    await currentPage.getByText(visibleLabel, { exact: true }).waitFor();
+    await visibleOverviewRow.waitFor();
   });
 });

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -36,6 +36,7 @@ function createGatewayHarness(client: GatewayBrowserClient) {
     hello: null,
   };
   const listeners = new Set<(next: typeof snapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
   return {
     gateway: {
       get snapshot() {
@@ -45,13 +46,37 @@ function createGatewayHarness(client: GatewayBrowserClient) {
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
-      subscribeEvents: () => () => undefined,
+      subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+        eventListeners.add(listener);
+        return () => eventListeners.delete(listener);
+      },
+    },
+    emitEvent: (event: GatewayEventFrame) => {
+      for (const listener of eventListeners) {
+        listener(event);
+      }
     },
     publish: (connected: boolean) => {
       snapshot = { ...snapshot, connected };
       for (const listener of listeners) {
         listener(snapshot);
       }
+    },
+  };
+}
+
+function sessionChangedEvent(key: string): GatewayEventFrame {
+  return {
+    type: "event",
+    event: "sessions.changed",
+    payload: {
+      session: {
+        key,
+        kind: "direct",
+        updatedAt: 2,
+        sessionId: "hidden-session",
+        label: "Hidden",
+      },
     },
   };
 }
@@ -378,6 +403,72 @@ describe("createSessionCapability", () => {
         endedAt: 160,
       }),
     ).toBe(result);
+  });
+
+  it("refreshes instead of inserting hidden sessions after configured-only lists", async () => {
+    const visibleKey = "agent:main:main";
+    const hiddenKey = "agent:local:hidden";
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(
+        [
+          {
+            key: visibleKey,
+            kind: "direct",
+            updatedAt: 1,
+            sessionId: "visible-session",
+          },
+        ],
+        1,
+      );
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, emitEvent } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({ configuredAgentsOnly: true }),
+    );
+
+    emitEvent(sessionChangedEvent(hiddenKey));
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(sessions.state.result?.sessions.map((row) => row.key)).toEqual([visibleKey]);
+    sessions.dispose();
+  });
+
+  it("reconciles broad events when configured-agent filtering is explicitly disabled", async () => {
+    const visibleKey = "agent:main:main";
+    const hiddenKey = "agent:local:hidden";
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult([{ key: visibleKey, kind: "direct", updatedAt: 1 }], 1);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway, emitEvent } = createGatewayHarness(client);
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ configuredAgentsOnly: false, force: true });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({
+        configuredAgentsOnly: false,
+        includeGlobal: true,
+        includeUnknown: true,
+      }),
+    );
+
+    emitEvent(sessionChangedEvent(hiddenKey));
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(sessions.state.result?.sessions.map((row) => row.key)).toContain(hiddenKey);
+    sessions.dispose();
   });
 
   it("refreshes stale active rows after a terminal session message", async () => {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -230,7 +230,10 @@ export type {
   SessionScopeHostWithKey,
 } from "./navigation.ts";
 
-const SESSION_LIST_PARAMS = {
+type EffectiveSessionListOptions = SessionListOptions &
+  Required<Pick<SessionListOptions, "includeGlobal" | "includeUnknown" | "configuredAgentsOnly">>;
+
+const SESSION_LIST_DEFAULTS = {
   includeGlobal: true,
   includeUnknown: true,
   configuredAgentsOnly: true,
@@ -248,23 +251,28 @@ function buildSessionRequestParams(
   };
 }
 
-function buildSessionListParams(options: SessionListOptions = {}): Record<string, unknown> {
+function resolveEffectiveSessionListOptions(
+  options: SessionListOptions = {},
+): EffectiveSessionListOptions {
+  return {
+    ...options,
+    includeGlobal: options.includeGlobal ?? SESSION_LIST_DEFAULTS.includeGlobal,
+    includeUnknown: options.includeUnknown ?? SESSION_LIST_DEFAULTS.includeUnknown,
+    configuredAgentsOnly:
+      options.configuredAgentsOnly ?? SESSION_LIST_DEFAULTS.configuredAgentsOnly,
+  };
+}
+
+function buildSessionListParams(options: EffectiveSessionListOptions): Record<string, unknown> {
   const params: Record<string, unknown> = {
-    ...SESSION_LIST_PARAMS,
+    includeGlobal: options.includeGlobal,
+    includeUnknown: options.includeUnknown,
+    configuredAgentsOnly: options.configuredAgentsOnly,
   };
   if (options.limit === undefined) {
     params.limit = 50;
   } else if (options.limit > 0) {
     params.limit = Math.floor(options.limit);
-  }
-  if (options.includeGlobal !== undefined) {
-    params.includeGlobal = options.includeGlobal;
-  }
-  if (options.includeUnknown !== undefined) {
-    params.includeUnknown = options.includeUnknown;
-  }
-  if (options.configuredAgentsOnly !== undefined) {
-    params.configuredAgentsOnly = options.configuredAgentsOnly;
   }
   if (options.showArchived === true) {
     params.archived = true;
@@ -294,7 +302,7 @@ function buildSessionListParams(options: SessionListOptions = {}): Record<string
 
 async function requestSessionList(
   client: SessionRequestClient,
-  options: SessionListOptions = {},
+  options: EffectiveSessionListOptions,
 ): Promise<SessionsListResult | null> {
   const result = await client.request<SessionsListResult | undefined>(
     "sessions.list",
@@ -607,7 +615,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!scope) {
       return null;
     }
-    const result = await requestSessionList(scope.client, options);
+    const result = await requestSessionList(
+      scope.client,
+      resolveEffectiveSessionListOptions(options),
+    );
     return isCurrentConnection(scope) ? (result ?? null) : null;
   };
 
@@ -655,7 +666,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     if (!scope) {
       return;
     }
-    const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
+    const { append = false, force: _force, backgroundHydrate = false, ...listOptions } = options;
+    const requestOptions = resolveEffectiveSessionListOptions(listOptions);
+    // Event reconciliation must retain the boolean filters sent to sessions.list.
+    // Otherwise broad events can insert rows that the Gateway deliberately excluded.
     lastListOptions = requestOptions;
     if (!backgroundHydrate) {
       publish({ ...state, loading: true, error: null, deletedSessions: [] });


### PR DESCRIPTION
Related: #102485

## What Problem This Solves

Fixes an issue where Control UI users could see a hidden or unconfigured agent session appear in a configured-only session list after a live `sessions.changed` event, even though the Gateway had excluded that row from the list response.

## Why This Change Was Made

Session-list requests and live-event reconciliation now share one resolved filter scope, including the configured-agent defaults actually sent to the Gateway. Filtered events trigger a list refresh; explicitly broad lists still reconcile events incrementally.

This is a narrow maintainer replacement for #102485 because rebasing its old fork head onto current `main` would have rewritten 1,677 unrelated files. The replacement preserves @lzw112's authorship with a commit co-author trailer. Root changelog entries are release-automation owned, so the release-note context and contributor attribution remain here.

## User Impact

Configured-only Control UI session lists remain consistent while live session events arrive. Users no longer see hidden agent-store rows leak into the sidebar between refreshes, while callers that explicitly disable the filter retain the broader behavior.

## Evidence

- Exact head: `52cca9996d2c8543b5b9e2466128d175ed28a636`; three changed UI files, +215/−16.
- [Hosted CI run 29052591319](https://github.com/openclaw/openclaw/actions/runs/29052591319): passed.
- Blacksmith Testbox `tbx_01kx4drk3f2xrkd0jx7sv3b8fr`: focused session-capability unit tests 10/10 passed; Chromium/Vite mocked-Gateway WebSocket E2E 1/1 passed; `check:changed` passed.
- Regression coverage includes the default configured-only scope and the explicit `configuredAgentsOnly: false` sibling path.
- `pnpm exec oxfmt --write ui/src/lib/sessions/index.ts ui/src/lib/sessions/index.test.ts ui/src/e2e/session-list-filter.e2e.test.ts`
- `git diff --check`
- Fresh exact-head Codex autoreview: no actionable findings (0.86 confidence); independent deep review also approved.
