### PR TITLE
fix(utils): chain caller AbortSignal into fetchWithTimeout timeout controller

### DIFF
--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -182,12 +182,13 @@ export async function fetchWithTimeout(
   timeoutMs: number,
   fetchFn: typeof fetch = fetch,
 ): Promise<Response> {
+  const callerSignal = init.signal ?? undefined;
   const { signal: timeoutSignal, cleanup } = buildTimeoutAbortSignal({
     timeoutMs: Math.max(1, timeoutMs),
     operation: "fetchWithTimeout",
     url,
+    signal: callerSignal,
   });
-  const callerSignal = init.signal ?? undefined;
   // The wrapper timeout ends once fetch returns headers, but the response body
   // must keep following caller cancellation (and its reason) after that point.
   const signal =


### PR DESCRIPTION
## What Problem This Solves

Fixes #102928: `fetchWithTimeout` ignores the caller-provided `AbortSignal` in `RequestInit` when building the timeout controller, causing two issues:

1. The timeout timer keeps running after the caller aborts, wasting a timer slot until expiry.
2. The abort relay from the parent signal to the timeout controller never fires, so the timeout controller's cleanup cannot remove its event listener on the parent signal (potential memory leak).

## Why This Change Was Made

The current code already used `AbortSignal.any` to merge `callerSignal` with `timeoutSignal` for the fetch call itself, but it did not pass `init.signal` to `buildTimeoutAbortSignal`. This is a partial fix — the merged signal correctly aborts the fetch, but the timeout controller internals (timer, relay listener) are not cleaned up on caller abort.

This change passes `init.signal` to `buildTimeoutAbortSignal` so that:
- A caller abort immediately cancels the timeout timer (no wasted timer slot)
- The relay listener from parent signal to timeout controller fires, allowing proper cleanup
- `AbortSignal.any` still merges both signals for the fetch call, preserving the existing post-headers caller-cancellation behavior

## User Impact

- Caller-provided AbortSignals are now properly chained into the timeout controller lifecycle
- Timeout timers are cleaned up immediately on caller abort instead of running to expiry
- No change to existing fetch behavior or API contract

## Evidence

- `src/utils/fetch-timeout.test.ts` — 22 tests pass (including existing tests for caller abort, timeout abort, and mixed abort scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>