### PR TITLE
fix(utils): pass caller AbortSignal to buildTimeoutAbortSignal in fetchWithTimeout

### DIFF
--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -306,6 +306,38 @@ describe("buildTimeoutAbortSignal", () => {
     ).resolves.toBe(response);
   });
 
+  it("cancels the timeout timer when the caller aborts before timeout", async () => {
+    const parent = new AbortController();
+    const fetchFn = vi.fn<typeof fetch>(
+      async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("missing signal"));
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+            { once: true },
+          );
+        }),
+    );
+
+    const result = fetchWithTimeout(
+      "https://example.com/v1/audio",
+      { signal: parent.signal },
+      25,
+      fetchFn,
+    );
+    parent.abort(new Error("caller cancelled"));
+
+    await expect(result).rejects.toMatchObject({ message: "caller cancelled" });
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("clamps oversized fetchWithTimeout delays before fetch starts", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const response = new Response("ok");

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -182,14 +182,18 @@ export async function fetchWithTimeout(
   timeoutMs: number,
   fetchFn: typeof fetch = fetch,
 ): Promise<Response> {
+  const callerSignal = init.signal ?? undefined;
   const { signal: timeoutSignal, cleanup } = buildTimeoutAbortSignal({
     timeoutMs: Math.max(1, timeoutMs),
+    signal: callerSignal,
     operation: "fetchWithTimeout",
     url,
   });
-  const callerSignal = init.signal ?? undefined;
-  // The wrapper timeout ends once fetch returns headers, but the response body
-  // must keep following caller cancellation (and its reason) after that point.
+  // AbortSignal.any preserves the caller's abort reason (buildTimeoutAbortSignal
+  // relays parent aborts without forwarding the reason), while passing the
+  // caller signal into buildTimeoutAbortSignal ensures the timeout timer is
+  // cancelled immediately when the caller aborts rather than running until the
+  // finally block.
   const signal =
     callerSignal && timeoutSignal
       ? AbortSignal.any([callerSignal, timeoutSignal])


### PR DESCRIPTION
### What Problem This Solves

When a caller provides an `AbortSignal` in `RequestInit`, `fetchWithTimeout` did not pass it to `buildTimeoutAbortSignal`. This meant the timeout timer kept running even after the caller aborted, wasting resources and potentially emitting misleading timeout log messages.

Fixes #102928

### Why This Change Was Made

`fetchWithTimeout` already combined the caller signal with the timeout signal via `AbortSignal.any()` (lines 193-200), which correctly propagates abort events and preserves the caller's abort reason. However, it did not pass the caller signal to `buildTimeoutAbortSignal`, so:

1. When the caller aborted, the internal timeout timer was not cancelled — it continued running until the `finally` block's `cleanup()` ran after the fetch promise settled.
2. If the timer fired after the caller had already aborted, it would log a misleading timeout warning even though the real cause was caller cancellation.

By passing `init.signal` as the parent signal to `buildTimeoutAbortSignal`, the timeout timer is now cancelled immediately when the caller aborts. The `AbortSignal.any()` combination is still needed to preserve the caller's abort reason, since `buildTimeoutAbortSignal`'s `relayAbort` calls `controller.abort()` without forwarding the parent's reason.

### User Impact

No behavior change for callers who don't provide an `AbortSignal`. For callers who do:
- The timeout timer is now properly cancelled on caller abort (resource cleanup)
- No more misleading timeout log messages when the real cause was caller cancellation
- Caller abort reasons are still preserved as before

### Evidence

All 23 existing + new tests pass:

```
✓ src/utils/fetch-timeout.test.ts (23 tests) 549ms
```

New test added: "cancels the timeout timer when the caller aborts before timeout" — verifies that when the caller aborts before the timeout fires, no timeout warning is logged.

## Real behavior proof

```
$ node scripts/run-vitest.mjs src/utils/fetch-timeout.test.ts

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  08:56:19
   Duration  549ms

 ✓ |utils| src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > cancels the timeout timer when the caller aborts before timeout 1ms
 ✓ |utils| src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > preserves caller abort reasons before response headers 2ms
 ✓ |utils| src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > keeps following caller aborts while the returned body is consumed 2ms
 ✓ |utils| src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > accepts a null RequestInit signal 2ms
```
