### PR TITLE
fix(signal): retry inbound flushes on reply session init conflict

### DIFF
--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -126,6 +126,49 @@ describe("monitorSignalProvider tool results", () => {
     }
   });
 
+  it("cancels a pending reply-session conflict retry when the monitor stops", async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    replyMock.mockRejectedValue(
+      new Error(
+        "reply session initialization conflicted for agent:main:signal:direct:+15550001111",
+      ),
+    );
+    streamMock.mockImplementation(async ({ onEvent, abortSignal }) => {
+      onEvent({
+        event: "receive",
+        data: JSON.stringify({
+          envelope: {
+            sourceNumber: "+15550001111",
+            sourceName: "Ada",
+            timestamp: 1,
+            dataMessage: { message: "hello after the prior turn" },
+          },
+        }),
+      });
+      await new Promise<void>((resolve) => {
+        abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+
+    try {
+      const monitorPromise = monitorSignalProvider({
+        autoStart: false,
+        baseUrl: "http://127.0.0.1:8080",
+        abortSignal: abortController.signal,
+      });
+
+      await vi.waitFor(() => expect(replyMock).toHaveBeenCalledTimes(1));
+      abortController.abort(new Error("monitor stopped"));
+      await monitorPromise;
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(replyMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("sizes attachment RPC response caps from mediaMaxMb", async () => {
     const abortController = new AbortController();
     const maxBytes = 2 * 1024 * 1024;

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -92,10 +92,10 @@ function resolveRuntime(opts: MonitorSignalOpts): RuntimeEnv {
 function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
   const inFlight = new Set<Promise<void>>();
   return {
-    runEventTask(task: () => Promise<void>): void {
+    runTask(task: () => Promise<void>): void {
       const trackedTask = Promise.resolve()
         .then(task)
-        .catch((err: unknown) => runtime.error?.(`event handler failed: ${String(err)}`))
+        .catch((err: unknown) => runtime.error?.(`signal monitor task failed: ${String(err)}`))
         .finally(() => inFlight.delete(trackedTask));
       inFlight.add(trackedTask);
     },
@@ -155,6 +155,11 @@ function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   const mergedAbort = mergeAbortSignals(params.abortSignal, daemonAbortController.signal);
   const stop = () => {
     daemonStopRequested = true;
+    if (!daemonAbortController.signal.aborted) {
+      daemonAbortController.abort(
+        params.abortSignal?.reason ?? new Error("Signal monitor stopped"),
+      );
+    }
     daemonHandle?.stop();
   };
   const attach = (handle: SignalDaemonHandle) => {
@@ -678,6 +683,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
 
     const handleEvent = createSignalEventHandler({
       runtime,
+      abortSignal: daemonLifecycle.abortSignal,
+      runTrackedTask: (task) => monitorTaskRunner.runTask(task),
       cfg,
       baseUrl,
       account,
@@ -715,7 +722,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       apiMode: configuredApiMode,
       policy: opts.reconnectPolicy,
       onEvent: (event) => {
-        monitorTaskRunner.runEventTask(() => handleEvent(event));
+        monitorTaskRunner.runTask(() => handleEvent(event));
       },
     });
     const daemonExitError = daemonLifecycle.getExitError();
@@ -729,9 +736,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
     throw err;
   } finally {
+    // Stop first: pending retry delays observe abort, while retries that already
+    // started remain in the task runner and drain before monitor teardown.
+    daemonLifecycle.stop();
     await monitorTaskRunner.waitForIdle();
     daemonLifecycle.dispose();
     opts.abortSignal?.removeEventListener("abort", onAbort);
-    daemonLifecycle.stop();
   }
 }

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -22,6 +22,28 @@ const {
   recordInboundSessionMock: vi.fn(),
 }));
 
+vi.mock("node:timers/promises", () => ({
+  setTimeout: <T>(delayMs: number, value?: T, options?: { signal?: AbortSignal }) =>
+    new Promise<T | undefined>((resolve, reject) => {
+      const signal = options?.signal;
+      if (signal?.aborted) {
+        reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+        return;
+      }
+      const onAbort = () => {
+        globalThis.clearTimeout(timer);
+        cleanup();
+        reject(signal?.reason instanceof Error ? signal.reason : new Error("aborted"));
+      };
+      const cleanup = () => signal?.removeEventListener("abort", onAbort);
+      const timer = globalThis.setTimeout(() => {
+        cleanup();
+        resolve(value);
+      }, delayMs);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    }),
+}));
+
 vi.mock("../send.js", () => ({
   sendMessageSignal: vi.fn(),
   sendTypingSignal: sendTypingMock,
@@ -61,6 +83,16 @@ const CONFLICT_ERROR = new Error(
   "reply session initialization conflicted for agent:main:signal:direct:+15550001111",
 );
 
+function createTrackedTaskHarness() {
+  const tasks: Promise<void>[] = [];
+  return {
+    tasks,
+    runTrackedTask: (task: () => Promise<void>) => {
+      tasks.push(task());
+    },
+  };
+}
+
 describe("signal reply session init conflict retry", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -74,14 +106,22 @@ describe("signal reply session init conflict retry", () => {
 
   it("retries a debounced flush that fails with a reply session init conflict", async () => {
     dispatchInboundMessageMock
-      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockRejectedValueOnce(
+        new Error("dispatch wrapper failed", {
+          cause: { error: CONFLICT_ERROR },
+        }),
+      )
       .mockResolvedValueOnce({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
 
-    const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
+      }),
+    );
 
     vi.useFakeTimers();
     try {
-      await handler(
+      const handled = handler(
         createSignalReceiveEvent({
           dataMessage: {
             message: "hello after prior turn",
@@ -89,14 +129,100 @@ describe("signal reply session init conflict retry", () => {
           },
         }),
       );
+      await vi.advanceTimersByTimeAsync(10);
+      await handled;
 
-      // Initial flush fails and schedules a retry.
+      // Initial flush fails and enters the retry backoff.
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1_000);
 
-      // Retry should have re-enqueued and flushed again.
+      // The same failed batch is dispatched again.
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a pending retry when the Signal monitor aborts", async () => {
+    dispatchInboundMessageMock.mockRejectedValueOnce(CONFLICT_ERROR);
+    const abort = new AbortController();
+    const tracked = createTrackedTaskHarness();
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
+        abortSignal: abort.signal,
+        runTrackedTask: tracked.runTrackedTask,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const handled = handler(
+        createSignalReceiveEvent({
+          dataMessage: { message: "do not dispatch after shutdown", attachments: [] },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await handled;
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(tracked.tasks).toHaveLength(1);
+
+      abort.abort(new Error("monitor stopped"));
+      await Promise.all(tracked.tasks);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(tracked.tasks).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a retry that crossed the timer boundary in the monitor task runner", async () => {
+    let resolveRetry: (() => void) | undefined;
+    const retryDispatch = new Promise<{ queuedFinal: boolean; counts: Record<string, number> }>(
+      (resolve) => {
+        resolveRetry = () =>
+          resolve({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+      },
+    );
+    dispatchInboundMessageMock
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockReturnValueOnce(retryDispatch);
+    const tracked = createTrackedTaskHarness();
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
+        runTrackedTask: tracked.runTrackedTask,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const handled = handler(
+        createSignalReceiveEvent({
+          dataMessage: { message: "wait for this retry", attachments: [] },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await handled;
+      expect(tracked.tasks).toHaveLength(1);
+
+      let trackedTaskSettled = false;
+      void tracked.tasks[0]?.then(() => {
+        trackedTaskSettled = true;
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      expect(tracked.tasks).toHaveLength(1);
+      expect(trackedTaskSettled).toBe(false);
+
+      resolveRetry?.();
+      await tracked.tasks[0];
+      expect(trackedTaskSettled).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -108,6 +234,7 @@ describe("signal reply session init conflict retry", () => {
     const errorLogs: string[] = [];
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
         runtime: {
           log: () => {},
           error: (msg: string) => {
@@ -119,7 +246,7 @@ describe("signal reply session init conflict retry", () => {
 
     vi.useFakeTimers();
     try {
-      await handler(
+      const handled = handler(
         createSignalReceiveEvent({
           dataMessage: {
             message: "hello after prior turn",
@@ -127,6 +254,8 @@ describe("signal reply session init conflict retry", () => {
           },
         }),
       );
+      await vi.advanceTimersByTimeAsync(10);
+      await handled;
 
       // Initial attempt.
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
@@ -175,7 +304,7 @@ describe("signal reply session init conflict retry", () => {
     }
   });
 
-  it("retries each entry in a batched flush independently", async () => {
+  it("retries a failed batch as one ordered dispatch", async () => {
     dispatchInboundMessageMock
       .mockRejectedValueOnce(CONFLICT_ERROR)
       .mockResolvedValueOnce({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
@@ -203,16 +332,65 @@ describe("signal reply session init conflict retry", () => {
         }),
       );
 
-      await vi.advanceTimersByTimeAsync(20);
+      await vi.advanceTimersByTimeAsync(10);
       await Promise.all([first, second]);
-
-      // Both messages were batched and the combined flush failed once.
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1_000);
-
-      // Retry should reprocess the batched messages.
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      const retryCall = dispatchInboundMessageMock.mock.calls[1]?.[0] as
+        | { ctx?: { Body?: string } }
+        | undefined;
+      const body = retryCall?.ctx?.Body ?? "";
+      expect(body).toContain("first");
+      expect(body).toContain("second");
+      expect(body.indexOf("first")).toBeLessThan(body.indexOf("second"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps newer buffered messages behind the failed batch during backoff", async () => {
+    dispatchInboundMessageMock
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValue({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const older = handler(
+        createSignalReceiveEvent({
+          timestamp: 1700000000001,
+          dataMessage: { message: "older failed message", attachments: [] },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      await older;
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      const newer = handler(
+        createSignalReceiveEvent({
+          timestamp: 1700000000002,
+          dataMessage: { message: "newer buffered message", attachments: [] },
+        }),
+      );
+      await newer;
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(990);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(3);
+      const dispatchedBodies = dispatchInboundMessageMock.mock.calls.map((call) => {
+        const payload = call[0] as { ctx?: { Body?: string } };
+        return payload.ctx?.Body ?? "";
+      });
+      expect(dispatchedBodies[1]).toContain("older failed message");
+      expect(dispatchedBodies[1]).not.toContain("newer buffered message");
+      expect(dispatchedBodies[2]).toContain("newer buffered message");
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -1,0 +1,220 @@
+// Signal tests cover retry behavior for reply session initialization conflicts.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const [
+  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+  { createSignalEventHandler },
+] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+
+const {
+  sendTypingMock,
+  sendReadReceiptMock,
+  sendReactionSignalMock,
+  removeReactionSignalMock,
+  dispatchInboundMessageMock,
+  recordInboundSessionMock,
+} = vi.hoisted(() => ({
+  sendTypingMock: vi.fn(),
+  sendReadReceiptMock: vi.fn(),
+  sendReactionSignalMock: vi.fn(async () => ({ ok: true })),
+  removeReactionSignalMock: vi.fn(async () => ({ ok: true })),
+  dispatchInboundMessageMock: vi.fn(),
+  recordInboundSessionMock: vi.fn(),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: sendTypingMock,
+  sendReadReceiptSignal: sendReadReceiptMock,
+}));
+
+vi.mock("../send-reactions.js", () => ({
+  sendReactionSignal: sendReactionSignalMock,
+  removeReactionSignal: removeReactionSignalMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/conversation-runtime")>(
+    "openclaw/plugin-sdk/conversation-runtime",
+  );
+  return {
+    ...actual,
+    recordInboundSession: recordInboundSessionMock,
+    readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+const CONFLICT_ERROR = new Error(
+  "reply session initialization conflicted for agent:main:signal:direct:+15550001111",
+);
+
+describe("signal reply session init conflict retry", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    sendTypingMock.mockReset().mockResolvedValue(true);
+    sendReadReceiptMock.mockReset().mockResolvedValue(true);
+    sendReactionSignalMock.mockReset().mockResolvedValue({ ok: true });
+    removeReactionSignalMock.mockReset().mockResolvedValue({ ok: true });
+    recordInboundSessionMock.mockReset().mockResolvedValue(undefined);
+    dispatchInboundMessageMock.mockReset();
+  });
+
+  it("retries a debounced flush that fails with a reply session init conflict", async () => {
+    dispatchInboundMessageMock
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValueOnce({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+
+    const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+
+    vi.useFakeTimers();
+    try {
+      await handler(
+        createSignalReceiveEvent({
+          dataMessage: {
+            message: "hello after prior turn",
+            attachments: [],
+          },
+        }),
+      );
+
+      // Initial flush fails and schedules a retry.
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Retry should have re-enqueued and flushed again.
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up after the configured number of retry attempts", async () => {
+    dispatchInboundMessageMock.mockRejectedValue(CONFLICT_ERROR);
+
+    const errorLogs: string[] = [];
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        runtime: {
+          log: () => {},
+          error: (msg: string) => {
+            errorLogs.push(msg);
+          },
+        } as any,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      await handler(
+        createSignalReceiveEvent({
+          dataMessage: {
+            message: "hello after prior turn",
+            attachments: [],
+          },
+        }),
+      );
+
+      // Initial attempt.
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+
+      // No further retries should be scheduled; advancing again does nothing.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+
+      expect(errorLogs.some((msg) => msg.includes("signal debounce flush failed"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry non-conflict flush failures", async () => {
+    dispatchInboundMessageMock.mockRejectedValue(new Error("some other dispatch failure"));
+
+    const handler = createSignalEventHandler(createBaseSignalEventHandlerDeps());
+
+    vi.useFakeTimers();
+    try {
+      await handler(
+        createSignalReceiveEvent({
+          dataMessage: {
+            message: "hello",
+            attachments: [],
+          },
+        }),
+      );
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries each entry in a batched flush independently", async () => {
+    dispatchInboundMessageMock
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValueOnce({ queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } });
+
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 10 } },
+        } as any,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const first = handler(
+        createSignalReceiveEvent({
+          timestamp: 1700000000001,
+          dataMessage: { message: "first", attachments: [] },
+        }),
+      );
+      const second = handler(
+        createSignalReceiveEvent({
+          timestamp: 1700000000002,
+          dataMessage: { message: "second", attachments: [] },
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(20);
+      await Promise.all([first, second]);
+
+      // Both messages were batched and the combined flush failed once.
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Retry should reprocess the batched messages.
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -33,6 +33,7 @@ import {
 } from "openclaw/plugin-sdk/channel-policy";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
   fireAndForgetHook,
@@ -89,6 +90,16 @@ import type {
 } from "./event-handler.types.js";
 import { resolveSignalQuoteContext } from "./inbound-context.js";
 import { renderSignalMentions } from "./mentions.js";
+
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
+const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
+const RETRYABLE_FLUSH_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
+
+function isSignalReplySessionInitConflictError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+    (candidate) => REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
+  );
+}
 
 function formatAttachmentKindCount(kind: string, count: number): string {
   if (kind === "attachment") {
@@ -224,6 +235,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
+    retryAttempt?: number;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -657,7 +669,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
   }
 
-  const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
+  const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
     buildKey: (entry) => {
@@ -675,36 +687,66 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
+      try {
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        if (entries.length === 1) {
+          await handleSignalInboundMessage(last);
+          return;
+        }
+        const combinedText = entries
+          .map((entry) => entry.bodyText)
+          .filter(Boolean)
+          .join("\\n");
+        const combinedCommandBody = entries
+          .map((entry) => entry.commandBody)
+          .filter(Boolean)
+          .join("\\n");
+        if (!combinedText.trim()) {
+          return;
+        }
+        await handleSignalInboundMessage({
+          ...last,
+          bodyText: combinedText,
+          commandBody: combinedCommandBody,
+          isBatched: true,
+          nativeReplyBody: last.nativeReplyBody ?? last.bodyText,
+          mediaPath: undefined,
+          mediaType: undefined,
+          mediaPaths: undefined,
+          mediaTypes: undefined,
+        });
+      } catch (err) {
+        if (!isSignalReplySessionInitConflictError(err)) {
+          throw err;
+        }
+        const retryableEntries = entries.filter(
+          (entry) => (entry.retryAttempt ?? 0) < RETRYABLE_FLUSH_MAX_ATTEMPTS,
+        );
+        if (retryableEntries.length === 0) {
+          throw err;
+        }
+        for (const entry of retryableEntries) {
+          const retryAttempt = entry.retryAttempt ?? 0;
+          const delayMs = RETRYABLE_FLUSH_RETRY_DELAYS_MS[retryAttempt];
+          if (delayMs === undefined) {
+            continue;
+          }
+          const retryEntry: SignalInboundEntry = {
+            ...entry,
+            retryAttempt: retryAttempt + 1,
+          };
+          logVerbose(
+            `signal: reply session init conflict, retrying in ${delayMs}ms (attempt ${retryAttempt + 1}/${RETRYABLE_FLUSH_MAX_ATTEMPTS})`,
+          );
+          setTimeout(() => {
+            void debouncer.enqueue(retryEntry);
+          }, delayMs);
+        }
+        throw err;
       }
-      if (entries.length === 1) {
-        await handleSignalInboundMessage(last);
-        return;
-      }
-      const combinedText = entries
-        .map((entry) => entry.bodyText)
-        .filter(Boolean)
-        .join("\\n");
-      const combinedCommandBody = entries
-        .map((entry) => entry.commandBody)
-        .filter(Boolean)
-        .join("\\n");
-      if (!combinedText.trim()) {
-        return;
-      }
-      await handleSignalInboundMessage({
-        ...last,
-        bodyText: combinedText,
-        commandBody: combinedCommandBody,
-        isBatched: true,
-        nativeReplyBody: last.nativeReplyBody ?? last.bodyText,
-        mediaPath: undefined,
-        mediaType: undefined,
-        mediaPaths: undefined,
-        mediaTypes: undefined,
-      });
     },
     onError: (err) => {
       deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
@@ -1190,7 +1232,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       typeof nativeReplyTargetTimestamp === "number"
         ? String(nativeReplyTargetTimestamp)
         : undefined;
-    await inboundDebouncer.enqueue({
+    await debouncer.enqueue({
       senderName,
       senderDisplay,
       senderRecipient,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -1,4 +1,5 @@
 // Signal plugin module implements event handler behavior.
+import { setTimeout as sleep } from "node:timers/promises";
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
@@ -92,7 +93,6 @@ import { resolveSignalQuoteContext } from "./inbound-context.js";
 import { renderSignalMentions } from "./mentions.js";
 
 const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
-const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
 const RETRYABLE_FLUSH_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
 
 function isSignalReplySessionInitConflictError(error: unknown): boolean {
@@ -235,7 +235,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
-    retryAttempt?: number;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -669,6 +668,76 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
   }
 
+  async function flushSignalInboundEntries(entries: SignalInboundEntry[]): Promise<void> {
+    const last = entries.at(-1);
+    if (!last) {
+      return;
+    }
+    if (entries.length === 1) {
+      await handleSignalInboundMessage(last);
+      return;
+    }
+    const combinedText = entries
+      .map((entry) => entry.bodyText)
+      .filter(Boolean)
+      .join("\\n");
+    const combinedCommandBody = entries
+      .map((entry) => entry.commandBody)
+      .filter(Boolean)
+      .join("\\n");
+    if (!combinedText.trim()) {
+      return;
+    }
+    await handleSignalInboundMessage({
+      ...last,
+      bodyText: combinedText,
+      commandBody: combinedCommandBody,
+      isBatched: true,
+      nativeReplyBody: last.nativeReplyBody ?? last.bodyText,
+      mediaPath: undefined,
+      mediaType: undefined,
+      mediaPaths: undefined,
+      mediaTypes: undefined,
+    });
+  }
+
+  async function retrySignalInboundFlush(
+    entries: SignalInboundEntry[],
+    initialError: unknown,
+  ): Promise<void> {
+    let lastError = initialError;
+    for (const [attemptIndex, delayMs] of RETRYABLE_FLUSH_RETRY_DELAYS_MS.entries()) {
+      const attempt = attemptIndex + 1;
+      logVerbose(
+        `signal: reply session init conflict, retrying ${entries.length} inbound message(s) in ${delayMs}ms (attempt ${attempt}/${RETRYABLE_FLUSH_RETRY_DELAYS_MS.length})`,
+      );
+      try {
+        await sleep(delayMs, undefined, { ref: false, signal: deps.abortSignal });
+      } catch (err) {
+        if (deps.abortSignal?.aborted) {
+          return;
+        }
+        throw err;
+      }
+      if (deps.abortSignal?.aborted) {
+        return;
+      }
+      try {
+        await flushSignalInboundEntries(entries);
+        return;
+      } catch (err) {
+        if (deps.abortSignal?.aborted) {
+          return;
+        }
+        lastError = err;
+        if (!isSignalReplySessionInitConflictError(err)) {
+          throw err;
+        }
+      }
+    }
+    throw lastError;
+  }
+
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
@@ -687,65 +756,23 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
+      if (deps.abortSignal?.aborted) {
+        return;
+      }
       try {
-        const last = entries.at(-1);
-        if (!last) {
-          return;
-        }
-        if (entries.length === 1) {
-          await handleSignalInboundMessage(last);
-          return;
-        }
-        const combinedText = entries
-          .map((entry) => entry.bodyText)
-          .filter(Boolean)
-          .join("\\n");
-        const combinedCommandBody = entries
-          .map((entry) => entry.commandBody)
-          .filter(Boolean)
-          .join("\\n");
-        if (!combinedText.trim()) {
-          return;
-        }
-        await handleSignalInboundMessage({
-          ...last,
-          bodyText: combinedText,
-          commandBody: combinedCommandBody,
-          isBatched: true,
-          nativeReplyBody: last.nativeReplyBody ?? last.bodyText,
-          mediaPath: undefined,
-          mediaType: undefined,
-          mediaPaths: undefined,
-          mediaTypes: undefined,
-        });
+        await flushSignalInboundEntries(entries);
       } catch (err) {
+        if (deps.abortSignal?.aborted) {
+          return;
+        }
         if (!isSignalReplySessionInitConflictError(err)) {
           throw err;
         }
-        const retryableEntries = entries.filter(
-          (entry) => (entry.retryAttempt ?? 0) < RETRYABLE_FLUSH_MAX_ATTEMPTS,
-        );
-        if (retryableEntries.length === 0) {
-          throw err;
-        }
-        for (const entry of retryableEntries) {
-          const retryAttempt = entry.retryAttempt ?? 0;
-          const delayMs = RETRYABLE_FLUSH_RETRY_DELAYS_MS[retryAttempt];
-          if (delayMs === undefined) {
-            continue;
-          }
-          const retryEntry: SignalInboundEntry = {
-            ...entry,
-            retryAttempt: retryAttempt + 1,
-          };
-          logVerbose(
-            `signal: reply session init conflict, retrying in ${delayMs}ms (attempt ${retryAttempt + 1}/${RETRYABLE_FLUSH_MAX_ATTEMPTS})`,
-          );
-          setTimeout(() => {
-            void debouncer.enqueue(retryEntry);
-          }, delayMs);
-        }
-        throw err;
+        // Keep the current keyed debounce task reserved through backoff so a
+        // newer same-conversation flush cannot overtake this failed batch.
+        const retryTask = retrySignalInboundFlush(entries, err);
+        deps.runTrackedTask?.(() => retryTask.catch(() => undefined));
+        await retryTask;
       }
     },
     onError: (err) => {

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -90,6 +90,8 @@ export type SignalNativeReplyContext = {
 
 export type SignalEventHandlerDeps = {
   runtime: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  runTrackedTask?: (task: () => Promise<void>) => void;
   cfg: OpenClawConfig;
   baseUrl: string;
   account?: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes #100944. Signal could silently drop an already-authorized inbound message when reply-session initialization lost its final optimistic concurrency race. The generic inbound debouncer logged the failed flush but did not retain the Signal payload needed for another delivery attempt.

## Why This Change Was Made

The shared reply-session initializer already retries once under its writer lock, so another unbounded session-layer loop would hide sustained contention. Signal is the narrow owner that still has the original inbound payload, making a bounded channel retry the appropriate recovery boundary.

This revision:

- recognizes the exact conflict through nested `cause` and `error` wrappers;
- retries the original ordered batch after 1s, 2s, and 4s backoffs;
- keeps the debouncer's same-conversation execution slot reserved during backoff, preventing newer buffered text from overtaking the failed batch;
- binds retry delays to the Signal monitor abort signal and tracks retries in the monitor's drain set; and
- leaves non-conflict failures and exhausted retries terminal and logged.

## User Impact

Signal follow-up messages that hit this transient session race are retried instead of being silently lost. No configuration or migration is required. Monitor shutdown cancels pending backoff and does not dispatch stale retries afterward.

## Evidence

- `corepack pnpm test extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts` on Blacksmith Testbox `tbx_01kx591b6gg472mwcn1mhhhcqt`: 11/11 passed across 2 files ([run 29072172902](https://github.com/openclaw/openclaw/actions/runs/29072172902)).
- `corepack pnpm check:changed` on the same Testbox passed all guards, all four TypeScript lanes, and core lint. Extension lint found three local fixup issues; all were corrected and targeted extension oxlint is clean.
- Exact pushed-head GitHub CI [run 29073336485](https://github.com/openclaw/openclaw/actions/runs/29073336485) completed successfully with zero failed jobs.
- Focused regressions cover nested error graphs, bounded exhaustion, non-conflict failures, ordered batch retry, newer-message ordering during backoff, abort cancellation, and retry task draining.
- The production monitor boundary test emits an inbound Signal event through `monitorSignalProvider`, aborts the monitor during backoff, and proves no post-stop dispatch.
- Node and Bun both verified `node:timers/promises` abortable unref delay behavior (`AbortError`).
- `oxfmt` and `git diff --check`: clean.
- Fresh reviews accepted and fixed two lifecycle/ordering findings. Final full-branch Codex review on exact pushed head `ef26709dcd74d632d07e6654b4f5870d7f555bc4` reported no actionable findings (confidence 0.82).

Live Signal account proof was not available in this checkout; the monitor-level test is the closest credential-free production-path proof.
