### PR TITLE
fix(ai): honor Azure deployment maps with mixed-case model ids

### DIFF
--- a/packages/ai/src/providers/azure-deployment-map.test.ts
+++ b/packages/ai/src/providers/azure-deployment-map.test.ts
@@ -19,6 +19,18 @@ describe("Azure deployment name map", () => {
     ).toBe("deployment=blue");
   });
 
+  it("matches model ids case-insensitively while preserving deployment names", () => {
+    const map = parseAzureDeploymentNameMap("GPT-4o = Deployment-GPT-4o");
+
+    expect(map.get("gpt-4o")).toBe("Deployment-GPT-4o");
+    expect(
+      resolveAzureDeploymentNameFromMap({
+        modelId: "gpt-4O",
+        deploymentMap: "GPT-4o = Deployment-GPT-4o",
+      }),
+    ).toBe("Deployment-GPT-4o");
+  });
+
   it("falls back to the model id when the map has no usable entry", () => {
     expect(
       resolveAzureDeploymentNameFromMap({

--- a/packages/ai/src/providers/azure-deployment-map.ts
+++ b/packages/ai/src/providers/azure-deployment-map.ts
@@ -1,3 +1,10 @@
+// The deployment map is process config/env; cache only the latest value used on hot stream paths.
+let cachedDeploymentMap: { source: string | undefined; map: Map<string, string> } | undefined;
+
+function normalizeAzureDeploymentMapKey(modelId: string): string {
+  return modelId.trim().toLowerCase();
+}
+
 /** Parses AZURE_OPENAI_DEPLOYMENT_MAP-style model=deployment entries. */
 export function parseAzureDeploymentNameMap(value: string | undefined): Map<string, string> {
   const map = new Map<string, string>();
@@ -13,7 +20,7 @@ export function parseAzureDeploymentNameMap(value: string | undefined): Map<stri
     if (separator <= 0) {
       continue;
     }
-    const modelId = trimmed.slice(0, separator).trim();
+    const modelId = normalizeAzureDeploymentMapKey(trimmed.slice(0, separator));
     const deploymentName = trimmed.slice(separator + 1).trim();
     if (!modelId || !deploymentName) {
       continue;
@@ -23,10 +30,24 @@ export function parseAzureDeploymentNameMap(value: string | undefined): Map<stri
   return map;
 }
 
+function getCachedAzureDeploymentNameMap(value: string | undefined): Map<string, string> {
+  const cached = cachedDeploymentMap;
+  if (cached && cached.source === value) {
+    return cached.map;
+  }
+  const map = parseAzureDeploymentNameMap(value);
+  cachedDeploymentMap = { source: value, map };
+  return map;
+}
+
 /** Resolves the Azure deployment name for a model id, falling back to the model id. */
 export function resolveAzureDeploymentNameFromMap(params: {
   modelId: string;
   deploymentMap?: string;
 }): string {
-  return parseAzureDeploymentNameMap(params.deploymentMap).get(params.modelId) || params.modelId;
+  return (
+    getCachedAzureDeploymentNameMap(params.deploymentMap).get(
+      normalizeAzureDeploymentMapKey(params.modelId),
+    ) || params.modelId
+  );
 }


### PR DESCRIPTION
Fixes #102936.

## What Problem This Solves

Fixes an issue where Azure OpenAI users with `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` entries could fall back to the raw model id when the configured model id casing differed from the runtime model id.

That fallback can route requests to a non-existent Azure deployment and produce avoidable provider failures. The same helper also rebuilt the deployment map on every stream-path lookup.

AI-assisted: yes. I understand this change; it keeps the behavior inside the existing Azure deployment-map helper and does not add a new config surface.

## Why This Change Was Made

The Azure deployment-map helper now normalizes only model keys for parsing and lookup, while preserving deployment-name values exactly as configured. The resolver also caches the latest deployment map string so hot Azure Responses paths do not repeatedly parse the same process config.

Fallback behavior is unchanged when no usable entry exists.

## User Impact

Azure OpenAI configurations are more forgiving of model-id casing differences, so a map such as `GPT-4o=deployment-name` can still match a runtime `gpt-4o` model id. Azure stream setup also avoids repeated parsing of the same deployment map on repeated lookups.

## Evidence

- Duplicate check: live open and closed PR searches for `102936`, `resolveAzureDeploymentNameFromMap`, and Azure deployment-map wording found no existing owning PR.
- Negative control: after adding the mixed-case regression test, `node scripts/run-vitest.mjs packages/ai/src/providers/azure-deployment-map.test.ts -- --reporter=verbose` failed on current behavior because `map.get("gpt-4o")` returned `undefined`.
- Focused proof: bundled Node `node scripts/run-vitest.mjs packages/ai/src/providers/azure-deployment-map.test.ts -- --reporter=verbose` passed.
- Adjacent proof: bundled Node `node scripts/run-vitest.mjs packages/ai/src/providers/azure-deployment-map.test.ts packages/ai/src/providers/azure-openai-responses.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=verbose` passed 3 files / 307 tests.
- `git diff --check` passed.
- Local autoreview clean: no accepted/actionable findings.

Known gap: I did not run a live Azure request; proof is source-level and mocked/local caller coverage for the shared resolver.
