### PR TITLE
chore(deps): update docs-i18n x/net

### DIFF
--- a/scripts/docs-i18n/go.mod
+++ b/scripts/docs-i18n/go.mod
@@ -4,6 +4,6 @@ go 1.25.0
 
 require (
 	github.com/yuin/goldmark v1.8.2
-	golang.org/x/net v0.53.0
+	golang.org/x/net v0.55.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/scripts/docs-i18n/go.sum
+++ b/scripts/docs-i18n/go.sum
@@ -1,7 +1,7 @@
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Closes #103221

## What Problem This Solves

Resolves a problem where the docs translation maintainer tool directly pinned `golang.org/x/net` v0.53.0, below the first patched release in [GO-2026-5028](https://pkg.go.dev/vuln/GO-2026-5028).

The tool uses `html.NewTokenizer`; the reviewed advisory's affected-symbol list covers the `Parse` and `ParseFragment` families, so no affected OpenClaw call path was demonstrated. The direct vulnerable module should still not remain pinned in the repository.

## Why This Change Was Made

Updates only the direct dependency and checksums to v0.55.0, the first upstream patched release. That release retains the same Go 1.25 module floor already declared by docs-i18n.

## User Impact

No product runtime behavior changes. Maintainers can build and run the docs translation tool without the vulnerable x/net release in its module graph.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kx4sfanxswy9bchks0zy6rq3`: Go 1.25 `go mod tidy -diff`, `go test ./...`, and `go build ./...` passed.
- The repository-mapped `test/scripts/docs-i18n.test.ts` suite passed all 4 tests.
- `pnpm check:changed -- scripts/docs-i18n/go.mod scripts/docs-i18n/go.sum` passed.
- Official `govulncheck` source analysis recognized GO-2026-5028 on the old v0.53.0 graph but found zero reachable vulnerable calls; after the bump, GO-2026-5028 was absent and the scan still reported zero affected code.
- Fresh Codex autoreview: clean, patch correct at 0.99 confidence.
- `git diff --check` passed.

AI-assisted: Codex implemented and verified this focused dependency update.
