### PR TITLE
fix(codex): keep diagnostics reason truncation UTF-16 safe

### DIFF
--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -1,5 +1,6 @@
 // Codex plugin module implements command handlers behavior.
 import crypto from "node:crypto";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentDir, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
@@ -1669,7 +1670,7 @@ function formatCodexDiagnosticsTargetLine(target: CodexDiagnosticsTarget): strin
 
 function normalizeDiagnosticsReason(note: string): string | undefined {
   const normalized = normalizeOptionalString(note);
-  return normalized ? normalized.slice(0, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
 }
 
 function parseDiagnosticsArgs(args: string): ParsedDiagnosticsArgs {


### PR DESCRIPTION
## What Problem This Solves

`normalizeDiagnosticsReason()` in `extensions/codex/src/command-handlers.ts` uses `normalized.slice(0, CODEX_DIAGNOSTICS_REASON_MAX_CHARS)` to truncate user-provided diagnostics notes. User input can contain emoji that would be split at the boundary.

## Why This Change Was Made

Replaced with `truncateUtf16Safe(normalized, CODEX_DIAGNOSTICS_REASON_MAX_CHARS)`.

## User Impact

- Codex diagnostics reason notes keep emoji intact at the 2048-char boundary
- No behavior change for ASCII text

## Evidence

- Trivial one-liner: `normalized.slice(0, N)` → `truncateUtf16Safe(normalized, N)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)