### PR TITLE
fix(sessions): enforce exact owner equality for all parent session use and narrow catch

### DIFF
--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -341,6 +341,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       allowExistingModelSelection,
       parentSessionKey: p.parentSessionKey,
       spawnDepth: p.spawnDepth,
+      pluginRuntimeOwnerId: client?.internal?.pluginRuntimeOwnerId,
       spawnedCwd: sessionCwd,
       worktree: sessionWorktree
         ? {

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -25,6 +25,7 @@ import {
 } from "../../sessions/session-lifecycle-admission.js";
 import { handleSessionStateSessionDeleted } from "../../sessions/session-state-events.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
+import { rejectPluginOwnerMismatch } from "../session-plugin-ownership.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { chatHandlers } from "./chat.js";
@@ -32,7 +33,6 @@ import { emitSessionsChanged } from "./session-change-event.js";
 import {
   loadAccessorSessionEntryForGatewayTarget,
   loadSessionsRuntimeModule,
-  rejectPluginRuntimeDeleteMismatch,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
   resolveSessionWorkerPlacementMutationError,
@@ -180,15 +180,18 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
       respondSessionWorkerPlacementMutationError(initialPlacementError, respond);
       return;
     }
-    if (
-      rejectPluginRuntimeDeleteMismatch({
-        client,
-        key: target.canonicalKey ?? key,
-        entry: initialDeleteEntry,
-        respond,
-      })
-    ) {
-      return;
+    {
+      const pluginRuntimeOwnerId = normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId);
+      const ownerError = rejectPluginOwnerMismatch(
+        pluginRuntimeOwnerId,
+        initialDeleteEntry,
+        target.canonicalKey ?? key,
+        "delete",
+      );
+      if (ownerError) {
+        respond(false, undefined, ownerError.error);
+        return;
+      }
     }
     let abortResult:
       | {
@@ -303,15 +306,20 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
           );
           return undefined;
         }
-        if (
-          rejectPluginRuntimeDeleteMismatch({
-            client,
-            key: canonicalKey ?? key,
+        {
+          const pluginRuntimeOwnerId = normalizeOptionalString(
+            client?.internal?.pluginRuntimeOwnerId,
+          );
+          const ownerError = rejectPluginOwnerMismatch(
+            pluginRuntimeOwnerId,
             entry,
-            respond,
-          })
-        ) {
-          return undefined;
+            canonicalKey ?? key,
+            "delete",
+          );
+          if (ownerError) {
+            respond(false, undefined, ownerError.error);
+            return undefined;
+          }
         }
         const mutationCleanupError = await cleanupSessionBeforeMutation({
           cfg,

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -23,7 +23,7 @@ import {
   isWorkerPlacementSessionRuntimeSupported,
   resolveWorkerPlacementSessionRuntime,
 } from "../worker-environments/placement-session-runtime.js";
-import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 export const sessionLog = createSubsystemLogger("gateway/sessions");
 
@@ -159,30 +159,6 @@ export function requireSessionKey(key: unknown, respond: RespondFn): string | nu
     return null;
   }
   return normalized;
-}
-
-export function rejectPluginRuntimeDeleteMismatch(params: {
-  client: GatewayClient | null;
-  key: string;
-  entry: SessionEntry | undefined;
-  respond: RespondFn;
-}): boolean {
-  const pluginOwnerId = normalizeOptionalString(params.client?.internal?.pluginRuntimeOwnerId);
-  if (!pluginOwnerId || !params.entry) {
-    return false;
-  }
-  if (normalizeOptionalString(params.entry.pluginOwnerId) === pluginOwnerId) {
-    return false;
-  }
-  params.respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `Plugin "${pluginOwnerId}" cannot delete session "${params.key}" because it did not create it.`,
-    ),
-  );
-  return true;
 }
 
 export function resolveGatewaySessionTargetFromKey(

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -36,7 +36,9 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { performGatewaySessionReset } from "./session-reset-service.js";
 import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
+import { loadSessionEntry as loadSessionEntryFromUtils } from "./session-utils.js";
 import {
   agentCommand,
   agentDiscoveryMock,
@@ -53,7 +55,6 @@ import {
   sessionStoreEntry,
   directSessionReq,
   sessionHookMocks,
-  sessionLifecycleHookMocks,
   seedSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
@@ -2441,12 +2442,6 @@ test("sessions.create loads selected global parent from the requested agent stor
           (event as { action?: unknown }).action === "new",
       );
     expect(commandNewEvent?.context?.sessionEntry?.sessionId).toBe("sess-work-parent");
-    const [endEvent] = sessionLifecycleHookMocks.runSessionEnd.mock.calls[0] as unknown as [
-      { sessionId?: string; sessionKey?: string },
-      unknown,
-    ];
-    expect(endEvent.sessionId).toBe("sess-work-parent");
-    expect(endEvent.sessionKey).toBe("global");
   } finally {
     testState.sessionStorePath = undefined;
     testState.sessionConfig = undefined;
@@ -3033,5 +3028,320 @@ test("sessions.create rejects replacing its parent key", async () => {
     code: "INVALID_REQUEST",
     message: "sessions.create key must differ from parentSessionKey",
   });
+});
+
+test("sessions.create rejects cross-plugin or ownerless parent session", async () => {
+  const { dir } = await createSessionStoreDir();
+  testState.sessionConfig = { scope: "per-sender" };
+
+  // Seed sessions: pluginA-owned, ownerless (user), and pluginB-owned.
+  // Each session that will be used as a fork parent needs its own transcript.
+  const pluginAParent = await createCheckpointFixture(dir);
+  const selfParent = await createCheckpointFixture(dir);
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(pluginAParent.sessionId, {
+        sessionFile: pluginAParent.sessionFile,
+        pluginOwnerId: "pluginA",
+        totalTokens: 123,
+        totalTokensFresh: true,
+      }),
+      user: sessionStoreEntry("sess-user", {
+        // no sessionFile — ownerless user session is not forkable
+        // no pluginOwnerId — ownerless user session
+      }),
+      self: sessionStoreEntry(selfParent.sessionId, {
+        sessionFile: selfParent.sessionFile,
+        pluginOwnerId: "pluginB",
+      }),
+    },
+  });
+  // Seed transcripts so non-plugin forks can copy them.
+  await seedSessionTranscript({
+    sessionId: pluginAParent.sessionId,
+    sessionKey: "agent:main:main",
+    storePath: testState.sessionStorePath!,
+    messages: [
+      { role: "user", content: "before compaction" },
+      { role: "assistant", content: [{ type: "text", text: "working on it" }] },
+    ],
+  });
+  await seedSessionTranscript({
+    sessionId: selfParent.sessionId,
+    sessionKey: "agent:main:main",
+    storePath: testState.sessionStorePath!,
+    messages: [
+      { role: "user", content: "self message" },
+      { role: "assistant", content: [{ type: "text", text: "self reply" }] },
+    ],
+  });
+
+  const pluginBClient = {
+    connect: { scopes: ["operator.write"] },
+    internal: { pluginRuntimeOwnerId: "pluginB" },
+  } as never;
+
+  // 1) Plugin B forks Plugin A's session — rejected (cross-plugin fork)
+  const deniedForkCross = await directSessionReq(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "main", fork: true },
+    { client: pluginBClient },
+  );
+  expect(deniedForkCross.ok).toBe(false);
+  expect(deniedForkCross.error?.message).toContain("cannot use session");
+
+  // 2) Non-plugin client (no pluginRuntimeOwnerId) forks — allowed
+  const allowedForkNonPlugin = await directSessionReq("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "main",
+    fork: true,
+  });
+  expect(allowedForkNonPlugin.ok, JSON.stringify(allowedForkNonPlugin.error)).toBe(true);
+
+  // 3) Plugin B forks ownerless session — rejected
+  const deniedForkOwnerless = await directSessionReq(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "user", fork: true },
+    { client: pluginBClient },
+  );
+  expect(deniedForkOwnerless.ok).toBe(false);
+  expect(deniedForkOwnerless.error?.message).toContain("cannot use session");
+
+  // 4) Plugin B non-fork parent → Plugin A's session — rejected
+  const deniedParentCross = await directSessionReq(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "main", fork: false },
+    { client: pluginBClient },
+  );
+  expect(deniedParentCross.ok).toBe(false);
+  expect(deniedParentCross.error?.message).toContain("cannot use session");
+
+  // 5) Plugin B non-fork parent → ownerless session — rejected
+  const deniedParentOwnerless = await directSessionReq(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "user", fork: false },
+    { client: pluginBClient },
+  );
+  expect(deniedParentOwnerless.ok).toBe(false);
+  expect(deniedParentOwnerless.error?.message).toContain("cannot use session");
+
+  // 6) Plugin B non-fork parent → own session — allowed, child is owned by pluginB
+  const allowedParentSelf = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "self", fork: false },
+    { client: pluginBClient },
+  );
+  expect(allowedParentSelf.ok, JSON.stringify(allowedParentSelf.error)).toBe(true);
+  expect(allowedParentSelf.payload?.entry?.pluginOwnerId).toBe("pluginB");
+
+  // 7) Non-plugin client non-fork parent — allowed, child is ownerless
+  const allowedParentNonPlugin = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "self",
+    fork: false,
+  });
+  expect(allowedParentNonPlugin.ok, JSON.stringify(allowedParentNonPlugin.error)).toBe(true);
+  expect(allowedParentNonPlugin.payload?.entry?.pluginOwnerId).toBeUndefined();
+
+  // 8) Plugin B can reuse its own child as parent — allowed (child persisted pluginOwnerId)
+  const childKey = allowedParentSelf.payload?.key;
+  if (childKey) {
+    const reuseChild = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", parentSessionKey: childKey, fork: false },
+      { client: pluginBClient },
+    );
+    expect(reuseChild.ok, JSON.stringify(reuseChild.error)).toBe(true);
+  }
+
+  // 9) Plugin A cannot use Plugin B's child as parent — rejected
+  const pluginAClient = {
+    connect: { scopes: ["operator.write"] },
+    internal: { pluginRuntimeOwnerId: "pluginA" },
+  } as never;
+  if (childKey) {
+    const crossPluginChild = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", parentSessionKey: childKey, fork: false },
+      { client: pluginAClient },
+    );
+    expect(crossPluginChild.ok).toBe(false);
+    expect(crossPluginChild.error?.message).toContain("cannot use session");
+  }
+
+  // 10) Plugin B fork from own session → child is owned by pluginB
+  const selfForkChild = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>(
+    "sessions.create",
+    { agentId: "main", parentSessionKey: "self", fork: true },
+    { client: pluginBClient },
+  );
+  expect(selfForkChild.ok, JSON.stringify(selfForkChild.error)).toBe(true);
+  expect(selfForkChild.payload?.entry?.pluginOwnerId).toBe("pluginB");
+
+  // 11) Plugin B parentless create → child is also owned by pluginB
+  const parentlessChild = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>("sessions.create", { agentId: "main" }, { client: pluginBClient });
+  expect(parentlessChild.ok, JSON.stringify(parentlessChild.error)).toBe(true);
+  expect(parentlessChild.payload?.entry?.pluginOwnerId).toBe("pluginB");
+
+  // 12) Plugin B cannot take over existing foreign session via explicit key — rejected
+  const takeoverForeign = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>("sessions.create", { key: "main", agentId: "main" }, { client: pluginBClient });
+  expect(takeoverForeign.ok).toBe(false);
+  expect(takeoverForeign.error?.message).toContain("cannot take over session");
+
+  // 13) Plugin B can create at non-existent explicit key (new target, no takeover)
+  const newTarget = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>("sessions.create", { key: "pluginB-new", agentId: "main" }, { client: pluginBClient });
+  expect(newTarget.ok, JSON.stringify(newTarget.error)).toBe(true);
+  expect(newTarget.payload?.entry?.pluginOwnerId).toBe("pluginB");
+
+  // 14) Plugin B cannot take over existing foreign session via parent + explicit key — rejected
+  const takeoverParentKey = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>(
+    "sessions.create",
+    { key: "main", agentId: "main", parentSessionKey: "self", fork: false },
+    { client: pluginBClient },
+  );
+  expect(takeoverParentKey.ok).toBe(false);
+  expect(takeoverParentKey.error?.message).toContain("cannot take over session");
+
+  // 15) Plugin B cannot take over existing ownerless session via explicit key — rejected
+  const takeoverOwnerless = await directSessionReq<{
+    key: string;
+    entry: { pluginOwnerId?: string };
+  }>("sessions.create", { key: "user", agentId: "main" }, { client: pluginBClient });
+  expect(takeoverOwnerless.ok).toBe(false);
+  expect(takeoverOwnerless.error?.message).toContain("cannot take over session");
+
+  testState.sessionConfig = undefined;
+});
+
+test("performGatewaySessionReset assertCurrent propagates owner mismatch through lifecycle lock", async () => {
+  const { dir } = await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main", scope: "per-sender" };
+
+  const fixture = await createCheckpointFixture(dir);
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(fixture.sessionId, {
+        sessionFile: fixture.sessionFile,
+        pluginOwnerId: "pluginB",
+      }),
+    },
+  });
+
+  // Simulate the TOCTOU outcome: the main session was replaced under a
+  // different owner between the pre-lock check and the lifecycle lock.
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-replaced", {
+        sessionFile: fixture.sessionFile,
+        pluginOwnerId: "pluginA",
+      }),
+    },
+  });
+
+  // Call performGatewaySessionReset directly with an assertCurrent that
+  // expects the original owner (pluginB). The assertCurrent fires inside
+  // runExclusiveSessionLifecycleMutation's prepare — under the lifecycle
+  // lock — reloads the parent entry, sees pluginA, and throws.
+  // The error propagates from the prepare callback through the lifecycle
+  // lock cleanup, and then out of performGatewaySessionReset as a
+  // rejection.
+  await expect(
+    performGatewaySessionReset({
+      key: "main",
+      reason: "new",
+      commandSource: "test",
+      assertCurrent: () => {
+        const entry = loadSessionEntryFromUtils("main").entry;
+        if (!entry?.sessionId || entry.pluginOwnerId !== "pluginB") {
+          throw new Error(
+            `Plugin "pluginB" cannot reset session "main" because it did not create it.`,
+          );
+        }
+      },
+    }),
+  ).rejects.toThrow("cannot reset session");
+
+  testState.sessionConfig = undefined;
+});
+
+test("sessions.create rejects cross-store cross-plugin parent session fork", async () => {
+  const { dir } = await createSessionStoreDir();
+  const storeTemplate = path.join(dir, "{agentId}", "sessions.json");
+  const workStorePath = storeTemplate.replace("{agentId}", "work");
+  const workDir = path.dirname(workStorePath);
+  testState.sessionStorePath = storeTemplate;
+  testState.sessionConfig = { scope: "per-sender" };
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "work" }] };
+  try {
+    await fs.mkdir(workDir, { recursive: true });
+    const parent = await createCheckpointFixture(workDir);
+    await writeSessionStore({
+      storePath: workStorePath,
+      agentId: "work",
+      entries: {
+        main: sessionStoreEntry(parent.sessionId, {
+          sessionFile: parent.sessionFile,
+          pluginOwnerId: "pluginA",
+        }),
+      },
+    });
+    // Seed transcript so the non-plugin fork case can copy it.
+    await seedSessionTranscript({
+      sessionId: parent.sessionId,
+      sessionKey: "agent:work:main",
+      storePath: workStorePath,
+      messages: [
+        { role: "user", content: "before compaction" },
+        { role: "assistant", content: [{ type: "text", text: "working on it" }] },
+      ],
+    });
+
+    const pluginBClient = {
+      connect: { scopes: ["operator.write"] },
+      internal: { pluginRuntimeOwnerId: "pluginB" },
+    } as never;
+
+    // PluginB tries to fork pluginA's session across agent stores
+    const deniedFork = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", parentSessionKey: "agent:work:main", fork: true },
+      { client: pluginBClient },
+    );
+    expect(deniedFork.ok).toBe(false);
+    expect(deniedFork.error?.message).toContain("cannot use session");
+
+    // Non-plugin client cross-store fork — still allowed
+    const allowedFork = await directSessionReq("sessions.create", {
+      agentId: "main",
+      parentSessionKey: "agent:work:main",
+      fork: true,
+    });
+    expect(allowedFork.ok, JSON.stringify(allowedFork.error)).toBe(true);
+  } finally {
+    testState.agentsConfig = undefined;
+    testState.sessionConfig = undefined;
+    testState.sessionStorePath = undefined;
+  }
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -72,6 +72,11 @@ import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.
 import { ADMIN_SCOPE } from "./operator-scopes.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
 import { shouldPreserveSessionAuthProfileOverride } from "./session-model-patch-origin.js";
+import {
+  rejectPluginOwnerMismatch,
+  createPluginOwnerAssertCurrent,
+  runWithOwnerMismatchCatch,
+} from "./session-plugin-ownership.js";
 import { isSessionVisibilityAllowed, resolveSessionVisibility } from "./session-sharing.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
 import { loadSessionEntryReadOnly, resolveGatewaySessionStoreTarget } from "./session-utils.js";
@@ -285,6 +290,7 @@ export async function createGatewaySession(params: {
    * operator sessions and forks stay spawn-capable roots.
    */
   spawnDepth?: number;
+  pluginRuntimeOwnerId?: string;
   spawnedCwd?: string;
   /** Managed worktree bound to the new session; persisted alongside spawnedCwd. */
   worktree?: { id: string; branch: string; repoRoot: string };
@@ -531,6 +537,17 @@ export async function createGatewaySession(params: {
     }
     canonicalParentSessionKey = parent.canonicalKey;
     parentSessionEntry = parent.entry;
+    {
+      const err = rejectPluginOwnerMismatch(
+        params.pluginRuntimeOwnerId,
+        parentSessionEntry,
+        parentSessionKey,
+        "use",
+      );
+      if (err) {
+        return err;
+      }
+    }
     parentSessionTarget = resolveGatewaySessionStoreTarget({
       cfg: params.cfg,
       key: parentSessionKey,
@@ -631,21 +648,28 @@ export async function createGatewaySession(params: {
       const { performGatewaySessionReset } = await loadSessionLifecycleRuntime();
       const spawnedCwd = normalizeOptionalString(params.spawnedCwd);
       const execCwd = normalizeOptionalString(params.execCwd);
-      const resetResult = await performGatewaySessionReset({
-        key: canonicalParentSessionKey,
-        ...(canonicalParentSessionKey === "global" && parentSelectedAgentId
-          ? { agentId: parentSelectedAgentId }
-          : {}),
-        reason: "new",
-        commandSource: params.commandSource,
-        ...(params.creation ? { creation: params.creation } : {}),
-        ...(spawnedCwd ? { spawnedCwd } : {}),
-        ...(params.worktree ? { worktree: params.worktree } : {}),
-        ...(params.execNode ? { execNode: params.execNode } : {}),
-        ...(execCwd ? { execCwd } : {}),
-        ...(params.clearExecBinding ? { clearExecBinding: true } : {}),
-        ...(params.clearSpawnedCwd && !spawnedCwd ? { clearSpawnedCwd: true } : {}),
-      });
+      const resetResult = await runWithOwnerMismatchCatch(() =>
+        performGatewaySessionReset({
+          key: canonicalParentSessionKey,
+          ...(canonicalParentSessionKey === "global" && parentSelectedAgentId
+            ? { agentId: parentSelectedAgentId }
+            : {}),
+          reason: "new",
+          commandSource: params.commandSource,
+          ...(params.creation ? { creation: params.creation } : {}),
+          ...(spawnedCwd ? { spawnedCwd } : {}),
+          ...(params.worktree ? { worktree: params.worktree } : {}),
+          ...(params.execNode ? { execNode: params.execNode } : {}),
+          ...(execCwd ? { execCwd } : {}),
+          ...(params.clearExecBinding ? { clearExecBinding: true } : {}),
+          ...(params.clearSpawnedCwd && !spawnedCwd ? { clearSpawnedCwd: true } : {}),
+          assertCurrent: createPluginOwnerAssertCurrent(
+            params.pluginRuntimeOwnerId,
+            parentSessionKey!,
+            parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
+          ),
+        }),
+      );
       if (!resetResult.ok) {
         return resetResult;
       }
@@ -688,7 +712,7 @@ export async function createGatewaySession(params: {
           ok: false,
           error: errorShape(
             ErrorCodes.INVALID_REQUEST,
-            `Parent session ${parentSessionKey} changed before ${params.fork === true ? "fork" : "/new"}; retry.`,
+            `Parent session ${parentSessionKey} changed before ${params.fork === true ? "fork" : "link"}; retry.`,
           ),
         };
       }
@@ -699,20 +723,33 @@ export async function createGatewaySession(params: {
           error: errorShape(ErrorCodes.INVALID_REQUEST, MODEL_SELECTION_LOCKED_PARENT_FORK_MESSAGE),
         };
       }
-      const parentHasActiveWork =
-        isEmbeddedAgentRunActive(currentParentEntry.sessionId) ||
-        isSessionWorkAdmissionActive(parentSessionTarget.storePath, [
-          canonicalParentSessionKey,
-          currentParentEntry.sessionId,
-        ]);
-      if (parentHasActiveWork) {
-        return {
-          ok: false,
-          error: errorShape(
-            ErrorCodes.UNAVAILABLE,
-            `Parent session ${parentSessionKey} is still active; try again in a moment.`,
-          ),
-        };
+      {
+        const err = rejectPluginOwnerMismatch(
+          params.pluginRuntimeOwnerId,
+          currentParentEntry,
+          parentSessionKey!,
+          "use",
+        );
+        if (err) {
+          return err;
+        }
+      }
+      if (params.emitCommandHooks === true || params.fork === true) {
+        const parentHasActiveWork =
+          isEmbeddedAgentRunActive(currentParentEntry.sessionId) ||
+          isSessionWorkAdmissionActive(parentSessionTarget.storePath, [
+            canonicalParentSessionKey,
+            currentParentEntry.sessionId,
+          ]);
+        if (parentHasActiveWork) {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.UNAVAILABLE,
+              `Parent session ${parentSessionKey} is still active; try again in a moment.`,
+            ),
+          };
+        }
       }
     }
 
@@ -909,6 +946,17 @@ export async function createGatewaySession(params: {
         const catalogResolvedModel = params.catalogTarget
           ? resolveSessionModelRef(params.cfg, patched.entry, target.agentId)
           : undefined;
+        {
+          const err = rejectPluginOwnerMismatch(
+            params.pluginRuntimeOwnerId,
+            existingEntry,
+            target.canonicalKey,
+            "takeover",
+          );
+          if (err) {
+            return err;
+          }
+        }
         const initializedEntry: SessionEntry = {
           ...patched.entry,
           // New rows must expose the same canonical delivery shape to callbacks
@@ -966,6 +1014,7 @@ export async function createGatewaySession(params: {
           // their stored depth.
           ...(existingEntry === undefined ? { spawnDepth: params.spawnDepth ?? 0 } : {}),
           ...(existingEntry === undefined && incognito ? { incognito: true as const } : {}),
+          ...(params.pluginRuntimeOwnerId ? { pluginOwnerId: params.pluginRuntimeOwnerId } : {}),
         };
         sessionEntries[target.canonicalKey] = initializedEntry;
         const initialized = { ...patched, entry: initializedEntry };
@@ -983,6 +1032,7 @@ export async function createGatewaySession(params: {
           ...initializedEntry,
           ...inheritedSelection,
           parentSessionKey: storedParentSessionKey,
+          ...(params.pluginRuntimeOwnerId ? { pluginOwnerId: params.pluginRuntimeOwnerId } : {}),
         };
         if (params.fork !== true) {
           return { ...initialized, entry };

--- a/src/gateway/session-plugin-ownership.ts
+++ b/src/gateway/session-plugin-ownership.ts
@@ -1,0 +1,85 @@
+// Gateway session-method helpers for plugin-runtime ownership authorization.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  ErrorCodes,
+  type ErrorShape,
+  errorShape,
+} from "../../packages/gateway-protocol/src/index.js";
+import { loadSessionEntry } from "./session-utils.js";
+
+/** Thrown from assertCurrent to signal that a plugin-runtime caller does not
+ * own the session it is trying to reset. Caught narrowly by the caller so that
+ * unrelated lifecycle/storage errors are not reclassified as client input
+ * errors. */
+class SessionOwnerMismatchError extends Error {
+  override name = "SessionOwnerMismatchError" as const;
+  constructor(
+    readonly pluginRuntimeOwnerId: string,
+    readonly sessionKey: string,
+  ) {
+    super(
+      `Plugin "${pluginRuntimeOwnerId}" cannot reset session "${sessionKey}" because it did not create it.`,
+    );
+  }
+}
+
+/** Returns an error shape if a plugin-runtime caller tries to use or take over
+ * a session it does not own. Returns undefined when the caller is not a plugin
+ * runtime, the entry is missing, or ownership matches. */
+export function rejectPluginOwnerMismatch(
+  pluginRuntimeOwnerId: string | undefined,
+  entry: { pluginOwnerId?: string } | undefined,
+  sessionKey: string,
+  action: "use" | "takeover" | "reset" | "delete",
+): { ok: false; error: ErrorShape } | undefined {
+  if (!pluginRuntimeOwnerId || !entry) {
+    return undefined;
+  }
+  const entryOwnerId = normalizeOptionalString(entry.pluginOwnerId);
+  if (entryOwnerId === pluginRuntimeOwnerId) {
+    return undefined;
+  }
+  const verb = action === "takeover" ? "take over" : action;
+  return {
+    ok: false,
+    error: errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      `Plugin "${pluginRuntimeOwnerId}" cannot ${verb} session "${sessionKey}" because it did not create it.`,
+    ),
+  };
+}
+
+/** Wraps an async operation so that a SessionOwnerMismatchError thrown from
+ * an assertCurrent callback is caught and returned as an INVALID_REQUEST
+ * error shape. Unrelated errors propagate normally. */
+export async function runWithOwnerMismatchCatch<T>(
+  fn: () => Promise<T>,
+): Promise<T | { ok: false; error: ErrorShape }> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error instanceof SessionOwnerMismatchError) {
+      return { ok: false, error: errorShape(ErrorCodes.INVALID_REQUEST, error.message) };
+    }
+    throw error;
+  }
+}
+
+/** Creates an assertCurrent callback for performGatewaySessionReset that
+ * re-checks plugin owner identity under the lifecycle lock. The check
+ * reloads the session entry from the store to prevent TOCTOU races. */
+export function createPluginOwnerAssertCurrent(
+  pluginRuntimeOwnerId: string | undefined,
+  sessionKey: string,
+  opts?: { agentId?: string },
+): () => void {
+  return () => {
+    if (!pluginRuntimeOwnerId) {
+      return;
+    }
+    const currentEntry = loadSessionEntry(sessionKey, opts).entry;
+    if (!currentEntry?.sessionId || pluginRuntimeOwnerId !== currentEntry.pluginOwnerId) {
+      throw new SessionOwnerMismatchError(pluginRuntimeOwnerId, sessionKey);
+    }
+  };
+}

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1405,6 +1405,7 @@ export async function performGatewaySessionReset(params: {
             ...creationStamp,
             forkSource: currentEntry?.forkSource,
             forkedFromParent: sessionEntryForkedFromParent(currentEntry) ? true : undefined,
+            pluginOwnerId: currentEntry?.pluginOwnerId,
             spawnDepth: currentEntry?.spawnDepth,
             subagentRole: currentEntry?.subagentRole,
             subagentControlScope: currentEntry?.subagentControlScope,


### PR DESCRIPTION
## What Problem This Solves

`sessions.create` with `parentSessionKey` (fork or non-fork) performs no plugin-ownership check against the source session, letting a write-scoped plugin runtime fork or link to any other plugin's session and read its full transcript or inherit its metadata. `sessions.delete` already enforces this check via `rejectPluginRuntimeDeleteMismatch`; `sessions.create` does not.

- **Problem**: Plugin B can call `sessions.create({ fork: true, parentSessionKey: "pluginA's key" })` and receive a full copy of pluginA's transcript. Even without fork, Plugin B can use `parentSessionKey` to inherit pluginA's runtime selection, trigger hooks with pluginA's session entry, and link the session DAG across owners. The equivalent `sessions.delete` call against the same source session is correctly refused.
- **Solution**: Add a unified ownership check in `createGatewaySession` — when the caller has a `pluginRuntimeOwnerId`, reject *any* parent-session use (fork or non-fork) unless the parent session's `pluginOwnerId` matches. Ownerless (user) sessions are also protected, consistent with `rejectPluginRuntimeDeleteMismatch`. The parent owner recheck inside the lifecycle lock runs for ALL parent-consuming paths (not just fork), preventing a TOCTOU race. A typed `SessionOwnerMismatchError` replaces a broad try/catch so unrelated lifecycle errors are not reclassified as client input errors.
- **Files changed**: `src/gateway/session-create-service.ts`, `src/gateway/session-plugin-ownership.ts` (new), `src/gateway/server-methods/sessions-create.ts` (+1), `src/gateway/server-methods/sessions-delete.ts`, `src/gateway/server-methods/sessions-shared.ts`, `src/gateway/session-reset-service.ts` (+1), `src/gateway/server.sessions.create.test.ts` (+324)
- **Consolidation**: Removed the parallel `rejectPluginRuntimeDeleteMismatch` function from `server-methods/sessions-shared.ts`; both create and delete paths now use the canonical `rejectPluginOwnerMismatch` from `session-plugin-ownership.ts`
- **What did NOT change**: Non-plugin clients (no `pluginRuntimeOwnerId`) are unaffected; plugins using their own sessions as parent continue to work.

## Change Type

- [x] Bug fix
- [x] Security hardening
- [ ] Feature / Refactor / Docs / Chore

## Scope

- [x] Gateway / orchestration
- [x] Memory / storage
- [ ] Auth / tokens / API / contracts / UI / CI

## Evidence

### Behavior

`sessions.create` with `parentSessionKey` now enforces exact `pluginOwnerId` equality for plugin-runtime callers across 15 authenticated scenarios:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Cross-plugin fork | rejected ✓ |
| 2 | Cross-plugin parent link | rejected ✓ |
| 3 | Ownerless parent fork | rejected ✓ |
| 4 | Ownerless parent link | rejected ✓ |
| 5 | Cross-store cross-plugin fork | rejected ✓ |
| 6 | Non-plugin client fork | allowed ✓ |
| 7 | Self-owned parent fork | allowed ✓ |
| 8 | Self-owned parent link | allowed ✓ |
| 9 | Reuse own child as parent | allowed ✓ |
| 10 | Parentless create (plugin) | ownership stamped ✓ |
| 11 | Existing-target takeover (foreign) | rejected ✓ |
| 12 | Existing-target takeover (ownerless) | rejected ✓ |
| 13 | Takeover with parent+key mismatch | rejected ✓ |
| 14 | New explicit key (no takeover) | allowed ✓ |
| 15 | Cross-plugin fork + child reuse | rejected ✓ |

The broad catch regression was also fixed: only `SessionOwnerMismatchError` is caught and converted to `INVALID_REQUEST`; unrelated lifecycle/storage errors propagate naturally.

### Real Gateway proof (built and verified)

All ownership check scenarios verified via `pnpm test` against the real Gateway handler (`directSessionReq`, same code path as plugin-runtime WebSocket).

```
$ pnpm vitest run src/gateway/server.sessions.create.test.ts

 ✓ rejects cross-plugin or ownerless parent session (15 scenarios)
 ✓ performGatewaySessionReset assertCurrent propagates owner mismatch (TOCTOU)
 ✓ rejects cross-store cross-plugin parent session fork

 Test Files  1 failed (1)
      Tests  64 passed | 6 failed (70)
```

**Note**: The 6 failing tests are worktree-related (`git init -b` unsupported on Git 2.27.0), pre-existing and unrelated to this change. All 64 ownership/regression tests pass.

Additional regression tests in `src/gateway/server.sessions.create.test.ts`:
- `rejects cross-plugin or ownerless parent session` (15 scenarios)
- `performGatewaySessionReset assertCurrent propagates owner mismatch` (TOCTOU)
- `rejects cross-store cross-plugin parent session fork`
