### PR TITLE
fix(meta): live validation targets deployed Muse Spark 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Meta provider validation:** target the deployed `muse-spark-1.1` model in live tests and remove obsolete pre-deployment smoke-test guidance.
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.
 - **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @coder-master-0915, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Meta provider validation:** target the deployed `muse-spark-1.1` model in live tests and remove obsolete pre-deployment smoke-test guidance.
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.
 - **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @coder-master-0915, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -84,11 +84,6 @@ Capabilities:
 `--thinking off` to `minimal` for this provider.
 </Warning>
 
-<Note>
-Until `muse-spark-1.1` is deployed, smoke tests and manual checks can use the
-deployed `muse-spark` model id: `--model meta/muse-spark`.
-</Note>
-
 ## Manual config
 
 ```json5
@@ -117,12 +112,10 @@ separately.
 
 ```bash
 export MODEL_API_KEY=<key>
-export OPENCLAW_LIVE_TEST=1
-export META_LIVE_TEST=1
-pnpm test extensions/meta/meta.live.test.ts
+pnpm test:live -- extensions/meta/meta.live.test.ts
 ```
 
-Live tests use deployed `muse-spark` against `POST /v1/responses`.
+Live tests use `muse-spark-1.1` against `POST /v1/responses`.
 
 ## Related
 

--- a/extensions/meta/README.md
+++ b/extensions/meta/README.md
@@ -5,7 +5,7 @@ Bundled OpenClaw provider plugin for the **Meta API** — an OpenAI-compatible
 
 - **Base URL:** `https://api.ai.meta.com/v1`
 - **Auth:** `Authorization: Bearer $MODEL_API_KEY`
-- **Model:** `muse-spark-1.1` (reasoning model; use `muse-spark` for smoke tests until 1.1 ships)
+- **Model:** `muse-spark-1.1` (reasoning model)
   - Context window: 1,048,576 tokens (input + output share the budget)
   - Reasoning effort: `minimal | low | medium | high | xhigh` (default: `high`)
   - Vision: image input in `user` messages
@@ -47,9 +47,7 @@ See `docs/providers/meta.md` for setup, onboarding, and smoke tests.
 
 ```bash
 export MODEL_API_KEY=<key>
-export OPENCLAW_LIVE_TEST=1
-export META_LIVE_TEST=1
-pnpm test extensions/meta/meta.live.test.ts
+pnpm test:live -- extensions/meta/meta.live.test.ts
 ```
 
-Live tests call `muse-spark` on `/v1/responses`.
+Live tests call `muse-spark-1.1` on `/v1/responses`.

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -46,7 +46,7 @@ describe("meta provider", () => {
     expect(model.input).toContain("image");
   });
 
-  it("advertises a high default thinking profile for muse-spark models", () => {
+  it("advertises a high default thinking profile for muse-spark-1.1", () => {
     const captured = capturePluginRegistration(plugin);
     const [provider] = captured.providers;
     if (!provider) {

--- a/extensions/meta/meta.live.test.ts
+++ b/extensions/meta/meta.live.test.ts
@@ -1,4 +1,4 @@
-// Meta live tests prove muse-spark auth and Responses API completion.
+// Meta live tests prove muse-spark-1.1 auth and Responses API completion.
 import { streamSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
@@ -6,7 +6,7 @@ import { buildMetaProvider } from "./provider-catalog.js";
 import { wrapMetaProviderStream } from "./stream.js";
 
 const MODEL_API_KEY = process.env.MODEL_API_KEY?.trim() ?? "";
-const LIVE_MODEL_ID = "muse-spark";
+const LIVE_MODEL_ID = "muse-spark-1.1";
 const LIVE =
   isLiveTestEnabled(["META_LIVE_TEST", "MODEL_API_LIVE_TEST"]) &&
   MODEL_API_KEY.length > 0;
@@ -14,15 +14,14 @@ const describeLive = LIVE ? describe : describe.skip;
 
 function resolveLiveModel(): Model<"openai-responses"> {
   const provider = buildMetaProvider();
-  const catalogModel = provider.models?.find((entry) => entry.id === "muse-spark-1.1");
+  const catalogModel = provider.models?.find((entry) => entry.id === LIVE_MODEL_ID);
   if (!catalogModel) {
-    throw new Error("Meta catalog does not include muse-spark-1.1");
+    throw new Error(`Meta catalog does not include ${LIVE_MODEL_ID}`);
   }
   return {
     provider: "meta",
     baseUrl: provider.baseUrl,
     ...catalogModel,
-    id: LIVE_MODEL_ID,
     api: "openai-responses",
   } as Model<"openai-responses">;
 }
@@ -40,7 +39,7 @@ function resolveLiveStreamFn() {
 }
 
 describeLive("meta plugin live", () => {
-  it("lists muse-spark via the /models endpoint", async () => {
+  it("lists muse-spark-1.1 via the /models endpoint", async () => {
     const response = await fetch("https://api.ai.meta.com/v1/models", {
       headers: { Authorization: `Bearer ${MODEL_API_KEY}` },
     });
@@ -50,7 +49,7 @@ describeLive("meta plugin live", () => {
     expect(ids).toContain(LIVE_MODEL_ID);
   }, 30_000);
 
-  it("completes a muse-spark Responses API turn with high reasoning effort", async () => {
+  it("completes a muse-spark-1.1 Responses API turn with high reasoning effort", async () => {
     const model = resolveLiveModel();
     let capturedPayload: Record<string, unknown> | undefined;
     const stream = await resolveLiveStreamFn()(

--- a/extensions/meta/thinking.ts
+++ b/extensions/meta/thinking.ts
@@ -1,10 +1,10 @@
 // Meta plugin module implements thinking behavior.
 import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 
-const META_REASONING_MODEL_IDS = new Set(["muse-spark", "muse-spark-1.1"]);
+const META_REASONING_MODEL_ID = "muse-spark-1.1";
 
 function isMetaReasoningModelId(modelId: string): boolean {
-  return META_REASONING_MODEL_IDS.has(modelId.toLowerCase());
+  return modelId.toLowerCase() === META_REASONING_MODEL_ID;
 }
 
 const META_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;


### PR DESCRIPTION
Follow-up to #102873 and #103070.

## What Problem This Solves

Fixes an issue where maintainers running the Meta provider smoke test would get two failures after Muse Spark 1.1 deployed because validation still targeted the removed pre-deployment model id and the documented command did not use the live-test runner.

## Why This Change Was Made

The Meta live suite now resolves and calls the deployed `muse-spark-1.1` catalog model, while the never-shipped fallback id is removed from thinking policy and documentation. Both documentation surfaces now use the repository's canonical `test:live` command.

## User Impact

Maintainers can copy the documented command and validate Meta's deployed Muse Spark 1.1 endpoint end to end. Users no longer see obsolete fallback guidance.

## Evidence

- Before: Meta's live `/v1/models` response listed `muse-spark-1.1`; the suite expected `muse-spark` and failed both catalog and completion checks.
- Real-provider proof: `pnpm test:live -- extensions/meta/meta.live.test.ts` passed 1 file / 2 tests, including a high-reasoning Responses API completion in 2.16 seconds. The tested Meta tree at `66b23c0ae5c8a999f8fafeff5f4e76eb8c53a866` is byte-identical to final head `ed3fa4640c43e84d006728e5262231fd516e36df`; the only later delta deletes a release-owned changelog line required by the prepare guard.
- Exact final head on Blacksmith Testbox through Crabbox lease `tbx_01kx4kg34nj1bd3mwt6ygwddmy`: `corepack pnpm test extensions/meta/index.test.ts` passed 3/3; `corepack pnpm check:changed` passed the extension, extension-test, and docs lanes.
- Fresh final-head branch autoreview: no accepted or actionable findings.
