### PR TITLE
fix(gateway): clear session suspension timers on shutdown

### DIFF
--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -121,6 +121,22 @@ describe("session suspension", () => {
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 
+  it("clears pending lane auto-resume timers without resuming after cleanup", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+
+    await suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
+    expect(clearSessionSuspensionTimers()).toBe(1);
+
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(clearSessionSuspensionTimers()).toBe(0);
+  });
+
   it("defers session suspension only for the outer fallback candidate run", async () => {
     const { resolveSessionSuspensionTarget, runWithDeferredSessionSuspension } =
       await import("./session-suspension.js");

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -184,6 +184,24 @@ describe("session suspension", () => {
     expect(enableSessionSuspensionTimersForGatewayStart()).toBe(0);
   });
 
+  it("leaves built-in lane restoration to gateway startup concurrency", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
+      await import("./session-suspension.js");
+
+    await suspendLane(
+      100,
+      { agents: { defaults: { maxConcurrent: 3 } } } as OpenClawConfig,
+      CommandLane.Main,
+    );
+
+    expect(clearSessionSuspensionTimers()).toBe(1);
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
+
+    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(0);
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+  });
+
   it("does not throttle lanes when cleanup wins a pending suspension write race", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -121,20 +121,70 @@ describe("session suspension", () => {
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 
-  it("clears pending lane auto-resume timers without resuming after cleanup", async () => {
+  it("restores and clears pending lane auto-resume timers during cleanup", async () => {
     vi.useFakeTimers();
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
 
-    await suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+    await suspendLane(
+      100,
+      { agents: { defaults: { maxConcurrent: 3 } } } as OpenClawConfig,
+      CommandLane.Main,
+    );
 
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
     expect(clearSessionSuspensionTimers()).toBe(1);
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenLastCalledWith(
+      CommandLane.Main,
+      3,
+    );
 
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
     await vi.advanceTimersByTimeAsync(100);
 
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
     expect(clearSessionSuspensionTimers()).toBe(0);
+  });
+
+  it("restores custom lanes to their default resume concurrency during cleanup", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+
+    await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Nested, 0);
+    expect(clearSessionSuspensionTimers()).toBe(1);
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenLastCalledWith(
+      CommandLane.Nested,
+      1,
+    );
+  });
+
+  it("does not throttle lanes when cleanup wins a pending suspension write race", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+    let resolvePatch: (() => void) | undefined;
+    sessionAccessorMocks.patchSessionEntry.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+
+    const suspension = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+    await vi.waitFor(() => {
+      expect(resolvePatch).toBeTypeOf("function");
+    });
+
+    expect(clearSessionSuspensionTimers()).toBe(0);
+    resolvePatch?.();
+    await suspension;
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(sessionAccessorMocks.patchSessionEntry).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
   });
 
   it("defers session suspension only for the outer fallback candidate run", async () => {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -45,6 +45,10 @@ describe("session suspension", () => {
       vi.clearAllTimers();
     }
     vi.useRealTimers();
+    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
+      await import("./session-suspension.js");
+    clearSessionSuspensionTimers();
+    enableSessionSuspensionTimersForGatewayStart();
     sessionAccessorMocks.patchSessionEntry.mockClear();
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
   });
@@ -121,7 +125,7 @@ describe("session suspension", () => {
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 
-  it("restores and clears pending lane auto-resume timers during cleanup", async () => {
+  it("clears pending lane auto-resume timers without pumping queued work during cleanup", async () => {
     vi.useFakeTimers();
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
 
@@ -133,10 +137,6 @@ describe("session suspension", () => {
 
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
     expect(clearSessionSuspensionTimers()).toBe(1);
-    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenLastCalledWith(
-      CommandLane.Main,
-      3,
-    );
 
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
     await vi.advanceTimersByTimeAsync(100);
@@ -145,22 +145,30 @@ describe("session suspension", () => {
     expect(clearSessionSuspensionTimers()).toBe(0);
   });
 
-  it("restores custom lanes to their default resume concurrency during cleanup", async () => {
+  it("blocks new suspension timers until gateway startup re-enables them", async () => {
     vi.useFakeTimers();
-    const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
+      await import("./session-suspension.js");
 
     await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
 
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Nested, 0);
     expect(clearSessionSuspensionTimers()).toBe(1);
-    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenLastCalledWith(
-      CommandLane.Nested,
-      1,
-    );
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
+
+    await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+
+    enableSessionSuspensionTimersForGatewayStart();
+    await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Nested, 0);
   });
 
   it("does not throttle lanes when cleanup wins a pending suspension write race", async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(1_000);
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
     let resolvePatch: (() => void) | undefined;
     sessionAccessorMocks.patchSessionEntry.mockImplementationOnce(
@@ -181,6 +189,26 @@ describe("session suspension", () => {
 
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
     expect(sessionAccessorMocks.patchSessionEntry).toHaveBeenCalledTimes(2);
+    const cleanupPatch = sessionAccessorMocks.patchSessionEntry.mock.calls[1]?.[1] as (entry: {
+      quotaSuspension?: {
+        suspendedAt: number;
+        reason: string;
+        failedProvider: string;
+        failedModel: string;
+        laneId?: string;
+      };
+    }) => unknown;
+    expect(
+      cleanupPatch({
+        quotaSuspension: {
+          suspendedAt: -1,
+          reason: "quota_exhausted",
+          failedProvider: "anthropic",
+          failedModel: "claude-opus-4-6",
+          laneId: CommandLane.Main,
+        },
+      }),
+    ).toBeNull();
 
     await vi.advanceTimersByTimeAsync(100);
 

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -45,10 +45,8 @@ describe("session suspension", () => {
       vi.clearAllTimers();
     }
     vi.useRealTimers();
-    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
-      await import("./session-suspension.js");
-    clearSessionSuspensionTimers();
-    enableSessionSuspensionTimersForGatewayStart();
+    const { testing } = await import("./session-suspension.js");
+    testing.resetSessionSuspensionStateForTest();
     sessionAccessorMocks.patchSessionEntry.mockClear();
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
   });
@@ -164,6 +162,26 @@ describe("session suspension", () => {
     await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
 
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Nested, 0);
+  });
+
+  it("restores suspended custom lanes when gateway startup re-enables timers", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
+      await import("./session-suspension.js");
+    const customLaneId = "plugin:voice:room-1" as CommandLane;
+
+    await suspendLane(100, {} as OpenClawConfig, customLaneId);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(customLaneId, 0);
+    expect(clearSessionSuspensionTimers()).toBe(1);
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(1);
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(customLaneId, 1);
+    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(0);
   });
 
   it("does not throttle lanes when cleanup wins a pending suspension write race", async () => {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -116,10 +116,12 @@ describe("session suspension", () => {
     await suspendLane(Number.MAX_SAFE_INTEGER, {} as OpenClawConfig, CommandLane.Main);
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    const buildPatch = sessionAccessorMocks.patchSessionEntry.mock.calls[0]?.[1] as () => {
+    const buildPatch = sessionAccessorMocks.patchSessionEntry.mock.calls[0]?.[1] as (_entry: {
+      quotaSuspension?: unknown;
+    }) => {
       quotaSuspension?: { expectedResumeBy?: number };
     };
-    const patch = buildPatch();
+    const patch = buildPatch({});
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 
@@ -247,13 +249,36 @@ describe("session suspension", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+    const previousQuotaSuspension = {
+      schemaVersion: 1,
+      suspendedAt: 500,
+      reason: "circuit_open",
+      failedProvider: "openai",
+      failedModel: "gpt-5.5",
+      laneId: CommandLane.Main,
+      expectedResumeBy: 2_000,
+      state: "suspended",
+    };
     let resolvePatch: (() => void) | undefined;
-    sessionAccessorMocks.patchSessionEntry.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolvePatch = resolve;
-        }),
-    );
+    let writtenQuotaSuspension:
+      | {
+          suspendedAt: number;
+          reason: string;
+          failedProvider: string;
+          failedModel: string;
+          laneId?: string;
+        }
+      | undefined;
+    sessionAccessorMocks.patchSessionEntry.mockImplementationOnce(async (_scope, update) => {
+      await new Promise<void>((resolve) => {
+        resolvePatch = resolve;
+      });
+      const patch = update({ quotaSuspension: previousQuotaSuspension }) as {
+        quotaSuspension?: typeof writtenQuotaSuspension;
+      };
+      writtenQuotaSuspension = patch.quotaSuspension;
+      return patch;
+    });
 
     const suspension = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
     await vi.waitFor(() => {
@@ -275,6 +300,11 @@ describe("session suspension", () => {
         laneId?: string;
       };
     }) => unknown;
+    expect(
+      cleanupPatch({
+        quotaSuspension: writtenQuotaSuspension,
+      }),
+    ).toEqual({ quotaSuspension: previousQuotaSuspension });
     expect(
       cleanupPatch({
         quotaSuspension: {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -199,7 +199,8 @@ describe("session suspension", () => {
     const suspendedLaneIds = enableSessionSuspensionTimersForGatewayStart();
 
     expect(suspendedLaneIds).toEqual(new Set([customLaneId]));
-    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(customLaneId, 0);
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
 
     await vi.advanceTimersByTimeAsync(59);
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
@@ -223,7 +224,23 @@ describe("session suspension", () => {
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
 
     expect(enableSessionSuspensionTimersForGatewayStart()).toEqual(new Set([CommandLane.Main]));
-    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
+  });
+
+  it("clamps rescheduled cleanup timers after wall-clock rollback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { enableSessionSuspensionTimersForGatewayStart, testing } =
+      await import("./session-suspension.js");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const customLaneId = "plugin:voice:room-3";
+    testing.seedClearedLaneResumeForTest(customLaneId, {
+      resumeConcurrency: 1,
+      resumeAtMs: 1_000 + MAX_TIMER_TIMEOUT_MS + 1_000,
+    });
+
+    expect(enableSessionSuspensionTimersForGatewayStart()).toEqual(new Set([customLaneId]));
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 
   it("does not throttle lanes when cleanup wins a pending suspension write race", async () => {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -300,21 +300,19 @@ describe("session suspension", () => {
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
   });
 
-  it("restores the pre-cleanup suspension when multiple writes race cleanup", async () => {
+  it("restores the pre-cleanup absence when multiple writes race cleanup", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
-    const previousQuotaSuspension = {
-      schemaVersion: 1,
-      suspendedAt: 500,
-      reason: "circuit_open",
-      failedProvider: "openai",
-      failedModel: "gpt-5.5",
-      laneId: CommandLane.Main,
-      expectedResumeBy: 2_000,
-      state: "suspended",
-    };
-    let storeEntry = { quotaSuspension: previousQuotaSuspension };
+    let storeEntry: {
+      quotaSuspension?: {
+        suspendedAt: number;
+        reason: string;
+        failedProvider: string;
+        failedModel: string;
+        laneId?: string;
+      };
+    } = {};
     let initialWrites = 0;
     let releaseInitialWrites!: () => void;
     const initialWritesReleased = new Promise<void>((resolve) => {
@@ -322,8 +320,9 @@ describe("session suspension", () => {
     });
     sessionAccessorMocks.patchSessionEntry.mockImplementation(async (_scope, update) => {
       const patch = update(storeEntry) as typeof storeEntry | null;
-      if (patch?.quotaSuspension !== undefined) {
-        storeEntry = { quotaSuspension: patch.quotaSuspension };
+      if (patch && "quotaSuspension" in patch) {
+        storeEntry =
+          patch.quotaSuspension === undefined ? {} : { quotaSuspension: patch.quotaSuspension };
       }
       if (initialWrites < 2) {
         initialWrites += 1;
@@ -342,8 +341,22 @@ describe("session suspension", () => {
     releaseInitialWrites();
     await Promise.all([first, second]);
 
-    expect(storeEntry.quotaSuspension).toEqual(previousQuotaSuspension);
+    expect(storeEntry.quotaSuspension).toBeUndefined();
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+  });
+
+  it("still throttles the lane when persistence fails while gateway is active", async () => {
+    vi.useFakeTimers();
+    sessionAccessorMocks.patchSessionEntry.mockRejectedValueOnce(new Error("disk busy"));
+
+    await suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenLastCalledWith(
+      CommandLane.Main,
+      4,
+    );
   });
 
   it("defers session suspension only for the outer fallback candidate run", async () => {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -155,10 +155,12 @@ describe("session suspension", () => {
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Nested, 0);
     expect(clearSessionSuspensionTimers()).toBe(1);
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
+    sessionAccessorMocks.patchSessionEntry.mockClear();
 
     await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);
 
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+    expect(sessionAccessorMocks.patchSessionEntry).not.toHaveBeenCalled();
 
     enableSessionSuspensionTimersForGatewayStart();
     await suspendLane(100, {} as OpenClawConfig, CommandLane.Nested);

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -179,9 +179,33 @@ describe("session suspension", () => {
     await vi.advanceTimersByTimeAsync(100);
 
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
-    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(1);
+    expect(enableSessionSuspensionTimersForGatewayStart().size).toBe(0);
     expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(customLaneId, 1);
-    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(0);
+    expect(enableSessionSuspensionTimersForGatewayStart().size).toBe(0);
+  });
+
+  it("reschedules unexpired custom lane suspensions when gateway startup re-enables timers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { clearSessionSuspensionTimers, enableSessionSuspensionTimersForGatewayStart } =
+      await import("./session-suspension.js");
+    const customLaneId = "plugin:voice:room-2" as CommandLane;
+
+    await suspendLane(100, {} as OpenClawConfig, customLaneId);
+    expect(clearSessionSuspensionTimers()).toBe(1);
+    commandQueueMocks.setCommandLaneConcurrency.mockClear();
+
+    await vi.advanceTimersByTimeAsync(40);
+    const suspendedLaneIds = enableSessionSuspensionTimersForGatewayStart();
+
+    expect(suspendedLaneIds).toEqual(new Set([customLaneId]));
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(59);
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(customLaneId, 1);
   });
 
   it("leaves built-in lane restoration to gateway startup concurrency", async () => {
@@ -198,7 +222,7 @@ describe("session suspension", () => {
     expect(clearSessionSuspensionTimers()).toBe(1);
     commandQueueMocks.setCommandLaneConcurrency.mockClear();
 
-    expect(enableSessionSuspensionTimersForGatewayStart()).toBe(0);
+    expect(enableSessionSuspensionTimersForGatewayStart()).toEqual(new Set([CommandLane.Main]));
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
   });
 

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -292,35 +292,57 @@ describe("session suspension", () => {
     await suspension;
 
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
-    expect(sessionAccessorMocks.patchSessionEntry).toHaveBeenCalledTimes(2);
-    const cleanupPatch = sessionAccessorMocks.patchSessionEntry.mock.calls[1]?.[1] as (entry: {
-      quotaSuspension?: {
-        suspendedAt: number;
-        reason: string;
-        failedProvider: string;
-        failedModel: string;
-        laneId?: string;
-      };
-    }) => unknown;
-    expect(
-      cleanupPatch({
-        quotaSuspension: writtenQuotaSuspension,
-      }),
-    ).toEqual({ quotaSuspension: previousQuotaSuspension });
-    expect(
-      cleanupPatch({
-        quotaSuspension: {
-          suspendedAt: -1,
-          reason: "quota_exhausted",
-          failedProvider: "anthropic",
-          failedModel: "claude-opus-4-6",
-          laneId: CommandLane.Main,
-        },
-      }),
-    ).toBeNull();
+    expect(writtenQuotaSuspension).toBeUndefined();
+    expect(sessionAccessorMocks.patchSessionEntry).toHaveBeenCalledOnce();
 
     await vi.advanceTimersByTimeAsync(100);
 
+    expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
+  });
+
+  it("restores the pre-cleanup suspension when multiple writes race cleanup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
+    const previousQuotaSuspension = {
+      schemaVersion: 1,
+      suspendedAt: 500,
+      reason: "circuit_open",
+      failedProvider: "openai",
+      failedModel: "gpt-5.5",
+      laneId: CommandLane.Main,
+      expectedResumeBy: 2_000,
+      state: "suspended",
+    };
+    let storeEntry = { quotaSuspension: previousQuotaSuspension };
+    let initialWrites = 0;
+    let releaseInitialWrites!: () => void;
+    const initialWritesReleased = new Promise<void>((resolve) => {
+      releaseInitialWrites = resolve;
+    });
+    sessionAccessorMocks.patchSessionEntry.mockImplementation(async (_scope, update) => {
+      const patch = update(storeEntry) as typeof storeEntry | null;
+      if (patch?.quotaSuspension !== undefined) {
+        storeEntry = { quotaSuspension: patch.quotaSuspension };
+      }
+      if (initialWrites < 2) {
+        initialWrites += 1;
+        await initialWritesReleased;
+      }
+      return storeEntry;
+    });
+
+    const first = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+    const second = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
+    await vi.waitFor(() => {
+      expect(initialWrites).toBe(2);
+    });
+
+    expect(clearSessionSuspensionTimers()).toBe(0);
+    releaseInitialWrites();
+    await Promise.all([first, second]);
+
+    expect(storeEntry.quotaSuspension).toEqual(previousQuotaSuspension);
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
   });
 

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -300,7 +300,7 @@ describe("session suspension", () => {
     expect(commandQueueMocks.setCommandLaneConcurrency).not.toHaveBeenCalled();
   });
 
-  it("restores the pre-cleanup absence when multiple writes race cleanup", async () => {
+  it("serializes suspension writes so cleanup cannot leave an intermediate write", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const { clearSessionSuspensionTimers } = await import("./session-suspension.js");
@@ -334,7 +334,7 @@ describe("session suspension", () => {
     const first = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
     const second = suspendLane(100, {} as OpenClawConfig, CommandLane.Main);
     await vi.waitFor(() => {
-      expect(initialWrites).toBe(2);
+      expect(initialWrites).toBe(1);
     });
 
     expect(clearSessionSuspensionTimers()).toBe(0);

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -23,7 +23,13 @@ const log = createSubsystemLogger("session-suspension");
 const DEFAULT_CUSTOM_LANE_RESUME_CONCURRENCY = 1;
 const DEFAULT_QUOTA_SUSPENSION_RESUME_MS = 30 * 60 * 1000; // 30 min
 
-const laneResumeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+type LaneResumeTimer = {
+  timer: ReturnType<typeof setTimeout>;
+  resumeConcurrency: number;
+};
+
+const laneResumeTimers = new Map<string, LaneResumeTimer>();
+let cleanupGeneration = 0;
 const deferredSessionSuspension = new AsyncLocalStorage<{
   claimed: boolean;
   onDeferred?: (params: SessionSuspensionParams) => void;
@@ -90,10 +96,12 @@ export function resolveSessionSuspensionTarget(): SessionSuspensionTarget {
 function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurrency: number) {
   const existing = laneResumeTimers.get(laneId);
   if (existing) {
-    clearTimeout(existing);
+    clearTimeout(existing.timer);
   }
   const timer = setTimeout(() => {
-    laneResumeTimers.delete(laneId);
+    if (laneResumeTimers.get(laneId)?.timer === timer) {
+      laneResumeTimers.delete(laneId);
+    }
     setCommandLaneConcurrency(laneId, resumeConcurrency);
     log.info("auto-resumed lane after suspension TTL", {
       laneId,
@@ -104,13 +112,15 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
   if (typeof timer.unref === "function") {
     timer.unref();
   }
-  laneResumeTimers.set(laneId, timer);
+  laneResumeTimers.set(laneId, { timer, resumeConcurrency });
 }
 
 export function clearSessionSuspensionTimers(): number {
+  cleanupGeneration += 1;
   let cleared = 0;
-  for (const timer of laneResumeTimers.values()) {
-    clearTimeout(timer);
+  for (const [laneId, entry] of laneResumeTimers.entries()) {
+    clearTimeout(entry.timer);
+    setCommandLaneConcurrency(laneId, entry.resumeConcurrency);
     cleared += 1;
   }
   laneResumeTimers.clear();
@@ -135,6 +145,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const ttlMs = resolveTimerTimeoutMs(params.ttlMs, DEFAULT_QUOTA_SUSPENSION_RESUME_MS, 0);
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
+  const suspensionGeneration = cleanupGeneration;
 
   try {
     await patchSessionEntry(
@@ -160,6 +171,22 @@ export async function suspendSession(params: SessionSuspensionParams) {
       laneId: params.laneId,
       error: err instanceof Error ? err.message : String(err),
     });
+    return;
+  }
+
+  if (suspensionGeneration !== cleanupGeneration) {
+    try {
+      await patchSessionEntry({ storePath, sessionKey }, () => ({ quotaSuspension: undefined }), {
+        skipMaintenance: true,
+        takeCacheOwnership: true,
+      });
+    } catch (err) {
+      log.warn("failed to clear quota suspension after shutdown cleanup", {
+        sessionId: params.sessionId,
+        laneId: params.laneId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
     return;
   }
 

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -11,6 +11,7 @@ import { patchSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   resolveExpiresAtMsFromDurationMs,
   resolveTimerTimeoutMs,
@@ -28,9 +29,35 @@ type LaneResumeTimer = {
   resumeConcurrency: number;
 };
 
-const laneResumeTimers = new Map<string, LaneResumeTimer>();
-let cleanupGeneration = 0;
-let cleanupActive = false;
+type SessionSuspensionRuntimeState = {
+  laneResumeTimers: Map<string, LaneResumeTimer>;
+  clearedLaneResumes: Map<string, number>;
+  cleanupGeneration: number;
+  cleanupActive: boolean;
+};
+
+/**
+ * Keep timer shutdown state process-global so bundled gateway chunks cannot
+ * leave one module copy scheduling lane resumes after another copy cleaned up.
+ */
+const SESSION_SUSPENSION_STATE_KEY = Symbol.for("openclaw.sessionSuspensionRuntimeState");
+
+function getSessionSuspensionState(): SessionSuspensionRuntimeState {
+  const state = resolveGlobalSingleton<SessionSuspensionRuntimeState>(
+    SESSION_SUSPENSION_STATE_KEY,
+    () => ({
+      laneResumeTimers: new Map<string, LaneResumeTimer>(),
+      clearedLaneResumes: new Map<string, number>(),
+      cleanupGeneration: 0,
+      cleanupActive: false,
+    }),
+  );
+  if (!state.clearedLaneResumes) {
+    state.clearedLaneResumes = new Map<string, number>();
+  }
+  return state;
+}
+
 const deferredSessionSuspension = new AsyncLocalStorage<{
   claimed: boolean;
   onDeferred?: (params: SessionSuspensionParams) => void;
@@ -95,13 +122,14 @@ export function resolveSessionSuspensionTarget(): SessionSuspensionTarget {
 }
 
 function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurrency: number) {
-  const existing = laneResumeTimers.get(laneId);
+  const state = getSessionSuspensionState();
+  const existing = state.laneResumeTimers.get(laneId);
   if (existing) {
     clearTimeout(existing.timer);
   }
   const timer = setTimeout(() => {
-    if (laneResumeTimers.get(laneId)?.timer === timer) {
-      laneResumeTimers.delete(laneId);
+    if (state.laneResumeTimers.get(laneId)?.timer === timer) {
+      state.laneResumeTimers.delete(laneId);
     }
     setCommandLaneConcurrency(laneId, resumeConcurrency);
     log.info("auto-resumed lane after suspension TTL", {
@@ -113,24 +141,34 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
   if (typeof timer.unref === "function") {
     timer.unref();
   }
-  laneResumeTimers.set(laneId, { timer, resumeConcurrency });
+  state.laneResumeTimers.set(laneId, { timer, resumeConcurrency });
 }
 
 export function clearSessionSuspensionTimers(): number {
-  cleanupGeneration += 1;
-  cleanupActive = true;
+  const state = getSessionSuspensionState();
+  state.cleanupGeneration += 1;
+  state.cleanupActive = true;
   let cleared = 0;
-  for (const entry of laneResumeTimers.values()) {
+  for (const [laneId, entry] of state.laneResumeTimers) {
     clearTimeout(entry.timer);
+    state.clearedLaneResumes.set(laneId, entry.resumeConcurrency);
     cleared += 1;
   }
-  laneResumeTimers.clear();
+  state.laneResumeTimers.clear();
   return cleared;
 }
 
-export function enableSessionSuspensionTimersForGatewayStart(): void {
-  cleanupGeneration += 1;
-  cleanupActive = false;
+export function enableSessionSuspensionTimersForGatewayStart(): number {
+  const state = getSessionSuspensionState();
+  state.cleanupGeneration += 1;
+  state.cleanupActive = false;
+  let restored = 0;
+  for (const [laneId, resumeConcurrency] of state.clearedLaneResumes) {
+    setCommandLaneConcurrency(laneId, resumeConcurrency);
+    restored += 1;
+  }
+  state.clearedLaneResumes.clear();
+  return restored;
 }
 
 export async function suspendSession(params: SessionSuspensionParams) {
@@ -151,7 +189,8 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const ttlMs = resolveTimerTimeoutMs(params.ttlMs, DEFAULT_QUOTA_SUSPENSION_RESUME_MS, 0);
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
-  const suspensionGeneration = cleanupGeneration;
+  const state = getSessionSuspensionState();
+  const suspensionGeneration = state.cleanupGeneration;
 
   try {
     await patchSessionEntry(
@@ -180,7 +219,8 @@ export async function suspendSession(params: SessionSuspensionParams) {
     return;
   }
 
-  if (cleanupActive || suspensionGeneration !== cleanupGeneration) {
+  const postPatchState = getSessionSuspensionState();
+  if (postPatchState.cleanupActive || suspensionGeneration !== postPatchState.cleanupGeneration) {
     try {
       await patchSessionEntry(
         { storePath, sessionKey },
@@ -218,6 +258,16 @@ export async function suspendSession(params: SessionSuspensionParams) {
 }
 
 export const testing = {
+  resetSessionSuspensionStateForTest: () => {
+    const state = getSessionSuspensionState();
+    for (const entry of state.laneResumeTimers.values()) {
+      clearTimeout(entry.timer);
+    }
+    state.laneResumeTimers.clear();
+    state.clearedLaneResumes.clear();
+    state.cleanupGeneration = 0;
+    state.cleanupActive = false;
+  },
   resolveLaneResumeConcurrency,
   resolveSessionSuspensionReason,
 } as const;

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
 import { patchSessionEntry } from "../config/sessions/session-accessor.js";
+import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
@@ -233,23 +234,27 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
   const state = getSessionSuspensionState();
   const suspensionGeneration = state.cleanupGeneration;
+  let previousQuotaSuspension: QuotaSuspension | undefined;
 
   try {
     await patchSessionEntry(
       { storePath, sessionKey },
-      () => ({
-        quotaSuspension: {
-          schemaVersion: 1,
-          suspendedAt: now,
-          reason: params.reason,
-          failedProvider: params.failedProvider,
-          failedModel: params.failedModel,
-          summary: params.summary,
-          laneId: params.laneId,
-          expectedResumeBy,
-          state: "suspended",
-        },
-      }),
+      (entry) => {
+        previousQuotaSuspension = entry.quotaSuspension;
+        return {
+          quotaSuspension: {
+            schemaVersion: 1,
+            suspendedAt: now,
+            reason: params.reason,
+            failedProvider: params.failedProvider,
+            failedModel: params.failedModel,
+            summary: params.summary,
+            laneId: params.laneId,
+            expectedResumeBy,
+            state: "suspended",
+          },
+        };
+      },
       { skipMaintenance: true, takeCacheOwnership: true },
     );
   } catch (err) {
@@ -272,7 +277,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
           entry.quotaSuspension.failedProvider === params.failedProvider &&
           entry.quotaSuspension.failedModel === params.failedModel &&
           entry.quotaSuspension.laneId === params.laneId
-            ? { quotaSuspension: undefined }
+            ? { quotaSuspension: previousQuotaSuspension }
             : null,
         {
           skipMaintenance: true,

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -30,6 +30,7 @@ type LaneResumeTimer = {
 
 const laneResumeTimers = new Map<string, LaneResumeTimer>();
 let cleanupGeneration = 0;
+let cleanupActive = false;
 const deferredSessionSuspension = new AsyncLocalStorage<{
   claimed: boolean;
   onDeferred?: (params: SessionSuspensionParams) => void;
@@ -117,14 +118,19 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
 
 export function clearSessionSuspensionTimers(): number {
   cleanupGeneration += 1;
+  cleanupActive = true;
   let cleared = 0;
-  for (const [laneId, entry] of laneResumeTimers.entries()) {
+  for (const entry of laneResumeTimers.values()) {
     clearTimeout(entry.timer);
-    setCommandLaneConcurrency(laneId, entry.resumeConcurrency);
     cleared += 1;
   }
   laneResumeTimers.clear();
   return cleared;
+}
+
+export function enableSessionSuspensionTimersForGatewayStart(): void {
+  cleanupGeneration += 1;
+  cleanupActive = false;
 }
 
 export async function suspendSession(params: SessionSuspensionParams) {
@@ -174,12 +180,23 @@ export async function suspendSession(params: SessionSuspensionParams) {
     return;
   }
 
-  if (suspensionGeneration !== cleanupGeneration) {
+  if (cleanupActive || suspensionGeneration !== cleanupGeneration) {
     try {
-      await patchSessionEntry({ storePath, sessionKey }, () => ({ quotaSuspension: undefined }), {
-        skipMaintenance: true,
-        takeCacheOwnership: true,
-      });
+      await patchSessionEntry(
+        { storePath, sessionKey },
+        (entry) =>
+          entry.quotaSuspension?.suspendedAt === now &&
+          entry.quotaSuspension.reason === params.reason &&
+          entry.quotaSuspension.failedProvider === params.failedProvider &&
+          entry.quotaSuspension.failedModel === params.failedModel &&
+          entry.quotaSuspension.laneId === params.laneId
+            ? { quotaSuspension: undefined }
+            : null,
+        {
+          skipMaintenance: true,
+          takeCacheOwnership: true,
+        },
+      );
     } catch (err) {
       log.warn("failed to clear quota suspension after shutdown cleanup", {
         sessionId: params.sessionId,

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -11,6 +11,7 @@ import { patchSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
   resolveExpiresAtMsFromDurationMs,
@@ -93,6 +94,16 @@ function resolveLaneResumeConcurrency(cfg: OpenClawConfig | undefined, laneId: s
   }
 }
 
+function isGatewayManagedLane(laneId: string): boolean {
+  return (
+    laneId === CommandLane.Main ||
+    laneId === CommandLane.Subagent ||
+    laneId === CommandLane.Cron ||
+    laneId === CommandLane.CronNested ||
+    laneId === CommandLane.Nested
+  );
+}
+
 export function resolveSessionSuspensionReason(reason: FailoverReason): SessionSuspensionReason {
   if (reason === "billing") {
     return "manual";
@@ -164,6 +175,9 @@ export function enableSessionSuspensionTimersForGatewayStart(): number {
   state.cleanupActive = false;
   let restored = 0;
   for (const [laneId, resumeConcurrency] of state.clearedLaneResumes) {
+    if (isGatewayManagedLane(laneId)) {
+      continue;
+    }
     setCommandLaneConcurrency(laneId, resumeConcurrency);
     restored += 1;
   }

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -255,9 +255,10 @@ export function getCleanupSuspendedLaneIdsForGatewayPublication(): Set<string> {
 
 export async function suspendSession(params: SessionSuspensionParams) {
   const state = getSessionSuspensionState();
+  const queuedGeneration = state.cleanupGeneration;
   const run = state.suspensionWriteChain
     .catch(() => undefined)
-    .then(() => suspendSessionQueued(params));
+    .then(() => suspendSessionQueued(params, queuedGeneration));
   // Suspension persistence is per-process and rare; serialize it so cleanup
   // rollback has one winner and cannot erase another in-flight suspension.
   state.suspensionWriteChain = run.then(
@@ -267,7 +268,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
   await run;
 }
 
-async function suspendSessionQueued(params: SessionSuspensionParams) {
+async function suspendSessionQueued(params: SessionSuspensionParams, queuedGeneration: number) {
   if (!params.cfg) {
     return;
   }
@@ -286,7 +287,7 @@ async function suspendSessionQueued(params: SessionSuspensionParams) {
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
   const state = getSessionSuspensionState();
-  if (state.cleanupActive) {
+  if (state.cleanupActive || state.cleanupGeneration !== queuedGeneration) {
     return;
   }
   const suspensionGeneration = state.cleanupGeneration;
@@ -370,7 +371,10 @@ async function suspendSessionQueued(params: SessionSuspensionParams) {
   }
 
   const postPatchState = getSessionSuspensionState();
-  if (postPatchState.cleanupActive || suspensionGeneration !== postPatchState.cleanupGeneration) {
+  if (
+    persistedSuspension &&
+    (postPatchState.cleanupActive || suspensionGeneration !== postPatchState.cleanupGeneration)
+  ) {
     try {
       await patchSessionEntry(
         { storePath, sessionKey },

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -107,6 +107,16 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
   laneResumeTimers.set(laneId, timer);
 }
 
+export function clearSessionSuspensionTimers(): number {
+  let cleared = 0;
+  for (const timer of laneResumeTimers.values()) {
+    clearTimeout(timer);
+    cleared += 1;
+  }
+  laneResumeTimers.clear();
+  return cleared;
+}
+
 export async function suspendSession(params: SessionSuspensionParams) {
   if (!params.cfg) {
     return;

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -40,6 +40,14 @@ type ClearedLaneResume = {
 type SessionSuspensionRuntimeState = {
   laneResumeTimers: Map<string, LaneResumeTimer>;
   clearedLaneResumes: Map<string, ClearedLaneResume>;
+  pendingSuspensionWrites: Map<
+    string,
+    {
+      generation: number;
+      previousQuotaSuspension: QuotaSuspension | undefined;
+      activeCount: number;
+    }
+  >;
   cleanupGeneration: number;
   cleanupActive: boolean;
 };
@@ -56,12 +64,30 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
     () => ({
       laneResumeTimers: new Map<string, LaneResumeTimer>(),
       clearedLaneResumes: new Map<string, ClearedLaneResume>(),
+      pendingSuspensionWrites: new Map<
+        string,
+        {
+          generation: number;
+          previousQuotaSuspension: QuotaSuspension | undefined;
+          activeCount: number;
+        }
+      >(),
       cleanupGeneration: 0,
       cleanupActive: false,
     }),
   );
   if (!state.clearedLaneResumes) {
     state.clearedLaneResumes = new Map<string, ClearedLaneResume>();
+  }
+  if (!state.pendingSuspensionWrites) {
+    state.pendingSuspensionWrites = new Map<
+      string,
+      {
+        generation: number;
+        previousQuotaSuspension: QuotaSuspension | undefined;
+        activeCount: number;
+      }
+    >();
   }
   return state;
 }
@@ -242,13 +268,35 @@ export async function suspendSession(params: SessionSuspensionParams) {
     return;
   }
   const suspensionGeneration = state.cleanupGeneration;
-  let previousQuotaSuspension: QuotaSuspension | undefined;
+  const pendingWriteKey = `${storePath}\0${sessionKey}`;
+  const existingPendingWrite = state.pendingSuspensionWrites.get(pendingWriteKey);
+  const pendingWrite =
+    existingPendingWrite?.generation === suspensionGeneration
+      ? existingPendingWrite
+      : {
+          generation: suspensionGeneration,
+          previousQuotaSuspension: undefined as QuotaSuspension | undefined,
+          activeCount: 0,
+        };
+  pendingWrite.activeCount += 1;
+  state.pendingSuspensionWrites.set(pendingWriteKey, pendingWrite);
+  const releasePendingWrite = () => {
+    pendingWrite.activeCount -= 1;
+    if (pendingWrite.activeCount <= 0) {
+      getSessionSuspensionState().pendingSuspensionWrites.delete(pendingWriteKey);
+    }
+  };
 
   try {
     await patchSessionEntry(
       { storePath, sessionKey },
       (entry) => {
-        previousQuotaSuspension = entry.quotaSuspension;
+        if (getSessionSuspensionState().cleanupGeneration !== suspensionGeneration) {
+          return null;
+        }
+        if (pendingWrite.previousQuotaSuspension === undefined) {
+          pendingWrite.previousQuotaSuspension = entry.quotaSuspension;
+        }
         return {
           quotaSuspension: {
             schemaVersion: 1,
@@ -271,6 +319,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
       laneId: params.laneId,
       error: err instanceof Error ? err.message : String(err),
     });
+    releasePendingWrite();
     return;
   }
 
@@ -285,7 +334,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
           entry.quotaSuspension.failedProvider === params.failedProvider &&
           entry.quotaSuspension.failedModel === params.failedModel &&
           entry.quotaSuspension.laneId === params.laneId
-            ? { quotaSuspension: previousQuotaSuspension }
+            ? { quotaSuspension: pendingWrite.previousQuotaSuspension }
             : null,
         {
           skipMaintenance: true,
@@ -299,6 +348,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+    releasePendingWrite();
     return;
   }
 
@@ -310,6 +360,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
       resolveLaneResumeConcurrency(params.cfg, params.laneId),
     );
   }
+  releasePendingWrite();
 }
 
 export const testing = {
@@ -320,6 +371,7 @@ export const testing = {
     }
     state.laneResumeTimers.clear();
     state.clearedLaneResumes.clear();
+    state.pendingSuspensionWrites.clear();
     state.cleanupGeneration = 0;
     state.cleanupActive = false;
   },

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -49,6 +49,7 @@ type SessionSuspensionRuntimeState = {
       activeCount: number;
     }
   >;
+  suspensionWriteChain: Promise<void>;
   cleanupGeneration: number;
   cleanupActive: boolean;
 };
@@ -74,6 +75,7 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
           activeCount: number;
         }
       >(),
+      suspensionWriteChain: Promise.resolve(),
       cleanupGeneration: 0,
       cleanupActive: false,
     }),
@@ -91,6 +93,9 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
         activeCount: number;
       }
     >();
+  }
+  if (!state.suspensionWriteChain) {
+    state.suspensionWriteChain = Promise.resolve();
   }
   return state;
 }
@@ -249,6 +254,20 @@ export function getCleanupSuspendedLaneIdsForGatewayPublication(): Set<string> {
 }
 
 export async function suspendSession(params: SessionSuspensionParams) {
+  const state = getSessionSuspensionState();
+  const run = state.suspensionWriteChain
+    .catch(() => undefined)
+    .then(() => suspendSessionQueued(params));
+  // Suspension persistence is per-process and rare; serialize it so cleanup
+  // rollback has one winner and cannot erase another in-flight suspension.
+  state.suspensionWriteChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  await run;
+}
+
+async function suspendSessionQueued(params: SessionSuspensionParams) {
   if (!params.cfg) {
     return;
   }
@@ -394,6 +413,7 @@ export const testing = {
     state.laneResumeTimers.clear();
     state.clearedLaneResumes.clear();
     state.pendingSuspensionWrites.clear();
+    state.suspensionWriteChain = Promise.resolve();
     state.cleanupGeneration = 0;
     state.cleanupActive = false;
   },

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -197,8 +197,9 @@ export function enableSessionSuspensionTimersForGatewayStart(
   const nowMs = Date.now();
   for (const [laneId, cleared] of state.clearedLaneResumes) {
     const resumeConcurrency = resolveResumeConcurrency(laneId, cleared.resumeConcurrency);
-    const remainingMs = Math.max(0, cleared.resumeAtMs - nowMs);
+    const remainingMs = resolveTimerTimeoutMs(cleared.resumeAtMs - nowMs, 0, 0);
     if (remainingMs > 0) {
+      setCommandLaneConcurrency(laneId, 0);
       scheduleLaneAutoResume(laneId, remainingMs, resumeConcurrency, { nowMs });
       suspendedLaneIds.add(laneId);
       continue;

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -28,11 +28,17 @@ const DEFAULT_QUOTA_SUSPENSION_RESUME_MS = 30 * 60 * 1000; // 30 min
 type LaneResumeTimer = {
   timer: ReturnType<typeof setTimeout>;
   resumeConcurrency: number;
+  resumeAtMs: number;
+};
+
+type ClearedLaneResume = {
+  resumeConcurrency: number;
+  resumeAtMs: number;
 };
 
 type SessionSuspensionRuntimeState = {
   laneResumeTimers: Map<string, LaneResumeTimer>;
-  clearedLaneResumes: Map<string, number>;
+  clearedLaneResumes: Map<string, ClearedLaneResume>;
   cleanupGeneration: number;
   cleanupActive: boolean;
 };
@@ -48,13 +54,13 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
     SESSION_SUSPENSION_STATE_KEY,
     () => ({
       laneResumeTimers: new Map<string, LaneResumeTimer>(),
-      clearedLaneResumes: new Map<string, number>(),
+      clearedLaneResumes: new Map<string, ClearedLaneResume>(),
       cleanupGeneration: 0,
       cleanupActive: false,
     }),
   );
   if (!state.clearedLaneResumes) {
-    state.clearedLaneResumes = new Map<string, number>();
+    state.clearedLaneResumes = new Map<string, ClearedLaneResume>();
   }
   return state;
 }
@@ -132,7 +138,13 @@ export function resolveSessionSuspensionTarget(): SessionSuspensionTarget {
   return { mode: "defer", defer: (params) => scope.onDeferred?.(params) };
 }
 
-function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurrency: number) {
+function scheduleLaneAutoResume(
+  laneId: string,
+  delayMs: number,
+  resumeConcurrency: number,
+  opts: { nowMs?: number } = {},
+) {
+  const nowMs = opts.nowMs ?? Date.now();
   const state = getSessionSuspensionState();
   const existing = state.laneResumeTimers.get(laneId);
   if (existing) {
@@ -152,7 +164,7 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
   if (typeof timer.unref === "function") {
     timer.unref();
   }
-  state.laneResumeTimers.set(laneId, { timer, resumeConcurrency });
+  state.laneResumeTimers.set(laneId, { timer, resumeConcurrency, resumeAtMs: nowMs + delayMs });
 }
 
 export function clearSessionSuspensionTimers(): number {
@@ -162,27 +174,42 @@ export function clearSessionSuspensionTimers(): number {
   let cleared = 0;
   for (const [laneId, entry] of state.laneResumeTimers) {
     clearTimeout(entry.timer);
-    state.clearedLaneResumes.set(laneId, entry.resumeConcurrency);
+    state.clearedLaneResumes.set(laneId, {
+      resumeConcurrency: entry.resumeConcurrency,
+      resumeAtMs: entry.resumeAtMs,
+    });
     cleared += 1;
   }
   state.laneResumeTimers.clear();
   return cleared;
 }
 
-export function enableSessionSuspensionTimersForGatewayStart(): number {
+export function enableSessionSuspensionTimersForGatewayStart(
+  resolveResumeConcurrency: (laneId: string, savedResumeConcurrency: number) => number = (
+    _laneId,
+    savedResumeConcurrency,
+  ) => savedResumeConcurrency,
+): Set<string> {
   const state = getSessionSuspensionState();
   state.cleanupGeneration += 1;
   state.cleanupActive = false;
-  let restored = 0;
-  for (const [laneId, resumeConcurrency] of state.clearedLaneResumes) {
+  const suspendedLaneIds = new Set<string>();
+  const nowMs = Date.now();
+  for (const [laneId, cleared] of state.clearedLaneResumes) {
+    const resumeConcurrency = resolveResumeConcurrency(laneId, cleared.resumeConcurrency);
+    const remainingMs = Math.max(0, cleared.resumeAtMs - nowMs);
+    if (remainingMs > 0) {
+      scheduleLaneAutoResume(laneId, remainingMs, resumeConcurrency, { nowMs });
+      suspendedLaneIds.add(laneId);
+      continue;
+    }
     if (isGatewayManagedLane(laneId)) {
       continue;
     }
     setCommandLaneConcurrency(laneId, resumeConcurrency);
-    restored += 1;
   }
   state.clearedLaneResumes.clear();
-  return restored;
+  return suspendedLaneIds;
 }
 
 export async function suspendSession(params: SessionSuspensionParams) {
@@ -281,6 +308,14 @@ export const testing = {
     state.clearedLaneResumes.clear();
     state.cleanupGeneration = 0;
     state.cleanupActive = false;
+  },
+  seedClearedLaneResumeForTest: (
+    laneId: string,
+    cleared: { resumeConcurrency: number; resumeAtMs: number },
+  ) => {
+    const state = getSessionSuspensionState();
+    state.cleanupActive = true;
+    state.clearedLaneResumes.set(laneId, cleared);
   },
   resolveLaneResumeConcurrency,
   resolveSessionSuspensionReason,

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -214,6 +214,11 @@ export function enableSessionSuspensionTimersForGatewayStart(
   return suspendedLaneIds;
 }
 
+export function getCleanupSuspendedLaneIdsForGatewayPublication(): Set<string> {
+  const state = getSessionSuspensionState();
+  return state.cleanupActive ? new Set(state.clearedLaneResumes.keys()) : new Set<string>();
+}
+
 export async function suspendSession(params: SessionSuspensionParams) {
   if (!params.cfg) {
     return;
@@ -233,6 +238,9 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
   const state = getSessionSuspensionState();
+  if (state.cleanupActive) {
+    return;
+  }
   const suspensionGeneration = state.cleanupGeneration;
   let previousQuotaSuspension: QuotaSuspension | undefined;
 

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -45,6 +45,7 @@ type SessionSuspensionRuntimeState = {
     {
       generation: number;
       previousQuotaSuspension: QuotaSuspension | undefined;
+      previousSnapshotCaptured: boolean;
       activeCount: number;
     }
   >;
@@ -69,6 +70,7 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
         {
           generation: number;
           previousQuotaSuspension: QuotaSuspension | undefined;
+          previousSnapshotCaptured: boolean;
           activeCount: number;
         }
       >(),
@@ -85,6 +87,7 @@ function getSessionSuspensionState(): SessionSuspensionRuntimeState {
       {
         generation: number;
         previousQuotaSuspension: QuotaSuspension | undefined;
+        previousSnapshotCaptured: boolean;
         activeCount: number;
       }
     >();
@@ -276,26 +279,43 @@ export async function suspendSession(params: SessionSuspensionParams) {
       : {
           generation: suspensionGeneration,
           previousQuotaSuspension: undefined as QuotaSuspension | undefined,
+          previousSnapshotCaptured: false,
           activeCount: 0,
         };
   pendingWrite.activeCount += 1;
   state.pendingSuspensionWrites.set(pendingWriteKey, pendingWrite);
   const releasePendingWrite = () => {
     pendingWrite.activeCount -= 1;
-    if (pendingWrite.activeCount <= 0) {
+    if (
+      pendingWrite.activeCount <= 0 &&
+      getSessionSuspensionState().pendingSuspensionWrites.get(pendingWriteKey) === pendingWrite
+    ) {
       getSessionSuspensionState().pendingSuspensionWrites.delete(pendingWriteKey);
     }
   };
+  const throttleLane = () => {
+    if (!params.laneId) {
+      return;
+    }
+    setCommandLaneConcurrency(params.laneId, 0);
+    scheduleLaneAutoResume(
+      params.laneId,
+      ttlMs,
+      resolveLaneResumeConcurrency(params.cfg, params.laneId),
+    );
+  };
+  let persistedSuspension = false;
 
   try {
-    await patchSessionEntry(
+    const patchedEntry = await patchSessionEntry(
       { storePath, sessionKey },
       (entry) => {
         if (getSessionSuspensionState().cleanupGeneration !== suspensionGeneration) {
           return null;
         }
-        if (pendingWrite.previousQuotaSuspension === undefined) {
+        if (!pendingWrite.previousSnapshotCaptured) {
           pendingWrite.previousQuotaSuspension = entry.quotaSuspension;
+          pendingWrite.previousSnapshotCaptured = true;
         }
         return {
           quotaSuspension: {
@@ -313,13 +333,20 @@ export async function suspendSession(params: SessionSuspensionParams) {
       },
       { skipMaintenance: true, takeCacheOwnership: true },
     );
+    persistedSuspension = patchedEntry !== null;
   } catch (err) {
-    log.warn("failed to persist quota suspension; not throttling lane", {
+    log.warn("failed to persist quota suspension; applying transient lane throttle", {
       sessionId: params.sessionId,
       laneId: params.laneId,
       error: err instanceof Error ? err.message : String(err),
     });
     releasePendingWrite();
+    if (
+      !getSessionSuspensionState().cleanupActive &&
+      suspensionGeneration === getSessionSuspensionState().cleanupGeneration
+    ) {
+      throttleLane();
+    }
     return;
   }
 
@@ -352,13 +379,8 @@ export async function suspendSession(params: SessionSuspensionParams) {
     return;
   }
 
-  if (params.laneId) {
-    setCommandLaneConcurrency(params.laneId, 0);
-    scheduleLaneAutoResume(
-      params.laneId,
-      ttlMs,
-      resolveLaneResumeConcurrency(params.cfg, params.laneId),
-    );
+  if (persistedSuspension) {
+    throttleLane();
   }
   releasePendingWrite();
 }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -195,6 +195,10 @@ describe("createGatewayCloseHandler", () => {
 
   it("joins an in-flight config reload before mutable runtime teardown", async () => {
     const events: string[] = [];
+    mocks.clearSessionSuspensionTimers.mockImplementation(() => {
+      events.push("session-suspension-timers");
+      return 1;
+    });
     let releaseReload!: () => void;
     const reloadStopped = new Promise<void>((resolve) => {
       releaseReload = resolve;
@@ -231,7 +235,7 @@ describe("createGatewayCloseHandler", () => {
 
     const closePromise = close({ reason: "test" });
     await vi.waitFor(() => {
-      expect(events).toEqual(["reload:stopping"]);
+      expect(events).toEqual(["session-suspension-timers", "reload:stopping"]);
     });
     expect(postReadySidecar.stop).not.toHaveBeenCalled();
     expect(pluginServices.stop).not.toHaveBeenCalled();
@@ -241,6 +245,7 @@ describe("createGatewayCloseHandler", () => {
     await closePromise;
 
     expect(events).toEqual([
+      "session-suspension-timers",
       "reload:stopping",
       "reload:stopped",
       "sidecar:stopped",

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_eventValue) => undefined),
   disposeAllBundleLspRuntimes: vi.fn(async () => undefined),
+  clearSessionSuspensionTimers: vi.fn(() => 0),
 }));
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
@@ -60,6 +61,10 @@ vi.mock("../agents/agent-bundle-lsp-runtime.js", async () => ({
     "../agents/agent-bundle-lsp-runtime.js",
   )),
   disposeAllBundleLspRuntimes: mocks.disposeAllBundleLspRuntimes,
+}));
+
+vi.mock("../agents/session-suspension.js", () => ({
+  clearSessionSuspensionTimers: mocks.clearSessionSuspensionTimers,
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
@@ -161,6 +166,8 @@ describe("createGatewayCloseHandler", () => {
     mocks.triggerInternalHook.mockResolvedValue(undefined);
     mocks.disposeAllBundleLspRuntimes.mockClear();
     mocks.disposeAllBundleLspRuntimes.mockResolvedValue(undefined);
+    mocks.clearSessionSuspensionTimers.mockReset();
+    mocks.clearSessionSuspensionTimers.mockReturnValue(0);
   });
 
   afterEach(() => {
@@ -306,6 +313,45 @@ describe("createGatewayCloseHandler", () => {
 
     expect(events).toEqual(["sidecar:start", "sidecar:end", "plugin-services", "channel:discord"]);
     expect(postReadySidecar.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears session suspension timers before sidecars, plugin services, and channels stop", async () => {
+    const events: string[] = [];
+    mocks.clearSessionSuspensionTimers.mockImplementation(() => {
+      events.push("session-suspension-timers");
+      return 1;
+    });
+    const postReadySidecar = {
+      stop: vi.fn(async () => {
+        events.push("sidecar");
+      }),
+    };
+    const pluginServices = {
+      stop: vi.fn(async () => {
+        events.push("plugin-services");
+      }),
+    };
+    const stopChannel = vi.fn(async (channelId: string) => {
+      events.push(`channel:${channelId}`);
+    });
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        channelIds: ["discord"],
+        postReadySidecars: [postReadySidecar],
+        pluginServices: pluginServices as never,
+        stopChannel,
+      }),
+    );
+
+    await close({ reason: "test shutdown" });
+
+    expect(mocks.clearSessionSuspensionTimers).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "session-suspension-timers",
+      "sidecar",
+      "plugin-services",
+      "channel:discord",
+    ]);
   });
 
   it("emits gateway shutdown and pre-restart hooks", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -6,6 +6,7 @@ import type { WebSocketServer } from "ws";
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
+import { clearSessionSuspensionTimers } from "../agents/session-suspension.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -840,6 +841,15 @@ export function createGatewayCloseHandler(
       if (params.tailscaleCleanup) {
         await shutdownStep("tailscale", () => params.tailscaleCleanup!(), warnings);
       }
+      await shutdownStep(
+        "session-suspension-timers",
+        () => {
+          // Lane auto-resume timers mutate command-lane concurrency; they must not fire
+          // after shutdown has started tearing down queues, channels, and runtimes.
+          clearSessionSuspensionTimers();
+        },
+        warnings,
+      );
       if (params.postReadySidecars?.length) {
         await measureCloseStep("post-ready-sidecars", async () => {
           for (const [index, sidecar] of params.postReadySidecars!.entries()) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -726,6 +726,9 @@ export function createGatewayCloseHandler(
     const measureCloseStep = <T>(name: string, run: () => Promise<T> | T) =>
       measureGatewayRestartTrace(`restart.close.${name}`, run, [["reason", reason]]);
     try {
+      // Fence lane auto-resume timers before the first awaited shutdown step;
+      // later teardown can stall long enough for a TTL callback to mutate queues.
+      clearSessionSuspensionTimers();
       // Debug-level: the signal handler already announced the stop/restart at
       // info, and the completion line below reports duration and outcome.
       shutdownLog.debug(`shutdown started: ${reason}`);
@@ -841,15 +844,6 @@ export function createGatewayCloseHandler(
       if (params.tailscaleCleanup) {
         await shutdownStep("tailscale", () => params.tailscaleCleanup!(), warnings);
       }
-      await shutdownStep(
-        "session-suspension-timers",
-        () => {
-          // Lane auto-resume timers mutate command-lane concurrency; they must not fire
-          // after shutdown has started tearing down queues, channels, and runtimes.
-          clearSessionSuspensionTimers();
-        },
-        warnings,
-      );
       if (params.postReadySidecars?.length) {
         await measureCloseStep("post-ready-sidecars", async () => {
           for (const [index, sidecar] of params.postReadySidecars!.entries()) {

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,7 +1,7 @@
 /**
  * Gateway server lane configuration tests.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -22,6 +22,11 @@ function applyConfigLaneConcurrency(
 
 describe("applyGatewayLaneConcurrency", () => {
   afterEach(async () => {
+    if (vi.isFakeTimers()) {
+      await vi.runOnlyPendingTimersAsync();
+      vi.clearAllTimers();
+    }
+    vi.useRealTimers();
     // Gateway startup drains the process-global suspension cleanup state.
     // Reset between tests so lane assertions only see this test's setup.
     const { testing } = await import("../agents/session-suspension.js");
@@ -161,6 +166,38 @@ describe("applyGatewayLaneConcurrency", () => {
     expect(started).toBe(false);
 
     setCommandLaneConcurrency(CommandLane.Nested, 1);
+    await nestedRun;
+    expect(started).toBe(true);
+  });
+
+  it("does not resume an unexpired shared nested lane during gateway startup", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { testing } = await import("../agents/session-suspension.js");
+    testing.seedClearedLaneResumeForTest(CommandLane.Nested, {
+      resumeConcurrency: 1,
+      resumeAtMs: 1_100,
+    });
+    setCommandLaneConcurrency(CommandLane.Nested, 0);
+
+    applyConfigLaneConcurrency({} as OpenClawConfig, { gatewayStart: true });
+
+    let started = false;
+    const nestedRun = enqueueCommandInLane(
+      CommandLane.Nested,
+      async () => {
+        started = true;
+      },
+      { warnAfterMs: 10_000 },
+    );
+    await Promise.resolve();
+
+    expect(started).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(started).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
     await nestedRun;
     expect(started).toBe(true);
   });

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -18,7 +18,11 @@ function applyConfigLaneConcurrency(config: OpenClawConfig): void {
 }
 
 describe("applyGatewayLaneConcurrency", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    // Gateway startup drains the process-global suspension cleanup state.
+    // Reset between tests so lane assertions only see this test's setup.
+    const { testing } = await import("../agents/session-suspension.js");
+    testing.resetSessionSuspensionStateForTest();
     resetCommandQueueStateForTest();
   });
 

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -4,7 +4,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { enqueueCommandInLane, resetCommandQueueStateForTest } from "../process/command-queue.js";
+import {
+  enqueueCommandInLane,
+  resetCommandQueueStateForTest,
+  setCommandLaneConcurrency,
+} from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
@@ -113,5 +117,21 @@ describe("applyGatewayLaneConcurrency", () => {
 
     releaseRuns.resolve();
     await Promise.all([first, second]);
+  });
+
+  it("restores a suspended shared nested lane on gateway startup", async () => {
+    setCommandLaneConcurrency(CommandLane.Nested, 0);
+    applyConfigLaneConcurrency({} as OpenClawConfig);
+
+    let started = false;
+    await enqueueCommandInLane(
+      CommandLane.Nested,
+      async () => {
+        started = true;
+      },
+      { warnAfterMs: 10_000 },
+    );
+
+    expect(started).toBe(true);
   });
 });

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -170,6 +170,33 @@ describe("applyGatewayLaneConcurrency", () => {
     expect(started).toBe(true);
   });
 
+  it("does not resume cleanup-held built-in lanes during live config publication", async () => {
+    const { testing } = await import("../agents/session-suspension.js");
+    testing.seedClearedLaneResumeForTest(CommandLane.Main, {
+      resumeConcurrency: 3,
+      resumeAtMs: Date.now() + 100,
+    });
+    setCommandLaneConcurrency(CommandLane.Main, 0);
+
+    applyConfigLaneConcurrency({ agents: { defaults: { maxConcurrent: 3 } } } as OpenClawConfig);
+
+    let started = false;
+    const mainRun = enqueueCommandInLane(
+      CommandLane.Main,
+      async () => {
+        started = true;
+      },
+      { warnAfterMs: 10_000 },
+    );
+    await Promise.resolve();
+
+    expect(started).toBe(false);
+
+    setCommandLaneConcurrency(CommandLane.Main, 1);
+    await mainRun;
+    expect(started).toBe(true);
+  });
+
   it("does not resume an unexpired shared nested lane during gateway startup", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -13,8 +13,11 @@ import { CommandLane } from "../process/lanes.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 
-function applyConfigLaneConcurrency(config: OpenClawConfig): void {
-  applyGatewayLaneConcurrency(resolveGatewayLaneConcurrency(config));
+function applyConfigLaneConcurrency(
+  config: OpenClawConfig,
+  opts: { gatewayStart?: boolean } = {},
+): void {
+  applyGatewayLaneConcurrency(resolveGatewayLaneConcurrency(config), opts);
 }
 
 describe("applyGatewayLaneConcurrency", () => {
@@ -104,7 +107,9 @@ describe("applyGatewayLaneConcurrency", () => {
   });
 
   it("keeps the shared nested lane at its default concurrency", async () => {
-    applyConfigLaneConcurrency({ cron: { maxConcurrentRuns: 2 } } as OpenClawConfig);
+    applyConfigLaneConcurrency({ cron: { maxConcurrentRuns: 2 } } as OpenClawConfig, {
+      gatewayStart: true,
+    });
 
     let startedRuns = 0;
     const releaseRuns = createDeferred();
@@ -125,7 +130,7 @@ describe("applyGatewayLaneConcurrency", () => {
 
   it("restores a suspended shared nested lane on gateway startup", async () => {
     setCommandLaneConcurrency(CommandLane.Nested, 0);
-    applyConfigLaneConcurrency({} as OpenClawConfig);
+    applyConfigLaneConcurrency({} as OpenClawConfig, { gatewayStart: true });
 
     let started = false;
     await enqueueCommandInLane(
@@ -136,6 +141,27 @@ describe("applyGatewayLaneConcurrency", () => {
       { warnAfterMs: 10_000 },
     );
 
+    expect(started).toBe(true);
+  });
+
+  it("does not resume a suspended shared nested lane during live config publication", async () => {
+    setCommandLaneConcurrency(CommandLane.Nested, 0);
+    applyConfigLaneConcurrency({} as OpenClawConfig);
+
+    let started = false;
+    const nestedRun = enqueueCommandInLane(
+      CommandLane.Nested,
+      async () => {
+        started = true;
+      },
+      { warnAfterMs: 10_000 },
+    );
+    await Promise.resolve();
+
+    expect(started).toBe(false);
+
+    setCommandLaneConcurrency(CommandLane.Nested, 1);
+    await nestedRun;
     expect(started).toBe(true);
   });
 });

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,3 +1,4 @@
+import { enableSessionSuspensionTimersForGatewayStart } from "../agents/session-suspension.js";
 // Gateway command-lane concurrency applier.
 // Pushes config-derived agent/cron limits into the process command queue.
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -21,11 +22,14 @@ export function resolveGatewayLaneConcurrency(cfg: OpenClawConfig): GatewayLaneC
 }
 
 export function applyGatewayLaneConcurrency(concurrency: GatewayLaneConcurrency): void {
+  enableSessionSuspensionTimersForGatewayStart();
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.
   setCommandLaneConcurrency(CommandLane.Cron, concurrency.cron);
   // Cron isolated agent turns remap inner LLM work to this lane.
   setCommandLaneConcurrency(CommandLane.CronNested, concurrency.cron);
   setCommandLaneConcurrency(CommandLane.Main, concurrency.main);
+  // sessions.send work uses a shared nested lane with no config knob.
+  setCommandLaneConcurrency(CommandLane.Nested, 1);
   setCommandLaneConcurrency(CommandLane.Subagent, concurrency.subagent);
 }

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,4 +1,7 @@
-import { enableSessionSuspensionTimersForGatewayStart } from "../agents/session-suspension.js";
+import {
+  enableSessionSuspensionTimersForGatewayStart,
+  getCleanupSuspendedLaneIdsForGatewayPublication,
+} from "../agents/session-suspension.js";
 // Gateway command-lane concurrency applier.
 // Pushes config-derived agent/cron limits into the process command queue.
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -44,6 +47,8 @@ export function applyGatewayLaneConcurrency(
         }
       },
     );
+  } else {
+    suspendedLaneIds = getCleanupSuspendedLaneIdsForGatewayPublication();
   }
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -21,15 +21,23 @@ export function resolveGatewayLaneConcurrency(cfg: OpenClawConfig): GatewayLaneC
   };
 }
 
-export function applyGatewayLaneConcurrency(concurrency: GatewayLaneConcurrency): void {
-  enableSessionSuspensionTimersForGatewayStart();
+export function applyGatewayLaneConcurrency(
+  concurrency: GatewayLaneConcurrency,
+  opts: { gatewayStart?: boolean } = {},
+): void {
+  if (opts.gatewayStart) {
+    enableSessionSuspensionTimersForGatewayStart();
+  }
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.
   setCommandLaneConcurrency(CommandLane.Cron, concurrency.cron);
   // Cron isolated agent turns remap inner LLM work to this lane.
   setCommandLaneConcurrency(CommandLane.CronNested, concurrency.cron);
   setCommandLaneConcurrency(CommandLane.Main, concurrency.main);
-  // sessions.send work uses a shared nested lane with no config knob.
-  setCommandLaneConcurrency(CommandLane.Nested, 1);
+  if (opts.gatewayStart) {
+    // sessions.send work uses a shared nested lane with no config knob; live
+    // reload must not resume a currently suspended nested lane before its TTL.
+    setCommandLaneConcurrency(CommandLane.Nested, 1);
+  }
   setCommandLaneConcurrency(CommandLane.Subagent, concurrency.subagent);
 }

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -25,19 +25,46 @@ export function applyGatewayLaneConcurrency(
   concurrency: GatewayLaneConcurrency,
   opts: { gatewayStart?: boolean } = {},
 ): void {
+  let suspendedLaneIds: ReadonlySet<string> = new Set<string>();
   if (opts.gatewayStart) {
-    enableSessionSuspensionTimersForGatewayStart();
+    suspendedLaneIds = enableSessionSuspensionTimersForGatewayStart(
+      (laneId, savedResumeConcurrency) => {
+        switch (laneId) {
+          case CommandLane.Cron:
+          case CommandLane.CronNested:
+            return concurrency.cron;
+          case CommandLane.Main:
+            return concurrency.main;
+          case CommandLane.Nested:
+            return 1;
+          case CommandLane.Subagent:
+            return concurrency.subagent;
+          default:
+            return savedResumeConcurrency;
+        }
+      },
+    );
   }
   // Resolution is deliberately separate: this commit-edge applier only updates
   // live queue state and cannot reject a config midway through publication.
-  setCommandLaneConcurrency(CommandLane.Cron, concurrency.cron);
+  if (!suspendedLaneIds.has(CommandLane.Cron)) {
+    setCommandLaneConcurrency(CommandLane.Cron, concurrency.cron);
+  }
   // Cron isolated agent turns remap inner LLM work to this lane.
-  setCommandLaneConcurrency(CommandLane.CronNested, concurrency.cron);
-  setCommandLaneConcurrency(CommandLane.Main, concurrency.main);
+  if (!suspendedLaneIds.has(CommandLane.CronNested)) {
+    setCommandLaneConcurrency(CommandLane.CronNested, concurrency.cron);
+  }
+  if (!suspendedLaneIds.has(CommandLane.Main)) {
+    setCommandLaneConcurrency(CommandLane.Main, concurrency.main);
+  }
   if (opts.gatewayStart) {
     // sessions.send work uses a shared nested lane with no config knob; live
     // reload must not resume a currently suspended nested lane before its TTL.
-    setCommandLaneConcurrency(CommandLane.Nested, 1);
+    if (!suspendedLaneIds.has(CommandLane.Nested)) {
+      setCommandLaneConcurrency(CommandLane.Nested, 1);
+    }
   }
-  setCommandLaneConcurrency(CommandLane.Subagent, concurrency.subagent);
+  if (!suspendedLaneIds.has(CommandLane.Subagent)) {
+    setCommandLaneConcurrency(CommandLane.Subagent, concurrency.subagent);
+  }
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -8,6 +8,7 @@ import {
   getActiveEmbeddedRunCount,
   resolveActiveEmbeddedRunSessionId,
 } from "../agents/embedded-agent-runner/run-state.js";
+import { clearSessionSuspensionTimers } from "../agents/session-suspension.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import {
   getLoadedChannelPluginEntryById,
@@ -1271,6 +1272,7 @@ export async function startGatewayServer(
     return configReloaderStopPromise;
   };
   const beginClosePrelude = async () => {
+    clearSessionSuspensionTimers();
     markClosePreludeStarted();
     // Join the last reload before any owner it can publish into is torn down.
     // The close handler re-awaits this same promise to retain warning reporting.

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1214,7 +1214,7 @@ export async function startGatewayServer(
       (cfgAtStart.gateway?.terminal?.detachedSessionTimeoutSeconds ??
         DEFAULT_TERMINAL_DETACH_SECONDS) * 1000,
   });
-  applyGatewayLaneConcurrency(resolveGatewayLaneConcurrency(cfgAtStart));
+  applyGatewayLaneConcurrency(resolveGatewayLaneConcurrency(cfgAtStart), { gatewayStart: true });
 
   runtimeState = createGatewayServerLiveState({
     hooksConfig: initialHooksConfig,


### PR DESCRIPTION
Closes #101720

## What Problem This Solves

`session-suspension.ts` schedules lane auto-resume timers that later call `setCommandLaneConcurrency()`. Gateway shutdown previously had no ownership cleanup for those timers, so a pending callback could mutate command-lane state after sidecars, channels, queues, and runtimes had started shutting down.

## Solution

- add `clearSessionSuspensionTimers()` to cancel and remove every pending lane auto-resume timer
- call it from the gateway close sequence before sidecars, plugin services, and channels stop
- preserve normal TTL auto-resume behavior while the gateway remains running
- cover timer cancellation and shutdown ordering with focused tests

## Impact

A pending suspension callback no longer runs after gateway close. In the reproduced lifecycle, the main lane stays suspended at `0` after shutdown and past the original TTL, then gateway startup restores configured concurrency to `2`; post-restart main-lane work completes normally.

## Evidence

A temporary proof harness used the production SQLite session accessor, production `suspendSession`, production `startGatewayServer`/`close`, real timers, and the production command queue. It performed:

1. start gateway with `agents.defaults.maxConcurrent=2`
2. persist a real session and suspend its main lane for 250 ms
3. close the gateway while the timer is pending
4. wait 400 ms, beyond the original TTL
5. restart the gateway and enqueue a main-lane work item

Clean `main` (`82d53fd91d3`):

```json
{
  "initialMaxConcurrent": 2,
  "suspendedMaxConcurrent": 0,
  "afterShutdownTtlMaxConcurrent": 2,
  "afterRestartMaxConcurrent": 2,
  "postRestartTurn": "post-restart-turn-ok"
}
```

The clean-main log also emitted `auto-resumed lane after suspension TTL` after shutdown, proving the stale callback ran.

Rebased PR branch:

```json
{
  "initialMaxConcurrent": 2,
  "suspendedMaxConcurrent": 0,
  "afterShutdownTtlMaxConcurrent": 0,
  "afterRestartMaxConcurrent": 2,
  "postRestartTurn": "post-restart-turn-ok"
}
```

No auto-resume log appeared after shutdown. Restart startup restored config-derived concurrency and post-restart main-lane work succeeded.

## Validation

- `node scripts/run-vitest.mjs run src/agents/session-suspension.test.ts src/gateway/server-close.test.ts`: `95 passed`
- `oxfmt --check` on all four changed files: passed
- `git diff --check`: passed
- branch rebased cleanly onto `9c948647468`

AI-assisted: implemented with Codex. I reviewed the touched agent/gateway lifecycle paths and understand the change.

Signed-off-by: Ho Lim <subhoya@gmail.com>
