### PR TITLE
fix(tlon): bound urbit auth cookie-flush body read

### DIFF
--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -24,14 +24,12 @@ describe("tlon urbit auth ssrf", () => {
   });
 
   it("allows private IPs when allowPrivateNetwork is enabled", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => "ok",
-      headers: new Headers({
-        "set-cookie": "urbauth-~zod=123; Path=/; HttpOnly",
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response("ok", {
+        status: 200,
+        headers: { "set-cookie": "urbauth-~zod=123; Path=/; HttpOnly" },
       }),
-    });
+    );
     vi.stubGlobal("fetch", mockFetch);
     const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
 
@@ -42,5 +40,47 @@ describe("tlon urbit auth ssrf", () => {
     });
     expect(cookie).toContain("urbauth-~zod=123");
     expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("drains login response body up to 64KB and cancels oversized bodies", async () => {
+    // Use a response body larger than the 64KB drain limit to prove the
+    // stream is cancelled rather than buffered in memory.
+    const largeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const chunk = new Uint8Array(1024);
+        // Enqueue 65 chunks = 65KB > 64KB limit
+        for (let i = 0; i < 65; i++) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+    const response = new Response(largeBody, {
+      status: 200,
+      headers: { "set-cookie": "urbauth-~zod=456; Path=/; HttpOnly" },
+    });
+    // Intercept getReader so we can spy on the reader's cancel call.
+    const originalGetReader = response.body!.getReader.bind(response.body);
+    let readerCancelSpy: ReturnType<typeof vi.fn>;
+    vi.spyOn(response.body!, "getReader").mockImplementation(
+      function (this: ReadableStream, options) {
+        const reader = originalGetReader(options);
+        readerCancelSpy = vi.spyOn(reader, "cancel");
+        return reader;
+      },
+    );
+    const mockFetch = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", mockFetch);
+    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+    const cookie = await authenticate("http://127.0.0.1:8080", "code", {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    expect(cookie).toContain("urbauth-~zod=456");
+    // Oversized body must be cancelled so the reader doesn't keep buffering.
+    expect(readerCancelSpy!).toHaveBeenCalled();
   });
 });

--- a/extensions/tlon/src/urbit/auth.ts
+++ b/extensions/tlon/src/urbit/auth.ts
@@ -1,7 +1,11 @@
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 // Tlon plugin module implements auth behavior.
 import type { LookupFn, SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { UrbitAuthError } from "./errors.js";
 import { urbitFetch } from "./fetch.js";
+
+/** Byte cap for draining the login response body so cookie headers finalize. */
+const AUTH_RESPONSE_DRAIN_LIMIT = 64 * 1024;
 
 type UrbitAuthenticateOptions = {
   ssrfPolicy?: SsrFPolicy;
@@ -37,7 +41,10 @@ export async function authenticate(
     }
 
     // Some Urbit setups require the response body to be read before cookie headers finalize.
-    await response.text().catch(() => {});
+    // Drain up to 64KB so auth succeeds on normal deployments without trusting the server to
+    // always return a small body.  If the body exceeds the limit the stream is cancelled and
+    // the error is caught so we still attempt cookie extraction.
+    await readResponseWithLimit(response, AUTH_RESPONSE_DRAIN_LIMIT).catch(() => {});
     const cookie = response.headers.get("set-cookie");
     if (!cookie) {
       throw new UrbitAuthError("missing_cookie", "No authentication cookie received");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Tlon Urbit authenticate function calls `response.text()` with no size limit to drain the login response body. The body must be read before Urbit cookie headers finalize, but `response.text()` buffers the entire response in memory regardless of size. A misconfigured or compromised Urbit endpoint returning an unexpectedly large body would cause unbounded memory consumption.

## Why This Change Was Made

Replaced `await response.text().catch(() => {})` with `readResponseWithLimit(response, 64 * 1024).catch(() => {})` from the plugin SDK response-limit runtime. This drains the body up to 64KB so cookies still finalize, cancels the stream and catches the error on overflow, and does not keep the entire body content in memory. The `.catch(() => {})` error-swallow is preserved so a failed body read does not block auth.

## User Impact

Operators of the Tlon channel plugin are protected against unbounded memory growth when the Urbit login endpoint returns an unexpectedly large response body. Auth behavior is unchanged for normal deployments — small login responses are fully drained and cookie extraction proceeds as before.

## Evidence

**Focused tests** (3/3 pass after rebase onto latest `upstream/main`):

```
node scripts/run-vitest.mjs run extensions/tlon/src/urbit/auth.ssrf.test.ts

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Tests cover: SSRF blocking (unchanged), small-body cookie extraction (updated mock to real Response), and oversized body stream cancellation with `reader.cancel()` spy (new — proves the 65KB body stream is cancelled instead of buffered).

**Real HTTP proof** — drove the real `authenticate()` function against a live localhost HTTP server emulating an Urbit login endpoint. Three response body sizes were tested; cookie headers are always returned before the body:

```
=== real http authenticate() proof (bounded 64KB drain) ===

[PASS] small body (128 B)
       elapsed:       61ms
       cookie:        urbauth-~zod=proof-cookie; Path=/; HttpOnly

[PASS] medium body (32 KB, under the 64KB cap)
       elapsed:       3ms
       cookie:        urbauth-~zod=proof-cookie; Path=/; HttpOnly

[PASS] oversized body (128 KB, exceeds 64KB cap)
       elapsed:       4ms
       cookie:        urbauth-~zod=proof-cookie; Path=/; HttpOnly
```

All three cases successfully extract the cookie. The oversized body case (128KB > 64KB cap) correctly triggers the `readResponseWithLimit` overflow path — the stream is cancelled and the overflow Error is caught by `.catch(() => {})`, then cookie extraction proceeds from the already-finalized headers. A `console.log` call inserted right after the drain confirmed the oversized-body path throws and is caught.

The `.catch(() => {})` wrapper ensures the overflow Error does not propagate, preserving the existing best-effort body-drain contract.

Branch refreshed against current `upstream/main` (be151c6f14).

AI-assisted. Real behavior proof collected by human.
