### PR TITLE
fix(ci): avoid false MCP timeout retry failures

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2556,11 +2556,10 @@ async function handle(message) {
     };
     if (await isFirstConnect()) {
       log("slow first initialize");
-      setTimeout(() => send(response), 600);
-    } else {
-      log("fast retry initialize");
-      send(response);
+      return;
     }
+    log("fast retry initialize");
+    send(response);
     return;
   }
   if (message.method === "tools/list") {
@@ -2626,11 +2625,29 @@ process.on("SIGINT", shutdown);`,
           LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
         );
 
-        const secondCatalog = await runtime.getCatalog();
-        await firstCatalog;
+        const secondCatalogPromise = runtime.getCatalog();
+        const [firstCatalogResult, secondCatalog] = await Promise.all([
+          firstCatalog,
+          secondCatalogPromise,
+        ]);
 
+        const firstSlowDiagnostic = firstCatalogResult.diagnostics?.find(
+          (diag) => diag.serverName === "slow",
+        );
+        expect(firstSlowDiagnostic?.message).toContain("timed out");
+        expect(firstCatalogResult.servers.slow).toBeUndefined();
         expect(secondCatalog.servers.trigger).toBeDefined();
-        expect(secondCatalog.diagnostics?.some((diag) => diag.serverName === "slow")).toBe(true);
+        const secondSlowDiagnostic = secondCatalog.diagnostics?.find(
+          (diag) => diag.serverName === "slow",
+        );
+        // A loaded runner can let generation one retire the timed-out client before
+        // generation two adopts it. Both the shared timeout and fast replacement are valid.
+        if (secondSlowDiagnostic) {
+          expect(secondSlowDiagnostic.message).toContain("timed out");
+          expect(secondCatalog.servers.slow).toBeUndefined();
+        } else {
+          expect(secondCatalog.servers.slow).toBeDefined();
+        }
         await waitForFileText(
           slowLogPath,
           "slow first initialize",
@@ -2654,9 +2671,7 @@ process.on("SIGINT", shutdown);`,
 
         const retriedCatalog = await runtime.getCatalog();
 
-        expect(retriedCatalog.diagnostics?.some((diag) => diag.serverName === "slow")).not.toBe(
-          true,
-        );
+        expect(retriedCatalog.diagnostics ?? []).toEqual([]);
         expect(retriedCatalog.servers.slow).toBeDefined();
         expect(retriedCatalog.tools.map((tool) => tool.toolName).toSorted()).toEqual([
           "poke",


### PR DESCRIPTION
Closes #103208

## What Problem This Solves

Fixes an issue where pull request and release CI could fail the agents-core shard when a timed-out MCP catalog generation retired before the test started its overlapping retry. The later generation could already be healthy, but the regression required it to publish the stale timeout diagnostic.

## Why This Change Was Made

The regression now asserts the timeout on the guaranteed first-generation result and explicitly validates both correct later-generation states: either it shared the timeout or it already connected the replacement session. The fixture leaves the first initialization pending until the runtime timeout retires it, and the final retry still has to publish both tools with zero diagnostics.

No production runtime behavior or timeout was changed.

## User Impact

Unrelated pull requests and release validation no longer require reruns for this valid MCP recovery ordering. There is no user-visible runtime behavior change.

## Evidence

- Before: CI run 29061112259, job 86263059388 failed this assertion with 1 failed / 1,318 passed; exact-SHA rerun job 86264152999 passed.
- Blacksmith Testbox through Crabbox `tbx_01kx4rvq6bwgqwrrd9a07jnkg7`: focused file passed 25 consecutive runs, 42 tests each.
- Same Testbox on current `main` base `28eb9e5d29f26b79d3b5c0d74ea188f6f49d9fb3`: focused file passed 42/42.
- Same Testbox: `pnpm check:changed -- src/agents/agent-bundle-mcp-runtime.test.ts` passed core-test typecheck, targeted oxlint, and guards.
- Autoreview (Codex, `gpt-5.5`, high): clean; no accepted/actionable findings.
- `git diff --check`: passed.

AI-assisted: yes.
