### PR TITLE
docs(agents): clarify plugin-sdk-internal namespace and Node engines range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Core stays plugin-agnostic. No bundled ids/defaults/policy in core when manifest/registry/capability contracts work.
 - Plugins cross into core only via `openclaw/plugin-sdk/*`, manifest metadata, injected runtime helpers, documented barrels (`api.ts`, `runtime-api.ts`).
-- Plugin prod code: no core `src/**`, `src/plugin-sdk-internal/**`, other plugin `src/**`, or relative outside package.
+- Plugin prod code: no core `src/**`, `src/plugin-sdk-internal/**` (guarded import namespace, not a dir), other plugin `src/**`, or relative outside package.
 - Core/tests: no deep plugin internals (`extensions/*/src/**`, `onboard.js`). Use public barrels, SDK facade, generic contracts.
 - Owner boundary: owner-specific repair/detection/onboarding/auth/defaults/provider behavior lives in owner plugin. Shared/core gets generic seams only.
 - Dependency ownership follows runtime ownership: plugin-only deps stay plugin-local; root deps only for core imports or intentionally internalized bundled plugin runtime.
@@ -111,7 +111,7 @@ Skills own workflows; root owns hard policy and routing.
 
 ## Commands
 
-- Runtime: Node 22.19+; Node 24 recommended. Keep Node + Bun paths working.
+- Runtime: Node 22.19+ (on the 23 line, 23.11+ only, per `package.json` engines); Node 24 recommended. Keep Node + Bun paths working.
 - Package manager/runtime: repo defaults only. No swaps without approval.
 - Install: `pnpm install` (keep Bun lock/patches aligned if touched). Agent dependency installation for tests/builds defaults to the selected remote box; do not reconcile a local Codex worktree just to run validation.
 - CLI: `pnpm openclaw ...` or `pnpm dev`; build: `pnpm build`.


### PR DESCRIPTION
## What Problem This Solves

Two lines in the root `AGENTS.md` can mislead a reader about the actual project structure and supported runtimes:

- The Architecture rule lists `src/plugin-sdk-internal/**` alongside real directories, but no such directory exists — it is a forbidden **import namespace** enforced by `src/channels/plugins/contracts/channel-import-guardrails.test.ts`. A reader can waste time looking for a missing path or "fix" it incorrectly.
- The Commands runtime line says "Node 22.19+", which glosses over the fact that `package.json` `engines` (`>=22.19.0 <23 || >=23.11.0`) excludes Node 23.0–23.10.

## Why This Change Was Made

Docs-only clarification. Line 59 gains a short parenthetical marking `src/plugin-sdk-internal/**` as a guarded import namespace (not a directory); line 114 restates the Node requirement to match `package.json` `engines` exactly. No policy, behavior, or structure changes.

## User Impact

Contributors and agents reading `AGENTS.md` get an accurate mental model: they won't hunt for a non-existent `src/plugin-sdk-internal/` directory, and they'll know Node 23.0–23.10 is unsupported. No runtime or product impact.

## Evidence

- `src/plugin-sdk-internal` has no directory on disk; the token appears only as a forbidden import pattern in `src/channels/plugins/contracts/channel-import-guardrails.test.ts` (e.g. `plugin-sdk-internal/discord`).
- `package.json` `engines.node` = `>=22.19.0 <23 || >=23.11.0`.
- Docs-only change; `git diff --check` is clean and the diff is limited to the two `AGENTS.md` lines (2 insertions / 2 deletions).
