### PR TITLE
fix(tasks): normalize legacy delivery status

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -556,7 +556,7 @@ function writeLegacyTaskStateSidecars(root: string): {
         "legacy-task-run",
         "Legacy cron task",
         "running",
-        "not_applicable",
+        "not-requested",
         "silent",
         100,
         110,
@@ -2802,6 +2802,7 @@ describe("doctor legacy state migrations", () => {
         requesterSessionKey: "",
         agentId: "ops",
         runId: "legacy-task-run",
+        deliveryStatus: "not_applicable",
       });
       expect(taskState.deliveryStates.get("legacy-task")).toMatchObject({
         taskId: "legacy-task",

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -864,6 +864,8 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
         (childAgentId && persistedAgentId !== childAgentId ? persistedAgentId : ""))
       : "");
   const executorAgentId = requesterAgentId ? childAgentId || persistedAgentId : persistedAgentId;
+  const deliveryStatus =
+    row.delivery_status === "not-requested" ? "not_applicable" : row.delivery_status;
   return {
     task_id: taskId,
     runtime,
@@ -881,7 +883,7 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
     label: legacyBindValue(row.label),
     task: legacyBindValue(row.task ?? ""),
     status: legacyBindValue(row.status ?? ""),
-    delivery_status: legacyBindValue(row.delivery_status ?? ""),
+    delivery_status: legacyBindValue(deliveryStatus ?? ""),
     notify_policy: legacyBindValue(row.notify_policy ?? ""),
     created_at: normalizeLegacySqliteInteger(row.created_at as number | bigint | null) ?? 0,
     started_at: normalizeLegacySqliteInteger(row.started_at as number | bigint | null),

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -423,6 +423,42 @@ describe("openclaw state database", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
+  it("normalizes obsolete task delivery statuses in existing state databases", () => {
+    const stateDir = createTempStateDir();
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    database.db
+      .prepare(
+        `INSERT INTO task_runs (
+          task_id, runtime, requester_session_key, owner_key, scope_kind, task, status,
+          delivery_status, notify_policy, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "legacy-delivery-status",
+        "cron",
+        "",
+        "system:cron:legacy",
+        "system",
+        "Legacy delivery status",
+        "cancelled",
+        "not-requested",
+        "silent",
+        100,
+      );
+    closeOpenClawStateDatabaseForTest();
+
+    const reopened = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    expect(
+      reopened.db
+        .prepare("SELECT delivery_status FROM task_runs WHERE task_id = ?")
+        .get("legacy-delivery-status"),
+    ).toEqual({ delivery_status: "not_applicable" });
+  });
+
   it("rolls back the requester attribution column when its backfill fails", () => {
     const stateDir = createTempStateDir();
     const database = openOpenClawStateDatabase({

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -192,6 +192,17 @@ function repairLegacyTaskAgentAttribution(db: DatabaseSync): void {
   `);
 }
 
+function repairLegacyTaskDeliveryStatuses(db: DatabaseSync): void {
+  if (!tableExists(db, "task_runs") || !tableHasColumn(db, "task_runs", "delivery_status")) {
+    return;
+  }
+  db.exec(`
+    UPDATE task_runs
+    SET delivery_status = 'not_applicable'
+    WHERE delivery_status = 'not-requested';
+  `);
+}
+
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
   if (!tableExists(db, "agent_databases")) {
     return true;
@@ -925,6 +936,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
     if (addedTaskRequesterAgentId) {
       repairLegacyTaskAgentAttribution(db);
     }
+    repairLegacyTaskDeliveryStatuses(db);
   });
   ensureColumn(db, "subagent_runs", "task_name TEXT");
 }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -151,6 +152,27 @@ describe("task-registry store runtime", () => {
     };
     expect(latestSnapshot.tasks.size).toBe(2);
     expect(latestSnapshot.tasks.get("task-restored")?.task).toBe("Restored task");
+  });
+
+  it("logs restore parser failures and keeps the registry empty", async () => {
+    const warnLogs = createWarnLogCapture("openclaw-task-registry-restore-test");
+    const invalidValue = "invalid-delivery-status";
+    try {
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () => {
+            throw new Error(`Invalid persisted task delivery status: ${invalidValue}`);
+          },
+          saveSnapshot: () => {},
+        },
+      });
+
+      expect(findTaskByRunId("run-restored")).toBeUndefined();
+      expect(await warnLogs.findText(invalidValue)).toContain(invalidValue);
+      expect(getTaskById("task-restored")).toBeUndefined();
+    } finally {
+      warnLogs.cleanup();
+    }
   });
 
   it("uses scoped owner lookups for fresh owner task reads", () => {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1216,7 +1216,7 @@ function restoreTaskRegistryOnce() {
       tasks: snapshotTaskRecords(tasks),
     }));
   } catch (error) {
-    log.warn("Failed to restore task registry", { error });
+    log.warn("Failed to restore task registry", { error: formatErrorMessage(error) });
   }
 }
 


### PR DESCRIPTION
## Summary

- normalize legacy task sidecar `not-requested` delivery statuses to the canonical `not_applicable` value during import
- repair already-migrated shared-state rows on database open so affected upgrades recover without manual SQL
- make strict atomic restore failures diagnosable without changing the no-throw boundary
- cover fresh sidecar migration, existing shared SQLite state, and parser-error logging

## Issue / Motivation

Closes #103168.

A task sidecar produced by an older release can contain `delivery_status = 'not-requested'`. The shared task registry only accepts `not_applicable`, so preserving the old value causes one row to abort restoration of the whole registry and makes linked TaskFlows appear to reference missing tasks.

## What Problem This Solves

Users upgrading from affected releases can have valid task rows stranded in shared SQLite under an obsolete delivery-status spelling. This change canonicalizes future imports and idempotently repairs existing shared-state rows before task restoration, preventing a single legacy value from making the durable task registry unavailable. If another invalid persisted value still blocks strict atomic restore, the warning now includes the formatted parser error so operators can diagnose the row value while the registry remains empty.

## Changes

- map `not-requested` to `not_applicable` at the legacy sidecar import boundary
- update matching existing `task_runs` rows in the additive shared-state migration transaction
- format caught task-registry restore errors before logging them
- add regression coverage for both migration paths and restore-error diagnostics

## Testing

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts src/state/openclaw-state-db.test.ts src/tasks/task-registry.store.test.ts` — 3 files passed, 127 tests passed
- `pnpm exec oxfmt --check src/tasks/task-registry.ts src/tasks/task-registry.store.test.ts` — passed
- `pnpm exec oxlint --type-aware --type-check --deny-warnings src/tasks/task-registry.ts src/tasks/task-registry.store.test.ts` — 0 warnings, 0 errors
- `git diff --check` — passed

## Evidence

### Real behavior proof

The affected-installation report provides redacted, real upgrade evidence from OpenClaw `2026.6.10` to `2026.6.11`: five persisted rows contained `not-requested`, the database passed `PRAGMA integrity_check`, and the task registry failed to restore. After backing up the database and applying the same exact normalization implemented here, `not-requested` → `not_applicable`, restart restored the registry, removed the false missing-linked-task TaskFlow findings, and `openclaw tasks audit --json` completed normally. See the issue's **Observed state** and **Verified workaround** sections: https://github.com/openclaw/openclaw/issues/103168

### Automated regression evidence

- the sidecar regression fixture starts with `delivery_status = 'not-requested'` and verifies the loaded task exposes `deliveryStatus: 'not_applicable'`
- the shared-state regression test seeds the obsolete value directly, reopens the database without a legacy sidecar, and verifies the stored value is repaired to `not_applicable`
- the logging regression makes `loadSnapshot()` throw the exact invalid-value parser error, verifies the warning contains that value, and confirms strict restore leaves the registry empty
- current-main overlap check: a local no-commit merge against current `main` completed without conflicts; no branch refresh is claimed
- pre-refresh focused validation on `c1911606c7f22f4b688ff03f0abd71e852e1b802`: 3 files and 127 tests passed; oxfmt, type-aware oxlint, diff check, and secret scan passed
- local post-refresh test execution was not claimed because this worktree had no `node_modules`; CI performs the exact-head run
