### PR TITLE
fix(ci): build iOS without named simulator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1631,7 +1631,7 @@
     "gen:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --write",
     "ghsa:patch": "node scripts/ghsa-patch.mjs",
     "ios:app-review-notes:pdf": "xcrun swift scripts/ios-app-review-notes-pdf.swift apps/ios/APP-REVIEW-NOTES.md apps/ios/build/app-review/APP-REVIEW-NOTES.pdf",
-    "ios:build": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-platform=iOS Simulator,name=iPhone 17}\" -configuration Debug build'",
+    "ios:build": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-generic/platform=iOS Simulator}\" -configuration Debug build'",
     "ios:filelist:gen": "node scripts/ios-write-swift-filelist.mjs",
     "ios:gen": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate'",
     "ios:open": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && open OpenClaw.xcodeproj'",

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -152,6 +152,13 @@ describe("package scripts", () => {
     expect(readPackageJson().scripts.start).toBe("node openclaw.mjs");
   });
 
+  it("builds iOS against a generic simulator by default", () => {
+    const script = readPackageJson().scripts["ios:build"];
+
+    expect(script).toContain('${IOS_DEST:-generic/platform=iOS Simulator}');
+    expect(script).not.toContain("name=iPhone");
+  });
+
   it("runs generated module formatting coverage in Windows CI", () => {
     expect(readPackageJson().scripts["test:windows:ci"]).toContain(
       "test/scripts/format-generated-module.test.ts",


### PR DESCRIPTION
Closes #103257

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where the build-only iOS CI lane failed before compilation when a macOS runner had the iOS simulator SDK but no installed `iPhone 17` simulator device.

## Why This Change Was Made

The canonical `pnpm ios:build` command now defaults to Xcode's generic iOS Simulator destination while preserving `IOS_DEST` for callers that need a concrete device. Runtime simulator flows remain unchanged: `scripts/ios-run.sh` still selects, boots, installs, and launches on a named simulator.

## User Impact

Release and full-CI validation no longer depend on runner-specific simulator device inventory. There is no product runtime behavior change.

## Evidence

- Before: [CI run 29063344821, iOS build job 86269735564](https://github.com/openclaw/openclaw/actions/runs/29063344821/job/86269735564) exited 70 because only the generic `Any iOS Simulator Device` destination was available.
- Regression guard: `pnpm test test/package-scripts.test.ts` failed on the old named-device default, then passed 13/13 after the fix on Blacksmith Testbox `tbx_01kx4wfatjh3m87mhak143rfys`.
- Changed gate: `pnpm check:changed -- package.json test/package-scripts.test.ts` passed on the same Testbox lease.
- Fresh autoreview: clean, with no accepted or actionable findings.
- Exact-head manual CI: [run 29064244378](https://github.com/openclaw/openclaw/actions/runs/29064244378) passed 107 jobs with 4 intentional skips and zero failures on `2bf0ec6445c355d65dcf5b950ea806f4fa2401ee`; iOS job 86272386564 used `generic/platform=iOS Simulator` and finished with `BUILD SUCCEEDED`.
- Canonical PR CI: [run 29064154930](https://github.com/openclaw/openclaw/actions/runs/29064154930) passed 43 jobs with expected scoped skips and zero failures.
- Repo-native prepare: hosted exact-head gates passed with `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 103259`.
