### PR TITLE
refactor(android): align talk levels and thinking state with iOS/macOS

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -171,7 +171,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 268,
+      "line": 269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2922,
+      "line": 2925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2924,
+      "line": 2927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2926,
+      "line": 2929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -4731,7 +4731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 319,
+      "line": 321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation",
       "surface": "android",
@@ -4739,7 +4739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 320,
+      "line": 322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Transcribe then send",
       "surface": "android",
@@ -4747,7 +4747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation settings",
       "surface": "android",
@@ -4755,7 +4755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 333,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending to chat...",
       "surface": "android",
@@ -4763,7 +4763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 333,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start speaking...",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 365,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Speech provider",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 417,
+      "line": 419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Tip: stop listening to send the captured turn.",
       "surface": "android",
@@ -4787,7 +4787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -4795,7 +4795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Send to Chat",
       "surface": "android",
@@ -4803,7 +4803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 456,
+      "line": 459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Back to voice",
       "surface": "android",
@@ -4811,7 +4811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 458,
+      "line": 461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -4819,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 475,
+      "line": 478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -4827,7 +4827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 499,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Live transcript",
       "surface": "android",
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute",
       "surface": "android",
@@ -4843,7 +4843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute",
       "surface": "android",
@@ -4851,7 +4851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 516,
+      "line": 519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End",
       "surface": "android",
@@ -4859,7 +4859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 539,
+      "line": 542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for your next turn.",
       "surface": "android",
@@ -4867,7 +4867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 624,
+      "line": 627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4875,7 +4875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 629,
+      "line": 632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Search voice",
       "surface": "android",
@@ -4883,7 +4883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 637,
+      "line": 640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -4891,7 +4891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 648,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -4899,7 +4899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 648,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute speaker",
       "surface": "android",
@@ -4907,7 +4907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 727,
+      "line": 730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -4915,7 +4915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 739,
+      "line": 742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Stop Dictation",
       "surface": "android",
@@ -4923,7 +4923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 876,
+      "line": 879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice setup",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
+      "line": 1040,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "You",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1055,
+      "line": 1058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1057,
+      "line": 1060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1072,
+      "line": 1075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Permission needed",
       "surface": "android",
@@ -4963,7 +4963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1073,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone access is needed.",
       "surface": "android",
@@ -4971,7 +4971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1075,
+      "line": 1078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw only listens when you start Talk or Dictation.",
       "surface": "android",
@@ -4979,7 +4979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1079,
+      "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Enable Microphone",
       "surface": "android",
@@ -5859,7 +5859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 612,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -5867,7 +5867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 612,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -5875,7 +5875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1021,
+      "line": 1035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -5883,7 +5883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1022,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -5891,7 +5891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1023,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2082,
+      "line": 2096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2082,
+      "line": 2096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2096,
+      "line": 2099,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2096,
+      "line": 2099,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -265,6 +265,7 @@ class MainViewModel(
   val talkInputLevel: StateFlow<Float> = runtimeState(initial = 0f) { it.talkInputLevel }
   val talkOutputLevel: StateFlow<Float?> = runtimeState(initial = null) { it.talkOutputLevel }
   val talkSpeechActive: StateFlow<Boolean> = runtimeState(initial = false) { it.talkSpeechActive }
+  val talkAwaitingAgent: StateFlow<Boolean> = runtimeState(initial = false) { it.talkAwaitingAgent }
   val talkModeStatusText: StateFlow<String> = runtimeState(initial = "Off") { it.talkModeStatusText }
   val talkModeConversation: StateFlow<List<VoiceConversationEntry>> =
     runtimeState(initial = emptyList()) { it.talkModeConversation }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1268,6 +1268,9 @@ class NodeRuntime private constructor(
   val talkSpeechActive: StateFlow<Boolean>
     get() = talkMode.speechActive
 
+  val talkAwaitingAgent: StateFlow<Boolean>
+    get() = talkMode.awaitingAgent
+
   val talkModeStatusText: StateFlow<String>
     get() = talkMode.statusText
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
@@ -1,6 +1,6 @@
 package ai.openclaw.app.chat
 
-import ai.openclaw.app.voice.smoothedAudioLevel
+import ai.openclaw.app.voice.TalkAudioLevel
 import android.content.Context
 import android.media.MediaRecorder
 import android.os.SystemClock
@@ -199,11 +199,11 @@ internal class VoiceNoteRecorderController(
         while (isActive && state.value is VoiceNoteRecorderState.Recording) {
           val elapsed = (elapsedRealtimeMillis() - startedAt).coerceIn(0L, VOICE_NOTE_MAX_DURATION_MS)
           _elapsedMs.value = elapsed
-          // MediaRecorder reports the peak since the last poll; at 10Hz that
-          // reads close to the mean-abs mic levels used by the other waveform
-          // surfaces, so peak/32767 needs no extra curve.
-          val rawLevel = (engine.pollAmplitude().coerceIn(0, 32_767)) / 32_767f
-          _inputLevel.value = smoothedAudioLevel(_inputLevel.value, rawLevel)
+          // MediaRecorder exposes only the peak since the last poll; running it
+          // through the shared dB window keeps this wave on the same visual
+          // scale as the RMS-metered talk and dictation waves.
+          val rawLevel = TalkAudioLevel.normalized((engine.pollAmplitude().coerceIn(0, 32_767)) / 32_767.0)
+          _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, rawLevel)
           // MediaRecorder's duration callback races its asynchronous auto-stop.
           // Own the cap here so every successful finish calls stop() exactly once.
           if (elapsed >= VOICE_NOTE_MAX_DURATION_MS) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
@@ -113,6 +113,7 @@ fun VoiceScreen(
   val talkInputLevel by viewModel.talkInputLevel.collectAsState()
   val talkOutputLevel by viewModel.talkOutputLevel.collectAsState()
   val talkSpeechActive by viewModel.talkSpeechActive.collectAsState()
+  val talkAwaitingAgent by viewModel.talkAwaitingAgent.collectAsState()
 
   var pendingAction by remember { mutableStateOf<VoiceAction?>(null) }
   var hasMicPermission by remember { mutableStateOf(context.hasRecordAudioPermission()) }
@@ -175,6 +176,7 @@ fun VoiceScreen(
       listening = talkModeListening,
       speaking = talkModeSpeaking,
       statusText = talkModeStatusText,
+      awaitingAgent = talkAwaitingAgent,
       inputLevel = talkInputLevel,
       outputLevel = talkOutputLevel,
       speechActive = talkSpeechActive,
@@ -436,6 +438,7 @@ private fun TalkSessionScreen(
   listening: Boolean,
   speaking: Boolean,
   statusText: String,
+  awaitingAgent: Boolean,
   inputLevel: Float,
   outputLevel: Float?,
   speechActive: Boolean,
@@ -486,7 +489,7 @@ private fun TalkSessionScreen(
           talkSessionWaveformPhase(
             speaking = speaking,
             listening = listening,
-            statusText = statusText,
+            awaitingAgent = awaitingAgent,
             inputLevel = inputLevel,
             speechActive = speechActive,
             outputLevel = outputLevel,
@@ -1099,21 +1102,17 @@ private fun runVoiceAction(
   }
 }
 
-// Status literals TalkModeManager publishes while a turn runs but no audio
-// flows yet; they are the only signal that the agent is being awaited.
-private val talkAwaitingAgentStatuses = setOf("Thinking…", "Connecting…", "Generating voice…")
-
 internal fun talkSessionWaveformPhase(
   speaking: Boolean,
   listening: Boolean,
-  statusText: String,
+  awaitingAgent: Boolean,
   inputLevel: Float,
   speechActive: Boolean,
   outputLevel: Float?,
 ): TalkWaveformPhase =
   when {
     speaking -> TalkWaveformPhase.Speaking(outputLevel)
-    statusText.trim() in talkAwaitingAgentStatuses -> TalkWaveformPhase.Thinking
+    awaitingAgent -> TalkWaveformPhase.Thinking
     listening -> TalkWaveformPhase.Listening(level = inputLevel, speechActive = speechActive)
     else -> TalkWaveformPhase.Idle
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -203,37 +203,6 @@ private class BluetoothCommunicationRoute {
 
 private val bluetoothCommunicationRoute = BluetoothCommunicationRoute()
 
-/**
- * Mean-abs level of little-endian PCM16 audio in 0..1. Single implementation
- * shared by mic capture (dictation, realtime talk) and playback metering so
- * every waveform surface reads the same scale.
- */
-internal fun pcm16MeanAbsLevel(
-  frame: ByteArray,
-  length: Int,
-): Float {
-  var total = 0L
-  var count = 0
-  var index = 0
-  val limit = length - (length % 2)
-  while (index < limit) {
-    val sample =
-      (frame[index].toInt() and 0xff) or
-        (frame[index + 1].toInt() shl 8)
-    total += kotlin.math.abs(sample.toShort().toInt())
-    count += 1
-    index += 2
-  }
-  if (count == 0) return 0f
-  return ((total / count).toFloat() / Short.MAX_VALUE).coerceIn(0f, 1f)
-}
-
-/** iOS-parity level smoothing (new = old*0.8 + raw*0.2) for waveform meters. */
-internal fun smoothedAudioLevel(
-  previous: Float,
-  raw: Float,
-): Float = previous * 0.8f + raw * 0.2f
-
 /** Converts AudioRecord's negative return codes into capture-session failures. */
 internal fun checkAudioRecordReadResult(result: Int): Int {
   if (result >= 0) return result

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -702,7 +702,7 @@ internal class MicCaptureManager(
           while (coroutineContext.isActive && _micEnabled.value && transcriptionSession == session) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
-            _inputLevel.value = pcm16MeanAbsLevel(buffer, read)
+            _inputLevel.value = TalkAudioLevel.pcm16Level(buffer, read)
             audioFrames.trySend(buffer.copyOf(read))
           }
         } catch (err: Throwable) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioLevel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioLevel.kt
@@ -1,0 +1,52 @@
+package ai.openclaw.app.voice
+
+import kotlin.math.log10
+import kotlin.math.max
+import kotlin.math.sqrt
+
+/**
+ * Kotlin port of OpenClawKit's `TalkAudioLevel`: the shared 0..1 UI level scale
+ * (dB full scale over a 50 dB window) used by every talk waveform surface, so
+ * Android levels read identically to iOS/macOS. Change the Swift original in
+ * `TalkPlaybackLevelMeters.swift` first; every constant mirrors it.
+ */
+internal object TalkAudioLevel {
+  fun normalized(rms: Double): Float = normalizedDecibels(20.0 * log10(max(rms, 1e-7)))
+
+  fun normalizedDecibels(decibels: Double): Float = ((decibels + 50.0) / 50.0).coerceIn(0.0, 1.0).toFloat()
+
+  /** Normalized level of little-endian PCM16 audio; 0 for empty frames. */
+  fun pcm16Level(
+    frame: ByteArray,
+    length: Int,
+  ): Float = normalized(pcm16Rms(frame, length))
+
+  /** RMS of little-endian PCM16 audio in 0..1; 0 for empty or odd-length frames. */
+  fun pcm16Rms(
+    frame: ByteArray,
+    length: Int,
+  ): Double {
+    var sum = 0.0
+    var count = 0
+    var index = 0
+    val limit = length - (length % 2)
+    while (index < limit) {
+      val sample =
+        ((frame[index].toInt() and 0xff) or (frame[index + 1].toInt() shl 8))
+          .toShort()
+          .toInt()
+      val value = sample / Short.MAX_VALUE.toDouble()
+      sum += value * value
+      count += 1
+      index += 2
+    }
+    if (count == 0) return 0.0
+    return sqrt(sum / count)
+  }
+
+  /** iOS-parity level smoothing (new = old*0.8 + raw*0.2) for waveform meters. */
+  fun smoothed(
+    previous: Float,
+    raw: Float,
+  ): Float = previous * 0.8f + raw * 0.2f
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -198,6 +198,20 @@ class TalkModeManager internal constructor(
   private val _statusText = MutableStateFlow("Off")
   val statusText: StateFlow<String> = _statusText
 
+  // Typed "waiting on the agent" signal for the waveform's Thinking phase, so
+  // UI never has to parse status strings. Every status change flows through
+  // setStatus; forgetting the flag fails safe (wave shows Listening/Idle).
+  private val _awaitingAgent = MutableStateFlow(false)
+  val awaitingAgent: StateFlow<Boolean> = _awaitingAgent
+
+  private fun setStatus(
+    text: String,
+    awaitingAgent: Boolean = false,
+  ) {
+    _statusText.value = text
+    _awaitingAgent.value = awaitingAgent
+  }
+
   private val _lastAssistantText = MutableStateFlow<String?>(null)
   val lastAssistantText: StateFlow<String?> = _lastAssistantText
 
@@ -436,7 +450,7 @@ class TalkModeManager internal constructor(
       throw IllegalStateException("PTT_BUSY: previous push-to-talk turn is still finishing")
     }
     if (!isConnected()) {
-      _statusText.value = "Gateway not connected"
+      setStatus("Gateway not connected")
       throw IllegalStateException("UNAVAILABLE: Gateway not connected")
     }
 
@@ -444,11 +458,11 @@ class TalkModeManager internal constructor(
       ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
         PackageManager.PERMISSION_GRANTED
     if (!micOk) {
-      _statusText.value = "Microphone permission required"
+      setStatus("Microphone permission required")
       throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
     }
     if (!SpeechRecognizer.isRecognitionAvailable(context)) {
-      _statusText.value = "Speech recognizer unavailable"
+      setStatus("Speech recognizer unavailable")
       throw IllegalStateException("UNAVAILABLE: Speech recognizer unavailable")
     }
 
@@ -509,10 +523,10 @@ class TalkModeManager internal constructor(
           pttCompletion = null
           completion?.cancel()
           resumeRealtimeCaptureAfterPushToTalk(captureId)
-          _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+          setStatus(if (_isEnabled.value) "Listening" else "Ready")
           throw err
         }
-        _statusText.value = "Listening (PTT)"
+        setStatus("Listening (PTT)")
         if (autoStopAfterMs != null) {
           pttAutoStopEnabled = true
           // Install one-shot jobs before yielding to lifecycle changes. Otherwise a
@@ -550,7 +564,7 @@ class TalkModeManager internal constructor(
       val transcript = cleared.transcript
 
       if (transcript.isEmpty()) {
-        _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+        setStatus(if (_isEnabled.value) "Listening" else "Ready")
         resumeRealtimeCaptureAfterPushToTalk(captureId)
         return@withContext finishPushToTalk(
           TalkPttStopPayload(captureId = captureId, transcript = null, status = "empty"),
@@ -559,7 +573,7 @@ class TalkModeManager internal constructor(
       }
 
       if (!isConnected()) {
-        _statusText.value = "Gateway not connected"
+        setStatus("Gateway not connected")
         resumeRealtimeCaptureAfterPushToTalk(captureId)
         return@withContext finishPushToTalk(
           TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "offline"),
@@ -567,7 +581,7 @@ class TalkModeManager internal constructor(
         )
       }
 
-      _statusText.value = "Thinking…"
+      setStatus("Thinking…", awaitingAgent = true)
       lateinit var finishingJob: Job
       finishingJob =
         // Gateway-scoped so a switch drops the stale finalize; the NonCancellable
@@ -609,7 +623,7 @@ class TalkModeManager internal constructor(
       val cleared =
         clearPushToTalkRecognition(captureId)
           ?: return@withContext TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle")
-      _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+      setStatus(if (_isEnabled.value) "Listening" else "Ready")
       resumeRealtimeCaptureAfterPushToTalk(captureId)
       finishPushToTalk(
         TalkPttStopPayload(captureId = captureId, transcript = null, status = "cancelled"),
@@ -691,7 +705,7 @@ class TalkModeManager internal constructor(
         val ack = sendChat(prompt, session)
         val runId = ack.runId ?: throw IllegalStateException("chat.send returned no run id")
         if (ack.isTerminalFailure) {
-          _statusText.value = if (ack.normalizedStatus == "error") "Chat error" else "Aborted"
+          setStatus(if (ack.normalizedStatus == "error") "Chat error" else "Aborted")
           return@launch
         }
         val ok = if (ack.isTerminalSuccess) true else waitForChatFinal(runId)
@@ -705,12 +719,12 @@ class TalkModeManager internal constructor(
         if (!assistant.isNullOrBlank()) {
           val playbackToken = playbackGeneration.incrementAndGet()
           cancelActivePlayback()
-          _statusText.value = "Speaking…"
+          setStatus("Speaking…")
           runPlaybackSession(playbackToken) {
             playAssistant(assistant, playbackToken)
           }
         } else {
-          _statusText.value = "No reply"
+          setStatus("No reply")
         }
       } catch (err: Throwable) {
         Log.w(tag, "speakWakeCommand failed: ${err.message}")
@@ -864,7 +878,7 @@ class TalkModeManager internal constructor(
         startRealtimeRelay(generation)
       } catch (err: Throwable) {
         if (err is CancellationException) return@launch
-        _statusText.value = "Start failed: ${err.message ?: err::class.simpleName}"
+        setStatus("Start failed: ${err.message ?: err::class.simpleName}")
         Log.w(tag, "start failed: ${err.message ?: err::class.simpleName}")
         stopRealtimeRelay(closeSession = false, preserveStatus = true)
         disableRealtimeModeAndNotifyOwner()
@@ -893,7 +907,7 @@ class TalkModeManager internal constructor(
     lastTranscript = ""
     lastHeardAtMs = null
     _isListening.value = false
-    _statusText.value = "Off"
+    setStatus("Off")
     stopRealtimeRelay()
     stopSpeaking()
     pendingRunId = null
@@ -927,7 +941,7 @@ class TalkModeManager internal constructor(
 
   private suspend fun startRealtimeRelay(generation: Long) {
     if (!isConnected()) {
-      _statusText.value = "Gateway not connected"
+      setStatus("Gateway not connected")
       Log.w(tag, "realtime start: gateway not connected")
       disableRealtimeModeAndNotifyOwner()
       return
@@ -937,7 +951,7 @@ class TalkModeManager internal constructor(
       ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
         PackageManager.PERMISSION_GRANTED
     if (!micOk) {
-      _statusText.value = "Microphone permission required"
+      setStatus("Microphone permission required")
       Log.w(tag, "realtime start: microphone permission required")
       disableRealtimeModeAndNotifyOwner()
       return
@@ -954,7 +968,7 @@ class TalkModeManager internal constructor(
       }
     }
 
-    _statusText.value = "Connecting…"
+    setStatus("Connecting…", awaitingAgent = true)
     val params =
       buildJsonObject {
         put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
@@ -987,7 +1001,7 @@ class TalkModeManager internal constructor(
         } else {
           realtimeOutputSuppressed = false
           _isListening.value = true
-          _statusText.value = "Listening"
+          setStatus("Listening")
           startRealtimeCaptureLocked(sessionId)
           false
         }
@@ -1011,7 +1025,7 @@ class TalkModeManager internal constructor(
     message: String,
   ) {
     if (realtimeSessionId != sessionId) return
-    _statusText.value = "Talk failed: $message"
+    setStatus("Talk failed: $message")
     stopRealtimeRelay(cancelCapture = false, cancelAppend = false, preserveStatus = true)
     disableRealtimeModeAndNotifyOwner()
   }
@@ -1072,7 +1086,7 @@ class TalkModeManager internal constructor(
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
-            _inputLevel.value = smoothedAudioLevel(_inputLevel.value, pcm16MeanAbsLevel(buffer, read))
+            _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.pcm16Level(buffer, read))
             if (!shouldAppendRealtimeCapturedFrame(read)) continue
             audioFrames.trySend(buffer.copyOf(read))
           }
@@ -1108,7 +1122,7 @@ class TalkModeManager internal constructor(
       "ready" -> {
         if (isRealtimeCapturePaused()) return
         _isListening.value = true
-        _statusText.value = "Listening"
+        setStatus("Listening")
       }
       "inputAudio" -> {
         synchronized(realtimeCapturePauseLock) {
@@ -1160,7 +1174,7 @@ class TalkModeManager internal constructor(
           _lastAssistantText.value = assistantText.trim()
         }
         if (isFinal && role == "user") {
-          _statusText.value = "Thinking…"
+          setStatus("Thinking…", awaitingAgent = true)
         } else if (isFinal && role == "assistant") {
           scheduleRealtimePlaybackIdle()
         }
@@ -1178,7 +1192,7 @@ class TalkModeManager internal constructor(
       "toolResult" -> Unit
       "error" -> {
         val message = obj["message"].asStringOrNull() ?: "realtime talk error"
-        _statusText.value = "Talk failed: $message"
+        setStatus("Talk failed: $message")
         Log.w(tag, "realtime error: $message")
       }
       "close" -> {
@@ -1190,7 +1204,7 @@ class TalkModeManager internal constructor(
         stopRealtimeRelay(closeSession = false, preserveStatus = true)
         if (_isEnabled.value) {
           _isEnabled.value = false
-          _statusText.value = closeStatus
+          setStatus(closeStatus)
           onStoppedByRelay()
         }
       }
@@ -1296,9 +1310,9 @@ class TalkModeManager internal constructor(
       // Blocking MODE_STREAM writes are playback-paced once the track buffer
       // fills, so per-write metering tracks what the speaker actually plays.
       _outputLevel.value =
-        smoothedAudioLevel(_outputLevel.value ?: 0f, pcm16MeanAbsLevel(bytes, writtenBytes))
+        TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
       _isSpeaking.value = true
-      _statusText.value = "Speaking…"
+      setStatus("Speaking…")
       val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
       val now = SystemClock.elapsedRealtime()
       realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
@@ -1322,7 +1336,7 @@ class TalkModeManager internal constructor(
             playbackIdle
           }
         if (idle && _isEnabled.value && realtimeSessionId != null) {
-          _statusText.value = "Listening"
+          setStatus("Listening")
         }
       }
   }
@@ -1352,7 +1366,7 @@ class TalkModeManager internal constructor(
     _isSpeaking.value = false
     _outputLevel.value = null
     if (_isEnabled.value) {
-      _statusText.value = "Listening"
+      setStatus("Listening")
     }
   }
 
@@ -1395,7 +1409,7 @@ class TalkModeManager internal constructor(
     _inputLevel.value = 0f
     stopRealtimePlayback()
     if (preserveStatus) {
-      _statusText.value = status
+      setStatus(status)
     }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
@@ -1466,7 +1480,7 @@ class TalkModeManager internal constructor(
         }
         realtimeCapturePause = null
         _isListening.value = true
-        _statusText.value = "Listening"
+        setStatus("Listening")
         startRealtimeCaptureLocked(sessionId)
         RealtimeCaptureResume.Resumed
       }
@@ -1475,7 +1489,7 @@ class TalkModeManager internal constructor(
       RealtimeCaptureResume.Resumed -> return
       RealtimeCaptureResume.Restart -> start()
       RealtimeCaptureResume.Disconnected -> {
-        _statusText.value = "Gateway not connected"
+        setStatus("Gateway not connected")
         stopRealtimeRelay(preserveStatus = true)
         disableRealtimeModeAndNotifyOwner()
       }
@@ -1526,7 +1540,7 @@ class TalkModeManager internal constructor(
         if (!runId.isNullOrBlank()) {
           when (val registration = registerRealtimeToolRun(runId, callId, relaySessionId)) {
             RealtimeToolRegistration.SessionEnded -> return@launch
-            RealtimeToolRegistration.AwaitingCompletion -> _statusText.value = "Thinking…"
+            RealtimeToolRegistration.AwaitingCompletion -> setStatus("Thinking…", awaitingAgent = true)
             is RealtimeToolRegistration.Completed ->
               dispatchRealtimeToolCompletion(registration.dispatch)
           }
@@ -1957,7 +1971,7 @@ class TalkModeManager internal constructor(
       }
 
     if (markListening) {
-      _statusText.value = "Listening"
+      setStatus("Listening")
       _isListening.value = true
     }
     r.startListening(intent)
@@ -2049,7 +2063,7 @@ class TalkModeManager internal constructor(
   private suspend fun finalizeTranscript(transcript: String) {
     listeningMode = false
     _isListening.value = false
-    _statusText.value = "Thinking…"
+    setStatus("Thinking…", awaitingAgent = true)
     lastTranscript = ""
     lastHeardAtMs = null
     // Release SpeechRecognizer before making the API call and playing TTS.
@@ -2066,7 +2080,7 @@ class TalkModeManager internal constructor(
     ensureConfigLoaded()
     val prompt = buildPrompt(transcript)
     if (!isConnected()) {
-      _statusText.value = "Gateway not connected"
+      setStatus("Gateway not connected")
       Log.w(tag, "finalize: gateway not connected")
       start()
       return
@@ -2079,7 +2093,7 @@ class TalkModeManager internal constructor(
       val runId = ack.runId ?: throw IllegalStateException("chat.send returned no run id")
       Log.d(tag, "chat.send ok runId=$runId status=${ack.status}")
       if (ack.isTerminalFailure) {
-        _statusText.value = if (ack.normalizedStatus == "error") "Chat error" else "Aborted"
+        setStatus(if (ack.normalizedStatus == "error") "Chat error" else "Aborted")
         start()
         return
       }
@@ -2096,7 +2110,7 @@ class TalkModeManager internal constructor(
             if (ok) 12_000 else 25_000,
           )
       if (assistant.isNullOrBlank()) {
-        _statusText.value = "No reply"
+        setStatus("No reply")
         Log.w(tag, "assistant text timeout runId=$runId")
         start()
         return
@@ -2112,7 +2126,7 @@ class TalkModeManager internal constructor(
         Log.d(tag, "finalize speech cancelled")
         return
       }
-      _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
+      setStatus("Talk failed: ${err.message ?: err::class.simpleName}")
       Log.w(tag, "finalize failed: ${err.message ?: err::class.simpleName}")
     }
 
@@ -2337,7 +2351,7 @@ class TalkModeManager internal constructor(
     _lastAssistantText.value = cleaned
     ensurePlaybackActive(playbackToken)
 
-    _statusText.value = "Generating voice…"
+    setStatus("Generating voice…", awaitingAgent = true)
     _isSpeaking.value = false
     lastSpokenText = cleaned
 
@@ -2365,7 +2379,7 @@ class TalkModeManager internal constructor(
         Log.d(tag, "assistant speech cancelled")
         return
       }
-      _statusText.value = "Speak failed: ${err.message ?: err::class.simpleName}"
+      setStatus("Speak failed: ${err.message ?: err::class.simpleName}")
       Log.w(tag, "talk playback failed: ${err.message ?: err::class.simpleName}")
     } finally {
       _isSpeaking.value = false
@@ -2513,7 +2527,7 @@ class TalkModeManager internal constructor(
 
   private fun markAudioPlaybackStarting(playbackToken: Long) {
     ensurePlaybackActive(playbackToken)
-    _statusText.value = "Speaking…"
+    setStatus("Speaking…")
     _isSpeaking.value = true
     ensureInterruptListener()
     requestAudioFocusForTts()
@@ -2525,7 +2539,7 @@ class TalkModeManager internal constructor(
     scope.launch { cancelRealtimeOutput(reason = "android-stop-tts") }
     stopSpeaking(resetInterrupt = true)
     _isSpeaking.value = false
-    _statusText.value = "Listening"
+    setStatus("Listening")
   }
 
   private suspend fun cancelRealtimeOutput(reason: String): Boolean =
@@ -2801,7 +2815,7 @@ class TalkModeManager internal constructor(
     object : RecognitionListener {
       override fun onReadyForSpeech(params: Bundle?) {
         if (_isEnabled.value) {
-          _statusText.value = if (_isListening.value) "Listening" else _statusText.value
+          setStatus(if (_isListening.value) "Listening" else _statusText.value)
         }
       }
 
@@ -2824,11 +2838,11 @@ class TalkModeManager internal constructor(
         if (stopRequested) return
         _isListening.value = false
         if (error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS) {
-          _statusText.value = "Microphone permission required"
+          setStatus("Microphone permission required")
           return
         }
 
-        _statusText.value =
+        setStatus(
           when (error) {
             SpeechRecognizer.ERROR_AUDIO -> "Audio error"
             SpeechRecognizer.ERROR_CLIENT -> "Client error"
@@ -2839,7 +2853,8 @@ class TalkModeManager internal constructor(
             SpeechRecognizer.ERROR_SERVER -> "Server error"
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "Listening"
             else -> "Speech error ($error)"
-          }
+          },
+        )
         scheduleRestart(delayMs = 600)
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1376,7 +1376,10 @@ class TalkModeManager internal constructor(
     cancelAppend: Boolean = true,
     preserveStatus: Boolean = false,
   ) {
+    // Capture both halves of the status so a preserved restore cannot split
+    // the user-visible text from the typed awaiting-agent flag.
     val status = _statusText.value
+    val awaiting = _awaitingAgent.value
     val (sessionId, captureJobs) =
       synchronized(realtimeCapturePauseLock) {
         val currentSessionId = realtimeSessionId
@@ -1409,7 +1412,7 @@ class TalkModeManager internal constructor(
     _inputLevel.value = 0f
     stopRealtimePlayback()
     if (preserveStatus) {
-      setStatus(status)
+      setStatus(status, awaitingAgent = awaiting)
     }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
@@ -2814,8 +2817,10 @@ class TalkModeManager internal constructor(
   private val listener =
     object : RecognitionListener {
       override fun onReadyForSpeech(params: Bundle?) {
-        if (_isEnabled.value) {
-          setStatus(if (_isListening.value) "Listening" else _statusText.value)
+        // Only a live listening session may claim the status; a speech-interrupt
+        // recognizer readying during playback must not touch Thinking state.
+        if (_isEnabled.value && _isListening.value) {
+          setStatus("Listening")
         }
       }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/VoiceScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/VoiceScreenLogicTest.kt
@@ -78,20 +78,20 @@ class VoiceScreenLogicTest {
   fun talkSessionWaveformPhaseFollowsTalkState() {
     assertEquals(
       TalkWaveformPhase.Speaking(0.4f),
-      talkSessionWaveformPhase(speaking = true, listening = true, statusText = "Speaking…", inputLevel = 0.2f, speechActive = true, outputLevel = 0.4f),
+      talkSessionWaveformPhase(speaking = true, listening = true, awaitingAgent = false, inputLevel = 0.2f, speechActive = true, outputLevel = 0.4f),
     )
-    // Thinking statuses win over the still-running capture loop.
+    // Awaiting the agent wins over the still-running capture loop.
     assertEquals(
       TalkWaveformPhase.Thinking,
-      talkSessionWaveformPhase(speaking = false, listening = true, statusText = "Thinking…", inputLevel = 0.2f, speechActive = false, outputLevel = null),
+      talkSessionWaveformPhase(speaking = false, listening = true, awaitingAgent = true, inputLevel = 0.2f, speechActive = false, outputLevel = null),
     )
     assertEquals(
       TalkWaveformPhase.Listening(level = 0.2f, speechActive = true),
-      talkSessionWaveformPhase(speaking = false, listening = true, statusText = "Listening", inputLevel = 0.2f, speechActive = true, outputLevel = null),
+      talkSessionWaveformPhase(speaking = false, listening = true, awaitingAgent = false, inputLevel = 0.2f, speechActive = true, outputLevel = null),
     )
     assertEquals(
       TalkWaveformPhase.Idle,
-      talkSessionWaveformPhase(speaking = false, listening = false, statusText = "Off", inputLevel = 0f, speechActive = false, outputLevel = null),
+      talkSessionWaveformPhase(speaking = false, listening = false, awaitingAgent = false, inputLevel = 0f, speechActive = false, outputLevel = null),
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AudioLevelsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AudioLevelsTest.kt
@@ -7,41 +7,55 @@ class AudioLevelsTest {
   @Test
   fun silenceMetersToZero() {
     val silence = ByteArray(640)
-    assertEquals(0f, pcm16MeanAbsLevel(silence, silence.size), 0f)
+    assertEquals(0.0, TalkAudioLevel.pcm16Rms(silence, silence.size), 0.0)
+    assertEquals(0f, TalkAudioLevel.pcm16Level(silence, silence.size), 0f)
   }
 
   @Test
   fun fullScaleMetersToOne() {
     val frame = pcm16Frame(samples = 160, sample = Short.MAX_VALUE)
-    assertEquals(1f, pcm16MeanAbsLevel(frame, frame.size), 1e-6f)
+    assertEquals(1.0, TalkAudioLevel.pcm16Rms(frame, frame.size), 1e-6)
+    assertEquals(1f, TalkAudioLevel.pcm16Level(frame, frame.size), 1e-6f)
   }
 
   @Test
   fun negativeFullScaleClampsToOne() {
     // abs(-32768) exceeds Short.MAX_VALUE by one; the level must stay in 0..1.
     val frame = pcm16Frame(samples = 160, sample = Short.MIN_VALUE)
-    assertEquals(1f, pcm16MeanAbsLevel(frame, frame.size), 0f)
+    assertEquals(1f, TalkAudioLevel.pcm16Level(frame, frame.size), 0f)
   }
 
   @Test
-  fun midScaleMetersToHalf() {
+  fun midScaleFollowsTheSharedDecibelCurve() {
+    // Same 50 dB window as OpenClawKit's TalkAudioLevel: half amplitude is
+    // -6.02 dBFS, so the normalized level is (50 - 6.02) / 50 = 0.8796.
     val frame = pcm16Frame(samples = 160, sample = (Short.MAX_VALUE / 2).toShort())
-    assertEquals(0.5f, pcm16MeanAbsLevel(frame, frame.size), 1e-3f)
+    assertEquals(0.5, TalkAudioLevel.pcm16Rms(frame, frame.size), 1e-3)
+    assertEquals(0.8796f, TalkAudioLevel.pcm16Level(frame, frame.size), 1e-3f)
+  }
+
+  @Test
+  fun quietSignalsStayVisibleOnTheDecibelCurve() {
+    // -40 dBFS (1% amplitude) still reads at 0.2 instead of vanishing, which is
+    // what makes the wave feel alive at conversational distance on iOS/macOS.
+    assertEquals(0.2f, TalkAudioLevel.normalized(rms = 0.01), 1e-3f)
+    assertEquals(0f, TalkAudioLevel.normalized(rms = 0.0), 0f)
+    assertEquals(1f, TalkAudioLevel.normalized(rms = 1.0), 0f)
   }
 
   @Test
   fun trailingOddByteAndEmptyLengthAreIgnored() {
     val frame = pcm16Frame(samples = 2, sample = Short.MAX_VALUE) + byteArrayOf(0x7F)
-    assertEquals(1f, pcm16MeanAbsLevel(frame, frame.size), 1e-6f)
-    assertEquals(0f, pcm16MeanAbsLevel(frame, 0), 0f)
-    assertEquals(0f, pcm16MeanAbsLevel(frame, 1), 0f)
+    assertEquals(1f, TalkAudioLevel.pcm16Level(frame, frame.size), 1e-6f)
+    assertEquals(0f, TalkAudioLevel.pcm16Level(frame, 0), 0f)
+    assertEquals(0f, TalkAudioLevel.pcm16Level(frame, 1), 0f)
   }
 
   @Test
   fun smoothingMatchesIosWeighting() {
-    assertEquals(0.2f, smoothedAudioLevel(previous = 0f, raw = 1f), 1e-6f)
-    assertEquals(0.36f, smoothedAudioLevel(previous = 0.2f, raw = 1f), 1e-6f)
-    assertEquals(0.8f, smoothedAudioLevel(previous = 1f, raw = 0f), 1e-6f)
+    assertEquals(0.2f, TalkAudioLevel.smoothed(previous = 0f, raw = 1f), 1e-6f)
+    assertEquals(0.36f, TalkAudioLevel.smoothed(previous = 0.2f, raw = 1f), 1e-6f)
+    assertEquals(0.8f, TalkAudioLevel.smoothed(previous = 1f, raw = 0f), 1e-6f)
   }
 
   private fun pcm16Frame(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -373,6 +373,22 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun finalUserTranscriptMarksAwaitingAgentUntilStatusMovesOn() {
+    val manager = createManager()
+
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+
+    assertFalse(manager.awaitingAgent.value)
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "user", text = "hello", final = true))
+    assertTrue(manager.awaitingAgent.value)
+    // Any later status transition clears the typed flag; forgetting it at a
+    // new setStatus site fails safe instead of showing a stale Thinking wave.
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "assistant", text = "hi there", final = true))
+    manager.stopAllCapture()
+    assertFalse(manager.awaitingAgent.value)
+  }
+
+  @Test
   fun realtimeTranscriptDeltasAccumulateVoiceConversation() {
     val manager = createManager()
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #102901/#103099: the Android talk stack still lagged the Apple platforms in two ways.

1. **Different loudness curve.** Android metered PCM with mean-abs and voice notes with linear peak/32767, while iOS/macOS use RMS through a 50 dB window (`TalkAudioLevel`). The same voice at the same distance rendered a much flatter wave on Android — quiet speech (-40 dBFS) reads 0.2 on iOS but ~0.01 linear on Android.
2. **Stringly-typed Thinking state.** The waveform's Thinking phase was derived by matching `statusText` against the literals `"Thinking…" / "Connecting…" / "Generating voice…"` in the UI — a drift-prone contract on user-visible copy.

## Why This Change Was Made

- New `TalkAudioLevel.kt` is an exact Kotlin port of OpenClawKit's `TalkAudioLevel` (PCM16 RMS, 50 dB window, iOS smoothing weights); dictation, realtime talk input, playback metering, and voice-note amplitude all use it, and the mean-abs/linear helpers are deleted. Unit tests assert the shared curve (half amplitude → 0.8796, -40 dBFS → 0.2) so the platforms cannot silently diverge again.
- `TalkModeManager` now publishes a typed `awaitingAgent: StateFlow<Boolean>`. Every status change flows through one `setStatus(text, awaitingAgent)` helper so the flag can never drift from the text; forgetting the flag at a new status site fails safe (wave shows Listening/Idle, never a stale Thinking). The UI's status-literal set is deleted and `talkSessionWaveformPhase` takes the boolean.
- Review-hardened: a formerly no-op status republish in `onReadyForSpeech` and the preserve-status teardown restore both keep the flag consistent with the text (caught by structured review, covered by the sweep).

## User Impact

Android talk, dictation, and voice-note waves now respond to voice exactly like iOS/macOS at the same loudness, and the Thinking wave can no longer be broken by rewording a status string.

## Evidence

- `:app:ktlintCheck` and `:app:testPlayDebugUnitTest` (AudioLevelsTest, TalkModeManagerTest incl. new awaiting-agent transition test, VoiceScreenLogicTest, VoiceNoteRecorderControllerTest) — BUILD SUCCESSFUL.
- Structured review: autoreview (codex, gpt-5.5) — one finding accepted and fixed (no-op status republish clearing the flag), rerun clean with zero findings.
- Note: the two follow-up chips from #102901 already landed separately as #103098 (SwiftFormat 0.62 pin — `pnpm ios:build` verified green on main with the lint phase active) and #103094 (orphaned composer removal); this PR is the remaining Android alignment.
