### PR TITLE
fix(status): preserve OAuth JSON diagnostics

### DIFF
--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -24,6 +24,44 @@ describe("summarizeLogTail", () => {
     expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
   });
 
+  it.each([
+    ["closing brace", "Session invalidated } due to signing in again"],
+    ["opening brace", "Session invalidated { due to signing in again"],
+    ["escaped quote before a brace", 'Session invalidated after "}" signing in again'],
+  ])("keeps OAuth JSON diagnostics with a %s", (_caseName, message) => {
+    const sentinel = "[gateway] synthetic sentinel after OAuth JSON";
+    const lines = summarizeLogTail([
+      "[openai] Token refresh failed: 401 {",
+      `"error":${JSON.stringify({ code: "invalid_grant", message })}`,
+      "}",
+      sentinel,
+    ]);
+
+    expect(lines).toEqual([
+      "[openai] token refresh 401 invalid_grant · re-auth required",
+      sentinel,
+    ]);
+  });
+
+  it("parses the first complete OAuth JSON object before an adjacent object", () => {
+    const lines = summarizeLogTail([
+      "[openai] Token refresh failed: 401 {",
+      '"error":{"code":"invalid_grant","message":"Session invalidated due to signing in again"}}{"ignored":true}',
+    ]);
+
+    expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
+  });
+
+  it("consumes an incomplete OAuth JSON block through the end of the tail", () => {
+    const lines = summarizeLogTail([
+      "[openai] Token refresh failed: 401 {",
+      '"error":{"code":"invalid_grant","message":"Session invalidated due to signing in again"}',
+      "unrelated-looking trailing line",
+    ]);
+
+    expect(lines).toEqual(["[openai] token refresh 401"]);
+  });
+
   it("keeps bounded OAuth diagnostics UTF-16 well-formed", () => {
     const lines = summarizeLogTail([
       "[openai] Token refresh failed: 500 {",

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyOAuthRefreshFailureReason } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { readGatewayLogTailLines } from "../../daemon/diagnostics.js";
+import { extractBalancedJsonPrefix } from "../../shared/balanced-json.js";
 
 /** Reads the last non-empty lines from a gateway log file, returning an empty list on read failure. */
 export async function readFileTailLines(filePath: string, maxLines: number): Promise<string[]> {
@@ -14,13 +15,6 @@ export async function readFileTailLines(filePath: string, maxLines: number): Pro
   }
   const out = lines.slice(Math.max(0, lines.length - maxLines));
   return out.map((line) => line.trimEnd()).filter((line) => line.trim().length > 0);
-}
-
-function countMatches(haystack: string, needle: string): number {
-  if (!haystack || !needle) {
-    return 0;
-  }
-  return haystack.split(needle).length - 1;
 }
 
 function shorten(message: string, maxLen: number): string {
@@ -51,16 +45,15 @@ function consumeJsonBlock(
     return null;
   }
 
-  const parts: string[] = [startLine.slice(braceAt)];
-  let depth = countMatches(parts[0] ?? "", "{") - countMatches(parts[0] ?? "", "}");
-  let i = startIndex;
-  while (depth > 0 && i + 1 < lines.length) {
-    i += 1;
-    const next = lines[i] ?? "";
-    parts.push(next);
-    depth += countMatches(next, "{") - countMatches(next, "}");
+  const raw = [startLine.slice(braceAt), ...lines.slice(startIndex + 1)].join("\n");
+  const fragment = extractBalancedJsonPrefix(raw);
+  if (!fragment) {
+    // A bounded tail can end mid-object. Consume the rest so orphaned JSON
+    // fields do not escape into the user-facing diagnosis as ordinary lines.
+    return { json: raw, endIndex: lines.length - 1 };
   }
-  return { json: parts.join("\n"), endIndex: i };
+  const consumedLineOffset = fragment.json.split("\n").length - 1;
+  return { json: fragment.json, endIndex: startIndex + consumedLineOffset };
 }
 
 /** Summarizes gateway log tail lines, grouping repeated failures and trimming long output. */


### PR DESCRIPTION
## What Problem This Solves

`openclaw status --all` summarizes structured OAuth refresh failures from Gateway log tails. Its private JSON-block reader counted every `{` and `}`, including delimiters inside quoted provider messages. A message such as `Session invalidated } due to signing in again` could therefore close the block early, make `JSON.parse` fail, and silently reduce the useful diagnosis to only the HTTP status.

This supersedes #102075 with the same contributor-authored fix intent. The contributor fork was too stale to update narrowly: a current-main fork mutation would have rewritten 1,884 unrelated paths.

## Why This Change Was Made

The final implementation reuses `extractBalancedJsonPrefix`, the existing shared owner for quote-, escape-, array-, and object-aware JSON fragment boundaries. It removes the bespoke scanner, parses only the first complete JSON object when adjacent content follows, and explicitly preserves the bounded-tail rule that an incomplete object consumes the rest of the tail rather than leaking orphaned fields as ordinary report lines.

The commit preserves @lzw112's contribution through a co-author trailer, with release-note credit recorded here for release automation.

## User Impact

OAuth refresh diagnostics retain their stable provider code and re-auth hint even when upstream messages contain braces or escaped quotes. Truncated Gateway tails remain contained and redacted as before.

## Evidence

- Root cause traced through `status --all` → report lines → diagnosis → bounded Gateway log tail → `summarizeLogTail` → OAuth failure classification.
- Focused regressions cover opening and closing braces inside strings, escaped quotes, a complete object followed by an adjacent object, exact post-block line consumption, incomplete-tail containment, and UTF-16-safe message shortening.
- `oxfmt --check src/commands/status-all/gateway.ts src/commands/status-all/gateway.test.ts`
- `git diff --check`
- Fresh Codex autoreview on exact head `d637d3c1f4c36a23948de080bf35b72e4a363367`: clean, no actionable findings, confidence 0.87.
- Blacksmith Testbox `tbx_01kx4bk7kkzzwjb05p6wqmxjag`: focused tests and an isolated real `openclaw status --all` behavior proof passed on the exact head.
- Exact-head CI run [29052125683](https://github.com/openclaw/openclaw/actions/runs/29052125683) passed all 55 jobs; complete commands and outputs will be recorded in the land-ready comment before merge.

Original contributor PR: #102075
