### PR TITLE
docs(changelog): credit recent UTF-16 and display fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.
+- **CLI model tables:** sanitize, truncate, and pad model-list cells by rendered terminal width so emoji, CJK, and other wide graphemes keep columns aligned. (#102819) Thanks @Kevin23-design and @vincentkoc.
+- **Skills prompt compaction:** preserve every included skill identity before using the remaining prompt budget for shortened, UTF-16-safe descriptions, retaining trigger guidance without exceeding the hard limit. (#88426) Thanks @abel-zer0.
+- **Channel Markdown code tables:** size columns by rendered display width so CJK, emoji, and mixed-width cells stay aligned across shared Telegram and Discord output. (#55596, #55512) Thanks @sparkyrider.
+- **QQ Bot approval previews:** wrap long sanitized commands and metadata at grapheme boundaries with visible continuation markers and safe fences, keeping desktop QQ reviews readable without changing command content. (#102119, #101979) Thanks @Bartok9.
 - **Codex computer control:** publish fixed-length coordinate pairs as homogeneous array schemas so Codex app-server can start threads with the `computer` tool instead of rejecting tuple-valued `items`.
 - **Google Chat request deadlines:** bound control calls to 30 seconds while giving media transfers size-aware total budgets and a separate 30-second stalled-body guard, preventing hung Chat API requests without breaking large attachment uploads. (#102227) Thanks @hugenshen.
 - **Google Gemini prefixed model IDs:** recognize `google/gemini-*` and `models/gemini-*` when selecting multimodal function-response behavior, preserving the Gemini 2 image fallback without regressing Gemini 3 inline image responses. (#102382) Thanks @LiLan0125.


### PR DESCRIPTION
Related: #102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034, #102819, #88426, #55596, #55512, #102119, #101979

## What Problem This Solves

Recent merged UTF-16 safety, terminal-width, prompt-compaction, Markdown-table, and QQ Bot approval-preview fixes were not represented in the Unreleased changelog, leaving the next release notes and contributor credits incomplete.

## Why This Change Was Made

Add five consolidated changelog bullets at the top of Unreleased Fixes. The broad Unicode bullet groups the distinct bounded-text surfaces into one user-facing outcome; the remaining entries preserve their focused behavior and linked issue context. Test-only #102685 is intentionally omitted.

## User Impact

The next release notes accurately describe these shipped fixes and credit the external contributors who helped land them. Runtime behavior is unchanged.

## Evidence

- Rebasing base: `71f7fef7a23ecdc0787db5e08eb5a329f2af83c4`
- Reviewed head: `ee5d509cffeb6b9710b482268e8a367fa0ef0dcf`
- `git diff --check origin/main...HEAD`
- `node scripts/check-changelog-attributions.mjs CHANGELOG.md`
- Exact reference audit: all 20 requested PR/issue references occur once in the diff; #102685 is absent
- Fresh Codex autoreview: clean, no accepted/actionable findings
- Tests not run: changelog-only change

AI-assisted: yes (Codex).
