### PR TITLE
chore(codex): update managed app-server to 0.144.1

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -50,7 +50,7 @@ Top-level fields:
 ## App-server transport
 
 By default OpenClaw starts the managed Codex binary shipped with the bundled
-plugin (currently `@openai/codex` `0.143.0`):
+plugin (currently `@openai/codex` `0.144.1`):
 
 ```bash
 codex app-server --listen stdio://
@@ -462,17 +462,21 @@ If discovery fails or times out, OpenClaw uses a bundled fallback catalog:
 | `gpt-5.4-mini` | GPT-5.4-Mini | low, medium, high, xhigh |
 
 <Note>
-The current bundled harness is `@openai/codex` `0.143.0`. A `model/list` probe
-against that bundled app-server returned these public picker rows beyond the
-fallback catalog:
+The current bundled harness is `@openai/codex` `0.144.1`. A `model/list` probe
+against that bundled app-server returned these public picker rows:
 
-| Model id        | Input modalities | Reasoning efforts        |
-| --------------- | ---------------- | ------------------------ |
-| `gpt-5.5`       | text, image      | low, medium, high, xhigh |
-| `gpt-5.4`       | text, image      | low, medium, high, xhigh |
-| `gpt-5.4-mini`  | text, image      | low, medium, high, xhigh |
-| `gpt-5.3-codex` | text, image      | low, medium, high, xhigh |
-| `gpt-5.2`       | text, image      | low, medium, high, xhigh |
+| Model id        | Input modalities | Reasoning efforts                    |
+| --------------- | ---------------- | ------------------------------------ |
+| `gpt-5.6-sol`   | text, image      | low, medium, high, xhigh, max, ultra |
+| `gpt-5.6-terra` | text, image      | low, medium, high, xhigh, max, ultra |
+| `gpt-5.6-luna`  | text, image      | low, medium, high, xhigh, max        |
+| `gpt-5.5`       | text, image      | low, medium, high, xhigh             |
+| `gpt-5.4`       | text, image      | low, medium, high, xhigh             |
+| `gpt-5.4-mini`  | text, image      | low, medium, high, xhigh             |
+| `gpt-5.2`       | text, image      | low, medium, high, xhigh             |
+
+The app-server catalog can report `ultra`; OpenClaw reasoning controls currently
+expose levels through `max`.
 
 Live picker rows are account-scoped and can change with the account, Codex
 catalog, or bundled version; run `/codex models` for the current list rather

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -8,16 +8,16 @@
       "name": "@openclaw/codex",
       "version": "2026.6.11",
       "dependencies": {
-        "@openai/codex": "0.143.0",
+        "@openai/codex": "0.144.1",
         "typebox": "1.3.3",
         "ws": "8.21.0",
         "zod": "4.4.3"
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0.tgz",
-      "integrity": "sha512-6h53sNtESIYncWVwU7zEjdVajwcad/0H94MOrgGqhwBMa9RRUDVG6DU9E9euC7yRdtrsKDAkJkz/m5moZ6MU3A==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -26,19 +26,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.143.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.143.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.143.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.143.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.143.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.143.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.143.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-darwin-arm64.tgz",
-      "integrity": "sha512-hs9bPkE1c0+EtbHxxVfhaaGl1u6/LVdhEtOX5t9N+ri54yjMUkzKJLc7MOBa1DYRMDTWT+lPEfeB+8Fv9coTKg==",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
       "cpu": [
         "arm64"
       ],
@@ -53,9 +53,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-darwin-x64.tgz",
-      "integrity": "sha512-xHbrb/Qkj+ZZqYkAuio3mcFxpqlg/NNpBDz5iMKlGa7XfK3miUu6R50c9cRW1ZPQVRfRnFhs4l7OhI5u5r+HvA==",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.143.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-arm64.tgz",
-      "integrity": "sha512-1TMx1a/YBEY0SBhPGn8z9HjOpaDssw+WJiIi/+r0CB5uZf6qnALN02TrZTZl2PSUI8olnBf/VccjnwVCrzR38w==",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
       "cpu": [
         "arm64"
       ],
@@ -87,9 +87,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-linux-x64.tgz",
-      "integrity": "sha512-B6v6oUgBbjt1bL7yBbRp7e0vLiVOjRdz9Wykotve52Aq2H2TeiCqxM5BSOaFkmNO6VxE0seW7hTi2UZF9x8LLA==",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
       "cpu": [
         "x64"
       ],
@@ -104,9 +104,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.143.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-arm64.tgz",
-      "integrity": "sha512-8ntYPI3IQWZuayL214tYanuYhom23RxHUWRkmay45hGymEW4TwwFqzppKXEzcBXrCF5uSWlOMMG+B2elN6kWuQ==",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +121,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.143.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.143.0-win32-x64.tgz",
-      "integrity": "sha512-d60HLkzSQ7rdL35xPxH1x3g8DuJjEbhEx1UOK5ivA1PBD9eWvP46rtdHkSvCZyqHUhaHFr5We2SugE9+Y8HhVA==",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
       "cpu": [
         "x64"
       ],

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.143.0",
+    "@openai/codex": "0.144.1",
     "typebox": "1.3.3",
     "ws": "8.21.0",
     "zod": "4.4.3"

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -10,4 +10,4 @@ export const MIN_CODEX_APP_SERVER_VERSION = "0.143.0";
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";
 // Keep this in sync with the Codex CLI live-test package pin.
 /** Managed Codex app-server package version installed by OpenClaw. */
-export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.143.0";
+export const MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION = "0.144.1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,8 +531,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.143.0
-        version: 0.143.0
+        specifier: 0.144.1
+        version: 0.144.1
       typebox:
         specifier: 1.3.3
         version: 1.3.3
@@ -3172,43 +3172,43 @@ packages:
     resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@openai/codex@0.143.0':
-    resolution: {integrity: sha512-6h53sNtESIYncWVwU7zEjdVajwcad/0H94MOrgGqhwBMa9RRUDVG6DU9E9euC7yRdtrsKDAkJkz/m5moZ6MU3A==}
+  '@openai/codex@0.144.1':
+    resolution: {integrity: sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.143.0-darwin-arm64':
-    resolution: {integrity: sha512-hs9bPkE1c0+EtbHxxVfhaaGl1u6/LVdhEtOX5t9N+ri54yjMUkzKJLc7MOBa1DYRMDTWT+lPEfeB+8Fv9coTKg==}
+  '@openai/codex@0.144.1-darwin-arm64':
+    resolution: {integrity: sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.143.0-darwin-x64':
-    resolution: {integrity: sha512-xHbrb/Qkj+ZZqYkAuio3mcFxpqlg/NNpBDz5iMKlGa7XfK3miUu6R50c9cRW1ZPQVRfRnFhs4l7OhI5u5r+HvA==}
+  '@openai/codex@0.144.1-darwin-x64':
+    resolution: {integrity: sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.143.0-linux-arm64':
-    resolution: {integrity: sha512-1TMx1a/YBEY0SBhPGn8z9HjOpaDssw+WJiIi/+r0CB5uZf6qnALN02TrZTZl2PSUI8olnBf/VccjnwVCrzR38w==}
+  '@openai/codex@0.144.1-linux-arm64':
+    resolution: {integrity: sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.143.0-linux-x64':
-    resolution: {integrity: sha512-B6v6oUgBbjt1bL7yBbRp7e0vLiVOjRdz9Wykotve52Aq2H2TeiCqxM5BSOaFkmNO6VxE0seW7hTi2UZF9x8LLA==}
+  '@openai/codex@0.144.1-linux-x64':
+    resolution: {integrity: sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.143.0-win32-arm64':
-    resolution: {integrity: sha512-8ntYPI3IQWZuayL214tYanuYhom23RxHUWRkmay45hGymEW4TwwFqzppKXEzcBXrCF5uSWlOMMG+B2elN6kWuQ==}
+  '@openai/codex@0.144.1-win32-arm64':
+    resolution: {integrity: sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.143.0-win32-x64':
-    resolution: {integrity: sha512-d60HLkzSQ7rdL35xPxH1x3g8DuJjEbhEx1UOK5ivA1PBD9eWvP46rtdHkSvCZyqHUhaHFr5We2SugE9+Y8HhVA==}
+  '@openai/codex@0.144.1-win32-x64':
+    resolution: {integrity: sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -8964,31 +8964,31 @@ snapshots:
 
   '@npmcli/redact@4.0.0': {}
 
-  '@openai/codex@0.143.0':
+  '@openai/codex@0.144.1':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.143.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.143.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.143.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.143.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.143.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.143.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.1-win32-x64'
 
-  '@openai/codex@0.143.0-darwin-arm64':
+  '@openai/codex@0.144.1-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.143.0-darwin-x64':
+  '@openai/codex@0.144.1-darwin-x64':
     optional: true
 
-  '@openai/codex@0.143.0-linux-arm64':
+  '@openai/codex@0.144.1-linux-arm64':
     optional: true
 
-  '@openai/codex@0.143.0-linux-x64':
+  '@openai/codex@0.144.1-linux-x64':
     optional: true
 
-  '@openai/codex@0.143.0-win32-arm64':
+  '@openai/codex@0.144.1-win32-arm64':
     optional: true
 
-  '@openai/codex@0.143.0-win32-x64':
+  '@openai/codex@0.144.1-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.9':


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's bundled Codex harness still pinned `@openai/codex` 0.143.0, while the
current stable Codex package is 0.144.1. The stale pin also left the harness
reference on the previous public `model/list` catalog.

## Why This Change Was Made

- Update the managed package and generated lock/shrinkwrap entries to 0.144.1.
- Keep the supported external app-server floor at 0.143.0.
- Refresh the documented public picker rows from the official 0.144.1
  app-server.
- Keep OpenClaw's public reasoning controls capped at `max` while documenting
  that the raw Codex catalog can report `ultra`.

The official `rust-v0.144.1` tag peels to
`44918ea10c0f99151c6710411b4322c2f5c96bea`. Its model catalog and complete
app-server protocol schema tree are byte-identical to `rust-v0.144.0`; no
protocol mirror regeneration is required.

## User Impact

Bundled Codex sessions use the current stable 0.144.1 app-server. Model
discovery now documents the Sol, Terra, and Luna picker rows returned by that
package, while existing custom app-server installs remain compatible from
0.143.0 onward.

## Evidence

Exact reviewed head: `23e8d7737be422d59568a91762f5b3d79a94b6b9`

Testbox: `tbx_01kx4j90ey1gha3hxc8ws40qfg`

Warmup workflow: https://github.com/openclaw/openclaw/actions/runs/29056593453

- `pnpm install --frozen-lockfile`: passed; installed `@openai/codex` 0.144.1.
- `pnpm codex-app-server:protocol:check` against official
  `rust-v0.144.1`: passed.
- Live isolated 0.144.1 `model/list`: returned the documented seven rows with
  `gpt-5.6-sol` as default.
- `pnpm test:serial` for the Codex manifest, client, managed-binary, models, and
  protocol-validator suites: 52/52 passed.
- `pnpm format:docs:check`, `pnpm docs:check-mdx`, and
  `pnpm docs:check-links`: passed.
- `pnpm deps:shrinkwrap:check`: passed for all 74 package artifacts.
- Selected npm and ClawHub plugin release checks for `@openclaw/codex`: passed.
- `pnpm check:changed`: passed all lanes, including tsgo, core/extensions/scripts
  lint, import cycles, dependency pins, shrinkwraps, and guards.
- Fresh branch autoreview: no accepted/actionable findings; patch correct,
  confidence 0.82.

The root npm shrinkwrap was regenerated and audited; it has no Codex-owned
change. Full `release:generated:check` also exposed pre-existing `main` drift in
the Vault plugin version alignment and config docs baseline, outside this
five-file Codex patch.

AI-assisted: yes.
