### PR TITLE
fix(gateway): reduce mcp loopback schema warning noise

### DIFF
--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -5,6 +5,8 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
+const MCP_LOOPBACK_LOG_PREFIX = "mcp-loopback";
+
 // MCP loopback schema projection adapts gateway tool definitions into MCP
 // tools/list entries. It flattens provider-hostile union schemas into object
 // schemas because some MCP clients cannot render anyOf/oneOf controls.
@@ -145,7 +147,7 @@ function flattenUnionSchema(
       for (const [key, schema] of Object.entries(props)) {
         if (!isPropertySchema(schema)) {
           warnSchemaOnce(
-            `mcp loopback: malformed schema definition for "${toolName}.${key}", ignoring that variant`,
+            `${MCP_LOOPBACK_LOG_PREFIX}: malformed schema definition for "${toolName}.${key}", ignoring that variant`,
           );
           continue;
         }
@@ -166,10 +168,13 @@ function flattenUnionSchema(
         if (incoming === false) {
           continue;
         }
+        if (areSchemaValuesEquivalent(existing, incoming)) {
+          continue;
+        }
         if (!isRecord(existing) || !isRecord(incoming)) {
           if (existing !== incoming) {
             warnSchemaOnce(
-              `mcp loopback: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
+              `${MCP_LOOPBACK_LOG_PREFIX}: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
             );
           }
           continue;
@@ -185,7 +190,7 @@ function flattenUnionSchema(
           continue;
         }
         warnSchemaOnce(
-          `mcp loopback: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
+          `${MCP_LOOPBACK_LOG_PREFIX}: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
         );
       }
     }
@@ -205,6 +210,57 @@ function flattenUnionSchema(
 
 function isPropertySchema(value: unknown): value is boolean | Record<string, unknown> {
   return typeof value === "boolean" || isRecord(value);
+}
+
+function rememberSchemaPair(
+  left: object,
+  right: object,
+  seen: WeakMap<object, WeakSet<object>>,
+): boolean {
+  const existing = seen.get(left);
+  if (existing?.has(right)) {
+    return true;
+  }
+  const next = existing ?? new WeakSet<object>();
+  next.add(right);
+  if (!existing) {
+    seen.set(left, next);
+  }
+  return false;
+}
+
+function areSchemaValuesEquivalent(
+  left: unknown,
+  right: unknown,
+  seen = new WeakMap<object, WeakSet<object>>(),
+): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    if (rememberSchemaPair(left, right, seen)) {
+      return true;
+    }
+    return left.every((value, index) => areSchemaValuesEquivalent(value, right[index], seen));
+  }
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+  if (rememberSchemaPair(left, right, seen)) {
+    return true;
+  }
+  const leftKeys = Object.keys(left).toSorted();
+  const rightKeys = Object.keys(right).toSorted();
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  return leftKeys.every(
+    (key, index) =>
+      key === rightKeys[index] && areSchemaValuesEquivalent(left[key], right[key], seen),
+  );
 }
 
 // Loopback schemas are rebuilt on every cache miss (per session/owner context and

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -863,7 +863,7 @@ describe("buildMcpToolSchema", () => {
       },
     });
     expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
-      'mcp loopback: conflicting schema definitions for "codex_threads_constrained_literals.action", keeping the first variant',
+      'mcp-loopback: conflicting schema definitions for "codex_threads_constrained_literals.action", keeping the first variant',
     ]);
   });
 

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1024,6 +1024,51 @@ describe("buildMcpToolSchema", () => {
 });
 
 describe("mcp loopback server", () => {
+  it("keeps equal schemas quiet and dedupes genuine conflicts across HTTP cache misses", async () => {
+    mockScopedTools([
+      makeMockTool({
+        name: "lark_doc_read",
+        parameters: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                doc_token: { type: "string", description: "Lark document token" },
+                action: { type: "string" },
+              },
+            },
+            {
+              type: "object",
+              properties: {
+                doc_token: { description: "Lark document token", type: "string" },
+                action: { type: "number" },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+    const { runtime } = await startLoopbackServerForTest();
+
+    for (let index = 0; index < 3; index += 1) {
+      const payload = await readOkMcpPayload(
+        await sendLoopbackToolsList({
+          token: runtime.ownerToken,
+          headers: {
+            ...MAIN_SESSION_HEADER,
+            "x-openclaw-current-message-id": `message-${index}`,
+          },
+        }),
+      );
+      expectMcpToolNames(payload, ["lark_doc_read"]);
+    }
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(3);
+    expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
+      'mcp-loopback: conflicting schema definitions for "lark_doc_read.action", keeping the first variant',
+    ]);
+  });
+
   it("rejects reserved harness contexts before tool resolution", async () => {
     const { runtime } = await startLoopbackServerForTest();
     const response = await sendLoopbackToolsList({

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -930,9 +930,51 @@ describe("buildMcpToolSchema", () => {
     }
 
     expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
-      'mcp loopback: conflicting schema definitions for "mcp_message_send_rebuild.action", keeping the first variant',
-      'mcp loopback: conflicting schema definitions for "mcp_message_send_rebuild.callId", keeping the first variant',
+      'mcp-loopback: conflicting schema definitions for "mcp_message_send_rebuild.action", keeping the first variant',
+      'mcp-loopback: conflicting schema definitions for "mcp_message_send_rebuild.callId", keeping the first variant',
     ]);
+  });
+
+  it("does not warn for structurally identical union property schemas", () => {
+    const tool = makeMockTool({
+      name: "lark_doc_read",
+      parameters: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              doc_token: {
+                type: "string",
+                description: "Lark document token",
+                minLength: 1,
+              },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              doc_token: {
+                minLength: 1,
+                description: "Lark document token",
+                type: "string",
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(buildMockMcpToolSchema([tool])[0]?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        doc_token: {
+          type: "string",
+          description: "Lark document token",
+          minLength: 1,
+        },
+      },
+    });
+    expect(logWarnMock).not.toHaveBeenCalled();
   });
 
   it("warns per tool for the same conflicting field name across different tools", () => {
@@ -956,8 +998,8 @@ describe("buildMcpToolSchema", () => {
     buildMockMcpToolSchema([messageTool, calendarTool]);
 
     expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
-      'mcp loopback: conflicting schema definitions for "mcp_message_send_per_tool.action", keeping the first variant',
-      'mcp loopback: conflicting schema definitions for "mcp_calendar_create_per_tool.action", keeping the first variant',
+      'mcp-loopback: conflicting schema definitions for "mcp_message_send_per_tool.action", keeping the first variant',
+      'mcp-loopback: conflicting schema definitions for "mcp_calendar_create_per_tool.action", keeping the first variant',
     ]);
   });
 
@@ -976,7 +1018,7 @@ describe("buildMcpToolSchema", () => {
     buildMockMcpToolSchema([tool]);
 
     expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
-      'mcp loopback: malformed schema definition for "mcp_message_send_malformed.action", ignoring that variant',
+      'mcp-loopback: malformed schema definition for "mcp_message_send_malformed.action", ignoring that variant',
     ]);
   });
 });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -418,7 +418,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(payload);
       } catch (error) {
-        logWarn(`mcp loopback: request handling failed: ${formatErrorMessage(error)}`);
+        logWarn(`mcp-loopback: request handling failed: ${formatErrorMessage(error)}`);
         logMcpLoopbackTraffic("request-failed", {
           message: formatErrorMessage(error),
         });

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -1,6 +1,8 @@
 // Console capture tests cover intercepting and restoring console output.
+import fs from "node:fs";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { setVerbose } from "../global-state.js";
+import { logWarn } from "../logger.js";
 import {
   enableConsoleCapture,
   resetLogger,
@@ -137,6 +139,17 @@ describe("enableConsoleCapture", () => {
     expect(stdoutWrite).toHaveBeenCalledWith('{\n  "ok": true\n}\n');
   });
 
+  it("routes subsystem-prefixed warnings through one file-log sink", () => {
+    const logPath = tempLogPath();
+    setLoggerOverride({ level: "info", file: logPath });
+    enableConsoleCapture();
+
+    logWarn("mcp-loopback: conflicting schema definitions");
+
+    const content = fs.readFileSync(logPath, "utf-8");
+    expect(countMatchingLines(content, "conflicting schema definitions")).toBe(1);
+  });
+
   it("redacts credentials before forwarding console output", () => {
     setLoggerOverride({ level: "info", file: tempLogPath() });
     const log = vi.fn();
@@ -243,6 +256,10 @@ describe("enableConsoleCapture", () => {
 
 function tempLogPath() {
   return logPathTracker.nextPath();
+}
+
+function countMatchingLines(value: string, needle: string): number {
+  return value.split(/\r?\n/u).filter((line) => line.includes(needle)).length;
 }
 
 function eioError() {


### PR DESCRIPTION
AI-assisted: yes. I reviewed the touched Gateway/logging paths and understand the schema projection and logging behavior changed by this patch.

## What Problem This Solves

Closes #98437.

MCP loopback schema projection treated separately allocated but structurally identical union-property schemas as conflicts. This produced false-positive warnings and used the space-containing `mcp loopback:` prefix, which bypassed subsystem parsing and could duplicate output across console-capture and file-log paths.

## Why This Change Was Made

- compare repeated JSON-schema values structurally before classifying them as conflicts;
- preserve first-variant behavior and warnings for genuine conflicts;
- retain process-lifetime warning dedupe across schema-cache misses;
- route remaining diagnostics through the `mcp-loopback:` subsystem prefix;
- cover real loopback HTTP requests plus the installed/configured Gateway path.

## User Impact

Equivalent plugin schemas no longer emit misleading warnings. Genuine conflicts still warn exactly once, while remaining MCP diagnostics follow the normal subsystem/file-log path.

## Evidence

Final rebase:

- `upstream/main`: `d361b4ccb85`
- branch head: `19a67844408`

Installed/configured Gateway proof:

1. Built and npm-installed the branch package as `OpenClaw 2026.7.2` into an isolated HOME/STATE directory.
2. Installed and enabled an npm-packed startup plugin exposing two tools: one with structurally equal schema variants and one with a genuine string-vs-number conflict.
3. Started the installed Gateway with token auth and file logging.
4. Created two distinct `attach.grant` sessions and sent authenticated MCP `tools/list` requests through each grant URL, forcing separate session/cache keys.
5. Both responses exposed exactly the two probe tools. The Gateway file log contained:

```text
schema_equal_probe.value warnings: 0
schema_conflict_probe.value warnings: 1
```

The installed Gateway console independently showed the single expected `mcp-loopback` conflict warning. No provider, model, Feishu, or external service credentials were used.

The package build completed `tsdown`; its post-build plugin-SDK guard hit an existing Node 22/CommonJS `execa` named-export incompatibility. Packaging with the completed build artifacts then reported missing Control UI assets, which are unrelated to this headless Gateway/MCP proof. The resulting tarball installed successfully and the installed Gateway health response reported `schema-warning-proof` loaded with no plugin errors.

## Validation

- `node scripts/run-vitest.mjs run src/gateway/mcp-http.test.ts src/logging/console-capture.test.ts` -> 101/101 tests passed on the final rebased head.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base upstream/main --timed` -> all selected gates passed before the final baseline-only rebase, including core typecheck (36.56s), core-test typecheck (633.11s), changed-file lint (108.66s), LOC, format, dependency pin, SDK baseline, import-cycle, database-first, and security guards.
- `git diff --check upstream/main...HEAD` -> passed on the final rebased head.

Focused HTTP invariants force separate cache keys, keep equal schemas quiet, retain one genuine conflict warning, and verify the projected tools remain present in `tools/list`.

Signed-off-by: Ho Lim <subhoya@gmail.com>

