### PR TITLE
fix(ci): prepare QA runtime for live shard

### DIFF
--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -33,6 +33,8 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["test/image-generation.infer-cli.live.test.ts", ["OPENCLAW_LIVE_INFER_CLI_TEST"]],
 ]);
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);
+const QA_RUNTIME_LIVE_TEST = "extensions/qa-lab/src/matrix-channel-driver.lifecycle.live.test.ts";
+const QA_RUNTIME_ARTIFACT = "dist/extensions/qa-lab/runtime-api.js";
 
 /** Live-test shards included in release validation. */
 export const RELEASE_LIVE_TEST_SHARDS = Object.freeze([
@@ -357,6 +359,19 @@ export function buildLiveShardPnpmArgs(files, passthroughArgs) {
 }
 
 /**
+ * Resolves build profiles required by selected live tests.
+ */
+export function resolveLiveShardPreparation(files) {
+  return files.includes(QA_RUNTIME_LIVE_TEST)
+    ? {
+        env: { OPENCLAW_BUILD_PRIVATE_QA: "1" },
+        profile: "qaRuntime",
+        requiredArtifact: QA_RUNTIME_ARTIFACT,
+      }
+    : null;
+}
+
+/**
  * Builds the Vitest JSON report path used to prove that a live shard ran tests.
  */
 export function buildLiveShardReportPath(shard, env = process.env) {
@@ -649,6 +664,36 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       console.log(file);
     }
     process.exit(0);
+  }
+
+  // Some live tests exercise built private surfaces. Prepare their owning profile so
+  // shard routing cannot select a test whose required runtime artifact is absent.
+  const preparation = resolveLiveShardPreparation(files);
+  if (preparation) {
+    console.log(
+      `[test:live:shard] preparing ${preparation.profile} for ${preparation.requiredArtifact}`,
+    );
+    const result = spawnSync(process.execPath, ["scripts/build-all.mjs", preparation.profile], {
+      env: { ...process.env, ...preparation.env },
+      stdio: "inherit",
+    });
+    if (result.error) {
+      console.error(result.error);
+      process.exit(1);
+    }
+    if (result.signal) {
+      process.kill(process.pid, result.signal);
+      process.exit(1);
+    }
+    if ((result.status ?? 1) !== 0) {
+      process.exit(result.status ?? 1);
+    }
+    if (!fs.existsSync(preparation.requiredArtifact)) {
+      console.error(
+        `[test:live:shard] ${preparation.profile} did not produce ${preparation.requiredArtifact}`,
+      );
+      process.exit(1);
+    }
   }
 
   console.log(`[test:live:shard] ${shard}: ${files.length} file(s)`);

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -15,6 +15,7 @@ import {
   collectAllLiveTestFiles,
   parseLiveShardArgs,
   removeLiveShardReportFile,
+  resolveLiveShardPreparation,
   selectLiveShardFiles,
   validateLiveShardReportPayload,
 } from "../../scripts/test-live-shard.mjs";
@@ -203,6 +204,26 @@ describe("scripts/test-live-shard", () => {
         addLiveShardReportArgs([], reportPath),
       ),
     ).toContain("--reporter=json");
+  });
+
+  it("prepares the private QA runtime for live shards that load its built API", () => {
+    const expected = {
+      env: { OPENCLAW_BUILD_PRIVATE_QA: "1" },
+      profile: "qaRuntime",
+      requiredArtifact: "dist/extensions/qa-lab/runtime-api.js",
+    };
+
+    expect(
+      resolveLiveShardPreparation(
+        selectLiveShardFiles("native-live-extensions-o-z-other", allFiles),
+      ),
+    ).toEqual(expected);
+    expect(
+      resolveLiveShardPreparation(selectLiveShardFiles("native-live-extensions-o-z", allFiles)),
+    ).toEqual(expected);
+    expect(
+      resolveLiveShardPreparation(selectLiveShardFiles("native-live-extensions-xai", allFiles)),
+    ).toBeNull();
   });
 
   it("fails live shard reports with no passing tests", () => {


### PR DESCRIPTION
Closes #103128

## What Problem This Solves

Fixes an issue where the full release validation's O-Z live shard could select the Matrix QA lifecycle test without building its required private runtime artifact. Both lifecycle cases then failed, but the advisory job still concluded successfully.

## Why This Change Was Made

The shared live-shard harness now declares preparation for selected tests that depend on built private surfaces. For the Matrix lifecycle test it builds the `qaRuntime` profile with `OPENCLAW_BUILD_PRIVATE_QA=1`, propagates build failures, and verifies the expected artifact before starting Vitest.

Keeping this in the shard harness protects every caller and avoids duplicating preparation policy in individual workflows.

## User Impact

No product runtime behavior changes. Release maintainers now get real Matrix lifecycle coverage instead of a green advisory job masking a deterministic missing-artifact failure.

## Evidence

- Before: [release-check job 86224945077](https://github.com/openclaw/openclaw/actions/runs/29048860509/job/86224945077) failed both Matrix lifecycle cases with a missing `dist/extensions/qa-lab/runtime-api.js` import, then swallowed the failure as advisory.
- Blacksmith Testbox lease `tbx_01kx4d9hps17pc1t30bqbdxqwk`:
  - `pnpm test test/scripts/test-live-shard.test.ts`: 20 passed.
  - `OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs qaRuntime` produced the required artifact; focused lifecycle live test: 2 passed.
  - `pnpm check:changed`: passed (tooling lane).
  - `oxfmt --check scripts/test-live-shard.mjs test/scripts/test-live-shard.test.ts`: passed.
- Fresh structured autoreview: no accepted/actionable findings.