### PR TITLE
fix: release startup migration lease before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.
 - **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @coder-master-0915, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,7 +1,7 @@
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { GatewayRunPreBootstrapOptions } from "./future-config-guard.js";
 import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
 import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
@@ -655,23 +655,30 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
 export async function recheckGatewayRunBootstrap(
   params: GatewayRunGuardParams & { snapshot?: ConfigFileSnapshot },
 ): Promise<boolean> {
+  // This callback can run while startup preflight owns the shared migration lease.
+  // Throw a typed exit so its finally releases the lease before the CLI exits.
+  const deferredExitRuntime: RuntimeEnv = {
+    ...params.runtime,
+    exit: (code) => {
+      throw new ExitError(code);
+    },
+  };
   const expected = preparedGatewayRunBootstrapSnapshot;
   if (!expected) {
     params.runtime.error(
       "Refusing to run automatic gateway startup migrations without a prepared config snapshot. Retry startup.",
     );
-    params.runtime.exit(1);
-    return false;
+    throw new ExitError(1);
   }
   const current = params.snapshot
     ? enforceGatewayRunFutureConfigGuard({
         opts: params.opts,
-        runtime: params.runtime,
+        runtime: deferredExitRuntime,
         snapshot: params.snapshot,
       })
       ? params.snapshot
       : null
-    : await readGuardedGatewayRunConfig(params);
+    : await readGuardedGatewayRunConfig({ ...params, runtime: deferredExitRuntime });
   if (!current) {
     return false;
   }
@@ -685,6 +692,5 @@ export async function recheckGatewayRunBootstrap(
   params.runtime.error(
     "Refusing to run automatic gateway startup migrations because the selected config changed during startup. Retry startup so the new config can be validated.",
   );
-  params.runtime.exit(1);
-  return false;
+  throw new ExitError(1);
 }

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../../packages/terminal-core/src/note.js";
+import { ExitError } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
@@ -222,6 +223,27 @@ describe("ensureConfigReady", () => {
     });
   });
 
+  it("honors a deferred migration exit after preflight resources unwind", async () => {
+    let preflightUnwound = false;
+    loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
+      try {
+        throw new ExitError(78);
+      } finally {
+        preflightUnwound = true;
+      }
+    });
+    const runtime = makeRuntime();
+    runtime.exit.mockImplementation(() => {
+      expect(preflightUnwound).toBe(true);
+    });
+
+    await expect(
+      ensureConfigReady({ runtime: runtime as never, commandPath: ["gateway"] }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 78 });
+
+    expect(runtime.exit).toHaveBeenCalledWith(78);
+  });
+
   it("does not require a startup migration checkpoint for gateway probes", async () => {
     await runEnsureConfigReady(["gateway", "health"]);
 
@@ -346,24 +368,27 @@ describe("ensureConfigReady", () => {
   it.each([
     { name: "status", commandPath: ["status"] },
     { name: "plugin listing", commandPath: ["plugins", "list"] },
-  ])("runs doctor flow for $name with configured custom session stores", async ({ commandPath }) => {
-    const root = useTempOpenClawHome();
-    const customStore = path.join(root, "sessions", "sessions.json");
-    const snapshot = {
-      ...makeSnapshot(),
-      config: { session: { store: customStore } },
-      runtimeConfig: { session: { store: customStore } },
-    };
-    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
-    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
-      snapshot,
-      baseConfig: {},
-    });
+  ])(
+    "runs doctor flow for $name with configured custom session stores",
+    async ({ commandPath }) => {
+      const root = useTempOpenClawHome();
+      const customStore = path.join(root, "sessions", "sessions.json");
+      const snapshot = {
+        ...makeSnapshot(),
+        config: { session: { store: customStore } },
+        runtimeConfig: { session: { store: customStore } },
+      };
+      readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+      loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
+        snapshot,
+        baseConfig: {},
+      });
 
-    await runEnsureConfigReady(commandPath);
+      await runEnsureConfigReady(commandPath);
 
-    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
-  });
+      expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
+    },
+  );
 
   it("pins a valid preflight snapshot for command code reuse", async () => {
     const snapshot = {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -7,7 +7,7 @@ import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/c
 import { resolveLegacyStateDirs, resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["audit", "doctor", "logs", "health", "help", "status"]);
@@ -225,9 +225,17 @@ export async function ensureConfigReady(params: {
           ? { beforeStateMigrations: params.beforeStateMigrations }
           : {}),
       });
-    return !params.suppressDoctorStdout
-      ? (await runDoctorConfigPreflight()).snapshot
-      : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+    try {
+      return !params.suppressDoctorStdout
+        ? (await runDoctorConfigPreflight()).snapshot
+        : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+    } catch (error) {
+      if (error instanceof ExitError) {
+        // The migration owner has unwound its lease and heartbeat before this handoff.
+        params.runtime.exit(error.code);
+      }
+      throw error;
+    }
   };
   if (
     !didRunDoctorConfigFlow &&

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -95,7 +95,7 @@ type GatewayRunCommandHooks = {
   beforeRun?: (opts: { reset?: boolean }) => Promise<void>;
 };
 type CliExecutionBootstrapOptions = {
-  beforeStateMigrations?: () => Promise<boolean>;
+  beforeStateMigrations?: (snapshot?: ConfigSnapshotStub) => Promise<boolean>;
 };
 const addGatewayRunCommandMock = vi.hoisted(() =>
   vi.fn<(command: unknown, hooks?: GatewayRunCommandHooks) => unknown>((command) => command),
@@ -610,7 +610,7 @@ describe("runCli exit behavior", () => {
     expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
   });
 
-  it("rechecks the effective guarded config before automatic startup migrations", async () => {
+  it("defers config-drift exit to the migration owner before startup migrations", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
       hash: "guarded",
@@ -629,7 +629,7 @@ describe("runCli exit behavior", () => {
     await hooks?.beforeRun?.({});
     const beforeStateMigrations = (
       ensureCliExecutionBootstrapMock.mock.calls[0]?.[0] as
-        | { beforeStateMigrations?: () => Promise<boolean> }
+        | { beforeStateMigrations?: (snapshot?: ConfigSnapshotStub) => Promise<boolean> }
         | undefined
     )?.beforeStateMigrations;
     readConfigFileSnapshotMock.mockResolvedValue({
@@ -648,8 +648,65 @@ describe("runCli exit behavior", () => {
       throw new Error(`exit:${String(code)}`);
     }) as typeof process.exit);
     try {
-      await expect(beforeStateMigrations?.()).rejects.toThrow("exit:1");
+      await expect(beforeStateMigrations?.()).rejects.toMatchObject({
+        name: "ExitError",
+        code: 1,
+      });
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("changed during startup"));
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("defers a service-mode future-config exit to the migration owner", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      hash: "guarded",
+      path: "/tmp/openclaw.json",
+      raw: "{}",
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    });
+    await runCli(["node", "openclaw", "gateway"]);
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({});
+    const beforeStateMigrations =
+      ensureCliExecutionBootstrapMock.mock.calls[0]?.[0]?.beforeStateMigrations;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+          OPENCLAW_SERVICE_MARKER: undefined,
+        },
+        async () => {
+          await expect(
+            beforeStateMigrations?.({
+              exists: true,
+              hash: "future",
+              path: "/tmp/openclaw.json",
+              raw: "{}",
+              valid: true,
+              sourceConfig: {
+                env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+                meta: { lastTouchedVersion: "9999.1.1" },
+              },
+            }),
+          ).rejects.toMatchObject({ name: "ExitError", code: 78 });
+          expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining("start the gateway service"),
+          );
+          expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+          expect(exitSpy).not.toHaveBeenCalled();
+        },
+      );
     } finally {
       exitSpy.mockRestore();
       errorSpy.mockRestore();

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -1,5 +1,6 @@
 // Doctor config preflight tests cover state migration preflight behavior before config repair.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExitError } from "../runtime.js";
 
 type StateMigrationResult = {
   migrated: boolean;
@@ -74,7 +75,9 @@ const startupMigrationLease = vi.hoisted(() => ({
   owner: "startup-test-owner",
   release: startupMigrationLeaseRelease,
 }));
-const acquireStartupMigrationLease = vi.hoisted(() => vi.fn(() => startupMigrationLease));
+const acquireStartupMigrationLease = vi.hoisted(() =>
+  vi.fn((_params: { env: NodeJS.ProcessEnv }) => startupMigrationLease),
+);
 const recordSuccessfulStartupMigrations = vi.hoisted(() => vi.fn());
 const runPostCorePluginConvergence = vi.hoisted(() =>
   vi.fn(
@@ -235,6 +238,73 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
+  it("releases the startup lease when the fresh config guard rejects", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-original-state";
+    let leaseEnv: NodeJS.ProcessEnv | undefined;
+    acquireStartupMigrationLease.mockImplementationOnce(({ env }) => {
+      leaseEnv = env;
+      return {
+        ...startupMigrationLease,
+        release: vi.fn(() => {
+          expect(env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-original-state");
+          startupMigrationLeaseRelease();
+        }),
+      };
+    });
+    const beforeStateMigrations = vi
+      .fn<(_snapshot?: Record<string, unknown>) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockImplementationOnce(async () => {
+        process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-drifted-state";
+        return false;
+      });
+
+    try {
+      await expect(
+        runDoctorConfigPreflight({
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+          beforeStateMigrations,
+          requireStartupMigrationCheckpoint: true,
+        }),
+      ).rejects.toThrow("selected config changed during startup");
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+
+    expect(leaseEnv).not.toBe(process.env);
+    expect(beforeStateMigrations).toHaveBeenCalledTimes(2);
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the startup lease before propagating a deferred service exit", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    const deferredExit = new ExitError(78);
+    const beforeStateMigrations = vi
+      .fn<(_snapshot?: Record<string, unknown>) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(deferredExit);
+
+    await expect(
+      runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        beforeStateMigrations,
+        requireStartupMigrationCheckpoint: true,
+      }),
+    ).rejects.toBe(deferredExit);
+
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
   it("skips config-dependent migrations when the fresh snapshot guard rejects", async () => {
     const beforeStateMigrations = vi
       .fn<(snapshot?: Record<string, unknown>) => Promise<boolean>>()
@@ -283,13 +353,16 @@ describe("runDoctorConfigPreflight state migration", () => {
       requireStartupMigrationCheckpoint: true,
     });
 
-    expect(acquireStartupMigrationLease).toHaveBeenCalledWith({ env: process.env });
+    const pinnedEnv = acquireStartupMigrationLease.mock.calls[0]?.[0]?.env;
+    expect(pinnedEnv).toBeDefined();
+    expect(pinnedEnv).not.toBe(process.env);
+    expect(needsStartupMigrationCheckpoint).toHaveBeenCalledWith({ env: pinnedEnv });
     expect(runPostCorePluginConvergence).toHaveBeenCalledWith({
       cfg: { gateway: { mode: "local", port: 19091 } },
       env: process.env,
     });
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith({
-      env: process.env,
+      env: pinnedEnv,
       lease: startupMigrationLease,
     });
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
@@ -311,8 +384,9 @@ describe("runDoctorConfigPreflight state migration", () => {
       requireStartupMigrationCheckpoint: true,
     });
 
+    const pinnedEnv = acquireStartupMigrationLease.mock.calls[0]?.[0]?.env;
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith({
-      env: process.env,
+      env: pinnedEnv,
       lease: startupMigrationLease,
     });
     expect(note).toHaveBeenCalledWith("- Left reviewed residue in place.", "Doctor notices");

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { cloneEnvWithPlatformSemantics } from "../config/env-vars.js";
 import {
   readConfigFileSnapshot,
   recoverConfigFromJsonRootSuffix,
@@ -158,6 +159,12 @@ function formatStartupMigrationFailure(params: { warnings: string[]; blockers: s
   ].join("\n");
 }
 
+function throwStartupMigrationGuardRejected(): never {
+  throw new Error(
+    "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
+  );
+}
+
 /**
  * Runs early doctor config checks before the main config repair flow.
  *
@@ -171,6 +178,7 @@ export async function runDoctorConfigPreflight(
     repairPrefixedConfig?: boolean;
     recoverCorruptTargetStore?: boolean;
     invalidConfigNote?: string | false;
+    /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
     requireStartupMigrationCheckpoint?: boolean;
   } = {},
@@ -181,6 +189,7 @@ export async function runDoctorConfigPreflight(
     options.requireStartupMigrationCheckpoint === true
       ? await import("../infra/startup-migration-checkpoint.js")
       : undefined;
+  let startupMigrationEnv = process.env;
   let shouldRecordStartupCheckpoint = false;
   let startupMigrationLease: StartupMigrationLease | undefined;
   let startupMigrationHeartbeat: ReturnType<typeof setInterval> | undefined;
@@ -202,16 +211,16 @@ export async function runDoctorConfigPreflight(
       options.beforeStateMigrations === undefined ||
       (await options.beforeStateMigrations());
     if (startupCheckpoint && !stateMigrationsAllowed) {
-      throw new Error(
-        "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
-      );
+      throwStartupMigrationGuardRejected();
     }
     if (startupCheckpoint) {
+      // Later config reads can apply state selectors. Pin the accepted lease target for its lifetime.
+      startupMigrationEnv = cloneEnvWithPlatformSemantics(process.env);
       shouldRecordStartupCheckpoint = startupCheckpoint.needsStartupMigrationCheckpoint({
-        env: process.env,
+        env: startupMigrationEnv,
       });
       startupMigrationLease = shouldRecordStartupCheckpoint
-        ? startupCheckpoint.acquireStartupMigrationLease({ env: process.env })
+        ? startupCheckpoint.acquireStartupMigrationLease({ env: startupMigrationEnv })
         : undefined;
       if (startupMigrationLease) {
         startupMigrationHeartbeat = setInterval(() => {
@@ -277,12 +286,15 @@ export async function runDoctorConfigPreflight(
 
     const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
     const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
-    const configStateMigrationsAllowed =
-      stateMigrations !== undefined &&
-      stateMigrationsAllowed &&
-      (options.beforeStateMigrations === undefined ||
-        (await options.beforeStateMigrations(snapshot)));
-    if (stateMigrations && configStateMigrationsAllowed) {
+    const freshConfigGuardAllowed =
+      stateMigrations === undefined ||
+      !stateMigrationsAllowed ||
+      options.beforeStateMigrations === undefined ||
+      (await options.beforeStateMigrations(snapshot));
+    if (startupCheckpoint && !freshConfigGuardAllowed) {
+      throwStartupMigrationGuardRejected();
+    }
+    if (stateMigrations && stateMigrationsAllowed && freshConfigGuardAllowed) {
       const {
         autoMigrateLegacyState,
         autoMigrateLegacyPluginDoctorState,
@@ -344,7 +356,7 @@ export async function runDoctorConfigPreflight(
         );
       }
       startupCheckpoint?.recordSuccessfulStartupMigrations({
-        env: process.env,
+        env: startupMigrationEnv,
         lease: startupMigrationLease,
       });
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -95,7 +95,7 @@ export const defaultRuntime: OutputRuntimeEnv = {
   },
 };
 
-/** Error thrown by createNonExitingRuntime.exit() to signal simulated process exit. */
+/** Signals a deferred or non-exiting runtime exit so callers can unwind owned resources. */
 export class ExitError extends Error {
   constructor(
     public readonly code: number,


### PR DESCRIPTION
Closes #103145

## What Problem This Solves

Gateway startup config drift can request a controlled process exit while doctor preflight still owns the shared startup-migration lease. A hard runtime exit bypasses the lease cleanup `finally`, so immediate retries wait for the five-minute lease expiry.

## Why This Change Was Made

Defer guarded exits with the existing typed `ExitError`, let doctor preflight unwind its heartbeat and lease, then hand the original exit code back to the CLI runtime. Pin lease and checkpoint operations to the accepted environment so a later config reload cannot redirect cleanup to another state database.

The preflight also treats a rejected second config guard as a startup failure instead of recording a successful migration checkpoint.

## User Impact

When the selected config changes during startup, the gateway exits with the existing status and can be retried immediately. Service-mode future-config rejection keeps exit code 78 and revokes the destructive override as before.

## Evidence

- Before-fix exact-base focused run: new regression tests failed at the hard exit paths in `pre-bootstrap.ts` and `future-config-guard.ts`.
- Blacksmith Testbox `tbx_01kx4hyn6qdjpyfpvakgyepk6h`: 211 focused tests passed across runtime, config guard, gateway startup, and migration preflight.
- Same Testbox: `pnpm check:changed` passed for core, core tests, and docs lanes.
- Same Testbox: `pnpm build` passed, including tsdown, CLI bootstrap import guard, runtime postbuild, and Control UI build.
- Targeted `pnpm format:check` passed for all 8 changed files.
- Fresh autoreview: clean, no accepted or actionable findings.

AI-assisted implementation and review.
