### PR TITLE
fix(web-fetch): recover from stale runtime providers

### DIFF
--- a/src/agents/tools/web-fetch.cache.test.ts
+++ b/src/agents/tools/web-fetch.cache.test.ts
@@ -63,7 +63,7 @@ describe.each(["direct", "provider fallback"])("web_fetch %s cache", (source) =>
       if (initialTtl > 0) {
         expect((await tool.execute("cached", args)).details).toMatchObject({ cached: true });
       }
-      expect(networkCalls).toBe(1);
+      expect(networkCalls).toBe(source === "direct" || initialTtl === 0 ? 1 : 2);
 
       setTtl(0);
       for (const freshBody of ["fresh body", "newest body"]) {
@@ -72,7 +72,7 @@ describe.each(["direct", "provider fallback"])("web_fetch %s cache", (source) =>
         expect(result.details).toMatchObject({ text: expect.stringContaining(freshBody) });
         expect(result.details).not.toHaveProperty("cached");
       }
-      expect(networkCalls).toBe(3);
+      expect(networkCalls).toBe(source === "provider fallback" && initialTtl > 0 ? 4 : 3);
       expect(providerExecute).toHaveBeenCalledTimes(source === "direct" ? 0 : 3);
 
       // Disabled requests neither replace another caller's entry nor insert their own.
@@ -82,7 +82,9 @@ describe.each(["direct", "provider fallback"])("web_fetch %s cache", (source) =>
       expect(enabled.details).toMatchObject({
         text: expect.stringContaining(initialTtl > 0 ? "original body" : "after re-enable"),
       });
-      expect(networkCalls).toBe(initialTtl > 0 ? 3 : 4);
+      expect(networkCalls).toBe(
+        source === "direct" ? (initialTtl > 0 ? 3 : 4) : initialTtl > 0 ? 5 : 4,
+      );
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -513,6 +513,13 @@ describe("web_fetch provider fallback normalization", () => {
         tools: { web: { fetch: { cacheTtlMinutes: 15 } } },
       } as OpenClawConfig,
       sandboxed: false,
+      runtimeWebFetch: {
+        providerConfigured: "firecrawl",
+        providerSource: "configured",
+        selectedProvider: "firecrawl",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
     });
     const url = "https://example.com/direct-recovery-after-fallback";
 

--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -488,6 +488,46 @@ describe("web_fetch provider fallback normalization", () => {
     expect(resolveWebFetchDefinitionMock).toHaveBeenCalledTimes(2);
   });
 
+  it("tries direct fetch before reusing a provider fallback cache entry", async () => {
+    const directFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network failed"))
+      .mockResolvedValueOnce(
+        new Response("direct body", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+      );
+    global.fetch = withFetchPreconnect(directFetch);
+    const providerExecute = vi.fn(async () => ({ text: "fallback body" }));
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: providerExecute,
+      },
+    });
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 15 } } },
+      } as OpenClawConfig,
+      sandboxed: false,
+    });
+    const url = "https://example.com/direct-recovery-after-fallback";
+
+    const first = await tool?.execute?.("provider-fallback-first", { url });
+    const second = await tool?.execute?.("direct-recovery-second", { url });
+    const firstDetails = first?.details as { externalContent?: { provider?: string } };
+    const secondDetails = second?.details as { cached?: boolean; text?: string };
+
+    expect(firstDetails.externalContent?.provider).toBe("firecrawl");
+    expect(secondDetails.text).toContain("direct body");
+    expect(secondDetails.cached).toBeUndefined();
+    expect(directFetch).toHaveBeenCalledTimes(2);
+    expect(providerExecute).toHaveBeenCalledTimes(1);
+  });
+
   it("late-binds direct request headers and partitions the cache by the refreshed values", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(
       new Response("# Routed", {

--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -414,6 +414,80 @@ describe("web_fetch provider fallback normalization", () => {
     expect(secondDetails.cached).toBeUndefined();
   });
 
+  it("does not replay an auto-recovered provider result for a configured unavailable provider", async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("network failed");
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+    resolveWebFetchDefinitionMock.mockImplementation(
+      ({ runtimeWebFetch }: { runtimeWebFetch?: { providerSource?: string } }) =>
+        runtimeWebFetch?.providerSource === "auto-detect"
+          ? {
+              provider: { id: "firecrawl" },
+              definition: {
+                description: "firecrawl",
+                parameters: {},
+                execute: async () => ({ text: "recovered firecrawl body" }),
+              },
+            }
+          : null,
+    );
+    const tool = createWebFetchTool({
+      config: {} as OpenClawConfig,
+      sandboxed: false,
+      lateBindRuntimeConfig: true,
+    });
+    const url = "https://example.com/recovered-provider-cache-scope";
+
+    runtimeState.activeSecretsRuntimeSnapshot = {
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 15 } } },
+      },
+    };
+    runtimeState.activeRuntimeWebToolsMetadata = {
+      fetch: {
+        providerSource: "auto-detect",
+        selectedProvider: "removed-provider",
+        diagnostics: [],
+      },
+      diagnostics: [],
+    };
+    const recovered = await tool?.execute?.("auto-recovered-provider", { url });
+    const recoveredDetails = recovered?.details as
+      | { externalContent?: { provider?: string } }
+      | undefined;
+    expect(recoveredDetails?.externalContent?.provider).toBe("firecrawl");
+
+    runtimeState.activeSecretsRuntimeSnapshot = {
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              provider: "removed-provider",
+              cacheTtlMinutes: 15,
+            },
+          },
+        },
+      },
+    };
+    runtimeState.activeRuntimeWebToolsMetadata = {
+      fetch: {
+        providerConfigured: "removed-provider",
+        providerSource: "configured",
+        selectedProvider: "removed-provider",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+      diagnostics: [],
+    };
+
+    await expect(tool?.execute?.("configured-unavailable-provider", { url })).rejects.toThrow(
+      "network failed",
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(resolveWebFetchDefinitionMock).toHaveBeenCalledTimes(2);
+  });
+
   it("late-binds direct request headers and partitions the cache by the refreshed values", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(
       new Response("# Routed", {

--- a/src/agents/tools/web-fetch.signal.test.ts
+++ b/src/agents/tools/web-fetch.signal.test.ts
@@ -129,7 +129,7 @@ describe("web_fetch provider cancellation", () => {
       expect.soft(outcome).toEqual([{ status: "rejected", reason }]);
       assert(isRecord(fresh.details));
       expect(cached.details).toEqual({ ...fresh.details, cached: true });
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(source === "provider" ? 2 : 1);
       expect(execute).toHaveBeenCalledTimes(source === "provider" ? 1 : 0);
     },
   );
@@ -191,7 +191,7 @@ describe("web_fetch provider cancellation", () => {
 
       expect.soft(cancelled).toEqual({ status: "rejected", reason });
       expect.soft(fresh.details).not.toHaveProperty("cached");
-      expect.soft(fetch).toHaveBeenCalledTimes(2);
+      expect.soft(fetch).toHaveBeenCalledTimes(source === "direct" ? 2 : 3);
       expect.soft(execute).toHaveBeenCalledTimes(source === "direct" ? 0 : 2);
       assert(isRecord(fresh.details));
       expect(cached.details).toEqual({ ...fresh.details, cached: true });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -516,8 +516,6 @@ type WebFetchRuntimeParams = {
   ssrfPolicy?: SsrFPolicy;
   providerCacheKey?: string;
   providerSource?: string;
-  sandboxed: boolean;
-  preferRuntimeProviders: boolean;
   lookupFn?: LookupFn;
   signal?: AbortSignal;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
@@ -527,7 +525,6 @@ type WebFetchPayloadResult = {
   payload: Record<string, unknown>;
   cacheKey: string;
   cacheHit?: boolean;
-  providerId?: string;
 };
 
 function createWebFetchCacheKey(params: {
@@ -725,7 +722,6 @@ async function buildWebFetchPayload(params: {
 async function maybeFetchProviderWebFetchPayload(
   params: WebFetchRuntimeParams & {
     urlToFetch: string;
-    cacheKey: string;
     createCacheKeyForProvider: (
       providerCacheKey: string | undefined,
       responseKind?: "direct" | "provider-fallback",
@@ -742,16 +738,13 @@ async function maybeFetchProviderWebFetchPayload(
   // This prevents stale runtime metadata from aliasing another provider's result.
   const providerCacheKey = normalizeOptionalLowercaseString(providerFallback.provider.id);
   const cacheKey = params.createCacheKeyForProvider(providerCacheKey, "provider-fallback");
-  if (cacheKey !== params.cacheKey) {
-    const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
-    if (cached) {
-      return {
-        payload: { ...cached.value, cached: true },
-        cacheKey,
-        cacheHit: true,
-        providerId: providerCacheKey,
-      };
-    }
+  const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
+  if (cached) {
+    return {
+      payload: { ...cached.value, cached: true },
+      cacheKey,
+      cacheHit: true,
+    };
   }
   let rawPayload: unknown;
   try {
@@ -778,7 +771,6 @@ async function maybeFetchProviderWebFetchPayload(
   return {
     payload,
     cacheKey,
-    providerId: providerCacheKey,
   };
 }
 
@@ -1132,8 +1124,6 @@ export function createWebFetchTool(options?: {
           ...(runtimeWebFetch?.providerSource
             ? { providerSource: runtimeWebFetch.providerSource }
             : {}),
-          sandboxed: options?.sandboxed === true,
-          preferRuntimeProviders,
           lookupFn: options?.lookupFn,
           signal,
           resolveProviderFallback,

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -536,6 +536,7 @@ function createWebFetchCacheKey(params: {
   ssrfPolicy?: SsrFPolicy;
   providerCacheKey?: string;
   providerSource?: string;
+  responseKind: "direct" | "provider-fallback";
 }): string {
   const headersCacheKey = resolveFetchHeadersCacheKey(params.runtime.headers);
   const cacheDiscriminators = [
@@ -549,6 +550,7 @@ function createWebFetchCacheKey(params: {
   return normalizeCacheKey(
     [
       `fetch:${params.parsedUrl.href}:${params.runtime.extractMode}:${params.runtime.maxChars}`,
+      `response-kind:${params.responseKind}`,
       ...cacheDiscriminators,
     ].join(":"),
   );
@@ -724,7 +726,10 @@ async function maybeFetchProviderWebFetchPayload(
   params: WebFetchRuntimeParams & {
     urlToFetch: string;
     cacheKey: string;
-    createCacheKeyForProvider: (providerCacheKey?: string) => string;
+    createCacheKeyForProvider: (
+      providerCacheKey: string | undefined,
+      responseKind?: "direct" | "provider-fallback",
+    ) => string;
     tookMs: number;
   },
 ): Promise<WebFetchPayloadResult | null> {
@@ -736,7 +741,7 @@ async function maybeFetchProviderWebFetchPayload(
   // Provider discovery is lazy, so use the actual fallback id for cache identity.
   // This prevents stale runtime metadata from aliasing another provider's result.
   const providerCacheKey = normalizeOptionalLowercaseString(providerFallback.provider.id);
-  const cacheKey = params.createCacheKeyForProvider(providerCacheKey);
+  const cacheKey = params.createCacheKeyForProvider(providerCacheKey, "provider-fallback");
   if (cacheKey !== params.cacheKey) {
     const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
     if (cached) {
@@ -789,13 +794,17 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new Error("Invalid URL: must be http or https");
   }
-  const createCacheKeyForProvider = (providerCacheKey?: string) =>
+  const createCacheKeyForProvider = (
+    providerCacheKey?: string,
+    responseKind: "direct" | "provider-fallback" = "direct",
+  ) =>
     createWebFetchCacheKey({
       parsedUrl,
       runtime: params,
       ssrfPolicy,
       providerCacheKey,
       providerSource: params.providerSource,
+      responseKind,
     });
   const cacheKey = createCacheKeyForProvider(params.providerCacheKey);
   const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -4,7 +4,6 @@
  * Fetches HTTP(S) content through SSRF guards, provider config, caching, and bounded extraction.
  */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -14,10 +13,8 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug, logWarn } from "../../logger.js";
-import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -83,10 +80,6 @@ const DEFAULT_FETCH_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
 const FETCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
-const FETCH_PROVIDER_HINT_MAX_ENTRIES = 100;
-const FETCH_PROVIDER_HINTS = new Map<string, { providerId: string; expiresAt: number }>();
-let fetchProviderHintsRegistryVersion: number | undefined;
-
 // Accept and Accept-Language are part of the fetch/readability contract,
 // User-Agent has its own tools.web.fetch.userAgent key, and Undici owns
 // Sec-Fetch-Mode.
@@ -537,34 +530,6 @@ type WebFetchPayloadResult = {
   providerId?: string;
 };
 
-function resolveFetchProviderHintKey(params: WebFetchRuntimeParams): string {
-  const registryVersion = getActivePluginRegistryVersion();
-  if (fetchProviderHintsRegistryVersion !== registryVersion) {
-    FETCH_PROVIDER_HINTS.clear();
-    fetchProviderHintsRegistryVersion = registryVersion;
-  }
-  const fetchConfig = params.config?.tools?.web?.fetch;
-  const configuredProvider =
-    fetchConfig && typeof fetchConfig === "object" && "provider" in fetchConfig
-      ? fetchConfig.provider
-      : undefined;
-  const providerSelectionFingerprint = sha256Hex(
-    stableStringify({
-      configuredProvider,
-      plugins: params.config?.plugins,
-      secrets: params.config?.secrets,
-    }),
-  );
-  return JSON.stringify([
-    registryVersion,
-    providerSelectionFingerprint,
-    params.sandboxed,
-    params.preferRuntimeProviders,
-    params.providerSource ?? "",
-    params.providerCacheKey ?? "",
-  ]);
-}
-
 function createWebFetchCacheKey(params: {
   parsedUrl: URL;
   runtime: WebFetchRuntimeParams;
@@ -837,23 +802,6 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   if (cached) {
     return { ...cached.value, cached: true };
   }
-  const providerHintKey = resolveFetchProviderHintKey(params);
-  const providerHint = FETCH_PROVIDER_HINTS.get(providerHintKey);
-  if (providerHint && providerHint.expiresAt <= Date.now()) {
-    FETCH_PROVIDER_HINTS.delete(providerHintKey);
-  }
-  const hintedProviderCacheKey =
-    providerHint?.expiresAt > Date.now() ? providerHint.providerId : undefined;
-  const hintedCacheKey = hintedProviderCacheKey
-    ? createCacheKeyForProvider(hintedProviderCacheKey)
-    : undefined;
-  if (hintedCacheKey && hintedCacheKey !== cacheKey) {
-    const hintedCache = readCache(FETCH_CACHE, hintedCacheKey, params.cacheTtlMs);
-    if (hintedCache) {
-      return { ...hintedCache.value, cached: true };
-    }
-  }
-
   // Preserve the direct fetch's rejection; replacing it with signal.reason would
   // discard the transport's own error detail.
   const result = await fetchWebPayload(params, { cacheKey, createCacheKeyForProvider });
@@ -862,13 +810,6 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   throwIfFetchAborted(params.signal);
   if (!result.cacheHit) {
     writeCache(FETCH_CACHE, result.cacheKey, result.payload, params.cacheTtlMs);
-  }
-  if (result.providerId && params.cacheTtlMs > 0) {
-    pruneMapToMaxSize(FETCH_PROVIDER_HINTS, FETCH_PROVIDER_HINT_MAX_ENTRIES - 1);
-    FETCH_PROVIDER_HINTS.set(providerHintKey, {
-      providerId: result.providerId,
-      expiresAt: Date.now() + params.cacheTtlMs,
-    });
   }
   return result.payload;
 }

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -4,6 +4,7 @@
  * Fetches HTTP(S) content through SSRF guards, provider config, caching, and bounded extraction.
  */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -13,8 +14,10 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
+import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { SsrFBlockedError, type LookupFn, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug, logWarn } from "../../logger.js";
+import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -80,6 +83,9 @@ const DEFAULT_FETCH_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
 const FETCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
+const FETCH_PROVIDER_HINT_MAX_ENTRIES = 100;
+const FETCH_PROVIDER_HINTS = new Map<string, { providerId: string; expiresAt: number }>();
+let fetchProviderHintsRegistryVersion: number | undefined;
 
 // Accept and Accept-Language are part of the fetch/readability contract,
 // User-Agent has its own tools.web.fetch.userAgent key, and Undici owns
@@ -516,10 +522,72 @@ type WebFetchRuntimeParams = {
   useTrustedEnvProxy: boolean;
   ssrfPolicy?: SsrFPolicy;
   providerCacheKey?: string;
+  providerSource?: string;
+  sandboxed: boolean;
+  preferRuntimeProviders: boolean;
   lookupFn?: LookupFn;
   signal?: AbortSignal;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
 };
+
+type WebFetchPayloadResult = {
+  payload: Record<string, unknown>;
+  cacheKey: string;
+  cacheHit?: boolean;
+  providerId?: string;
+};
+
+function resolveFetchProviderHintKey(params: WebFetchRuntimeParams): string {
+  const registryVersion = getActivePluginRegistryVersion();
+  if (fetchProviderHintsRegistryVersion !== registryVersion) {
+    FETCH_PROVIDER_HINTS.clear();
+    fetchProviderHintsRegistryVersion = registryVersion;
+  }
+  const fetchConfig = params.config?.tools?.web?.fetch;
+  const configuredProvider =
+    fetchConfig && typeof fetchConfig === "object" && "provider" in fetchConfig
+      ? fetchConfig.provider
+      : undefined;
+  const providerSelectionFingerprint = sha256Hex(
+    stableStringify({
+      configuredProvider,
+      plugins: params.config?.plugins,
+      secrets: params.config?.secrets,
+    }),
+  );
+  return JSON.stringify([
+    registryVersion,
+    providerSelectionFingerprint,
+    params.sandboxed,
+    params.preferRuntimeProviders,
+    params.providerSource ?? "",
+    params.providerCacheKey ?? "",
+  ]);
+}
+
+function createWebFetchCacheKey(params: {
+  parsedUrl: URL;
+  runtime: WebFetchRuntimeParams;
+  ssrfPolicy?: SsrFPolicy;
+  providerCacheKey?: string;
+  providerSource?: string;
+}): string {
+  const headersCacheKey = resolveFetchHeadersCacheKey(params.runtime.headers);
+  const cacheDiscriminators = [
+    `user-agent:${sha256Hex(params.runtime.userAgent)}`,
+    params.providerCacheKey ? `provider:${params.providerCacheKey}` : "",
+    params.providerSource ? `provider-source:${params.providerSource}` : "",
+    params.ssrfPolicy ? `ssrf-policy:${sha256Hex(JSON.stringify(params.ssrfPolicy))}` : "",
+    params.runtime.useTrustedEnvProxy ? "trusted-env-proxy" : "",
+    headersCacheKey ? `headers:${headersCacheKey}` : "",
+  ].filter(Boolean);
+  return normalizeCacheKey(
+    [
+      `fetch:${params.parsedUrl.href}:${params.runtime.extractMode}:${params.runtime.maxChars}`,
+      ...cacheDiscriminators,
+    ].join(":"),
+  );
+}
 
 function normalizeProviderFinalUrl(value: unknown): string | undefined {
   const trimmed = normalizeOptionalString(value);
@@ -690,13 +758,30 @@ async function buildWebFetchPayload(params: {
 async function maybeFetchProviderWebFetchPayload(
   params: WebFetchRuntimeParams & {
     urlToFetch: string;
+    cacheKey: string;
+    createCacheKeyForProvider: (providerCacheKey?: string) => string;
     tookMs: number;
   },
-): Promise<Record<string, unknown> | null> {
+): Promise<WebFetchPayloadResult | null> {
   const providerFallback = await params.resolveProviderFallback();
   throwIfFetchAborted(params.signal);
   if (!providerFallback) {
     return null;
+  }
+  // Provider discovery is lazy, so use the actual fallback id for cache identity.
+  // This prevents stale runtime metadata from aliasing another provider's result.
+  const providerCacheKey = normalizeOptionalLowercaseString(providerFallback.provider.id);
+  const cacheKey = params.createCacheKeyForProvider(providerCacheKey);
+  if (cacheKey !== params.cacheKey) {
+    const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
+    if (cached) {
+      return {
+        payload: { ...cached.value, cached: true },
+        cacheKey,
+        cacheHit: true,
+        providerId: providerCacheKey,
+      };
+    }
   }
   let rawPayload: unknown;
   try {
@@ -711,7 +796,7 @@ async function maybeFetchProviderWebFetchPayload(
     throw error;
   }
   throwIfFetchAborted(params.signal);
-  return await buildWebFetchPayload({
+  const payload = await buildWebFetchPayload({
     providerId: providerFallback.provider.id,
     payload: rawPayload,
     requestedUrl: params.url,
@@ -719,12 +804,17 @@ async function maybeFetchProviderWebFetchPayload(
     maxChars: params.maxChars,
     tookMs: params.tookMs,
   });
+  throwIfFetchAborted(params.signal);
+  return {
+    payload,
+    cacheKey,
+    providerId: providerCacheKey,
+  };
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
   throwIfFetchAborted(params.signal);
   const ssrfPolicy = params.ssrfPolicy;
-  const useTrustedEnvProxy = params.useTrustedEnvProxy;
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(params.url);
@@ -734,38 +824,62 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new Error("Invalid URL: must be http or https");
   }
-  const headersCacheKey = resolveFetchHeadersCacheKey(params.headers);
-  // Append the operator header set after the existing cache discriminators so
-  // requests without custom headers keep their current cache key.
-  const cacheDiscriminators = [
-    `user-agent:${sha256Hex(params.userAgent)}`,
-    params.providerCacheKey ? `provider:${params.providerCacheKey}` : "",
-    ssrfPolicy ? `ssrf-policy:${sha256Hex(JSON.stringify(ssrfPolicy))}` : "",
-    useTrustedEnvProxy ? "trusted-env-proxy" : "",
-    headersCacheKey ? `headers:${headersCacheKey}` : "",
-  ].filter(Boolean);
-  const cacheKey = normalizeCacheKey(
-    [
-      `fetch:${parsedUrl.href}:${params.extractMode}:${params.maxChars}`,
-      ...cacheDiscriminators,
-    ].join(":"),
-  );
+  const createCacheKeyForProvider = (providerCacheKey?: string) =>
+    createWebFetchCacheKey({
+      parsedUrl,
+      runtime: params,
+      ssrfPolicy,
+      providerCacheKey,
+      providerSource: params.providerSource,
+    });
+  const cacheKey = createCacheKeyForProvider(params.providerCacheKey);
   const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }
+  const providerHintKey = resolveFetchProviderHintKey(params);
+  const providerHint = FETCH_PROVIDER_HINTS.get(providerHintKey);
+  if (providerHint && providerHint.expiresAt <= Date.now()) {
+    FETCH_PROVIDER_HINTS.delete(providerHintKey);
+  }
+  const hintedProviderCacheKey =
+    providerHint?.expiresAt > Date.now() ? providerHint.providerId : undefined;
+  const hintedCacheKey = hintedProviderCacheKey
+    ? createCacheKeyForProvider(hintedProviderCacheKey)
+    : undefined;
+  if (hintedCacheKey && hintedCacheKey !== cacheKey) {
+    const hintedCache = readCache(FETCH_CACHE, hintedCacheKey, params.cacheTtlMs);
+    if (hintedCache) {
+      return { ...hintedCache.value, cached: true };
+    }
+  }
 
   // Preserve the direct fetch's rejection; replacing it with signal.reason would
   // discard the transport's own error detail.
-  const payload = await fetchWebPayload(params);
+  const result = await fetchWebPayload(params, { cacheKey, createCacheKeyForProvider });
   // Publish only after guard release: cancellation or cleanup failure must not
   // leave a successful cache entry for a call that never returned its content.
   throwIfFetchAborted(params.signal);
-  writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
-  return payload;
+  if (!result.cacheHit) {
+    writeCache(FETCH_CACHE, result.cacheKey, result.payload, params.cacheTtlMs);
+  }
+  if (result.providerId && params.cacheTtlMs > 0) {
+    pruneMapToMaxSize(FETCH_PROVIDER_HINTS, FETCH_PROVIDER_HINT_MAX_ENTRIES - 1);
+    FETCH_PROVIDER_HINTS.set(providerHintKey, {
+      providerId: result.providerId,
+      expiresAt: Date.now() + params.cacheTtlMs,
+    });
+  }
+  return result.payload;
 }
 
-async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+async function fetchWebPayload(
+  params: WebFetchRuntimeParams,
+  cacheContext: {
+    cacheKey: string;
+    createCacheKeyForProvider: (providerCacheKey?: string) => string;
+  },
+): Promise<WebFetchPayloadResult> {
   const start = Date.now();
   let res: Response;
   let release: () => Promise<void>;
@@ -805,13 +919,14 @@ async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<st
     if (error instanceof SsrFBlockedError || params.signal?.aborted) {
       throw error;
     }
-    const payload = await maybeFetchProviderWebFetchPayload({
+    const providerResult = await maybeFetchProviderWebFetchPayload({
       ...params,
       urlToFetch: finalUrl,
+      ...cacheContext,
       tookMs: Date.now() - start,
     });
-    if (payload) {
-      return payload;
+    if (providerResult) {
+      return providerResult;
     }
     throw error;
   }
@@ -819,13 +934,14 @@ async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<st
   try {
     if (!res.ok) {
       throwIfFetchAborted(params.signal);
-      const payload = await maybeFetchProviderWebFetchPayload({
+      const providerResult = await maybeFetchProviderWebFetchPayload({
         ...params,
         urlToFetch: params.url,
+        ...cacheContext,
         tookMs: Date.now() - start,
       });
-      if (payload) {
-        return payload;
+      if (providerResult) {
+        return providerResult;
       }
       const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });
       throwIfFetchAborted(params.signal);
@@ -870,18 +986,19 @@ async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<st
           title = readable.title;
           extractor = readable.extractor;
         } else {
-          let payload: Record<string, unknown> | null = null;
+          let providerResult: WebFetchPayloadResult | null = null;
           try {
-            payload = await maybeFetchProviderWebFetchPayload({
+            providerResult = await maybeFetchProviderWebFetchPayload({
               ...params,
               urlToFetch: finalUrl,
+              ...cacheContext,
               tookMs: Date.now() - start,
             });
           } catch {
             throwIfFetchAborted(params.signal);
           }
-          if (payload) {
-            return payload;
+          if (providerResult) {
+            return providerResult;
           }
           const basic = await extractBasicHtmlContent({
             html: body,
@@ -900,13 +1017,14 @@ async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<st
           }
         }
       } else {
-        const payload = await maybeFetchProviderWebFetchPayload({
+        const providerResult = await maybeFetchProviderWebFetchPayload({
           ...params,
           urlToFetch: finalUrl,
+          ...cacheContext,
           tookMs: Date.now() - start,
         });
-        if (payload) {
-          return payload;
+        if (providerResult) {
+          return providerResult;
         }
         throw new Error(
           "Web fetch extraction failed: Readability disabled and no fetch provider is available.",
@@ -922,22 +1040,25 @@ async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<st
       }
     }
 
-    return await buildWebFetchPayload({
-      payload: {
-        finalUrl,
-        status: res.status,
-        contentType: normalizedContentType,
-        title,
-        extractor,
-        text,
-        warning: responseTruncatedWarning,
-        truncated: bodyResult.truncated,
-      },
-      requestedUrl: params.url,
-      extractMode: params.extractMode,
-      maxChars: params.maxChars,
-      tookMs: Date.now() - start,
-    });
+    return {
+      payload: await buildWebFetchPayload({
+        payload: {
+          finalUrl,
+          status: res.status,
+          contentType: normalizedContentType,
+          title,
+          extractor,
+          text,
+          warning: responseTruncatedWarning,
+          truncated: bodyResult.truncated,
+        },
+        requestedUrl: params.url,
+        extractMode: params.extractMode,
+        maxChars: params.maxChars,
+        tookMs: Date.now() - start,
+      }),
+      cacheKey: cacheContext.cacheKey,
+    };
   } finally {
     if (!res.bodyUsed) {
       // Fallbacks and provider failures can abandon the upstream stream. Cancel
@@ -1058,6 +1179,11 @@ export function createWebFetchTool(options?: {
             ? { ...executionFetch?.ssrfPolicy, hostnameAllowlist }
             : executionFetch?.ssrfPolicy,
           ...(providerCacheKey ? { providerCacheKey } : {}),
+          ...(runtimeWebFetch?.providerSource
+            ? { providerSource: runtimeWebFetch.providerSource }
+            : {}),
+          sandboxed: options?.sandboxed === true,
+          preferRuntimeProviders,
           lookupFn: options?.lookupFn,
           signal,
           resolveProviderFallback,

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -241,6 +241,27 @@ describe("web fetch runtime", () => {
     expect(runtimeWebFetch.selectedProviderKeySource).toBe("missing");
   });
 
+  it.each(["", "unknown-provider", "firecrawl"])(
+    "keeps explicit provider %j authoritative over valid runtime metadata",
+    (providerId) => {
+      resolveRuntimeWebFetchProvidersMock.mockReturnValue([createFirecrawlProvider()]);
+
+      const resolved = resolveWebFetchDefinition({
+        config: {},
+        providerId,
+        preferRuntimeProviders: true,
+        runtimeWebFetch: {
+          providerSource: "auto-detect",
+          selectedProvider: "firecrawl",
+          selectedProviderKeySource: "env",
+          diagnostics: [],
+        },
+      });
+
+      expect(resolved?.provider.id ?? null).toBe(providerId === "firecrawl" ? "firecrawl" : null);
+    },
+  );
+
   it("does not replace an unavailable configured runtime provider with auto-detect", () => {
     const provider = createFirecrawlProvider({
       getConfiguredCredentialValue: () => "firecrawl-key",

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -192,6 +192,84 @@ describe("web fetch runtime", () => {
     });
   });
 
+  it("passes normalized runtime metadata after stale auto-detected metadata recovery", async () => {
+    const provider = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+      createTool: ({ runtimeMetadata }) => ({
+        description: "firecrawl",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          runtimeProviderConfigured: runtimeMetadata?.providerConfigured,
+          runtimeSelectedProvider: runtimeMetadata?.selectedProvider,
+          runtimeSelectedProviderKeySource: runtimeMetadata?.selectedProviderKeySource,
+        }),
+      }),
+    });
+    resolveRuntimeWebFetchProvidersMock.mockReturnValue([provider]);
+    const runtimeWebFetch: RuntimeWebFetchMetadata = {
+      providerSource: "auto-detect",
+      selectedProvider: "removed-provider",
+      selectedProviderKeySource: "missing",
+      diagnostics: [],
+    };
+
+    const webFetch = requireResolvedWebFetch(
+      resolveWebFetchDefinition({
+        config: {},
+        runtimeWebFetch,
+        preferRuntimeProviders: true,
+      }),
+    );
+
+    expect(webFetch.provider.id).toBe("firecrawl");
+    await expect(
+      webFetch.definition.execute({
+        url: "https://example.com",
+        extractMode: "markdown",
+        maxChars: 1000,
+      }),
+    ).resolves.toEqual({
+      url: "https://example.com",
+      extractMode: "markdown",
+      maxChars: 1000,
+      runtimeProviderConfigured: undefined,
+      runtimeSelectedProvider: "firecrawl",
+      runtimeSelectedProviderKeySource: undefined,
+    });
+    expect(runtimeWebFetch.selectedProvider).toBe("removed-provider");
+    expect(runtimeWebFetch.selectedProviderKeySource).toBe("missing");
+  });
+
+  it("does not replace an unavailable configured runtime provider with auto-detect", () => {
+    const provider = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    resolveRuntimeWebFetchProvidersMock.mockReturnValue([provider]);
+    const runtimeWebFetch: RuntimeWebFetchMetadata = {
+      providerConfigured: "removed-provider",
+      providerSource: "configured",
+      selectedProvider: "removed-provider",
+      selectedProviderKeySource: "missing",
+      diagnostics: [],
+    };
+
+    expect(
+      resolveWebFetchDefinition({
+        config: {},
+        runtimeWebFetch,
+        preferRuntimeProviders: true,
+      }),
+    ).toBeNull();
+    expect(runtimeWebFetch).toEqual({
+      providerConfigured: "removed-provider",
+      providerSource: "configured",
+      selectedProvider: "removed-provider",
+      selectedProviderKeySource: "missing",
+      diagnostics: [],
+    });
+  });
+
   it("auto-detects providers from provider-declared env vars", () => {
     const provider = createFirecrawlProvider();
     resolvePluginWebFetchProvidersMock.mockReturnValue([provider]);

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -253,11 +253,9 @@ export function resolveWebFetchDefinition(
   const configuredProviderId = resolveConfiguredWebFetchProviderId({ fetch, providers });
   const explicitProviderId = options?.providerId ?? configuredProviderId;
   const runtimeProviderId = runtimeWebFetch?.selectedProvider;
-  let provider = explicitProviderId
-    ? providers.find((entry) => entry.id === explicitProviderId)
-    : runtimeProviderId
-      ? providers.find((entry) => entry.id === runtimeProviderId)
-      : undefined;
+  // Even an empty explicit override is authoritative; do not execute a different provider.
+  const selectedProviderId = explicitProviderId ?? runtimeProviderId;
+  let provider = providers.find((entry) => entry.id === selectedProviderId);
   let didFallbackFromUnavailableRuntimeProvider = false;
   if (!provider && explicitProviderId === undefined) {
     const runtimeProviderIsConfigured = runtimeWebFetch?.providerSource === "configured";

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -250,19 +250,42 @@ export function resolveWebFetchDefinition(
   if (providers.length === 0) {
     return null;
   }
-  const providerId =
-    options?.providerId ??
-    resolveConfiguredWebFetchProviderId({ fetch, providers }) ??
-    runtimeWebFetch?.selectedProvider ??
-    resolveAutoWebFetchProviderId({ config: options?.config, fetch, providers });
-  const provider = providers.find((entry) => entry.id === providerId);
+  const configuredProviderId = resolveConfiguredWebFetchProviderId({ fetch, providers });
+  const explicitProviderId = options?.providerId ?? configuredProviderId;
+  const runtimeProviderId = runtimeWebFetch?.selectedProvider;
+  let provider = explicitProviderId
+    ? providers.find((entry) => entry.id === explicitProviderId)
+    : runtimeProviderId
+      ? providers.find((entry) => entry.id === runtimeProviderId)
+      : undefined;
+  let didFallbackFromUnavailableRuntimeProvider = false;
+  if (!provider && explicitProviderId === undefined) {
+    const runtimeProviderIsConfigured = runtimeWebFetch?.providerSource === "configured";
+    if (!runtimeProviderIsConfigured) {
+      const autoProviderId = resolveAutoWebFetchProviderId({
+        config: options?.config,
+        fetch,
+        providers,
+      });
+      provider = providers.find((entry) => entry.id === autoProviderId);
+      didFallbackFromUnavailableRuntimeProvider = Boolean(runtimeProviderId && provider);
+    }
+  }
   if (!provider) {
     return null;
   }
+  const normalizedRuntimeMetadata =
+    didFallbackFromUnavailableRuntimeProvider && runtimeWebFetch
+      ? {
+          ...runtimeWebFetch,
+          selectedProvider: provider.id,
+          selectedProviderKeySource: undefined,
+        }
+      : runtimeWebFetch;
   const definition = provider.createTool({
     config: options?.config,
     fetchConfig: fetch as Record<string, unknown> | undefined,
-    runtimeMetadata: runtimeWebFetch,
+    runtimeMetadata: normalizedRuntimeMetadata,
   });
   return definition ? { provider, definition } : null;
 }


### PR DESCRIPTION
## What Problem This Solves

Runtime web-fetch metadata can retain a selected provider id that is no longer available in the current provider list. When that selection came from automatic discovery, resolution returned no provider instead of falling back to the provider that is available now.

## Why This Change Was Made

The resolver now distinguishes authoritative selections from stale automatic runtime state:

- An explicit `providerId` or runtime metadata marked `providerSource: "configured"` remains authoritative and fail-closed.
- An unavailable non-configured runtime `selectedProvider` may fall back to the current auto-detected provider.
- Provider-facing metadata is normalized only after that fallback. Its `selectedProvider` becomes the resolved provider and the stale `selectedProviderKeySource` is cleared, while caller-owned metadata remains unchanged.
- Lazy fallback cache entries are keyed by the provider that actually handled the request, so recovered results cannot be replayed for a later unavailable configured provider.

This preserves the configured-versus-automatic boundary already used by the sibling web-search runtime without adding a new configuration surface.

## User Impact

Users recover web fetch automatically after auto-detected provider metadata becomes stale. Explicit provider choices do not silently route requests through another service, recovered content cannot cross provider cache identities, and valid aliases or explicit overrides retain their credential metadata.

## Evidence

### Maintenance validation — 2026-09-09

I rebased this PR onto upstream main `338a53fbde2cd2668e987156a22b4383b4207bdc`. The current contributor head is `d08a08346b230cb283c70d969eae07bd48f660e3`.

Updated the base to include the upstream subagent authority test synchronization: dynamic imports settle and the completed sibling task reaches succeeded before the assertion. The web-fetch feature/fix patch is unchanged by this rebase.

Validation on Linux with Node 24.16.0 and the repository-pinned pnpm 12.3.4 / Vitest 5:
- `node scripts/run-vitest.mjs run src/agents/tools/web-fetch.cache.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts src/agents/tools/web-fetch.signal.test.ts src/web-fetch/runtime.test.ts src/agents/subagents/spawn/subagent-spawn.authority.test.ts --reporter=dot`: 62 passed.
- Fresh structured autoreview covered actionable priorities P0–P3; no remaining accepted findings.
- `git diff --check` passed. Contributor author/committer identities and maintainer edit permission were verified before the exact-lease push.

These are focused regression checks, not a new live behavior proof. The earlier runtime/media/transcript receipts below belong to their stated historical heads and were not rerun on this rebased head. Upstream CI for the new head is reported by the checks attached to this PR; I am not claiming it green before completion.

### Earlier validation receipts (historical heads)


### September 5 Completed CI Status

Head: `f44e255f6d4083768ee873a27a28f513bed591bf`. The checks associated with this head have completed with 164 success, 50 skipped, 1 neutral and 2 failures (one actual test shard plus the aggregate gate). [Job 101324588308](https://github.com/openclaw/openclaw/actions/runs/33972918706/job/101324588308) failed `subagent-spawn.authority.test.ts:116`: a completed persistent sibling remained `running` when the test expected `succeeded`. CI actually checked merge commit `d0402dc51ffafa4aa24493ae0b1a39fa8392fefe`, whose base parent is `d3386f151859443fe9dd589d7451ffde1554afd0`; the failing test blob matches that base. The web-fetch patch does not modify the spawn/registry/task surfaces. This identifies an unchanged failing surface, not a proven baseline reproduction or a full root cause. The aggregate is still red. The focused HTTP evidence above does not override this CI result. Leon has read-only upstream repository permissions, so no upstream Actions rerun or maintainer approval is claimed.


### September 5 Repair And Exact-Head HTTP Recovery

Current head: `f44e255f6d4083768ee873a27a28f513bed591bf`. This follow-up addresses the explicit-empty-provider regression identified in the [durable review](https://github.com/openclaw/openclaw/pull/103113#issuecomment-4930384453), and removes unused internal fields plus a redundant cache-key inequality branch. Explicit selection now uses nullish precedence, so an empty explicit override cannot execute a provider selected by runtime metadata.

**Acceptance red -> green:** adding the empty/unknown/valid explicit-provider table before the production fix produced 1 failing and 23 passing resolver tests; the failure returned Firecrawl for the explicit empty override. After the fix, the same resolver suite passed 24/24 and the fallback suite passed 14/14. The three-file follow-up adds 21 test lines and removes 12 net production lines (+10/-22 production; +21/-0 tests). No generated files or lockfile changes are included.

```text
node scripts/run-vitest.mjs src/web-fetch/runtime.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts --reporter=dot
Resolver: 24 passed; fallback: 14 passed; 2 shards passed in 182.42s.

TARGET_SHA=f44e255f6d4083768ee873a27a28f513bed591bf node scripts/run-vitest.mjs src/agents/tools/web-fetch.http-recovery.proof.test.ts --reporter=verbose
Real HTTP scenario: 1 passed; Vitest duration 201.53s; scenario 143.83s.
```

**Observed behavior:** the first real origin request returns 503 and the production Firecrawl plugin posts to the local `/v2/scrape` receiver. The second origin request still returns 503 and reuses the provider fallback cache without another provider POST. An unavailable configured provider then fails closed on a third 503 without reading that fallback. Once the origin serves 200, the next tool call returns `ORIGIN_RECOVERED_CURRENT_CONTENT`, not the cached `PROVIDER_FALLBACK_CONTENT`; a final call reuses the direct cache. The receiver records exactly one provider request and four direct requests. No fetch, resolver, provider or network-guard function is mocked.

```json
{
  "sourceHead": "f44e255f6d4083768ee873a27a28f513bed591bf",
  "transport": "real loopback HTTP; production tool, resolver, Firecrawl plugin and network guard",
  "originResponses": [
    503,
    503,
    503,
    200
  ],
  "providerRequests": 1,
  "cachedFallback": true,
  "configuredUnavailableFailedClosed": true,
  "explicitEmptyFailedClosed": true,
  "directOriginRecovered": true,
  "directCacheReused": true,
  "paidServiceCalls": 0
}
```

**Provenance and limits:** executed September 5, 2026 on Linux / Node 24.15.0, at the exact commit above, with only the temporary harness below added outside the committed patch. The result above is a transcribed local receipt, not an external-service E2E or a downloadable CI artifact. The harness uses synthetic content and a dummy credential against loopback only; the DNS seam maps `proof.example` to loopback. No production account, channel or provider secret is used. Preinstalled dependencies were reused after a pinned-pnpm bootstrap install failed; they are not claimed to match the exact lockfile (for example fs-safe 0.7.0 vs pinned 0.7.2, markdown-it 15.0.0 vs 15.0.1). The wrapper reported two unrelated unresolved workspace imports. Exact-lock CI is tracked separately in [run 33972918706](https://github.com/openclaw/openclaw/actions/runs/33972918706); no green CI result is inferred from this local receipt. An initial 120-second harness budget timed out before the first result; the unchanged scenario passed with a 300-second budget and again after commit. This is not a latency benchmark.

**Review/checks:** fresh P0-P3 autoreview on the three-file repair returned no accepted/actionable findings, patch correct (0.98). `git diff --check` and focused formatting passed; the commit hook also completed on the three files. A broad lint-wrapper attempt timed out preparing SDK declarations and is not represented as a passed broad check.

**Remaining owner decisions:** automatic replacement-provider cost/data handling and the direct-first origin traffic/latency tradeoff remain maintainer decisions. The cache is the existing process-local TTL Map (`FETCH_CACHE`); no persisted data schema, database, migration, configuration or protocol surface is added. This clarification and the HTTP proof do not claim maintainer approval of those tradeoffs.

<details>
<summary>Complete secretless HTTP harness</summary>

Place this temporary scenario at `src/agents/tools/web-fetch.http-recovery.proof.test.ts` to reproduce the command above; it is not part of the product patch.

```ts
import assert from "node:assert/strict";
import { createServer } from "node:http";
import { test } from "vitest";
import type { OpenClawConfig } from "../../config/types.js";
import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
import { resolveWebFetchDefinition } from "../../web-fetch/runtime.js";
import { createWebFetchTool } from "./web-fetch.js";

test("reads recovered origin content after caching a real HTTP provider fallback", async () => {
  let originHealthy = false;
  let directRequests = 0;
  let providerRequests = 0;
  let providerTarget = "";
  const server = createServer((request, response) => {
    if (request.url === "/target") {
      directRequests += 1;
      response.writeHead(originHealthy ? 200 : 503, { "content-type": "text/plain" });
      response.end(originHealthy ? "ORIGIN_RECOVERED_CURRENT_CONTENT" : "origin unavailable");
      return;
    }
    if (request.url === "/v2/scrape" && request.method === "POST") {
      providerRequests += 1;
      const chunks: Buffer[] = [];
      request.on("data", (chunk: Buffer) => chunks.push(chunk));
      request.on("end", () => {
        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { url: string };
        providerTarget = body.url;
        response.writeHead(200, { "content-type": "application/json" });
        response.end(JSON.stringify({
          success: true,
          data: { markdown: "PROVIDER_FALLBACK_CONTENT", metadata: { sourceURL: body.url, statusCode: 200 } },
        }));
      });
      return;
    }
    response.writeHead(404).end();
  });
  await new Promise<void>((resolve, reject) => {
    server.once("error", reject);
    server.listen(0, "127.0.0.1", resolve);
  });
  try {
    const address = server.address();
    assert(address && typeof address === "object");
    const url = `http://proof.example:${address.port}/target`;
    const config: OpenClawConfig = {
      plugins: {
        allow: ["firecrawl"],
        entries: {
          firecrawl: { enabled: true, config: { webFetch: {
            apiKey: "synthetic-unused-credential",
            baseUrl: `http://127.0.0.1:${address.port}`,
          } } },
        },
      },
      tools: { web: { fetch: {
        cacheTtlMinutes: 15,
        timeoutSeconds: 5,
        ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
      } } },
    };
    const metadata: RuntimeWebFetchMetadata = {
      providerSource: "auto-detect",
      selectedProvider: "removed-provider",
      selectedProviderKeySource: "missing",
      diagnostics: [],
    };
    const lookupFn = async (hostname: string) => {
      assert.equal(hostname, "proof.example");
      return [{ address: "127.0.0.1", family: 4 }];
    };
    console.log("HTTP_PROOF_STAGE", "creating production tool");
    const tool = createWebFetchTool({ config, runtimeWebFetch: metadata, lookupFn });
    console.log("HTTP_PROOF_STAGE", "production tool created");
    assert(tool);
    const execute = async (id: string) => {
      console.log("HTTP_PROOF_STAGE", id);
      const result = await tool.execute(id, { url });
      console.log("HTTP_PROOF_COMPLETED", id);
      return result.details as { text: string; cached?: boolean; externalContent: { provider?: string } };
    };
    const first = await execute("fallback");
    assert.equal(first.externalContent.provider, "firecrawl");
    assert.match(first.text, /PROVIDER_FALLBACK_CONTENT/);
    assert.equal(first.cached, undefined);
    assert.equal(directRequests, 1);
    assert.equal(providerRequests, 1);
    assert.equal(providerTarget, url);

    const cachedFallback = await execute("cached-fallback");
    assert.equal(cachedFallback.cached, true);
    assert.match(cachedFallback.text, /PROVIDER_FALLBACK_CONTENT/);
    assert.equal(directRequests, 2);
    assert.equal(providerRequests, 1);

    const configuredMetadata: RuntimeWebFetchMetadata = {
      ...metadata, providerSource: "configured", providerConfigured: "removed-provider",
    };
    assert.equal(resolveWebFetchDefinition({ config, runtimeWebFetch: configuredMetadata, preferRuntimeProviders: true }), null);
    const configured = createWebFetchTool({ config, runtimeWebFetch: configuredMetadata, lookupFn });
    assert(configured);
    await assert.rejects(configured.execute("configured-unavailable", { url }), /Web fetch failed \(503\)/);
    assert.equal(directRequests, 3);
    assert.equal(providerRequests, 1);

    assert.equal(resolveWebFetchDefinition({
      config, providerId: "", preferRuntimeProviders: true,
      runtimeWebFetch: { ...metadata, selectedProvider: "firecrawl" },
    }), null);

    originHealthy = true;
    const recovered = await execute("origin-recovered");
    assert.match(recovered.text, /ORIGIN_RECOVERED_CURRENT_CONTENT/);
    assert.doesNotMatch(recovered.text, /PROVIDER_FALLBACK_CONTENT/);
    assert.equal(recovered.cached, undefined);
    assert.equal(recovered.externalContent.provider, undefined);
    assert.equal(directRequests, 4);
    assert.equal(providerRequests, 1);
    const directCached = await execute("cached-direct");
    assert.match(directCached.text, /ORIGIN_RECOVERED_CURRENT_CONTENT/);
    assert.equal(directCached.cached, true);
    assert.equal(directRequests, 4);
    assert.equal(providerRequests, 1);
    console.log("WEB_FETCH_HTTP_RECOVERY_RECEIPT", JSON.stringify({
      sourceHead: process.env.TARGET_SHA ?? "working-tree",
      transport: "real loopback HTTP; production tool, resolver, Firecrawl plugin and network guard",
      originResponses: [503, 503, 503, 200], providerRequests,
      cachedFallback: true, configuredUnavailableFailedClosed: true,
      explicitEmptyFailedClosed: true, directOriginRecovered: true, directCacheReused: true,
      paidServiceCalls: 0,
    }));
  } finally {
    server.closeAllConnections();
    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
  }
}, 300_000);
```

</details>

### Historical Verification At 9bb9b1a

The following commands and review claims were recorded at historical head `9bb9b1a67bc1de7a30de6b902fbcf269c415b6bb`, not rerun on the current head unless explicitly listed above.

- The branch merge parent is `main@1ac7f0161c9e5ae0b28be9a1537a75192456f8a7`. The only content conflict was in `src/agents/tools/web-fetch.ts`; the resolution preserves main's complete headers, SSRF-policy, and trusted-proxy cache discriminators while applying the resolved fallback provider id through that same cache-key constructor.
- The first exact-head CI run after that merge found one PR-owned assertion-safety ratchet failure in `src/web/provider-runtime-shared.ts` ([job 97308453424](https://github.com/openclaw/openclaw/actions/runs/32684979645/job/97308453424)). The final commit removes the added type assertion: fallback metadata is cloned as the constrained generic type, then its declared provider fields are updated directly.
- Exact-tree Node 24.15.0 focused tests passed: `src/web/provider-runtime-shared.test.ts` (18/18), `src/web-fetch/runtime.test.ts` (20/20), and `src/agents/tools/web-fetch.provider-fallback.test.ts` (13/13).
- Current-head `oxfmt --check`, `oxlint`, and the assertion-safety ratchet passed.
- Fresh current-head Codex autoreview reported no accepted/actionable findings and assessed the assertion fix as correct with 0.99 confidence. The preceding full-tree autoreview was also clean at 0.99.
- [Prior-head focused secretless runtime proof](https://github.com/Leon-SK668/openclaw/actions/runs/31365953937) anonymously fetched `refs/pull/103113/head` at `94ebda1921dabb1e3b8f4d37d835a381347b3902`, installed the locked dependency graph on Node 24.15.0, and ran one production-boundary Vitest case against a loopback HTTP/Firecrawl endpoint. It made no external provider request.
- That runtime proof recovered stale `auto-detect` metadata to Firecrawl, stored the result under the recovered provider identity, then proved the same URL did not satisfy an unavailable `configured` provider request. The configured resolver returned `null`; two direct attempts and one provider request establish that the second call did not hit the recovered cache entry.
- [Prior-head upstream CI](https://github.com/openclaw/openclaw/actions/runs/31358391030) was fully green for `94ebda1921dabb1e3b8f4d37d835a381347b3902`. Current-head GitHub CI is intentionally left to the new push rather than represented by the older run.

Focused commands:

```text
corepack pnpm dlx node@24.15.0 scripts/run-vitest.mjs src/web/provider-runtime-shared.test.ts
corepack pnpm dlx node@24.15.0 scripts/run-vitest.mjs src/web-fetch/runtime.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts
```

## Compatibility Contract Audit

- `resolveRuntimeWebTools` is the only production constructor for selected web-fetch runtime metadata. It initializes `providerSource: "none"`, passes `tools.web.fetch.provider` as `configuredProvider`, and the shared selector sets `providerConfigured` plus `providerSource: "configured"` before selecting it. Only selection without a configured provider can become `auto-detect`.
- Existing resolver tests cover both configured Firecrawl forms (credential-backed and keyless) as `configured`, while plugin-credential discovery without `tools.web.fetch.provider` is covered as `auto-detect`.
- `RuntimeWebFetchMetadata.providerSource` has been required since generic web-fetch metadata was introduced in `38d2faee20af2152a3815808bdf2af8adfe7306c`; that contract is present in stable tags including `v2026.6.8` and `v2026.6.9`.
- Active web-tool metadata is an in-process defensive clone populated from the prepared snapshot and cleared with runtime state; no file or database persistence path can restore an older unmarked shape. Agent tools only consume that typed clone. Direct capability CLI selection uses the explicit `providerId` path, which remains fail-closed.
- No production web-fetch provider currently implements `resolveRuntimeMetadata`; the optional plugin hook merges onto the already initialized typed metadata object rather than constructing it.

## Prior-Head Runtime Transcript

```text
WEB_FETCH_PROVIDER_CACHE_PROOF_103113_R3 {"head":"94ebda1921dabb1e3b8f4d37d835a381347b3902","recoveredProvider":"firecrawl","configuredSelectionFailedClosed":true,"directRequests":2,"providerRequests":1,"endpoint":"[redacted-loopback]"}
```

The proof uses a redacted dummy Firecrawl key only against a loopback receiver. It demonstrates automatic fallback, configured fail-closed behavior, and provider-correct cache partitioning through the production web-fetch tool without claiming an external provider E2E.

### Historical Rebase Reconciliation (before this repair)

- Rebase head at that time: `ad0d7b6e3c250501a2dd4bdfd498c83b0ce610cc`
- Rebased onto frozen `upstream/main` at `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`; upstream `main` advanced after this batch, so no later baseline is claimed here.
- The owner-level production/test change described above is preserved; this note records the new head after rebase and does not replace the original proof receipts.
- Current-head CI audit: no completed PR-owned failure was found at this rebase head.
- No new live proof is claimed by this reconciliation note.

### AI Assistance / Sanitized Maintenance Transcript

An AI coding agent assisted Leon with this repair. Redacted sequence: read the durable review and provider owner/caller/sibling contracts; reproduce the explicit-empty regression; restore nullish precedence and delete unused internal state; run 38 focused tests; run the production HTTP fallback/recovery scenario before and after commit; complete fresh autoreview; commit and push as Leon. Temporary endpoint content and credentials are synthetic. No private prompts, account data, secrets or production session logs are included.
