### PR TITLE
fix(ai): make normalizeOpenAIReasoningEffort case-insensitive

### DIFF
--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -1,6 +1,7 @@
 // Verifies model-specific OpenAI reasoning-effort normalization and disablement.
 import { describe, expect, it } from "vitest";
 import {
+  normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
   resolveOpenAISupportedReasoningEfforts,
 } from "./openai-reasoning-effort.js";
@@ -100,5 +101,41 @@ describe("OpenAI reasoning effort support", () => {
 
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
+  });
+
+  describe("normalizeOpenAIReasoningEffort", () => {
+    it("preserves lowercase effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("low")).toBe("low");
+      expect(normalizeOpenAIReasoningEffort("medium")).toBe("medium");
+      expect(normalizeOpenAIReasoningEffort("high")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("xhigh")).toBe("xhigh");
+      expect(normalizeOpenAIReasoningEffort("none")).toBe("none");
+      expect(normalizeOpenAIReasoningEffort("minimal")).toBe("minimal");
+    });
+
+    it("lowercases mixed-case effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("HIGH")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("High")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("Medium")).toBe("medium");
+      expect(normalizeOpenAIReasoningEffort("XHigh")).toBe("xhigh");
+      expect(normalizeOpenAIReasoningEffort("Minimal")).toBe("minimal");
+    });
+
+    it("trims whitespace from effort values", () => {
+      expect(normalizeOpenAIReasoningEffort("  high  ")).toBe("high");
+      expect(normalizeOpenAIReasoningEffort("\tmedium\n")).toBe("medium");
+    });
+
+    it("resolves mixed-case efforts through the model pipeline", () => {
+      const model = { provider: "openai", id: "gpt-5.1" };
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "HIGH" })).toBe("high");
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "LOW" })).toBe("low");
+    });
+
+    it("resolves uppercase none/off as disabled", () => {
+      const model = { provider: "openai", id: "gpt-5.1" };
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "NONE" })).toBe("none");
+      expect(resolveOpenAIReasoningEffortForModel({ model, effort: "OFF" })).toBeUndefined();
+    });
   });
 });

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -51,7 +51,7 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
-  return effort === "minimal" ? "minimal" : effort;
+  return normalizeLowercaseStringOrEmpty(effort);
 }
 
 function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[] | undefined {


### PR DESCRIPTION
## What Problem This Solves

`normalizeOpenAIReasoningEffort` in `src/agents/openai-reasoning-effort.ts` did not lowercase or trim its input. Mixed-case or uppercase reasoning-effort values (e.g. `"HIGH"`) failed to match the lowercase supported-effort lists used throughout `resolveOpenAIReasoningEffortForModel`, so requests could silently resolve to the wrong effort or fall back unexpectedly.

## Why This Change Was Made

Reuse the existing `normalizeLowercaseStringOrEmpty` helper (already imported in this file from `@openclaw/normalization-core/string-coerce`) to trim and lowercase the effort value consistently.

## User Impact

Users providing mixed-case reasoning-effort values in model config or API calls will now correctly resolve to the intended effort level. Previously `"HIGH"` would fall back unexpectedly while `"high"` worked fine.

## Evidence

- `normalizeOpenAIReasoningEffort("HIGH")` → `"high"` (previously `"HIGH"`)
- Mixed-case values correctly resolve through the full model pipeline
- All 12 tests pass (5 new case-insensitivity tests)

Closes #103169