### PR TITLE
docs(web): the Lobster gets its own page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1713,7 +1713,8 @@
                   "web/control-ui",
                   "web/dashboard",
                   "web/webchat",
-                  "web/tui"
+                  "web/tui",
+                  "web/lobster"
                 ]
               }
             ]

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9953,6 +9953,18 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Security notes
   - H2: Building the UI
 
+## web/lobster.md
+
+- Route: /web/lobster
+- Headings:
+  - H2: What you are looking at
+  - H2: When it shows up
+  - H2: Things you can do
+  - H2: Turning visits off (or back on)
+  - H2: The Lobsterdex
+  - H2: Field notes
+  - H2: Privacy
+
 ## web/tui.md
 
 - Route: /web/tui

--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -1,0 +1,62 @@
+---
+summary: "A lobster sometimes visits the Control UI. This page explains just enough."
+read_when:
+  - You saw a small lobster in your sidebar and want answers
+  - You want to turn lobster visits on or off
+  - You right-clicked a lobster and feel bad about it
+title: "The Lobster"
+sidebarTitle: "The Lobster"
+---
+
+If you use the [Control UI](/web/control-ui) long enough, at some point a small lobster will wander into the bottom of your sidebar, look around, and make itself at home for a few minutes.
+
+This is normal. This is OpenClaw.
+
+## What you are looking at
+
+Every session hatches its own lobster: its color, size, build, claw proportions, accessories, and personality are rolled fresh each time you load the page. Some are round, some are tall, some have claws that are frankly too big for them. Some nap constantly. Some never sit still. One of them waves a lot.
+
+Hover over a visitor and it will tell you its name.
+
+## When it shows up
+
+Sometimes. That is the point.
+
+The lobster is a guest, not furniture. It wanders in when it feels like it, stays a while, and leaves. Some sessions it never shows up at all. There is exactly one situation where it always appears: **when your Gateway disconnects**, the lobster comes out and paces, visibly worried, until the connection is back. If the lobster looks stressed, check your Gateway.
+
+## Things you can do
+
+- **Hover** to learn its name.
+- **Click it** to say hi. It startles, which is rude of you, but it forgives quickly.
+- **Click it repeatedly** and you will learn something about lobster patience. Keep going and you will learn something about lobster dignity.
+- **Right-click it** to shoo it away for the rest of the page load. It will not take it personally. It will, however, be gone.
+- **Watch it when a run finishes.** Lobsters take genuine pride in your completed work.
+
+## Turning visits off (or back on)
+
+Settings → Appearance → **Lobster visits**.
+
+The toggle is browser-local and does exactly what it says. Off means never, including the worried disconnect pacing. Your Gateway status dot continues to work regardless; the lobster was never your only source of truth, just the most sympathetic one.
+
+Reduced-motion users get calm, stationary lobsters automatically.
+
+## The Lobsterdex
+
+Next to the visits toggle lives the **Lobsterdex**: one silhouette for every coloration known to science, filling in with color as each kind visits you for the first time. It lives entirely in your browser. Nothing is tracked, nothing is synced, nothing is gamified. It is just a shelf.
+
+Most slots fill in on their own over time. A few will take considerably longer. One of them glows.
+
+## Field notes
+
+Collected observations from people who spend too much time watching their sidebar:
+
+- Lobsters visit the [Dreams page](/concepts/memory) too, where they are asleep. Observers report the sleeping lobster looks suspiciously familiar.
+- Night-shift users report their visitors yawn a lot after 10pm.
+- Lobsters have been seen shedding. Witnesses describe the experience as "a lot" and the lobster afterwards as "noticeably bigger."
+- Some visitors do not come alone.
+- Around certain times of the year, lobsters have been observed wearing things.
+- There is one day each year when every lobster looks like it walked out of an old logo. Nobody will tell you which day.
+
+## Privacy
+
+Everything on this page happens locally in your browser: the randomness, the schedule, the Lobsterdex. No lobster data leaves your machine. OpenClaw does not know which lobsters you have met, and frankly it is jealous.


### PR DESCRIPTION
Related: #102754 (lobster pet series) · Lands after #103172 so everything it hints at is on main.

## What Problem This Solves

The lobster pet spans five landed/landing PRs and has real user-facing controls (a settings toggle, right-click dismissal, the Lobsterdex) with zero documentation. It deserves a page — one that explains the controls without spoiling the surprises.

## Why This Change Was Made

Adds `docs/web/lobster.md` ("The Lobster") to the Web interfaces group: a short field guide written for fun. It documents the functional surface concretely — visit behavior, the always-appears-on-disconnect rule, hover names, poke etiquette, right-click shoo, the Settings → Appearance toggle, the Lobsterdex, reduced-motion, and a privacy note (everything is browser-local). The secrets stay secrets: rarity odds, specific variants, molt/twin mechanics, and the anniversary date are only teased in a "field notes" section. Registered in `docs.json` nav and the regenerated docs map.

## User Impact

People who meet a lobster can find out what it is, how to shoo it, and how to turn visits off — and get gently nerd-sniped into watching for the rare ones.

## Evidence

- `pnpm format:docs` clean; `pnpm docs:map:gen` output committed; `git diff --check` clean.
- Docs-only change: no runtime surface. Nav entry verified against the existing Web interfaces group structure; internal links use root-relative Mintlify form.
