### PR TITLE
fix(ui): settle canonical session refreshes in lifecycle E2Es

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -117,6 +117,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     const sessionListsBeforeStaleActive = (await gateway.getRequests("sessions.list")).length;
+    await gateway.deferNext("sessions.list");
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
       hasActiveRun: true,
@@ -132,12 +133,14 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .toBeGreaterThan(sessionListsBeforeStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await gateway.resolveDeferred("sessions.list");
 
     await currentPage.waitForTimeout(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     expect(await mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     const sessionListsBeforeOtherSession = (await gateway.getRequests("sessions.list")).length;
+    await gateway.deferNext("sessions.list");
     await gateway.emitGatewayEvent("sessions.changed", {
       key: "agent:main:another-session",
       kind: "direct",
@@ -150,11 +153,13 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .toBeGreaterThan(sessionListsBeforeOtherSession);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await gateway.resolveDeferred("sessions.list");
 
     // Re-publish after the former 10-second suppression window. The completed
     // run identity stays terminal until the Gateway publishes different state.
     await currentPage.waitForTimeout(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
     const sessionListsBeforeLateStaleActive = (await gateway.getRequests("sessions.list")).length;
+    await gateway.deferNext("sessions.list");
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
       hasActiveRun: true,
@@ -170,5 +175,6 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       .toBeGreaterThan(sessionListsBeforeLateStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    await gateway.resolveDeferred("sessions.list");
   });
 });

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -67,22 +67,56 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
 
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
     const mainSession = currentPage.locator(".sidebar-recent-session").filter({ hasText: "Main" });
+    await mainSession.waitFor({ state: "visible" });
+    const sessionListsBeforeActive = (await gateway.getRequests("sessions.list")).length;
+    await gateway.deferNext("sessions.list");
+    const activeUpdatedAt = Date.now();
+    const activeStartedAt = activeUpdatedAt - 1_000;
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
       hasActiveRun: true,
       key: "main",
       kind: "direct",
       reason: "lifecycle",
-      startedAt: Date.now() - 1_000,
+      startedAt: activeStartedAt,
       status: "running",
-      updatedAt: Date.now(),
+      updatedAt: activeUpdatedAt,
     });
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(sessionListsBeforeActive);
     await mainSession.locator(".session-run-spinner").waitFor();
 
     await gateway.emitChatFinal({ runId, text: "Run complete." });
     await currentPage.getByText("Run complete.", { exact: true }).waitFor();
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
+    const staleActiveLabel = "Main stale active snapshot";
+    await gateway.resolveDeferred("sessions.list", {
+      count: 1,
+      defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+      path: "",
+      sessions: [
+        {
+          activeRunIds: [runId],
+          displayName: staleActiveLabel,
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          label: staleActiveLabel,
+          model: "gpt-5.5",
+          modelProvider: "openai",
+          startedAt: activeStartedAt,
+          status: "running",
+          updatedAt: activeUpdatedAt,
+        },
+      ],
+      ts: activeUpdatedAt,
+    });
+    await currentPage.getByText(staleActiveLabel, { exact: true }).waitFor();
+    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
+    const sessionListsBeforeStaleActive = (await gateway.getRequests("sessions.list")).length;
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
       hasActiveRun: true,
@@ -93,6 +127,9 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       status: "running",
       updatedAt: Date.now(),
     });
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(sessionListsBeforeStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
@@ -100,6 +137,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     expect(await mainSession.locator(".session-run-spinner").count()).toBe(0);
 
+    const sessionListsBeforeOtherSession = (await gateway.getRequests("sessions.list")).length;
     await gateway.emitGatewayEvent("sessions.changed", {
       key: "agent:main:another-session",
       kind: "direct",
@@ -107,12 +145,16 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       reason: "lifecycle",
       updatedAt: Date.now(),
     });
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(sessionListsBeforeOtherSession);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     // Re-publish after the former 10-second suppression window. The completed
     // run identity stays terminal until the Gateway publishes different state.
     await currentPage.waitForTimeout(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
+    const sessionListsBeforeLateStaleActive = (await gateway.getRequests("sessions.list")).length;
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
       hasActiveRun: true,
@@ -123,6 +165,9 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       status: "running",
       updatedAt: Date.now(),
     });
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(sessionListsBeforeLateStaleActive);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
   });

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -495,6 +495,8 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
 
       await writableGateway.deferNext("workboard.cards.update");
       const syncBefore = (await writableGateway.getRequests("workboard.cards.update")).length;
+      const sessionListBeforeSync = (await writableGateway.getRequests("sessions.list")).length;
+      await writableGateway.deferNext("sessions.list");
       await writableGateway.emitGatewayEvent("sessions.changed", {
         ...sessionRow({
           hasActiveRun: false,
@@ -505,6 +507,13 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
         sessionKey: linkedSessionKey,
         ts: baseTime + 4,
       });
+      await waitForNextRequest(writableGateway, "sessions.list", sessionListBeforeSync);
+      await writableGateway.resolveDeferred(
+        "sessions.list",
+        sessionsListResponse([
+          sessionRow({ hasActiveRun: false, status: "done", updatedAt: baseTime + 4 }),
+        ]),
+      );
       const syncRequest = await waitForNextRequest(
         writableGateway,
         "workboard.cards.update",
@@ -512,6 +521,7 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       );
       expect(requestParams(syncRequest)).toMatchObject({ id: runningCard.id });
       expect(requireRecord(requestParams(syncRequest).patch)).toMatchObject({
+        metadata: { lifecycleStatusSourceUpdatedAt: baseTime + 4 },
         status: "review",
       });
       await writableGateway.resolveDeferred("workboard.cards.update", { card: reviewedCard });


### PR DESCRIPTION
Closes #103203

## What Problem This Solves

Fixes an issue where required Control UI release checks would time out after a `sessions.changed` event triggered the canonical `sessions.list` refresh introduced by #103134. The chat lifecycle scenario could lose its active spinner before rendering, while the Workboard scenario could miss the terminal row needed to persist its lifecycle move.

## Why This Change Was Made

Both browser scenarios now explicitly defer the event-triggered list request, prove the refresh was requested, and resolve it with the canonical row state under test. The chat scenario waits for the initial sidebar row, then proves a delayed stale-active list response was applied without reviving Stop or the spinner; the Workboard scenario proves the terminal list response carries the lifecycle timestamp into its persisted update.

This stays at the mocked scenario boundary. Production Gateway event and list projections already derive active-run state from the same registry, so no runtime behavior changes.

## User Impact

No product behavior changes. Maintainers get deterministic Control UI release validation for session lifecycle races instead of timing-dependent failures.

## Evidence

Regression provenance: #103134 (`af3a76f320a29197d92c313a617ede86d9cc2b2e`) made the Gateway list canonical after session events, exposing stale mocked list setup in these two scenarios.

Before:

- [Full Release Validation / Release Checks job 86260538378](https://github.com/openclaw/openclaw/actions/runs/29060157285/job/86260538378): both scenarios failed.
- Chat focused Testbox repro: `tbx_01kx4rgykjjjsn91d6b0ecqhsr`, 1/1 failed at the spinner assertion.
- [Workboard focused Testbox repro](https://github.com/openclaw/openclaw/actions/runs/29061426571): 1/2 failed waiting for lifecycle update request 2.

After, Blacksmith Testbox `tbx_01kx4rgykjjjsn91d6b0ecqhsr`:

- Exact-head combined focused files: 3/3 passed.
- Final isolated chat lifecycle scenario: 10 consecutive runs, 10/10 passed.
- Workboard scenario: 5 consecutive runs, 10/10 tests passed.
- Full Control UI E2E lane: 31/31 files, 96/96 tests passed.
- `pnpm check:changed`: passed, including core-test typecheck, lint, formatting, and guards.
- Fresh structured autoreview: no accepted or actionable findings.

Exact reviewed head: `2971c78373f87830beca48286188fff6cb06184e`

## Risk Checklist

- User-visible behavior: none; test-only.
- Config, protocol, storage, migration, or dependency changes: none.
- Security, auth, secrets, or permissions changes: none.
- Main risk: the scenarios could pass before a deferred response is applied. Each now waits for an observable settled-state signal: the chat's unique stale-list label or the Workboard lifecycle update with source timestamp.

AI-assisted: yes. Agent transcript not attached.
