### PR TITLE
fix(slack): remember resolved channel types so mpDM bot messages key one session (#102676)

### DIFF
--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -493,6 +493,7 @@ export async function authorizeSlackSystemEventSender(params: {
    *  and applies interactive-only owner allowFrom checks without changing the
    *  open-by-default channel behavior when no allowlists are configured. */
   interactiveEvent?: boolean;
+  eventScope?: SlackEventScope;
 }): Promise<SlackSystemEventAuthorization> {
   const senderId = params.senderId?.trim();
   if (!senderId) {
@@ -510,7 +511,11 @@ export async function authorizeSlackSystemEventSender(params: {
   }
 
   const channelId = params.channelId?.trim();
-  let channelType = normalizeSlackChannelType(params.channelType, channelId);
+  let channelType = normalizeSlackChannelType(
+    params.channelType ??
+      (channelId ? params.ctx.recallSlackChannelType(channelId, params.eventScope) : undefined),
+    channelId,
+  );
   let channelName: string | undefined;
   if (channelId) {
     const info: {
@@ -518,7 +523,10 @@ export async function authorizeSlackSystemEventSender(params: {
       type?: "im" | "mpim" | "channel" | "group";
     } = await params.ctx.resolveChannelName(channelId).catch(() => ({}));
     channelName = info.name;
-    const resolvedTypeSource = params.channelType ?? info.type;
+    const resolvedTypeSource =
+      params.channelType ??
+      info.type ??
+      params.ctx.recallSlackChannelType(channelId, params.eventScope);
     channelType = normalizeSlackChannelType(resolvedTypeSource, channelId);
     if (
       !params.ctx.isChannelAllowed({
@@ -599,6 +607,12 @@ export async function authorizeSlackSystemEventSender(params: {
     interactiveEvent: params.interactiveEvent === true,
   });
   if (decision.decision === "allow") {
+    // Remember the resolved channel type so later system events (e.g.
+    // message_changed, message_deleted) in the same mpDM room key the
+    // same session family as ordinary messages (#102676).
+    if (channelType && channelId) {
+      params.ctx.rememberSlackChannelType(channelId, channelType, params.eventScope);
+    }
     return {
       allowed: true,
       channelType,

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -125,4 +125,36 @@ describe("createSlackMonitorContext resolveSlackSystemEventSessionKey", () => {
       }),
     ).toBe("agent:main:slack:direct:u_shortcut");
   });
+
+  it("uses recallSlackChannelType for system events missing channel_type (#102676)", () => {
+    const ctx = createTestContext({ groupDmEnabled: true });
+
+    // First, remember the mpDM type via the normal recall/remember path
+    ctx.rememberSlackChannelType("C0MPDM42", "mpim");
+
+    // Then resolve a system event (message_changed/message_deleted) that
+    // omits channel_type — recall must supply the remembered "mpim" so
+    // the session key is slack:group: instead of slack:channel:.
+    const key = ctx.resolveSlackSystemEventSessionKey({
+      channelId: "C0MPDM42",
+      channelType: undefined,
+      senderId: "U_BOT",
+    });
+
+    expect(key).toMatch(/^agent:main:slack:group:/);
+  });
+
+  it("falls back to C-prefix inference when recall has not been primed (#102676)", () => {
+    const ctx = createTestContext();
+
+    // No rememberSlackChannelType call — recall returns undefined,
+    // so the session key falls through to C-prefix inference → "channel".
+    const key = ctx.resolveSlackSystemEventSessionKey({
+      channelId: "C0MPDM42",
+      channelType: undefined,
+      senderId: "U_BOT",
+    });
+
+    expect(key).toMatch(/^agent:main:slack:channel:/);
+  });
 });

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -171,6 +171,15 @@ export type SlackMonitorContext = {
     purpose?: string;
   }>;
   resolveUserName: (userId: string, eventScope?: SlackEventScope) => Promise<{ name?: string }>;
+  rememberSlackChannelType: (
+    channelId: string,
+    type: SlackMessageEvent["channel_type"],
+    eventScope?: SlackEventScope,
+  ) => void;
+  recallSlackChannelType: (
+    channelId: string,
+    eventScope?: SlackEventScope,
+  ) => SlackMessageEvent["channel_type"] | undefined;
   setSlackThreadStatus: (params: {
     channelId: string;
     threadTs?: string;
@@ -252,6 +261,11 @@ export function createSlackMonitorContext(params: {
       purpose?: string;
     }
   >();
+  /** Remembers authoritative channel types from explicit event data so
+   *  later messages in the same channel that lack channel_type (e.g.
+   *  bot-authored mpDM messages) can reuse the correct classification
+   *  instead of falling back to C-prefix → "channel" inference. */
+  const channelTypeMemory = new Map<string, SlackMessageEvent["channel_type"]>();
   const userCache = new Map<string, { name?: string }>();
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
@@ -268,6 +282,21 @@ export function createSlackMonitorContext(params: {
 
   const scopedKey = (key: string, eventScope?: SlackEventScope) =>
     eventScope ? `${params.accountId}:${eventScope.teamId}:${key}` : key;
+
+  const rememberSlackChannelType = (
+    channelId: string,
+    type: SlackMessageEvent["channel_type"],
+    eventScope?: SlackEventScope,
+  ) => {
+    channelTypeMemory.set(scopedKey(channelId, eventScope), type);
+  };
+
+  const recallSlackChannelType = (
+    channelId: string,
+    eventScope?: SlackEventScope,
+  ): SlackMessageEvent["channel_type"] | undefined => {
+    return channelTypeMemory.get(scopedKey(channelId, eventScope));
+  };
 
   const markMessageSeen = (
     channelId: string | undefined,
@@ -350,7 +379,10 @@ export function createSlackMonitorContext(params: {
   }) => {
     const channelId = normalizeOptionalString(p.channelId) ?? "";
     const senderId = normalizeOptionalString(p.senderId) ?? "";
-    const channelType = normalizeSlackChannelType(p.channelType, channelId);
+    const channelType = normalizeSlackChannelType(
+      p.channelType ?? recallSlackChannelType(channelId),
+      channelId,
+    );
     const isDirectMessage = channelType === "im";
     if (!channelId && (!isDirectMessage || !senderId)) {
       return params.mainKey;
@@ -692,6 +724,8 @@ export function createSlackMonitorContext(params: {
     isChannelAllowed,
     resolveChannelName,
     resolveUserName,
+    rememberSlackChannelType,
+    recallSlackChannelType,
     setSlackThreadStatus,
     getSlackAssistantThreadContext,
     saveSlackAssistantThreadContext,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -252,20 +252,18 @@ export function createSlackMonitorContext(params: {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
 
-  const channelCache = new Map<
-    string,
-    {
-      name?: string;
-      type?: SlackMessageEvent["channel_type"];
-      topic?: string;
-      purpose?: string;
-    }
-  >();
-  /** Remembers authoritative channel types from explicit event data so
-   *  later messages in the same channel that lack channel_type (e.g.
-   *  bot-authored mpDM messages) can reuse the correct classification
-   *  instead of falling back to C-prefix → "channel" inference. */
-  const channelTypeMemory = new Map<string, SlackMessageEvent["channel_type"]>();
+  const channelCache = new Map<string, ChannelCacheEntry>();
+  /** observedType tracks authoritative channel types from explicit event
+   *  channel_type data, stored in the same cache entry so classification
+   *  does not drift between API-fetched metadata and event-observed types.
+   *  See #102676. */
+  interface ChannelCacheEntry {
+    name?: string;
+    type?: SlackMessageEvent["channel_type"];
+    topic?: string;
+    purpose?: string;
+    observedType?: SlackMessageEvent["channel_type"];
+  }
   const userCache = new Map<string, { name?: string }>();
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
@@ -288,14 +286,17 @@ export function createSlackMonitorContext(params: {
     type: SlackMessageEvent["channel_type"],
     eventScope?: SlackEventScope,
   ) => {
-    channelTypeMemory.set(scopedKey(channelId, eventScope), type);
+    const key = scopedKey(channelId, eventScope);
+    const existing = channelCache.get(key) ?? {};
+    existing.observedType = type;
+    channelCache.set(key, existing);
   };
 
   const recallSlackChannelType = (
     channelId: string,
     eventScope?: SlackEventScope,
   ): SlackMessageEvent["channel_type"] | undefined => {
-    return channelTypeMemory.get(scopedKey(channelId, eventScope));
+    return channelCache.get(scopedKey(channelId, eventScope))?.observedType;
   };
 
   const markMessageSeen = (

--- a/extensions/slack/src/monitor/events/system-event-context.ts
+++ b/extensions/slack/src/monitor/events/system-event-context.ts
@@ -3,6 +3,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
+import type { SlackEventScope } from "../event-scope.js";
 
 type SlackAuthorizedSystemEventContext = {
   channelLabel: string;
@@ -15,13 +16,15 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
   channelId?: string;
   channelType?: string | null;
   eventKind: string;
+  eventScope?: SlackEventScope;
 }): Promise<SlackAuthorizedSystemEventContext | undefined> {
-  const { ctx, senderId, channelId, channelType, eventKind } = params;
+  const { ctx, senderId, channelId, channelType, eventKind, eventScope } = params;
   const auth = await authorizeSlackSystemEventSender({
     ctx,
     senderId,
     channelId,
     channelType,
+    eventScope,
   });
   if (!auth.allowed) {
     logVerbose(

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -4198,6 +4198,8 @@ describe("prepareSlackMessage sender prefix", () => {
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
       resolveUserName: async () => ({ name: "Alice" }),
       setSlackThreadStatus: async () => undefined,
+      rememberSlackChannelType: () => {},
+      recallSlackChannelType: () => undefined,
     } as unknown as SlackMonitorContext;
   }
 
@@ -4357,6 +4359,60 @@ describe("prepareSlackMessage sender prefix", () => {
       throw new Error("expected sender prefix message result");
     }
     expect(result.ctxPayload?.CommandAuthorized).toBe(true);
+  });
+
+  it("keeps one mpDM classification when a later event omits channel_type (#102676)", async () => {
+    const slackCtx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true, allowBots: true, groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    slackCtx.resolveChannelName = async () => ({});
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const account = createSlackTestAccount({ allowBots: true });
+
+    const humanMsg = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: {
+        channel: "C0MPDM42",
+        channel_type: "mpim",
+        user: "U_HUMAN",
+        text: "hello everyone",
+        ts: "1.000",
+      } as SlackMessageEvent,
+      opts: { source: "message" },
+    });
+    if (!humanMsg) {
+      throw new Error("expected human mpim message");
+    }
+    expect(humanMsg.ctxPayload.ChatType).toBe("group");
+    expect(humanMsg.ctxPayload.From).toMatch(/^slack:group:/);
+
+    const botMsg = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: {
+        channel: "C0MPDM42",
+        // No channel_type — bot-authored messages lack it
+        user: undefined,
+        bot_id: "B_OTHER",
+        subtype: "bot_message",
+        text: "I am a bot",
+        ts: "2.000",
+      } as SlackMessageEvent,
+      opts: { source: "message" },
+    });
+    if (!botMsg) {
+      throw new Error("expected bot mpim message");
+    }
+    expect(botMsg.ctxPayload.ChatType).toBe("group");
+    expect(botMsg.ctxPayload.From).toMatch(/^slack:group:/);
+
+    // Both messages share the same session key family
+    expect(humanMsg.ctxPayload.From).toBe(botMsg.ctxPayload.From);
   });
 });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -505,10 +505,16 @@ async function resolveSlackConversationContext(params: {
   if (resolvedChannelType !== "im" && (!message.channel_type || message.channel_type !== "im")) {
     channelInfo = await ctx.resolveChannelName(message.channel, params.eventScope);
     resolvedChannelType = normalizeSlackChannelType(
-      message.channel_type ?? channelInfo.type,
+      message.channel_type ??
+        channelInfo.type ??
+        ctx.recallSlackChannelType(message.channel, params.eventScope),
       message.channel,
     );
   }
+  // Remember the resolved channel type so later messages in the same room
+  // that lack channel_type (e.g. bot-authored mpDM messages) can reuse it
+  // instead of falling back to C-prefix → "channel" inference (#102676).
+  ctx.rememberSlackChannelType(message.channel, resolvedChannelType, params.eventScope);
   const channelName = channelInfo?.name;
   const isDirectMessage = resolvedChannelType === "im";
   const isGroupDm = resolvedChannelType === "mpim";


### PR DESCRIPTION
## What Problem This Solves

A Slack multi-party DM (`mpim`) room produces **two parallel sessions per agent**. Human-authored messages carry `channel_type: "mpim"` on the event and key `slack:group:<channelId>`; bot-authored inbound shapes omit `channel_type`, and when the `conversations.info` fill cannot resolve the type either, C-prefix inference falls back to `"channel"` and keys a second `slack:channel:<channelId>` session for the same room. Modern mpDM ids are C-prefixed, so prefix inference cannot disambiguate. (Fixes #102676.)

## Why This Change Was Made

The room's type is **already known** from events previously seen for it — the fix carries that knowledge forward instead of rediscovering (or guessing). An `observedType` field on the existing `channelCache` entry remembers explicit `channel_type` values after `normalizeSlackChannelType` resolves them; the resolution chain becomes `event type → channel-info fill → remembered type → prefix inference`. The system-event authorization path (`authorizeSlackSystemEventSender`) consults the same memory so `message_changed` / `message_deleted` events key identically, and remembers the type on success for future events.

Relative to closed attempts on this issue: **no new network lookups** (#102752 added one and was closed for it), and it fixes the reported **C-prefixed** path mechanism itself rather than special-casing an ID prefix (#102702 only changed G-prefixed IDs). The remembered value is a *last* fallback — an explicit event type or successful `conversations.info` result always wins.

## User Impact

One session per agent per mpDM room: agents keep a single conversation context and history instead of silently splitting across `slack:group:` and `slack:channel:` keys when bots talk to each other. No config change; no new public options; no behavior change for public/private channels (`slack:channel:`), DMs (`slack:direct:`), or G-prefixed group DMs.

## ClawSweeper Review Fixes Applied

Fixes from ClawSweeper review:

1. **Merged `channelTypeMemory` into `channelCache`** — replaced the separate Map with an `observedType` field on the existing `ChannelCacheEntry`, eliminating a second classification owner that could drift.

2. **Fixed system-event authorization path** — `authorizeSlackSystemEventSender` now calls `recallSlackChannelType` in its type-resolution chain (before C-prefix inference fallback), and remembers the resolved type on authorization success. Also added `eventScope` pass-through for Enterprise Grid compatibility.

3. **Added system-event regression tests** — `context.test.ts` now covers `resolveSlackSystemEventSessionKey` with primed and unprimed recall.

## Files Changed

- **extensions/slack/src/monitor/context.ts** — Add `observedType` to `ChannelCacheEntry`; `rememberSlackChannelType`/`recallSlackChannelType` now read/write channelCache instead of a separate Map; recall fallback in `resolveSlackSystemEventSessionKey`
- **extensions/slack/src/monitor/auth.ts** — Add `eventScope` param, `recallSlackChannelType` fallback in type-resolution chain; remember resolved type on auth success
- **extensions/slack/src/monitor/events/system-event-context.ts** — Add `eventScope` param pass-through
- **extensions/slack/src/monitor/message-handler/prepare.ts** — Add recall fallback in `resolveSlackConversationContext` type-resolution chain; remember resolved type after every message
- **extensions/slack/src/monitor/message-handler/prepare.test.ts** — Regression test for human+bot same-mpDM classification; add new methods to mock context
- **extensions/slack/src/monitor/context.test.ts** — System-event recall regression tests (primed + unprimed paths)