### PR TITLE
feat(webchat): the dreams scene sleeps your own seeded lobster

### DIFF
--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -582,9 +582,9 @@ const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
 
 // Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
 // with stubby legs, side claws, antennae, and teal-glint eyes.
-function renderLobsterSvg(
+export function renderLobsterSvg(
   look: LobsterPetLook,
-  options: { grumpy?: boolean; shell?: boolean } = {},
+  options: { grumpy?: boolean; shell?: boolean; sleeping?: boolean } = {},
 ) {
   return svg`
     <svg
@@ -620,7 +620,7 @@ function renderLobsterSvg(
       ${look.palette.id === "split" ? SPLIT_HALF : nothing}
       ${look.palette.id === "calico" ? CALICO_SPOTS : nothing}
       <ellipse cx="48" cy="28" rx="20" ry="11" fill="#ffffff" opacity="0.1" />
-      <g class="lob-eye-open" style=${options.shell ? "display:none" : ""}>
+      <g class="lob-eye-open" style=${options.shell || options.sleeping ? "display:none" : ""}>
         <circle cx="45" cy="32" r="5.5" fill="#0a1014" />
         <circle cx="75" cy="32" r="5.5" fill="#0a1014" />
         <circle cx="46.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
@@ -632,6 +632,7 @@ function renderLobsterSvg(
         stroke-width="3"
         stroke-linecap="round"
         fill="none"
+        style=${options.shell || options.sleeping ? "opacity:1" : ""}
       >
         <path d="M39 33 Q45 28 51 33" />
         <path d="M69 33 Q75 28 81 33" />

--- a/ui/src/pages/dreams/view.test.ts
+++ b/ui/src/pages/dreams/view.test.ts
@@ -250,6 +250,15 @@ describe("dreaming view", () => {
 
     expectElement(container, ".dreams__lobster svg");
 
+    // The sleeper is the seeded pet cameo: eyes closed, pupils hidden.
+    const closedEyes = container.querySelector<SVGGElement>(".dreams__lobster .lob-eye-closed");
+    expect(closedEyes?.getAttribute("style")).toContain("opacity:1");
+    const openEyes = container.querySelector<SVGGElement>(".dreams__lobster .lob-eye-open");
+    expect(openEyes?.getAttribute("style")).toContain("display:none");
+    expect(
+      container.querySelector<HTMLElement>(".dreams__lobster")?.getAttribute("style"),
+    ).toContain("--lob-shell:");
+
     expect(textItems(container, ".dreams__z")).toEqual(["z", "z", "Z"]);
 
     const stars = [...container.querySelectorAll<HTMLElement>(".dreams__star")].map((star) => ({

--- a/ui/src/pages/dreams/view.ts
+++ b/ui/src/pages/dreams/view.ts
@@ -2,6 +2,11 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import {
+  createLobsterPetLook,
+  lobsterPetSeed,
+  renderLobsterSvg,
+} from "../../components/lobster-pet.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
 import type { DreamingEntry, WikiImportInsights, WikiMemoryPalace } from "./dreaming.ts";
@@ -261,41 +266,15 @@ const STARS: {
   { top: 88, left: 18, size: 2, delay: 2.3, hue: "neutral" },
 ];
 
-const sleepingLobster = html`
-  <svg viewBox="0 0 120 120" fill="none">
-    <defs>
-      <linearGradient id="dream-lob-g" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#ff4d4d" />
-        <stop offset="100%" stop-color="#991b1b" />
-      </linearGradient>
-    </defs>
-    <path
-      d="M60 10C30 10 15 35 15 55C15 75 30 95 45 100L45 110L55 110L55 100C55 100 60 102 65 100L65 110L75 110L75 100C90 95 105 75 105 55C105 35 90 10 60 10Z"
-      fill="url(#dream-lob-g)"
-    />
-    <path d="M20 45C5 40 0 50 5 60C10 70 20 65 25 55C28 48 25 45 20 45Z" fill="url(#dream-lob-g)" />
-    <path
-      d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z"
-      fill="url(#dream-lob-g)"
-    />
-    <path d="M45 15Q38 8 35 14" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
-    <path d="M75 15Q82 8 85 14" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
-    <path
-      d="M39 36Q45 32 51 36"
-      stroke="#050810"
-      stroke-width="2.5"
-      stroke-linecap="round"
-      fill="none"
-    />
-    <path
-      d="M69 36Q75 32 81 36"
-      stroke="#050810"
-      stroke-width="2.5"
-      stroke-linecap="round"
-      fill="none"
-    />
-  </svg>
-`;
+// The dreams sleeper is the same seeded lobster that visits the sidebar for
+// this agent (eyes closed), so the pet identity carries across surfaces.
+function renderDreamsCameo(agentId: string) {
+  const look = createLobsterPetLook(lobsterPetSeed(agentId));
+  const style = `--lob-shell:${look.palette.shell};--lob-claw:${look.palette.claw}`;
+  return html`
+    <div class="dreams__lobster" style=${style}>${renderLobsterSvg(look, { sleeping: true })}</div>
+  `;
+}
 
 export function renderDreaming(props: DreamingProps) {
   const state = props.viewState;
@@ -449,7 +428,7 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
         : nothing}
 
       <div class="dreams__glow"></div>
-      <div class="dreams__lobster">${sleepingLobster}</div>
+      ${renderDreamsCameo(props.selectedAgentId)}
       <span class="dreams__z">z</span>
       <span class="dreams__z">z</span>
       <span class="dreams__z">Z</span>


### PR DESCRIPTION
Related: #102754 · Stacked on #103158 (seasonal) — lands after it.

## What Problem This Solves

The dreams page shows a generic hand-drawn sleeping lobster while the sidebar hosts your seeded pet — two unrelated lobsters, no shared identity.

## Why This Change Was Made

The dreams sleeper is now **your lobster**: the same seeded look system (palette, build, claws, antennae, accessory, tail fan) rendered asleep via a new `sleeping` option on the exported sprite renderer — pupils hidden, closed-lid curves visible inline so the cameo needs no `.lobster-pet` CSS context. The bespoke dreams svg is deleted; the cameo wrapper supplies the palette variables. Same species, same individual, across surfaces.

## User Impact

Open Dreams and the lobster snoozing under the stars is the one that visits your sidebar — gold sessions dream in gold, retro grails dream as the OG.

## Evidence

![dreams cameo](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/dreams-cameo.png)

Validation (delegated Blacksmith Testbox, `exit=0`):

- `pnpm test ui/src/components/lobster-pet.test.ts ui/src/pages/dreams/view.test.ts` — 44/44; the dreams scene test now asserts the cameo's closed eyes, hidden pupils, and palette vars.
- `pnpm tsgo:test:ui` and `pnpm --dir ui build`.
- Live screenshot above from the running mock UI's dreams page (the mock agent seeds a gold slender sleeper).
- Codex autoreview clean.
