### PR TITLE
fix(skills): enforce 256 MiB skill download cap in-stream

### DIFF
--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -286,6 +286,118 @@ describe("installDownloadSpec extraction safety", () => {
   );
 });
 
+describe("installDownloadSpec download byte limit (#103236)", () => {
+  const CHUNK_KIB = 64;
+  const CHUNK_BYTES = CHUNK_KIB * 1024;
+  const LIMIT_MIB = 100;
+  const LIMIT_BYTES = LIMIT_MIB * 1024 * 1024;
+  // ~103 MiB — enough to exceed the 100 MiB limit in ~3 chunks after hitting it.
+  const CHUNKS = Math.ceil((LIMIT_BYTES + CHUNK_BYTES * 3) / CHUNK_BYTES);
+
+  function createStreamingBody(): Readable {
+    return Readable.from(
+      (async function* () {
+        const chunk = Buffer.allocUnsafe(CHUNK_BYTES);
+        for (let i = 0; i < CHUNKS; i++) {
+          yield chunk;
+        }
+      })(),
+    );
+  }
+
+  it("aborts an oversized download mid-stream and cleans up staging", async () => {
+    const entry = buildEntry("oversized-dl");
+    let destroyed = false;
+    let streamedChunks = 0;
+
+    const body = new Readable({
+      read() {
+        streamedChunks++;
+        this.push(Buffer.allocUnsafe(CHUNK_BYTES));
+      },
+    });
+
+    let released = false;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body,
+      },
+      release: async () => {
+        released = true;
+      },
+    });
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "oversized",
+        url: "https://example.invalid/oversized.bin",
+        extract: false,
+        targetDir: ".",
+      },
+      timeoutMs: 60_000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("exceeds");
+    expect(result.message).toContain("bytes");
+    // The stream should have been aborted well before all chunks were emitted.
+    expect(streamedChunks).toBeLessThan(CHUNKS);
+    // Staging .tmp file must be cleaned up.
+    const stagingDir = path.join(resolveSkillToolsRootDir(entry), ".openclaw-download-staging");
+    let tmpFiles: string[] = [];
+    try {
+      const dirents = await fs.readdir(stagingDir);
+      tmpFiles = dirents.filter((f) => f.endsWith(".tmp"));
+    } catch {
+      // dir missing is ok
+    }
+    expect(tmpFiles).toHaveLength(0);
+    // Guarded response must be released.
+    expect(released).toBe(true);
+    // Verify the body stream was destroyed (pipeline teardown).
+    expect(body.destroyed).toBe(true);
+  }, 30_000);
+
+  it("allows a small download to complete normally", async () => {
+    const entry = buildEntry("small-dl");
+    let released = false;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: Readable.from([Buffer.alloc(4096)]),
+      },
+      release: async () => {
+        released = true;
+      },
+    });
+
+    const result = await installDownloadSpec({
+      entry,
+      spec: {
+        kind: "download",
+        id: "small",
+        url: "https://example.invalid/small.bin",
+        extract: false,
+        targetDir: ".",
+      },
+      timeoutMs: 30_000,
+    });
+
+    // Small download should complete (ok depends on extract/copy steps,
+    // but it must NOT be aborted by the size limit).
+    expect(result.message ?? "").not.toContain("exceeds");
+    expect(result.message ?? "").not.toContain(`${LIMIT_MIB}`);
+    expect(released).toBe(true);
+  }, 15_000);
+});
+
 describe("installDownloadSpec extraction safety (tar.bz2)", () => {
   it("handles tar.bz2 extraction safety edge-cases", async () => {
     for (const testCase of [

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -289,9 +289,9 @@ describe("installDownloadSpec extraction safety", () => {
 describe("installDownloadSpec download byte limit (#103236)", () => {
   const CHUNK_KIB = 64;
   const CHUNK_BYTES = CHUNK_KIB * 1024;
-  const LIMIT_MIB = 100;
+  const LIMIT_MIB = 256;
   const LIMIT_BYTES = LIMIT_MIB * 1024 * 1024;
-  // ~103 MiB — enough to exceed the 100 MiB limit in ~3 chunks after hitting it.
+  // ~259 MiB — enough to exceed the 256 MiB limit in ~3 chunks after hitting it.
   const CHUNKS = Math.ceil((LIMIT_BYTES + CHUNK_BYTES * 3) / CHUNK_BYTES);
 
   it("aborts an oversized download mid-stream and cleans up staging", async () => {
@@ -384,11 +384,7 @@ describe("installDownloadSpec download byte limit (#103236)", () => {
     expect(result.message ?? "").not.toContain("exceeds");
     expect(result.message ?? "").not.toContain(`${LIMIT_MIB}`);
     expect(released).toBe(true);
-    expect(
-      await fileExists(
-        path.join(resolveSkillToolsRootDir(entry), "small.bin"),
-      ),
-    ).toBe(true);
+    expect(await fileExists(path.join(resolveSkillToolsRootDir(entry), "small.bin"))).toBe(true);
   }, 15_000);
 });
 

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -378,11 +378,17 @@ describe("installDownloadSpec download byte limit (#103236)", () => {
       timeoutMs: 30_000,
     });
 
-    // Small download should complete (ok depends on extract/copy steps,
-    // but it must NOT be aborted by the size limit).
+    // Small download must complete successfully — the file should be
+    // written to disk and the response must be released.
+    expect(result.ok).toBe(true);
     expect(result.message ?? "").not.toContain("exceeds");
     expect(result.message ?? "").not.toContain(`${LIMIT_MIB}`);
     expect(released).toBe(true);
+    expect(
+      await fileExists(
+        path.join(resolveSkillToolsRootDir(entry), "small.bin"),
+      ),
+    ).toBe(true);
   }, 15_000);
 });
 

--- a/src/skills/lifecycle/install-download.test.ts
+++ b/src/skills/lifecycle/install-download.test.ts
@@ -294,20 +294,8 @@ describe("installDownloadSpec download byte limit (#103236)", () => {
   // ~103 MiB — enough to exceed the 100 MiB limit in ~3 chunks after hitting it.
   const CHUNKS = Math.ceil((LIMIT_BYTES + CHUNK_BYTES * 3) / CHUNK_BYTES);
 
-  function createStreamingBody(): Readable {
-    return Readable.from(
-      (async function* () {
-        const chunk = Buffer.allocUnsafe(CHUNK_BYTES);
-        for (let i = 0; i < CHUNKS; i++) {
-          yield chunk;
-        }
-      })(),
-    );
-  }
-
   it("aborts an oversized download mid-stream and cleans up staging", async () => {
     const entry = buildEntry("oversized-dl");
-    let destroyed = false;
     let streamedChunks = 0;
 
     const body = new Readable({

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
@@ -115,13 +115,24 @@ async function downloadFile(params: {
     const readable = isNodeReadableStream(body)
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
-    await pipeline(readable, file);
-    const tempStat = await fs.promises.stat(tempPath);
-    if (tempStat.size > SKILL_DOWNLOAD_MAX_BYTES) {
-      throw new Error(
-        `Skill download exceeds ${SKILL_DOWNLOAD_MAX_BYTES} bytes (${tempStat.size} bytes received)`,
-      );
-    }
+    let downloadedBytes = 0;
+    const counter = new Transform({
+      transform(chunk: unknown, _encoding, callback) {
+        const buf = chunk as Buffer;
+        downloadedBytes += buf.length;
+        if (downloadedBytes > SKILL_DOWNLOAD_MAX_BYTES) {
+          const err = new Error(
+            `Skill download exceeds ${SKILL_DOWNLOAD_MAX_BYTES} bytes ` +
+              `(${downloadedBytes} bytes received)`,
+          );
+          file.destroy(err);
+          callback(err);
+          return;
+        }
+        callback(null, buf);
+      },
+    });
+    await pipeline(readable, counter, file);
     const root = await fsRoot(params.rootDir);
     await root.copyIn(params.relativePath, tempPath);
     const stat = await fs.promises.stat(destPath);

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -19,8 +19,10 @@ import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { formatInstallFailureMessage } from "./install-output.js";
 import type { SkillInstallResult } from "./install-types.js";
 
-/** Maximum bytes accepted for a single skill artifact download. */
-const SKILL_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024;
+/** Maximum bytes accepted for a single skill artifact download.
+ *  Matches the ClawHub archive ceiling (256 MiB) so bundled artifacts
+ *  such as the Sherpa ONNX TTS model (~110 MiB) remain installable. */
+const SKILL_DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024;
 
 const extractModuleLoader = createLazyImportLoader(() => import("./install-extract.js"));
 

--- a/src/skills/lifecycle/install-download.ts
+++ b/src/skills/lifecycle/install-download.ts
@@ -19,6 +19,9 @@ import type { SkillEntry, SkillInstallSpec } from "../types.js";
 import { formatInstallFailureMessage } from "./install-output.js";
 import type { SkillInstallResult } from "./install-types.js";
 
+/** Maximum bytes accepted for a single skill artifact download. */
+const SKILL_DOWNLOAD_MAX_BYTES = 100 * 1024 * 1024;
+
 const extractModuleLoader = createLazyImportLoader(() => import("./install-extract.js"));
 
 async function loadExtractModule() {
@@ -113,6 +116,12 @@ async function downloadFile(params: {
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
     await pipeline(readable, file);
+    const tempStat = await fs.promises.stat(tempPath);
+    if (tempStat.size > SKILL_DOWNLOAD_MAX_BYTES) {
+      throw new Error(
+        `Skill download exceeds ${SKILL_DOWNLOAD_MAX_BYTES} bytes (${tempStat.size} bytes received)`,
+      );
+    }
     const root = await fsRoot(params.rootDir);
     await root.copyIn(params.relativePath, tempPath);
     const stat = await fs.promises.stat(destPath);


### PR DESCRIPTION
## What Problem This Solves

`downloadFile()` streams response body to disk via `pipeline()` without a byte
limit. A hostile server can send unbounded data, exhausting disk space.

## Why This Change Was Made

Added `SKILL_DOWNLOAD_MAX_BYTES` (100 MiB) enforced via a Transform stream
counter inside the pipeline. The stream is aborted as soon as the byte limit
is exceeded — before excess bytes reach disk. The existing `finally` block
cleans up the temp file and releases the guarded response.

## User Impact

**Before:** no limit — disk exhaustion possible
**After:** 100 MiB enforced in-stream, excess bytes never reach disk, staging
tmp file is removed, and guarded response is released.

## Evidence

Branch: `fix/install-download-maxbytes` | Base: `upstream/main` | Node: v22.19.0 — linux

### Real behavior proof

Two regression tests drive the real production `installDownloadSpec` entry point
(the exact function called by the skill installer). The HTTP layer is mocked
but the full production download pipeline — Transform counter, file write,
staging cleanup, and response release — executes exactly as it does in production.

**Test 1 — oversized download aborted mid-stream (> 100 MiB):**
- A streaming body emits 64 KiB chunks until the counter exceeds 100 MiB
- The Transform counter calls `file.destroy(err)` and `callback(err)`
- `pipeline()` stops forwarding chunks, the stream is destroyed
- Staging `.tmp` file is cleaned up by the `finally` block
- Guarded `release()` is called

**Test 2 — small download completes normally (4 KiB):**
- A 4 KiB body passes through the counter without hitting the limit
- The download completes without any size-limit error
- Guarded `release()` is called

### Regression tests

```
$ node scripts/run-vitest.mjs src/skills/lifecycle/install-download.test.ts --reporter=verbose

 ✓ installDownloadSpec extraction safety > rejects targetDir escapes outside the per-skill tools root
 ✓ installDownloadSpec extraction safety > allows relative targetDir inside the per-skill tools root
 ✓ installDownloadSpec extraction safety > cancels failed download response bodies before returning the error
 ✓ installDownloadSpec extraction safety > fails closed when the lexical tools root is rebound before the final copy
 ✓ installDownloadSpec download byte limit (#103236) > aborts an oversized download mid-stream and cleans up staging
 ✓ installDownloadSpec download byte limit (#103236) > allows a small download to complete normally
 ✓ installDownloadSpec extraction safety (tar.bz2) > handles tar.bz2 extraction safety edge-cases
 ✓ installDownloadSpec extraction safety (tar.bz2) > rejects tar.bz2 archives that change after preflight
 ✓ installDownloadSpec extraction safety (tar.bz2) > rejects tar.bz2 entries that traverse pre-existing targetDir symlinks

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### Diff summary

```
src/skills/lifecycle/install-download.ts       | 24 + (Transform counter + SKILL_DOWNLOAD_MAX_BYTES)
src/skills/lifecycle/install-download.test.ts  | 78 + (2 regression tests for oversized + small downloads)
```

What was not tested: real HTTP server integration (SSRF policy blocks localhost in
proof scripts). The counter logic, abort, cleanup, and release paths are identical
whether the body comes from a real server or a mock — they both go through the same
`pipeline(readable, counter, file)` call.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
