### PR TITLE
fix(ci): restore live OpenAI performance evidence

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -45,7 +45,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: b20d3b35118841db050a14f241098169aff4b9a2
+        default: 886a0005269de56632491cfac89bf55256fff778
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -105,7 +105,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'b20d3b35118841db050a14f241098169aff4b9a2' }}
+      KOVA_REF: ${{ inputs.kova_ref || '886a0005269de56632491cfac89bf55256fff778' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}
@@ -283,7 +283,7 @@ jobs:
           chmod 0755 "$HOME/.local/bin/kova"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Allow live auth for OpenAI candidate state
+      - name: Prepare live OpenAI candidate state
         if: ${{ steps.lane.outputs.run == 'true' && matrix.live == 'true' }}
         shell: bash
         run: |
@@ -301,6 +301,19 @@ jobs:
           // This ephemeral checkout must honor the lane's explicit --auth live selection.
           state.auth.mode = "default";
           state.auth.reason = "Honor the workflow lane's explicit run-level auth selection.";
+          state.setup = [
+            ...(state.setup ?? []),
+            {
+              id: "force-openclaw-agent-runtime",
+              title: "Force OpenClaw Agent Runtime",
+              intent: "Keep live provider requests inside the OpenClaw harness for timeline evidence.",
+              afterPhase: "provision",
+              commands: [
+                "ocm @{env} -- config set models.providers.openai.agentRuntime.id openclaw"
+              ],
+              evidence: ["OpenAI provider runtime is pinned to the OpenClaw harness"]
+            }
+          ];
           fs.writeFileSync(file, `${JSON.stringify(state, null, 2)}\n`, "utf8");
           NODE
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -55,7 +55,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator that reads agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "b20d3b35118841db050a14f241098169aff4b9a2";
+    const kovaRef = "886a0005269de56632491cfac89bf55256fff778";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);
@@ -188,8 +188,8 @@ describe("OpenClaw performance workflow", () => {
     expect(sanity.run).not.toContain("--include scenario:fresh-install");
   });
 
-  it("makes the live lane honor explicit live auth in the ephemeral Kova checkout", () => {
-    const override = findStep("Allow live auth for OpenAI candidate state");
+  it("makes the live lane use live auth through the OpenClaw runtime", () => {
+    const override = findStep("Prepare live OpenAI candidate state");
 
     expect(override.if).toContain("matrix.live == 'true'");
     expect(override.run).toContain("states/mock-openai-provider.json");
@@ -201,6 +201,12 @@ describe("OpenClaw performance workflow", () => {
     expect(override.run).toContain(
       'state.auth.reason = "Honor the workflow lane\'s explicit run-level auth selection."',
     );
+    expect(override.run).toContain('id: "force-openclaw-agent-runtime"');
+    expect(override.run).toContain('afterPhase: "provision"');
+    expect(override.run).toContain(
+      "ocm @{env} -- config set models.providers.openai.agentRuntime.id openclaw",
+    );
+    expect(override.run).not.toContain("agents.defaults.agentRuntime");
   });
 
   it("runs the trusted lane evidence validator before tolerating gate failures", () => {


### PR DESCRIPTION
Related: #103110

## What Problem This Solves

Fixes an issue where the release live OpenAI performance lane could complete real GPT-5.5 turns but fail to record OpenClaw timeline provider evidence because the official OpenAI provider selected the external Codex harness.

## Why This Change Was Made

The live lane now applies an ephemeral provider-level runtime override after provisioning so its requests stay inside the OpenClaw harness and remain observable by the existing timeline validator. The workflow also pins Kova `886a0005269de56632491cfac89bf55256fff778`, which includes the corrected release resource gates and bundled-plugin startup readiness fixes.

## User Impact

Release operators get genuine live OpenAI performance evidence with the expected provider request attribution. There is no product runtime behavior change outside this validation workflow.

## Evidence

- Testbox `tbx_01kx4jaxh4316regb15q79p8w9`, run https://github.com/openclaw/openclaw/actions/runs/29056639803
- `corepack pnpm test test/scripts/openclaw-performance-workflow.test.ts`: 14/14 passed
- `corepack pnpm check:workflows`: passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`: passed
- Fresh autoreview: no accepted/actionable findings, confidence 0.82
- Kova resource-gate fix: https://github.com/openclaw/Kova/pull/10, CI https://github.com/openclaw/Kova/actions/runs/29054829596
- Kova startup-readiness fix: https://github.com/openclaw/Kova/pull/13, CI https://github.com/openclaw/Kova/actions/runs/29056313238
