### PR TITLE
fix: preserve tools when local-model lean agents use provider overrides

### DIFF
--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -201,6 +201,7 @@ export async function createCopilotToolBridge(
     isRawModelRun: isCopilotRawModelRun(attemptParams),
     modelId: input.modelId,
     modelProvider: input.modelProvider,
+    modelBaseUrl: attemptParams.model?.baseUrl,
     modelToolsEnabled: true,
     prompt: attemptParams.prompt,
     runId: attemptParams.runId,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -264,6 +264,7 @@ function applyModelProviderToolPolicy(
     config?: OpenClawConfig;
     modelProvider?: string;
     modelApi?: string;
+    modelBaseUrl?: string;
     modelId?: string;
     agentId?: string;
     sessionKey?: string;
@@ -280,6 +281,10 @@ function applyModelProviderToolPolicy(
     config: params?.config,
     agentId: params?.agentId,
     sessionKey: params?.sessionKey,
+    modelProvider: params?.modelProvider,
+    modelApi: params?.modelApi,
+    modelBaseUrl: params?.modelBaseUrl,
+    modelId: params?.modelId,
     preserveToolNames: params?.localModelLeanPreserveToolNames ?? params?.runtimeToolAllowlist,
   });
 
@@ -451,6 +456,8 @@ export function createOpenClawCodingTools(options?: {
   modelId?: string;
   /** Model API for the current provider (used for provider-native tool arbitration). */
   modelApi?: string;
+  /** Resolved endpoint used by the active model transport. */
+  modelBaseUrl?: string;
   /** Model context window in tokens (used to scale read-tool output budget). */
   modelContextWindowTokens?: number;
   /** Resolved runtime model compatibility hints. */
@@ -1107,6 +1114,7 @@ export function createOpenClawCodingTools(options?: {
     config: options?.config,
     modelProvider: options?.modelProvider,
     modelApi: options?.modelApi,
+    modelBaseUrl: options?.modelBaseUrl,
     modelId: options?.modelId,
     agentId: options?.agentId,
     sessionKey: options?.sessionKey,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1246,6 +1246,9 @@ export async function runEmbeddedAttempt(
           config: params.config,
           agentId: sessionAgentId,
           sessionKey: sandboxSessionKey,
+          modelProvider: params.provider,
+          modelApi: params.model.api,
+          modelId: params.modelId,
         });
     const toolSearchConfig = resolveToolSearchConfig(toolSearchRuntimeConfig);
     const codeModeControlsEnabledForRun =
@@ -1340,6 +1343,9 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: sessionAgentId,
       sessionKey: params.sessionKey,
+      modelProvider: params.provider,
+      modelApi: params.model.api,
+      modelId: params.modelId,
     });
     const localModelLeanPreserveToolNames = resolveLocalModelLeanPreserveToolNames({
       toolNames: runtimeCapabilityProfile.policy.explicitToolOverrideAllowlist,
@@ -1725,6 +1731,9 @@ export async function runEmbeddedAttempt(
       tools: [...tools, ...normalizedBundledTools],
       config: params.config,
       agentId: sessionAgentId,
+      modelProvider: params.provider,
+      modelApi: params.model.api,
+      modelId: params.modelId,
       preserveToolNames: localModelLeanPreserveToolNames,
     });
     if (cronCreatorToolAllowlist.length > 0) {
@@ -1847,6 +1856,9 @@ export async function runEmbeddedAttempt(
       tools: toolSearch.tools,
       config: params.config,
       agentId: sessionAgentId,
+      modelProvider: params.provider,
+      modelApi: params.model.api,
+      modelId: params.modelId,
       preserveToolNames: localModelLeanPreserveToolNames,
     });
     const toolSearchSchemaProjection = filterRuntimeCompatibleTools(projectedToolSearchTools);

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -14,11 +14,15 @@ function tools(names: string[]) {
   return names.map(createStubTool);
 }
 
-function createRuntime(config: OpenClawConfig) {
+function createRuntime(
+  config: OpenClawConfig,
+  modelScope: { modelProvider?: string; modelBaseUrl?: string; modelId?: string } = {},
+) {
   return createAgentHarnessToolSurfaceRuntime({
     config,
     executeTool: async () => ({ content: [], details: {} }),
     modelToolsEnabled: true,
+    ...modelScope,
   });
 }
 
@@ -40,6 +44,102 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
         .compactTools(tools(["read", "browser"]), { localModelLeanApplied: true })
         .tools.map((tool) => tool.name),
     ).toEqual(["read", "browser"]);
+    runtime.cleanup();
+  });
+
+  it("keeps the full harness tool surface for hosted provider overrides", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "ollama/qwen3-coder",
+          experimental: { localModelLean: true },
+        },
+      },
+    };
+    const runtime = createRuntime(config, {
+      modelProvider: "meta",
+      modelId: "muse-spark-1.1",
+    });
+
+    expect(runtime.toolSearchControlsEnabled).toBe(false);
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser", "cron", "message", "exec"]))
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "browser", "cron", "message", "exec"]);
+    runtime.cleanup();
+  });
+
+  it("keeps the full harness surface for an unknown provider on a public endpoint", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            model: "ollama/qwen3-coder",
+            experimental: { localModelLean: true },
+          },
+        ],
+      },
+    };
+    const runtime = createRuntime(config, {
+      modelProvider: "custom-provider",
+      modelBaseUrl: "https://models.example.com/v1",
+      modelId: "hosted-model",
+    });
+
+    expect(runtime.toolSearchControlsEnabled).toBe(false);
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser", "cron", "message", "exec"]))
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "browser", "cron", "message", "exec"]);
+    runtime.cleanup();
+  });
+
+  it("applies lean filtering for an unknown provider on a private endpoint", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            model: "ollama/qwen3-coder",
+            experimental: { localModelLean: true },
+          },
+        ],
+      },
+      tools: { toolSearch: { enabled: false } },
+    };
+    const runtime = createRuntime(config, {
+      modelProvider: "custom-provider",
+      modelBaseUrl: "http://192.168.1.50:1234/v1",
+      modelId: "local-model",
+    });
+
+    expect(runtime.toolSearchControlsEnabled).toBe(false);
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser", "cron", "message", "exec"]))
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "exec"]);
+    runtime.cleanup();
+  });
+
+  it("still applies lean filtering for known local harness providers", () => {
+    const config: OpenClawConfig = {
+      agents: { defaults: { experimental: { localModelLean: true } } },
+      tools: { toolSearch: { enabled: false } },
+    };
+    const runtime = createRuntime(config, {
+      modelProvider: "lmstudio",
+      modelId: "qwen3-coder",
+    });
+
+    expect(
+      runtime
+        .compactTools(tools(["read", "browser", "cron", "message", "exec"]))
+        .tools.map((tool) => tool.name),
+    ).toEqual(["read", "exec"]);
     runtime.cleanup();
   });
 

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -67,6 +67,7 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
   isRawModelRun?: boolean;
   modelId?: string;
   modelProvider?: string;
+  modelBaseUrl?: string;
   modelToolsEnabled: boolean;
   prompt?: string;
   runId?: string;
@@ -82,6 +83,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
     config: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    modelProvider: params.modelProvider,
+    modelBaseUrl: params.modelBaseUrl,
+    modelId: params.modelId,
   });
   const codeModeConfig = resolveCodeModeConfig(params.config, params.agentId);
   const toolSearchRuntimeConfig = forceDirectMessageTool
@@ -90,6 +94,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
         config: params.config,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        modelProvider: params.modelProvider,
+        modelBaseUrl: params.modelBaseUrl,
+        modelId: params.modelId,
       });
   const toolSearchConfig = resolveToolSearchConfig(toolSearchRuntimeConfig);
   const toolsAvailable =
@@ -142,6 +149,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
           config: params.config,
           agentId: params.agentId,
           sessionKey: params.sessionKey,
+          modelProvider: params.modelProvider,
+          modelBaseUrl: params.modelBaseUrl,
+          modelId: params.modelId,
           preserveToolNames,
         });
     const uncompactedProjection = filterRuntimeCompatibleTools(projectedUncompactedTools);
@@ -219,6 +229,9 @@ export function createAgentHarnessToolSurfaceRuntime(params: {
           config: params.config,
           agentId: params.agentId,
           sessionKey: params.sessionKey,
+          modelProvider: params.modelProvider,
+          modelBaseUrl: params.modelBaseUrl,
+          modelId: params.modelId,
           preserveToolNames,
         });
     effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];

--- a/src/agents/local-model-lean-provider-scope.test.ts
+++ b/src/agents/local-model-lean-provider-scope.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { filterLocalModelLeanTools, isLocalModelLeanEnabled } from "./local-model-lean.js";
+
+function configWithLeanEnabled(): OpenClawConfig {
+  return {
+    agents: {
+      list: [
+        {
+          id: "main",
+          model: "ollama/qwen3-coder",
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      ],
+    },
+  };
+}
+
+function tools(names: string[]): AnyAgentTool[] {
+  return names.map((name) => ({ name })) as AnyAgentTool[];
+}
+
+describe("local model lean provider scope", () => {
+  it("does not treat a known hosted provider override as local", () => {
+    const config = configWithLeanEnabled();
+    const modelScope = {
+      modelProvider: "meta",
+      modelApi: "openai-completions",
+      modelId: "muse-spark-1.1",
+    } as const;
+
+    expect(isLocalModelLeanEnabled({ config, agentId: "main", ...modelScope })).toBe(false);
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config,
+        agentId: "main",
+        ...modelScope,
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "browser", "cron", "message", "exec"]);
+  });
+
+  it("preserves lean behavior when no configured model establishes an override", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          experimental: {
+            localModelLean: true,
+          },
+        },
+      },
+    };
+
+    expect(
+      isLocalModelLeanEnabled({
+        config,
+        agentId: "main",
+        modelProvider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-test",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps arbitrary custom local OpenAI-compatible providers eligible", () => {
+    const config: OpenClawConfig = {
+      ...configWithLeanEnabled(),
+      models: {
+        providers: {
+          "custom-local": {
+            baseUrl: "http://192.168.1.25:1234/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    };
+    const modelScope = {
+      modelProvider: "custom-local",
+      modelApi: "openai-completions",
+      modelId: "qwen3-coder",
+    } as const;
+
+    expect(isLocalModelLeanEnabled({ config, agentId: "main", ...modelScope })).toBe(true);
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config,
+        agentId: "main",
+        ...modelScope,
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "exec"]);
+  });
+
+  it("disables lean mode for configured custom hosted endpoints", () => {
+    const config: OpenClawConfig = {
+      ...configWithLeanEnabled(),
+      models: {
+        providers: {
+          "custom-hosted": {
+            baseUrl: "https://models.example.com/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(
+      isLocalModelLeanEnabled({
+        config,
+        agentId: "main",
+        modelProvider: "custom-hosted",
+        modelApi: "openai-completions",
+        modelId: "hosted-model",
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["minimax", "opencode", "opencode-go"])(
+    "disables lean mode from the resolved hosted endpoint for %s",
+    (modelProvider) => {
+      const config: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              model: "ollama/qwen3-coder",
+              experimental: { localModelLean: true },
+            },
+          ],
+        },
+      };
+
+      expect(
+        isLocalModelLeanEnabled({
+          config,
+          agentId: "main",
+          modelProvider,
+          modelBaseUrl: "https://models.example.com/v1",
+          modelId: "hosted-model",
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("keeps LM Studio eligible when only provider and model id are resolved", () => {
+    const config = configWithLeanEnabled();
+    const modelScope = {
+      modelProvider: "lmstudio",
+      modelId: "qwen3-coder",
+    } as const;
+
+    expect(isLocalModelLeanEnabled({ config, agentId: "main", ...modelScope })).toBe(true);
+    expect(
+      filterLocalModelLeanTools({
+        tools: tools(["read", "browser", "cron", "message", "exec"]),
+        config,
+        agentId: "main",
+        ...modelScope,
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "exec"]);
+  });
+
+  it("preserves opt-in behavior for unknown providers without endpoint facts", () => {
+    const config = configWithLeanEnabled();
+
+    expect(
+      isLocalModelLeanEnabled({
+        config,
+        agentId: "main",
+        modelProvider: "custom-unresolved",
+        modelApi: "openai-completions",
+        modelId: "custom-model",
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves legacy config-only resolution when model scope is unavailable", () => {
+    const config = configWithLeanEnabled();
+
+    expect(isLocalModelLeanEnabled({ config, agentId: "main" })).toBe(true);
+  });
+});

--- a/src/agents/local-model-lean-provider-scope.test.ts
+++ b/src/agents/local-model-lean-provider-scope.test.ts
@@ -95,6 +95,32 @@ describe("local model lean provider scope", () => {
     ).toEqual(["read", "exec"]);
   });
 
+  it("prefers the resolved public endpoint over a configured private provider endpoint", () => {
+    const config: OpenClawConfig = {
+      ...configWithLeanEnabled(),
+      models: {
+        providers: {
+          "custom-local": {
+            baseUrl: "http://192.168.1.25:1234/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(
+      isLocalModelLeanEnabled({
+        config,
+        agentId: "main",
+        modelProvider: "custom-local",
+        modelApi: "openai-completions",
+        modelBaseUrl: "https://models.example.com/v1",
+        modelId: "qwen3-coder",
+      }),
+    ).toBe(false);
+  });
+
   it("disables lean mode for configured custom hosted endpoints", () => {
     const config: OpenClawConfig = {
       ...configWithLeanEnabled(),

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -3,6 +3,8 @@
  * Removes high-latency or channel-dependent tools for local models while
  * preserving explicitly required delivery tools.
  */
+import { isPrivateOrLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.js";
@@ -27,6 +29,214 @@ const LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS = {
   searchDefaultLimit: 5,
   maxSearchLimit: 10,
 } as const;
+
+const KNOWN_LOCAL_MODEL_PROVIDERS = new Set([
+  "llama-cpp",
+  "lm-studio",
+  "lmstudio",
+  "ollama",
+  "ollama-local",
+]);
+const KNOWN_LOCAL_MODEL_APIS = new Set(["llama-cpp", "lm-studio", "lmstudio", "ollama"]);
+
+// These provider ids have hosted default transports. A configured local endpoint
+// or local service always takes precedence, so custom local overrides remain lean.
+const KNOWN_HOSTED_MODEL_PROVIDERS = new Set([
+  "anthropic",
+  "bedrock",
+  "cerebras",
+  "chutes",
+  "cohere",
+  "deepinfra",
+  "deepseek",
+  "fireworks",
+  "github-copilot",
+  "google",
+  "google-gemini-cli",
+  "google-vertex",
+  "groq",
+  "meta",
+  "minimax",
+  "mistral",
+  "moonshot",
+  "opencode",
+  "opencode-go",
+  "openai",
+  "openrouter",
+  "perplexity",
+  "together",
+  "vercel-ai-gateway",
+  "xai",
+  "zai",
+]);
+
+type LocalModelLeanModelScope = {
+  modelProvider?: string;
+  modelApi?: string;
+  modelBaseUrl?: string;
+  modelId?: string;
+};
+
+type ConfiguredModelProvider = NonNullable<
+  NonNullable<OpenClawConfig["models"]>["providers"]
+>[string];
+
+function normalizeModelScopeValue(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function resolveConfiguredModelProvider(params: {
+  config?: OpenClawConfig;
+  modelProvider?: string;
+}): ConfiguredModelProvider | undefined {
+  const provider = normalizeModelScopeValue(params.modelProvider);
+  if (!provider) {
+    return undefined;
+  }
+  const providers = params.config?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  for (const [candidate, providerConfig] of Object.entries(providers)) {
+    if (normalizeModelScopeValue(candidate) === provider) {
+      return providerConfig;
+    }
+  }
+  return undefined;
+}
+
+function resolveConfiguredModelBaseUrl(params: {
+  providerConfig: ConfiguredModelProvider;
+  modelId?: string;
+}): string | undefined {
+  const modelId = normalizeModelScopeValue(params.modelId);
+  if (modelId) {
+    const unqualifiedModelId = modelId.includes("/")
+      ? modelId.slice(modelId.indexOf("/") + 1)
+      : modelId;
+    const configuredModel = params.providerConfig.models?.find((candidate) => {
+      const candidateId = normalizeModelScopeValue(candidate.id);
+      return candidateId === modelId || candidateId === unqualifiedModelId;
+    });
+    const modelBaseUrl = configuredModel?.baseUrl?.trim();
+    if (modelBaseUrl) {
+      return modelBaseUrl;
+    }
+  }
+  const providerBaseUrl = params.providerConfig.baseUrl?.trim();
+  return providerBaseUrl || undefined;
+}
+
+function resolveConfiguredEndpointLocality(baseUrl: string | undefined): boolean | undefined {
+  if (!baseUrl) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    const hostname = parsed.hostname
+      .trim()
+      .toLowerCase()
+      .replace(/^\[(.*)\]$/, "$1")
+      .replace(/\.+$/, "");
+    if (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "host.docker.internal" ||
+      hostname === "gateway.docker.internal" ||
+      hostname.endsWith(".local") ||
+      hostname.endsWith(".lan") ||
+      hostname.endsWith(".home.arpa") ||
+      (!hostname.includes(".") && !hostname.includes(":"))
+    ) {
+      return true;
+    }
+    if (isPrivateOrLoopbackIpAddress(hostname)) {
+      return true;
+    }
+    return false;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveConfiguredPrimaryModelProvider(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+}): string | undefined {
+  if (!params.config) {
+    return undefined;
+  }
+  const agentModel = params.agentId
+    ? resolveAgentConfig(params.config, params.agentId)?.model
+    : undefined;
+  const primaryModel =
+    resolveAgentModelPrimaryValue(agentModel) ??
+    resolveAgentModelPrimaryValue(params.config.agents?.defaults?.model);
+  if (!primaryModel) {
+    return undefined;
+  }
+  const slashIndex = primaryModel.indexOf("/");
+  if (slashIndex <= 0) {
+    return undefined;
+  }
+  return normalizeModelScopeValue(primaryModel.slice(0, slashIndex));
+}
+
+function resolveLocalModelLeanModelLocality(
+  params: {
+    config?: OpenClawConfig;
+    configuredPrimaryProvider?: string;
+  } & LocalModelLeanModelScope,
+): boolean | undefined {
+  const provider = normalizeModelScopeValue(params.modelProvider);
+  const api = normalizeModelScopeValue(params.modelApi);
+  const modelId = normalizeModelScopeValue(params.modelId);
+
+  const resolvedEndpointLocality = resolveConfiguredEndpointLocality(params.modelBaseUrl);
+  if (resolvedEndpointLocality !== undefined) {
+    return resolvedEndpointLocality;
+  }
+
+  const providerConfig = resolveConfiguredModelProvider(params);
+  if (providerConfig?.localService) {
+    return true;
+  }
+  const configuredEndpointLocality = providerConfig
+    ? resolveConfiguredEndpointLocality(
+        resolveConfiguredModelBaseUrl({
+          providerConfig,
+          modelId: params.modelId,
+        }),
+      )
+    : undefined;
+  if (configuredEndpointLocality !== undefined) {
+    return configuredEndpointLocality;
+  }
+
+  if (
+    KNOWN_LOCAL_MODEL_PROVIDERS.has(provider) ||
+    KNOWN_LOCAL_MODEL_APIS.has(api) ||
+    modelId.startsWith("ollama/") ||
+    modelId.startsWith("ollama-local/") ||
+    modelId.startsWith("lmstudio/") ||
+    modelId.startsWith("lm-studio/")
+  ) {
+    return true;
+  }
+  if (KNOWN_HOSTED_MODEL_PROVIDERS.has(provider)) {
+    const configuredPrimaryProvider = normalizeModelScopeValue(params.configuredPrimaryProvider);
+    if (configuredPrimaryProvider && configuredPrimaryProvider !== provider) {
+      return false;
+    }
+  }
+
+  // When endpoint or configured-provider facts do not establish locality,
+  // preserve the existing explicit opt-in behavior.
+  return undefined;
+}
 
 function resolvePreservedLocalModelLeanToolNames(names?: Iterable<string>) {
   if (!names) {
@@ -73,28 +283,43 @@ function resolveLocalModelLeanAgentId(params: {
 }
 
 /** Returns true when local-model lean mode is enabled for the selected agent. */
-export function isLocalModelLeanEnabled(params: {
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-}): boolean {
+export function isLocalModelLeanEnabled(
+  params: {
+    config?: OpenClawConfig;
+    agentId?: string;
+    sessionKey?: string;
+  } & LocalModelLeanModelScope,
+): boolean {
   const normalizedAgentId = resolveLocalModelLeanAgentId(params);
   const resolvedExperimental =
     params.config && normalizedAgentId
       ? (resolveAgentConfig(params.config, normalizedAgentId)?.experimental ??
         params.config.agents?.defaults?.experimental)
       : params.config?.agents?.defaults?.experimental;
-  return resolvedExperimental?.localModelLean ?? false;
+  if (resolvedExperimental?.localModelLean !== true) {
+    return false;
+  }
+  return (
+    resolveLocalModelLeanModelLocality({
+      ...params,
+      configuredPrimaryProvider: resolveConfiguredPrimaryModelProvider({
+        config: params.config,
+        agentId: normalizedAgentId,
+      }),
+    }) !== false
+  );
 }
 
 /** Filters tools for local-model lean mode while preserving required delivery tools. */
-export function filterLocalModelLeanTools(params: {
-  tools: AnyAgentTool[];
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  preserveToolNames?: Iterable<string>;
-}): AnyAgentTool[] {
+export function filterLocalModelLeanTools(
+  params: {
+    tools: AnyAgentTool[];
+    config?: OpenClawConfig;
+    agentId?: string;
+    sessionKey?: string;
+    preserveToolNames?: Iterable<string>;
+  } & LocalModelLeanModelScope,
+): AnyAgentTool[] {
   if (!isLocalModelLeanEnabled(params)) {
     return params.tools;
   }
@@ -114,11 +339,13 @@ export function shouldCatalogToolForLocalModelLean(tool: AnyAgentTool): boolean 
   return !LOCAL_MODEL_LEAN_DIRECT_TOOL_NAMES.has(normalizeToolName(tool.name));
 }
 
-export function applyLocalModelLeanToolSearchDefaults(params: {
-  config?: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-}): OpenClawConfig | undefined {
+export function applyLocalModelLeanToolSearchDefaults(
+  params: {
+    config?: OpenClawConfig;
+    agentId?: string;
+    sessionKey?: string;
+  } & LocalModelLeanModelScope,
+): OpenClawConfig | undefined {
   if (!params.config || !isLocalModelLeanEnabled(params)) {
     return params.config;
   }


### PR DESCRIPTION
## Summary

Fixes local-model lean tool filtering when an agent configured for a local model is temporarily routed to a hosted provider override.

A hosted override keeps the normal tool surface. Local providers and custom local OpenAI-compatible endpoints remain eligible for lean filtering.

## Problem

`experimental.localModelLean=true` was originally resolved from agent configuration without enough active-model context. A local-model-oriented agent routed to `meta/muse-spark-1.1` could inherit lean Tool Search behavior and lose direct tools such as `exec`.

## Implementation

The active model provider, API, model id, and resolved endpoint are carried through every lean-mode decision that controls Tool Search defaults or tool filtering.

Locality is resolved in this order:

1. The active resolved endpoint, when available.
2. Configured model or provider endpoint and `localService` metadata.
3. Known local provider/API identities.
4. Known hosted provider identity when it differs from the configured primary provider.
5. Existing explicit opt-in behavior when locality cannot be established.

This means runtime endpoint facts override stale or generic provider configuration. A configured private provider routed to a public endpoint is treated as hosted for that run.

## Compatibility

The patch preserves:

- existing config-only lean behavior
- embedded-runner Tool Search defaults
- message-tool-only filtering
- Ollama, llama.cpp, and LM Studio eligibility
- arbitrary custom local OpenAI-compatible providers
- configured local services and private endpoints

It prevents lean mode from applying to hosted provider overrides and public custom endpoints.

## Regression coverage

Coverage includes:

- local primary model to known hosted provider override
- hosted provider selection without a configured override
- custom provider on private and public endpoints
- resolved public endpoint precedence over configured private endpoint
- LM Studio provider resolution
- unknown-provider fallback behavior
- config-only fallback behavior
- harness Tool Search and compacted/uncompacted tool surfaces

## Validation

Current head: `1815b6b1c4b707c7943c49edb372adfaf10a6a4c`

The current-main repair runner completed successfully before pushing the clean branch:

- focused provider-scope and harness tests passed
- `pnpm tsgo:core:test` passed
- formatting, lint, and `git diff --check` passed

Fresh full GitHub Actions are running on the exact current head.

## Runtime evidence

Before the patch:

- `main.experimental.localModelLean=true`
- fresh `main` session
- override: `meta/muse-spark-1.1`
- observed result: `Tool exec not found`

Isolation check:

- disabled `main.experimental.localModelLean`
- restarted the gateway
- repeated the same fresh Meta smoke
- observed output: `main-meta-fixed-tool-ok`

Exact-head live hosted and local provider proof still requires the contributor's gateway and provider sessions. The branch now has complete endpoint-aware automated coverage and a clean current-main history.

## Scope

This PR changes local-model lean runtime scoping only. It does not change authorization, static tool policy, or provider credentials.

## Tests

AI-assisted: yes.
