### PR TITLE
ci: pin docs i18n Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,6 +1170,10 @@ jobs:
           go-version-file: scripts/docs-i18n/go.mod
           cache-dependency-path: scripts/docs-i18n/go.sum
 
+      - name: Verify docs i18n Go toolchain
+        if: matrix.requires_go == true
+        run: test "$(go env GOVERSION)" = "go1.25.12"
+
       - name: Configure Node test resources
         run: echo "OPENCLAW_VITEST_MAX_WORKERS=2" >> "$GITHUB_ENV"
 

--- a/scripts/docs-i18n/go.mod
+++ b/scripts/docs-i18n/go.mod
@@ -2,6 +2,8 @@ module github.com/openclaw/openclaw/scripts/docs-i18n
 
 go 1.25.0
 
+toolchain go1.25.12
+
 require (
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/net v0.55.0

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -3267,7 +3267,11 @@ function resolveDocsI18nGoTargets(changedPath) {
   if (!/^scripts\/docs-i18n\/(?:go\.(?:mod|sum)|[^/]+\.go)$/u.test(changedPath)) {
     return null;
   }
-  return ["test/scripts/docs-i18n.test.ts"];
+  const targets = ["test/scripts/docs-i18n.test.ts"];
+  if (changedPath === "scripts/docs-i18n/go.mod") {
+    targets.push("test/scripts/ci-workflow-guards.test.ts");
+  }
+  return targets;
 }
 
 function resolveK8sManifestTargets(changedPath) {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -799,19 +799,13 @@ describe("ci workflow guards", () => {
     );
   });
 
-  it("fails and retries quiet Node test shard stalls quickly", () => {
+  it("keeps docs i18n CI on the patched preferred Go toolchain", () => {
     const workflow = readCiWorkflow();
-    const preflightJob = workflow.jobs.preflight;
-    const manifestStep = preflightJob.steps.find((step) => step.name === "Build CI manifest");
     const nodeTestJob = workflow.jobs["checks-node-core-test-nondist-shard"];
     const setupGoStep = nodeTestJob.steps.find((step) => step.name === "Setup Go for docs i18n");
-    const runStep = nodeTestJob.steps.find((step) => step.name === "Run Node test shard");
-
-    expect(JSON.stringify(preflightJob.steps)).toContain("timeout_minutes: shard.timeoutMinutes");
-    expect(manifestStep.run).toContain(
-      'shard.groups?.some((group) => group.shard_name === "core-tooling")',
+    const verifyGoStep = nodeTestJob.steps.find(
+      (step) => step.name === "Verify docs i18n Go toolchain",
     );
-    expect(nodeTestJob["timeout-minutes"]).toBe("${{ matrix.timeout_minutes || 60 }}");
     expect(setupGoStep).toMatchObject({
       if: "matrix.requires_go == true",
       uses: SETUP_GO_V6,
@@ -820,6 +814,29 @@ describe("ci workflow guards", () => {
         "cache-dependency-path": "scripts/docs-i18n/go.sum",
       },
     });
+    expect(setupGoStep.with).not.toHaveProperty("go-version");
+    expect(verifyGoStep).toMatchObject({
+      if: "matrix.requires_go == true",
+      run: 'test "$(go env GOVERSION)" = "go1.25.12"',
+    });
+
+    const goMod = readTrackedText("scripts/docs-i18n/go.mod");
+    expect(goMod).toMatch(/^go 1\.25\.0$/mu);
+    expect(goMod).toMatch(/^toolchain go1\.25\.12$/mu);
+  });
+
+  it("fails and retries quiet Node test shard stalls quickly", () => {
+    const workflow = readCiWorkflow();
+    const preflightJob = workflow.jobs.preflight;
+    const manifestStep = preflightJob.steps.find((step) => step.name === "Build CI manifest");
+    const nodeTestJob = workflow.jobs["checks-node-core-test-nondist-shard"];
+    const runStep = nodeTestJob.steps.find((step) => step.name === "Run Node test shard");
+
+    expect(JSON.stringify(preflightJob.steps)).toContain("timeout_minutes: shard.timeoutMinutes");
+    expect(manifestStep.run).toContain(
+      'shard.groups?.some((group) => group.shard_name === "core-tooling")',
+    );
+    expect(nodeTestJob["timeout-minutes"]).toBe("${{ matrix.timeout_minutes || 60 }}");
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS).toBe("300000");
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_TEST_PROJECTS_PARALLEL).toBe("2");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1188,15 +1188,19 @@ describe("scripts/test-projects changed-target routing", () => {
     }
   });
 
-  it("keeps docs i18n Go module edits on Go module tests", () => {
-    for (const modulePath of [
-      "scripts/docs-i18n/main.go",
-      "scripts/docs-i18n/main_test.go",
-      "scripts/docs-i18n/go.mod",
-    ]) {
+  it("keeps docs i18n Go edits on their module and workflow guards", () => {
+    const cases = [
+      ["scripts/docs-i18n/main.go", ["test/scripts/docs-i18n.test.ts"]],
+      ["scripts/docs-i18n/main_test.go", ["test/scripts/docs-i18n.test.ts"]],
+      [
+        "scripts/docs-i18n/go.mod",
+        ["test/scripts/docs-i18n.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
+      ],
+    ] as const;
+    for (const [modulePath, targets] of cases) {
       expect(resolveChangedTestTargetPlan([modulePath]), modulePath).toEqual({
         mode: "targets",
-        targets: ["test/scripts/docs-i18n.test.ts"],
+        targets,
       });
     }
   });


### PR DESCRIPTION
Closes #103240

## What Problem This Solves

Resolves a release-CI problem where the docs translation shard installed exact Go 1.25.0 from the module's minimum `go` directive. That toolchain predates supported Go 1.25 security patches, including the `os.ReadDir` fix documented in [GO-2026-4602](https://pkg.go.dev/vuln/GO-2026-4602).

Source-mode `govulncheck` traces that symbol through docs-i18n's locale discovery. The tool operates on a trusted maintainer docs root, and the advisory's impact is limited to metadata disclosure through an `os.Root`; this PR does not claim a remotely exploitable OpenClaw product vulnerability.

## Why This Change Was Made

Keeps `go 1.25.0` as the module's minimum language/dependency floor and adds `toolchain go1.25.12` as its preferred patched toolchain. The pinned setup-go v6 action prefers this directive when reading `go.mod`, then fixes `GOTOOLCHAIN=local`, so CI reproducibly installs 1.25.12 without raising the module compatibility floor.

The workflow now verifies the resolved `GOVERSION` before tests. Its regression guard jointly checks the workflow, setup-go input, module floor, preferred toolchain, and absence of an overriding `go-version`; changed-test routing guarantees a future `go.mod` edit runs that guard.

## User Impact

No product runtime behavior changes. Release CI and local docs-i18n development select the current patched Go 1.25 toolchain while retaining Go 1.25.0 compatibility semantics.

## Evidence

- Before: exact-head CI [run 29062338754](https://github.com/openclaw/openclaw/actions/runs/29062338754) installed `go1.25.0`; Testbox source analysis reported reachable symbol GO-2026-4602 through `localized_links.go:126`.
- Blacksmith Testbox through Crabbox `tbx_01kx4tv9yyv7f1qfzx14y5mren`: selected `go version go1.25.12 linux/amd64`.
- Go 1.25.12: `go mod tidy -diff`, `go test ./...`, and `go build ./...` passed.
- Post-change official `govulncheck`: GO-2026-4602 absent; `No vulnerabilities found`.
- Focused tooling suites: 227/227 tests passed across changed-target routing, CI workflow guards, and docs-i18n behavior.
- `pnpm check:changed` and `pnpm check:workflows` passed, including actionlint and zizmor.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct at 0.98 confidence.
- `git diff --check` passed.

AI-assisted: Codex implemented and verified this focused CI/toolchain hardening.
