### PR TITLE
fix(ai): make normalizeOpenAIReasoningEffort case-insensitive

### DIFF
--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -1,6 +1,7 @@
 // Verifies model-specific OpenAI reasoning-effort normalization and disablement.
 import { describe, expect, it } from "vitest";
 import {
+  normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
   resolveOpenAISupportedReasoningEfforts,
 } from "./openai-reasoning-effort.js";
@@ -110,5 +111,17 @@ describe("OpenAI reasoning effort support", () => {
 
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
+  });
+
+  it("lowercases mixed-case and uppercase effort names", () => {
+    expect(normalizeOpenAIReasoningEffort("HIGH")).toBe("high");
+    expect(normalizeOpenAIReasoningEffort("Medium")).toBe("medium");
+    expect(normalizeOpenAIReasoningEffort("mInImAl")).toBe("minimal");
+  });
+
+  it("matches mixed-case effort input against the supported list", () => {
+    const model = { provider: "openai", id: "gpt-5" };
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("high");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "Medium" })).toBe("medium");
   });
 });

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -59,7 +59,7 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
-  return effort === "minimal" ? "minimal" : effort;
+  return normalizeLowercaseStringOrEmpty(effort) || effort;
 }
 
 function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[] | undefined {


### PR DESCRIPTION
## What Problem This Solves

`normalizeOpenAIReasoningEffort` in `packages/ai/src/providers/openai-reasoning-effort.ts` did not lowercase or trim its input. Mixed-case or uppercase reasoning-effort values (e.g. `"HIGH"`) failed to match the lowercase supported-effort lists used throughout `resolveOpenAIReasoningEffortForModel`, so requests could silently resolve to the wrong effort or fall back unexpectedly.

## Why This Change Was Made

Reuse the existing `normalizeLowercaseStringOrEmpty` helper (already imported in this file from `@openclaw/normalization-core/string-coerce`) to trim and lowercase the effort value consistently, falling back to the original value only when the input is not string-like. This keeps the fix small and consistent with existing normalization conventions in the codebase.

## User Impact

Callers that pass a mixed-case `reasoningEffort` (for example via CLI flags, config, or upstream integrations that don't normalize case) will now correctly match the supported-effort lists and fallback maps instead of silently mismatching.

## Evidence

- Added regression tests in `packages/ai/src/providers/openai-reasoning-effort.test.ts` covering direct normalization (`"HIGH"` -> `"high"`, `"Medium"` -> `"medium"`, `"mInImAl"` -> `"minimal"`) and end-to-end resolution via `resolveOpenAIReasoningEffortForModel`.
- Ran `node scripts/run-vitest.mjs packages/ai/src/providers/openai-reasoning-effort.test.ts` — all 12 tests pass (10 existing + 2 new).
- Verified all current `compat.supportedReasoningEfforts` / `reasoningEffortMap` usages across `extensions/`, `docs/`, and `src/` use lowercase strings exclusively, so lowercasing the fallback-mapped value carries no regression risk in the current codebase.

Closes #102908

<!-- AI-assisted: this PR was authored with GitHub Copilot CLI assistance. -->
