### PR TITLE
fix(memory): normalize malformed batch failure attempts [AI-assisted]

### DIFF
--- a/extensions/memory-core/src/memory/manager-batch-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.test.ts
@@ -62,6 +62,60 @@ describe("memory batch state", () => {
     });
   });
 
+  it("honors valid positive safe-integer attempt counts", () => {
+    expect(
+      recordMemoryBatchFailure(
+        { enabled: true, count: 0 },
+        { provider: "openai", message: "batch failed", attempts: 2 },
+      ),
+    ).toEqual({
+      enabled: false,
+      count: 2,
+      lastError: "batch failed",
+      lastProvider: "openai",
+    });
+  });
+
+  it("treats malformed attempt counts as one failed attempt", () => {
+    const malformed = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      1.5,
+      0,
+      -3,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+    for (const attempts of malformed) {
+      expect(
+        recordMemoryBatchFailure(
+          { enabled: true, count: 0 },
+          { provider: "openai", message: "batch failed", attempts },
+        ),
+      ).toEqual({
+        enabled: true,
+        count: 1,
+        lastError: "batch failed",
+        lastProvider: "openai",
+      });
+    }
+  });
+
+  it("still disables batching after repeated malformed-attempt failures", () => {
+    let state = recordMemoryBatchFailure(
+      { enabled: true, count: 0 },
+      { provider: "openai", message: "first", attempts: Number.NaN },
+    );
+    expect(state.enabled).toBe(true);
+    expect(state.count).toBe(1);
+    state = recordMemoryBatchFailure(state, {
+      provider: "openai",
+      message: "second",
+      attempts: Number.NaN,
+    });
+    expect(state.enabled).toBe(false);
+    expect(state.count).toBe(MEMORY_BATCH_FAILURE_LIMIT);
+  });
+
   it("leaves disabled state unchanged", () => {
     expect(
       recordMemoryBatchFailure(

--- a/extensions/memory-core/src/memory/manager-batch-state.ts
+++ b/extensions/memory-core/src/memory/manager-batch-state.ts
@@ -19,6 +19,18 @@ export function resetMemoryBatchFailureState(
   };
 }
 
+/**
+ * Coerces a caller-supplied attempt count into a safe positive-integer
+ * increment. Provider errors may carry non-finite (NaN/Infinity from JSON
+ * overflow), fractional, zero, negative, or unsafe-integer `batchAttempts`
+ * metadata; without normalization such values poison the failure counter
+ * (NaN makes `count >= limit` never trip, Infinity disables on one failure
+ * through an invalid count). Any malformed value falls back to one attempt.
+ */
+function normalizeFailureAttempts(value: number | undefined): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : 1;
+}
+
 export function recordMemoryBatchFailure(
   state: MemoryBatchFailureState,
   params: {
@@ -33,7 +45,7 @@ export function recordMemoryBatchFailure(
   }
   const increment = params.forceDisable
     ? MEMORY_BATCH_FAILURE_LIMIT
-    : Math.max(1, params.attempts ?? 1);
+    : normalizeFailureAttempts(params.attempts);
   const count = state.count + increment;
   const enabled = !(params.forceDisable || count >= MEMORY_BATCH_FAILURE_LIMIT);
   return {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where the memory embedding batch fallback could **never disable itself after repeated provider failures** when a provider error carried non-finite or otherwise malformed `batchAttempts` metadata.

In `recordMemoryBatchFailure`, the failure increment was computed as `Math.max(1, params.attempts ?? 1)`. Because `??` only guards `null`/`undefined`, a `NaN` attempt count flows straight through: `Math.max(1, NaN)` is `NaN`, the running `count` becomes `NaN`, and the disable check `count >= MEMORY_BATCH_FAILURE_LIMIT` is **always false** for `NaN`. So batching silently stays enabled forever instead of falling back to non-batch embeddings. `Infinity` has the opposite failure: it disables batching on a single failure through an invalid (non-finite) count. Fractional, zero, negative, and unsafe-integer values are similarly malformed.

## Why This Change Was Made

Attempt counts are normalized to a positive safe integer at the `recordMemoryBatchFailure` boundary — the single narrow owner of the disable counter. Any non-finite (`NaN`/`Infinity`, e.g. from JSON overflow), fractional, zero, negative, or unsafe-integer value falls back to **one** failed attempt, so the counter increments correctly and disables at exactly `MEMORY_BATCH_FAILURE_LIMIT` failures.

This is the narrowest maintainable fix: the only runtime caller (`runBatchWithFallback` in `manager-embedding-ops.ts`) funnels `err.batchAttempts` through this helper, so normalizing at the boundary repairs the counter without touching caller or store logic. Valid positive safe-integer attempt counts (e.g. a legitimate retry count) are still honored unchanged.

Non-goals: no change to the disable threshold value, the fallback behavior, or any persisted state shape — only the arithmetic that feeds the existing counter.

## User Impact

Operators using remote memory embeddings reliably get the intended behavior: after repeated batch failures, memory embedding automatically falls back to non-batch (single-request) embeddings as designed, rather than staying stuck in a broken batch path when a provider returns malformed failure metadata. Correctly-formed providers see no behavior change.

## Evidence

Real behavior proof captured by running the **production** `recordMemoryBatchFailure` code path through `pnpm exec tsx`, replaying the `runBatchWithFallback` caller scenario (two consecutive batch failures carrying malformed `batchAttempts`). Same script, unpatched vs patched.

**Command run:**
```
pnpm exec tsx scripts/proof-memory-batch.ts   # imports recordMemoryBatchFailure from extensions/memory-core/src/memory/manager-batch-state.ts
```

**BEFORE (current main, attempts = NaN — the reported poisoning path):**
```
=== terminal output: NaN attempt metadata (attempts=NaN) ===
MEMORY_BATCH_FAILURE_LIMIT = 2
after failure 1: count=NaN, enabled=true
after failure 2: count=NaN, enabled=true
verdict: final count is finite = false
verdict: batching disabled after 2 failures = false

=== terminal output: Infinity attempt metadata (attempts=Infinity) ===
MEMORY_BATCH_FAILURE_LIMIT = 2
after failure 1: count=Infinity, enabled=false
after failure 2: count=Infinity, enabled=false
verdict: final count is finite = false
verdict: batching disabled after 2 failures = true
```

**AFTER (this PR):**
```
=== terminal output: NaN attempt metadata (attempts=NaN) ===
MEMORY_BATCH_FAILURE_LIMIT = 2
after failure 1: count=1, enabled=true
after failure 2: count=2, enabled=false
verdict: final count is finite = true
verdict: batching disabled after 2 failures = true

=== terminal output: Infinity attempt metadata (attempts=Infinity) ===
MEMORY_BATCH_FAILURE_LIMIT = 2
after failure 1: count=1, enabled=true
after failure 2: count=2, enabled=false
verdict: final count is finite = true
verdict: batching disabled after 2 failures = true
```

After the fix, malformed metadata no longer poisons the counter: the count stays finite and batching disables at exactly 2 failures for both `NaN` and `Infinity`.

**Regression tests** added in `extensions/memory-core/src/memory/manager-batch-state.test.ts` (7/7 passing):
- valid positive safe-integer attempts (e.g. `2`) are still honored → disables correctly
- malformed values (`NaN`, `Infinity`, `1.5`, `0`, `-3`, `MAX_SAFE_INTEGER + 1`) each count as one attempt
- two consecutive malformed-attempt failures → batching disables at the limit (the end-to-end bug scenario)

**Verification run locally (changed files only):**
- `pnpm exec oxfmt --check` — clean
- `pnpm exec oxlint --type-aware` — clean
- `pnpm tsgo:extensions` (typechecks `extensions/memory-core` source + tests) — exit 0
- `pnpm exec tsx scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-batch-state.test.ts` — 7/7 pass

What was **not** tested: no live remote embedding provider was run; the proof exercises the production counter logic directly — the deterministic code path that contains the bug. Swift surfaces not applicable.

## Security Impact

- Changes auth, authorization, or trust boundaries? **No.**
- Changes how secrets/tokens/credentials are handled? **No.**
- Changes a security boundary (sandbox, network egress, prompt isolation)? **No.**
- Introduces new external data ingestion or code execution? **No.**
- Changes logging/telemetry that could leak sensitive data? **No.**

Pure numeric normalization inside an in-process batch-state helper. No dependency, workflow, secret, permission, install, or supply-chain surface changed.

## Compatibility / Migration

Backward compatible. The only behavior change is for previously-malformed attempt values, which now count as one failure instead of poisoning or mis-disabling the counter. Valid attempt counts are byte-for-byte unchanged. No config, API, or persisted-state-shape change.

## Failure Recovery

Revert the single commit. The change is isolated to the increment expression in `recordMemoryBatchFailure` (`Math.max(1, params.attempts ?? 1)` → `normalizeFailureAttempts(params.attempts)`); reverting restores the prior behavior.

## Risks and Mitigations

- **Fallback of "one attempt" for malformed values could under-count a real multi-attempt failure.** Mitigation: malformed `batchAttempts` is itself a provider bug; counting it as one failure is the safe conservative choice that still lets batching disable after `MEMORY_BATCH_FAILURE_LIMIT` repeated failures. Legitimate multi-attempt counts are safe positive integers and pass through unchanged.
