### PR TITLE
fix(llm): stop retrying permanent errors and long-window rate limits

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -54,4 +54,32 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it.each([
+    "model gpt-5.5-preview-0429 not found",
+    "Image dimensions 1504x1504 exceed the maximum allowed size",
+    "invalid api key sk-proj-abc502xyz",
+  ])(
+    "does not retry permanent errors whose text merely embeds a status-code substring: %s",
+    (text) => {
+      expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+    },
+  );
+
+  it.each([
+    "429 You exceeded your daily request limit. Please try again in 24 hours.",
+    "rate limit reached for requests. Retry after 6h.",
+    "You have hit your allotted requests per day.",
+  ])("does not retry long-window rate limits a sub-15s backoff cannot clear: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
+    "429 Too Many Requests",
+    "HTTP 503 Service Unavailable",
+    "500 Internal Server Error",
+    "Error 502 Bad Gateway",
+  ])("still retries standalone HTTP status codes: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
 });

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -59,18 +59,21 @@ describe("isRetryableAssistantError", () => {
     "model gpt-5.5-preview-0429 not found",
     "Image dimensions 1504x1504 exceed the maximum allowed size",
     "invalid api key sk-proj-abc502xyz",
+    // A standalone number that is not a leading HTTP status must not look like a
+    // 5xx; word boundaries alone did not catch this. (issue #102250)
+    "maximum width is 500 pixels",
   ])(
-    "does not retry permanent errors whose text merely embeds a status-code substring: %s",
+    "does not retry permanent errors whose text merely embeds a status-code-like number: %s",
     (text) => {
       expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
     },
   );
 
   it.each([
-    "429 You exceeded your daily request limit. Please try again in 24 hours.",
-    "rate limit reached for requests. Retry after 6h.",
-    "You have hit your allotted requests per day.",
-  ])("does not retry long-window rate limits a sub-15s backoff cannot clear: %s", (text) => {
+    "404 model not found",
+    "400 Bad Request: unsupported image dimensions",
+    "401 invalid api key",
+  ])("does not retry permanent errors carrying a leading 4xx status: %s", (text) => {
     expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
   });
 
@@ -79,7 +82,8 @@ describe("isRetryableAssistantError", () => {
     "HTTP 503 Service Unavailable",
     "500 Internal Server Error",
     "Error 502 Bad Gateway",
-  ])("still retries standalone HTTP status codes: %s", (text) => {
+    "504 Gateway Timeout",
+  ])("still retries genuine transient HTTP status errors: %s", (text) => {
     expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
   });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -11,17 +11,31 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
   "available balance",
   "insufficient_quota",
   "out of budget",
+  // Long-window rate limits (daily/multi-hour reset). The outer retry budget is
+  // a handful of sub-15s exponential backoffs, which can never clear a window
+  // measured in hours or days — retrying only re-sends the full context and
+  // re-bills tokens. Matched here so they short-circuit the retryable "rate
+  // limit"/"429" patterns below. (issue #102250)
+  "per day",
+  "daily.{0,40}limit",
+  "try again in \\d+\\s*(?:hour|hours|day|days)",
+  "retry after \\d+\\s*(?:h(?:ours?)?|d(?:ays?)?)\\b",
 ]);
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
+  // Anchor bare HTTP status tokens on word boundaries so they only match a
+  // standalone status code, not a digit run embedded in a model id, image
+  // dimension, request id, or API key (e.g. "…preview-0429", "1504x1504",
+  // "sk-proj-abc502xyz"). Unanchored, those substrings made permanent 400/401/
+  // 404 errors look retryable, burning tokens on doomed re-sends. (issue #102250)
+  "\\b429\\b",
+  "\\b500\\b",
+  "\\b502\\b",
+  "\\b503\\b",
+  "\\b504\\b",
   "service.?unavailable",
   "server.?error",
   "internal.?error",

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,3 +1,4 @@
+import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
 import type { AssistantMessage } from "../types.js";
 
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
@@ -11,32 +12,14 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
   "available balance",
   "insufficient_quota",
   "out of budget",
-  // Long-window rate limits (daily/multi-hour reset). The outer retry budget is
-  // a handful of sub-15s exponential backoffs, which can never clear a window
-  // measured in hours or days — retrying only re-sends the full context and
-  // re-bills tokens. Matched here so they short-circuit the retryable "rate
-  // limit"/"429" patterns below. (issue #102250)
-  "per day",
-  "daily.{0,40}limit",
-  "try again in \\d+\\s*(?:hour|hours|day|days)",
-  "retry after \\d+\\s*(?:h(?:ours?)?|d(?:ays?)?)\\b",
 ]);
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  // Anchor bare HTTP status tokens on word boundaries so they only match a
-  // standalone status code, not a digit run embedded in a model id, image
-  // dimension, request id, or API key (e.g. "…preview-0429", "1504x1504",
-  // "sk-proj-abc502xyz"). Unanchored, those substrings made permanent 400/401/
-  // 404 errors look retryable, burning tokens on doomed re-sends. (issue #102250)
-  "\\b429\\b",
-  "\\b500\\b",
-  "\\b502\\b",
-  "\\b503\\b",
-  "\\b504\\b",
   "service.?unavailable",
+  "bad gateway",
   "server.?error",
   "internal.?error",
   "provider.?returned.?error",
@@ -63,13 +46,33 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+// A leading HTTP status is retryable only for transient server/throttle codes:
+// request-timeout (408), too-early (425), too-many-requests (429), and any 5xx
+// (server/gateway/overloaded/Cloudflare). Every other status — the permanent
+// 4xx family (400/401/403/404/422 …) — fails fast.
+function isRetryableHttpStatus(code: number): boolean {
+  if (code === 408 || code === 425 || code === 429) {
+    return true;
+  }
+  return code >= 500 && code <= 599;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
     return false;
   }
-  if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message.errorMessage)) {
+  const errorText = message.errorMessage;
+  if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorText)) {
     return false;
   }
-  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);
+  // Prefer structured status classification over substring matching: a leading
+  // status code is authoritative, so permanent 4xx errors fail fast and a bare
+  // number embedded in prose (e.g. "maximum width is 500 pixels", a model id, or
+  // an API key) is never mistaken for a 5xx and retried. (issue #102250)
+  const status = extractLeadingHttpStatus(errorText);
+  if (status) {
+    return isRetryableHttpStatus(status.code);
+  }
+  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorText);
 }


### PR DESCRIPTION
Closes #102250

## What Problem This Solves

The session auto-retry classifier (`isRetryableAssistantError`) treated **permanent** provider errors as transient, so the outer retry loop re-sent the entire conversation up to `maxRetries` (default 3) before giving up — re-billing full input/context tokens on a request that can never succeed. The trigger was substring matching of bare HTTP status tokens (`429`/`500`/`502`/`503`/`504`) anywhere in the error text, so any message that merely embedded those digits classified as retryable:

- `model gpt-5.5-preview-0429 not found` → matched `429` → a permanent **404** was retried
- `Image dimensions 1504x1504 exceed the maximum allowed size` → matched `504` → a permanent **400** was retried
- `invalid api key sk-proj-abc502xyz` → matched `502` → a permanent **401** was retried
- `maximum width is 500 pixels` → matched `500` → retried

## Why This Change Was Made

Following review, the classifier now uses **structured leading-HTTP-status detection** instead of substring matching:

- A leading status code (`extractLeadingHttpStatus`, already used by the shared error-format helpers) is authoritative. Transient codes — `408`, `425`, `429`, and any `5xx` — remain retryable; every other status, including the permanent `4xx` family, fails fast. A standalone number in prose (`maximum width is 500 pixels`) has no leading status, so it is no longer mistaken for a `5xx`.
- The bare `429/5xx` substring tokens are removed. Transient errors that don't lead with a status are still caught by the existing phrase patterns (`overloaded`, `rate limit`, `service unavailable`, `bad gateway`, timeouts, connection/socket/stream failures, explicit "please retry" guidance).

Long-window rate-limit windowing is intentionally **not** handled here. That policy already has an owner — the embedded-agent failover path (`src/agents/embedded-agent-runner/run/assistant-failover.ts`: `LONG_WINDOW_RATE_LIMIT_RE` plus `Retry-After` duration parsing and the per-minute short-window exception). Encoding a second copy in the session classifier would create a drift-prone second source of truth (and naively would misclassify per-minute quota throttles that must stay retryable). The session classifier stays status/phrase-only; long-window handling remains with its owner.

The change is confined to the `llm` layer. `extractLeadingHttpStatus` lives in `src/shared/` and imports nothing from `agents`/`llm`, so there is no new module cycle (`pnpm check:import-cycles`: 0 cycles).

## User Impact

Permanent errors (bad model id, invalid image dimensions, invalid API key, other 4xx whose text embedded or led with a status number) now fail fast on the first response instead of being retried up to 3× with the full context re-sent each time — directly cutting token spend and surfacing the real error sooner. Genuine transient failures (real 429/5xx, overload, timeouts, connection resets, explicit retry guidance) retry exactly as before.

## Evidence

**Session-boundary proof.** The following replays the exact `AgentSession` retry budget (`isRetryableError` → `prepareRetry`: `retryCount++`, stop when `> maxRetries`, `delayMs = baseDelayMs * 2 ** (retryCount - 1)`; defaults `maxRetries=3`, `baseDelayMs=2000`) driving the **real** post-fix classifier imported from source, versus current `main`'s classifier. Each `auto_retry_start` event is one extra full-context provider call. Messages are synthetic; the API-key string is fake.

```
Retry budget: maxRetries=3, baseDelayMs=2000 (2s/4s/8s)

[FIX ] permanent 404 (model id embeds 0429)   "model gpt-5.5-preview-0429 not found"
   BEFORE (main): 3 extra provider calls (attempt 1/3 2s, 2/3 4s, 3/3 8s)
   AFTER  (fix):  0
[FIX ] permanent 400 (dims embed 1504)         "Image dimensions 1504x1504 exceed the maximum allowed size"
   BEFORE: 3    AFTER: 0
[FIX ] permanent 401 (key embeds 502)          "invalid api key sk-proj-abc502xyz"
   BEFORE: 3    AFTER: 0
[FIX ] permanent 400 (prose '500 pixels')      "maximum width is 500 pixels"
   BEFORE: 3    AFTER: 0
[KEEP] transient 503                            "HTTP 503 Service Unavailable"
   BEFORE: 3    AFTER: 3  (unchanged)
[KEEP] transient 429                            "429 Too Many Requests"
   BEFORE: 3    AFTER: 3  (unchanged)
[KEEP] transient overload                       "overloaded_error: the model is overloaded"
   BEFORE: 3    AFTER: 3  (unchanged)

Permanent errors:  12 wasted full-context provider calls  ->  0
Genuine transient: retry identically before and after (9 -> 9)
```

**Tests** — `src/llm/utils/retry.test.ts`: permanent errors that embed a status-code-like number (including the standalone `maximum width is 500 pixels` regression case) → non-retryable; permanent errors with a leading `4xx` status → non-retryable; genuine transient HTTP status errors (429/503/500/502/504) → retryable. Existing cases (explicit retry guidance, quota failures, short-window `requests per minute` exhaustion, transient billing-service failure) still pass. `pnpm test src/llm/utils/retry.test.ts` → 18 passed.

**Static checks** — `oxfmt`, `oxlint`, and `pnpm check:import-cycles` (0 cycles) pass on the changed files; `tsgo` reports no errors in the changed files.
