### PR TITLE
fix(crestodian): prevent stale rescue approvals after new commands

### DIFF
--- a/scripts/e2e/crestodian-rescue-docker-client.ts
+++ b/scripts/e2e/crestodian-rescue-docker-client.ts
@@ -132,6 +132,63 @@ async function main() {
 
   const gatewayRestarts: string[] = [];
   const gatewayCommand = makeParams("/crestodian restart gateway", cfg).command;
+  const staleGatewayRestarts: string[] = [];
+  const staleGatewayPlan = await runCrestodianRescueMessage({
+    cfg,
+    command: gatewayCommand,
+    commandBody: "/crestodian restart gateway",
+    agentId: "default",
+    isGroup: false,
+    deps: {
+      runGatewayRestart: async () => {
+        staleGatewayRestarts.push("restart");
+      },
+    },
+  });
+  assert(
+    staleGatewayPlan?.includes("Reply /crestodian yes to apply"),
+    "stale-approval scenario did not create a gateway restart plan",
+  );
+  const pluginList = await runCrestodianRescueMessage({
+    cfg,
+    command: makeParams("/crestodian plugins list", cfg).command,
+    commandBody: "/crestodian plugins list",
+    agentId: "default",
+    isGroup: false,
+    deps: {
+      runPluginsList: async (runtime) => {
+        runtime.log("plugin rows");
+      },
+    },
+  });
+  assert(pluginList?.includes("plugin rows"), "intervening plugin list did not complete");
+  const staleApproval = await runCrestodianRescueMessage({
+    cfg,
+    command: makeParams("/crestodian yes", cfg).command,
+    commandBody: "/crestodian yes",
+    agentId: "default",
+    isGroup: false,
+    deps: {
+      runGatewayRestart: async () => {
+        staleGatewayRestarts.push("restart");
+      },
+    },
+  });
+  assert(
+    staleApproval === "No pending Crestodian rescue change is waiting for approval.",
+    "approval after an intervening command did not report no pending change",
+  );
+  assert(staleGatewayRestarts.length === 0, "stale gateway restart unexpectedly executed");
+  console.log(
+    [
+      "Crestodian stale-approval behavior:",
+      "persistent-plan=approval-required",
+      "intervening-command=plugins-list-completed",
+      "later-approval=no-pending-change",
+      `stale-gateway-restarts=${staleGatewayRestarts.length}`,
+    ].join("\n"),
+  );
+
   const gatewayPlan = await runCrestodianRescueMessage({
     cfg,
     command: gatewayCommand,

--- a/src/crestodian/rescue-message.test.ts
+++ b/src/crestodian/rescue-message.test.ts
@@ -258,6 +258,29 @@ describe("Crestodian rescue message", () => {
     });
   });
 
+  it("drops stale pending rescue changes before a new non-persistent command", async () => {
+    await withRescueStateDir("intervening-command-", async () => {
+      const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
+      const deps = {
+        runGatewayRestart: vi.fn(async () => {}),
+        runPluginsList: vi.fn(async (runtime: RuntimeEnv) => {
+          runtime.log("plugin rows");
+        }),
+      };
+
+      await expect(
+        runRescue("/crestodian restart gateway", cfg, commandContext(), deps),
+      ).resolves.toContain("Reply /crestodian yes to apply");
+      await expect(
+        runRescue("/crestodian plugins list", cfg, commandContext(), deps),
+      ).resolves.toContain("plugin rows");
+      await expect(runRescue("/crestodian yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending Crestodian rescue change is waiting for approval.",
+      );
+      expect(deps.runGatewayRestart).not.toHaveBeenCalled();
+    });
+  });
+
   it("refuses plugin install from remote rescue", async () => {
     const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
     const deps = {

--- a/src/crestodian/rescue-message.ts
+++ b/src/crestodian/rescue-message.ts
@@ -217,6 +217,9 @@ export async function runCrestodianRescueMessage(
   }
 
   const operation = parseCrestodianOperation(rescueMessage);
+  // A new rescue command supersedes any older proposal for this sender. Persistent
+  // operations below replace it with a fresh plan; read-only/unsupported commands leave none.
+  await fs.rm(pendingPath, { force: true });
   const unsupported = formatUnsupportedRemoteOperation(operation);
   if (unsupported) {
     return unsupported;


### PR DESCRIPTION
Closes #102930

AI-assisted with Codex. I reviewed the implementation and validation results.

## What Problem This Solves

Fixes an issue where a later `/crestodian yes` could apply an older state-changing rescue operation after the user had already issued a different non-persistent rescue command.

## Why This Change Was Made

Every new non-approval rescue command now supersedes the pending proposal for the same sender and channel. The pending file is cleared after rescue policy checks and parsing; a fresh persistent command replaces it with a new plan, while read-only or unsupported commands leave no stale approval behind.

The packaged Docker client now exercises this exact lifecycle so the installed-package lane cannot pass without proving the changed behavior.

## User Impact

Users can no longer accidentally approve an obsolete rescue operation after running another command. Approval remains scoped to the currently presented persistent rescue plan.

## Evidence

- Added a regression covering `restart gateway` -> `plugins list` -> `/crestodian yes`; the stale restart is not executed and the final approval reports no pending change.
- Added the same sequence to `scripts/e2e/crestodian-rescue-docker-client.ts`, which imports the packaged `/app/dist` runtime from the functional Docker image.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/crestodian/rescue-message.test.ts src/crestodian/operations.test.ts src/crestodian/audit.test.ts -- --reporter=verbose` (41 tests passed).
- `node_modules/.bin/oxfmt --check --threads=1 scripts/e2e/crestodian-rescue-docker-client.ts src/crestodian/rescue-message.ts src/crestodian/rescue-message.test.ts` (passed).
- `git diff --check` (passed).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings, patch correct 0.89).

### Installed real-behavior proof

Behavior addressed: a pending gateway restart must be invalidated by a later non-persistent plugin-list command, so a subsequent approval cannot execute the stale restart.

Real environment tested: macOS arm64 host, Docker Desktop 29.0.1, Linux arm64 functional container, Node 22.22.3, and pnpm 11.2.2. No provider or channel secrets were used.

Exact redacted command:

```sh
DOCKER_CONFIG=<temporary-anonymous-config> \
DOCKER_HOST=unix://$HOME/.docker/run/docker.sock \
pnpm test:docker:crestodian-rescue
```

The lane rebuilt OpenClaw, checked the npm tarball, installed that tarball into the functional image, and ran the mounted E2E client against the packaged `/app/dist` modules.

Redacted installed-run output:

```text
OpenClaw package tarball integrity passed.
Running in-container Crestodian rescue smoke...
Crestodian stale-approval behavior:
persistent-plan=approval-required
intervening-command=plugins-list-completed
later-approval=no-pending-change
stale-gateway-restarts=0
Crestodian rescue Docker E2E passed
OK
```

Observed result: the persistent plan was created, the intervening non-persistent command completed, the later approval reported no pending change, and the injected gateway restart dependency was invoked zero times.

What was not tested: this was the explicitly requested local Docker fallback, not Blacksmith Testbox or brokered AWS Crabbox, and it did not use a live messaging provider.
