### PR TITLE
fix(copilot): restore prerelease after tool metadata consolidation

### DIFF
--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1086,7 +1086,7 @@ describe("runCopilotAttempt", () => {
     });
   });
 
-  it("replay-shim: mutating tool side effects make the attempt replay-unsafe", async () => {
+  it("replay-shim: consolidated mutating tool metadata makes the attempt replay-unsafe", async () => {
     const sdk = makeFakeSdk({
       onCreateSession: (session) => {
         session.sendAndWait.mockImplementationOnce(async () => {
@@ -1107,10 +1107,7 @@ describe("runCopilotAttempt", () => {
 
     const result = await runCopilotAttempt(makeParams(), { pool });
 
-    expect(result.toolMetas).toEqual([
-      { toolName: "write" },
-      { meta: "wrote file", toolName: "write" },
-    ]);
+    expect(result.toolMetas).toEqual([{ meta: "wrote file", toolName: "write" }]);
     expect(result.replayMetadata).toEqual({
       hadPotentialSideEffects: true,
       replaySafe: false,


### PR DESCRIPTION
Closes #103180

## What Problem This Solves

Fixes an issue where the Copilot plugin prerelease shard failed after one tool call when its attempt-level replay test expected the pre-#102981 duplicate metadata shape.

## Why This Change Was Made

The event bridge now intentionally keeps one consolidated metadata entry per tool call. This updates the missed attempt-level assertion to validate that canonical result while retaining the replay-safety regression coverage.

## User Impact

No runtime behavior changes. Copilot prerelease validation can pass again, unblocking the full release profile.

## Evidence

- Before: Plugin Prerelease run 29060157297, job 86260106578 failed with 1 failed / 114 passed in `extensions/copilot/src/attempt.test.ts`.
- Blacksmith Testbox through Crabbox `tbx_01kx4q5ffgbjw81sn3d5psmdqf`: `pnpm test extensions/copilot/src/attempt.test.ts extensions/copilot/src/event-bridge.test.ts` — 150 passed.
- Same Testbox: `pnpm check:changed` — passed, including extension-test typecheck and lint.
- Autoreview (Codex gpt-5.5/high): clean; no accepted/actionable findings.
- `git diff --check` — passed.

AI-assisted: yes.
