### PR TITLE
fix(infra): normalize legacy not-requested task delivery status

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -648,6 +648,35 @@ function appendLegacyCrossAgentTask(taskRunsPath: string): void {
   }
 }
 
+function appendLegacyTaskWithObsoleteDeliveryStatus(taskRunsPath: string): void {
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(taskRunsPath);
+  try {
+    db.prepare(
+      `
+        INSERT INTO task_runs (
+          task_id, runtime, requester_session_key, agent_id, run_id, task,
+          status, delivery_status, notify_policy, created_at, last_event_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      "legacy-not-requested",
+      "cron",
+      "",
+      "ops",
+      "legacy-not-requested-run",
+      "Legacy cancelled task",
+      "cancelled",
+      "not-requested",
+      "silent",
+      150,
+      160,
+    );
+  } finally {
+    db.close();
+  }
+}
+
 async function detectAndRunMigrations(params: {
   root: string;
   cfg: OpenClawConfig;
@@ -3062,6 +3091,27 @@ describe("doctor legacy state migrations", () => {
         requesterAgentId: "main",
         requesterSessionKey: "agent:main:main",
         childSessionKey: "agent:worker:subagent:child",
+      });
+    });
+  });
+
+  it("normalizes legacy not-requested delivery status so one bad row does not abort restore", async () => {
+    const root = await makeTempRoot();
+    const { taskRunsPath } = writeLegacyTaskStateSidecars(root);
+    appendLegacyTaskWithObsoleteDeliveryStatus(taskRunsPath);
+
+    const result = await autoMigrateLegacyTaskStateSidecars({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 2 task registry sidecar rows → shared SQLite state");
+
+    await withStateDir(root, async () => {
+      const taskState = loadTaskRegistryStateFromSqlite();
+      expect(taskState.tasks.get("legacy-not-requested")).toMatchObject({
+        taskId: "legacy-not-requested",
+        deliveryStatus: "not_applicable",
       });
     });
   });

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -832,6 +832,13 @@ function legacyStringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+// Legacy sidecars persisted delivery_status="not-requested"; the current shared schema only
+// accepts "not_applicable" for that state. Left unmapped, one such row throws inside
+// parseTaskDeliveryStatus() and aborts restoration of the entire task registry (#103168).
+function normalizeLegacyTaskDeliveryStatus(value: unknown): unknown {
+  return value === "not-requested" ? "not_applicable" : value;
+}
+
 function legacyKeyValue(value: SQLInputValue): string {
   if (typeof value === "string") {
     return value;
@@ -882,7 +889,7 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
     label: legacyBindValue(row.label),
     task: legacyBindValue(row.task ?? ""),
     status: legacyBindValue(row.status ?? ""),
-    delivery_status: legacyBindValue(row.delivery_status ?? ""),
+    delivery_status: legacyBindValue(normalizeLegacyTaskDeliveryStatus(row.delivery_status ?? "")),
     notify_policy: legacyBindValue(row.notify_policy ?? ""),
     created_at: normalizeLegacySqliteInteger(row.created_at as number | bigint | null) ?? 0,
     started_at: normalizeLegacySqliteInteger(row.started_at as number | bigint | null),


### PR DESCRIPTION
## What Problem This Solves

Legacy OpenClaw task-registry SQLite sidecars (from pre-2026.6.11 installs) can contain rows with `delivery_status = "not-requested"`. The current shared-schema parser `parseTaskDeliveryStatus` (`src/tasks/task-registry.types.ts`) only accepts one of `"pending" | "delivered" | "session_queued" | "failed" | "parent_missing" | "not_applicable"`, and throws `Invalid persisted task delivery status: ...` for anything else.

Because `normalizeLegacyTaskRow` (`src/infra/state-migrations.ts`) previously copied `delivery_status` verbatim with no normalization, a single legacy row with the obsolete `"not-requested"` value throws during registry restoration. `restoreTaskRegistryOnce` wraps the whole snapshot load in one try/catch, so that single bad row silently drops the **entire** task registry (only a `log.warn`), leaving every task — including valid ones — missing from the in-memory registry, and causing linked TaskFlows to falsely report their tasks as missing.

## Why This Change Was Made

`AGENTS.md` states legacy/retired shapes should be normalized only in doctor/migration code before runtime, never as a runtime shim. This fix follows that convention exactly: it adds a small, pure helper `normalizeLegacyTaskDeliveryStatus` that maps the one known obsolete value `"not-requested"` to the current schema's `"not_applicable"`, applied only at the legacy-row migration boundary (`normalizeLegacyTaskRow`). No other fields are touched, and no other unrecognized values are silently passed through differently than before.

## User Impact

Users upgrading from pre-2026.6.11 installs with legacy task sidecars containing `delivery_status = "not-requested"` rows will have their **entire** task registry restored correctly instead of silently losing all tasks and TaskFlow linkage.

## Evidence

- Root cause confirmed by reading `src/tasks/task-registry.types.ts` (`TASK_DELIVERY_STATUSES` enum), `src/infra/state-migrations.ts` (`normalizeLegacyTaskRow`), and `src/tasks/task-registry.ts` (`restoreTaskRegistryOnce`'s single try/catch around the whole snapshot load).
- Added regression test `"normalizes legacy not-requested delivery status so one bad row does not abort restore"` in `src/commands/doctor-state-migrations.test.ts`, using a new helper `appendLegacyTaskWithObsoleteDeliveryStatus` that inserts a legacy row with `delivery_status = "not-requested"` alongside the existing valid row, then verifies both rows migrate and the obsolete row's status is normalized to `"not_applicable"` via `loadTaskRegistryStateFromSqlite()`.
- Verified the fix actually addresses the bug: temporarily reverted the one-line normalization and reran the new test — it failed with `Invalid persisted task delivery status: "not-requested"` thrown from `parseTaskDeliveryStatus`, exactly matching the issue's described failure. Re-applied the fix and the test passes.
- Local test run: `node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts` — all 78 tests pass (no regressions).
- Grepped the codebase for other obsolete `task_runs.delivery_status` legacy literals; found none — the only other `"not-requested"` occurrence belongs to the unrelated `CronDeliveryStatus` enum (`src/cron/types.ts`), a different schema.

Closes #103168

---

This PR was prepared with AI assistance (GitHub Copilot CLI) under human supervision. All code changes, tests, and this description were reviewed before submission.
