### PR TITLE
fix(ci): exclude setup RSS from performance gates

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -45,7 +45,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: a18f4c018151f5885d980804d863643bc78933b3
+        default: 6a1c20bf818f71f93d6d4cad7dabac74a2996bc0
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -148,7 +148,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'a18f4c018151f5885d980804d863643bc78933b3' }}
+      KOVA_REF: ${{ inputs.kova_ref || '6a1c20bf818f71f93d6d4cad7dabac74a2996bc0' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator that reads agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "a18f4c018151f5885d980804d863643bc78933b3";
+    const kovaRef = "6a1c20bf818f71f93d6d4cad7dabac74a2996bc0";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);


### PR DESCRIPTION
Related: https://github.com/openclaw/Kova/pull/19

## What Problem This Solves

Resolves a release-validation problem where OpenClaw Performance used an older
Kova evaluator that included setup-only package-manager RSS in product resource
gates. The beta3 candidate therefore failed despite the actual live agent path
remaining below its product RSS limit.

## Why This Change Was Made

Pin OpenClaw Performance to immutable Kova commit
`6a1c20bf818f71f93d6d4cad7dabac74a2996bc0`, which versions the
product-only resource accounting contract, preserves phase-owned measurement
scope, and prevents incompatible historical resource baselines from hiding
regressions.

That commit is the GitHub-verified squash merge of Kova PR #19, parent
`ac287f10744d2eb458cb4fefb6a6a29504a726b9`, tree
`2484a38b7ee542271b82b52339ba2d36ca441616`, and is directly reachable from
Kova `refs/heads/fix/agent-payload-truncation`. It is intentionally pinned by
full commit SHA. Kova `main` is not the source of this pin.

## User Impact

Release performance validation still records setup resource usage, but only
product-scoped measurements decide the RSS/CPU gate. Genuine product
regressions remain blocking, and old accounting contracts are reported as
non-comparable instead of silently reused.

## Evidence

- Original failing OpenClaw Performance run:
  https://github.com/openclaw/openclaw/actions/runs/29059635824
- Replayed its exact artifacts with Kova
  `6a1c20bf818f71f93d6d4cad7dabac74a2996bc0`:
  - live OpenAI lane: 1/1 passed
  - mock-provider lane: 18/18 passed
  - setup RSS 1548.2 MB remained recorded but excluded
  - product agent RSS remained 855.1 MB
- Kova PR #19 CI:
  https://github.com/openclaw/Kova/actions/runs/29061255311
  - Ubuntu passed
  - macOS passed
- Blacksmith Testbox `tbx_01kx4qc4s58vkja8gfv8nvmbmx`:
  - `pnpm test:serial test/scripts/openclaw-performance-workflow.test.ts`
    passed 21/21
  - `pnpm check:changed` passed
  - `pnpm check:workflows` passed actionlint, zizmor, and interpolation guards
- Fresh structured autoreview: no accepted/actionable findings; confidence
  0.86.
- Hosted exact-head PR checks and repo-native prepare proof will be added before
  merge.

AI-assisted: yes. The pin, upstream implementation, artifact replay, and test
evidence were manually verified.
