### PR TITLE
fix(tlon): add request timeout to media downloads and image uploads

### DIFF
--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -14,6 +14,9 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 const MAX_IMAGES_PER_MESSAGE = 8;
 const TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
 
+/** Overall request timeout for remote media fetches that are idle before any data. */
+const TLON_MEDIA_DOWNLOAD_TIMEOUT_MS = 120_000;
+
 interface ExtractedImage {
   url: string;
   alt?: string;
@@ -70,6 +73,7 @@ export async function downloadMedia(
     const fetchOptions = {
       url,
       maxBytes: MAX_IMAGE_BYTES,
+      timeoutMs: TLON_MEDIA_DOWNLOAD_TIMEOUT_MS,
       readIdleTimeoutMs: TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -6,6 +6,9 @@ import { uploadFile } from "../tlon-api.js";
 
 const TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS = 30_000;
 
+/** Overall request timeout for image upload fetches that are idle before any data. */
+const TLON_UPLOAD_IMAGE_TIMEOUT_MS = 120_000;
+
 /**
  * Fetch an image from a URL and upload it to Tlon storage.
  * Returns the uploaded URL, or falls back to the original URL on error.
@@ -24,6 +27,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
     const fetched = await readRemoteMediaBuffer({
       url: imageUrl,
       maxBytes: MAX_IMAGE_BYTES,
+      timeoutMs: TLON_UPLOAD_IMAGE_TIMEOUT_MS,
       readIdleTimeoutMs: TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },


### PR DESCRIPTION
## What Problem This Solves

The Tlon media download helpers (`downloadMedia`, `uploadImageFromUrl`) already time out idle chunks via `readIdleTimeoutMs` (30s) but have no overall request timeout. A remote server that accepts the TCP connection then hangs without sending any data will hold the download open indefinitely.

This is the same gap Alix-007 is systematically fixing across channel extensions (telegram #103020, nodes-camera #103019, qqbot #103018).

## Why This Change Was Made

`saveRemoteMedia` and `readRemoteMediaBuffer` already support `timeoutMs` in their options. The helpers just weren't passing it through.

## User Impact

Prevents indefinite hangs on Tlon media downloads/uploads when the remote server never responds.

## Evidence

- `extensions/tlon/src/monitor/media.ts`: `downloadMedia()` calls `saveRemoteMedia`/`readRemoteMediaBuffer` — added `timeoutMs: 120_000`
- `extensions/tlon/src/urbit/upload.ts`: `uploadImageFromUrl()` calls `readRemoteMediaBuffer` — added `timeoutMs: 120_000`
- Both `timeoutMs` and `readIdleTimeoutMs` parallel the structure used by Alix-007's telegram PR #103020

Change: 8 insertions, 0 deletions across 2 files.
