### PR TITLE
fix(text): keep tool-call shaped text scan UTF-16 safe

### DIFF
--- a/src/shared/text/tool-call-shaped-text.test.ts
+++ b/src/shared/text/tool-call-shaped-text.test.ts
@@ -43,4 +43,10 @@ describe("detectToolCallShapedText", () => {
     expect(detectToolCallShapedText("Use tool_call tags only in examples.")).toBeNull();
     expect(detectToolCallShapedText("Use <tool_call> to invoke tools.")).toBeNull();
   });
+
+  it("does not break on surrogate pairs at the scan boundary", () => {
+    // Emoji near MAX_SCAN_CHARS should not cause scan failure
+    const input = `${"x".repeat(19_998)}🚀{ "name": "test" }`;
+    expect(() => detectToolCallShapedText(input)).not.toThrow();
+  });
 });

--- a/src/shared/text/tool-call-shaped-text.ts
+++ b/src/shared/text/tool-call-shaped-text.ts
@@ -1,6 +1,7 @@
 // Tool-call shaped text helpers detect malformed text that resembles tool calls.
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as readTrimmedString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 type ToolCallShapedTextDetection = {
   kind: "json_tool_call" | "xml_tool_call" | "bracketed_tool_call" | "react_action";
@@ -220,7 +221,7 @@ function detectReactAction(text: string): ToolCallShapedTextDetection | null {
 
 /** Detects assistant-visible text that looks like an unexecuted tool call instead of prose. */
 export function detectToolCallShapedText(text: string): ToolCallShapedTextDetection | null {
-  const trimmed = text.slice(0, MAX_SCAN_CHARS).trim();
+  const trimmed = truncateUtf16Safe(text, MAX_SCAN_CHARS).trim();
   if (!trimmed || !TOOL_TEXT_PREFILTER_RE.test(trimmed)) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

`detectToolCallShapedText()` in `src/shared/text/tool-call-shaped-text.ts` uses `text.slice(0, MAX_SCAN_CHARS)` to truncate model output text before scanning for tool-call patterns. When the 20,000-char boundary lands in the middle of a surrogate pair, the scan operates on broken text.

## Why This Change Was Made

Replaced `text.slice(0, MAX_SCAN_CHARS)` with `truncateUtf16Safe(text, MAX_SCAN_CHARS)`.

## User Impact

- Model output containing emoji at the scan boundary is handled correctly
- No behavior change for ASCII text

## Evidence

- 1 new test: emoji near boundary does not throw
- Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)