### PR TITLE
fix(gateway): keep oversized transcript metadata prefix UTF-16 safe

### DIFF
--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -2,6 +2,7 @@
 // Streams JSONL transcript files into byte-offset indexes for history paging.
 import fs from "node:fs";
 import { StringDecoder } from "node:string_decoder";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   parseSessionTranscriptTreeEntry,
   scanSessionTranscriptTree,
@@ -120,7 +121,7 @@ function buildOversizedIndexedRawEntry(params: {
 }): IndexedRawEntry | null {
   // Oversized lines may contain huge message arrays, so recover only metadata
   // from a bounded prefix and synthesize a visible placeholder record.
-  const prefix = params.line.slice(0, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS);
+  const prefix = truncateUtf16Safe(params.line, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS);
   const messageMatch = /"message"\s*:/.exec(prefix);
   const recordPrefix = messageMatch ? prefix.slice(0, messageMatch.index) : prefix;
   const id = extractJsonStringFieldPrefix(prefix, "id");


### PR DESCRIPTION
## What Problem This Solves

`recoverOversizedEntry()` in `src/gateway/session-transcript-index.fs.ts` uses `params.line.slice(0, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS)` to extract metadata from oversized JSONL transcript lines. When the 64KB boundary lands in a surrogate pair, the prefix starts with a broken character.

## Why This Change Was Made

Replaced with `truncateUtf16Safe(params.line, OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS)`.

## User Impact

- Transcript indexing handles emoji in session messages correctly at oversized line boundaries
- No behavior change for ASCII text

## Evidence

- Trivial one-liner: `params.line.slice(0, N)` → `truncateUtf16Safe(params.line, N)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)