### PR TITLE
fix(acpx): keep Codex wrapper error tail truncation UTF-16 safe

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -5,6 +5,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import fs from "node:fs/promises";
 import path, { resolve as resolvePath } from "node:path";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   ACPX_BACKEND_ID,
   AcpxRuntime as BaseAcpxRuntime,
@@ -139,7 +140,7 @@ async function readCodexWrapperStderrTail(params: {
       "utf8",
     );
     return compactDiagnosticText(
-      redactSensitiveText(text.slice(-CODEX_WRAPPER_ERROR_TAIL_MAX_CHARS)),
+      redactSensitiveText(sliceUtf16Safe(text, -CODEX_WRAPPER_ERROR_TAIL_MAX_CHARS)),
     );
   } catch {
     return "";


### PR DESCRIPTION
## What Problem This Solves

ACPX runtime reads Codex wrapper stderr logs and truncates to the tail with `text.slice(-CODEX_WRAPPER_ERROR_TAIL_MAX_CHARS)`. A negative slice can split a surrogate pair at the leading edge.

## Why This Change Was Made

Replaced with `sliceUtf16Safe(text, -CODEX_WRAPPER_ERROR_TAIL_MAX_CHARS)`.

## User Impact

- Codex wrapper error diagnostics keep emoji intact at tail boundary
- No behavior change for ASCII text

## Evidence

- Trivial one-liner: negative slice → sliceUtf16Safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)