### PR TITLE
improve(webchat): compact the model picker reasoning and speed rows

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:23.076Z",
+  "generatedAt": "2026-07-09T22:36:07.560Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:21.317Z",
+  "generatedAt": "2026-07-09T22:36:06.003Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:21.594Z",
+  "generatedAt": "2026-07-09T22:36:06.206Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:25.602Z",
+  "generatedAt": "2026-07-09T22:36:09.581Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:22.513Z",
+  "generatedAt": "2026-07-09T22:36:07.061Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:22.800Z",
+  "generatedAt": "2026-07-09T22:36:07.315Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:24.199Z",
+  "generatedAt": "2026-07-09T22:36:08.407Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:23.349Z",
+  "generatedAt": "2026-07-09T22:36:07.788Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:21.913Z",
+  "generatedAt": "2026-07-09T22:36:06.460Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:22.264Z",
+  "generatedAt": "2026-07-09T22:36:06.781Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:25.316Z",
+  "generatedAt": "2026-07-09T22:36:09.342Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:24.469Z",
+  "generatedAt": "2026-07-09T22:36:08.624Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:21.041Z",
+  "generatedAt": "2026-07-09T22:36:05.805Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:25.869Z",
+  "generatedAt": "2026-07-09T22:36:09.894Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:24.766Z",
+  "generatedAt": "2026-07-09T22:36:08.831Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:23.603Z",
+  "generatedAt": "2026-07-09T22:36:07.995Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:23.879Z",
+  "generatedAt": "2026-07-09T22:36:08.212Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:25.042Z",
+  "generatedAt": "2026-07-09T22:36:09.107Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:20.275Z",
+  "generatedAt": "2026-07-09T22:36:05.375Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T22:18:20.685Z",
+  "generatedAt": "2026-07-09T22:36:05.638Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "7cd5adcd7617e86b7331e5c2e56fbfb81dd32dbb8cfe6d88c4666d0780e0cdfb",
-  "totalKeys": 1767,
-  "translatedKeys": 1767,
+  "sourceHash": "f48c9999ed39d92c2ca0c9e84a97ae7243f5d192f5a35d59153e626c6806e9fb",
+  "totalKeys": 1765,
+  "translatedKeys": 1765,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1726,10 +1726,6 @@ export const ar: TranslationMap = {
       retrySend: "إعادة محاولة الإرسال",
       retryQueuedMessage: "إعادة محاولة الرسالة في قائمة الانتظار",
     },
-    modelPicker: {
-      faster: "أسرع",
-      smarter: "أذكى",
-    },
     pairingQrExpired: {
       title: "انتهت صلاحية رمز الاقتران QR",
       reason: "شغّل ‎/pair qr‎ مرة أخرى لإنشاء رمز إعداد جديد.",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1760,10 +1760,6 @@ export const de: TranslationMap = {
       retrySend: "Senden wiederholen",
       retryQueuedMessage: "Nachricht in der Warteschlange erneut senden",
     },
-    modelPicker: {
-      faster: "Schneller",
-      smarter: "Intelligenter",
-    },
     pairingQrExpired: {
       title: "Kopplungs-QR-Code abgelaufen",
       reason: "Führen Sie /pair qr erneut aus, um einen neuen Einrichtungscode zu generieren.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1734,10 +1734,6 @@ export const en: TranslationMap = {
       retrySend: "Retry send",
       retryQueuedMessage: "Retry queued message",
     },
-    modelPicker: {
-      faster: "Faster",
-      smarter: "Smarter",
-    },
     pairingQrExpired: {
       title: "Pairing QR expired",
       reason: "Run /pair qr again to generate a fresh setup code.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1757,10 +1757,6 @@ export const es: TranslationMap = {
       retrySend: "Reintentar envío",
       retryQueuedMessage: "Reintentar mensaje en cola",
     },
-    modelPicker: {
-      faster: "Más rápido",
-      smarter: "Más inteligente",
-    },
     pairingQrExpired: {
       title: "Código QR de emparejamiento caducado",
       reason: "Ejecuta /pair qr de nuevo para generar un código de configuración nuevo.",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1747,10 +1747,6 @@ export const fa: TranslationMap = {
       retrySend: "تلاش دوباره برای ارسال",
       retryQueuedMessage: "تلاش دوباره برای پیام در صف",
     },
-    modelPicker: {
-      faster: "سریع‌تر",
-      smarter: "هوشمندتر",
-    },
     pairingQrExpired: {
       title: "کد QR جفت‌سازی منقضی شد",
       reason: "برای ساخت کد راه‌اندازی جدید، دوباره /pair qr را اجرا کنید.",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1769,10 +1769,6 @@ export const fr: TranslationMap = {
       retrySend: "Réessayer l’envoi",
       retryQueuedMessage: "Réessayer le message en file d’attente",
     },
-    modelPicker: {
-      faster: "Plus rapide",
-      smarter: "Plus intelligent",
-    },
     pairingQrExpired: {
       title: "QR d'appairage expiré",
       reason: "Exécutez /pair qr à nouveau pour générer un nouveau code de configuration.",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1729,10 +1729,6 @@ export const hi: TranslationMap = {
       retrySend: "भेजने का पुनः प्रयास करें",
       retryQueuedMessage: "कतारबद्ध संदेश का पुनः प्रयास करें",
     },
-    modelPicker: {
-      faster: "तेज़",
-      smarter: "अधिक बुद्धिमान",
-    },
     pairingQrExpired: {
       title: "पेयरिंग QR की समय-सीमा समाप्त हो गई",
       reason: "नया सेटअप कोड जनरेट करने के लिए /pair qr फिर से चलाएँ।",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1747,10 +1747,6 @@ export const id: TranslationMap = {
       retrySend: "Coba kirim lagi",
       retryQueuedMessage: "Coba lagi pesan dalam antrean",
     },
-    modelPicker: {
-      faster: "Lebih cepat",
-      smarter: "Lebih cerdas",
-    },
     pairingQrExpired: {
       title: "QR pemasangan kedaluwarsa",
       reason: "Jalankan /pair qr lagi untuk membuat kode pengaturan baru.",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1760,10 +1760,6 @@ export const it: TranslationMap = {
       retrySend: "Riprova invio",
       retryQueuedMessage: "Riprova messaggio in coda",
     },
-    modelPicker: {
-      faster: "Più veloce",
-      smarter: "Più intelligente",
-    },
     pairingQrExpired: {
       title: "QR di pairing scaduto",
       reason: "Esegui di nuovo /pair qr per generare un nuovo codice di configurazione.",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1754,10 +1754,6 @@ export const ja_JP: TranslationMap = {
       retrySend: "送信を再試行",
       retryQueuedMessage: "キュー内のメッセージを再試行",
     },
-    modelPicker: {
-      faster: "より速く",
-      smarter: "より賢く",
-    },
     pairingQrExpired: {
       title: "ペアリングQRの有効期限が切れました",
       reason: "新しいセットアップコードを生成するには、もう一度 /pair qr を実行してください。",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1736,10 +1736,6 @@ export const ko: TranslationMap = {
       retrySend: "보내기 다시 시도",
       retryQueuedMessage: "대기 중인 메시지 다시 시도",
     },
-    modelPicker: {
-      faster: "더 빠르게",
-      smarter: "더 똑똑하게",
-    },
     pairingQrExpired: {
       title: "페어링 QR 만료됨",
       reason: "새 설정 코드를 생성하려면 /pair qr을 다시 실행하세요.",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1753,10 +1753,6 @@ export const nl: TranslationMap = {
       retrySend: "Verzenden opnieuw proberen",
       retryQueuedMessage: "Bericht in wachtrij opnieuw proberen",
     },
-    modelPicker: {
-      faster: "Sneller",
-      smarter: "Slimmer",
-    },
     pairingQrExpired: {
       title: "Koppelings-QR verlopen",
       reason: "Voer /pair qr opnieuw uit om een nieuwe installatiecode te genereren.",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1753,10 +1753,6 @@ export const pl: TranslationMap = {
       retrySend: "Ponów wysłanie",
       retryQueuedMessage: "Ponów wiadomość w kolejce",
     },
-    modelPicker: {
-      faster: "Szybciej",
-      smarter: "Inteligentniej",
-    },
     pairingQrExpired: {
       title: "Kod QR parowania wygasł",
       reason: "Uruchom ponownie /pair qr, aby wygenerować nowy kod konfiguracyjny.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1749,10 +1749,6 @@ export const pt_BR: TranslationMap = {
       retrySend: "Tentar enviar novamente",
       retryQueuedMessage: "Tentar novamente mensagem na fila",
     },
-    modelPicker: {
-      faster: "Mais rápido",
-      smarter: "Mais inteligente",
-    },
     pairingQrExpired: {
       title: "QR de pareamento expirado",
       reason: "Execute /pair qr novamente para gerar um novo código de configuração.",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1762,10 +1762,6 @@ export const ru: TranslationMap = {
       retrySend: "Повторить отправку",
       retryQueuedMessage: "Повторить сообщение в очереди",
     },
-    modelPicker: {
-      faster: "Быстрее",
-      smarter: "Умнее",
-    },
     pairingQrExpired: {
       title: "QR-код сопряжения истек",
       reason: "Запустите /pair qr еще раз, чтобы создать новый код настройки.",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1710,10 +1710,6 @@ export const th: TranslationMap = {
       retrySend: "ลองส่งอีกครั้ง",
       retryQueuedMessage: "ลองส่งข้อความในคิวอีกครั้ง",
     },
-    modelPicker: {
-      faster: "เร็วขึ้น",
-      smarter: "ฉลาดขึ้น",
-    },
     pairingQrExpired: {
       title: "QR การจับคู่หมดอายุ",
       reason: "เรียกใช้ /pair qr อีกครั้งเพื่อสร้างรหัสตั้งค่าใหม่",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1755,10 +1755,6 @@ export const tr: TranslationMap = {
       retrySend: "Göndermeyi yeniden dene",
       retryQueuedMessage: "Kuyruğa alınan iletiyi yeniden dene",
     },
-    modelPicker: {
-      faster: "Daha hızlı",
-      smarter: "Daha akıllı",
-    },
     pairingQrExpired: {
       title: "Eşleştirme QR kodunun süresi doldu",
       reason: "Yeni bir kurulum kodu oluşturmak için /pair qr komutunu tekrar çalıştırın.",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1750,10 +1750,6 @@ export const uk: TranslationMap = {
       retrySend: "Повторити надсилання",
       retryQueuedMessage: "Повторити повідомлення в черзі",
     },
-    modelPicker: {
-      faster: "Швидше",
-      smarter: "Розумніше",
-    },
     pairingQrExpired: {
       title: "QR-код для пар'ювання застарів",
       reason: "Виконайте /pair qr знову, щоб згенерувати новий код налаштування.",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1738,10 +1738,6 @@ export const vi: TranslationMap = {
       retrySend: "Thử gửi lại",
       retryQueuedMessage: "Thử lại tin nhắn trong hàng đợi",
     },
-    modelPicker: {
-      faster: "Nhanh hơn",
-      smarter: "Thông minh hơn",
-    },
     pairingQrExpired: {
       title: "Mã QR ghép nối đã hết hạn",
       reason: "Chạy /pair qr một lần nữa để tạo mã thiết lập mới.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1705,10 +1705,6 @@ export const zh_CN: TranslationMap = {
       retrySend: "重试发送",
       retryQueuedMessage: "重试排队消息",
     },
-    modelPicker: {
-      faster: "更快",
-      smarter: "更智能",
-    },
     pairingQrExpired: {
       title: "配对二维码已过期",
       reason: "再次运行 /pair qr 以生成新的设置代码。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1707,10 +1707,6 @@ export const zh_TW: TranslationMap = {
       retrySend: "重新傳送",
       retryQueuedMessage: "重試佇列中的訊息",
     },
-    modelPicker: {
-      faster: "更快",
-      smarter: "更智慧",
-    },
     pairingQrExpired: {
       title: "配對 QR 碼已過期",
       reason: "請再次執行 /pair qr 以產生新的設定碼。",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3700,7 +3700,7 @@ describe("chat model controls", () => {
       // Drag preview is attribute-only: mutating rendered text would eject
       // Lit's ChildPart markers and freeze later menu renders.
       expect(slider.getAttribute("aria-valuetext")).toBe("Low");
-      expect(getThinkingReasoningValueLabel(container)).toBe("Default (High)");
+      expect(getThinkingReasoningValueLabel(container)).toBe("High");
       slider.dispatchEvent(new Event("change", { bubbles: true }));
     }
     expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
@@ -3848,8 +3848,44 @@ describe("chat model controls", () => {
     render(renderChatModelControls(createChatModelControlsProps(state)), container);
 
     expect(getThinkingSliderValues(container)).toEqual(["off", "adaptive", "xhigh", "max"]);
-    expect(getThinkingResetButton(container)).toBeInstanceOf(HTMLButtonElement);
-    expect(getThinkingResetButton(container)?.disabled).toBe(true);
+    // No override -> nothing to reset, so the icon reset is not rendered.
+    expect(getThinkingResetButton(container)).toBeNull();
+  });
+
+  it("clears a reasoning override from the icon reset", async () => {
+    const { state, request } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      thinkingDefault: "high",
+    });
+    state.sessionsResult = createSessionsListResult({
+      defaultsModel: "gpt-5.5",
+      defaultsProvider: "openai",
+      defaultsThinkingDefault: "high",
+      defaultsThinkingLevels: [
+        { id: "low", label: "low" },
+        { id: "high", label: "high" },
+      ],
+    });
+    state.sessionsResult.sessions[0] = {
+      ...state.sessionsResult.sessions[0]!,
+      thinkingLevel: "low",
+    };
+    const container = document.createElement("div");
+    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+
+    expect(getThinkingReasoningValueLabel(container)).toBe("Low");
+    const reset = getThinkingResetButton(container);
+    expect(reset).toBeInstanceOf(HTMLButtonElement);
+    expect(reset?.disabled).toBe(false);
+    reset?.click();
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith("sessions.patch", {
+        key: "main",
+        thinkingLevel: null,
+      });
+    });
   });
 
   it("lets an unanchored slider select its first stop directly", async () => {
@@ -3864,7 +3900,7 @@ describe("chat model controls", () => {
     const thinkingSelect = getThinkingSelect(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Adaptive");
     expect(getThinkingSliderValues(container)).not.toContain("adaptive");
     const slider = getThinkingSlider(container);
     expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(true);
@@ -4005,7 +4041,7 @@ describe("chat model controls", () => {
     const container = document.createElement("div");
     render(renderChatModelControls(createChatModelControlsProps(state)), container);
 
-    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Low)");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Low");
   });
 
   it("always renders full thinking labels", () => {
@@ -4038,7 +4074,7 @@ describe("chat model controls", () => {
     expect(triggerLabel?.textContent?.trim()).toBe("GPT-5.5 · High");
     expect(getThinkingSliderValues(container)).toEqual(["off", "low", "medium", "high", "xhigh"]);
     expect(getThinkingSlider(container)?.value).toBe("3");
-    expect(getThinkingReasoningValueLabel(container)).toBe("Default (High)");
+    expect(getThinkingReasoningValueLabel(container)).toBe("High");
   });
 
   it("labels chat thinking default from session defaults when the row is absent", () => {
@@ -4052,7 +4088,7 @@ describe("chat model controls", () => {
     const thinkingSelect = getThinkingSelect(container);
 
     expect(getChatThinkingValue(thinkingSelect)).toBe("");
-    expect(getThinkingReasoningValueLabel(container)).toBe("Default (Adaptive)");
+    expect(getThinkingReasoningValueLabel(container)).toBe("Adaptive");
   });
 });
 

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -459,10 +459,16 @@ function renderChatModelReasoningSelect(params: {
   const selectedThinkingOption = thinkingOptions.find(
     (option) => option.value === selectedThinkingValue,
   );
-  const reasoningValueLabel = hasThinkingOverride
+  // Visible state is just the level word; inherited defaults render muted with
+  // no reset affordance, overrides render strong with an icon reset. Screen
+  // readers keep the verbose default phrasing via aria-valuetext.
+  const reasoningValueText = hasThinkingOverride
     ? formatCombinedPickerThinkingLabel(
         selectedThinkingOption?.label ?? formatThinkingOverrideLabel(selectedThinkingValue),
       )
+    : defaultLevelLabel;
+  const reasoningValueLabel = hasThinkingOverride
+    ? reasoningValueText
     : `Default (${defaultLevelLabel})`;
   // Selections commit immediately; the picker stays open so model, reasoning,
   // and speed can be adjusted together. The extra onRequestUpdate re-renders
@@ -687,27 +693,41 @@ function renderChatModelReasoningSelect(params: {
                 ${showReasoning
                   ? html`
                       <div class="chat-controls__reasoning-head">
-                        <div class="chat-controls__reasoning-heading">
-                          <span class="chat-controls__inline-select-section-label">Reasoning</span>
-                          <button
-                            class="chat-controls__reasoning-default"
-                            data-chat-thinking-option=""
-                            type="button"
-                            aria-label=${`Use default reasoning (${defaultLevelLabel})`}
-                            ?disabled=${thinkingDisabled || !hasThinkingOverride}
-                            @click=${(event: MouseEvent) => {
-                              event.stopPropagation();
-                              if (thinkingDisabled || !hasThinkingOverride) {
-                                event.preventDefault();
-                                return;
-                              }
-                              commitThinking("");
-                            }}
+                        <span class="chat-controls__inline-select-section-label">Reasoning</span>
+                        <span class="chat-controls__reasoning-state">
+                          <span
+                            class="chat-controls__reasoning-value ${hasThinkingOverride
+                              ? ""
+                              : "chat-controls__reasoning-value--inherit"}"
                           >
-                            (Default is ${defaultLevelLabel})
-                          </button>
-                        </div>
-                        <span class="chat-controls__reasoning-value">${reasoningValueLabel}</span>
+                            ${reasoningValueText}
+                          </span>
+                          ${hasThinkingOverride
+                            ? html`
+                                <openclaw-tooltip
+                                  .content=${`Reset to default (${defaultLevelLabel})`}
+                                >
+                                  <button
+                                    class="chat-controls__reasoning-reset"
+                                    data-chat-thinking-option=""
+                                    type="button"
+                                    aria-label=${`Use default reasoning (${defaultLevelLabel})`}
+                                    ?disabled=${thinkingDisabled}
+                                    @click=${(event: MouseEvent) => {
+                                      event.stopPropagation();
+                                      if (thinkingDisabled) {
+                                        event.preventDefault();
+                                        return;
+                                      }
+                                      commitThinking("");
+                                    }}
+                                  >
+                                    ${icons.x}
+                                  </button>
+                                </openclaw-tooltip>
+                              `
+                            : ""}
+                        </span>
                       </div>
                       ${sliderStops.length > 1
                         ? html`
@@ -748,10 +768,6 @@ function renderChatModelReasoningSelect(params: {
                                 @click=${onUnanchoredSliderClick}
                                 @keydown=${onUnanchoredSliderKeyDown}
                               />
-                            </div>
-                            <div class="chat-controls__reasoning-scale" aria-hidden="true">
-                              <span>${t("chat.modelPicker.faster")}</span>
-                              <span>${t("chat.modelPicker.smarter")}</span>
                             </div>
                           `
                         : onlyStop

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2476,8 +2476,8 @@ openclaw-chat-page {
     left: auto;
     right: max(12px, var(--safe-area-right));
     bottom: calc(96px + var(--safe-area-bottom));
-    width: min(420px, calc(100vw - 24px));
-    max-height: min(460px, calc(100vh - 116px - var(--safe-area-bottom)));
+    width: min(392px, calc(100vw - 24px));
+    max-height: min(440px, calc(100vh - 116px - var(--safe-area-bottom)));
   }
 
   .chat-settings-popover-wrapper {
@@ -3167,18 +3167,18 @@ openclaw-chat-page {
   display: flex;
   flex-direction: column;
   gap: 0;
-  width: min(420px, calc(100vw - 24px));
-  max-height: min(460px, calc(100vh - 96px));
+  width: min(392px, calc(100vw - 24px));
+  max-height: min(440px, calc(100vh - 96px));
   padding: 0;
   overflow: hidden;
 }
 
 .chat-controls__model-browser {
   display: grid;
-  grid-template-columns: 136px minmax(0, 1fr);
+  grid-template-columns: 120px minmax(0, 1fr);
   min-height: 132px;
-  max-height: 236px;
-  flex: 1 1 236px;
+  max-height: 220px;
+  flex: 1 1 220px;
   overflow: hidden;
 }
 
@@ -3311,8 +3311,8 @@ openclaw-chat-page {
 .chat-controls__combined-model-option {
   justify-content: flex-start;
   gap: 8px;
-  min-height: 44px;
-  padding: 6px 8px;
+  min-height: 40px;
+  padding: 5px 8px;
 }
 
 .chat-controls__model-option-copy {
@@ -3348,7 +3348,7 @@ openclaw-chat-page {
   flex: 0 0 auto;
   width: auto;
   max-height: none;
-  padding: 9px 10px 10px;
+  padding: 8px 10px 9px;
   border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   background: color-mix(in srgb, var(--card) 78%, transparent);
   overflow: visible;
@@ -3362,45 +3362,63 @@ openclaw-chat-page {
   min-width: 0;
 }
 
-.chat-controls__reasoning-heading {
-  display: flex;
-  align-items: baseline;
+.chat-controls__reasoning-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   min-width: 0;
-}
-
-.chat-controls__reasoning-default {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--muted);
-  font: inherit;
-  font-size: 11px;
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.chat-controls__reasoning-default:hover:not(:disabled),
-.chat-controls__reasoning-default:focus-visible {
-  color: var(--text);
-  text-decoration: underline;
-}
-
-.chat-controls__reasoning-default:focus-visible {
-  outline: none;
-}
-
-.chat-controls__reasoning-default:disabled {
-  cursor: default;
+  padding-right: 6px;
 }
 
 .chat-controls__reasoning-value {
-  padding-right: 8px;
   overflow: hidden;
   color: var(--text-strong);
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+/* Muted value = inherited model default; no reset shows because there is no
+   override to clear. */
+.chat-controls__reasoning-value--inherit {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.chat-controls__reasoning-reset {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-full);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.chat-controls__reasoning-reset:hover:not(:disabled),
+.chat-controls__reasoning-reset:focus-visible {
+  background: var(--bg-hover);
+  color: var(--text);
+  outline: none;
+}
+
+.chat-controls__reasoning-reset:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.chat-controls__reasoning-reset svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
 }
 
 /* Discrete effort slider: native range input for keyboard/a11y, decorative
@@ -3516,14 +3534,6 @@ openclaw-chat-page {
 
 .chat-controls__reasoning-range--unanchored::-moz-range-thumb {
   opacity: 0.35;
-}
-
-.chat-controls__reasoning-scale {
-  display: flex;
-  justify-content: space-between;
-  margin: 0 6px;
-  color: var(--muted);
-  font-size: 11px;
 }
 
 /* Speed is a single fast-mode toggle: bolt icon plus the current state word.


### PR DESCRIPTION
## What Problem This Solves

The chat model picker's reasoning section was wordy and the menu still felt large: the header read `REASONING (Default is Off)` while the right side repeated `Default (Off)`, and a whole `Faster / Smarter` caption row sat under the slider. Three pieces of text all explained the same idle state.

## Why This Change Was Made

The reasoning header now shows just the level word: muted (`Off`) when the session inherits the model default, strong with an icon-only reset (`High ✕`) when an override is set - the reset only exists when there is something to clear, and its tooltip/aria-label carries the "Reset to default (Off)" phrasing. The `Faster / Smarter` scale row is gone (the slider dots plus the live value already communicate direction), along with its now-unused `chat.modelPicker.*` i18n keys. The menu itself tightened: 392px wide (was 420px), shorter model rows, slightly trimmed paddings. Screen readers keep the verbose `Default (Off)` phrasing via `aria-valuetext`.

## User Impact

The picker is visibly smaller and quieter: one word for the reasoning state instead of three redundant labels, one caption row less, and a narrower menu. Resetting a reasoning override is now a small ✕ next to the value instead of parenthetical link text.

## Evidence

Before / after (mock-gateway harness, Anthropic session, dark scheme):

| Before | After (inherited) | After (override) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/picker-compact-pass/before-picker-menu.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/picker-compact-pass/after-picker-menu.png) | ![after-override](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/picker-compact-pass/after-picker-menu-override.png) |

- Testbox (Blacksmith): `pnpm test ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-controls.test.ts ui/src/i18n/test/translate.test.ts ui/src/lib/chat/model-select-state.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts ui/src/e2e/chat-flow.e2e.test.ts` - all green, including a new regression test for the icon reset (renders only with an override, click patches `thinkingLevel: null`).
- Testbox: `pnpm check:changed` - exit 0.
- Locale bundles regenerated via `pnpm ui:i18n:sync` (drops `chat.modelPicker.faster`/`smarter`).
