### PR TITLE
fix(ui): split-view pane header opens a hidden session dropdown when clicked

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -296,7 +296,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       expect(Math.abs(topbarBox.y - toolbarBox.y)).toBeLessThanOrEqual(1);
       expect(Math.abs(topbarBox.height - toolbarBox.height)).toBeLessThanOrEqual(1);
 
-      await toolbarPanes.first().getByRole("combobox").focus();
+      // Pane headers render a static session title (no form control may sit in
+      // the titlebar drag strip); keyboard focus lands on the pane buttons.
+      await toolbarPanes.first().getByRole("button", { name: "Split down" }).focus();
       await expect.poll(() => toolbarPanes.first().getAttribute("class")).toContain("--active");
 
       await page.evaluate(() => {

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.348Z",
+  "generatedAt": "2026-07-09T20:43:30.124Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.700Z",
+  "generatedAt": "2026-07-09T20:43:28.256Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.809Z",
+  "generatedAt": "2026-07-09T20:43:28.556Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:55.313Z",
+  "generatedAt": "2026-07-09T20:43:33.106Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.130Z",
+  "generatedAt": "2026-07-09T20:43:29.591Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.243Z",
+  "generatedAt": "2026-07-09T20:43:29.889Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.776Z",
+  "generatedAt": "2026-07-09T20:43:31.440Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.452Z",
+  "generatedAt": "2026-07-09T20:43:30.430Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.916Z",
+  "generatedAt": "2026-07-09T20:43:28.964Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.025Z",
+  "generatedAt": "2026-07-09T20:43:29.330Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:55.210Z",
+  "generatedAt": "2026-07-09T20:43:32.784Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.887Z",
+  "generatedAt": "2026-07-09T20:43:31.896Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.593Z",
+  "generatedAt": "2026-07-09T20:43:27.848Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:55.424Z",
+  "generatedAt": "2026-07-09T20:43:33.366Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.997Z",
+  "generatedAt": "2026-07-09T20:43:32.174Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.560Z",
+  "generatedAt": "2026-07-09T20:43:30.721Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:54.670Z",
+  "generatedAt": "2026-07-09T20:43:31.089Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:55.106Z",
+  "generatedAt": "2026-07-09T20:43:32.475Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.379Z",
+  "generatedAt": "2026-07-09T20:43:26.909Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T14:24:53.504Z",
+  "generatedAt": "2026-07-09T20:43:27.471Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "1cc4869bd2d34cadbdb88693afdab00ce06bd0bdebcc6c4e8778b0c8335ff412",
-  "totalKeys": 1764,
-  "translatedKeys": 1764,
+  "sourceHash": "8a7deda5778eeac847c79267bd07568817c963bf39447fe1f9da0504ae872058",
+  "totalKeys": 1763,
+  "translatedKeys": 1763,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1679,7 +1679,6 @@ export const ar: TranslationMap = {
       splitRight: "تقسيم إلى اليمين",
       splitDown: "تقسيم إلى الأسفل",
       closePane: "إغلاق الجزء",
-      sessionSelect: "جلسة الجزء",
       dropSplit: "تقسيم",
       dropOpenHere: "افتح هنا",
     },

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1713,7 +1713,6 @@ export const de: TranslationMap = {
       splitRight: "Nach rechts teilen",
       splitDown: "Nach unten teilen",
       closePane: "Bereich schließen",
-      sessionSelect: "Bereichssitzung",
       dropSplit: "Teilen",
       dropOpenHere: "Hier öffnen",
     },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1687,7 +1687,6 @@ export const en: TranslationMap = {
       splitRight: "Split right",
       splitDown: "Split down",
       closePane: "Close pane",
-      sessionSelect: "Pane session",
       dropSplit: "Split",
       dropOpenHere: "Open here",
     },

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1710,7 +1710,6 @@ export const es: TranslationMap = {
       splitRight: "Dividir a la derecha",
       splitDown: "Dividir hacia abajo",
       closePane: "Cerrar panel",
-      sessionSelect: "Sesión del panel",
       dropSplit: "Dividir",
       dropOpenHere: "Abrir aquí",
     },

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1700,7 +1700,6 @@ export const fa: TranslationMap = {
       splitRight: "تقسیم به راست",
       splitDown: "تقسیم به پایین",
       closePane: "بستن پنل",
-      sessionSelect: "نشست پنل",
       dropSplit: "تقسیم",
       dropOpenHere: "اینجا باز شود",
     },

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1722,7 +1722,6 @@ export const fr: TranslationMap = {
       splitRight: "Fractionner à droite",
       splitDown: "Fractionner vers le bas",
       closePane: "Fermer le volet",
-      sessionSelect: "Session du volet",
       dropSplit: "Scinder",
       dropOpenHere: "Ouvrir ici",
     },

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1682,7 +1682,6 @@ export const hi: TranslationMap = {
       splitRight: "दाईं ओर विभाजित करें",
       splitDown: "नीचे विभाजित करें",
       closePane: "पैन बंद करें",
-      sessionSelect: "पैन सत्र",
       dropSplit: "विभाजित करें",
       dropOpenHere: "यहाँ खोलें",
     },

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1700,7 +1700,6 @@ export const id: TranslationMap = {
       splitRight: "Bagi ke kanan",
       splitDown: "Bagi ke bawah",
       closePane: "Tutup panel",
-      sessionSelect: "Sesi panel",
       dropSplit: "Bagi",
       dropOpenHere: "Buka di sini",
     },

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1713,7 +1713,6 @@ export const it: TranslationMap = {
       splitRight: "Dividi a destra",
       splitDown: "Dividi in basso",
       closePane: "Chiudi riquadro",
-      sessionSelect: "Sessione del riquadro",
       dropSplit: "Dividi",
       dropOpenHere: "Apri qui",
     },

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1707,7 +1707,6 @@ export const ja_JP: TranslationMap = {
       splitRight: "右に分割",
       splitDown: "下に分割",
       closePane: "ペインを閉じる",
-      sessionSelect: "ペインのセッション",
       dropSplit: "分割",
       dropOpenHere: "ここで開く",
     },

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1689,7 +1689,6 @@ export const ko: TranslationMap = {
       splitRight: "오른쪽으로 분할",
       splitDown: "아래쪽으로 분할",
       closePane: "창 닫기",
-      sessionSelect: "창 세션",
       dropSplit: "분할",
       dropOpenHere: "여기에서 열기",
     },

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1706,7 +1706,6 @@ export const nl: TranslationMap = {
       splitRight: "Rechts splitsen",
       splitDown: "Omlaag splitsen",
       closePane: "Deelvenster sluiten",
-      sessionSelect: "Deelvenstersessie",
       dropSplit: "Splitsen",
       dropOpenHere: "Hier openen",
     },

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1706,7 +1706,6 @@ export const pl: TranslationMap = {
       splitRight: "Podziel w prawo",
       splitDown: "Podziel w dół",
       closePane: "Zamknij panel",
-      sessionSelect: "Sesja panelu",
       dropSplit: "Podziel",
       dropOpenHere: "Otwórz tutaj",
     },

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1702,7 +1702,6 @@ export const pt_BR: TranslationMap = {
       splitRight: "Dividir à direita",
       splitDown: "Dividir para baixo",
       closePane: "Fechar painel",
-      sessionSelect: "Sessão do painel",
       dropSplit: "Dividir",
       dropOpenHere: "Abrir aqui",
     },

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1715,7 +1715,6 @@ export const ru: TranslationMap = {
       splitRight: "Разделить вправо",
       splitDown: "Разделить вниз",
       closePane: "Закрыть панель",
-      sessionSelect: "Сессия панели",
       dropSplit: "Разделить",
       dropOpenHere: "Открыть здесь",
     },

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1663,7 +1663,6 @@ export const th: TranslationMap = {
       splitRight: "แบ่งไปทางขวา",
       splitDown: "แบ่งลงด้านล่าง",
       closePane: "ปิดบานหน้าต่าง",
-      sessionSelect: "เซสชันของบานหน้าต่าง",
       dropSplit: "แยก",
       dropOpenHere: "เปิดที่นี่",
     },

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1708,7 +1708,6 @@ export const tr: TranslationMap = {
       splitRight: "Sağa böl",
       splitDown: "Aşağı böl",
       closePane: "Bölmeyi kapat",
-      sessionSelect: "Bölme oturumu",
       dropSplit: "Böl",
       dropOpenHere: "Burada aç",
     },

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1703,7 +1703,6 @@ export const uk: TranslationMap = {
       splitRight: "Розділити праворуч",
       splitDown: "Розділити вниз",
       closePane: "Закрити панель",
-      sessionSelect: "Сеанс панелі",
       dropSplit: "Розділити",
       dropOpenHere: "Відкрити тут",
     },

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1691,7 +1691,6 @@ export const vi: TranslationMap = {
       splitRight: "Chia sang phải",
       splitDown: "Chia xuống dưới",
       closePane: "Đóng khung",
-      sessionSelect: "Phiên trong khung",
       dropSplit: "Chia đôi",
       dropOpenHere: "Mở tại đây",
     },

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1658,7 +1658,6 @@ export const zh_CN: TranslationMap = {
       splitRight: "向右拆分",
       splitDown: "向下拆分",
       closePane: "关闭窗格",
-      sessionSelect: "窗格会话",
       dropSplit: "拆分",
       dropOpenHere: "在此处打开",
     },

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1660,7 +1660,6 @@ export const zh_TW: TranslationMap = {
       splitRight: "向右分割",
       splitDown: "向下分割",
       closePane: "關閉窗格",
-      sessionSelect: "窗格工作階段",
       dropSplit: "分割",
       dropOpenHere: "在此開啟",
     },

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -144,10 +144,12 @@ describe("chat page split layout host", () => {
     expect(page.querySelector("resizable-divider")).toBeNull();
   });
 
-  it("refreshes split toolbar sessions after the shared list loads", async () => {
+  it("refreshes split toolbar titles after the shared list loads", async () => {
     const page = new ChatPage();
     const cleanup = vi.fn();
-    const sessionsState: { result: { sessions: Array<{ key: string }> } | null } = {
+    const sessionsState: {
+      result: { sessions: Array<{ key: string; displayName?: string }> } | null;
+    } = {
       result: null,
     };
     let notify = () => {};
@@ -165,16 +167,24 @@ describe("chat page split layout host", () => {
     setLayout(page, createSplitLayout("main"));
     await page.updateComplete;
 
+    const titlesBefore = [...page.querySelectorAll(".chat-pane__session-title")];
+    expect(titlesBefore.map((title) => title.textContent?.trim())).toEqual([
+      "Main Session",
+      "Main Session",
+    ]);
+    // The pane header is intentionally a static, non-interactive title: the
+    // strip doubles as the Mac app titlebar drag area, so no form control may
+    // sit there. Sessions change via the sidebar or drag-and-drop instead.
+    expect(page.querySelector(".chat-split-toolbar select")).toBeNull();
+
     sessionsState.result = {
-      sessions: [{ key: "agent:main:work" }, { key: "main" }],
+      sessions: [{ key: "main", displayName: "Main desk" }],
     };
     notify();
     await page.updateComplete;
 
-    const selects = [...page.querySelectorAll<HTMLSelectElement>(".chat-pane__session-select")];
-    expect(selects).toHaveLength(2);
-    expect(selects.map((select) => select.options.length)).toEqual([2, 2]);
-    expect(selects.map((select) => select.value)).toEqual(["main", "main"]);
+    const titles = [...page.querySelectorAll(".chat-pane__session-title")];
+    expect(titles.map((title) => title.textContent?.trim())).toEqual(["Main desk", "Main desk"]);
 
     page.remove();
     expect(cleanup).toHaveBeenCalledOnce();

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -98,12 +98,6 @@ export class ChatPage extends OpenClawLightDomElement {
     if (changedProperties.has("data")) {
       this.syncRouteToActivePane();
     }
-    for (const select of this.querySelectorAll<HTMLSelectElement>(".chat-pane__session-select")) {
-      const sessionKey = select.dataset.sessionKey;
-      if (sessionKey && select.value !== sessionKey) {
-        select.value = sessionKey;
-      }
-    }
   }
 
   private readonly handleViewportChange = (event: MediaQueryListEvent) => {
@@ -425,40 +419,20 @@ export class ChatPage extends OpenClawLightDomElement {
   private renderSplitToolbarPane(layout: ChatSplitLayout, pane: ChatSplitPane) {
     const sessions = this.context?.sessions?.state.result?.sessions ?? [];
     const active = pane.id === layout.activePaneId;
-    const currentSession = sessions.find((row) => row.key === pane.sessionKey);
-    const options = currentSession ? sessions : [{ key: pane.sessionKey }, ...sessions];
+    const title = resolveSessionDisplayName(
+      pane.sessionKey,
+      sessions.find((row) => row.key === pane.sessionKey),
+    );
     return html`
       <div
         class="chat-split-toolbar__pane ${active ? "chat-split-toolbar__pane--active" : ""}"
         @pointerdown=${() => this.handleFocusPane(pane.id)}
         @focusin=${() => this.handleToolbarPaneFocus(pane.id)}
       >
-        <label class="chat-pane__session-label">
-          <span class="agent-chat__sr-only">${t("chat.splitView.sessionSelect")}</span>
-          <select
-            class="chat-pane__session-select"
-            data-session-key=${pane.sessionKey}
-            aria-label=${t("chat.splitView.sessionSelect")}
-            .value=${pane.sessionKey}
-            @change=${(event: Event) => {
-              const nextSessionKey = (event.target as HTMLSelectElement).value;
-              if (nextSessionKey && nextSessionKey !== pane.sessionKey) {
-                this.handlePaneSessionChange(pane.id, nextSessionKey);
-              }
-            }}
-          >
-            ${options.map(
-              (row) => html`
-                <option value=${row.key}>
-                  ${resolveSessionDisplayName(
-                    row.key,
-                    sessions.find((session) => session.key === row.key),
-                  )}
-                </option>
-              `,
-            )}
-          </select>
-        </label>
+        <!-- Static text on purpose: this strip doubles as the Mac app titlebar
+             drag area, and an interactive session picker here swallows window
+             drags. Panes change sessions via the sidebar or drag-and-drop. -->
+        <span class="chat-pane__session-title" title=${title}>${title}</span>
         <div class="chat-pane__actions">
           ${!this.narrow
             ? html`

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -194,19 +194,13 @@ openclaw-chat-pane {
   visibility: hidden;
 }
 
-.chat-pane__session-label {
+.chat-pane__session-title {
   flex: 1 1 auto;
   min-width: 0;
-}
-
-.chat-pane__session-select {
-  width: 100%;
-  min-width: 0;
-  border: 0;
+  overflow: hidden;
   color: var(--text);
-  background: transparent;
-  font: inherit;
   font-size: 12px;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clicking near the top of a chat split pane would unexpectedly open or flip a session dropdown. Each split-view pane header rendered a native `<select>` stretched to the full pane width (styled borderless/transparent), so the entire top strip of every pane was one invisible browser control. In the macOS app this strip sits directly under the window's titlebar drag region: trying to move the window by its top edge frequently landed a few pixels low, opened the native picker, and switched the pane to a random session.

## Why This Change Was Made

The pane header now shows a static, non-interactive session title (with an ellipsis and a hover tooltip for long names). The dropdown was redundant: sessions are already switched via the sessions sidebar (routes sync into the active pane through `syncRouteToActivePane`) and via drag-and-drop onto a pane (`applySessionDrop`), both of which keep working unchanged. The unused `chat.splitView.sessionSelect` i18n key was removed and locale bundles regenerated.

## User Impact

Clicking or mis-aiming a window drag on a pane header no longer opens a hidden dropdown or flips the pane to another session. Pane headers still show which session each pane holds, and split/close controls are unchanged. Session switching stays in the sidebar and drag-and-drop.

## Evidence

- `ui/src/pages/chat/chat-page.test.ts` updated: asserts pane headers render static titles that refresh when the shared session list loads, and that no `<select>` exists in the split toolbar (regression guard).
- Net −43 lines; removed the `updated()` select-value sync loop that existed only to service the dropdown.
- Focused Vitest run + `ui:i18n:check` via Testbox (run linked below in comments/CI).
