### PR TITLE
fix(agent): preserve silent-reply prompt mode

### DIFF
--- a/src/agents/embedded-agent-runner/run.silent-reply-prompt-mode.test.ts
+++ b/src/agents/embedded-agent-runner/run.silent-reply-prompt-mode.test.ts
@@ -1,0 +1,38 @@
+// Coverage for preserving channel-aware silent-reply policy through embedded attempts.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+  warmRunOverflowCompactionHarness,
+} from "./run.overflow-compaction.harness.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+describe("runEmbeddedAgent silent-reply prompt mode", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
+    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+  });
+
+  it("forwards channel-aware suppression to the embedded attempt", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-silent-reply-prompt-mode",
+      silentReplyPromptMode: "none",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({ silentReplyPromptMode: "none" }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2274,6 +2274,7 @@ async function runEmbeddedAgentInternal(
             onExecutionPhase: params.onExecutionPhase,
             extraSystemPrompt: params.extraSystemPrompt,
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+            silentReplyPromptMode: params.silentReplyPromptMode,
             taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,


### PR DESCRIPTION
## Summary

Direct webchat messages could silently disappear because the embedded agent runner dropped the caller's reply policy before building the model prompt.
This change preserves that policy and adds a regression test for the exact runner boundary where it was lost.

AI-assisted: yes. I reviewed the implementation, reproduced the failure against a real webchat run, and verified the corrected model request.

## What Problem This Solves

Fixes an issue where users sending direct browser-chat messages could receive no visible response because the model was incorrectly instructed that it could answer with `NO_REPLY`.

## Why This Change Was Made

The direct webchat path already computes `silentReplyPromptMode: "none"`, but `runEmbeddedAgentInternal` did not forward it into `runEmbeddedAttemptWithBackend`. The system-prompt builder therefore fell back to the generic silent-reply policy.

- Forward `silentReplyPromptMode` through the embedded runner attempt boundary.
- Add a focused regression test that asserts `"none"` reaches the attempt.

## User Impact

Direct webchat messages now keep their visible-reply policy through the embedded runner. Models are no longer incorrectly shown the generic `NO_REPLY` instruction for those turns.

## Evidence

The focused regression test fails when the forwarding line is removed and passes with this change.

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.silent-reply-prompt-mode.test.ts`
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.silent-reply-prompt-mode.test.ts`
- Built an OpenClaw image from this commit and ran an actual WebSocket `chat.send` request through the embedded runner.
- Before: the captured model system prompt contained `## Silent Replies` and `NO_REPLY`.
- After: the same direct-webchat request contained the direct-conversation context and no silent-reply instruction.
- A live Hugging Face Router request returned HTTP 200 and produced a visible assistant reply.

## Risks

Risk is low because the change only forwards an existing typed option to the layer that already consumes it. Callers that omit the option retain the current default behavior.
