### PR TITLE
docs(browser): clarify JSON flag placement

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -20,10 +20,11 @@ Related: [Browser tool](/tools/browser)
 - `--timeout <ms>`: request timeout in ms (default: `30000`).
 - `--expect-final`: wait for a final Gateway response.
 - `--browser-profile <name>`: choose a browser profile (default: `openclaw`, or `browser.defaultProfile`).
-- `--json`: machine-readable output (where supported). Prefer the browser-level flag before
-  the subcommand, for example `openclaw browser --json status`; trailing placement such as
-  `openclaw browser status --json` is also supported when the selected child command does
-  not define its own `--json`.
+- `--json`: machine-readable output (where supported). This is a browser-level option, so
+  place it before the subcommand for an unambiguous form, such as
+  `openclaw browser --json status`. Trailing placement such as
+  `openclaw browser status --json` also works when the selected child command does not
+  define its own `--json`.
 
 ## Quick start (local)
 
@@ -67,7 +68,7 @@ openclaw browser --browser-profile openclaw reset-profile
 - For a running local managed profile, `status` and `doctor` report cached
   graphics diagnostics from Chrome: hardware/software classification, renderer,
   backend, device/driver, feature and disabled-status details, and accelerated
-  video capabilities. `status --json` returns the full structured payload.
+  video capabilities. `openclaw browser --json status` returns the full structured payload.
   Passive status never launches Chrome just to collect these facts.
 - `stop` closes the active control session and clears temporary emulation overrides even for `attachOnly` and remote CDP profiles where OpenClaw did not launch the browser process itself. For local managed profiles, `stop` also stops the spawned browser process.
 - `start --headless` applies only to that start request, and only when OpenClaw launches a local managed browser. It does not rewrite `browser.headless` or profile config, and is a no-op for an already-running browser.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -20,7 +20,10 @@ Related: [Browser tool](/tools/browser)
 - `--timeout <ms>`: request timeout in ms (default: `30000`).
 - `--expect-final`: wait for a final Gateway response.
 - `--browser-profile <name>`: choose a browser profile (default: `openclaw`, or `browser.defaultProfile`).
-- `--json`: machine-readable output (where supported).
+- `--json`: machine-readable output (where supported). Prefer the browser-level flag before
+  the subcommand, for example `openclaw browser --json status`; trailing placement such as
+  `openclaw browser status --json` is also supported when the selected child command does
+  not define its own `--json`.
 
 ## Quick start (local)
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -389,10 +389,10 @@ When an action fails (e.g. "not visible", "strict mode violation", "covered"):
 Examples:
 
 ```bash
-openclaw browser status --json
-openclaw browser snapshot --interactive --json
-openclaw browser requests --filter api --json
-openclaw browser cookies --json
+openclaw browser --json status
+openclaw browser --json snapshot --interactive
+openclaw browser --json requests --filter api
+openclaw browser --json cookies
 ```
 
 Role snapshots in JSON include `refs` plus a small `stats` block (lines/chars/refs/interactive) so tools can reason about payload size and density.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -312,8 +312,10 @@ main model can read the screenshot directly.
   browser processes.
 - On Linux hosts without `DISPLAY` or `WAYLAND_DISPLAY`, local managed profiles
   default to headless automatically when neither the environment nor profile/global
-  config explicitly chooses headed mode. `openclaw browser status --json`
-  reports `headlessSource` as `env`, `profile`, `config`,
+  config explicitly chooses headed mode. The canonical JSON form is
+  `openclaw browser --json status`, and trailing `status --json` also works
+  because `status` does not define its own `--json`. It reports
+  `headlessSource` as `env`, `profile`, `config`,
   `request`, `linux-display-fallback`, or `default`.
 - `OPENCLAW_BROWSER_HEADLESS=1` forces local managed launches headless for the
   current process. `OPENCLAW_BROWSER_HEADLESS=0` forces headed mode for ordinary

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -312,9 +312,9 @@ main model can read the screenshot directly.
   browser processes.
 - On Linux hosts without `DISPLAY` or `WAYLAND_DISPLAY`, local managed profiles
   default to headless automatically when neither the environment nor profile/global
-  config explicitly chooses headed mode. The canonical JSON form is
-  `openclaw browser --json status`, and trailing `status --json` also works
-  because `status` does not define its own `--json`. It reports
+  config explicitly chooses headed mode. Use the unambiguous browser-level form
+  `openclaw browser --json status`; trailing `openclaw browser status --json`
+  also works because `status` does not define its own `--json`. The command reports
   `headlessSource` as `env`, `profile`, `config`,
   `request`, `linux-display-fallback`, or `default`.
 - `OPENCLAW_BROWSER_HEADLESS=1` forces local managed launches headless for the
@@ -330,7 +330,7 @@ main model can read the screenshot directly.
   browser-level CDP endpoint for renderer, backend, device/driver, feature
   status, driver workarounds, and accelerated video capabilities. The result is
   cached for that browser process and exposed in full by
-  `openclaw browser status --json`. A passive status call does not launch Chrome.
+  `openclaw browser --json status`. A passive status call does not launch Chrome.
   Existing-session, extension, remote CDP, and sandbox browsers remain separate
   and are not inspected through this managed-host path.
 - Headless managed Chrome still uses the conservative `--disable-gpu` default.


### PR DESCRIPTION
## What Problem This Solves

The browser CLI reference described `--json` as a common flag without explaining the preferred placement or the supported trailing compatibility path. One browser tool page also showed the trailing `openclaw browser status --json` form without clarifying the canonical browser-level form.

AI-assisted: yes.

## Why This Change Was Made

This updates the browser CLI reference to show `openclaw browser --json status` as the canonical form while noting that trailing placement, such as `openclaw browser status --json`, remains supported when the selected child command does not define its own `--json`. The matching browser tool page now uses the same distinction. The change is docs-only and does not alter CLI behavior.

## User Impact

Users following the browser docs get the preferred command form without being told that the supported trailing form is invalid.

## Evidence

- `git diff --check`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed -- docs/cli/browser.md docs/tools/browser.md`
- Verified the edited docs mention both canonical `openclaw browser --json status` and supported trailing `openclaw browser status --json` for non-colliding child commands.
- ACP Codex review was unavailable due to authentication; local Codex CLI fallback was logged in but timed out before returning review results.