### PR TITLE
fix(discord): inherit forum auto archive duration

### DIFF
--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -1,5 +1,5 @@
 // Discord plugin module implements send.outbound behavior.
-import { ChannelType } from "discord-api-types/v10";
+import { ChannelType, type APIChannel } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
@@ -28,7 +28,7 @@ import {
   normalizeStickerIds,
   resolveDiscordMessageFlags,
   resolveChannelId,
-  resolveDiscordChannelType,
+  resolveDiscordChannel,
   resolveDiscordSendComponents,
   resolveDiscordSendEmbeds,
   sendDiscordMedia,
@@ -125,6 +125,17 @@ function isForumLikeType(channelType?: number): boolean {
   return channelType === ChannelType.GuildForum || channelType === ChannelType.GuildMedia;
 }
 
+function resolveForumDefaultAutoArchiveDuration(channel?: APIChannel): number | undefined {
+  if (!channel || !isForumLikeType(channel.type)) {
+    return undefined;
+  }
+  if (!("default_auto_archive_duration" in channel)) {
+    return undefined;
+  }
+  const duration = channel.default_auto_archive_duration;
+  return typeof duration === "number" ? duration : undefined;
+}
+
 function toDiscordSendResult(
   result: DiscordChannelMessageResult,
   fallbackChannelId: string,
@@ -199,10 +210,11 @@ export async function sendMessageDiscord(
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.
-  const channelType = await resolveDiscordChannelType(rest, channelId);
+  const channel = await resolveDiscordChannel(rest, channelId);
 
-  if (isForumLikeType(channelType)) {
+  if (isForumLikeType(channel?.type)) {
     const threadName = deriveForumThreadName(textWithTables);
+    const autoArchiveDuration = resolveForumDefaultAutoArchiveDuration(channel);
     const chunks = buildDiscordTextChunks(textWithMentions, {
       maxLinesPerMessage,
       chunkMode,
@@ -236,6 +248,9 @@ export async function sendMessageDiscord(
             {
               body: {
                 name: threadName,
+                ...(autoArchiveDuration === undefined
+                  ? {}
+                  : { auto_archive_duration: autoArchiveDuration }),
                 message: starterBody,
               },
             },

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -432,7 +432,10 @@ describe("sendMessageDiscord", () => {
   it("auto-creates a forum thread when target is a Forum channel", async () => {
     const { rest, postMock, getMock } = makeDiscordRest();
     // Channel type lookup returns a Forum channel.
-    getMock.mockResolvedValueOnce({ type: ChannelType.GuildForum });
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildForum,
+      default_auto_archive_duration: 1440,
+    });
     postMock.mockResolvedValue({
       id: "thread1",
       message: { id: "starter1", channel_id: "thread1" },
@@ -453,6 +456,7 @@ describe("sendMessageDiscord", () => {
     expectRestRoute(postMock, 0, Routes.threads("forum1"));
     expect(requireRestBody(postMock)).toEqual({
       name: "Discussion topic",
+      auto_archive_duration: 1440,
       message: {
         content: "Discussion topic\nBody of the post",
         flags: MessageFlags.SuppressEmbeds,

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -282,9 +282,15 @@ export async function resolveDiscordChannelType(
   rest: RequestClient,
   channelId: string,
 ): Promise<number | undefined> {
+  return (await resolveDiscordChannel(rest, channelId))?.type;
+}
+
+export async function resolveDiscordChannel(
+  rest: RequestClient,
+  channelId: string,
+): Promise<APIChannel | undefined> {
   try {
-    const channel = (await getChannel(rest, channelId)) as APIChannel | undefined;
-    return channel?.type;
+    return (await getChannel(rest, channelId)) as APIChannel | undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Fixes #103021.

## What Problem This Solves

Fixes an issue where users sending Discord messages into forum or media channels would get an auto-created starter thread that ignored the parent forum's configured archive window.

When the parent forum used a shorter default archive duration, OpenClaw omitted that duration from Discord's create-thread request, so Discord fell back to its API default instead.

AI-assisted: yes. I understand this change; it keeps the fix inside the Discord plugin send path and does not add a new message-tool parameter.

## Why This Change Was Made

The send path already fetches the target Discord channel to determine whether it is a forum/media parent. This change reuses that resolved channel object and, when Discord returns `default_auto_archive_duration`, carries it into the implicit starter-thread create request as `auto_archive_duration`.

The explicit `thread-create` action is unchanged; this only covers implicit forum/media thread creation from `action=send`.

## User Impact

Operators who configure Discord forum archive defaults now get matching archive behavior for threads created by OpenClaw message sends. Threads no longer silently linger at Discord's default duration when the forum default is shorter.

## Evidence

- Duplicate check: live open/closed PR searches for `103021`, `default_auto_archive_duration`, `auto_archive_duration`, and Discord forum thread wording found no existing fix PR before implementation.
- Dependency contract: `discord-api-types` exposes `default_auto_archive_duration` on forum/media channels and accepts `auto_archive_duration` in forum/media thread create bodies.
- `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts -- --reporter=verbose` failed before test execution on the local system Node because that Node version is below the repo engine floor; rerun with the bundled Node passed 53 tests.
- Bundled Node proof: `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts -- --reporter=verbose` passed.
- Adjacent proof: `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/actions/runtime.test.ts extensions/discord/src/channel-actions.test.ts -- --reporter=verbose` passed 222 tests.
- `git diff --check` passed.
- Local autoreview clean: no accepted/actionable findings.
