### PR TITLE
fix(doctor): suppress clean-state repair trailer

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3213,6 +3213,26 @@ describe("doctor health contributions", () => {
     );
   });
 
+  it("does not suggest --fix after a clean doctor run", async () => {
+    const cfg = {};
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await requireDoctorContribution("doctor:write-config").run({
+      cfg,
+      cfgForPersistence: cfg,
+      configResult: { cfg, shouldWriteConfig: false },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime,
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext);
+
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   describe("config size drops during update", () => {
     beforeEach(() => {
       mocks.replaceConfigFile.mockReset();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1268,7 +1268,6 @@ async function runGatewayDaemonHealth(ctx: DoctorHealthFlowContext): Promise<voi
 }
 
 async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  const { formatCliCommand } = await loadCommandFormatModule();
   const { applyWizardMetadata } = await loadOnboardHelpersModule();
   const { replaceConfigFile } = await loadConfigModule();
   const { logConfigUpdated } = await import("../config/logging.js");
@@ -1312,10 +1311,6 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     if (fs.existsSync(backupPath)) {
       ctx.runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
-    return;
-  }
-  if (!ctx.prompter.shouldRepair) {
-    ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }
 


### PR DESCRIPTION
Closes #80435

Supersedes #80455 with a smaller current-main maintainer rewrite. The original report and fix direction came from @KeWang0622; contributor credit is preserved in the commit and PR body.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor` against a settled configuration would always see a generic instruction to run `doctor --fix`, even though there was nothing to apply.

## Why This Change Was Made

Doctor's config finalization flow already emits specific repair guidance when actionable config migrations are declined or deferred. This change removes the redundant fallback trailer from the later write contribution while leaving actual config writes, structured health findings, and targeted repair hints unchanged.

## User Impact

Clean doctor inspections now finish without a misleading repair instruction. Configurations that need migration still show their specific `doctor --fix` guidance, and repair mode continues to persist both config-flow and health-phase changes.

## Evidence

- Testbox-through-Crabbox `tbx_01kx4s3kydq6cb9eqnt6pswz6t` (`swift-prawn`):
  - `corepack pnpm test src/flows/doctor-health-contributions.test.ts src/commands/doctor/finalize-config-flow.test.ts`
  - 89 doctor-health tests and 3 finalization tests passed.
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed all selected typecheck, lint, attribution, database-first, import-cycle, and guard lanes.
- Live isolated-home CLI matrix on the same Testbox:
  - settled clean config: exit 0, `Doctor complete.`, stable config hash, generic trailer absent;
  - legacy `gateway.webchat` preview: config unchanged, specific migration guidance present, generic trailer absent;
  - `doctor --fix`: legacy field removed; follow-up clean inspection remained stable and trailer-free.
- Source-blind behavior validation: all four contract clauses passed, including distinct clean/legacy fixtures, SHA-256 state probes, repaired JSON parsing, and no provider credentials.
- GPT-5.5 autoreview, high reasoning: clean, no accepted/actionable findings; patch correctness confidence 0.88.
- `git diff --check` passed.

No OpenAI key or provider credential was needed: this behavior is entirely within local doctor config and CLI output handling.
