### PR TITLE
improve(webchat): picker speed control becomes a single fast-mode toggle

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -175,14 +175,14 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
 
       await model.click();
       const thinkingSlider = composer.locator('[data-chat-thinking-slider="true"]');
-      const speedButtons = composer.locator("[data-chat-speed-option]");
+      const speedToggle = composer.locator("[data-chat-speed-toggle]");
       await expect
         .poll(() => thinkingSlider.getAttribute("data-chat-thinking-values"))
         .toBe("off,low,medium,high");
       await expect.poll(() => thinkingSlider.inputValue()).toBe("3");
-      await expect
-        .poll(async () => (await speedButtons.allTextContents()).map((label) => label.trim()))
-        .toEqual(["Standard", "Fast"]);
+      // OpenAI sessions toggle between the standard and priority tiers.
+      await expect.poll(async () => (await speedToggle.textContent())?.trim()).toBe("Standard");
+      await expect.poll(() => speedToggle.getAttribute("aria-checked")).toBe("false");
       await expect
         .poll(() => composer.locator(".chat-controls__model-option-icon").count())
         .toBe(0);
@@ -206,7 +206,7 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         .toBe(true);
       await expect.poll(() => model.getAttribute("data-chat-thinking-value")).toBe("low");
       await expect.poll(() => thinkingSlider.inputValue()).toBe("1");
-      await composer.locator('[data-chat-speed-option="on"]').click();
+      await speedToggle.click();
       await expect
         .poll(async () =>
           (await gateway.getRequests("sessions.patch")).some(
@@ -218,17 +218,14 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
           ),
         )
         .toBe(true);
-      await expect
-        .poll(() => composer.locator('[data-chat-speed-option="on"]').getAttribute("aria-pressed"))
-        .toBe("true");
+      await expect.poll(() => speedToggle.getAttribute("aria-checked")).toBe("true");
+      await expect.poll(async () => (await speedToggle.textContent())?.trim()).toBe("Fast");
       await page.keyboard.press("Escape");
       await expect
         .poll(() => composer.locator(".chat-controls__inline-select-menu").isVisible())
         .toBe(false);
       await model.click();
-      await expect
-        .poll(() => composer.locator('[data-chat-speed-option="on"]').getAttribute("aria-pressed"))
-        .toBe("true");
+      await expect.poll(() => speedToggle.getAttribute("aria-checked")).toBe("true");
       await expect
         .poll(() => composer.locator('[data-chat-thinking-slider="true"]').count())
         .toBe(1);

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -57,34 +57,63 @@ function resolveFastModeState(params: {
 }
 
 describe("chat-model-select-state", () => {
-  it("offers only Standard and Fast for OpenAI models", () => {
+  it("toggles between Standard and Fast for OpenAI models", () => {
     expect(resolveFastModeState({ provider: "openai" })).toMatchObject({
+      active: false,
       currentOverride: "off",
-      options: [
-        { value: "off", label: "Standard" },
-        { value: "on", label: "Fast" },
-      ],
+      label: "Standard",
+      nextValue: "on",
       supported: true,
     });
-    expect(resolveFastModeState({ provider: "openai", fastMode: true }).currentOverride).toBe("on");
-    expect(
-      resolveFastModeState({ provider: "openai", effectiveFastMode: true }).currentOverride,
-    ).toBe("on");
-    expect(resolveFastModeState({ provider: "openai", fastMode: "auto" }).currentOverride).toBe(
-      "auto",
-    );
+    expect(resolveFastModeState({ provider: "openai", fastMode: true })).toMatchObject({
+      active: true,
+      currentOverride: "on",
+      label: "Fast",
+      nextValue: "off",
+    });
+    expect(resolveFastModeState({ provider: "openai", effectiveFastMode: true })).toMatchObject({
+      active: true,
+      currentOverride: "on",
+    });
+    expect(resolveFastModeState({ provider: "openai", fastMode: "auto" })).toMatchObject({
+      active: true,
+      currentOverride: "auto",
+      label: "Auto",
+      nextValue: "off",
+    });
   });
 
-  it("keeps inherited and auto choices for other fast-mode providers", () => {
-    expect(resolveFastModeState({ provider: "anthropic", fastMode: "auto" })).toMatchObject({
-      currentOverride: "auto",
-      options: [
-        { value: "", label: "Default" },
-        { value: "on", label: "Fast" },
-        { value: "off", label: "Standard" },
-        { value: "auto", label: "Auto" },
-      ],
+  it("toggles between the inherited default and Fast for other fast-mode providers", () => {
+    expect(resolveFastModeState({ provider: "anthropic" })).toMatchObject({
+      active: false,
+      currentOverride: "",
+      label: "Default",
+      nextValue: "on",
       supported: true,
+    });
+    expect(resolveFastModeState({ provider: "anthropic", fastMode: true })).toMatchObject({
+      active: true,
+      label: "Fast",
+      nextValue: "",
+    });
+    // Fast inherited from the agent default: the toggle must write an
+    // explicit off override instead of clearing to the (fast) default.
+    expect(resolveFastModeState({ provider: "anthropic", effectiveFastMode: true })).toMatchObject({
+      active: true,
+      currentOverride: "",
+      nextValue: "off",
+    });
+    expect(resolveFastModeState({ provider: "anthropic", fastMode: false })).toMatchObject({
+      active: false,
+      currentOverride: "off",
+      label: "Standard",
+      nextValue: "on",
+    });
+    expect(resolveFastModeState({ provider: "anthropic", fastMode: "auto" })).toMatchObject({
+      active: true,
+      currentOverride: "auto",
+      label: "Auto",
+      nextValue: "",
     });
   });
 
@@ -315,9 +344,9 @@ describe("chat-model-select-state", () => {
   it("uses the session provider for fast mode with a slash-containing raw model id", () => {
     const sessionsResult = createSessionsListResult({
       model: "google/gemma-4-26b-a4b-it",
-      modelProvider: "openrouter",
+      modelProvider: "xai",
       defaultsModel: "google/gemma-4-26b-a4b-it",
-      defaultsProvider: "openrouter",
+      defaultsProvider: "xai",
     });
 
     expect(
@@ -334,6 +363,16 @@ describe("chat-model-select-state", () => {
         stream: null,
       }).supported,
     ).toBe(true);
+  });
+
+  it("does not offer the speed toggle for providers without a runtime fast-mode mapping", () => {
+    // openrouter is proxied without a fast-mode wire mapping; an enabled
+    // toggle there would silently do nothing.
+    expect(resolveFastModeState({ provider: "openrouter" })).toMatchObject({
+      supported: false,
+      disabled: true,
+    });
+    expect(resolveFastModeState({ provider: "openrouter", fastMode: true }).supported).toBe(true);
   });
 
   it("uses a catalog-qualified model provider before a stale session runtime provider", () => {

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -91,13 +91,14 @@ describe("chat-model-select-state", () => {
       nextValue: "on",
       supported: true,
     });
+    // Turning fast off always writes an explicit off override: the inherited
+    // baseline is unknowable while an override exists, and clearing could
+    // land on a fast default, turning the click into a visible no-op.
     expect(resolveFastModeState({ provider: "anthropic", fastMode: true })).toMatchObject({
       active: true,
       label: "Fast",
-      nextValue: "",
+      nextValue: "off",
     });
-    // Fast inherited from the agent default: the toggle must write an
-    // explicit off override instead of clearing to the (fast) default.
     expect(resolveFastModeState({ provider: "anthropic", effectiveFastMode: true })).toMatchObject({
       active: true,
       currentOverride: "",
@@ -113,7 +114,7 @@ describe("chat-model-select-state", () => {
       active: true,
       currentOverride: "auto",
       label: "Auto",
-      nextValue: "",
+      nextValue: "off",
     });
   });
 

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -372,7 +372,19 @@ describe("chat-model-select-state", () => {
       supported: false,
       disabled: true,
     });
-    expect(resolveFastModeState({ provider: "openrouter", fastMode: true }).supported).toBe(true);
+    // Legacy overrides stay visible but the toggle is clear-only: it must
+    // never write a fresh no-op fast override for an unmapped provider.
+    expect(resolveFastModeState({ provider: "openrouter", fastMode: true })).toMatchObject({
+      supported: true,
+      active: true,
+      nextValue: "",
+    });
+    expect(resolveFastModeState({ provider: "openrouter", fastMode: false })).toMatchObject({
+      supported: true,
+      active: false,
+      label: "Standard",
+      nextValue: "",
+    });
   });
 
   it("uses a catalog-qualified model provider before a stale session runtime provider", () => {

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -378,13 +378,11 @@ export function resolveChatFastModeSelectState(
             : "Default";
   // A legacy override on a provider without a wire mapping stays visible so it
   // can be cleared, but the toggle must not write a new no-op fast override.
-  const nextValue: ChatFastModeSelectValue = !providerSupported
-    ? ""
-    : active
-      ? isOpenAI || currentOverride === ""
-        ? "off"
-        : ""
-      : "on";
+  // For mapped providers an active toggle always writes an explicit off: the
+  // inherited baseline is unknowable while an override exists, and clearing
+  // could land on a fast default, turning the click into a visible no-op.
+  // /fast default remains the way back to the inherited setting.
+  const nextValue: ChatFastModeSelectValue = !providerSupported ? "" : active ? "off" : "on";
   return {
     active,
     currentOverride,

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -357,9 +357,10 @@ export function resolveChatFastModeSelectState(
         ? "auto"
         : "off"
     : configuredOverride;
-  const supported = Boolean(
-    (effectiveProvider && FAST_MODE_PROVIDER_IDS.has(effectiveProvider)) || configuredOverride,
+  const providerSupported = Boolean(
+    effectiveProvider && FAST_MODE_PROVIDER_IDS.has(effectiveProvider),
   );
+  const supported = providerSupported || Boolean(configuredOverride);
   // The picker exposes speed as a two-state toggle: fast on, or back to the
   // provider baseline (explicit off for OpenAI's priority tier, inherited
   // default elsewhere). Auto and explicit standard overrides remain reachable
@@ -375,11 +376,15 @@ export function resolveChatFastModeSelectState(
           : currentOverride === "off"
             ? "Standard"
             : "Default";
-  const nextValue: ChatFastModeSelectValue = active
-    ? isOpenAI || currentOverride === ""
-      ? "off"
-      : ""
-    : "on";
+  // A legacy override on a provider without a wire mapping stays visible so it
+  // can be cleared, but the toggle must not write a new no-op fast override.
+  const nextValue: ChatFastModeSelectValue = !providerSupported
+    ? ""
+    : active
+      ? isOpenAI || currentOverride === ""
+        ? "off"
+        : ""
+      : "on";
   return {
     active,
     currentOverride,

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -43,9 +43,14 @@ type ChatModelSelectState = {
 export type ChatFastModeSelectValue = "" | "on" | "off" | "auto";
 
 export type ChatFastModeSelectState = {
+  /** Fast output is effectively enabled (explicitly or via auto/inherited default). */
+  active: boolean;
   currentOverride: ChatFastModeSelectValue;
   disabled: boolean;
-  options: ChatModelSelectOption[];
+  /** Short state word shown inside the speed toggle. */
+  label: string;
+  /** Value the toggle commits when clicked. */
+  nextValue: ChatFastModeSelectValue;
   supported: boolean;
 };
 
@@ -62,14 +67,11 @@ type ChatFastModeSelectStateInput = {
   stream: string | null;
 };
 
-const FAST_MODE_PROVIDER_IDS = new Set([
-  "anthropic",
-  "minimax",
-  "minimax-portal",
-  "openai",
-  "openrouter",
-  "xai",
-]);
+// Providers with a real runtime fast-mode mapping: anthropic sets
+// service_tier auto/standard_only (extensions/anthropic/stream-wrappers.ts),
+// openai sets service_tier priority, minimax/xai swap to fast model variants.
+// Providers without a wire mapping must not offer the toggle.
+const FAST_MODE_PROVIDER_IDS = new Set(["anthropic", "minimax", "minimax-portal", "openai", "xai"]);
 
 function resolveActiveSessionRow(state: ChatModelSelectStateInput) {
   return state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
@@ -345,20 +347,41 @@ export function resolveChatFastModeSelectState(
           ? "off"
           : "";
   const isOpenAI = effectiveProvider === "openai";
-  const effectiveOpenAIMode = activeRow?.effectiveFastMode ?? activeRow?.fastMode;
+  const effectiveMode = activeRow?.effectiveFastMode ?? activeRow?.fastMode;
   // OpenAI exposes one optional priority tier. Keep legacy auto unselected so
   // either binary choice replaces it instead of implying the wrong tier.
   const currentOverride = isOpenAI
-    ? effectiveOpenAIMode === true
+    ? effectiveMode === true
       ? "on"
-      : effectiveOpenAIMode === "auto"
+      : effectiveMode === "auto"
         ? "auto"
         : "off"
     : configuredOverride;
   const supported = Boolean(
     (effectiveProvider && FAST_MODE_PROVIDER_IDS.has(effectiveProvider)) || configuredOverride,
   );
+  // The picker exposes speed as a two-state toggle: fast on, or back to the
+  // provider baseline (explicit off for OpenAI's priority tier, inherited
+  // default elsewhere). Auto and explicit standard overrides remain reachable
+  // through /fast and still render truthfully here.
+  const active = effectiveMode === true || effectiveMode === "auto";
+  const label =
+    effectiveMode === "auto"
+      ? "Auto"
+      : active
+        ? "Fast"
+        : isOpenAI
+          ? "Standard"
+          : currentOverride === "off"
+            ? "Standard"
+            : "Default";
+  const nextValue: ChatFastModeSelectValue = active
+    ? isOpenAI || currentOverride === ""
+      ? "off"
+      : ""
+    : "on";
   return {
+    active,
     currentOverride,
     disabled:
       !supported ||
@@ -368,17 +391,8 @@ export function resolveChatFastModeSelectState(
       Boolean(input.activeRunId) ||
       input.stream !== null ||
       !input.gatewayAvailable,
-    options: isOpenAI
-      ? [
-          { value: "off", label: "Standard" },
-          { value: "on", label: "Fast" },
-        ]
-      : [
-          { value: "", label: "Default" },
-          { value: "on", label: "Fast" },
-          { value: "off", label: "Standard" },
-          { value: "auto", label: "Auto" },
-        ],
+    label,
+    nextValue,
     supported,
   };
 }

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -285,6 +285,7 @@ export async function switchChatFastMode(
   }
   const activeRow = host.sessionsResult?.sessions?.find((row) => row.key === targetSessionKey);
   const previousFastMode = activeRow?.fastMode;
+  const previousEffectiveFastMode = activeRow?.effectiveFastMode;
   const next: FastMode | undefined =
     nextFastMode === "" ? undefined : nextFastMode === "auto" ? "auto" : nextFastMode === "on";
   if (previousFastMode === next) {
@@ -292,7 +293,9 @@ export async function switchChatFastMode(
   }
   const token = claimChatSettingsPatch(chatFastModePatchTokens, host, targetSessionKey);
   setChatError(host, null, true);
-  patchSessionRow(host, targetSessionKey, { fastMode: next });
+  // Patch effectiveFastMode too: the toggle displays the effective value, and
+  // the server-resolved one stays stale until the session list refreshes.
+  patchSessionRow(host, targetSessionKey, { fastMode: next, effectiveFastMode: next });
   try {
     await host.sessions.patch(
       targetSessionKey,
@@ -308,7 +311,10 @@ export async function switchChatFastMode(
     return true;
   } catch (err) {
     if (isCurrentChatSettingsPatch(chatFastModePatchTokens, host, targetSessionKey, token)) {
-      patchSessionRow(host, targetSessionKey, { fastMode: previousFastMode });
+      patchSessionRow(host, targetSessionKey, {
+        fastMode: previousFastMode,
+        effectiveFastMode: previousEffectiveFastMode,
+      });
     }
     setChatError(host, `Failed to set speed: ${String(err)}`, true);
     return false;

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3608,7 +3608,7 @@ describe("chat model controls", () => {
     ).toBe(false);
   });
 
-  it("renders reasoning as a slider and speed as a segmented button row", () => {
+  it("renders reasoning as a slider and speed as a fast-mode toggle", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -3630,14 +3630,14 @@ describe("chat model controls", () => {
     render(renderChatModelControls(createChatModelControlsProps(state)), container);
 
     const slider = getThinkingSlider(container);
-    const speedButtons = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    );
+    const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
 
     expect(getThinkingSliderValues(container)).toEqual(["adaptive", "low", "medium", "high"]);
     expect(slider?.value).toBe("3");
     expect(slider?.getAttribute("aria-valuetext")).toBe("Default (High)");
-    expect(speedButtons.map((button) => button.textContent?.trim())).toEqual(["Standard", "Fast"]);
+    expect(speedToggle?.textContent?.trim()).toBe("Standard");
+    expect(speedToggle?.getAttribute("aria-checked")).toBe("false");
+    expect(speedToggle?.dataset.chatSpeedToggle).toBe("on");
     expect(
       container.querySelector('[data-chat-model-select="true"] .chat-controls__provider-icon'),
     ).toBeNull();
@@ -3697,19 +3697,19 @@ describe("chat model controls", () => {
     if (slider) {
       slider.value = "0";
       slider.dispatchEvent(new Event("input", { bubbles: true }));
-      // Drag preview updates the value label before the change commit.
-      expect(getThinkingReasoningValueLabel(container)).toBe("Low");
+      // Drag preview is attribute-only: mutating rendered text would eject
+      // Lit's ChildPart markers and freeze later menu renders.
+      expect(slider.getAttribute("aria-valuetext")).toBe("Low");
+      expect(getThinkingReasoningValueLabel(container)).toBe("Default (High)");
       slider.dispatchEvent(new Event("change", { bubbles: true }));
     }
     expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
 
-    const fastButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    ).find((button) => button.textContent?.trim() === "Fast");
-    expect(fastButton).toBeInstanceOf(HTMLButtonElement);
-    fastButton?.click();
+    const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
+    expect(speedToggle).toBeInstanceOf(HTMLButtonElement);
+    expect(speedToggle?.textContent?.trim()).toBe("Standard");
+    speedToggle?.click();
     expect(onFastModeSelect).toHaveBeenCalledWith("on", "main");
-    expect(fastButton?.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("locks reasoning and speed while a model switch is pending", () => {
@@ -3743,11 +3743,9 @@ describe("chat model controls", () => {
     // The session row still describes the previous model while the switch is
     // pending, so committing reasoning/speed then would target stale levels.
     expect(getThinkingSlider(container)?.disabled).toBe(true);
-    const speedButtons = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    );
-    expect(speedButtons.length).toBeGreaterThan(0);
-    expect(speedButtons.every((button) => button.disabled)).toBe(true);
+    const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
+    expect(speedToggle).toBeInstanceOf(HTMLButtonElement);
+    expect(speedToggle?.disabled).toBe(true);
   });
 
   it("keeps the newest speed selection when an older patch fails late", async () => {
@@ -3818,7 +3816,7 @@ describe("chat model controls", () => {
     ).toBe("true");
   });
 
-  it("keeps speed choices visible and disabled for unsupported providers", () => {
+  it("keeps the speed toggle visible and disabled for unsupported providers", () => {
     const { state } = createChatHeaderState({
       model: "local-model",
       modelProvider: "ollama",
@@ -3827,16 +3825,10 @@ describe("chat model controls", () => {
     const container = document.createElement("div");
     render(renderChatModelControls(createChatModelControlsProps(state)), container);
 
-    const speedButtons = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    );
-    expect(speedButtons.map((button) => button.textContent?.trim())).toEqual([
-      "Default",
-      "Fast",
-      "Standard",
-      "Auto",
-    ]);
-    expect(speedButtons.every((button) => button.disabled)).toBe(true);
+    const speedToggle = container.querySelector<HTMLButtonElement>("[data-chat-speed-toggle]");
+    expect(speedToggle).toBeInstanceOf(HTMLButtonElement);
+    expect(speedToggle?.textContent?.trim()).toBe("Default");
+    expect(speedToggle?.disabled).toBe(true);
   });
 
   it("uses default thinking options when the active session is absent", () => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -477,20 +477,25 @@ function renderChatModelReasoningSelect(params: {
     void onThinkingSelect(value, sessionKey).finally(() => onRequestUpdate?.());
     onRequestUpdate?.();
   };
+  const commitFastMode = (value: ChatFastModeSelectValue) => {
+    void onFastModeSelect(value, sessionKey).finally(() => onRequestUpdate?.());
+    onRequestUpdate?.();
+  };
+  const speedTooltip = fastMode.supported
+    ? "Fast responses finish sooner and can use more of your usage limits."
+    : "Speed control is not supported for this model.";
   const onSliderDrag = (event: Event) => {
     const input = event.currentTarget as HTMLInputElement;
     const stop = sliderStops[Number(input.value)];
     if (!stop) {
       return;
     }
+    // Style/attribute-only drag preview; change commits on release and the
+    // re-render refreshes the visible value label. Never write into rendered
+    // text here: setting textContent on a Lit-managed span ejects the
+    // ChildPart markers and permanently breaks every later menu render.
     input.style.setProperty("--reasoning-fill", `${sliderFillPercent(Number(input.value))}%`);
-    // Live drag preview without committing; change commits on release.
-    const valueLabel = input
-      .closest(".chat-controls__reasoning-panel")
-      ?.querySelector(".chat-controls__reasoning-value");
-    if (valueLabel) {
-      valueLabel.textContent = formatCombinedPickerThinkingLabel(stop.label);
-    }
+    input.setAttribute("aria-valuetext", formatCombinedPickerThinkingLabel(stop.label));
   };
   const onSliderCommit = (event: Event) => {
     if (thinkingDisabled) {
@@ -520,7 +525,7 @@ function renderChatModelReasoningSelect(params: {
   const onlyStop = sliderStops.length === 1 ? sliderStops[0] : undefined;
   const effectiveThinkingValue = selectedThinkingValue || thinkingDefaultValue;
   const onlyStopSelected = onlyStop?.value === effectiveThinkingValue;
-  const showReasoningPanel = showReasoning || fastMode.options.length > 0;
+  const showReasoningPanel = true;
   const providerGroups = new Map<string, ChatModelProviderOption[]>();
   for (const option of modelOptions) {
     if (option.value === "") {
@@ -784,57 +789,34 @@ function renderChatModelReasoningSelect(params: {
                           : ""}
                     `
                   : ""}
-                <div class="chat-controls__inline-select-section-label">Speed</div>
-                <div
-                  class="chat-controls__reasoning-options chat-controls__reasoning-options--speed"
-                  role="group"
-                  aria-label="Speed"
-                >
-                  ${repeat(
-                    fastMode.options,
-                    (speed) => speed.value,
-                    (speed) => {
-                      const speedValue = speed.value as ChatFastModeSelectValue;
-                      const speedSelected = speedValue === fastMode.currentOverride;
-                      return html`
-                        <button
-                          class="chat-controls__reasoning-option ${speedSelected
-                            ? "chat-controls__reasoning-option--selected"
-                            : ""}"
-                          data-chat-speed-option=${speed.value}
-                          aria-pressed=${speedSelected ? "true" : "false"}
-                          type="button"
-                          ?disabled=${fastMode.disabled}
-                          @click=${(event: MouseEvent) => {
-                            event.stopPropagation();
-                            if (fastMode.disabled || speedSelected) {
-                              event.preventDefault();
-                              return;
-                            }
-                            void onFastModeSelect(speedValue, sessionKey).finally(() =>
-                              onRequestUpdate?.(),
-                            );
-                            // Instant toggle feedback: effectiveFastMode masks the
-                            // optimistic fastMode patch until the session list refreshes.
-                            const currentButton = event.currentTarget as HTMLButtonElement;
-                            currentButton
-                              .closest(".chat-controls__reasoning-options--speed")
-                              ?.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]")
-                              .forEach((button) => {
-                                const selected = button.dataset.chatSpeedOption === speed.value;
-                                button.setAttribute("aria-pressed", selected ? "true" : "false");
-                                button.classList.toggle(
-                                  "chat-controls__reasoning-option--selected",
-                                  selected,
-                                );
-                              });
-                          }}
-                        >
-                          <span>${speed.label}</span>
-                        </button>
-                      `;
-                    },
-                  )}
+                <div class="chat-controls__speed-row">
+                  <span class="chat-controls__inline-select-section-label">Speed</span>
+                  <openclaw-tooltip .content=${speedTooltip}>
+                    <button
+                      class="chat-controls__speed-toggle ${fastMode.active
+                        ? "chat-controls__speed-toggle--active"
+                        : ""}"
+                      data-chat-speed-toggle=${fastMode.nextValue}
+                      type="button"
+                      role="switch"
+                      aria-checked=${fastMode.active ? "true" : "false"}
+                      aria-label=${`Fast responses: ${fastMode.label}`}
+                      ?disabled=${fastMode.disabled}
+                      @click=${(event: MouseEvent) => {
+                        event.stopPropagation();
+                        if (fastMode.disabled) {
+                          event.preventDefault();
+                          return;
+                        }
+                        commitFastMode(fastMode.nextValue);
+                      }}
+                    >
+                      <span class="chat-controls__speed-toggle-icon" aria-hidden="true">
+                        ${icons.zap}
+                      </span>
+                      <span>${fastMode.label}</span>
+                    </button>
+                  </openclaw-tooltip>
                 </div>
               </div>
             `

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3526,10 +3526,71 @@ openclaw-chat-page {
   font-size: 11px;
 }
 
-.chat-controls__reasoning-options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(58px, 1fr));
+/* Speed is a single fast-mode toggle: bolt icon plus the current state word.
+   Explicit off/auto overrides stay reachable through the /fast command. */
+.chat-controls__speed-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
+  min-width: 0;
+}
+
+.chat-controls__speed-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 92%, var(--text));
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 4%, var(--card));
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 550;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.chat-controls__speed-toggle:hover:not(:disabled),
+.chat-controls__speed-toggle:focus-visible {
+  border-color: color-mix(in srgb, var(--text) 20%, var(--border));
+  background: color-mix(in srgb, var(--text) 6%, var(--card));
+  color: var(--text);
+  outline: none;
+}
+
+.chat-controls__speed-toggle--active {
+  border-color: color-mix(in srgb, var(--accent) 76%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, var(--card));
+  color: var(--text-strong);
+}
+
+.chat-controls__speed-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.chat-controls__speed-toggle-icon {
+  display: inline-flex;
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+
+.chat-controls__speed-toggle-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+
+/* Filled bolt telegraphs the active fast tier without relying on color alone. */
+.chat-controls__speed-toggle--active .chat-controls__speed-toggle-icon svg {
+  fill: currentColor;
 }
 
 .chat-controls__reasoning-option {


### PR DESCRIPTION
## What Problem This Solves

The chat picker offered four speed buttons (`Default / Fast / Standard / Auto`) for every non-OpenAI provider, implying four provider tiers that do not exist. Every provider with a fast path consumes fast mode as a boolean at request time (Anthropic maps it to `service_tier: "auto" | "standard_only"`, OpenAI to `service_tier: "priority"`, MiniMax/xAI swap to fast model variants), so for Anthropic the honest choices are default vs fast - not four. The row also took a whole button grid for what is a single decision.

## Why This Change Was Made

Speed is now one bolt toggle in the picker showing the current state word (Default/Standard/Fast/Auto). Turning fast on writes an explicit on override; turning it off always writes an explicit off - the inherited baseline is unknowable client-side while an override exists, and clearing could land on a fast default, turning the click into a visible no-op (Codex review caught this). An untouched session still reads `Default`; `/fast default` (and auto) remain the power path back to inherited behavior and still render truthfully on the toggle. Providers without a runtime fast-mode mapping get a disabled toggle, and a legacy override on such a provider is clear-only so the UI can never write a fresh no-op fast override. openrouter is removed from the supported-provider set because it has no runtime fast-mode mapping at all - its wrapper never reads `fastMode`, so an enabled control there silently did nothing. `switchChatFastMode` now also patches `effectiveFastMode` optimistically so the toggle reflects the click immediately instead of relying on manual DOM twiddling.

This surfaced (and fixes) a real render-freeze bug from the immediate-apply picker: the reasoning slider's drag preview wrote `textContent` into a Lit-managed span, ejecting the ChildPart markers - after the first slider drag every later render of the menu threw `ChildPart has no parentNode` and the UI below the slider froze. The drag preview is now attribute-only (`--reasoning-fill` + `aria-valuetext`); the visible label updates on commit.

## User Impact

The picker's speed section is now a single bolt toggle showing the current state (Default/Standard/Fast/Auto) - one click switches between fast and the provider baseline. Anthropic sessions no longer see bogus Standard/Auto tiles; openrouter sessions no longer see a speed control that does nothing; and the picker no longer silently stops re-rendering after using the reasoning slider.

## Evidence

Before / after (mock-gateway harness, Anthropic session, dark scheme):

| Before | After (default) | After (fast) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/speed-toggle-redesign/before-picker-menu.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/speed-toggle-redesign/after-picker-menu.png) | ![after-fast](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/speed-toggle-redesign/after-picker-menu-fast.png) |

- Provider contract evidence: `extensions/anthropic/stream-wrappers.ts` (`resolveAnthropicFastServiceTier`: true→`auto`, false→`standard_only`), `src/llm/providers/stream-wrappers/openai.ts` (`service_tier: "priority"`), `src/llm/providers/stream-wrappers/minimax.ts` (`-highspeed` swap), `extensions/xai/stream.ts` (`-fast` swap); openrouter's `createOpenRouterWrapper` (`src/llm/providers/stream-wrappers/proxy.ts`) never reads `fastMode`. The "auto" window resolves to a boolean generically in `src/shared/fast-mode.ts` before any provider sees it.
- Testbox (Blacksmith): `pnpm test ui/src/lib/chat/model-select-state.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-controls.test.ts ui/src/i18n/test/translate.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts ui/src/e2e/chat-flow.e2e.test.ts` - all green (unit + e2e shards, exit 0), including new toggle-state unit coverage (openai/anthropic/auto/inherited-fast/unsupported) and the reworked composer e2e (toggle click patches `fastMode: true` immediately and survives close/reopen).
- The ChildPart freeze reproduces on current `main` with a Playwright probe (drag slider, click any control below it - `ChildPart has no parentNode` page error, DOM frozen); gone after this change.
- Codex review (gpt-5.5, 3 rounds): two findings accepted and fixed in-branch (clear-only toggle for unmapped-provider legacy overrides; active toggle writes explicit off instead of clearing onto a possibly-fast default); final round clean.
- Not landed on request - PR is up for review.
