### PR TITLE
ci(release): retry transient MiniMax image failures

### DIFF
--- a/extensions/minimax/image-generation-provider.test.ts
+++ b/extensions/minimax/image-generation-provider.test.ts
@@ -141,6 +141,37 @@ describe("minimax image-generation provider", () => {
     ).rejects.toThrow("MiniMax image generation returned malformed image base64");
   });
 
+  it("preserves transient response envelope codes for caller retry policy", async () => {
+    mockMinimaxApiKey();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            base_resp: {
+              status_code: 1000,
+              status_msg: "rpc timeout: timeout=1m0s",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const provider = buildMinimaxImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "minimax",
+        model: "image-01",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax image generation API error (1000): rpc timeout: timeout=1m0s");
+  });
+
   it("passes request SSRF policy to the provider HTTP helper", async () => {
     mockMinimaxApiKey();
     const postJsonRequest = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({

--- a/scripts/ci-live-command-retry.sh
+++ b/scripts/ci-live-command-retry.sh
@@ -14,7 +14,8 @@ fi
 attempts="${OPENCLAW_LIVE_COMMAND_ATTEMPTS:-2}"
 delay_seconds="${OPENCLAW_LIVE_COMMAND_RETRY_DELAY_SECONDS:-10}"
 rate_limit_delay_seconds="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_RETRY_DELAY_SECONDS:-60}"
-retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
+# MiniMax code 1000 is documented as transient; keep auth/input failures fail-fast.
+retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|MiniMax image generation API error \\(1000\\)|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
 rate_limit_pattern="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_PATTERN:-Rate limit reached|rate.?limit|tokens per min|requests per min|\\bTPM\\b|\\bRPM\\b}"
 
 if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then

--- a/test/scripts/ci-live-command-retry.test.ts
+++ b/test/scripts/ci-live-command-retry.test.ts
@@ -1,0 +1,84 @@
+// CI live command retry tests cover transient provider failure classification.
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = path.resolve("scripts/ci-live-command-retry.sh");
+const tempDirs: string[] = [];
+
+function writeCommand(
+  prefix: string,
+  lines: string[],
+): { commandPath: string; counterPath: string } {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  const commandPath = path.join(dir, "command.sh");
+  const counterPath = path.join(dir, "attempts.txt");
+  writeFileSync(commandPath, ["#!/bin/bash", "set -euo pipefail", ...lines, ""].join("\n"));
+  chmodSync(commandPath, 0o755);
+  return { commandPath, counterPath };
+}
+
+function runRetryHelper(commandPath: string, counterPath: string) {
+  const env = { ...process.env };
+  delete env.OPENCLAW_LIVE_COMMAND_RETRY_PATTERN;
+  delete env.OPENCLAW_LIVE_COMMAND_RATE_LIMIT_PATTERN;
+  return spawnSync("/bin/bash", [SCRIPT_PATH], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...env,
+      OPENCLAW_LIVE_COMMAND: `/bin/bash ${JSON.stringify(commandPath)}`,
+      OPENCLAW_LIVE_COMMAND_ATTEMPTS: "2",
+      OPENCLAW_LIVE_COMMAND_RETRY_DELAY_SECONDS: "0",
+      OPENCLAW_LIVE_COMMAND_RATE_LIMIT_RETRY_DELAY_SECONDS: "0",
+      OPENCLAW_RETRY_TEST_COUNTER: counterPath,
+    },
+  });
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe("scripts/ci-live-command-retry.sh", () => {
+  it("retries a provider-internal RPC timeout", () => {
+    const { commandPath, counterPath } = writeCommand("openclaw-ci-live-rpc-timeout-", [
+      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
+      'attempts="$((attempts + 1))"',
+      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
+      'if [[ "$attempts" -eq 1 ]]; then',
+      '  echo "MiniMax image generation API error (1000): rpc timeout: timeout=1m0s" >&2',
+      "  exit 42",
+      "fi",
+    ]);
+
+    const result = runRetryHelper(commandPath, counterPath);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(counterPath, "utf8")).toBe("2");
+    expect(result.stderr).toContain(
+      "Live command failed with a retryable provider/network error; retrying (1/2)",
+    );
+  });
+
+  it("does not retry a MiniMax authentication failure", () => {
+    const { commandPath, counterPath } = writeCommand("openclaw-ci-live-auth-failure-", [
+      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
+      'attempts="$((attempts + 1))"',
+      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
+      'echo "MiniMax image generation API error (1004): authentication failed" >&2',
+      "exit 42",
+    ]);
+
+    const result = runRetryHelper(commandPath, counterPath);
+
+    expect(result.status).toBe(42);
+    expect(readFileSync(counterPath, "utf8")).toBe("1");
+    expect(result.stderr).not.toContain("retrying");
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -255,6 +255,13 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
+  it("routes live command retry helper changes through its regression test", () => {
+    expect(resolveChangedTestTargetPlan(["scripts/ci-live-command-retry.sh"])).toEqual({
+      mode: "targets",
+      targets: ["test/scripts/ci-live-command-retry.test.ts"],
+    });
+  });
+
   it("routes release wrapper changes through their owner tests", () => {
     expect(resolveChangedTestTargetPlan(["scripts/android-release.sh"])).toEqual({
       mode: "targets",


### PR DESCRIPTION
## What Problem This Solves

Full release run [29048860509](https://github.com/openclaw/openclaw/actions/runs/29048860509) failed the required `native-live-test` shard when MiniMax returned its documented transient image-generation envelope code `1000` after an internal RPC timeout. MiniMax edit immediately succeeded, every other provider passed, and twelve earlier July 9 sweeps passed the same generate case.

The existing live-command wrapper already grants two attempts for classified provider/network failures, but code `1000` was not in its classifier, so the second attempt never ran. Full-release fail-fast then canceled package Docker and Telegram acceptance before meaningful execution.

## Why This Change Was Made

- Add only the stable MiniMax image-generation error code `1000` to the existing CI retry classifier.
- Keep authentication/input code `1004` and other non-transient failures fail-fast.
- Preserve the product runtime's no-automatic-retry rule for image creation; this change is confined to the existing release test retry boundary.
- Add behavioral shell tests proving one retry followed by success for `1000`, and a single attempt for `1004`.
- Add provider coverage proving an HTTP 200 response with `base_resp.status_code: 1000` preserves the stable code-bearing error.
- Route retry-helper changes through the new regression test in changed-test planning.

## User Impact

No product behavior change. Required live release coverage remains strict, but the existing bounded CI retry now recognizes MiniMax's documented transient service code instead of canceling the rest of the release matrix on the first provider-internal timeout.

## Evidence

- Testbox-through-Crabbox `tbx_01kx4atk975ehf4hph53az0ep4`:
  - retry helper + changed-test routing: 186/186 passed;
  - MiniMax provider suite: 10/10 passed;
  - `pnpm check:changed`: passed, including extension test types and lint.
- Targeted formatting: green.
- Fresh autoreview: clean at 0.98 confidence.
- Focused exact-head native-live rerun: [29050325689](https://github.com/openclaw/openclaw/actions/runs/29050325689) (running at PR creation; final result will be posted before merge).
- Focused package rerun: [29050308352](https://github.com/openclaw/openclaw/actions/runs/29050308352) (running independently after the original fail-fast cancellation).

MiniMax documents code `1000` as a transient error that should be retried later: https://platform.minimax.io/docs/api-reference/errorcode
