### PR TITLE
fix(agents): bound compaction planning worker payloads

### DIFF
--- a/src/agents/compaction-planning-projection.ts
+++ b/src/agents/compaction-planning-projection.ts
@@ -1,0 +1,109 @@
+/** Builds bounded transcript projections for compaction worker planning. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { AgentMessage } from "./runtime/index.js";
+
+const TEXT_TRUNCATE_THRESHOLD_CHARS = 32_768;
+const TEXT_SAMPLE_CHARS = 8_192;
+const OMITTED_CHARS_FIELD = "__openclawCompactionPlanningOmittedChars";
+
+export function readCompactionPlanningOmittedChars(message: AgentMessage): number {
+  const value = (message as unknown as Record<string, unknown>)[OMITTED_CHARS_FIELD];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function projectText(text: string): { text: string; omittedChars: number } | null {
+  if (text.length <= TEXT_TRUNCATE_THRESHOLD_CHARS) {
+    return null;
+  }
+  const sample = truncateUtf16Safe(text, TEXT_SAMPLE_CHARS);
+  const droppedChars = text.length - sample.length;
+  const projected = `${sample}\n\n[... ${droppedChars} characters omitted from compaction planning]`;
+  return {
+    text: projected,
+    omittedChars: Math.max(0, text.length - projected.length),
+  };
+}
+
+function projectContentBlock(
+  block: unknown,
+  projectTextContent: boolean,
+): { block: unknown; omittedChars: number; changed: boolean } {
+  if (!block || typeof block !== "object") {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const record = block as Record<string, unknown>;
+  const type = typeof record.type === "string" ? record.type : "";
+  if (type === "image" && typeof record.data === "string" && record.data.length > 0) {
+    return {
+      block: { ...record, data: "" },
+      omittedChars: 0,
+      changed: true,
+    };
+  }
+  if (!projectTextContent) {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const textIsModelVisible =
+    type === "text" ||
+    ((type === "toolResult" || type === "tool_result") && typeof record.text === "string");
+  const contentIsModelVisible =
+    (type === "toolResult" || type === "tool_result") &&
+    typeof record.text !== "string" &&
+    typeof record.content === "string";
+  const projectedText = typeof record.text === "string" ? projectText(record.text) : null;
+  const projectedContent = typeof record.content === "string" ? projectText(record.content) : null;
+  if (!projectedText && !projectedContent) {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const next = { ...record };
+  let omittedChars = 0;
+  if (projectedText) {
+    next.text = projectedText.text;
+    omittedChars += textIsModelVisible ? projectedText.omittedChars : 0;
+  }
+  if (projectedContent) {
+    next.content = projectedContent.text;
+    omittedChars += contentIsModelVisible ? projectedContent.omittedChars : 0;
+  }
+  return { block: next, omittedChars, changed: true };
+}
+
+function projectMessage(message: AgentMessage): AgentMessage {
+  const currentOmittedChars = readCompactionPlanningOmittedChars(message);
+  const content = (message as { content?: unknown }).content;
+  if (message.role === "toolResult" && typeof content === "string") {
+    const projected = projectText(content);
+    if (!projected) {
+      return message;
+    }
+    return {
+      ...(message as unknown as Record<string, unknown>),
+      content: projected.text,
+      [OMITTED_CHARS_FIELD]: currentOmittedChars + projected.omittedChars,
+    } as unknown as AgentMessage;
+  }
+  if (!Array.isArray(content)) {
+    return message;
+  }
+
+  let omittedChars = 0;
+  let changed = false;
+  const projectedContent = content.map((block) => {
+    const projected = projectContentBlock(block, message.role === "toolResult");
+    omittedChars += projected.omittedChars;
+    changed ||= projected.changed;
+    return projected.block;
+  });
+  if (!changed) {
+    return message;
+  }
+  return {
+    ...(message as unknown as Record<string, unknown>),
+    content: projectedContent,
+    [OMITTED_CHARS_FIELD]: currentOmittedChars + omittedChars,
+  } as unknown as AgentMessage;
+}
+
+export function projectCompactionPlanningMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.map(projectMessage);
+}

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -67,13 +67,11 @@ describe("compaction planning worker", () => {
     if (packagedSummaryChunks.kind !== "summaryChunks") {
       return;
     }
-    expect(packagedSummaryChunks.chunks.flat().map((message) => message.timestamp)).toEqual([
-      1, 2, 3,
-    ]);
-    expect(packagedSummaryChunks.chunks.length).toBeGreaterThan(1);
+    expect(packagedSummaryChunks.chunkIndexes.flat()).toEqual([0, 1, 2]);
+    expect(packagedSummaryChunks.chunkIndexes.length).toBeGreaterThan(1);
   }, 45_000);
 
-  it("bounds image data across the packaged worker without changing planning pressure", async () => {
+  it("bounds image data in worker planning without changing returned summary input", async () => {
     const imageData = "a".repeat(1_000_000);
     const imageMessage = {
       role: "toolResult",
@@ -106,9 +104,9 @@ describe("compaction planning worker", () => {
       throw new Error("expected planned tool result");
     }
 
-    expect(plannedImageMessage.content[0]).toMatchObject({
+    expect(plannedImageMessage.content[0]).toEqual({
       type: "image",
-      data: "",
+      data: imageData,
       mimeType: "image/png",
     });
     expect(plannedUserImageMessage?.role).toBe("user");
@@ -116,15 +114,35 @@ describe("compaction planning worker", () => {
       throw new Error("expected planned user message");
     }
     expect(plannedUserImageMessage.content).toEqual([
-      { type: "image", data: "", mimeType: "image/png" },
+      { type: "image", data: imageData, mimeType: "image/png" },
     ]);
-    expect(JSON.stringify(plannedMessages)).not.toContain(imageData);
     expect(estimateMessagesTokens([plannedImageMessage])).toBe(
       estimateMessagesTokens([imageMessage]),
     );
     expect(serializeConversation([plannedImageMessage])).toBe(
       serializeConversation([imageMessage]),
     );
+  }, 45_000);
+
+  it("preserves oversized tool-result text in returned summary input", async () => {
+    const hugeText = "x".repeat(120_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_large",
+        toolName: "browser",
+        isError: false,
+        content: [{ type: "text", text: hugeText }],
+        timestamp: 1,
+      },
+      ...Array.from({ length: 63 }, (_, index) => makeMessage(index + 2)),
+    ];
+
+    const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
+    const returnedMessages = chunks.flat();
+
+    expect(serializeConversation(returnedMessages)).toBe(serializeConversation(messages));
+    expect(JSON.stringify(returnedMessages)).toContain(hugeText);
   }, 45_000);
 
   it("plans summary chunks for worker input", () => {
@@ -143,8 +161,8 @@ describe("compaction planning worker", () => {
     if (value.kind !== "summaryChunks") {
       return;
     }
-    expect(value.chunks.flat().map((message) => message.timestamp)).toEqual([1, 2, 3]);
-    expect(value.chunks.length).toBeGreaterThan(1);
+    expect(value.chunkIndexes.flat()).toEqual([0, 1, 2]);
+    expect(value.chunkIndexes.length).toBeGreaterThan(1);
   });
 
   it("clamps oversized worker timeouts before scheduling", async () => {

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -1,7 +1,12 @@
 // Covers the compaction planning worker boundary and timeout behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { compactionPlanningWorkerTesting } from "./compaction-planning-worker.js";
+import {
+  buildSummaryChunksWithWorker,
+  compactionPlanningWorkerTesting,
+} from "./compaction-planning-worker.js";
+import { estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -66,6 +71,60 @@ describe("compaction planning worker", () => {
       1, 2, 3,
     ]);
     expect(packagedSummaryChunks.chunks.length).toBeGreaterThan(1);
+  }, 45_000);
+
+  it("bounds image data across the packaged worker without changing planning pressure", async () => {
+    const imageData = "a".repeat(1_000_000);
+    const imageMessage = {
+      role: "toolResult",
+      toolCallId: "call_image",
+      toolName: "browser",
+      isError: false,
+      content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+      timestamp: 1,
+    } satisfies AgentMessage;
+    const messages = [
+      {
+        role: "user" as const,
+        content: [{ type: "image" as const, data: imageData, mimeType: "image/png" }],
+        timestamp: 0,
+      },
+      imageMessage,
+      ...Array.from({ length: 62 }, (_, index) => makeMessage(index + 2)),
+    ];
+
+    const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
+    const plannedMessages = chunks.flat();
+    const plannedImageMessage = plannedMessages.find(
+      (message) => message.role === "toolResult" && message.toolCallId === "call_image",
+    );
+    const plannedUserImageMessage = plannedMessages.find(
+      (message) => message.role === "user" && message.timestamp === 0,
+    );
+    expect(plannedImageMessage?.role).toBe("toolResult");
+    if (!plannedImageMessage || plannedImageMessage.role !== "toolResult") {
+      throw new Error("expected planned tool result");
+    }
+
+    expect(plannedImageMessage.content[0]).toMatchObject({
+      type: "image",
+      data: "",
+      mimeType: "image/png",
+    });
+    expect(plannedUserImageMessage?.role).toBe("user");
+    if (!plannedUserImageMessage || plannedUserImageMessage.role !== "user") {
+      throw new Error("expected planned user message");
+    }
+    expect(plannedUserImageMessage.content).toEqual([
+      { type: "image", data: "", mimeType: "image/png" },
+    ]);
+    expect(JSON.stringify(plannedMessages)).not.toContain(imageData);
+    expect(estimateMessagesTokens([plannedImageMessage])).toBe(
+      estimateMessagesTokens([imageMessage]),
+    );
+    expect(serializeConversation([plannedImageMessage])).toBe(
+      serializeConversation([imageMessage]),
+    );
   }, 45_000);
 
   it("plans summary chunks for worker input", () => {

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -1,6 +1,6 @@
 // Covers the compaction planning worker boundary and timeout behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
+import { convertToLlm, serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
   buildSummaryChunksWithWorker,
@@ -141,7 +141,9 @@ describe("compaction planning worker", () => {
     const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
     const returnedMessages = chunks.flat();
 
-    expect(serializeConversation(returnedMessages)).toBe(serializeConversation(messages));
+    expect(serializeConversation(convertToLlm(returnedMessages))).toBe(
+      serializeConversation(convertToLlm(messages)),
+    );
     expect(JSON.stringify(returnedMessages)).toContain(hugeText);
   }, 45_000);
 

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -13,6 +13,7 @@ import {
   buildStageSplitPlan,
   buildSummaryChunks,
   computeAdaptiveChunkRatio,
+  projectCompactionMessagesForPlanning,
   sanitizeCompactionMessages,
   type HistoryPrunePlan,
   type OversizedFallbackPlan,
@@ -206,10 +207,11 @@ export async function buildSummaryChunksWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildSummaryChunks(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "summaryChunks",
-      messages,
+      messages: planningMessages,
       maxChunkTokens: params.maxChunkTokens,
     },
     signal: params.signal,
@@ -235,10 +237,11 @@ export async function buildOversizedFallbackPlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildOversizedFallbackPlan(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "oversizedFallback",
-      messages,
+      messages: planningMessages,
       contextWindow: params.contextWindow,
     },
     signal: params.signal,
@@ -269,10 +272,11 @@ export async function buildStageSplitPlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildStageSplitPlan(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "stageSplit",
-      messages,
+      messages: planningMessages,
       maxChunkTokens: params.maxChunkTokens,
       parts: params.parts,
       minMessagesForSplit: params.minMessagesForSplit,
@@ -305,11 +309,13 @@ export async function buildHistoryPrunePlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messagesToSummarize.length + turnPrefixMessages.length)) {
     return buildHistoryPrunePlan(params);
   }
+  const planningMessagesToSummarize = projectCompactionMessagesForPlanning(messagesToSummarize);
+  const planningTurnPrefixMessages = projectCompactionMessagesForPlanning(turnPrefixMessages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "historyPrune",
-      messagesToSummarize,
-      turnPrefixMessages,
+      messagesToSummarize: planningMessagesToSummarize,
+      turnPrefixMessages: planningTurnPrefixMessages,
       tokensBefore: params.tokensBefore,
       contextWindowTokens: params.contextWindowTokens,
       maxHistoryShare: params.maxHistoryShare,
@@ -343,10 +349,11 @@ export async function computeAdaptiveChunkRatioWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return computeAdaptiveChunkRatio(params.messages, params.contextWindow);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "adaptiveChunkRatio",
-      messages,
+      messages: planningMessages,
       contextWindow: params.contextWindow,
     },
     signal: params.signal,

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -171,6 +171,67 @@ function shouldUsePlanningWorker(messageCount: number): boolean {
   return messageCount >= COMPACTION_PLANNING_WORKER_MIN_MESSAGES;
 }
 
+function indexSelectedMessages(
+  indexByMessage: ReadonlyMap<AgentMessage, number>,
+  selected: AgentMessage[],
+): number[] {
+  return selected.map((message) => {
+    const index = indexByMessage.get(message);
+    if (index === undefined) {
+      throw new CompactionPlanningWorkerError(
+        "compaction planning result contains an unknown message",
+        "failed",
+      );
+    }
+    return index;
+  });
+}
+
+function indexMessageChunks(source: AgentMessage[], chunks: AgentMessage[][]): number[][] {
+  const indexByMessage = new Map(source.map((message, index) => [message, index]));
+  return chunks.map((chunk) => indexSelectedMessages(indexByMessage, chunk));
+}
+
+function indexOversizedFallbackPlan(
+  source: AgentMessage[],
+  plan: OversizedFallbackPlan,
+): Extract<CompactionPlanningWorkerValue, { kind: "oversizedFallback" }> {
+  return {
+    kind: "oversizedFallback",
+    smallMessageIndexes: indexSelectedMessages(
+      new Map(source.map((message, index) => [message, index])),
+      plan.smallMessages,
+    ),
+    oversizedNotes: plan.oversizedNotes,
+  };
+}
+
+function indexStageSplitPlan(
+  source: AgentMessage[],
+  plan: StageSplitPlan,
+): Extract<CompactionPlanningWorkerValue, { kind: "stageSplit" }> {
+  return plan.mode === "split"
+    ? {
+        kind: "stageSplit",
+        mode: "split",
+        chunkIndexes: indexMessageChunks(source, plan.chunks),
+      }
+    : { kind: "stageSplit", mode: "single" };
+}
+
+function restoreIndexedMessages(source: AgentMessage[], indexes: number[]): AgentMessage[] {
+  return indexes.map((index) => {
+    const message = source.at(index);
+    if (!Number.isInteger(index) || index < 0 || !message) {
+      throw new CompactionPlanningWorkerError(
+        "compaction planning result contains an invalid message index",
+        "failed",
+      );
+    }
+    return message;
+  });
+}
+
 async function runWithUnavailableFallback<T extends CompactionPlanningWorkerValue>(params: {
   input: CompactionPlanningWorkerInput;
   signal?: AbortSignal;
@@ -217,14 +278,17 @@ export async function buildSummaryChunksWithWorker(params: {
     signal: params.signal,
     fallback: () => ({
       kind: "summaryChunks" as const,
-      chunks: buildSummaryChunks(params),
+      chunkIndexes: indexMessageChunks(
+        messages,
+        buildSummaryChunks({ messages, maxChunkTokens: params.maxChunkTokens }),
+      ),
     }),
     isExpected: (
       valueCandidate,
     ): valueCandidate is Extract<CompactionPlanningWorkerValue, { kind: "summaryChunks" }> =>
       valueCandidate.kind === "summaryChunks",
   });
-  return value.chunks;
+  return value.chunkIndexes.map((indexes) => restoreIndexedMessages(messages, indexes));
 }
 
 /** Builds an oversized-message fallback plan, using the worker when worthwhile. */
@@ -245,17 +309,18 @@ export async function buildOversizedFallbackPlanWithWorker(params: {
       contextWindow: params.contextWindow,
     },
     signal: params.signal,
-    fallback: () => ({
-      kind: "oversizedFallback" as const,
-      ...buildOversizedFallbackPlan(params),
-    }),
+    fallback: () =>
+      indexOversizedFallbackPlan(
+        messages,
+        buildOversizedFallbackPlan({ messages, contextWindow: params.contextWindow }),
+      ),
     isExpected: (
       valueEntry,
     ): valueEntry is Extract<CompactionPlanningWorkerValue, { kind: "oversizedFallback" }> =>
       valueEntry.kind === "oversizedFallback",
   });
   return {
-    smallMessages: value.smallMessages,
+    smallMessages: restoreIndexedMessages(messages, value.smallMessageIndexes),
     oversizedNotes: value.oversizedNotes,
   };
 }
@@ -282,16 +347,27 @@ export async function buildStageSplitPlanWithWorker(params: {
       minMessagesForSplit: params.minMessagesForSplit,
     },
     signal: params.signal,
-    fallback: () => ({
-      kind: "stageSplit" as const,
-      ...buildStageSplitPlan(params),
-    }),
+    fallback: () =>
+      indexStageSplitPlan(
+        messages,
+        buildStageSplitPlan({
+          messages,
+          maxChunkTokens: params.maxChunkTokens,
+          parts: params.parts,
+          minMessagesForSplit: params.minMessagesForSplit,
+        }),
+      ),
     isExpected: (
       valueResult,
     ): valueResult is Extract<CompactionPlanningWorkerValue, { kind: "stageSplit" }> =>
       valueResult.kind === "stageSplit",
   });
-  return value.mode === "split" ? { mode: "split", chunks: value.chunks } : { mode: "single" };
+  return value.mode === "split"
+    ? {
+        mode: "split",
+        chunks: value.chunkIndexes.map((indexes) => restoreIndexedMessages(messages, indexes)),
+      }
+    : { mode: "single" };
 }
 
 /** Builds a history-pruning plan with worker fallback for large transcripts. */
@@ -309,13 +385,11 @@ export async function buildHistoryPrunePlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messagesToSummarize.length + turnPrefixMessages.length)) {
     return buildHistoryPrunePlan(params);
   }
-  const planningMessagesToSummarize = projectCompactionMessagesForPlanning(messagesToSummarize);
-  const planningTurnPrefixMessages = projectCompactionMessagesForPlanning(turnPrefixMessages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "historyPrune",
-      messagesToSummarize: planningMessagesToSummarize,
-      turnPrefixMessages: planningTurnPrefixMessages,
+      messagesToSummarize,
+      turnPrefixMessages,
       tokensBefore: params.tokensBefore,
       contextWindowTokens: params.contextWindowTokens,
       maxHistoryShare: params.maxHistoryShare,

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -3,7 +3,10 @@
  * token usage, chooses chunking strategy, and preserves active tool-use pairs
  * while splitting history for summaries.
  */
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  projectCompactionPlanningMessages,
+  readCompactionPlanningOmittedChars,
+} from "./compaction-planning-projection.js";
 import { stripRuntimeContextCustomMessages } from "./internal-runtime-context.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
@@ -17,9 +20,6 @@ export const MIN_CHUNK_RATIO = 0.15;
 /** Buffer for estimateTokens() inaccuracy. */
 export const SAFETY_MARGIN = 1.2;
 const DEFAULT_PARTS = 2;
-const COMPACTION_PLANNING_TEXT_TRUNCATE_THRESHOLD_CHARS = 32_768;
-const COMPACTION_PLANNING_TEXT_SAMPLE_CHARS = 8_192;
-const COMPACTION_PLANNING_OMITTED_CHARS_FIELD = "__openclawCompactionPlanningOmittedChars";
 
 /**
  * Overhead reserved for summary prompt, system prompt, prior summary, wrapper
@@ -84,13 +84,6 @@ function estimateCompactionMessageTokens(message: AgentMessage): number {
   return estimateMessagesTokens([message]);
 }
 
-function readCompactionPlanningOmittedChars(message: AgentMessage): number {
-  const value = (message as unknown as Record<string, unknown>)[
-    COMPACTION_PLANNING_OMITTED_CHARS_FIELD
-  ];
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
-}
-
 function estimateCompactionPlanningTokens(message: AgentMessage): number {
   const omittedChars = readCompactionPlanningOmittedChars(message);
   if (omittedChars === 0) {
@@ -99,111 +92,10 @@ function estimateCompactionPlanningTokens(message: AgentMessage): number {
   return estimateTokens(message) + Math.ceil(omittedChars / 4);
 }
 
-function projectTextForCompactionPlanning(
-  text: string,
-): { text: string; omittedChars: number } | null {
-  if (text.length <= COMPACTION_PLANNING_TEXT_TRUNCATE_THRESHOLD_CHARS) {
-    return null;
-  }
-  const sample = truncateUtf16Safe(text, COMPACTION_PLANNING_TEXT_SAMPLE_CHARS);
-  const droppedChars = text.length - sample.length;
-  const projected = `${sample}\n\n[... ${droppedChars} characters omitted from compaction planning]`;
-  return {
-    text: projected,
-    omittedChars: Math.max(0, text.length - projected.length),
-  };
-}
-
-function projectContentBlockForPlanning(
-  block: unknown,
-  projectText: boolean,
-): {
-  block: unknown;
-  omittedChars: number;
-  changed: boolean;
-} {
-  if (!block || typeof block !== "object") {
-    return { block, omittedChars: 0, changed: false };
-  }
-  const record = block as Record<string, unknown>;
-  const type = typeof record.type === "string" ? record.type : "";
-  if (type === "image" && typeof record.data === "string" && record.data.length > 0) {
-    return {
-      block: { ...record, data: "" },
-      omittedChars: 0,
-      changed: true,
-    };
-  }
-  if (!projectText) {
-    return { block, omittedChars: 0, changed: false };
-  }
-  const textIsModelVisible =
-    type === "text" ||
-    ((type === "toolResult" || type === "tool_result") && typeof record.text === "string");
-  const contentIsModelVisible =
-    (type === "toolResult" || type === "tool_result") &&
-    typeof record.text !== "string" &&
-    typeof record.content === "string";
-  const projectedText =
-    typeof record.text === "string" ? projectTextForCompactionPlanning(record.text) : null;
-  const projectedContent =
-    typeof record.content === "string" ? projectTextForCompactionPlanning(record.content) : null;
-  if (!projectedText && !projectedContent) {
-    return { block, omittedChars: 0, changed: false };
-  }
-  const next = { ...record };
-  let omittedChars = 0;
-  if (projectedText) {
-    next.text = projectedText.text;
-    omittedChars += textIsModelVisible ? projectedText.omittedChars : 0;
-  }
-  if (projectedContent) {
-    next.content = projectedContent.text;
-    omittedChars += contentIsModelVisible ? projectedContent.omittedChars : 0;
-  }
-  return { block: next, omittedChars, changed: true };
-}
-
-function projectMessageForPlanning(message: AgentMessage): AgentMessage {
-  const currentOmittedChars = readCompactionPlanningOmittedChars(message);
-  const content = (message as { content?: unknown }).content;
-  if (message.role === "toolResult" && typeof content === "string") {
-    const projected = projectTextForCompactionPlanning(content);
-    if (!projected) {
-      return message;
-    }
-    return {
-      ...(message as unknown as Record<string, unknown>),
-      content: projected.text,
-      [COMPACTION_PLANNING_OMITTED_CHARS_FIELD]: currentOmittedChars + projected.omittedChars,
-    } as unknown as AgentMessage;
-  }
-  if (!Array.isArray(content)) {
-    return message;
-  }
-
-  let omittedChars = 0;
-  let changed = false;
-  const projectedContent = content.map((block) => {
-    const projected = projectContentBlockForPlanning(block, message.role === "toolResult");
-    omittedChars += projected.omittedChars;
-    changed ||= projected.changed;
-    return projected.block;
-  });
-  if (!changed) {
-    return message;
-  }
-  return {
-    ...(message as unknown as Record<string, unknown>),
-    content: projectedContent,
-    [COMPACTION_PLANNING_OMITTED_CHARS_FIELD]: currentOmittedChars + omittedChars,
-  } as unknown as AgentMessage;
-}
-
 /** Builds a bounded planning projection that preserves token pressure accounting. */
 export function projectCompactionMessagesForPlanning(messages: AgentMessage[]): AgentMessage[] {
   const safe = sanitizeCompactionMessages(messages);
-  return safe.map(projectMessageForPlanning);
+  return projectCompactionPlanningMessages(safe);
 }
 
 /** Clamps requested split parts to a usable count for the available messages. */

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -3,6 +3,7 @@
  * token usage, chooses chunking strategy, and preserves active tool-use pairs
  * while splitting history for summaries.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripRuntimeContextCustomMessages } from "./internal-runtime-context.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
@@ -16,6 +17,9 @@ export const MIN_CHUNK_RATIO = 0.15;
 /** Buffer for estimateTokens() inaccuracy. */
 export const SAFETY_MARGIN = 1.2;
 const DEFAULT_PARTS = 2;
+const COMPACTION_PLANNING_TEXT_TRUNCATE_THRESHOLD_CHARS = 32_768;
+const COMPACTION_PLANNING_TEXT_SAMPLE_CHARS = 8_192;
+const COMPACTION_PLANNING_OMITTED_CHARS_FIELD = "__openclawCompactionPlanningOmittedChars";
 
 /**
  * Overhead reserved for summary prompt, system prompt, prior summary, wrapper
@@ -51,7 +55,7 @@ export type HistoryPrunePlan = {
 export function estimateMessagesTokens(messages: AgentMessage[]): number {
   // SECURITY: toolResult.details and runtime-context transcript entries must never enter LLM-facing compaction.
   const safe = sanitizeCompactionMessages(messages);
-  return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
+  return safe.reduce((sum, message) => sum + estimateCompactionPlanningTokens(message), 0);
 }
 
 /**
@@ -65,7 +69,9 @@ function estimatePerMessageTokens(messages: AgentMessage[]): number[] {
   const detailStripped = stripToolResultDetails(messages);
   // stripRuntimeContextCustomMessages filters by reference, so kept entries keep their identity.
   const modelVisible = new Set(stripRuntimeContextCustomMessages(detailStripped));
-  return detailStripped.map((message) => (modelVisible.has(message) ? estimateTokens(message) : 0));
+  return detailStripped.map((message) =>
+    modelVisible.has(message) ? estimateCompactionPlanningTokens(message) : 0,
+  );
 }
 
 /** Removes runtime-only context and tool-result details before token estimates or summaries. */
@@ -76,6 +82,118 @@ export function sanitizeCompactionMessages(messages: AgentMessage[]): AgentMessa
 /** Estimates one message using the same sanitization path as multi-message planning. */
 function estimateCompactionMessageTokens(message: AgentMessage): number {
   return estimateMessagesTokens([message]);
+}
+
+function readCompactionPlanningOmittedChars(message: AgentMessage): number {
+  const value = (message as unknown as Record<string, unknown>)[
+    COMPACTION_PLANNING_OMITTED_CHARS_FIELD
+  ];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function estimateCompactionPlanningTokens(message: AgentMessage): number {
+  const omittedChars = readCompactionPlanningOmittedChars(message);
+  if (omittedChars === 0) {
+    return estimateTokens(message);
+  }
+  return estimateTokens(message) + Math.ceil(omittedChars / 4);
+}
+
+function projectTextForCompactionPlanning(
+  text: string,
+): { text: string; omittedChars: number } | null {
+  if (text.length <= COMPACTION_PLANNING_TEXT_TRUNCATE_THRESHOLD_CHARS) {
+    return null;
+  }
+  const sample = truncateUtf16Safe(text, COMPACTION_PLANNING_TEXT_SAMPLE_CHARS);
+  const droppedChars = text.length - sample.length;
+  const projected = `${sample}\n\n[... ${droppedChars} characters omitted from compaction planning]`;
+  return {
+    text: projected,
+    omittedChars: Math.max(0, text.length - projected.length),
+  };
+}
+
+function projectToolResultBlockForPlanning(block: unknown): {
+  block: unknown;
+  omittedChars: number;
+  changed: boolean;
+} {
+  if (!block || typeof block !== "object") {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const record = block as Record<string, unknown>;
+  const type = typeof record.type === "string" ? record.type : "";
+  const textIsModelVisible =
+    type === "text" ||
+    ((type === "toolResult" || type === "tool_result") && typeof record.text === "string");
+  const contentIsModelVisible =
+    (type === "toolResult" || type === "tool_result") &&
+    typeof record.text !== "string" &&
+    typeof record.content === "string";
+  const projectedText =
+    typeof record.text === "string" ? projectTextForCompactionPlanning(record.text) : null;
+  const projectedContent =
+    typeof record.content === "string" ? projectTextForCompactionPlanning(record.content) : null;
+  if (!projectedText && !projectedContent) {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const next = { ...record };
+  let omittedChars = 0;
+  if (projectedText) {
+    next.text = projectedText.text;
+    omittedChars += textIsModelVisible ? projectedText.omittedChars : 0;
+  }
+  if (projectedContent) {
+    next.content = projectedContent.text;
+    omittedChars += contentIsModelVisible ? projectedContent.omittedChars : 0;
+  }
+  return { block: next, omittedChars, changed: true };
+}
+
+function projectToolResultMessageForPlanning(message: AgentMessage): AgentMessage {
+  if (message.role !== "toolResult") {
+    return message;
+  }
+  const currentOmittedChars = readCompactionPlanningOmittedChars(message);
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    const projected = projectTextForCompactionPlanning(content);
+    if (!projected) {
+      return message;
+    }
+    return {
+      ...(message as unknown as Record<string, unknown>),
+      content: projected.text,
+      [COMPACTION_PLANNING_OMITTED_CHARS_FIELD]: currentOmittedChars + projected.omittedChars,
+    } as unknown as AgentMessage;
+  }
+  if (!Array.isArray(content)) {
+    return message;
+  }
+
+  let omittedChars = 0;
+  let changed = false;
+  const projectedContent = content.map((block) => {
+    const projected = projectToolResultBlockForPlanning(block);
+    omittedChars += projected.omittedChars;
+    changed ||= projected.changed;
+    return projected.block;
+  });
+  if (!changed) {
+    return message;
+  }
+  return {
+    ...(message as unknown as Record<string, unknown>),
+    content: projectedContent,
+    [COMPACTION_PLANNING_OMITTED_CHARS_FIELD]: currentOmittedChars + omittedChars,
+  } as unknown as AgentMessage;
+}
+
+/** Builds a bounded planning projection that preserves token pressure accounting. */
+export function projectCompactionMessagesForPlanning(messages: AgentMessage[]): AgentMessage[] {
+  const safe = sanitizeCompactionMessages(messages);
+  return safe.map(projectToolResultMessageForPlanning);
 }
 
 /** Clamps requested split parts to a usable count for the available messages. */

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -114,7 +114,10 @@ function projectTextForCompactionPlanning(
   };
 }
 
-function projectToolResultBlockForPlanning(block: unknown): {
+function projectContentBlockForPlanning(
+  block: unknown,
+  projectText: boolean,
+): {
   block: unknown;
   omittedChars: number;
   changed: boolean;
@@ -124,6 +127,16 @@ function projectToolResultBlockForPlanning(block: unknown): {
   }
   const record = block as Record<string, unknown>;
   const type = typeof record.type === "string" ? record.type : "";
+  if (type === "image" && typeof record.data === "string" && record.data.length > 0) {
+    return {
+      block: { ...record, data: "" },
+      omittedChars: 0,
+      changed: true,
+    };
+  }
+  if (!projectText) {
+    return { block, omittedChars: 0, changed: false };
+  }
   const textIsModelVisible =
     type === "text" ||
     ((type === "toolResult" || type === "tool_result") && typeof record.text === "string");
@@ -151,13 +164,10 @@ function projectToolResultBlockForPlanning(block: unknown): {
   return { block: next, omittedChars, changed: true };
 }
 
-function projectToolResultMessageForPlanning(message: AgentMessage): AgentMessage {
-  if (message.role !== "toolResult") {
-    return message;
-  }
+function projectMessageForPlanning(message: AgentMessage): AgentMessage {
   const currentOmittedChars = readCompactionPlanningOmittedChars(message);
   const content = (message as { content?: unknown }).content;
-  if (typeof content === "string") {
+  if (message.role === "toolResult" && typeof content === "string") {
     const projected = projectTextForCompactionPlanning(content);
     if (!projected) {
       return message;
@@ -175,7 +185,7 @@ function projectToolResultMessageForPlanning(message: AgentMessage): AgentMessag
   let omittedChars = 0;
   let changed = false;
   const projectedContent = content.map((block) => {
-    const projected = projectToolResultBlockForPlanning(block);
+    const projected = projectContentBlockForPlanning(block, message.role === "toolResult");
     omittedChars += projected.omittedChars;
     changed ||= projected.changed;
     return projected.block;
@@ -193,7 +203,7 @@ function projectToolResultMessageForPlanning(message: AgentMessage): AgentMessag
 /** Builds a bounded planning projection that preserves token pressure accounting. */
 export function projectCompactionMessagesForPlanning(messages: AgentMessage[]): AgentMessage[] {
   const safe = sanitizeCompactionMessages(messages);
-  return safe.map(projectToolResultMessageForPlanning);
+  return safe.map(projectMessageForPlanning);
 }
 
 /** Clamps requested split parts to a usable count for the available messages. */

--- a/src/agents/compaction-planning.worker.ts
+++ b/src/agents/compaction-planning.worker.ts
@@ -9,8 +9,6 @@ import {
   buildSummaryChunks,
   computeAdaptiveChunkRatio,
   type HistoryPrunePlan,
-  type OversizedFallbackPlan,
-  type StageSplitPlan,
 } from "./compaction-planning.js";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -52,14 +50,22 @@ export type CompactionPlanningWorkerInput =
 export type CompactionPlanningWorkerValue =
   | {
       kind: "summaryChunks";
-      chunks: AgentMessage[][];
+      chunkIndexes: number[][];
     }
-  | ({
+  | {
       kind: "oversizedFallback";
-    } & OversizedFallbackPlan)
-  | ({
+      smallMessageIndexes: number[];
+      oversizedNotes: string[];
+    }
+  | {
       kind: "stageSplit";
-    } & StageSplitPlan)
+      mode: "single";
+    }
+  | {
+      kind: "stageSplit";
+      mode: "split";
+      chunkIndexes: number[][];
+    }
   | ({
       kind: "historyPrune";
     } & HistoryPrunePlan)
@@ -114,6 +120,24 @@ function isWorkerInput(value: unknown): value is CompactionPlanningWorkerInput {
   }
 }
 
+function indexSelectedMessages(
+  indexByMessage: ReadonlyMap<AgentMessage, number>,
+  selected: AgentMessage[],
+): number[] {
+  return selected.map((message) => {
+    const index = indexByMessage.get(message);
+    if (index === undefined) {
+      throw new Error("Compaction planning result contains an unknown message");
+    }
+    return index;
+  });
+}
+
+function indexMessageChunks(source: AgentMessage[], chunks: AgentMessage[][]): number[][] {
+  const indexByMessage = new Map(source.map((message, index) => [message, index]));
+  return chunks.map((chunk) => indexSelectedMessages(indexByMessage, chunk));
+}
+
 /** Run one compaction planning request and return a serializable result. */
 export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlanningWorkerResult {
   if (!isWorkerInput(input)) {
@@ -125,30 +149,42 @@ export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlan
 
   try {
     switch (input.kind) {
-      case "summaryChunks":
+      case "summaryChunks": {
+        const chunks = buildSummaryChunks(input);
         return {
           status: "ok",
           value: {
             kind: "summaryChunks",
-            chunks: buildSummaryChunks(input),
+            chunkIndexes: indexMessageChunks(input.messages, chunks),
           },
         };
-      case "oversizedFallback":
+      }
+      case "oversizedFallback": {
+        const plan = buildOversizedFallbackPlan(input);
+        const indexByMessage = new Map(input.messages.map((message, index) => [message, index]));
         return {
           status: "ok",
           value: {
             kind: "oversizedFallback",
-            ...buildOversizedFallbackPlan(input),
+            smallMessageIndexes: indexSelectedMessages(indexByMessage, plan.smallMessages),
+            oversizedNotes: plan.oversizedNotes,
           },
         };
-      case "stageSplit":
+      }
+      case "stageSplit": {
+        const plan = buildStageSplitPlan(input);
         return {
           status: "ok",
-          value: {
-            kind: "stageSplit",
-            ...buildStageSplitPlan(input),
-          },
+          value:
+            plan.mode === "split"
+              ? {
+                  kind: "stageSplit",
+                  mode: "split",
+                  chunkIndexes: indexMessageChunks(input.messages, plan.chunks),
+                }
+              : { kind: "stageSplit", mode: "single" },
         };
+      }
       case "historyPrune":
         return {
           status: "ok",

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -21,6 +21,8 @@ vi.mock("openclaw/plugin-sdk/agent-sessions", async () => {
 import {
   buildStageSplitPlan,
   buildSummaryChunks,
+  estimateMessagesTokens,
+  projectCompactionMessagesForPlanning,
   sanitizeCompactionMessages,
 } from "./compaction-planning.js";
 
@@ -87,5 +89,29 @@ describe("compaction token accounting sanitization", () => {
     expect(sanitized).toHaveLength(2);
     expect(sanitized[0]).not.toHaveProperty("details");
     expect(sanitized.map((message) => message.role)).toEqual(["toolResult", "user"]);
+  });
+
+  it("bounds oversized tool-result text before worker cloning while preserving token pressure", () => {
+    const hugeText = "x".repeat(120_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "browser",
+        isError: false,
+        content: [{ type: "text", text: hugeText }],
+        timestamp: 1,
+      } as AgentMessage,
+    ];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const originalJson = JSON.stringify(messages);
+    const projectedJson = JSON.stringify(projected);
+
+    expect(projectedJson.length).toBeLessThan(originalJson.length / 4);
+    expect(projectedJson).not.toContain(hugeText);
+    expect(estimateMessagesTokens(projected)).toBeGreaterThanOrEqual(
+      estimateMessagesTokens(messages),
+    );
   });
 });

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -1,5 +1,5 @@
 // Verifies compaction token planning strips private/non-model fields first.
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { serializeConversation, type AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 
 const agentSessionMocks = vi.hoisted(() => ({
@@ -112,6 +112,51 @@ describe("compaction token accounting sanitization", () => {
     expect(projectedJson).not.toContain(hugeText);
     expect(estimateMessagesTokens(projected)).toBeGreaterThanOrEqual(
       estimateMessagesTokens(messages),
+    );
+  });
+
+  it("removes tool-result image bytes while preserving image pressure and summary semantics", () => {
+    const imageData = "a".repeat(1_000_000);
+    const userImageMessage = {
+      role: "user",
+      content: [
+        { type: "text", text: "describe this image" },
+        { type: "image", data: imageData, mimeType: "image/png" },
+      ],
+      timestamp: 0,
+    } satisfies AgentMessage;
+    const imageMessage = {
+      role: "toolResult",
+      toolCallId: "call_image",
+      toolName: "browser",
+      isError: false,
+      content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+      timestamp: 1,
+    } satisfies AgentMessage;
+    const messages: AgentMessage[] = [userImageMessage, imageMessage];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const projectedUserMessage = projected[0];
+    expect(projectedUserMessage?.role).toBe("user");
+    if (!projectedUserMessage || projectedUserMessage.role !== "user") {
+      throw new Error("expected projected user message");
+    }
+    const projectedUserImage = Array.isArray(projectedUserMessage.content)
+      ? projectedUserMessage.content[1]
+      : undefined;
+    const projectedMessage = projected[1];
+    expect(projectedMessage?.role).toBe("toolResult");
+    if (!projectedMessage || projectedMessage.role !== "toolResult") {
+      throw new Error("expected projected tool result");
+    }
+    const projectedImage = projectedMessage.content[0];
+
+    expect(projectedUserImage).toMatchObject({ type: "image", data: "", mimeType: "image/png" });
+    expect(projectedImage).toMatchObject({ type: "image", data: "", mimeType: "image/png" });
+    expect(JSON.stringify(projected)).not.toContain(imageData);
+    expect(estimateMessagesTokens(projected)).toBe(estimateMessagesTokens(messages));
+    expect(serializeConversation([projectedUserMessage, projectedMessage])).toBe(
+      serializeConversation([userImageMessage, imageMessage]),
     );
   });
 });

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -101,7 +101,7 @@ describe("compaction token accounting sanitization", () => {
         isError: false,
         content: [{ type: "text", text: hugeText }],
         timestamp: 1,
-      } as AgentMessage,
+      } satisfies AgentMessage,
     ];
 
     const projected = projectCompactionMessagesForPlanning(messages);


### PR DESCRIPTION
AI-assisted: yes. I reviewed the compaction planning and worker handoff paths, checked duplicate/open PR state for #100635, and independently reviewed and validated the branch locally.

## What Problem This Solves

Addresses #100635.

Compaction planning sanitizes private fields before worker handoff, but previously still sent full model-visible tool-result text and base64 image data through `workerData`. Large browser/command results or multimodal transcripts could therefore force multi-megabyte structured-clone work before summary-prompt truncation had a chance to help.

## Why This Change Was Made

This adds a planning-only projection for worker operations that do not need the original message bodies:

- oversized tool-result text/content keeps a bounded UTF-16-safe sample plus omitted-character accounting;
- image blocks keep type/MIME metadata but omit base64 bytes;
- token-pressure accounting remains conservative, so adaptive-ratio and summary chunking decisions still reflect the original payload;
- summary planning returns message indexes, and the caller remaps them to the exact sanitized originals before summary generation;
- history-prune planning keeps full-fidelity messages because that worker path may synthesize or repair messages and cannot be safely remapped by index;
- local fallback behavior and private-field sanitization remain unchanged.

The index remapping is the key fidelity guard: projection reduces worker cloning, but projected/truncated content is never used as the final summary input.

## User Impact

Long or multimodal sessions should spend less time and memory cloning redundant payloads into compaction planning workers, reducing event-loop stall and OOM risk while preserving the exact sanitized messages used to generate summaries.

## Evidence

Final rebase:

- `upstream/main`: `4bff6b188e2`
- branch head: `b381dadada5`

Validation on the final rebased head:

- `pnpm build` -> passed, including Plugin SDK export and UI performance gates.
- `pnpm tsgo:core` -> passed.
- `pnpm tsgo:core:test` -> passed.
- `pnpm tsgo:test:root` -> passed.
- `node scripts/run-vitest.mjs src/agents/compaction.token-sanitize.test.ts` -> 4/4 passed.
- Real `Worker` production-path proof with 64 messages and a 120k-character tool result -> `123,522 -> 123,522` serialized bytes, byte-for-byte exact after index remapping.
- `git diff --check upstream/main...HEAD` -> passed.
- Type-aware `oxlint` and `oxfmt` on all touched files -> passed.

Measured planning-projection results:

- 1 x 120k-character tool result: `120,134 -> 8,436` bytes (`92.98%` reduction), conservative token estimate `30,000 -> 30,001`.
- 65 x 40k-character tool results: `2,608,758 -> 548,258` bytes (`78.98%` reduction), conservative token estimate `650,000 -> 650,065`.
- One 1 MB user image plus one 1 MB tool-result image in a 64-message request: `2,251,077 -> 251,167` bytes (`88.84%` reduction), token estimate unchanged.

The repository's source-worker Vitest bootstrap currently cannot resolve the source `.worker.ts` module's emitted `.js` import; the equivalent real `Worker` path was therefore exercised directly with `tsx`. The full build and both production/test typechecks pass.

Signed-off-by: Ho Lim <subhoya@gmail.com>

