### PR TITLE
feat(webchat): seasonal lobster wardrobe — santa, pumpkin, and an anniversary dress code

### DIFF
--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -105,8 +105,9 @@ describe("lobster pet look", () => {
     const builds = new Set<string>();
     const clawSizes = new Set<string>();
     const tailFans = new Set<boolean>();
+    const neutralDate = new Date("2026-07-15T12:00:00");
     for (let seed = 0; seed < 300; seed++) {
-      const look = createLobsterPetLook(seed);
+      const look = createLobsterPetLook(seed, neutralDate);
       palettes.add(look.palette.id);
       personalities.add(look.personality);
       builds.add(look.build);
@@ -133,8 +134,9 @@ describe("lobster pet look", () => {
   it("hatches every rarity tier, with rares staying rare", () => {
     const counts = new Map<string, number>();
     const total = 20_000;
+    const neutralDate = new Date("2026-07-15T12:00:00");
     for (let seed = 0; seed < total; seed++) {
-      const id = createLobsterPetLook(seed).palette.id;
+      const id = createLobsterPetLook(seed, neutralDate).palette.id;
       counts.set(id, (counts.get(id) ?? 0) + 1);
     }
     // Every palette, including the 1% grails, must be reachable.
@@ -172,6 +174,38 @@ describe("lobsterPetName", () => {
       palette: { id: "gold" as const, shell: "#f4b840", claw: "#f9d47a" },
     };
     expect(lobsterPetName(goldLook, 1)).toBe("Goldie");
+  });
+});
+
+describe("seasonal wardrobe", () => {
+  it("adds santa hats in December and pumpkins in late October", () => {
+    const december = new Date("2026-12-10T12:00:00");
+    const october = new Date("2026-10-25T12:00:00");
+    const july = new Date("2026-07-15T12:00:00");
+    const accessoriesOn = (date: Date) =>
+      new Set(Array.from({ length: 400 }, (_, seed) => createLobsterPetLook(seed, date).accessory));
+    const decemberSet = accessoriesOn(december);
+    expect(decemberSet.has("santa")).toBe(true);
+    expect(decemberSet.has("pumpkin")).toBe(false);
+    const octoberSet = accessoriesOn(october);
+    expect(octoberSet.has("pumpkin")).toBe(true);
+    expect(octoberSet.has("santa")).toBe(false);
+    const julySet = accessoriesOn(july);
+    expect(julySet.has("santa")).toBe(false);
+    expect(julySet.has("pumpkin")).toBe(false);
+    expect(julySet.has("party")).toBe(false);
+  });
+
+  it("dresses everyone as the classic logo on the repo anniversary", () => {
+    const anniversary = new Date("2026-11-24T12:00:00");
+    for (let seed = 0; seed < 50; seed++) {
+      const look = createLobsterPetLook(seed, anniversary);
+      expect(look.palette.id).toBe("retro");
+      expect(look.accessory).toBe("party");
+    }
+    // The day after is business as usual.
+    const after = createLobsterPetLook(7, new Date("2026-11-25T12:00:00"));
+    expect(after.accessory).not.toBe("party");
   });
 });
 

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -44,7 +44,14 @@ export type LobsterPetPalette = {
   claw: string;
 };
 
-export type LobsterPetAccessory = "none" | "crown" | "sprout" | "patch";
+export type LobsterPetAccessory =
+  | "none"
+  | "crown"
+  | "sprout"
+  | "patch"
+  | "santa"
+  | "pumpkin"
+  | "party";
 
 export type LobsterPetAntennae = "perky" | "droopy";
 
@@ -184,6 +191,29 @@ const ACCESSORIES: Array<[LobsterPetAccessory, number]> = [
   ["patch", 14],
   ["crown", 10],
 ];
+
+// OpenClaw's repository was born 2025-11-24 (GitHub created_at); on the
+// anniversary every visitor dresses as the classic logo and parties.
+const ANNIVERSARY = { month: 10, day: 24 } as const;
+
+function isLobsterAnniversary(now: Date): boolean {
+  return now.getMonth() === ANNIVERSARY.month && now.getDate() === ANNIVERSARY.day;
+}
+
+// Seasonal wardrobe: extra accessory entries join the pool on the right
+// dates. One weighted roll either way, so the rest of the look sequence is
+// unchanged on any given seed.
+function seasonalAccessories(now: Date): Array<[LobsterPetAccessory, number]> {
+  const month = now.getMonth();
+  const day = now.getDate();
+  if (month === 11) {
+    return [["santa", 18]];
+  }
+  if (month === 9 && day >= 20) {
+    return [["pumpkin", 18]];
+  }
+  return [];
+}
 
 const PERSONALITY_IDS: Array<[LobsterPetPersonalityId, number]> = [
   ["sleepy", 25],
@@ -351,11 +381,11 @@ export function lobsterPetSeed(sessionKey: string): number {
   return (fnv1a(sessionKey) ^ LOAD_SALT) >>> 0;
 }
 
-export function createLobsterPetLook(seed: number): LobsterPetLook {
+export function createLobsterPetLook(seed: number, now: Date = new Date()): LobsterPetLook {
   const rng = mulberry32(seed);
   const palette = pickWeighted(rng, PALETTES);
   const scale = pickWeighted(rng, SCALES);
-  const accessory = pickWeighted(rng, ACCESSORIES);
+  const accessory = pickWeighted(rng, [...ACCESSORIES, ...seasonalAccessories(now)]);
   const antennae: LobsterPetAntennae = rng() < 0.6 ? "perky" : "droopy";
   const side = rng() < 0.5 ? "left" : "right";
   const zone = SPOT_ZONES[side];
@@ -368,6 +398,24 @@ export function createLobsterPetLook(seed: number): LobsterPetLook {
   const build = pickWeighted(rng, BUILDS);
   const clawSize = pickWeighted(rng, CLAW_SIZES);
   const tailFan = rng() < 0.3;
+  if (isLobsterAnniversary(now)) {
+    // Birthday dress code: everyone is the classic logo, party hats on.
+    const retro = PALETTES.find(([entry]) => entry.id === "retro")?.[0];
+    return {
+      palette: retro ?? palette,
+      scale,
+      accessory: "party",
+      antennae,
+      side,
+      spotPct,
+      facing,
+      personality,
+      blinkDelayS,
+      build,
+      clawSize,
+      tailFan,
+    };
+  }
   return {
     palette,
     scale,
@@ -419,6 +467,27 @@ const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateRe
     <g>
       <path d="M28 27 Q60 14 92 22" stroke="#101820" stroke-width="4" stroke-linecap="round" fill="none" />
       <circle cx="75" cy="32" r="9" fill="#101820" />
+    </g>
+  `,
+  santa: svg`
+    <g>
+      <path d="M47 10 Q54 1 68 3 L72 9 Z" fill="#e0312f" />
+      <circle cx="71" cy="3.5" r="3.5" fill="#f5f7fa" />
+      <ellipse cx="59" cy="10.5" rx="15" ry="3.5" fill="#f5f7fa" />
+    </g>
+  `,
+  pumpkin: svg`
+    <g>
+      <ellipse cx="60" cy="6.5" rx="8.5" ry="5.5" fill="#e8871e" />
+      <path d="M56 2.5 Q56 6.5 56 10.5 M64 2.5 Q64 6.5 64 10.5" stroke="#c96a10" stroke-width="1.5" fill="none" />
+      <path d="M60 1.5 Q60.5 0 63 0.5" stroke="#4c9a4c" stroke-width="2.5" stroke-linecap="round" fill="none" />
+    </g>
+  `,
+  party: svg`
+    <g>
+      <path d="M52 11 L60 0.5 L68 11 Z" fill="#7c5cff" />
+      <path d="M55.5 6.5 L64.5 6.5" stroke="#ffd166" stroke-width="2" />
+      <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
     </g>
   `,
 };
@@ -973,6 +1042,7 @@ export class LobsterPet extends LitElement {
       `lobster-pet--${this.mode}`,
       `lobster-pet--palette-${look.palette.id}`,
       twin ? "lobster-pet--twin" : "",
+      look.accessory === "party" ? "lobster-pet--party" : "",
       this.presence === "leaving" ? "lobster-pet--away" : "",
       this.entering ? "lobster-pet--entering" : "",
       this.grumpy ? "lobster-pet--grumpy" : "",

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -299,6 +299,19 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   animation-delay: calc(var(--i, 0) * 0.7s);
 }
 
+/* Party days: confetti-colored z's. */
+.lobster-pet--party .lobster-pet__z:nth-of-type(1) {
+  color: #ffd166;
+}
+
+.lobster-pet--party .lobster-pet__z:nth-of-type(2) {
+  color: #5cd9c4;
+}
+
+.lobster-pet--party .lobster-pet__z:nth-of-type(3) {
+  color: #ff5c8a;
+}
+
 /* ---- Bubbles ---- */
 
 .lobster-pet__bubble {


### PR DESCRIPTION
Related: #102754 · Stacked on #103154 (rare events) — lands after it.

## What Problem This Solves

The pet has no sense of occasion. Seasonal touches are cheap delight and make long-time users notice the calendar.

## Why This Change Was Made

Date-gated wardrobe, kept pure and testable by injecting the date into look generation:

- **December:** a santa hat joins the accessory pool (~15% of visitors).
- **Oct 20–31:** a pumpkin joins instead.
- **Nov 24 — the repo's birthday** (GitHub `created_at` 2025-11-24): every visitor is the classic-logo **retro** wearing a **party hat**, and their nap z's turn confetti-colored.

Seasonal entries are extra weighted rows appended to the accessory table for the day — a single roll either way, so a seed's remaining look (palette, build, personality...) is identical on and off season. Existing look tests pin a neutral date so CI stays deterministic year-round.

## User Impact

Santa lobsters in December, pumpkin-hatted ones around Halloween, and one day a year the whole population dresses as the old logo and parties. No config, no behavior changes.

## Evidence

![seasonal](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/seasonal.png)

Validation (delegated Blacksmith Testbox, `exit=0`):

- `pnpm test ui/src/components/lobster-pet.test.ts` — 27/27: December rolls santa (never pumpkin), late October rolls pumpkin (never santa), July rolls neither, Nov 24 forces retro + party for every seed and Nov 25 is business as usual; full existing suite date-pinned and green.
- `pnpm tsgo:test:ui` and `pnpm --dir ui build`.
- Live showcase (screenshot above) rendered from the running mock UI with date-injected looks.
- Codex autoreview clean on the final diff.
