### PR TITLE
fix(memory-wiki): keep terminal string truncation UTF-16 safe

### DIFF
--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -15,7 +15,11 @@ import {
 } from "./cli.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
 import { parseWikiMarkdown, renderWikiMarkdown } from "./markdown.js";
-import type { MemoryWikiDoctorReport, MemoryWikiStatus } from "./status.js";
+import {
+  renderMemoryWikiStatus,
+  type MemoryWikiDoctorReport,
+  type MemoryWikiStatus,
+} from "./status.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const callGatewayFromCliMock = vi.hoisted(() => vi.fn());
@@ -631,7 +635,7 @@ cli note
     );
   });
 
-  it("truncates gateway status text output after rendering", async () => {
+  it("truncates gateway status text output without splitting surrogate pairs", async () => {
     const { config } = await createCliVault({
       config: {
         vaultMode: "bridge",
@@ -640,12 +644,20 @@ cli note
       initialize: true,
     });
     const status = createGatewayStatus(config);
+    const warningWithoutMessage = renderMemoryWikiStatus({
+      ...status,
+      warnings: [{ code: "bridge-artifacts-missing", message: "" }],
+    });
+    const warningPrefix = "x".repeat(1_999 - warningWithoutMessage.length);
     status.warnings = [
       {
         code: "bridge-artifacts-missing",
-        message: `${"warning ".repeat(500)}tail`,
+        message: `${warningPrefix}\u{1F600}tail`,
       },
     ];
+    const renderedStatus = renderMemoryWikiStatus(status);
+    expect(renderedStatus.charCodeAt(1_999)).toBe(0xd83d);
+    expect(renderedStatus.charCodeAt(2_000)).toBe(0xde00);
     const textOutput: string[] = [];
     callGatewayFromCliMock.mockResolvedValueOnce(status);
 
@@ -657,7 +669,12 @@ cli note
     });
 
     const renderedText = textOutput.join("");
-    expect(renderedText).toContain("... [truncated]");
+    const truncationMarker = "... [truncated]\n";
+    expect(renderedText.length).toBeLessThanOrEqual(2_000 + truncationMarker.length);
+    expect(renderedText.length).toBeGreaterThan(1_990 + truncationMarker.length);
+    expect(renderedText.endsWith(truncationMarker)).toBe(true);
+    expect(renderedText).not.toContain("\ud83d");
+    expect(Buffer.from(renderedText).includes(Buffer.from([0xef, 0xbf, 0xbd]))).toBe(false);
     expect(renderedText).not.toContain("tail");
   });
 

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -8,6 +8,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation } from "./apply.js";
 import {
@@ -177,7 +178,7 @@ export type MemoryWikiCliRegistration = {
 function sanitizeGatewayStringForTerminal(value: string): string {
   const truncated =
     value.length > GATEWAY_TERMINAL_STRING_MAX_CHARS
-      ? value.slice(0, GATEWAY_TERMINAL_STRING_MAX_CHARS)
+      ? truncateUtf16Safe(value, GATEWAY_TERMINAL_STRING_MAX_CHARS)
       : value;
   const sanitized = truncated
     .replace(ANSI_ESCAPE_SEQUENCE_PATTERN, "")


### PR DESCRIPTION
## What Problem This Solves

`sanitizeGatewayStringForTerminal` in the memory-wiki CLI truncates gateway response strings at 2000 UTF-16 code units with a raw `.slice(0, 2000)`. When a surrogate pair (emoji, CJK supplementary characters) straddles the 2000-unit boundary, the truncation produces a lone high surrogate — corrupting the terminal output.

## Why This Change Was Made

Replace `.slice(0, GATEWAY_TERMINAL_STRING_MAX_CHARS)` with `truncateUtf16Safe(value, GATEWAY_TERMINAL_STRING_MAX_CHARS)`. When the boundary falls inside a surrogate pair, `truncateUtf16Safe` backs up one code unit so the pair is fully excluded instead of split. This matches the pattern used across 20+ recently merged UTF-16 truncation fixes.

## User Impact

Memory-wiki CLI output (`openclaw wiki ...` commands) no longer risks broken surrogate characters in truncated terminal output. No functional change to the wiki operations themselves.

## Evidence

**Real behavior proof — negative control (main branch, `.slice`):**

```
$ node --import tsx -e "
const text = 'x'.repeat(1999) + '\u{1F600}';
const broken = text.slice(0, 2000);
const last = broken.charCodeAt(1999);
console.log('lone high surrogate:', last >= 0xD800 && last <= 0xDBFF ? 'YES (BROKEN)' : 'no');
"

lone high surrogate: YES (BROKEN)
```

**Behavior or issue addressed:** Raw `.slice(0, 2000)` on a string with an emoji at position 1999–2000 produces a lone high surrogate (invalid UTF-16).

**Real environment tested:** Node 22.x on Linux x64, latest origin/main (d8624a4e1b).

**Exact steps or command run after this patch:**

```
$ node --import tsx -e "
import { truncateUtf16Safe } from '@openclaw/normalization-core/utf16-slice';
const text = 'x'.repeat(1999) + '\u{1F600}';
const safe = truncateUtf16Safe(text, 2000);
console.log('safe length:', safe.length);
"

safe length: 1999
```

**Evidence after fix:**

```text
safe length: 1999   ← surrogate pair fully excluded, no broken character
```

**Observed result after fix:** `.slice(0, 2000)` on main produces a lone high surrogate at position 1999 (0xd83d). `truncateUtf16Safe(text, 2000)` on the fix branch backs up to 1999 UTF-16 code units, keeping the string valid. The emoji pair is fully excluded rather than split.

**What was not tested:** Live memory-wiki CLI invocation with a long wiki page containing emoji at the 2000-character boundary. The proof exercises the production truncation utility (`truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice`) directly, which is the same function the patched production code now calls.