### PR TITLE
ci: pin corrected Kova release evaluator

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -45,7 +45,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 01babd4435815a26dce468fab13905dc69e428e7
+        default: b20d3b35118841db050a14f241098169aff4b9a2
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -105,7 +105,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '01babd4435815a26dce468fab13905dc69e428e7' }}
+      KOVA_REF: ${{ inputs.kova_ref || 'b20d3b35118841db050a14f241098169aff4b9a2' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -45,7 +45,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 4f146016583018bad9e24f8e64a6af5f963bb7ee
+        default: 01babd4435815a26dce468fab13905dc69e428e7
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -105,7 +105,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '4f146016583018bad9e24f8e64a6af5f963bb7ee' }}
+      KOVA_REF: ${{ inputs.kova_ref || '01babd4435815a26dce468fab13905dc69e428e7' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -55,7 +55,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator that reads agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "01babd4435815a26dce468fab13905dc69e428e7";
+    const kovaRef = "b20d3b35118841db050a14f241098169aff4b9a2";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -55,7 +55,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator that reads agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "4f146016583018bad9e24f8e64a6af5f963bb7ee";
+    const kovaRef = "01babd4435815a26dce468fab13905dc69e428e7";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);


### PR DESCRIPTION
## What Problem This Solves

The full release performance lane now exercises all six managed-service scenarios. The previously pinned Kova evaluator races OCM child-log creation and applies stale aggregate/per-role RSS ceilings, so it rejects both current `main` and the accepted shipped release even when runtime behavior is healthy.

Kova [PR #7](https://github.com/openclaw/Kova/pull/7) fixes the evidence timing, exact process-role attribution, baseline contract, and scoped release calibration on the existing OpenClaw-pinned lineage. This PR pins its landed immutable commit.

## Why This Change Was Made

The landed Kova ref `01babd4435815a26dce468fab13905dc69e428e7` preserves the existing truncated-agent-payload parser and 300-second release timeout while adding:

- post-readiness runtime-dependency evidence collection;
- fail-closed typed evidence that accepts legitimate zero-event cold/warm summaries;
- primary-role resource gating with aggregate RSS retained as diagnostics;
- exact role membership, so `gateway-tree` descendants do not inflate `gateway`;
- explicit legacy baseline incompatibility handling;
- release-surface ceilings calibrated from repeated current and shipped controls without broadening global defaults.

Both workflow defaults and their regression assertion move together.

## User Impact

No product behavior changes. Release performance failures become actionable: real primary-process regressions still block, while wrapper/CLI concurrency and the OCM log race no longer produce false negatives.

## Evidence

- Kova PR #7: Linux and macOS CI green.
- Independent Kova review: 36 saved current/shipped records re-evaluate with zero resource violations.
- Exact observed maxima remain below the scoped caps; missing/failed/incomplete log collectors still fail closed.
- Testbox-through-Crabbox `tbx_01kx4atk975ehf4hph53az0ep4` ([run 29049801393](https://github.com/openclaw/openclaw/actions/runs/29049801393)):
  - `pnpm test test/scripts/openclaw-performance-workflow.test.ts`: 14/14 passed.
  - `pnpm check:workflows`: passed, including actionlint and zizmor.
  - targeted oxfmt check: passed.
- Fresh autoreview: no accepted/actionable findings.

After landing, the exact hosted release profile will run repeat=3 against this pin before release sign-off.
