### PR TITLE
fix(browser): handle managed Chrome spawn errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
+- **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -103,6 +103,24 @@ function makeFakeProc(overrides: Partial<FakeProc> = {}): FakeProc {
   return Object.assign(proc, overrides);
 }
 
+function makeFailedSpawnProc(error: NodeJS.ErrnoException): FakeProc {
+  const proc = makeFakeProc({ pid: undefined });
+  queueMicrotask(() => proc.emit("error", error));
+  return proc;
+}
+
+function stubBrowserExecutableAndPrefs(preferences: "present" | "missing") {
+  vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+    const value = String(p);
+    const isExecutable =
+      value.includes("Google Chrome") ||
+      value.includes("google-chrome") ||
+      value.includes("/usr/bin/chromium");
+    const isPreferences = value.endsWith("Local State") || value.endsWith("Preferences");
+    return isExecutable || (preferences === "present" && isPreferences);
+  });
+}
+
 function requireSpawnCall(index = 0): unknown[] {
   const call = spawnMock.mock.calls[index];
   if (!call) {
@@ -611,6 +629,52 @@ describe("chrome.ts internal", () => {
         /No supported browser found/,
       );
       expect(ensurePortAvailableMock).toHaveBeenCalledWith(51111, "127.0.0.1");
+    });
+
+    it("rejects a runtime spawn error before polling CDP", async () => {
+      stubBrowserExecutableAndPrefs("present");
+      const spawnError = Object.assign(new Error("spawn EACCES"), { code: "EACCES" });
+      spawnMock.mockImplementation(() => makeFailedSpawnProc(spawnError));
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(launchOpenClawChrome(makeResolved(), makeProfile(51112))).rejects.toBe(
+        spawnError,
+      );
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bootstrap spawn error without attempting the runtime launch", async () => {
+      stubBrowserExecutableAndPrefs("missing");
+      const spawnError = Object.assign(new Error("spawn EACCES"), { code: "EACCES" });
+      spawnMock.mockImplementation(() => makeFailedSpawnProc(spawnError));
+
+      await expect(launchOpenClawChrome(makeResolved(), makeProfile(51113))).rejects.toBe(
+        spawnError,
+      );
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps handling process errors after a successful spawn", async () => {
+      stubBrowserExecutableAndPrefs("present");
+      const proc = makeFakeProc();
+      spawnMock.mockReturnValue(proc);
+
+      await withMockChromeCdpServer({
+        wsPath: "/devtools/browser/LATE_PROCESS_ERROR",
+        run: async (baseUrl) => {
+          const running = await launchOpenClawChrome(
+            makeResolved(),
+            makeProfile(Number(new URL(baseUrl).port)),
+          );
+          expect(proc.listenerCount("error")).toBeGreaterThan(0);
+          expect(() => proc.emit("error", new Error("late child-process error"))).not.toThrow();
+          running.proc.kill?.("SIGTERM");
+        },
+      });
     });
 
     it.each([
@@ -1929,25 +1993,12 @@ describe("chrome.ts internal", () => {
       writeSpy.mockRestore();
     });
 
-    it("logs pid as -1 when the spawned proc reports no pid", async () => {
-      // Covers the `proc.pid ?? -1` falsy side.
-      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-        const s = String(p);
-        if (
-          s.includes("Google Chrome") ||
-          s.includes("google-chrome") ||
-          s.includes("/usr/bin/chromium")
-        ) {
-          return true;
-        }
-        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
-          return true;
-        }
-        return false;
-      });
+    it("rejects if a spawn event arrives without a process id", async () => {
+      stubBrowserExecutableAndPrefs("present");
       spawnMock.mockImplementation(() => {
         const fp = makeFakeProc();
         fp.pid = undefined;
+        queueMicrotask(() => fp.emit("spawn"));
         return fp;
       });
       await withMockChromeCdpServer({
@@ -1966,9 +2017,9 @@ describe("chrome.ts internal", () => {
             noSandbox: true,
             extraArgs: [],
           } as unknown as ResolvedBrowserConfig;
-          const running = await launchOpenClawChrome(resolved, profile);
-          expect(running.pid).toBe(-1);
-          running.proc.kill?.("SIGTERM");
+          await expect(launchOpenClawChrome(resolved, profile)).rejects.toThrow(
+            "Managed Chrome process spawned without a pid.",
+          );
         },
       });
     });

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -10,6 +10,7 @@ import {
   execFileSync,
   spawn,
 } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -1030,7 +1031,7 @@ export async function launchOpenClawChrome(
   );
 
   // First launch to create preference files if missing, then decorate and relaunch.
-  const spawnOnce = () => {
+  const spawnOnce = async (onStderr?: (chunk: Buffer | string) => void) => {
     const args = buildOpenClawChromeLaunchArgs({
       resolved,
       profile,
@@ -1055,10 +1056,26 @@ export async function launchOpenClawChrome(
     const preparedSpawn = prepareOomScoreAdjustedSpawn(exe.path, args, {
       env,
     });
-    return spawn(preparedSpawn.command, preparedSpawn.args, {
+    const proc = spawn(preparedSpawn.command, preparedSpawn.args, {
       stdio: ["ignore", "ignore", "pipe"],
       env: preparedSpawn.env,
     }) as unknown as ChildProcessWithoutNullStreams;
+    // Spawn and later kill failures arrive through EventEmitter. Keep this
+    // listener for the whole child lifetime so neither path can crash Gateway.
+    proc.on("error", (err) => {
+      log.debug(`managed Chrome process error: ${redactToolPayloadText(String(err))}`);
+    });
+    if (onStderr) {
+      proc.stderr?.on("data", onStderr);
+    }
+    if (proc.pid == null) {
+      await once(proc, "spawn");
+    }
+    const pid = proc.pid;
+    if (pid == null) {
+      throw new Error("Managed Chrome process spawned without a pid.");
+    }
+    return { pid, proc };
   };
 
   const startedAt = Date.now();
@@ -1066,7 +1083,7 @@ export async function launchOpenClawChrome(
   // If the profile doesn't exist yet, bootstrap it once so Chrome creates defaults.
   // Then decorate (if needed) before the "real" run.
   if (needsBootstrap) {
-    const bootstrap = spawnOnce();
+    const { proc: bootstrap } = await spawnOnce();
     const deadline = Date.now() + CHROME_BOOTSTRAP_PREFS_TIMEOUT_MS;
     while (Date.now() < deadline) {
       if (exists(localStatePath) && exists(preferencesPath)) {
@@ -1113,20 +1130,19 @@ export async function launchOpenClawChrome(
   }
 
   const launchOnceAndWait = async (allowSingletonRecovery: boolean): Promise<RunningChrome> => {
-    const proc = spawnOnce();
-
     // Keep a bounded stderr tail for diagnostics in case Chrome fails to start.
-    // The listener is removed on success to avoid retaining output from a
-    // long-lived Chrome process that emits periodic warnings.
+    // Attach before awaiting spawn so immediate diagnostics cannot be lost.
     const stderrDiagnostics = createChromeLaunchStderrDiagnostics(
       CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES,
     );
     const onStderr = (chunk: Buffer | string) => {
       stderrDiagnostics.append(chunk);
     };
-    proc.stderr?.on("data", onStderr);
+    let proc: ChildProcessWithoutNullStreams | undefined;
 
     try {
+      const spawned = await spawnOnce(onStderr);
+      proc = spawned.proc;
       const readyDeadline =
         Date.now() + (resolved.localLaunchTimeoutMs ?? CHROME_LAUNCH_READY_WINDOW_MS);
       let launchHttpReachable = false;
@@ -1198,7 +1214,7 @@ export async function launchOpenClawChrome(
         }
       }
 
-      const pid = proc.pid ?? -1;
+      const pid = spawned.pid;
       log.info(
         `🦞 openclaw browser started (${exe.kind}) profile "${profile.name}" on 127.0.0.1:${profile.cdpPort} (pid ${pid})`,
       );
@@ -1216,7 +1232,7 @@ export async function launchOpenClawChrome(
     } finally {
       // Chrome started successfully or launch failed — detach the stderr listener
       // and release the bounded tail buffer.
-      proc.stderr?.off("data", onStderr);
+      proc?.stderr?.off("data", onStderr);
       stderrDiagnostics.clear();
     }
   };


### PR DESCRIPTION
## What Problem This Solves

Managed Chrome launch failures such as `EACCES`, `ENOENT`, `EAGAIN`, `EMFILE`, and `ENFILE` are emitted asynchronously by Node's `ChildProcess`. The browser plugin returned the child without an `error` listener, so failures during either first-run bootstrap or the real launch could become an unhandled EventEmitter error and terminate Gateway instead of returning a browser launch error.

## Why This Change Was Made

Node 24.18.0's `internal/child_process` schedules common spawn failures onto the next tick and emits `error`; successful spawn assigns the PID before emitting `spawn`. The browser plugin now installs a permanent redacted process-error listener immediately, waits for initial spawn only when no PID was assigned synchronously, and uses the same helper for bootstrap and runtime launches. Runtime stderr capture is attached inside that boundary before any await so immediate Chrome diagnostics remain available. The old `-1` PID sentinel is removed; a successful spawn without a PID fails explicitly.

## User Impact

An invalid or inaccessible managed-browser executable now produces a normal browser-tool error while Gateway remains alive. Operators can correct the executable path and retry without losing their agent session. Successful launches, bootstrap decoration, stderr diagnostics, singleton-lock recovery, and normal shutdown behavior remain unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kx4semjkvf525ajrefwapkwa`: `chrome.internal.test.ts` passed 60/60, including new bootstrap/runtime `EACCES`, later process-error, and missing-PID regressions.
- The first focused draft run exposed lost immediate stderr during the new await; the final helper attaches stderr before yielding, and all existing bounded-tail/display/singleton diagnostics pass.
- Blacksmith Testbox: current-main full `pnpm check:changed` passed, including project typecheck, full lint, storage guards, and import-cycle checks.
- Blacksmith Testbox: full `pnpm build` passed.
- Fresh structured Codex autoreview: no accepted/actionable findings; `patch is correct` (0.86 confidence).
- Dedicated Blacksmith Testbox `tbx_01kx4v7jder7f17a6946pjyrvh` on exact pre-rebase head `0df343bd3f47049594bd23831f929486772ca895`: a real Gateway (PID 7795), OpenAI `gpt-5.4`, and managed Chromium completed the failure/recovery flow. The agent received the intentional `/usr` runtime spawn error, Gateway health and PID remained unchanged, config reloaded a valid Chromium executable, and the same canonical agent session opened and snapshotted a local proof page. Transcript inspection confirmed Gateway transport, browser failure-then-success tool calls, and no key exposure. After rebasing over unrelated `main` changes, both touched code/test blobs are byte-identical and the focused 60/60 suite passed again on final head `8e2dbdb3b8738d38436a11f47ab6c5f14e0622e0`.
- An additional source-blind validator reached a healthy fresh Gateway and real Chromium prewarm but was blocked before the hostile step when its public `browser stop` command returned no JSON or error. It reported no product-clause failure; the real-agent flow above is the end-to-end behavior proof.

Provenance: the unmanaged spawn boundary originated in `8eeb7f082975` (2026-03-26); the Linux OOM wrapper path was added in `cc9dcd3d69e3` (2026-04-23). Targeted live GitHub searches found no matching open issue or pull request.
