### PR TITLE
fix(tui): keep assistant text chronological across tool calls and resume; condense tool cards

### DIFF
--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -10,7 +10,7 @@ import {
 import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.js";
 
-const VERBOSE_LEVELS = ["on", "off"];
+const VERBOSE_LEVELS = ["on", "off", "full"];
 const TRACE_LEVELS = ["on", "off"];
 const FAST_LEVELS = ["status", "auto", "on", "off"];
 const REASONING_LEVELS = ["on", "off"];
@@ -139,7 +139,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     },
     {
       name: "verbose",
-      description: "Set verbose on/off",
+      description: "Set verbose on/off/full (full includes tool output)",
       getArgumentCompletions: verboseCompletions,
     },
     {
@@ -227,7 +227,7 @@ export function helpText(options: SlashCommandOptions = {}): string {
     "/model <provider/model> (or /models)",
     `/think <${thinkLevels}>`,
     "/fast <status|auto|on|off>",
-    "/verbose <on|off>",
+    "/verbose <on|off|full>",
     "/trace <on|off>",
     "/reasoning <on|off>",
     "/usage <off|tokens|full|reset|inherit|clear|default>",

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -75,6 +75,61 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(1);
   });
 
+  it("renders assistant text after a mid-run tool call below the tool card, not above it", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Let me check that for you.", "run-1");
+    chatLog.startTool("tool-1", "bash", { command: "ls" });
+    chatLog.updateToolResult("tool-1", { content: [{ type: "text", text: "file1\nfile2" }] });
+    // Same runId: the underlying run streams one cumulative buffer across the
+    // whole tool-calling loop, so this includes the pre-tool text too.
+    chatLog.updateAssistant(
+      "Let me check that for you.\n\nHere's what I found: file1, file2.",
+      "run-1",
+    );
+
+    expect(chatLog.children.map((c) => c.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+    ]);
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    const preToolIndex = rendered.indexOf("Let me check that for you.");
+    const toolIndex = rendered.indexOf("Bash");
+    const postToolIndex = rendered.indexOf("Here's what I found");
+    expect(preToolIndex).toBeGreaterThanOrEqual(0);
+    expect(toolIndex).toBeGreaterThan(preToolIndex);
+    expect(postToolIndex).toBeGreaterThan(toolIndex);
+  });
+
+  it("does not duplicate earlier segments across a second mid-run tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.updateAssistant("Sure, let me look.", "run-1");
+    chatLog.startTool("tool-1", "bash", { command: "ls" });
+    chatLog.updateToolResult("tool-1", { content: [{ type: "text", text: "a.txt" }] });
+    chatLog.updateAssistant("Sure, let me look.\n\nAlright, found a file.", "run-1");
+    chatLog.startTool("tool-2", "bash", { command: "cat a.txt" });
+    chatLog.updateToolResult("tool-2", { content: [{ type: "text", text: "hello" }] });
+    chatLog.updateAssistant(
+      "Sure, let me look.\n\nAlright, found a file.\n\nIt says hello.",
+      "run-1",
+    );
+
+    expect(chatLog.children.map((c) => c.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+    ]);
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    const occurrences = (needle: string) => rendered.split(needle).length - 1;
+    expect(occurrences("Sure, let me look.")).toBe(1);
+    expect(occurrences("Alright, found a file.")).toBe(1);
+    expect(occurrences("It says hello.")).toBe(1);
+  });
+
   it("reserves assistant position without clearing existing streamed text", () => {
     const chatLog = new ChatLog(40);
     chatLog.startAssistant("partial", "run-active");
@@ -96,6 +151,73 @@ describe("ChatLog", () => {
     chatLog.updateToolResult("tool-1", { content: [{ type: "text", text: "done" }] });
 
     expect(chatLog.children.length).toBe(20);
+  });
+
+  it("shows a one-line fuzzy activity summary that updates in place as tools run", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.recordToolActivity("run-1", "read", "tool-1");
+    let rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("Read a file");
+    expect(chatLog.children.length).toBe(1);
+
+    chatLog.recordToolActivity("run-1", "bash", "tool-2");
+    rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("Read a file and ran a command");
+    // Same run, same component: updates in place instead of adding a new row.
+    expect(chatLog.children.length).toBe(1);
+  });
+
+  it("does not double-count a repeated start event for the same tool call", () => {
+    const chatLog = new ChatLog(40);
+
+    chatLog.recordToolActivity("run-1", "read", "tool-1");
+    chatLog.recordToolActivity("run-1", "read", "tool-1");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("Read a file");
+    expect(rendered).not.toContain("Read 2 files");
+  });
+
+  it("does not duplicate assistant text when history replay crosses tool boundaries", () => {
+    // Simulates loadHistory() replay: updateAssistant() for assistant messages,
+    // startTool() for tool results. Before the fix, the cumulative text from
+    // a run that spans tool calls would duplicate the pre-tool portion.
+    const chatLog = new ChatLog(40);
+
+    // Replay: assistant says something, then a tool call happens.
+    chatLog.updateAssistant("Let me look into that.", "replay-run");
+    chatLog.startTool("t1", "bash", { command: "ls" });
+    chatLog.updateToolResult("t1", { content: [{ type: "text", text: "a.txt b.txt" }] });
+    // Replay: assistant continues with cumulative text (includes pre-tool part).
+    chatLog.updateAssistant("Let me look into that.\n\nFound a.txt and b.txt.", "replay-run");
+    chatLog.startTool("t2", "bash", { command: "cat a.txt" });
+    chatLog.updateToolResult("t2", { content: [{ type: "text", text: "hello world" }] });
+    // Replay: final assistant message with full cumulative text.
+    chatLog.updateAssistant(
+      "Let me look into that.\n\nFound a.txt and b.txt.\n\nIt says hello world.",
+      "replay-run",
+    );
+
+    // Clean up streaming state as loadHistory does after replay.
+    chatLog["committedTextByRun"].clear();
+    chatLog["lastFullTextByRun"].clear();
+    chatLog["streamingRuns"].clear();
+
+    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+    const occurrences = (needle: string) => rendered.split(needle).length - 1;
+    // Each segment should appear exactly once — no duplication.
+    expect(occurrences("Let me look into that.")).toBe(1);
+    expect(occurrences("Found a.txt and b.txt.")).toBe(1);
+    expect(occurrences("It says hello world.")).toBe(1);
+    // Correct ordering: pre-tool text, tool, post-tool text, tool, final text.
+    expect(chatLog.children.map((c) => c.constructor.name)).toEqual([
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+      "ToolExecutionComponent",
+      "AssistantMessageComponent",
+    ]);
   });
 
   it("clears visible tool entries and stale tool references", () => {

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -2,6 +2,12 @@
 import type { Component } from "@earendil-works/pi-tui";
 import { Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { theme } from "../theme/theme.js";
+import {
+  categorizeToolActivity,
+  createEmptyToolActivityCounts,
+  formatToolActivitySummary,
+  type ToolActivityCounts,
+} from "../tool-activity-summary.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { BtwInlineMessage } from "./btw-inline-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
@@ -34,6 +40,26 @@ export class ChatLog extends Container {
   private btwMessage: BtwInlineMessage | null = null;
   private toolsExpanded = false;
   private repeatableSystemMessage: RepeatableSystemMessage | null = null;
+  // Text already frozen into a completed segment component for a run, keyed by
+  // runId. A run's assistant text streams cumulatively for its whole lifetime
+  // (through tool calls) with no segment boundaries of its own, so once a tool
+  // card lands mid-run we record how much text it already showed here and
+  // strip that prefix from later updates — otherwise the next delta would
+  // either duplicate that text in a new block or silently rewrite the old
+  // component that is now stuck above the tool card.
+  private committedTextByRun = new Map<string, string>();
+  // Last full (unstripped) cumulative buffer seen per run. Freezing must
+  // snapshot this, not the live component's already-stripped display text —
+  // otherwise a second freeze in the same run loses the first freeze's
+  // committed prefix and segmentTextFor's startsWith check falls through to
+  // re-rendering the whole buffer (duplicating every earlier segment).
+  private lastFullTextByRun = new Map<string, string>();
+  // Per-run tool-call tally backing the one-line fuzzy summary shown when
+  // verbose is off (startTool/updateToolResult are never called in that mode,
+  // so this is the only tool feedback the user gets).
+  private toolActivityCounts = new Map<string, ToolActivityCounts>();
+  private toolActivitySeenCallIds = new Map<string, Set<string>>();
+  private toolActivitySummaries = new Map<string, { component: Container; textNode: Text }>();
 
   constructor(maxComponents = 180) {
     super();
@@ -60,6 +86,11 @@ export class ChatLog extends Container {
     for (const [runId, entry] of this.pendingSystemNotices.entries()) {
       if (entry === component) {
         this.pendingSystemNotices.delete(runId);
+      }
+    }
+    for (const [runId, entry] of this.toolActivitySummaries.entries()) {
+      if (entry.component === component) {
+        this.toolActivitySummaries.delete(runId);
       }
     }
     if (this.btwMessage === component) {
@@ -95,6 +126,11 @@ export class ChatLog extends Container {
     this.clear();
     this.toolById.clear();
     this.streamingRuns.clear();
+    this.committedTextByRun.clear();
+    this.lastFullTextByRun.clear();
+    this.toolActivityCounts.clear();
+    this.toolActivitySeenCallIds.clear();
+    this.toolActivitySummaries.clear();
     this.pendingSystemNotices.clear();
     this.btwMessage = null;
     this.repeatableSystemMessage = null;
@@ -266,18 +302,53 @@ export class ChatLog extends Container {
     return this.pendingUsers.size;
   }
 
+  // History replay (tui-session-actions.ts) feeds discrete, already-final
+  // historical turns through updateAssistant()/startTool() so any tool call in
+  // the replayed history freezes and segments text the same way a live run
+  // does. Those turns are not a live cumulative run, so once replay finishes
+  // the caller resets this bookkeeping — otherwise stale freeze state could
+  // incorrectly strip a prefix from the next live run's first delta.
+  resetStreamingAssistantState() {
+    this.committedTextByRun.clear();
+    this.lastFullTextByRun.clear();
+    this.streamingRuns.clear();
+  }
+
   private resolveRunId(runId?: string) {
     return runId ?? "default";
   }
 
+  // Strips text already frozen into an earlier segment component for this run,
+  // so a resumed run only renders the portion generated since that freeze.
+  private segmentTextFor(runId: string, fullText: string) {
+    const committed = this.committedTextByRun.get(runId);
+    if (committed && fullText.startsWith(committed)) {
+      return fullText.slice(committed.length).trimStart();
+    }
+    return fullText;
+  }
+
+  // Freezes any live streaming assistant components in place before a tool
+  // card is appended. Without this, later deltas for the same run keep
+  // rewriting the old component that now sits above the tool card instead of
+  // starting a fresh one below it.
+  private freezeStreamingRuns() {
+    for (const runId of this.streamingRuns.keys()) {
+      this.committedTextByRun.set(runId, this.lastFullTextByRun.get(runId) ?? "");
+    }
+    this.streamingRuns.clear();
+  }
+
   startAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.lastFullTextByRun.set(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
+    const segmentText = this.segmentTextFor(effectiveRunId, text);
     if (existing) {
-      existing.setText(text);
+      existing.setText(segmentText);
       return existing;
     }
-    const component = new AssistantMessageComponent(text);
+    const component = new AssistantMessageComponent(segmentText);
     this.streamingRuns.set(effectiveRunId, component);
     this.appendNonSystem(component);
     return component;
@@ -294,27 +365,33 @@ export class ChatLog extends Container {
 
   updateAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.lastFullTextByRun.set(effectiveRunId, text);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (!existing) {
       this.startAssistant(text, runId);
       return;
     }
-    existing.setText(text);
+    existing.setText(this.segmentTextFor(effectiveRunId, text));
   }
 
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
+    const segmentText = this.segmentTextFor(effectiveRunId, text);
+    this.committedTextByRun.delete(effectiveRunId);
+    this.lastFullTextByRun.delete(effectiveRunId);
     if (existing) {
-      existing.setText(text);
+      existing.setText(segmentText);
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
-    this.appendNonSystem(new AssistantMessageComponent(text));
+    this.appendNonSystem(new AssistantMessageComponent(segmentText));
   }
 
   dropAssistant(runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
+    this.committedTextByRun.delete(effectiveRunId);
+    this.lastFullTextByRun.delete(effectiveRunId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (!existing) {
       return;
@@ -356,6 +433,7 @@ export class ChatLog extends Container {
       existing.setArgs(args);
       return existing;
     }
+    this.freezeStreamingRuns();
     const component = new ToolExecutionComponent(toolName, args);
     component.setExpanded(this.toolsExpanded);
     this.toolById.set(toolCallId, component);
@@ -386,5 +464,36 @@ export class ChatLog extends Container {
     for (const tool of this.toolById.values()) {
       tool.setExpanded(expanded);
     }
+  }
+
+  // One-line fuzzy activity summary for when verbose is off, e.g. "Read 2
+  // files, ran 1 command and searched for 3 patterns" — updated in place as
+  // more tools run in the same turn. Deduped by toolCallId so a duplicate
+  // start event for the same call never double-counts.
+  recordToolActivity(runId: string, toolName: string, toolCallId: string) {
+    const seen = this.toolActivitySeenCallIds.get(runId) ?? new Set<string>();
+    this.toolActivitySeenCallIds.set(runId, seen);
+    if (seen.has(toolCallId)) {
+      return;
+    }
+    seen.add(toolCallId);
+
+    const counts = this.toolActivityCounts.get(runId) ?? createEmptyToolActivityCounts();
+    counts[categorizeToolActivity(toolName)] += 1;
+    this.toolActivityCounts.set(runId, counts);
+    const text = theme.system(formatToolActivitySummary(counts));
+
+    const existing = this.toolActivitySummaries.get(runId);
+    if (existing) {
+      existing.textNode.setText(text);
+      return;
+    }
+    this.freezeStreamingRuns();
+    const component = new Container();
+    const textNode = new Text(text, 1, 0);
+    component.addChild(new Spacer(1));
+    component.addChild(textNode);
+    this.toolActivitySummaries.set(runId, { component, textNode });
+    this.appendNonSystem(component);
   }
 }

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { ToolExecutionComponent } from "./tool-execution.js";
+
+describe("ToolExecutionComponent", () => {
+  it("truncates an over-wide title+args header to the render width instead of wrapping", () => {
+    const width = 80;
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const short = new ToolExecutionComponent("read", { path: "/tmp/short" });
+    short.setResult(result);
+    const long = new ToolExecutionComponent("read", {
+      path: `/tmp/${"deeply-nested-".repeat(60)}file.txt`,
+    });
+    long.setResult(result);
+
+    const longLines = long.render(width);
+    for (const line of longLines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    }
+    // The header owns exactly one row in the condensed card: an over-wide
+    // title+args line must truncate, never wrap into extra rows.
+    expect(longLines.length).toBe(short.render(width).length);
+  });
+});

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,5 +1,12 @@
 // Tool execution component renders tool call status and output in the TUI.
-import { Box, Container, Markdown, Text } from "@earendil-works/pi-tui";
+import {
+  Box,
+  type Component,
+  Container,
+  Markdown,
+  Text,
+  truncateToWidth,
+} from "@earendil-works/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
@@ -19,6 +26,24 @@ type ToolResult = {
 };
 
 const PREVIEW_LINES = 12;
+
+// The condensed card gives the title+args header exactly one row; an over-wide
+// header must truncate at the render width (ANSI-aware), not word-wrap and push
+// the card layout open. pi-tui's TruncatedText does that but has no setter, so
+// this shim adds the setText() the refresh() cycle needs.
+class SingleLineText implements Component {
+  private text = "";
+
+  setText(text: string) {
+    this.text = text;
+  }
+
+  invalidate() {}
+
+  render(width: number): string[] {
+    return [truncateToWidth(this.text, Math.max(1, width), "…")];
+  }
+}
 
 // Prefer curated display summaries, then fall back to sanitized JSON args.
 function formatArgs(toolName: string, args: unknown): string {
@@ -59,7 +84,7 @@ function extractText(result?: ToolResult): string {
 /** Displays a running or completed tool call with optional expandable output. */
 export class ToolExecutionComponent extends Container {
   private box: Box;
-  private header: Text;
+  private header: SingleLineText;
   private argsLine: Text;
   private output: Markdown;
   private toolName: string;
@@ -74,7 +99,7 @@ export class ToolExecutionComponent extends Container {
     this.toolName = toolName;
     this.args = args;
     this.box = new Box(1, 0, (line) => theme.toolPendingBg(line));
-    this.header = new Text("", 0, 0);
+    this.header = new SingleLineText();
     this.argsLine = new Text("", 0, 0);
     this.output = new Markdown("", 0, 0, markdownTheme, {
       color: (line) => theme.toolOutput(line),

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,5 +1,5 @@
 // Tool execution component renders tool call status and output in the TUI.
-import { Box, Container, Markdown, Spacer, Text } from "@earendil-works/pi-tui";
+import { Box, Container, Markdown, Text } from "@earendil-works/pi-tui";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { markdownTheme, theme } from "../theme/theme.js";
 import { sanitizeRenderableText } from "../tui-formatters.js";
@@ -73,13 +73,12 @@ export class ToolExecutionComponent extends Container {
     super();
     this.toolName = toolName;
     this.args = args;
-    this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
+    this.box = new Box(1, 0, (line) => theme.toolPendingBg(line));
     this.header = new Text("", 0, 0);
     this.argsLine = new Text("", 0, 0);
     this.output = new Markdown("", 0, 0, markdownTheme, {
       color: (line) => theme.toolOutput(line),
     });
-    this.addChild(new Spacer(1));
     this.addChild(this.box);
     this.box.addChild(this.header);
     this.box.addChild(this.argsLine);
@@ -127,10 +126,12 @@ export class ToolExecutionComponent extends Container {
       args: this.args,
     });
     const title = `${display.emoji} ${display.label}${this.isPartial ? " (running)" : ""}`;
-    this.header.setText(theme.toolTitle(theme.bold(title)));
-
     const argLine = formatArgs(this.toolName, this.args);
-    this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
+    const combined = argLine
+      ? `${theme.toolTitle(theme.bold(title))}  ${theme.dim(argLine)}`
+      : theme.toolTitle(theme.bold(title));
+    this.header.setText(combined);
+    this.argsLine.setText("");
 
     const raw = extractText(this.result);
     const text = raw || (this.isPartial ? "…" : "");

--- a/src/tui/run-abort-notice.ts
+++ b/src/tui/run-abort-notice.ts
@@ -1,0 +1,20 @@
+// Composes the operator-facing "run aborted" notice, bounding the untrusted
+// abort diagnostic to one sanitized line before it reaches the chat log.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeRenderableText } from "./tui-formatters.js";
+
+const MAX_ABORT_DIAGNOSTIC_LENGTH = 160;
+
+export function formatRunAbortedNotice(errorMessage: string | undefined): string {
+  const diagnostic = sanitizeRenderableText(errorMessage ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!diagnostic) {
+    return "run aborted";
+  }
+  const bounded =
+    diagnostic.length > MAX_ABORT_DIAGNOSTIC_LENGTH
+      ? `${truncateUtf16Safe(diagnostic, MAX_ABORT_DIAGNOSTIC_LENGTH - 1)}…`
+      : diagnostic;
+  return `run aborted: ${bounded}`;
+}

--- a/src/tui/tool-activity-summary.test.ts
+++ b/src/tui/tool-activity-summary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  categorizeToolActivity,
+  createEmptyToolActivityCounts,
+  formatToolActivitySummary,
+} from "./tool-activity-summary.js";
+
+describe("categorizeToolActivity", () => {
+  it("maps known tool names to their activity category", () => {
+    expect(categorizeToolActivity("read")).toBe("read");
+    expect(categorizeToolActivity("write")).toBe("write");
+    expect(categorizeToolActivity("edit")).toBe("write");
+    expect(categorizeToolActivity("bash")).toBe("exec");
+    expect(categorizeToolActivity("exec")).toBe("exec");
+    expect(categorizeToolActivity("grep")).toBe("search");
+    expect(categorizeToolActivity("web_search")).toBe("search");
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(categorizeToolActivity(" Bash ")).toBe("exec");
+    expect(categorizeToolActivity("READ")).toBe("read");
+  });
+
+  it("falls back to other for unknown tool names", () => {
+    expect(categorizeToolActivity("some_future_tool")).toBe("other");
+  });
+});
+
+describe("formatToolActivitySummary", () => {
+  it("formats a single read", () => {
+    const counts = { ...createEmptyToolActivityCounts(), read: 1 };
+    expect(formatToolActivitySummary(counts)).toBe("Read a file");
+  });
+
+  it("formats a single write", () => {
+    const counts = { ...createEmptyToolActivityCounts(), write: 1 };
+    expect(formatToolActivitySummary(counts)).toBe("Wrote to a file");
+  });
+
+  it("formats a single search", () => {
+    const counts = { ...createEmptyToolActivityCounts(), search: 1 };
+    expect(formatToolActivitySummary(counts)).toBe("Searched for a pattern");
+  });
+
+  it("pluralizes counts greater than one", () => {
+    const counts = { ...createEmptyToolActivityCounts(), exec: 3 };
+    expect(formatToolActivitySummary(counts)).toBe("Ran 3 commands");
+  });
+
+  it("joins multiple categories naturally without an Oxford comma", () => {
+    const counts = { read: 2, exec: 3, write: 1, search: 2, other: 0 };
+    expect(formatToolActivitySummary(counts)).toBe(
+      "Read 2 files, wrote to a file, ran 3 commands and searched for 2 patterns",
+    );
+  });
+
+  it("appends an other-tools clause when uncategorized tools ran", () => {
+    const counts = { ...createEmptyToolActivityCounts(), read: 1, other: 2 };
+    expect(formatToolActivitySummary(counts)).toBe("Read a file and used 2 other tools");
+  });
+
+  it("returns an empty string when there is no activity", () => {
+    expect(formatToolActivitySummary(createEmptyToolActivityCounts())).toBe("");
+  });
+});

--- a/src/tui/tool-activity-summary.ts
+++ b/src/tui/tool-activity-summary.ts
@@ -1,0 +1,75 @@
+// Builds the compact one-line tool-activity summary shown when verbose mode
+// is off. Full per-call detail (tool-execution.ts) is suppressed entirely in
+// that mode, so this is the only signal a user gets that tools ran at all.
+const ACTIVITY_CATEGORIES = ["read", "write", "exec", "search"] as const;
+export type ToolActivityCategory = (typeof ACTIVITY_CATEGORIES)[number] | "other";
+
+export type ToolActivityCounts = Record<ToolActivityCategory, number>;
+
+const CATEGORY_BY_TOOL_NAME: Record<string, (typeof ACTIVITY_CATEGORIES)[number]> = {
+  read: "read",
+  write: "write",
+  edit: "write",
+  apply_patch: "write",
+  bash: "exec",
+  exec: "exec",
+  process: "exec",
+  grep: "search",
+  glob: "search",
+  web_search: "search",
+  memory_search: "search",
+  x_search: "search",
+};
+
+/** Maps a tool name to its display category, defaulting to "other" for anything uncategorized. */
+export function categorizeToolActivity(toolName: string): ToolActivityCategory {
+  const normalized = toolName.trim().toLowerCase();
+  return CATEGORY_BY_TOOL_NAME[normalized] ?? "other";
+}
+
+export function createEmptyToolActivityCounts(): ToolActivityCounts {
+  return { read: 0, write: 0, exec: 0, search: 0, other: 0 };
+}
+
+const PHRASES: Record<
+  (typeof ACTIVITY_CATEGORIES)[number],
+  { singular: string; plural: (count: number) => string }
+> = {
+  read: { singular: "Read a file", plural: (count) => `Read ${count} files` },
+  write: { singular: "Wrote to a file", plural: (count) => `Wrote to ${count} files` },
+  exec: { singular: "Ran a command", plural: (count) => `Ran ${count} commands` },
+  search: {
+    singular: "Searched for a pattern",
+    plural: (count) => `Searched for ${count} patterns`,
+  },
+};
+
+// Joins parts the way people speak a list out loud: no Oxford comma, "and"
+// only before the last item.
+function joinNaturally(parts: string[]): string {
+  if (parts.length <= 1) {
+    return parts[0] ?? "";
+  }
+  return `${parts.slice(0, -1).join(", ")} and ${parts.at(-1)}`;
+}
+
+/** Formats a fuzzy one-line summary of tool activity for a run, e.g. "Read 2 files, ran 1 command and searched for 3 patterns". */
+export function formatToolActivitySummary(counts: ToolActivityCounts): string {
+  const parts: string[] = [];
+  for (const category of ACTIVITY_CATEGORIES) {
+    const count = counts[category];
+    if (count <= 0) {
+      continue;
+    }
+    const phrase = PHRASES[category];
+    parts.push(count === 1 ? phrase.singular : phrase.plural(count));
+  }
+  if (counts.other > 0) {
+    parts.push(counts.other === 1 ? "Used another tool" : `Used ${counts.other} other tools`);
+  }
+  // Read as a continuous sentence: only the first clause keeps its capital.
+  const sentenceCased = parts.map((part, index) =>
+    index === 0 ? part : part.charAt(0).toLowerCase() + part.slice(1),
+  );
+  return joinNaturally(sentenceCased);
+}

--- a/src/tui/tool-activity-summary.ts
+++ b/src/tui/tool-activity-summary.ts
@@ -2,7 +2,7 @@
 // is off. Full per-call detail (tool-execution.ts) is suppressed entirely in
 // that mode, so this is the only signal a user gets that tools ran at all.
 const ACTIVITY_CATEGORIES = ["read", "write", "exec", "search"] as const;
-export type ToolActivityCategory = (typeof ACTIVITY_CATEGORIES)[number] | "other";
+type ToolActivityCategory = (typeof ACTIVITY_CATEGORIES)[number] | "other";
 
 export type ToolActivityCounts = Record<ToolActivityCategory, number>;
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -566,7 +566,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         break;
       case "verbose":
         if (!args) {
-          chatLog.addSystem("usage: /verbose <on|off>");
+          chatLog.addSystem("usage: /verbose <on|off|full>");
           break;
         }
         try {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -16,6 +16,7 @@ type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
   startTool: (...args: unknown[]) => void;
   updateToolResult: (...args: unknown[]) => void;
+  recordToolActivity: (...args: unknown[]) => void;
   addSystem: (...args: unknown[]) => void;
   addPendingSystem: (...args: unknown[]) => void;
   dismissPendingSystem: (...args: unknown[]) => void;
@@ -31,6 +32,7 @@ type HandlerTui = { requestRender: (...args: unknown[]) => void };
 type MockChatLog = {
   startTool: MockFn;
   updateToolResult: MockFn;
+  recordToolActivity: MockFn;
   addSystem: MockFn;
   addPendingSystem: MockFn;
   dismissPendingSystem: MockFn;
@@ -48,6 +50,7 @@ function createMockChatLog(): MockChatLog & HandlerChatLog {
   return {
     startTool: vi.fn(),
     updateToolResult: vi.fn(),
+    recordToolActivity: vi.fn(),
     addSystem: vi.fn(),
     addPendingSystem: vi.fn(),
     dismissPendingSystem: vi.fn(),
@@ -1143,7 +1146,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).not.toHaveBeenCalled();
   });
 
-  it("suppresses tool events when verbose is off", () => {
+  it("suppresses full tool cards when verbose is off but records a fuzzy activity summary", () => {
     const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
       state: {
         activeChatRunId: "run-123",
@@ -1158,7 +1161,31 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(chatLog.startTool).not.toHaveBeenCalled();
-    expect(tui.requestRender).not.toHaveBeenCalled();
+    expect(chatLog.recordToolActivity).toHaveBeenCalledWith("run-123", "session_status", "tc-off");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("does not record tool activity for non-start phases when verbose is off", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: "run-123",
+        sessionInfo: { verboseLevel: "off" },
+      },
+    });
+
+    handleAgentEvent({
+      runId: "run-123",
+      stream: "tool",
+      data: {
+        phase: "result",
+        toolCallId: "tc-off",
+        name: "session_status",
+        result: { content: [{ type: "text", text: "secret" }] },
+      },
+    });
+
+    expect(chatLog.recordToolActivity).not.toHaveBeenCalled();
+    expect(chatLog.updateToolResult).not.toHaveBeenCalled();
   });
 
   it("omits tool output when verbose is on (non-full)", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -33,6 +33,7 @@ type EventHandlerChatLog = {
     result: unknown,
     options?: { partial?: boolean; isError?: boolean },
   ) => void;
+  recordToolActivity: (runId: string, toolName: string, toolCallId: string) => void;
   addSystem: (text: string) => void;
   addPendingSystem: (runId: string, text: string) => void;
   dismissPendingSystem: (runId: string) => void;
@@ -1034,16 +1035,21 @@ export function createEventHandlers(context: EventHandlerContext) {
         armStreamingWatchdog(evt.runId);
       }
       const verbose = state.sessionInfo.verboseLevel ?? "off";
-      const allowToolEvents = verbose !== "off";
       const allowToolOutput = verbose === "full";
-      if (!allowToolEvents) {
-        return;
-      }
       const data = evt.data ?? {};
       const phase = asString(data.phase, "");
       const toolCallId = asString(data.toolCallId, "");
       const toolName = asString(data.name, "tool");
       if (!toolCallId) {
+        return;
+      }
+      if (verbose === "off") {
+        // Full tool cards are suppressed entirely in this mode; fall back to a
+        // compact one-line fuzzy summary so the user still sees that tools ran.
+        if (phase === "start") {
+          chatLog.recordToolActivity(evt.runId, toolName, toolCallId);
+          tui.requestRender();
+        }
         return;
       }
       if (phase === "start") {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,15 +1,10 @@
 // Handles TUI keyboard, paste, backend, and command events.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyFailoverReason, isAuthErrorMessage } from "../agents/embedded-agent-helpers.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
-import {
-  asString,
-  extractTextFromMessage,
-  isCommandMessage,
-  sanitizeRenderableText,
-} from "./tui-formatters.js";
+import { formatRunAbortedNotice } from "./run-abort-notice.js";
+import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import {
   clearPendingSubmit,
@@ -50,20 +45,6 @@ type EventHandlerBtwPresenter = {
   showResult: (params: { question: string; text: string; isError?: boolean }) => void;
   clear: () => void;
 };
-
-const MAX_ABORT_DIAGNOSTIC_LENGTH = 160;
-
-function formatAbortDiagnostic(value: string | undefined): string | undefined {
-  const diagnostic = sanitizeRenderableText(value ?? "")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!diagnostic) {
-    return undefined;
-  }
-  return diagnostic.length > MAX_ABORT_DIAGNOSTIC_LENGTH
-    ? `${truncateUtf16Safe(diagnostic, MAX_ABORT_DIAGNOSTIC_LENGTH - 1)}…`
-    : diagnostic;
-}
 
 type EventHandlerContext = {
   chatLog: EventHandlerChatLog;
@@ -795,8 +776,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "aborted") {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
-      const diagnostic = formatAbortDiagnostic(evt.errorMessage);
-      chatLog.addSystem(diagnostic ? `run aborted: ${diagnostic}` : "run aborted");
+      chatLog.addSystem(formatRunAbortedNotice(evt.errorMessage));
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
       maybeRefreshHistoryForRun(evt.runId);
     }

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1687,6 +1687,61 @@ describe("tui session actions", () => {
     expect(updateAssistant.mock.calls[1]?.[1]).toBe(activityRunId);
   });
 
+  it("replays tool cards with the live output policy: header-only below `full` verbosity", async () => {
+    // The live tool-event path blanks result content below `full` so cards stay
+    // header-only; replay must apply the same policy or resume renders louder
+    // than the run it replays.
+    const makeHarness = (verboseLevel: string) => {
+      const loadHistory = vi.fn().mockResolvedValue({
+        sessionId: "session-main",
+        messages: [
+          { role: "user", content: "question" },
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "read",
+            content: [{ type: "text", text: "stored output" }],
+          },
+        ],
+      });
+      const setResult = vi.fn();
+      const startTool = vi.fn().mockReturnValue({ setResult });
+      const chatLog = {
+        addSystem: vi.fn(),
+        addUser: vi.fn(),
+        updateAssistant: vi.fn(),
+        finalizeAssistant: vi.fn(),
+        startTool,
+        recordToolActivity: vi.fn(),
+        clearAll: vi.fn(),
+        clearPendingUsers: vi.fn(),
+        reconcilePendingUsers: vi.fn().mockReturnValue([]),
+        restorePendingUsers: vi.fn(),
+        resetStreamingAssistantState: vi.fn(),
+      };
+      const state = createBaseState({
+        sessionInfo: { verboseLevel } as TuiStateAccess["sessionInfo"],
+      });
+      const { loadHistory: runLoadHistory } = createTestSessionActions({
+        client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+        chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+        state,
+      });
+      return { runLoadHistory, setResult };
+    };
+
+    const collapsed = makeHarness("on");
+    await collapsed.runLoadHistory();
+    expect(collapsed.setResult).toHaveBeenCalledWith({ content: [] }, { isError: false });
+
+    const full = makeHarness("full");
+    await full.runLoadHistory();
+    expect(full.setResult).toHaveBeenCalledWith(
+      { content: [{ type: "text", text: "stored output" }], details: undefined },
+      { isError: false },
+    );
+  });
+
   it("force-renders after rebuilding chat history so transient status rows are cleared", async () => {
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-main",

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1637,33 +1637,30 @@ describe("tui session actions", () => {
     expect(firstCall[1]).not.toBe(secondCall[1]);
   });
 
-  it("replays a persisted bashExecution (`!`/`!!`) message as local-echo system lines", async () => {
+  it("records a segment boundary for replayed tool calls even when verbose is off", async () => {
+    // Default verbose level hides tool cards on replay. The hidden card must
+    // still freeze the pre-tool assistant text (via the verbose-off activity
+    // path), or the turn's later cumulative text rewrites the earlier component
+    // in place, reproducing the chronology defect on the default resume path.
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-main",
       messages: [
-        {
-          role: "bashExecution",
-          command: "echo hi",
-          output: "hi",
-          exitCode: 0,
-          excludeFromContext: false,
-        },
-        {
-          role: "bashExecution",
-          command: "false",
-          output: "",
-          exitCode: 1,
-          cancelled: false,
-          excludeFromContext: true,
-        },
+        { role: "user", content: "question" },
+        { role: "assistant", content: [{ type: "text", text: "before tool" }] },
+        { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [] },
+        { role: "assistant", content: [{ type: "text", text: "before tool\n\nafter tool" }] },
       ],
     });
-    const addSystem = vi.fn();
+    const updateAssistant = vi.fn();
+    const startTool = vi.fn();
+    const recordToolActivity = vi.fn();
     const chatLog = {
-      addSystem,
+      addSystem: vi.fn(),
       addUser: vi.fn(),
-      updateAssistant: vi.fn(),
+      updateAssistant,
       finalizeAssistant: vi.fn(),
+      startTool,
+      recordToolActivity,
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
       reconcilePendingUsers: vi.fn().mockReturnValue([]),
@@ -1678,13 +1675,16 @@ describe("tui session actions", () => {
 
     await runLoadHistory();
 
-    // Rendered regardless of excludeFromContext: that flag only controls whether the
-    // model sees it, never whether the TUI shows it back to the user on resume.
-    expect(addSystem).toHaveBeenCalledWith("[local] $ echo hi");
-    expect(addSystem).toHaveBeenCalledWith("[local] hi");
-    expect(addSystem).toHaveBeenCalledWith("[local] exit 0");
-    expect(addSystem).toHaveBeenCalledWith("[local] $ false");
-    expect(addSystem).toHaveBeenCalledWith("[local] exit 1");
+    expect(startTool).not.toHaveBeenCalled();
+    expect(recordToolActivity).toHaveBeenCalledTimes(1);
+    const [activityRunId, toolName, toolCallId] = recordToolActivity.mock.calls[0];
+    expect(toolName).toBe("read");
+    expect(toolCallId).toBe("call-1");
+    // The boundary must key to the same turn runId the surrounding assistant
+    // text streams under, or freezing it would not affect that text at all.
+    expect(updateAssistant).toHaveBeenCalledTimes(2);
+    expect(updateAssistant.mock.calls[0][1]).toBe(activityRunId);
+    expect(updateAssistant.mock.calls[1][1]).toBe(activityRunId);
   });
 
   it("force-renders after rebuilding chat history so transient status rows are cleared", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -83,11 +83,13 @@ describe("tui session actions", () => {
       chatLog: {
         addSystem: vi.fn(),
         addUser: vi.fn(),
+        updateAssistant: vi.fn(),
         finalizeAssistant: vi.fn(),
         clearPendingUsers: vi.fn(),
         clearAll: vi.fn(),
         reconcilePendingUsers: vi.fn().mockReturnValue([]),
         restorePendingUsers: vi.fn(),
+        resetStreamingAssistantState: vi.fn(),
       } as unknown as import("./components/chat-log.js").ChatLog,
       btw: createBtwPresenter(),
       tui: { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI,
@@ -628,6 +630,7 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -663,6 +666,7 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -695,6 +699,7 @@ describe("tui session actions", () => {
       finalizeAssistant: vi.fn(),
       reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
       updateAssistant,
       startTool: vi.fn(),
     } as unknown as import("./components/chat-log.js").ChatLog;
@@ -1505,11 +1510,13 @@ describe("tui session actions", () => {
     const chatLog = {
       addSystem: vi.fn(),
       addUser: vi.fn(),
+      updateAssistant: vi.fn(),
       finalizeAssistant: vi.fn(),
       clearAll: vi.fn(),
       clearPendingUsers: vi.fn(),
       reconcilePendingUsers: vi.fn().mockReturnValue([]),
       restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
     };
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
@@ -1585,6 +1592,99 @@ describe("tui session actions", () => {
       runId: "run-pending",
       text: "not persisted",
     });
+  });
+
+  it("gives each replayed assistant turn its own runId so separate turns cannot collapse into one component (#onresume)", async () => {
+    // Two user/assistant turns with nothing (no tool call) between them. Before
+    // the fix, both updateAssistant() calls shared the same default runId, so
+    // the second call's setText() silently overwrote the first turn's component
+    // instead of rendering as its own row in its own chronological position.
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [
+        { role: "user", content: "first question" },
+        { role: "assistant", content: [{ type: "text", text: "first answer" }] },
+        { role: "user", content: "second question" },
+        { role: "assistant", content: [{ type: "text", text: "second answer" }] },
+      ],
+    });
+    const updateAssistant = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      updateAssistant,
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
+    };
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    await runLoadHistory();
+
+    expect(updateAssistant).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = updateAssistant.mock.calls;
+    expect(firstCall[0]).toBe("first answer");
+    expect(secondCall[0]).toBe("second answer");
+    expect(firstCall[1]).toBeTruthy();
+    expect(secondCall[1]).toBeTruthy();
+    expect(firstCall[1]).not.toBe(secondCall[1]);
+  });
+
+  it("replays a persisted bashExecution (`!`/`!!`) message as local-echo system lines", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [
+        {
+          role: "bashExecution",
+          command: "echo hi",
+          output: "hi",
+          exitCode: 0,
+          excludeFromContext: false,
+        },
+        {
+          role: "bashExecution",
+          command: "false",
+          output: "",
+          exitCode: 1,
+          cancelled: false,
+          excludeFromContext: true,
+        },
+      ],
+    });
+    const addSystem = vi.fn();
+    const chatLog = {
+      addSystem,
+      addUser: vi.fn(),
+      updateAssistant: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
+    };
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+    });
+
+    await runLoadHistory();
+
+    // Rendered regardless of excludeFromContext: that flag only controls whether the
+    // model sees it, never whether the TUI shows it back to the user on resume.
+    expect(addSystem).toHaveBeenCalledWith("[local] $ echo hi");
+    expect(addSystem).toHaveBeenCalledWith("[local] hi");
+    expect(addSystem).toHaveBeenCalledWith("[local] exit 0");
+    expect(addSystem).toHaveBeenCalledWith("[local] $ false");
+    expect(addSystem).toHaveBeenCalledWith("[local] exit 1");
   });
 
   it("force-renders after rebuilding chat history so transient status rows are cleared", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1677,14 +1677,14 @@ describe("tui session actions", () => {
 
     expect(startTool).not.toHaveBeenCalled();
     expect(recordToolActivity).toHaveBeenCalledTimes(1);
-    const [activityRunId, toolName, toolCallId] = recordToolActivity.mock.calls[0];
+    const [activityRunId, toolName, toolCallId] = recordToolActivity.mock.calls[0] ?? [];
     expect(toolName).toBe("read");
     expect(toolCallId).toBe("call-1");
     // The boundary must key to the same turn runId the surrounding assistant
     // text streams under, or freezing it would not affect that text at all.
     expect(updateAssistant).toHaveBeenCalledTimes(2);
-    expect(updateAssistant.mock.calls[0][1]).toBe(activityRunId);
-    expect(updateAssistant.mock.calls[1][1]).toBe(activityRunId);
+    expect(updateAssistant.mock.calls[0]?.[1]).toBe(activityRunId);
+    expect(updateAssistant.mock.calls[1]?.[1]).toBe(activityRunId);
   });
 
   it("force-renders after rebuilding chat history so transient status rows are cleared", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -47,6 +47,8 @@ describe("tui session actions", () => {
       restorePendingUsers: vi.fn(),
       updateAssistant: vi.fn(),
       startTool: vi.fn(),
+      recordToolActivity: vi.fn(),
+      resetStreamingAssistantState: vi.fn(),
     } as unknown as ChatLog;
     return { chatLog, addSystem, addUser };
   };

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1630,11 +1630,11 @@ describe("tui session actions", () => {
 
     expect(updateAssistant).toHaveBeenCalledTimes(2);
     const [firstCall, secondCall] = updateAssistant.mock.calls;
-    expect(firstCall[0]).toBe("first answer");
-    expect(secondCall[0]).toBe("second answer");
-    expect(firstCall[1]).toBeTruthy();
-    expect(secondCall[1]).toBeTruthy();
-    expect(firstCall[1]).not.toBe(secondCall[1]);
+    expect(firstCall?.[0]).toBe("first answer");
+    expect(secondCall?.[0]).toBe("second answer");
+    expect(firstCall?.[1]).toBeTruthy();
+    expect(secondCall?.[1]).toBeTruthy();
+    expect(firstCall?.[1]).not.toBe(secondCall?.[1]);
   });
 
   it("records a segment boundary for replayed tool calls even when verbose is off", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -565,29 +565,17 @@ export function createSessionActions(context: SessionActionContext) {
           }
           continue;
         }
-        if (message.role === "bashExecution") {
-          // A user-run `!`/`!!` local shell command, not an agent tool call: always
-          // shown on replay regardless of verbose level, matching the live echo in
-          // tui-local-shell.ts (which itself never gates on verbose either).
-          const command = asString(message.command, "");
-          chatLog.addSystem(`[local] $ ${command}`);
-          const output = asString(message.output, "");
-          if (output) {
-            for (const outputLine of output.split("\n")) {
-              chatLog.addSystem(`[local] ${outputLine}`);
-            }
-          }
-          const exitCode = typeof message.exitCode === "number" ? message.exitCode : undefined;
-          const cancelled = message.cancelled === true;
-          chatLog.addSystem(`[local] exit ${cancelled ? "cancelled" : (exitCode ?? "?")}`);
-          continue;
-        }
         if (message.role === "toolResult") {
-          if (!showTools) {
-            continue;
-          }
           const toolCallId = asString(message.toolCallId, "");
           const toolName = asString(message.toolName, "tool");
+          if (!showTools) {
+            // A hidden card is still a segment boundary. Route through the same
+            // verbose-off path a live run uses: it freezes the pre-tool text so
+            // this turn's later cumulative text starts a new component instead
+            // of rewriting the old one, and restores the activity summary line.
+            chatLog.recordToolActivity(historyTurnRunId, toolName, toolCallId);
+            continue;
+          }
           const component = chatLog.startTool(toolCallId, toolName, {});
           component.setResult(
             {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -525,7 +525,9 @@ export function createSessionActions(context: SessionActionContext) {
             chatLog.recordToolActivity(historyTurnRunId, toolName, toolCallId);
             continue;
           }
-          const component = chatLog.startTool(toolCallId, toolName, {});
+          // History rows do not persist tool args; undefined renders a clean title-only
+          // header instead of a literal "{}" args summary on every replayed card.
+          const component = chatLog.startTool(toolCallId, toolName, undefined);
           // Mirror the live tool-event output policy: below `full` verbosity the
           // live path blanks result content so cards stay header-only. Replaying
           // stored content unfiltered would dump previews the live session

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -524,6 +524,13 @@ export function createSessionActions(context: SessionActionContext) {
       chatLog.clearAll({ preservePendingUsers: true });
       btw.clear();
       chatLog.addSystem(`session ${state.currentSessionKey}`);
+      // Groups replayed assistant/toolResult entries by the user turn they
+      // answer. Each distinct turn must get its own chatLog runId: updateAssistant()
+      // reuses an existing component for a given runId, so two separate historical
+      // turns sharing one key would collapse into a single component showing only
+      // the later turn's text, stranded at the earlier turn's position (#onresume).
+      let historyTurnSeq = 0;
+      let historyTurnRunId = `history-turn-${historyTurnSeq}`;
       for (const entry of record.messages ?? []) {
         if (!entry || typeof entry !== "object") {
           continue;
@@ -545,6 +552,8 @@ export function createSessionActions(context: SessionActionContext) {
             });
             chatLog.addUser(text);
           }
+          historyTurnSeq += 1;
+          historyTurnRunId = `history-turn-${historyTurnSeq}`;
           continue;
         }
         if (message.role === "assistant") {
@@ -552,8 +561,25 @@ export function createSessionActions(context: SessionActionContext) {
             includeThinking: state.showThinking,
           });
           if (text) {
-            chatLog.finalizeAssistant(text);
+            chatLog.updateAssistant(text, historyTurnRunId);
           }
+          continue;
+        }
+        if (message.role === "bashExecution") {
+          // A user-run `!`/`!!` local shell command, not an agent tool call: always
+          // shown on replay regardless of verbose level, matching the live echo in
+          // tui-local-shell.ts (which itself never gates on verbose either).
+          const command = asString(message.command, "");
+          chatLog.addSystem(`[local] $ ${command}`);
+          const output = asString(message.output, "");
+          if (output) {
+            for (const outputLine of output.split("\n")) {
+              chatLog.addSystem(`[local] ${outputLine}`);
+            }
+          }
+          const exitCode = typeof message.exitCode === "number" ? message.exitCode : undefined;
+          const cancelled = message.cancelled === true;
+          chatLog.addSystem(`[local] exit ${cancelled ? "cancelled" : (exitCode ?? "?")}`);
           continue;
         }
         if (message.role === "toolResult") {
@@ -579,6 +605,7 @@ export function createSessionActions(context: SessionActionContext) {
       }
       submit.reconcilePendingSubmitHistory(state, chatLog.reconcilePendingUsers(historyUsers));
       chatLog.restorePendingUsers();
+      chatLog.resetStreamingAssistantState();
       // Restore a run still streaming for this session+agent that the gateway
       // reports as in-flight. Its live deltas were delivered to a per-agent key
       // we stopped watching after switching away, so the persisted history above

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -526,16 +526,23 @@ export function createSessionActions(context: SessionActionContext) {
             continue;
           }
           const component = chatLog.startTool(toolCallId, toolName, {});
+          // Mirror the live tool-event output policy: below `full` verbosity the
+          // live path blanks result content so cards stay header-only. Replaying
+          // stored content unfiltered would dump previews the live session
+          // suppressed, making resume render louder than the run it replays.
+          const allowToolOutput = (state.sessionInfo.verboseLevel ?? "off") === "full";
           component.setResult(
-            {
-              content: Array.isArray(message.content)
-                ? (message.content as Record<string, unknown>[])
-                : [],
-              details:
-                typeof message.details === "object" && message.details
-                  ? (message.details as Record<string, unknown>)
-                  : undefined,
-            },
+            allowToolOutput
+              ? {
+                  content: Array.isArray(message.content)
+                    ? (message.content as Record<string, unknown>[])
+                    : [],
+                  details:
+                    typeof message.details === "object" && message.details
+                      ? (message.details as Record<string, unknown>)
+                      : undefined,
+                }
+              : { content: [] },
             { isError: Boolean(message.isError) },
           );
         }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -13,6 +13,7 @@ import {
 import type { ChatLog } from "./components/chat-log.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import { sessionInfoUiEquals } from "./tui-session-info-equality.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import * as submit from "./tui-submit-state.js";
 import type { SessionInfo, TuiHistoryLoadResult, TuiOptions, TuiStateAccess } from "./tui-types.js";
@@ -53,58 +54,6 @@ type SessionInfoEntry = SessionInfo & {
   modelOverride?: string;
   providerOverride?: string;
 };
-
-function thinkingLevelsEqual(
-  left?: Array<{ id: string; label: string }>,
-  right?: Array<{ id: string; label: string }>,
-): boolean {
-  if (left === right) {
-    return true;
-  }
-  if (!left || !right || left.length !== right.length) {
-    return false;
-  }
-  return left.every((level, index) => {
-    const other = right[index];
-    return other?.id === level.id && other.label === level.label;
-  });
-}
-
-function goalEquals(left: SessionInfo["goal"], right: SessionInfo["goal"]): boolean {
-  return left === right || JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
-}
-
-function agentRuntimeEquals(
-  left: SessionInfo["agentRuntime"],
-  right: SessionInfo["agentRuntime"],
-): boolean {
-  return (
-    left === right ||
-    (left?.id === right?.id && left?.source === right?.source && left?.fallback === right?.fallback)
-  );
-}
-
-function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
-  return (
-    left.thinkingLevel === right.thinkingLevel &&
-    thinkingLevelsEqual(left.thinkingLevels, right.thinkingLevels) &&
-    left.fastMode === right.fastMode &&
-    left.verboseLevel === right.verboseLevel &&
-    left.traceLevel === right.traceLevel &&
-    left.reasoningLevel === right.reasoningLevel &&
-    left.model === right.model &&
-    left.modelProvider === right.modelProvider &&
-    agentRuntimeEquals(left.agentRuntime, right.agentRuntime) &&
-    left.contextTokens === right.contextTokens &&
-    left.inputTokens === right.inputTokens &&
-    left.outputTokens === right.outputTokens &&
-    left.totalTokens === right.totalTokens &&
-    left.responseUsage === right.responseUsage &&
-    left.effectiveResponseUsage === right.effectiveResponseUsage &&
-    left.displayName === right.displayName &&
-    goalEquals(left.goal, right.goal)
-  );
-}
 
 function extractMessageTimestamp(message: Record<string, unknown>): number | null {
   const raw = message.timestamp;

--- a/src/tui/tui-session-info-equality.ts
+++ b/src/tui/tui-session-info-equality.ts
@@ -1,0 +1,55 @@
+// UI-relevant equality for SessionInfo: decides whether a session-info refresh
+// actually changes what the TUI renders (footer, model line, token counts).
+import type { SessionInfo } from "./tui-types.js";
+
+function thinkingLevelsEqual(
+  left?: Array<{ id: string; label: string }>,
+  right?: Array<{ id: string; label: string }>,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right || left.length !== right.length) {
+    return false;
+  }
+  return left.every((level, index) => {
+    const other = right[index];
+    return other?.id === level.id && other.label === level.label;
+  });
+}
+
+function goalEquals(left: SessionInfo["goal"], right: SessionInfo["goal"]): boolean {
+  return left === right || JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function agentRuntimeEquals(
+  left: SessionInfo["agentRuntime"],
+  right: SessionInfo["agentRuntime"],
+): boolean {
+  return (
+    left === right ||
+    (left?.id === right?.id && left?.source === right?.source && left?.fallback === right?.fallback)
+  );
+}
+
+export function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
+  return (
+    left.thinkingLevel === right.thinkingLevel &&
+    thinkingLevelsEqual(left.thinkingLevels, right.thinkingLevels) &&
+    left.fastMode === right.fastMode &&
+    left.verboseLevel === right.verboseLevel &&
+    left.traceLevel === right.traceLevel &&
+    left.reasoningLevel === right.reasoningLevel &&
+    left.model === right.model &&
+    left.modelProvider === right.modelProvider &&
+    agentRuntimeEquals(left.agentRuntime, right.agentRuntime) &&
+    left.contextTokens === right.contextTokens &&
+    left.inputTokens === right.inputTokens &&
+    left.outputTokens === right.outputTokens &&
+    left.totalTokens === right.totalTokens &&
+    left.responseUsage === right.responseUsage &&
+    left.effectiveResponseUsage === right.effectiveResponseUsage &&
+    left.displayName === right.displayName &&
+    goalEquals(left.goal, right.goal)
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

Two user-visible TUI rendering defects and one readability problem:

1. **Assistant text rendered out of chronological order around tool calls.** The TUI kept one streaming assistant component per run and updated it in place while tool cards appended separately, so text the model produced *after* a tool call rendered *above* that tool's card. The same defect corrupted ordering when replaying history on session resume.
2. **Tool cards were tall and noisy**, taking several lines each even when collapsed, which made runs with many tool calls hard to scan.
3. **With verbose mode off there was no indication of tool activity at all** — the TUI sat silent during long tool-heavy stretches.

## Why This Change Was Made

- Assistant streaming text is now segmented around tool cards: each new burst of assistant text after a tool call gets its own component in true arrival order, both live and on history replay (replay assigns distinct per-turn identities instead of merging a whole run into one block).
- Tool cards are condensed to one line with middle-ellipsis truncation.
- When verbose is off, a one-line tool-activity summary shows what the agent is doing instead of nothing.

Scope note: this PR originally also carried persistence for `!`/`!!` local shell commands; per review feedback it was split out and now lives in #103648. This PR is purely rendering/display.

## User Impact

- Assistant text and tool cards appear in the order they actually happened, live and after resume.
- Tool-heavy runs are much more compact and scannable.
- Verbose-off sessions show a lightweight activity line instead of appearing frozen.

## Evidence

- `src/tui/components/chat-log.test.ts` — regression tests for chronological segmentation live and on replay.
- `src/tui/tool-activity-summary.test.ts` — activity summary behavior.
- `src/tui/tui-event-handlers.test.ts`, `src/tui/tui-session-actions.test.ts` — event wiring and resume-ordering coverage.
- Full `src/tui` suite green locally; fake-backend PTY lane green (`test/vitest/vitest.tui-pty.config.ts`).
- **Real-terminal evidence** (real gateway, live inference, no mocks): live compact cards + chronological ordering, verbose-off summaries, and resume replay in both verbose tiers — https://github.com/openclaw/openclaw/pull/103147#issuecomment-4975353033. The recording process itself surfaced two replay defects, both fixed in-branch with regression tests (see the comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

