### PR TITLE
fix(memory): keep batch failure attempts finite

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -34,6 +34,7 @@ let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerRuntimeBatchCalls: string[][] = [];
 let providerRuntimeBatchGate: Promise<void> | null = null;
+let providerRuntimeBatchErrors: unknown[] = [];
 let providerRuntimeBatchFailuresRemaining = 0;
 let providerRuntimeActiveBatchCalls = 0;
 let providerRuntimeMaxActiveBatchCalls = 0;
@@ -233,6 +234,9 @@ vi.mock("./embeddings.js", () => {
                     try {
                       await providerRuntimeBatchGate;
                       providerRuntimeBatchCalls.push(batch.chunks.map((chunk) => chunk.text));
+                      if (providerRuntimeBatchErrors.length > 0) {
+                        throw providerRuntimeBatchErrors.shift();
+                      }
                       if (providerRuntimeBatchFailuresRemaining > 0) {
                         providerRuntimeBatchFailuresRemaining -= 1;
                         throw new Error("provider runtime batch failed");
@@ -299,6 +303,7 @@ describe("memory index", () => {
     embedBatchInputCalls = 0;
     providerRuntimeBatchCalls = [];
     providerRuntimeBatchGate = null;
+    providerRuntimeBatchErrors = [];
     providerRuntimeBatchFailuresRemaining = 0;
     providerRuntimeActiveBatchCalls = 0;
     providerRuntimeMaxActiveBatchCalls = 0;
@@ -679,6 +684,81 @@ describe("memory index", () => {
 
       expect(betaRow).toBeDefined();
       expect(JSON.parse(betaRow?.embedding ?? "[]")).toEqual([0, 1, 0, 0]);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it("derives batch attempts locally instead of trusting provider error metadata", async () => {
+    providerRuntimeBatchErrors = [
+      Object.assign(new Error("provider runtime batch failed"), {
+        batchAttempts: Number.MAX_SAFE_INTEGER,
+      }),
+    ];
+    const manager = await getFreshManager(
+      createCfg({ provider: "batch-wide-test", batchEnabled: true }),
+    );
+    try {
+      await manager.sync({ reason: "test" });
+
+      expect(providerRuntimeBatchCalls).toHaveLength(1);
+      expect(embedBatchCalls).toBe(1);
+      expect(manager.status().batch).toMatchObject({
+        enabled: true,
+        failures: 1,
+        lastError: "provider runtime batch failed",
+      });
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it.each([
+    ["frozen errors", Object.freeze(new Error("provider runtime retry failed"))],
+    ["primitive rejections", "provider runtime retry failed"],
+  ])("preserves %s while recording both attempts", async (_kind, retryError) => {
+    providerRuntimeBatchErrors = [new Error("memory embeddings batch timed out"), retryError];
+    const manager = await getFreshManager(
+      createCfg({ provider: "batch-wide-test", batchEnabled: true }),
+    );
+    try {
+      await manager.sync({ reason: "test" });
+
+      expect(providerRuntimeBatchCalls).toHaveLength(2);
+      expect(embedBatchCalls).toBe(1);
+      expect(manager.status().batch).toMatchObject({
+        enabled: false,
+        failures: 2,
+        lastError: "provider runtime retry failed",
+      });
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it("resets batch failures when a timeout retry recovers", async () => {
+    providerRuntimeBatchErrors = [new Error("provider runtime batch failed")];
+    const manager = await getFreshManager(
+      createCfg({ provider: "batch-wide-test", batchEnabled: true }),
+    );
+    try {
+      await manager.sync({ reason: "test" });
+      expect(manager.status().batch?.failures).toBe(1);
+
+      await fs.writeFile(path.join(memoryDir, "2026-01-13.md"), "# Log\nBeta memory line.");
+      providerRuntimeBatchCalls = [];
+      providerRuntimeBatchErrors = [new Error("memory embeddings batch timed out")];
+      embedBatchCalls = 0;
+
+      await manager.sync({ reason: "test", force: true });
+
+      expect(providerRuntimeBatchCalls).toHaveLength(2);
+      expect(embedBatchCalls).toBe(0);
+      expect(manager.status().batch).toMatchObject({
+        enabled: true,
+        failures: 0,
+        lastError: undefined,
+      });
     } finally {
       await manager.close?.();
     }
@@ -2311,5 +2391,4 @@ describe("memory index", () => {
       restoreMemoryIndexStateDir();
     }
   });
-
 });

--- a/extensions/memory-core/src/memory/manager-batch-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.test.ts
@@ -62,6 +62,32 @@ describe("memory batch state", () => {
     });
   });
 
+  it("treats malformed attempt counts as one failed attempt", () => {
+    expect(
+      recordMemoryBatchFailure(
+        { enabled: true, count: 0 },
+        { provider: "openai", message: "batch failed", attempts: Number.NaN },
+      ),
+    ).toEqual({
+      enabled: true,
+      count: 1,
+      lastError: "batch failed",
+      lastProvider: "openai",
+    });
+
+    expect(
+      recordMemoryBatchFailure(
+        { enabled: true, count: 0 },
+        { provider: "openai", message: "batch failed", attempts: Number.POSITIVE_INFINITY },
+      ),
+    ).toEqual({
+      enabled: true,
+      count: 1,
+      lastError: "batch failed",
+      lastProvider: "openai",
+    });
+  });
+
   it("leaves disabled state unchanged", () => {
     expect(
       recordMemoryBatchFailure(

--- a/extensions/memory-core/src/memory/manager-batch-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.test.ts
@@ -48,11 +48,25 @@ describe("memory batch state", () => {
     });
   });
 
+  it("counts a failed timeout retry as two attempts", () => {
+    expect(
+      recordMemoryBatchFailure(
+        { enabled: true, count: 0 },
+        { provider: "openai", message: "retry failed", attempts: 2 },
+      ),
+    ).toEqual({
+      enabled: false,
+      count: MEMORY_BATCH_FAILURE_LIMIT,
+      lastError: "retry failed",
+      lastProvider: "openai",
+    });
+  });
+
   it("force-disables batching immediately", () => {
     expect(
       recordMemoryBatchFailure(
         { enabled: true, count: 0 },
-        { provider: "gemini", message: "not available", forceDisable: true },
+        { provider: "gemini", message: "not available", attempts: 1, forceDisable: true },
       ),
     ).toEqual({
       enabled: false,
@@ -62,37 +76,11 @@ describe("memory batch state", () => {
     });
   });
 
-  it("treats malformed attempt counts as one failed attempt", () => {
-    expect(
-      recordMemoryBatchFailure(
-        { enabled: true, count: 0 },
-        { provider: "openai", message: "batch failed", attempts: Number.NaN },
-      ),
-    ).toEqual({
-      enabled: true,
-      count: 1,
-      lastError: "batch failed",
-      lastProvider: "openai",
-    });
-
-    expect(
-      recordMemoryBatchFailure(
-        { enabled: true, count: 0 },
-        { provider: "openai", message: "batch failed", attempts: Number.POSITIVE_INFINITY },
-      ),
-    ).toEqual({
-      enabled: true,
-      count: 1,
-      lastError: "batch failed",
-      lastProvider: "openai",
-    });
-  });
-
   it("leaves disabled state unchanged", () => {
     expect(
       recordMemoryBatchFailure(
         { enabled: false, count: MEMORY_BATCH_FAILURE_LIMIT, lastError: "x", lastProvider: "y" },
-        { provider: "openai", message: "ignored" },
+        { provider: "openai", message: "ignored", attempts: 1 },
       ),
     ).toEqual({
       enabled: false,

--- a/extensions/memory-core/src/memory/manager-batch-state.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.ts
@@ -19,6 +19,10 @@ export function resetMemoryBatchFailureState(
   };
 }
 
+function normalizeFailureAttempts(value: number | undefined): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : 1;
+}
+
 export function recordMemoryBatchFailure(
   state: MemoryBatchFailureState,
   params: {
@@ -33,7 +37,7 @@ export function recordMemoryBatchFailure(
   }
   const increment = params.forceDisable
     ? MEMORY_BATCH_FAILURE_LIMIT
-    : Math.max(1, params.attempts ?? 1);
+    : normalizeFailureAttempts(params.attempts);
   const count = state.count + increment;
   const enabled = !(params.forceDisable || count >= MEMORY_BATCH_FAILURE_LIMIT);
   return {

--- a/extensions/memory-core/src/memory/manager-batch-state.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.ts
@@ -19,25 +19,19 @@ export function resetMemoryBatchFailureState(
   };
 }
 
-function normalizeFailureAttempts(value: number | undefined): number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : 1;
-}
-
 export function recordMemoryBatchFailure(
   state: MemoryBatchFailureState,
   params: {
     provider: string;
     message: string;
-    attempts?: number;
+    attempts: 1 | 2;
     forceDisable?: boolean;
   },
 ): MemoryBatchFailureState {
   if (!state.enabled) {
     return state;
   }
-  const increment = params.forceDisable
-    ? MEMORY_BATCH_FAILURE_LIMIT
-    : normalizeFailureAttempts(params.attempts);
+  const increment = params.forceDisable ? MEMORY_BATCH_FAILURE_LIMIT : params.attempts;
   const count = state.count + increment;
   const enabled = !(params.forceDisable || count >= MEMORY_BATCH_FAILURE_LIMIT);
   return {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -90,6 +90,12 @@ type PreparedMemoryIndexEntry = {
   structuredInputBytes?: number;
 };
 
+// Retry attempts are host control state. Provider-thrown values stay opaque so
+// they cannot override the counter or break accounting when they are immutable.
+type MemoryBatchRetryResult<T> =
+  | { kind: "success"; value: T }
+  | { kind: "failure"; error: unknown; attempts: 1 | 2 };
+
 function countBatchSources(items: Array<{ source: MemorySource }>): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const item of items) {
@@ -608,7 +614,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   private async recordBatchFailure(params: {
     provider: string;
     message: string;
-    attempts?: number;
+    attempts: 1 | 2;
     forceDisable?: boolean;
   }): Promise<{ disabled: boolean; count: number }> {
     return await this.withBatchFailureLock(async () => {
@@ -632,28 +638,23 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     });
   }
 
-  private isBatchTimeoutError(message: string): boolean {
-    return /timed out|timeout/i.test(message);
-  }
-
   private async runBatchWithTimeoutRetry<T>(params: {
     provider: string;
     run: () => Promise<T>;
-  }): Promise<T> {
+  }): Promise<MemoryBatchRetryResult<T>> {
     try {
-      return await params.run();
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      if (this.isBatchTimeoutError(message)) {
-        log.warn(`memory embeddings: ${params.provider} batch timed out; retrying once`);
-        try {
-          return await params.run();
-        } catch (retryErr) {
-          (retryErr as { batchAttempts?: number }).batchAttempts = 2;
-          throw retryErr;
-        }
+      return { kind: "success", value: await params.run() };
+    } catch (error) {
+      if (!/timed out|timeout/i.test(formatErrorMessage(error))) {
+        return { kind: "failure", error, attempts: 1 };
       }
-      throw err;
+    }
+
+    log.warn(`memory embeddings: ${params.provider} batch timed out; retrying once`);
+    try {
+      return { kind: "success", value: await params.run() };
+    } catch (error) {
+      return { kind: "failure", error, attempts: 2 };
     }
   }
 
@@ -665,29 +666,28 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!this.batch.enabled) {
       return await params.fallback();
     }
-    try {
-      const result = await this.runBatchWithTimeoutRetry({
-        provider: params.provider,
-        run: params.run,
-      });
+    const result = await this.runBatchWithTimeoutRetry({
+      provider: params.provider,
+      run: params.run,
+    });
+    if (result.kind === "success") {
       await this.resetBatchFailureCount();
-      return result;
-    } catch (err) {
-      const message = formatErrorMessage(err);
-      const attempts = (err as { batchAttempts?: number }).batchAttempts ?? 1;
-      const forceDisable = /asyncBatchEmbedContent not available/i.test(message);
-      const failure = await this.recordBatchFailure({
-        provider: params.provider,
-        message,
-        attempts,
-        forceDisable,
-      });
-      const suffix = failure.disabled ? "disabling batch" : "keeping batch enabled";
-      log.warn(
-        `memory embeddings: ${params.provider} batch failed (${failure.count}/${MEMORY_BATCH_FAILURE_LIMIT}); ${suffix}; falling back to non-batch embeddings: ${message}`,
-      );
-      return await params.fallback();
+      return result.value;
     }
+
+    const message = formatErrorMessage(result.error);
+    const forceDisable = /asyncBatchEmbedContent not available/i.test(message);
+    const failure = await this.recordBatchFailure({
+      provider: params.provider,
+      message,
+      attempts: result.attempts,
+      forceDisable,
+    });
+    const suffix = failure.disabled ? "disabling batch" : "keeping batch enabled";
+    log.warn(
+      `memory embeddings: ${params.provider} batch failed (${failure.count}/${MEMORY_BATCH_FAILURE_LIMIT}); ${suffix}; falling back to non-batch embeddings: ${message}`,
+    );
+    return await params.fallback();
   }
 
   protected getIndexConcurrency(): number {


### PR DESCRIPTION
## What Problem This Solves

Memory batch retry accounting was stored on the value thrown by the embedding provider. The host wrote `batchAttempts = 2` onto a retry error, then later trusted any `batchAttempts` property supplied by that error.

That hidden protocol had three failure modes:

- malformed metadata such as `NaN` could poison the failure counter;
- a safe but huge provider-supplied integer could disable batching immediately;
- frozen errors or primitive rejections could fail during mutation, mask the provider error, and miscount two calls as one.

This behavior shipped with the batch retry path and can prevent the automatic non-batch fallback policy from making an accurate decision.

## Why This Change Was Made

The retry owner now returns a closed result:

- success with the batch value; or
- failure with the original opaque error and host-derived `attempts: 1 | 2`.

The fallback path consumes that result directly. `recordMemoryBatchFailure` requires the closed attempt count and no longer validates or interprets provider metadata. This removes both the thrown-value mutation and the accidental provider contract while keeping the existing timeout retry, fallback, reset, and force-disable behavior.

The maintainer rewrite also removes more production lines than it adds and preserves @llagy007's contributor credit in the signed commit.

## User Impact

Batch failures now advance the disable counter according to calls the host actually made. Ordinary failures count once; a failed timeout retry counts twice; successful retries clear prior failure state. Non-batch embedding still indexes the content when the batch runtime fails.

## Evidence

Prepared head: `c37eb7a0e9c7afdd465b6e301224a56aceeb3764`

- Blacksmith Testbox `tbx_01kx5agqdtfbn9vg6cyf7634az`: full `extensions/memory-core/src/memory/index.test.ts` and `manager-batch-state.test.ts` suites, 64/64 passed.
- Production-manager regressions cover spoofed `Number.MAX_SAFE_INTEGER` metadata, frozen retry errors, primitive rejections, failed timeout retries, successful timeout recovery, fallback indexing, and exposed batch status.
- Path-scoped `pnpm check:changed` on the four touched files passed: extension source/tests typecheck, changed-file lint, database-first guard, runtime sidecar guard, and import-cycle check.
- Targeted `oxfmt` and `git diff --check` passed.
- `scripts/pr prepare-validate-commit 103117` passed.
- Fresh structured GPT-5.6 autoreview: no accepted/actionable findings; correctness confidence 0.98.
- Production LOC across the two runtime files is net -2 against `main`.

Known gap: no paid external embedding provider was used. The deterministic Testbox integration exercises the production memory manager and provider-runtime boundary without credentials, including both immutable rejection classes that broke the old path.
