### PR TITLE
fix(xai): align current model catalog and tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
+- **xAI model compatibility:** publish canonical Grok 4.20 model ids and 1M context limits while preserving moving aliases, remove stale generated catalog rows and repair tool/image defaults, move server-tool defaults to Grok 4.3, align per-model reasoning controls, preserve supported tool-schema bounds, and disable Responses storage for dedicated xAI tools.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
-- **xAI model compatibility:** publish canonical Grok 4.20 model ids and 1M context limits while preserving moving aliases, remove stale generated catalog rows and repair tool/image defaults, move server-tool defaults to Grok 4.3, align per-model reasoning controls, preserve supported tool-schema bounds, and disable Responses storage for dedicated xAI tools.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)
 - **Apple timeout recovery:** return promptly from shared operation deadlines and caller cancellation even when platform work ignores cancellation, while isolating late Gateway handshakes and cleaning up location and permission waiters. (#103066) Thanks @NianJiuZst.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -326,7 +326,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
     Model ids use a `nvidia/<vendor>/<model>` namespace (for example `nvidia/nvidia/nemotron-...` alongside `nvidia/moonshotai/kimi-k2.5`); pickers preserve the literal `<provider>/<model-id>` composition while the canonical key sent to the API stays single-prefixed.
   </Accordion>
   <Accordion title="xAI">
-    Uses the xAI Responses path. The recommended path is SuperGrok/X Premium OAuth; API keys still work via `XAI_API_KEY` or plugin config, and Grok `web_search` reuses the same auth profile before API-key fallback. Grok 4.5 is selectable for chat, coding, and agentic work where available; `grok-4.3` remains the regional-safe bundled default. `/fast` or `params.fastMode: true` rewrites `grok-3`, `grok-3-mini`, `grok-4`, and `grok-4-0709` to their `*-fast` variants. `tool_stream` defaults on; disable via `agents.defaults.models["xai/<model>"].params.tool_stream=false`.
+    Uses the xAI Responses path. The recommended path is SuperGrok/X Premium OAuth; API keys still work via `XAI_API_KEY` or plugin config, and Grok `web_search` reuses the same auth profile before API-key fallback. Grok 4.5 is selectable for chat, coding, and agentic work where available; `grok-4.3` remains the regional-safe bundled default. Older `/fast` and `params.fastMode: true` configurations still resolve through xAI's Grok 4.3 compatibility redirects, but new configurations should select a current model directly. `tool_stream` defaults on; disable via `agents.defaults.models["xai/<model>"].params.tool_stream=false`.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8031,8 +8031,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: OAuth troubleshooting
   - H2: Built-in catalog
   - H2: Feature coverage
-  - H3: Fast-mode mappings
-  - H3: Legacy compatibility aliases
+  - H3: Legacy fast-mode compatibility
+  - H3: Legacy compatibility and moving aliases
   - H2: Features
   - H2: Live testing
   - H2: Related

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -360,7 +360,7 @@ read, account-wide exposure fails closed.
   - `timeoutSeconds`: scrape request timeout in seconds (default: `60`).
 - `plugins.entries.xai.config.xSearch`: xAI X Search (Grok web search) settings.
   - `enabled`: enable the X Search provider.
-  - `model`: Grok model to use for search (e.g. `"grok-4-1-fast"`).
+  - `model`: Grok model to use for search (e.g. `"grok-4.3"`).
 - `plugins.entries.memory-core.config.dreaming`: memory dreaming settings. See [Dreaming](/concepts/dreaming) for phases and thresholds.
   - `enabled`: master dreaming switch (default `false`).
   - `frequency`: cron cadence for each full dreaming sweep (`"0 3 * * *"` by default).

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -106,41 +106,41 @@ process polls xAI for the completed token exchange.
 
 Selectable ids in model pickers. The plugin still resolves older Grok 3,
 Grok 4, Grok 4 Fast, Grok 4.1 Fast, and Grok Code ids for existing configs;
-see [legacy compatibility aliases](#legacy-compatibility-aliases).
+see [legacy compatibility and moving aliases](#legacy-compatibility-and-moving-aliases).
 
-| Family         | Model ids                                                                |
-| -------------- | ------------------------------------------------------------------------ |
-| Grok 4.5       | `grok-4.5` (aliases: `grok-4.5-latest`, `grok-build-latest`)             |
-| Grok Build 0.1 | `grok-build-0.1`                                                         |
-| Grok 4.3       | `grok-4.3`                                                               |
-| Grok 4.20 Beta | `grok-4.20-beta-latest-reasoning`, `grok-4.20-beta-latest-non-reasoning` |
+| Family         | Model ids                                                    |
+| -------------- | ------------------------------------------------------------ |
+| Grok 4.5       | `grok-4.5` (aliases: `grok-4.5-latest`, `grok-build-latest`) |
+| Grok Build 0.1 | `grok-build-0.1`                                             |
+| Grok 4.3       | `grok-4.3` (aliases: `grok-4.3-latest`, `grok-latest`)       |
+| Grok 4.20      | `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`   |
 
 <Tip>
 Use `grok-4.5` for general chat, coding, and agentic work where it is available.
-Grok 4.3 remains the regional-safe setup default; `grok-build-0.1` and the Grok
-4.20 beta aliases remain selectable.
+Grok 4.3 remains the regional-safe setup default; `grok-build-0.1` and both
+dated Grok 4.20 variants remain selectable.
 </Tip>
 
 ## Feature coverage
 
-The bundled plugin maps xAI's current public API surface onto OpenClaw's
-shared provider and tool contracts. Capabilities that do not fit the shared
-contract, such as streaming TTS and realtime voice, are not exposed.
+The bundled plugin maps supported xAI APIs onto OpenClaw's shared provider and
+tool contracts. Capabilities that do not fit the shared contract are listed
+below or under known limits.
 
-| xAI capability             | OpenClaw surface                        | Status                                                              |
-| -------------------------- | --------------------------------------- | ------------------------------------------------------------------- |
-| Chat / Responses           | `xai/<model>` model provider            | Yes                                                                 |
-| Server-side web search     | `web_search` provider `grok`            | Yes                                                                 |
-| Server-side X search       | `x_search` tool                         | Yes                                                                 |
-| Server-side code execution | `code_execution` tool                   | Yes                                                                 |
-| Images                     | `image_generate`                        | Yes                                                                 |
-| Videos                     | `video_generate`                        | Yes                                                                 |
-| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`  | Yes                                                                 |
-| Streaming TTS              | -                                       | Not exposed; OpenClaw's TTS contract returns complete audio buffers |
-| Batch speech-to-text       | `tools.media.audio` media understanding | Yes                                                                 |
-| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`  | Yes                                                                 |
-| Realtime voice             | -                                       | Not exposed yet; needs a different session/WebSocket contract       |
-| Files / batches            | Generic model API compatibility only    | Not a first-class OpenClaw tool                                     |
+| xAI capability             | OpenClaw surface                        | Status                                                        |
+| -------------------------- | --------------------------------------- | ------------------------------------------------------------- |
+| Chat / Responses           | `xai/<model>` model provider            | Yes                                                           |
+| Server-side web search     | `web_search` provider `grok`            | Yes                                                           |
+| Server-side X search       | `x_search` tool                         | Yes                                                           |
+| Server-side code execution | `code_execution` tool                   | Yes                                                           |
+| Images                     | `image_generate`                        | Yes                                                           |
+| Videos                     | `video_generate`                        | Classic model; Video 1.5 is not exposed yet                   |
+| Batch text-to-speech       | `messages.tts.provider: "xai"` / `tts`  | Yes                                                           |
+| Streaming TTS              | -                                       | Not implemented by the xAI provider yet                       |
+| Batch speech-to-text       | `tools.media.audio` media understanding | Yes                                                           |
+| Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`  | Yes                                                           |
+| Realtime voice             | -                                       | Not exposed yet; needs a different session/WebSocket contract |
+| Files / batches            | Generic model API compatibility only    | Not a first-class OpenClaw tool                               |
 
 <Note>
 OpenClaw uses xAI's REST image/video/TTS/STT APIs for media generation and
@@ -149,10 +149,12 @@ transcription, and the Responses API for chat, search, and code-execution
 tools.
 </Note>
 
-### Fast-mode mappings
+### Legacy fast-mode compatibility
 
 `/fast on` or `agents.defaults.models["xai/<model>"].params.fastMode: true`
-rewrites native xAI requests as follows:
+still rewrites older xAI configurations as follows. These target ids are
+kept only for compatibility; use current selectable models for new
+configurations.
 
 | Source model  | Fast-mode target   |
 | ------------- | ------------------ |
@@ -161,17 +163,34 @@ rewrites native xAI requests as follows:
 | `grok-4`      | `grok-4-fast`      |
 | `grok-4-0709` | `grok-4-fast`      |
 
-### Legacy compatibility aliases
+### Legacy compatibility and moving aliases
 
-Legacy aliases normalize to the canonical bundled ids:
+Older aliases normalize as follows:
 
-| Legacy alias                                                                | Canonical id                          |
-| --------------------------------------------------------------------------- | ------------------------------------- |
-| `grok-code-fast-1`, `grok-code-fast`, `grok-code-fast-1-0825`               | `grok-build-0.1`                      |
-| `grok-4-fast-reasoning`                                                     | `grok-4-fast`                         |
-| `grok-4-1-fast-reasoning`                                                   | `grok-4-1-fast`                       |
-| `grok-4.20-reasoning`, `grok-4.20-experimental-beta-0304-reasoning`         | `grok-4.20-beta-latest-reasoning`     |
-| `grok-4.20-non-reasoning`, `grok-4.20-experimental-beta-0304-non-reasoning` | `grok-4.20-beta-latest-non-reasoning` |
+| Legacy alias                                                  | Normalized id    |
+| ------------------------------------------------------------- | ---------------- |
+| `grok-code-fast-1`, `grok-code-fast`, `grok-code-fast-1-0825` | `grok-build-0.1` |
+
+The dated 0309 ids are the selectable catalog entries. OpenClaw sends all other
+current Grok 4.20 aliases verbatim so xAI retains control of stable, latest,
+beta, experimental, and dated alias semantics. The global `grok-latest` alias is
+also preserved verbatim.
+
+xAI retired the following exact ids. OpenClaw keeps them as hidden compatibility
+rows for shipped configurations, with the limits and pricing of their current
+redirect targets:
+
+| Retired ids                                                          | Current behavior                 |
+| -------------------------------------------------------------------- | -------------------------------- |
+| `grok-4-1-fast-reasoning`, `grok-4-fast-reasoning`, `grok-4-0709`    | Grok 4.3 with `low` reasoning    |
+| `grok-4-1-fast-non-reasoning`, `grok-4-fast-non-reasoning`, `grok-3` | Grok 4.3 with reasoning disabled |
+| `grok-code-fast-1`                                                   | Grok Build 0.1                   |
+| `grok-imagine-image-pro`                                             | Grok Imagine Image Quality       |
+
+`openclaw doctor --fix` updates persisted xAI server-tool defaults and the
+retired quality image slug, removes stale generated catalog rows, and repairs
+stale context metadata on active 4.20 rows. It does not pin active 4.20
+`beta-latest` aliases to a dated snapshot.
 
 ## Features
 
@@ -302,8 +321,8 @@ Legacy aliases normalize to the canonical bundled ids:
 
     <Note>
     OpenClaw uses xAI's batch `/v1/tts` endpoint. xAI also offers streaming
-    TTS over WebSocket, but the OpenClaw speech provider contract currently
-    expects a complete audio buffer before reply delivery.
+    TTS over WebSocket, but the bundled xAI provider does not implement that
+    streaming hook yet.
     </Note>
 
   </Accordion>
@@ -405,7 +424,7 @@ Legacy aliases normalize to the canonical bundled ids:
     | Key               | Type    | Default                       | Description                          |
     | ----------------- | ------- | ------------------------------ | ------------------------------------- |
     | `enabled`         | boolean | `true` (if key available)     | Enable or disable x_search           |
-    | `model`           | string  | `grok-4-1-fast-non-reasoning` | Model used for x_search requests     |
+    | `model`           | string  | `grok-4.3`                    | Model used for x_search requests     |
     | `baseUrl`         | string  | -                              | xAI Responses base URL override      |
     | `inlineCitations` | boolean | -                              | Include inline citations in results  |
     | `maxTurns`        | number  | -                              | Maximum conversation turns            |
@@ -420,7 +439,7 @@ Legacy aliases normalize to the canonical bundled ids:
             config: {
               xSearch: {
                 enabled: true,
-                model: "grok-4-1-fast-non-reasoning",
+                model: "grok-4.3",
                 baseUrl: "https://api.x.ai/v1",
                 inlineCitations: true,
               },
@@ -442,7 +461,7 @@ Legacy aliases normalize to the canonical bundled ids:
     | Key              | Type    | Default                  | Description                            |
     | ---------------- | ------- | -------------------------- | ---------------------------------------- |
     | `enabled`        | boolean | `true` (if key available) | Enable or disable code execution        |
-    | `model`          | string  | `grok-4-1-fast`           | Model used for code execution requests  |
+    | `model`          | string  | `grok-4.3`                | Model used for code execution requests  |
     | `maxTurns`       | number  | -                           | Maximum conversation turns              |
     | `timeoutSeconds` | number  | `30`                        | Request timeout in seconds              |
 
@@ -458,7 +477,7 @@ Legacy aliases normalize to the canonical bundled ids:
             config: {
               codeExecution: {
                 enabled: true,
-                model: "grok-4-1-fast",
+                model: "grok-4.3",
               },
             },
           },
@@ -483,6 +502,9 @@ Legacy aliases normalize to the canonical bundled ids:
     - xAI Realtime voice is not registered as an OpenClaw provider yet. It
       needs a different bidirectional voice session contract than batch STT
       or streaming transcription.
+    - `grok-imagine-video-1.5` is not exposed yet. Unlike the classic video
+      model, it is image-to-video only and needs model-specific mode and 1080p
+      validation in the shared provider contract.
     - xAI image `quality`, image `mask`, and extra native-only aspect ratios
       are not exposed until the shared `image_generate` tool has
       corresponding cross-provider controls.
@@ -494,10 +516,12 @@ Legacy aliases normalize to the canonical bundled ids:
     - Native xAI requests default `tool_stream: true`. Set
       `agents.defaults.models["xai/<model>"].params.tool_stream` to `false`
       to disable it.
-    - The bundled xAI wrapper strips unsupported strict tool-schema flags and
-      reasoning *effort* payload keys before sending native xAI requests. Grok
-      4.5 supports low, medium, and high effort (default high); Grok 4.3 also
-      supports disabling reasoning. All other reasoning-capable xAI models request
+    - The bundled xAI wrapper strips unsupported contains-count schema bounds
+      and unsupported reasoning *effort* payload keys before sending native
+      xAI requests. Grok 4.5 supports low, medium, and
+      high effort (default high). Grok 4.3 supports none, low, medium, and high
+      effort (default low). Other reasoning-capable xAI models do not expose a
+      configurable effort control, but still request
       `include: ["reasoning.encrypted_content"]` so prior encrypted reasoning
       can be replayed on follow-up turns.
     - `web_search`, `x_search`, and `code_execution` are exposed as OpenClaw
@@ -522,6 +546,8 @@ The xAI media paths are covered by unit tests and opt-in live suites. Export
 ```bash
 pnpm test extensions/xai
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 pnpm test:live -- extensions/xai/xai.live.test.ts
+OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 pnpm test:live -- extensions/xai/x-search.live.test.ts
+OPENCLAW_LIVE_GATEWAY_MODELS="xai/grok-4.5,xai/grok-build-0.1,xai/grok-4.3,xai/grok-4.20-0309-reasoning,xai/grok-4.20-0309-non-reasoning" OPENCLAW_LIVE_GATEWAY_MAX_MODELS=0 OPENCLAW_LIVE_GATEWAY_SMOKE=0 pnpm test:live -- src/gateway/gateway-models.profiles.live.test.ts
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS=xai pnpm test:live -- test/image-generation.runtime.live.test.ts
 ```
 

--- a/docs/tools/code-execution.md
+++ b/docs/tools/code-execution.md
@@ -16,7 +16,7 @@ registered by the bundled `xai` plugin under the `tools` contract.
 | Tool name          | `code_execution`                                                                  |
 | Provider plugin    | `xai` (bundled, `enabledByDefault: true`)                                         |
 | Auth               | xAI auth profile, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` |
-| Default model      | `grok-4-1-fast`                                                                   |
+| Default model      | `grok-4.3`                                                                        |
 | Default timeout    | 30 seconds                                                                        |
 | Default `maxTurns` | unset (xAI applies its own internal limit)                                        |
 
@@ -89,7 +89,7 @@ For local execution, use [`exec`](/tools/exec) instead.
             config: {
               codeExecution: {
                 enabled: true,
-                model: "grok-4-1-fast", // override the default xAI code-execution model
+                model: "grok-4.3", // override the default xAI code-execution model
                 maxTurns: 2,            // optional cap on internal tool turns
                 timeoutSeconds: 30,     // request timeout (default: 30)
               },

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -437,7 +437,7 @@ active for the turn that actually calls it.
         config: {
           xSearch: {
             enabled: true,
-            model: "grok-4-1-fast-non-reasoning",
+            model: "grok-4.3",
             baseUrl: "https://api.x.ai/v1", // optional, overrides webSearch.baseUrl
             inlineCitations: false,
             maxTurns: 2,

--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -138,7 +138,6 @@ describe("xai code_execution tool", () => {
                   apiKey: "xai-config-test", // pragma: allowlist secret
                 },
                 codeExecution: {
-                  model: "grok-4-1-fast",
                   maxTurns: 2,
                   timeoutSeconds: 45,
                 },
@@ -156,7 +155,9 @@ describe("xai code_execution tool", () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(firstFetchUrl(mockFetch)).toContain("api.x.ai/v1/responses");
     const body = parseFirstRequestBody(mockFetch);
-    expect(body.model).toBe("grok-4-1-fast");
+    expect(body.model).toBe("grok-4.3");
+    expect(body.store).toBe(false);
+    expect(body.reasoning).toEqual({ effort: "low" });
     expect(body.max_turns).toBe(2);
     expect(body.tools).toEqual([{ type: "code_interpreter" }]);
     expect(

--- a/extensions/xai/doctor-contract-api.test.ts
+++ b/extensions/xai/doctor-contract-api.test.ts
@@ -1,0 +1,123 @@
+// Xai tests cover plugin-owned doctor compatibility migrations.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+
+describe("xAI doctor contract", () => {
+  it("detects and migrates retired server-tool defaults without changing other settings", () => {
+    const config = {
+      plugins: {
+        entries: {
+          xai: {
+            config: {
+              webSearch: { model: "grok-4-1-fast", timeoutSeconds: 60 },
+              xSearch: { model: "grok-4-1-fast-non-reasoning", inlineCitations: true },
+              codeExecution: { model: "grok-code-fast-1", maxTurns: 2 },
+            },
+          },
+        },
+      },
+      tools: {
+        web: {
+          search: { grok: { model: "grok-4-0709", baseUrl: "https://api.x.ai/v1" } },
+          x_search: { model: "grok-3", enabled: true },
+        },
+      },
+      models: {
+        providers: {
+          xai: {
+            baseUrl: "https://api.x.ai/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "grok-4-1-fast",
+                name: "Grok 4.1 Fast",
+                reasoning: true,
+                input: ["text", "image"],
+                cost: { input: 0.2, output: 0.5, cacheRead: 0.05, cacheWrite: 0 },
+                contextWindow: 2_000_000,
+                maxTokens: 30_000,
+              },
+              {
+                id: "grok-3-mini",
+                name: "Custom Grok 3 Mini",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0.3, output: 0.5, cacheRead: 0.075, cacheWrite: 0 },
+                contextWindow: 131_072,
+                maxTokens: 8_192,
+              },
+              { id: "grok-4.20-beta-latest-reasoning", name: "moving alias" },
+              { id: "custom-model", name: "custom" },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      legacyConfigRules.filter((rule) => rule.match(readPathForTest(config, rule.path))),
+    ).toHaveLength(4);
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toHaveLength(4);
+    expect(result.config).not.toBe(config);
+    expect(result.config.plugins?.entries?.xai?.config).toEqual({
+      webSearch: { model: "grok-4.3", timeoutSeconds: 60 },
+      xSearch: { model: "grok-4.3", inlineCitations: true },
+      codeExecution: { model: "grok-build-0.1", maxTurns: 2 },
+    });
+    expect(result.config.tools?.web).toEqual(config.tools?.web);
+    expect(result.config.models?.providers?.xai?.models).toEqual([
+      {
+        id: "grok-3-mini",
+        name: "Custom Grok 3 Mini",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0.3, output: 0.5, cacheRead: 0.075, cacheWrite: 0 },
+        contextWindow: 131_072,
+        maxTokens: 8_192,
+      },
+      { id: "grok-4.20-beta-latest-reasoning", name: "moving alias" },
+      { id: "custom-model", name: "custom" },
+    ]);
+    expect(config.plugins?.entries?.xai?.config).toMatchObject({
+      webSearch: { model: "grok-4-1-fast" },
+    });
+    expect(config.models?.providers?.xai?.models).toHaveLength(4);
+    expect(normalizeCompatibilityConfig({ cfg: result.config })).toEqual({
+      config: result.config,
+      changes: [],
+    });
+  });
+
+  it("leaves active aliases and intentional cross-mode choices unchanged", () => {
+    const config = {
+      plugins: {
+        entries: {
+          xai: {
+            config: {
+              webSearch: { model: "grok-4.20-beta-latest-reasoning" },
+              xSearch: { model: "grok-4-1-fast" },
+              codeExecution: { model: "grok-4-fast-non-reasoning" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(normalizeCompatibilityConfig({ cfg: config })).toEqual({ config, changes: [] });
+  });
+});
+
+function readPathForTest(root: unknown, path: readonly (string | number)[]): unknown {
+  let current = root;
+  for (const segment of path) {
+    if (!current || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string | number, unknown>)[segment];
+  }
+  return current;
+}

--- a/extensions/xai/doctor-contract-api.ts
+++ b/extensions/xai/doctor-contract-api.ts
@@ -1,0 +1,141 @@
+// Xai doctor contract repairs plugin-owned model configuration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isLegacyXaiBuiltinModel } from "./model-definitions.js";
+
+type LegacyConfigRule = {
+  path: Array<string | number>;
+  message: string;
+  match: (value: unknown) => boolean;
+};
+
+type PluginModelMigration = {
+  path: string[];
+  retiredModels: ReadonlySet<string>;
+  targetModel: string;
+};
+
+const RETIRED_REASONING_MODELS = new Set([
+  "grok-4-1-fast",
+  "grok-4-1-fast-reasoning",
+  "grok-4-fast",
+  "grok-4-fast-reasoning",
+  "grok-4-0709",
+]);
+const RETIRED_NON_REASONING_MODELS = new Set([
+  "grok-4-1-fast-non-reasoning",
+  "grok-4-fast-non-reasoning",
+  "grok-3",
+]);
+const RETIRED_CODE_MODELS = new Set([
+  "grok-code-fast-1",
+  "grok-code-fast",
+  "grok-code-fast-1-0825",
+]);
+
+const PLUGIN_MODEL_MIGRATIONS: PluginModelMigration[] = [
+  {
+    path: ["plugins", "entries", "xai", "config", "webSearch"],
+    retiredModels: RETIRED_REASONING_MODELS,
+    targetModel: "grok-4.3",
+  },
+  {
+    path: ["plugins", "entries", "xai", "config", "codeExecution"],
+    retiredModels: RETIRED_REASONING_MODELS,
+    targetModel: "grok-4.3",
+  },
+  {
+    path: ["plugins", "entries", "xai", "config", "xSearch"],
+    retiredModels: RETIRED_NON_REASONING_MODELS,
+    targetModel: "grok-4.3",
+  },
+  ...[
+    ["plugins", "entries", "xai", "config", "webSearch"],
+    ["plugins", "entries", "xai", "config", "codeExecution"],
+    ["plugins", "entries", "xai", "config", "xSearch"],
+  ].map((path) => ({ path, retiredModels: RETIRED_CODE_MODELS, targetModel: "grok-build-0.1" })),
+];
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readPath(root: unknown, path: readonly string[]): unknown {
+  let current = root;
+  for (const segment of path) {
+    current = asRecord(current)?.[segment];
+    if (current === undefined) {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function isRetiredToolModel(value: unknown, retiredModels: ReadonlySet<string>): boolean {
+  const model = asRecord(value)?.model;
+  return typeof model === "string" && retiredModels.has(model.trim().toLowerCase());
+}
+
+function hasLegacyBuiltinCatalogRows(value: unknown): boolean {
+  return Array.isArray(value) && value.some((model) => isLegacyXaiBuiltinModel(model));
+}
+
+export const legacyConfigRules: LegacyConfigRule[] = [
+  ...PLUGIN_MODEL_MIGRATIONS.map((migration) => ({
+    path: migration.path,
+    message: `${migration.path.join(".")}.model uses a retired xAI model; run "openclaw doctor --fix" to use ${migration.targetModel}.`,
+    match: (value: unknown) => isRetiredToolModel(value, migration.retiredModels),
+  })),
+  {
+    path: ["models", "providers", "xai", "models"],
+    message:
+      'models.providers.xai.models contains stale generated xAI catalog rows; run "openclaw doctor --fix" to remove them.',
+    match: hasLegacyBuiltinCatalogRows,
+  },
+];
+
+export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  let next = cfg;
+  const changes: string[] = [];
+
+  for (const migration of PLUGIN_MODEL_MIGRATIONS) {
+    const current = readPath(next, migration.path);
+    if (!isRetiredToolModel(current, migration.retiredModels)) {
+      continue;
+    }
+    if (next === cfg) {
+      next = structuredClone(cfg);
+    }
+    const target = asRecord(readPath(next, migration.path));
+    if (!target) {
+      continue;
+    }
+    const previous = target.model;
+    target.model = migration.targetModel;
+    changes.push(
+      `Updated ${migration.path.join(".")}.model from ${JSON.stringify(previous)} to ${JSON.stringify(migration.targetModel)}.`,
+    );
+  }
+
+  const modelsPath = ["models", "providers", "xai", "models"];
+  const configuredModels = readPath(next, modelsPath);
+  if (hasLegacyBuiltinCatalogRows(configuredModels)) {
+    if (next === cfg) {
+      next = structuredClone(cfg);
+    }
+    const provider = asRecord(readPath(next, ["models", "providers", "xai"]));
+    const models = provider?.models;
+    if (provider && Array.isArray(models)) {
+      const retained = models.filter((model) => !isLegacyXaiBuiltinModel(model));
+      const removed = models.length - retained.length;
+      provider.models = retained;
+      changes.push(`Removed ${removed} stale generated xAI model catalog row(s).`);
+    }
+  }
+
+  return { config: next, changes };
+}

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -109,6 +109,8 @@ describe("xai provider plugin", () => {
       response: Response.json({
         data: [
           { id: "grok-4.5", object: "model" },
+          { id: "grok-4.20-0309-reasoning", object: "model" },
+          { id: "grok-4.20-0309-non-reasoning", object: "model" },
           { id: "not-in-manifest", object: "model" },
         ],
       }),
@@ -123,6 +125,8 @@ describe("xai provider plugin", () => {
 
     expect(provider.apiKey).toBe("xai-key");
     expect(provider.models.map((model) => model.id)).toContain("grok-4.5");
+    expect(provider.models.map((model) => model.id)).toContain("grok-4.20-0309-reasoning");
+    expect(provider.models.map((model) => model.id)).toContain("grok-4.20-0309-non-reasoning");
     expect(provider.models.map((model) => model.id)).not.toContain("not-in-manifest");
     const fetchParams = vi.mocked(fetchGuard).mock.calls[0]?.[0];
     expect(fetchParams?.url).toBe("https://api.x.ai/v1/models");
@@ -591,7 +595,7 @@ describe("xai provider plugin", () => {
       model: createProviderModel({ id: "grok-4.3" }),
     } as never);
     expect(normalized?.thinkingLevelMap).toEqual({
-      off: null,
+      off: "none",
       minimal: "low",
       low: "low",
       medium: "medium",
@@ -616,10 +620,12 @@ describe("xai provider plugin", () => {
           toolSchemaProfile?: string;
           nativeWebSearchTool?: boolean;
           toolCallArgumentsEncoding?: string;
+          unsupportedToolSchemaKeywords?: string[];
         }
       | undefined;
     expect(normalizedCompat?.toolSchemaProfile).toBe("xai");
     expect(normalizedCompat?.nativeWebSearchTool).toBe(true);
     expect(normalizedCompat?.toolCallArgumentsEncoding).toBe("html-entities");
+    expect(normalizedCompat?.unsupportedToolSchemaKeywords).toEqual(["minContains", "maxContains"]);
   });
 });

--- a/extensions/xai/model-compat.ts
+++ b/extensions/xai/model-compat.ts
@@ -9,14 +9,9 @@ export { normalizeXaiModelId as normalizeNativeXaiModelId } from "./model-id.js"
 export const XAI_TOOL_SCHEMA_PROFILE = "xai";
 export const HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING = "html-entities";
 
-const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
-  "minLength",
-  "maxLength",
-  "minItems",
-  "maxItems",
-  "minContains",
-  "maxContains",
-]);
+// Native xAI accepts common length/item bounds; only contains-count bounds remain
+// outside its documented schema contract. Proxy providers own stricter downstream policy.
+const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["minContains", "maxContains"]);
 
 function resolveXaiModelCompatPatch(): ModelCompatConfig {
   return {

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -1,18 +1,15 @@
 // Xai plugin module implements model definitions behavior.
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeXaiModelId } from "./model-id.js";
 
 export const XAI_BASE_URL = "https://api.x.ai/v1";
 export const XAI_DEFAULT_IMAGE_MODEL = "grok-imagine-image";
 export const XAI_IMAGE_MODELS = ["grok-imagine-image", "grok-imagine-image-quality"] as const;
 export const XAI_DEFAULT_CONTEXT_WINDOW = 1_000_000;
-const XAI_LARGE_CONTEXT_WINDOW = 2_000_000;
 const XAI_GROK_45_CONTEXT_WINDOW = 500_000;
-const XAI_GROK_4_CONTEXT_WINDOW = 256_000;
 const XAI_CODE_CONTEXT_WINDOW = 256_000;
 export const XAI_DEFAULT_MAX_TOKENS = 64_000;
-const XAI_LEGACY_CONTEXT_WINDOW = 131_072;
-const XAI_LEGACY_MAX_TOKENS = 8_192;
 export const XAI_DEFAULT_MODEL_ID = "grok-4.3";
 
 type XaiCost = ModelDefinitionConfig["cost"];
@@ -26,20 +23,6 @@ type XaiCatalogEntry = {
   maxTokens?: number;
   cost: XaiCost;
 };
-
-const XAI_GROK_4_COST = {
-  input: 3,
-  output: 15,
-  cacheRead: 0.75,
-  cacheWrite: 0,
-} satisfies XaiCost;
-
-const XAI_FAST_COST = {
-  input: 0.2,
-  output: 0.5,
-  cacheRead: 0.05,
-  cacheWrite: 0,
-} satisfies XaiCost;
 
 const XAI_GROK_420_COST = {
   input: 1.25,
@@ -69,13 +52,6 @@ const XAI_GROK_BUILD_COST = {
   cacheWrite: 0,
 } satisfies XaiCost;
 
-const XAI_CODE_FAST_COST = {
-  input: 0.2,
-  output: 1.5,
-  cacheRead: 0.02,
-  cacheWrite: 0,
-} satisfies XaiCost;
-
 const XAI_MODEL_CATALOG = [
   {
     id: "grok-4.5",
@@ -99,36 +75,36 @@ const XAI_MODEL_CATALOG = [
     name: "Grok 3",
     reasoning: false,
     input: ["text"],
-    contextWindow: XAI_LEGACY_CONTEXT_WINDOW,
-    maxTokens: XAI_LEGACY_MAX_TOKENS,
-    cost: XAI_GROK_4_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-3-fast",
     name: "Grok 3 Fast",
     reasoning: false,
     input: ["text"],
-    contextWindow: XAI_LEGACY_CONTEXT_WINDOW,
-    maxTokens: XAI_LEGACY_MAX_TOKENS,
-    cost: { input: 5, output: 25, cacheRead: 1.25, cacheWrite: 0 },
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-3-mini",
     name: "Grok 3 Mini",
     reasoning: true,
     input: ["text"],
-    contextWindow: XAI_LEGACY_CONTEXT_WINDOW,
-    maxTokens: XAI_LEGACY_MAX_TOKENS,
-    cost: { input: 0.3, output: 0.5, cacheRead: 0.075, cacheWrite: 0 },
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-3-mini-fast",
     name: "Grok 3 Mini Fast",
     reasoning: true,
     input: ["text"],
-    contextWindow: XAI_LEGACY_CONTEXT_WINDOW,
-    maxTokens: XAI_LEGACY_MAX_TOKENS,
-    cost: { input: 0.6, output: 4, cacheRead: 0.15, cacheWrite: 0 },
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4.3",
@@ -144,70 +120,70 @@ const XAI_MODEL_CATALOG = [
     name: "Grok 4",
     reasoning: true,
     input: ["text"],
-    contextWindow: XAI_GROK_4_CONTEXT_WINDOW,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
     maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_4_COST,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4-0709",
     name: "Grok 4 0709",
-    reasoning: false,
+    reasoning: true,
     input: ["text"],
-    contextWindow: XAI_GROK_4_CONTEXT_WINDOW,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
     maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_4_COST,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4-fast",
     name: "Grok 4 Fast",
     reasoning: true,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_FAST_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4-fast-non-reasoning",
     name: "Grok 4 Fast (Non-Reasoning)",
     reasoning: false,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_FAST_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4-1-fast",
     name: "Grok 4.1 Fast",
     reasoning: true,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_FAST_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
     id: "grok-4-1-fast-non-reasoning",
     name: "Grok 4.1 Fast (Non-Reasoning)",
     reasoning: false,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_FAST_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+    cost: XAI_GROK_43_COST,
   },
   {
-    id: "grok-4.20-beta-latest-reasoning",
-    name: "Grok 4.20 Beta Latest (Reasoning)",
+    id: "grok-4.20-0309-reasoning",
+    name: "Grok 4.20 0309 (Reasoning)",
     reasoning: true,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
     maxTokens: 30_000,
     cost: XAI_GROK_420_COST,
   },
   {
-    id: "grok-4.20-beta-latest-non-reasoning",
-    name: "Grok 4.20 Beta Latest (Non-Reasoning)",
+    id: "grok-4.20-0309-non-reasoning",
+    name: "Grok 4.20 0309 (Non-Reasoning)",
     reasoning: false,
     input: ["text", "image"],
-    contextWindow: XAI_LARGE_CONTEXT_WINDOW,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
     maxTokens: 30_000,
     cost: XAI_GROK_420_COST,
   },
@@ -217,39 +193,117 @@ const XAI_SELECTABLE_MODEL_IDS = new Set<string>([
   "grok-4.5",
   "grok-build-0.1",
   "grok-4.3",
-  "grok-4.20-beta-latest-reasoning",
-  "grok-4.20-beta-latest-non-reasoning",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
 ]);
 
-const XAI_GROK_BUILD_ALIASES = new Set<string>([
-  "grok-code-fast-1",
-  "grok-code-fast",
-  "grok-code-fast-1-0825",
-]);
+type LegacyXaiBuiltinSignature = readonly [
+  name: string,
+  reasoning: boolean,
+  input: string,
+  contextWindow: number,
+  maxTokens: number,
+  inputCost: number,
+  outputCost: number,
+  cacheReadCost: number,
+  cacheWriteCost: number,
+];
 
-const XAI_RETIRED_BUILTIN_MODEL_IDS = new Set<string>(
-  XAI_MODEL_CATALOG.map((entry) => entry.id).filter((id) => !XAI_SELECTABLE_MODEL_IDS.has(id)),
-);
+const LEGACY_XAI_BUILTIN_SIGNATURES = {
+  "grok-3": ["Grok 3", false, "text", 131_072, 8_192, 3, 15, 0.75, 0],
+  "grok-3-fast": ["Grok 3 Fast", false, "text", 131_072, 8_192, 5, 25, 1.25, 0],
+  "grok-3-mini": ["Grok 3 Mini", true, "text", 131_072, 8_192, 0.3, 0.5, 0.075, 0],
+  "grok-3-mini-fast": ["Grok 3 Mini Fast", true, "text", 131_072, 8_192, 0.6, 4, 0.15, 0],
+  "grok-4": ["Grok 4", true, "text", 256_000, 64_000, 3, 15, 0.75, 0],
+  "grok-4-0709": ["Grok 4 0709", false, "text", 256_000, 64_000, 3, 15, 0.75, 0],
+  "grok-4-fast": ["Grok 4 Fast", true, "text,image", 2_000_000, 30_000, 0.2, 0.5, 0.05, 0],
+  "grok-4-fast-non-reasoning": [
+    "Grok 4 Fast (Non-Reasoning)",
+    false,
+    "text,image",
+    2_000_000,
+    30_000,
+    0.2,
+    0.5,
+    0.05,
+    0,
+  ],
+  "grok-4-1-fast": ["Grok 4.1 Fast", true, "text,image", 2_000_000, 30_000, 0.2, 0.5, 0.05, 0],
+  "grok-4-1-fast-non-reasoning": [
+    "Grok 4.1 Fast (Non-Reasoning)",
+    false,
+    "text,image",
+    2_000_000,
+    30_000,
+    0.2,
+    0.5,
+    0.05,
+    0,
+  ],
+} satisfies Record<string, LegacyXaiBuiltinSignature>;
+
+const LEGACY_MODEL_KEYS = new Set([
+  "id",
+  "name",
+  "reasoning",
+  "input",
+  "cost",
+  "contextWindow",
+  "maxTokens",
+]);
+const LEGACY_COST_KEYS = new Set(["input", "output", "cacheRead", "cacheWrite"]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
 
 function normalizeXaiCatalogModelId(modelId: string): string {
   const lower = normalizeOptionalLowercaseString(modelId) ?? "";
   const unprefixed = lower.startsWith("xai/") ? lower.slice("xai/".length) : lower;
-  if (unprefixed === "grok-build-latest") {
-    return "grok-4.5";
-  }
-  if (XAI_GROK_BUILD_ALIASES.has(unprefixed)) {
-    return "grok-build-0.1";
-  }
-  return unprefixed;
+  return normalizeXaiModelId(unprefixed);
 }
 
-export function isRetiredXaiBuiltinModelId(modelId: string): boolean {
-  const lower = normalizeOptionalLowercaseString(modelId) ?? "";
-  const unprefixed = lower.startsWith("xai/") ? lower.slice("xai/".length) : lower;
-  if (XAI_GROK_BUILD_ALIASES.has(unprefixed)) {
-    return true;
+export function isLegacyXaiBuiltinModel(model: unknown): boolean {
+  const record = asRecord(model);
+  const id = normalizeOptionalLowercaseString(record?.id);
+  const signature = id
+    ? LEGACY_XAI_BUILTIN_SIGNATURES[id as keyof typeof LEGACY_XAI_BUILTIN_SIGNATURES]
+    : undefined;
+  const cost = asRecord(record?.cost);
+  if (!record || !signature || !cost) {
+    return false;
   }
-  return XAI_RETIRED_BUILTIN_MODEL_IDS.has(normalizeXaiCatalogModelId(modelId));
+  if (
+    Object.keys(record).some((key) => !LEGACY_MODEL_KEYS.has(key)) ||
+    Object.keys(cost).some((key) => !LEGACY_COST_KEYS.has(key))
+  ) {
+    return false;
+  }
+  const [
+    name,
+    reasoning,
+    input,
+    contextWindow,
+    maxTokens,
+    inputCost,
+    outputCost,
+    cacheReadCost,
+    cacheWriteCost,
+  ] = signature;
+  return (
+    record.name === name &&
+    record.reasoning === reasoning &&
+    Array.isArray(record.input) &&
+    record.input.join(",") === input &&
+    record.contextWindow === contextWindow &&
+    record.maxTokens === maxTokens &&
+    cost.input === inputCost &&
+    cost.output === outputCost &&
+    cost.cacheRead === cacheReadCost &&
+    cost.cacheWrite === cacheWriteCost
+  );
 }
 
 function toModelDefinition(entry: XaiCatalogEntry): ModelDefinitionConfig {
@@ -293,19 +347,19 @@ export function resolveXaiCatalogEntry(modelId: string) {
   if (exact) {
     return toModelDefinition(exact);
   }
-  if (lower.includes("multi-agent")) {
-    return undefined;
-  }
-  if (lower.startsWith("grok-code-fast")) {
+  if (lower === "grok-latest") {
     return toModelDefinition({
       id: trimmed,
       name: trimmed,
       reasoning: true,
-      input: ["text"],
-      contextWindow: XAI_CODE_CONTEXT_WINDOW,
-      maxTokens: 10_000,
-      cost: XAI_CODE_FAST_COST,
+      input: ["text", "image"],
+      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: XAI_DEFAULT_MAX_TOKENS,
+      cost: XAI_GROK_43_COST,
     });
+  }
+  if (lower.includes("multi-agent")) {
+    return undefined;
   }
   if (
     lower.startsWith("grok-3-mini-fast") ||
@@ -313,21 +367,14 @@ export function resolveXaiCatalogEntry(modelId: string) {
     lower.startsWith("grok-3-fast") ||
     lower.startsWith("grok-3")
   ) {
-    const legacyCost = lower.startsWith("grok-3-mini-fast")
-      ? { input: 0.6, output: 4, cacheRead: 0.15, cacheWrite: 0 }
-      : lower.startsWith("grok-3-mini")
-        ? { input: 0.3, output: 0.5, cacheRead: 0.075, cacheWrite: 0 }
-        : lower.startsWith("grok-3-fast")
-          ? { input: 5, output: 25, cacheRead: 1.25, cacheWrite: 0 }
-          : XAI_GROK_4_COST;
     return toModelDefinition({
       id: trimmed,
       name: trimmed,
       reasoning: lower.includes("mini"),
       input: ["text"],
-      contextWindow: XAI_LEGACY_CONTEXT_WINDOW,
-      maxTokens: XAI_LEGACY_MAX_TOKENS,
-      cost: legacyCost,
+      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: XAI_DEFAULT_MAX_TOKENS,
+      cost: XAI_GROK_43_COST,
     });
   }
   if (
@@ -344,31 +391,31 @@ export function resolveXaiCatalogEntry(modelId: string) {
       input: ["text", "image"],
       contextWindow: lower.startsWith("grok-4.5")
         ? XAI_GROK_45_CONTEXT_WINDOW
-        : lower.startsWith("grok-4.3")
-          ? XAI_DEFAULT_CONTEXT_WINDOW
-          : XAI_LARGE_CONTEXT_WINDOW,
+        : XAI_DEFAULT_CONTEXT_WINDOW,
       maxTokens:
         lower.startsWith("grok-4.5") || lower.startsWith("grok-4.3")
           ? XAI_DEFAULT_MAX_TOKENS
-          : 30_000,
+          : lower.startsWith("grok-4.20")
+            ? 30_000
+            : XAI_DEFAULT_MAX_TOKENS,
       cost: lower.startsWith("grok-4.5")
         ? XAI_GROK_45_COST
         : lower.startsWith("grok-4.3")
           ? XAI_GROK_43_COST
           : lower.startsWith("grok-4.20")
             ? XAI_GROK_420_COST
-            : XAI_FAST_COST,
+            : XAI_GROK_43_COST,
     });
   }
   if (lower.startsWith("grok-4")) {
     return toModelDefinition({
       id: modelId.trim(),
       name: modelId.trim(),
-      reasoning: lower.includes("reasoning"),
+      reasoning: !lower.includes("non-reasoning"),
       input: ["text"],
-      contextWindow: XAI_GROK_4_CONTEXT_WINDOW,
+      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
       maxTokens: XAI_DEFAULT_MAX_TOKENS,
-      cost: XAI_GROK_4_COST,
+      cost: XAI_GROK_43_COST,
     });
   }
   return undefined;

--- a/extensions/xai/model-id.test.ts
+++ b/extensions/xai/model-id.test.ts
@@ -3,35 +3,40 @@ import { describe, expect, it } from "vitest";
 import { normalizeXaiModelId } from "./api.js";
 
 describe("normalizeXaiModelId", () => {
+  it("normalizes family-specific aliases but preserves the global alias", () => {
+    expect(normalizeXaiModelId("grok-4.3-latest")).toBe("grok-4.3");
+    expect(normalizeXaiModelId("grok-latest")).toBe("grok-latest");
+    expect(normalizeXaiModelId("grok-4.5-latest")).toBe("grok-4.5");
+  });
+
   it("normalizes the current Grok Build alias", () => {
     expect(normalizeXaiModelId("grok-build-latest")).toBe("grok-4.5");
   });
 
-  it("maps deprecated grok 4.20 beta ids to GA ids", () => {
+  it("preserves provider-owned Grok 4.20 aliases", () => {
     expect(normalizeXaiModelId("grok-4.20-experimental-beta-0304-reasoning")).toBe(
-      "grok-4.20-beta-latest-reasoning",
+      "grok-4.20-experimental-beta-0304-reasoning",
     );
     expect(normalizeXaiModelId("grok-4.20-experimental-beta-0304-non-reasoning")).toBe(
-      "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-experimental-beta-0304-non-reasoning",
     );
   });
 
-  it("maps older fast and 4.20 ids to the current OpenClaw-backed ids", () => {
+  it("maps retired code and fast ids to current OpenClaw-backed ids", () => {
     expect(normalizeXaiModelId("grok-code-fast-1")).toBe("grok-build-0.1");
     expect(normalizeXaiModelId("grok-code-fast")).toBe("grok-build-0.1");
     expect(normalizeXaiModelId("grok-code-fast-1-0825")).toBe("grok-build-0.1");
     expect(normalizeXaiModelId("grok-4-fast-reasoning")).toBe("grok-4-fast");
     expect(normalizeXaiModelId("grok-4-1-fast-reasoning")).toBe("grok-4-1-fast");
-    expect(normalizeXaiModelId("grok-4.20-reasoning")).toBe("grok-4.20-beta-latest-reasoning");
-    expect(normalizeXaiModelId("grok-4.20-non-reasoning")).toBe(
-      "grok-4.20-beta-latest-non-reasoning",
-    );
+    expect(normalizeXaiModelId("grok-4.20-reasoning")).toBe("grok-4.20-reasoning");
+    expect(normalizeXaiModelId("grok-4.20-non-reasoning")).toBe("grok-4.20-non-reasoning");
   });
 
   it("leaves current xai model ids unchanged", () => {
     expect(normalizeXaiModelId("grok-4.20-beta-latest-reasoning")).toBe(
       "grok-4.20-beta-latest-reasoning",
     );
+    expect(normalizeXaiModelId("grok-4.20-0309-reasoning")).toBe("grok-4.20-0309-reasoning");
     expect(normalizeXaiModelId("grok-4")).toBe("grok-4");
   });
 });

--- a/extensions/xai/model-id.ts
+++ b/extensions/xai/model-id.ts
@@ -1,5 +1,11 @@
 // Xai plugin module implements model id behavior.
 export function normalizeXaiModelId(id: string): string {
+  if (id === "grok-4.3-latest") {
+    return "grok-4.3";
+  }
+  if (id === "grok-4.5-latest") {
+    return "grok-4.5";
+  }
   if (id === "grok-build-latest") {
     return "grok-4.5";
   }
@@ -11,18 +17,6 @@ export function normalizeXaiModelId(id: string): string {
   }
   if (id === "grok-4-1-fast-reasoning") {
     return "grok-4-1-fast";
-  }
-  if (id === "grok-4.20-experimental-beta-0304-reasoning") {
-    return "grok-4.20-beta-latest-reasoning";
-  }
-  if (id === "grok-4.20-experimental-beta-0304-non-reasoning") {
-    return "grok-4.20-beta-latest-non-reasoning";
-  }
-  if (id === "grok-4.20-reasoning") {
-    return "grok-4.20-beta-latest-reasoning";
-  }
-  if (id === "grok-4.20-non-reasoning") {
-    return "grok-4.20-beta-latest-non-reasoning";
   }
   return id;
 }

--- a/extensions/xai/onboard.test.ts
+++ b/extensions/xai/onboard.test.ts
@@ -49,6 +49,15 @@ describe("xai onboard", () => {
         contextWindow: 1000,
         maxTokens: 100,
       },
+      {
+        id: "grok-4.20-beta-latest-reasoning",
+        name: "Custom Moving Grok 4.20",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+        contextWindow: 2_000_000,
+        maxTokens: 30_000,
+      },
     );
 
     const cfg = applyXaiProviderConfig(legacy);
@@ -58,12 +67,20 @@ describe("xai onboard", () => {
     expect(cfg.models?.providers?.xai?.apiKey).toBe("old-key");
     expect(cfg.models?.providers?.xai?.models.map((m) => m.id)).toEqual([
       "custom-model",
+      "grok-3",
+      "grok-code-fast-1",
+      "grok-4.20-beta-latest-reasoning",
       "grok-4.5",
       "grok-build-0.1",
       "grok-4.3",
-      "grok-4.20-beta-latest-reasoning",
-      "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-0309-reasoning",
+      "grok-4.20-0309-non-reasoning",
     ]);
+    expect(
+      cfg.models?.providers?.xai?.models.find(
+        (model) => model.id === "grok-4.20-beta-latest-reasoning",
+      )?.name,
+    ).toBe("Custom Moving Grok 4.20");
   });
 
   it("publishes current xAI models newest first for fresh setup", () => {
@@ -75,8 +92,8 @@ describe("xai onboard", () => {
       "grok-4.5",
       "grok-build-0.1",
       "grok-4.3",
-      "grok-4.20-beta-latest-reasoning",
-      "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-0309-reasoning",
+      "grok-4.20-0309-non-reasoning",
     ]);
   });
 

--- a/extensions/xai/onboard.ts
+++ b/extensions/xai/onboard.ts
@@ -3,8 +3,12 @@ import {
   createModelCatalogPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
-import { XAI_BASE_URL, XAI_DEFAULT_MODEL_ID } from "./model-definitions.js";
-import { buildXaiCatalogModels, isRetiredXaiBuiltinModelId } from "./model-definitions.js";
+import {
+  buildXaiCatalogModels,
+  isLegacyXaiBuiltinModel,
+  XAI_BASE_URL,
+  XAI_DEFAULT_MODEL_ID,
+} from "./model-definitions.js";
 
 export const XAI_DEFAULT_MODEL_REF = `xai/${XAI_DEFAULT_MODEL_ID}`;
 
@@ -26,7 +30,7 @@ function pruneRetiredXaiBuiltinModels(cfg: OpenClawConfig): OpenClawConfig {
   if (!provider || !Array.isArray(provider.models)) {
     return cfg;
   }
-  const models = provider.models.filter((model) => !isRetiredXaiBuiltinModelId(model.id));
+  const models = provider.models.filter((model) => !isLegacyXaiBuiltinModel(model));
   if (models.length === provider.models.length) {
     return cfg;
   }

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -5,16 +5,17 @@
   },
   "enabledByDefault": true,
   "providers": ["xai"],
+  "providerAuthAliases": {
+    "x-ai": "xai"
+  },
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelIdNormalization": {
     "providers": {
       "xai": {
         "aliases": {
-          "grok-build-latest": "grok-4.5",
-          "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-beta-latest-reasoning",
-          "grok-4.20-experimental-beta-0304-non-reasoning": "grok-4.20-beta-latest-non-reasoning",
-          "grok-4.20-reasoning": "grok-4.20-beta-latest-reasoning",
-          "grok-4.20-non-reasoning": "grok-4.20-beta-latest-non-reasoning"
+          "grok-4.3-latest": "grok-4.3",
+          "grok-4.5-latest": "grok-4.5",
+          "grok-build-latest": "grok-4.5"
         }
       }
     }

--- a/extensions/xai/openclaw.plugin.test.ts
+++ b/extensions/xai/openclaw.plugin.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 const manifest = JSON.parse(
   readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
 ) as {
+  providerAuthAliases?: Record<string, string>;
   modelIdNormalization?: {
     providers?: Record<string, { aliases?: Record<string, string> }>;
   };
@@ -23,10 +24,37 @@ const XAI_MULTI_AGENT_MODELS = [
 ] as const;
 
 describe("xAI plugin manifest", () => {
+  it("owns the shipped x-ai auth alias", () => {
+    expect(manifest.providerAuthAliases).toEqual({ "x-ai": "xai" });
+  });
+
   it("normalizes the Grok Build latest alias to Grok 4.5", () => {
     expect(manifest.modelIdNormalization?.providers?.xai?.aliases?.["grok-build-latest"]).toBe(
       "grok-4.5",
     );
+  });
+
+  it("normalizes current flagship aliases", () => {
+    expect(manifest.modelIdNormalization?.providers?.xai?.aliases).toMatchObject({
+      "grok-4.3-latest": "grok-4.3",
+      "grok-4.5-latest": "grok-4.5",
+    });
+    expect(manifest.modelIdNormalization?.providers?.xai?.aliases).not.toHaveProperty(
+      "grok-latest",
+    );
+  });
+
+  it("preserves all provider-owned Grok 4.20 aliases", () => {
+    for (const id of [
+      "grok-4.20-reasoning",
+      "grok-4.20-non-reasoning",
+      "grok-4.20-beta-latest-reasoning",
+      "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-experimental-beta-0304-reasoning",
+      "grok-4.20-experimental-beta-0304-non-reasoning",
+    ]) {
+      expect(manifest.modelIdNormalization?.providers?.xai?.aliases).not.toHaveProperty(id);
+    }
   });
 
   it("suppresses the unsupported multi-agent model aliases", () => {

--- a/extensions/xai/provider-discovery.ts
+++ b/extensions/xai/provider-discovery.ts
@@ -20,7 +20,7 @@ function resolveXaiSyntheticAuth(config: unknown) {
 const xaiProviderDiscovery: ProviderPlugin = {
   id: PROVIDER_ID,
   label: "xAI",
-  docsPath: "/providers/models",
+  docsPath: "/providers/xai",
   auth: [],
   resolveSyntheticAuth: ({ config }) => resolveXaiSyntheticAuth(config),
 };

--- a/extensions/xai/provider-policy-api.test.ts
+++ b/extensions/xai/provider-policy-api.test.ts
@@ -3,21 +3,24 @@ import { describe, expect, it } from "vitest";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("xai provider thinking policy", () => {
-  it("exposes thinking levels for reasoning-capable xAI models", () => {
-    const profile = resolveThinkingProfile({
-      provider: "xai",
-      modelId: "grok-4.3",
-    });
+  it.each(["grok-4.3", "grok-4.3-latest", "grok-latest"])(
+    "exposes Grok 4.3 thinking levels for %s",
+    (modelId) => {
+      const profile = resolveThinkingProfile({
+        provider: "xai",
+        modelId,
+      });
 
-    expect(profile.defaultLevel).toBe("low");
-    expect(profile.levels.map((level) => level.id)).toEqual([
-      "off",
-      "minimal",
-      "low",
-      "medium",
-      "high",
-    ]);
-  });
+      expect(profile.defaultLevel).toBe("low");
+      expect(profile.levels.map((level) => level.id)).toEqual([
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+      ]);
+    },
+  );
 
   it.each(["grok-4.5", "grok-4.5-latest", "grok-build-latest"])(
     "uses xAI's high reasoning default for %s",
@@ -50,4 +53,14 @@ describe("xai provider thinking policy", () => {
       }),
     ).toEqual({ levels: [{ id: "off" }], defaultLevel: "off" });
   });
+
+  it.each(["grok-build-0.1", "grok-4.20-0309-reasoning", "grok-4.20-beta-latest-reasoning"])(
+    "does not advertise configurable reasoning for %s",
+    (modelId) => {
+      expect(resolveThinkingProfile({ provider: "xai", modelId })).toEqual({
+        levels: [{ id: "off" }],
+        defaultLevel: "off",
+      });
+    },
+  );
 });

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -4,6 +4,7 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
+import { normalizeXaiModelId } from "./model-id.js";
 
 export function resolveThinkingProfile(
   ctx: ProviderDefaultThinkingPolicyContext,
@@ -12,14 +13,18 @@ export function resolveThinkingProfile(
   if (ctx.provider !== "xai" || !reasoning) {
     return { levels: [{ id: "off" }], defaultLevel: "off" };
   }
-  const modelId = ctx.modelId.trim().toLowerCase();
-  const isGrok45 =
-    modelId === "grok-4.5" || modelId.startsWith("grok-4.5-") || modelId === "grok-build-latest";
+  const modelId = normalizeXaiModelId(ctx.modelId.trim().toLowerCase());
+  const isGrok45 = modelId === "grok-4.5" || modelId.startsWith("grok-4.5-");
   if (isGrok45) {
     return {
       levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
       defaultLevel: "high",
     };
+  }
+  const isGrok43 =
+    modelId === "grok-latest" || modelId === "grok-4.3" || modelId.startsWith("grok-4.3-");
+  if (!isGrok43) {
+    return { levels: [{ id: "off" }], defaultLevel: "off" };
   }
   return {
     levels: [{ id: "off" }, { id: "minimal" }, { id: "low" }, { id: "medium" }, { id: "high" }],

--- a/extensions/xai/runtime-model-compat.test.ts
+++ b/extensions/xai/runtime-model-compat.test.ts
@@ -12,10 +12,10 @@ describe("xai runtime model compat", () => {
 
     expect(model.compat).toMatchObject({
       supportsReasoningEffort: true,
-      supportedReasoningEfforts: ["low", "medium", "high"],
+      supportedReasoningEfforts: ["none", "low", "medium", "high"],
     });
     expect(model.thinkingLevelMap).toEqual({
-      off: null,
+      off: "none",
       minimal: "low",
       low: "low",
       medium: "medium",
@@ -64,7 +64,7 @@ describe("xai runtime model compat", () => {
 
   it("does not advertise configurable reasoning effort for older xAI reasoning models", () => {
     const model = applyXaiRuntimeModelCompat({
-      id: "grok-4.20-beta-latest-reasoning",
+      id: "grok-4.20-0309-reasoning",
       provider: "xai",
       reasoning: true,
     });

--- a/extensions/xai/runtime-model-compat.ts
+++ b/extensions/xai/runtime-model-compat.ts
@@ -33,23 +33,29 @@ const XAI_REASONING_EFFORTS = {
 
 const XAI_SUPPORTED_REASONING_EFFORTS = ["low", "medium", "high"] as const;
 
+function isGrok43Model(id: string): boolean {
+  return id === "grok-latest" || id === "grok-4.3" || id.startsWith("grok-4.3-");
+}
+
 function normalizeXaiCompatModelId(id: unknown): string {
   return typeof id === "string" ? id.trim().toLowerCase() : "";
 }
 
 function supportsConfigurableXaiReasoningEffort(model: XaiRuntimeModelCompat): boolean {
   const id = normalizeXaiCompatModelId(model.id);
-  const isConfigurableModel = ["grok-4.3", "grok-4.5"].some(
-    (prefix) => id === prefix || id.startsWith(`${prefix}-`),
-  );
+  const isConfigurableModel = isGrok43Model(id) || id === "grok-4.5" || id.startsWith("grok-4.5-");
   return model.reasoning === true && isConfigurableModel;
 }
 
 function resolveXaiReasoningEffortCompat(model: XaiRuntimeModelCompat): Record<string, unknown> {
   if (supportsConfigurableXaiReasoningEffort(model)) {
+    const id = normalizeXaiCompatModelId(model.id);
     return {
       supportsReasoningEffort: true,
-      supportedReasoningEfforts: [...XAI_SUPPORTED_REASONING_EFFORTS],
+      supportedReasoningEfforts: [
+        ...(isGrok43Model(id) ? ["none"] : []),
+        ...XAI_SUPPORTED_REASONING_EFFORTS,
+      ],
     };
   }
   return { supportsReasoningEffort: false };
@@ -60,6 +66,7 @@ export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
 ): T & { compat: Record<string, unknown>; thinkingLevelMap: XaiThinkingLevelMap } {
   const withCompat = applyXaiModelCompat(model);
   const supportsReasoningEffort = supportsConfigurableXaiReasoningEffort(withCompat);
+  const id = normalizeXaiCompatModelId(withCompat.id);
   const existingCompat =
     withCompat.compat && typeof withCompat.compat === "object"
       ? (withCompat.compat as Record<string, unknown>)
@@ -73,6 +80,7 @@ export function applyXaiRuntimeModelCompat<T extends XaiRuntimeModelCompat>(
     thinkingLevelMap: {
       ...withCompat.thinkingLevelMap,
       ...(supportsReasoningEffort ? XAI_REASONING_EFFORTS : XAI_UNSUPPORTED_REASONING_EFFORTS),
+      ...(supportsReasoningEffort && isGrok43Model(id) ? { off: "none" } : {}),
     },
   };
 }

--- a/extensions/xai/src/code-execution-shared.ts
+++ b/extensions/xai/src/code-execution-shared.ts
@@ -1,6 +1,7 @@
 // Xai plugin module implements code execution shared behavior.
 import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import { postTrustedWebToolsJson } from "openclaw/plugin-sdk/provider-web-search";
+import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import {
   buildXaiResponsesToolBody,
   requireXaiResponseTextAndCitations,
@@ -13,7 +14,7 @@ import {
 import type { XaiWebSearchResponse } from "./web-search-shared.js";
 
 const XAI_CODE_EXECUTION_ENDPOINT = XAI_RESPONSES_ENDPOINT;
-const XAI_DEFAULT_CODE_EXECUTION_MODEL = "grok-4-1-fast";
+const XAI_DEFAULT_CODE_EXECUTION_MODEL = XAI_DEFAULT_MODEL_ID;
 
 type XaiCodeExecutionResponse = XaiWebSearchResponse & {
   output?: Array<{
@@ -79,6 +80,7 @@ export async function requestXaiCodeExecution(params: {
         inputText: params.task,
         tools: [{ type: "code_interpreter" }],
         maxTurns: params.maxTurns,
+        reasoningEffort: params.model === XAI_DEFAULT_CODE_EXECUTION_MODEL ? "low" : undefined,
       }),
       errorLabel: "xAI",
     },

--- a/extensions/xai/src/responses-tool-shared.test.ts
+++ b/extensions/xai/src/responses-tool-shared.test.ts
@@ -6,16 +6,34 @@ describe("xai responses tool helpers", () => {
   it("builds the shared xAI Responses tool body", () => {
     expect(
       testing.buildXaiResponsesToolBody({
-        model: "grok-4-1-fast",
+        model: "grok-4.3",
         inputText: "search for openclaw",
         tools: [{ type: "x_search" }],
         maxTurns: 2,
+        reasoningEffort: "none",
       }),
     ).toEqual({
-      model: "grok-4-1-fast",
+      model: "grok-4.3",
       input: [{ role: "user", content: "search for openclaw" }],
       tools: [{ type: "x_search" }],
+      store: false,
+      reasoning: { effort: "none" },
       max_turns: 2,
+    });
+  });
+
+  it("keeps custom model reasoning untouched while disabling response storage", () => {
+    expect(
+      testing.buildXaiResponsesToolBody({
+        model: "grok-build-0.1",
+        inputText: "run code",
+        tools: [{ type: "code_interpreter" }],
+      }),
+    ).toEqual({
+      model: "grok-build-0.1",
+      input: [{ role: "user", content: "run code" }],
+      tools: [{ type: "code_interpreter" }],
+      store: false,
     });
   });
 

--- a/extensions/xai/src/responses-tool-shared.ts
+++ b/extensions/xai/src/responses-tool-shared.ts
@@ -35,11 +35,14 @@ export function buildXaiResponsesToolBody(params: {
   inputText: string;
   tools: Array<Record<string, unknown>>;
   maxTurns?: number;
+  reasoningEffort?: "none" | "low" | "medium" | "high";
 }): Record<string, unknown> {
   return {
     model: params.model,
     input: [{ role: "user", content: params.inputText }],
     tools: params.tools,
+    store: false,
+    ...(params.reasoningEffort ? { reasoning: { effort: params.reasoningEffort } } : {}),
     ...(params.maxTurns ? { max_turns: params.maxTurns } : {}),
   };
 }

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -45,12 +45,7 @@ const X_SEARCH_MODEL_OPTIONS = [
   {
     value: XAI_DEFAULT_X_SEARCH_MODEL,
     label: XAI_DEFAULT_X_SEARCH_MODEL,
-    hint: "default · fast, no reasoning",
-  },
-  {
-    value: "grok-4-1-fast",
-    label: "grok-4-1-fast",
-    hint: "fast with reasoning",
+    hint: "default · reasoning disabled",
   },
 ] as const;
 

--- a/extensions/xai/src/web-search-shared.ts
+++ b/extensions/xai/src/web-search-shared.ts
@@ -1,6 +1,7 @@
 // Xai plugin module implements web search shared behavior.
 import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import { postTrustedWebToolsJson, wrapWebContent } from "openclaw/plugin-sdk/provider-web-search";
+import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import { normalizeXaiModelId } from "../model-id.js";
 import {
   buildXaiResponsesToolBody,
@@ -12,7 +13,7 @@ import type { XaiWebSearchResponse } from "./web-search-response.types.js";
 export { extractXaiWebSearchContent } from "./responses-tool-shared.js";
 export type { XaiWebSearchResponse } from "./web-search-response.types.js";
 
-const XAI_DEFAULT_WEB_SEARCH_MODEL = "grok-4-1-fast";
+const XAI_DEFAULT_WEB_SEARCH_MODEL = XAI_DEFAULT_MODEL_ID;
 
 type XaiWebSearchConfig = Record<string, unknown> & {
   baseUrl?: unknown;
@@ -107,6 +108,7 @@ export async function requestXaiWebSearch(params: {
         model: params.model,
         inputText: params.query,
         tools: [{ type: "web_search" }],
+        reasoningEffort: params.model === XAI_DEFAULT_WEB_SEARCH_MODEL ? "low" : undefined,
       }),
       errorLabel: "xAI",
     },

--- a/extensions/xai/src/x-search-shared.ts
+++ b/extensions/xai/src/x-search-shared.ts
@@ -1,6 +1,7 @@
 // Xai plugin module implements x search shared behavior.
 import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import { postTrustedWebToolsJson, wrapWebContent } from "openclaw/plugin-sdk/provider-web-search";
+import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import {
   buildXaiResponsesToolBody,
   requireXaiResponseTextCitationsAndInline,
@@ -13,7 +14,7 @@ import {
 } from "./tool-config-shared.js";
 import type { XaiWebSearchResponse } from "./web-search-shared.js";
 
-export const XAI_DEFAULT_X_SEARCH_MODEL = "grok-4-1-fast-non-reasoning";
+export const XAI_DEFAULT_X_SEARCH_MODEL = XAI_DEFAULT_MODEL_ID;
 
 type XaiXSearchConfig = {
   apiKey?: unknown;
@@ -129,6 +130,7 @@ export async function requestXaiXSearch(params: {
         inputText: params.options.query,
         tools: [buildXSearchTool(params.options)],
         maxTurns: params.maxTurns,
+        reasoningEffort: params.model === XAI_DEFAULT_X_SEARCH_MODEL ? "none" : undefined,
       }),
       errorLabel: "xAI",
     },

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -103,11 +103,12 @@ function runXaiToolPayloadWrapper(params: {
 
 async function captureXaiResponsesPayloadWithThinking(
   reasoning: ModelThinkingLevel = "low",
+  modelId = "grok-4.5",
 ): Promise<Record<string, unknown>> {
   const model = applyXaiRuntimeModelCompat({
     api: "openai-responses",
     provider: "xai",
-    id: "grok-4.5",
+    id: modelId,
     baseUrl: "https://api.x.ai/v1",
     reasoning: true,
     input: ["text", "image"],
@@ -320,7 +321,7 @@ describe("xai stream wrappers", () => {
     expect(capturedModelIds).toEqual(["grok-4-fast", "grok-4"]);
   });
 
-  it("strips unsupported strict and reasoning controls from tool payloads", () => {
+  it("preserves supported strict flags while stripping unsupported reasoning controls", () => {
     const payload = {
       reasoning: "high",
       reasoningEffort: "high",
@@ -345,7 +346,7 @@ describe("xai stream wrappers", () => {
     expect(payload).not.toHaveProperty("reasoning");
     expect(payload).not.toHaveProperty("reasoningEffort");
     expect(payload).not.toHaveProperty("reasoning_effort");
-    expect(payload.tools[0]?.function).not.toHaveProperty("strict");
+    expect(payload.tools[0]?.function).toHaveProperty("strict", true);
   });
 
   it("strips unsupported reasoning controls from non-reasoning xai payloads", () => {
@@ -390,7 +391,7 @@ describe("xai stream wrappers", () => {
       {
         api: "openai-responses",
         provider: "xai",
-        id: "grok-4.20-beta-latest-reasoning",
+        id: "grok-4.20-0309-reasoning",
         reasoning: true,
         compat: { supportsReasoningEffort: false },
       } as unknown as Model<"openai-responses">,
@@ -463,6 +464,12 @@ describe("xai stream wrappers", () => {
     const payload = await captureXaiResponsesPayloadWithThinking("off");
 
     expect(payload.reasoning).toEqual({ effort: "low", summary: "auto" });
+  });
+
+  it("maps Grok 4.3 off reasoning to xAI none", async () => {
+    const payload = await captureXaiResponsesPayloadWithThinking("off", "grok-4.3");
+
+    expect(payload.reasoning).toEqual({ effort: "none" });
   });
 
   it("moves image-bearing tool results out of function_call_output payloads", () => {

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -23,24 +23,6 @@ function resolveXaiFastModelId(modelId: unknown): string | undefined {
   return XAI_FAST_MODEL_IDS.get(modelId.trim());
 }
 
-function stripUnsupportedStrictFlag(tool: unknown): unknown {
-  if (!tool || typeof tool !== "object") {
-    return tool;
-  }
-  const toolObj = tool as Record<string, unknown>;
-  const fn = toolObj.function;
-  if (!fn || typeof fn !== "object") {
-    return tool;
-  }
-  const fnObj = fn as Record<string, unknown>;
-  if (typeof fnObj.strict !== "boolean") {
-    return tool;
-  }
-  const nextFunction = { ...fnObj };
-  delete nextFunction.strict;
-  return { ...toolObj, function: nextFunction };
-}
-
 function supportsExplicitImageInput(model: { input?: unknown }): boolean {
   return Array.isArray(model.input) && model.input.includes("image");
 }
@@ -238,9 +220,6 @@ export function createXaiToolPayloadCompatibilityWrapper(
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
-          if (Array.isArray(payloadObj.tools)) {
-            payloadObj.tools = payloadObj.tools.map((tool) => stripUnsupportedStrictFlag(tool));
-          }
           normalizeXaiResponsesToolResultPayload(payloadObj, model);
           if (!supportsReasoningControls(model)) {
             // Only current flagship Grok models advertise configurable effort.

--- a/extensions/xai/test-helpers.ts
+++ b/extensions/xai/test-helpers.ts
@@ -70,5 +70,5 @@ export function expectXaiFastToolStreamShaping(
   expect(capturedPayload).toMatchObject({ tool_stream: true });
   expect(capturedPayload).not.toHaveProperty("reasoning");
   const payloadTools = capturedPayload?.tools as XaiToolPayloadFunction[] | undefined;
-  expect(payloadTools?.[0]?.function).not.toHaveProperty("strict");
+  expect(payloadTools?.[0]?.function).toHaveProperty("strict", true);
 }

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -121,6 +121,11 @@ function firstFetchUrl(mockFetch: ReturnType<typeof installXaiWebSearchFetch>) {
   return String(url);
 }
 
+function firstFetchBody(mockFetch: ReturnType<typeof installXaiWebSearchFetch>) {
+  const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+  return JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<string, unknown>;
+}
+
 function fetchCallHeader(
   mockFetch: { mock: { calls: unknown[][] } },
   index: number,
@@ -190,7 +195,7 @@ describe("xai web search config resolution", () => {
 
   it("prefers configured api keys and resolves grok scoped defaults", () => {
     expect(resolveXaiWebSearchCredential({ grok: { apiKey: "xai-secret" } })).toBe("xai-secret");
-    expect(resolveXaiWebSearchModel()).toBe("grok-4-1-fast");
+    expect(resolveXaiWebSearchModel()).toBe("grok-4.3");
     expect(resolveXaiInlineCitations()).toBe(false);
   });
 
@@ -649,7 +654,7 @@ describe("xai web search config resolution", () => {
 
   it("offers plugin-owned xSearch setup after Grok is selected", async () => {
     const provider = createXaiWebSearchProvider();
-    const select = vi.fn().mockResolvedValueOnce("yes").mockResolvedValueOnce("grok-4-1-fast");
+    const select = vi.fn().mockResolvedValueOnce("yes").mockResolvedValueOnce("grok-4.3");
     const prompter = createTestWizardPrompter({
       select: select as never,
     });
@@ -685,7 +690,7 @@ describe("xai web search config resolution", () => {
       | { enabled?: boolean; model?: string }
       | undefined;
     expect(xSearch?.enabled).toBe(true);
-    expect(xSearch?.model).toBe("grok-4-1-fast");
+    expect(xSearch?.model).toBe("grok-4.3");
   });
 
   it("keeps explicit xSearch disablement untouched during provider-owned setup", async () => {
@@ -785,8 +790,8 @@ describe("xai web search config resolution", () => {
   });
 
   it("uses default model when not specified", () => {
-    expect(resolveXaiWebSearchModel({})).toBe("grok-4-1-fast");
-    expect(resolveXaiWebSearchModel(undefined)).toBe("grok-4-1-fast");
+    expect(resolveXaiWebSearchModel({})).toBe("grok-4.3");
+    expect(resolveXaiWebSearchModel(undefined)).toBe("grok-4.3");
   });
 
   it("uses a Grok-specific 60s default timeout while preserving overrides", () => {
@@ -828,6 +833,12 @@ describe("xai web search config resolution", () => {
     await tool.execute({ query: "OpenClaw Grok proxy test" });
 
     expect(firstFetchUrl(mockFetch)).toBe("https://api.x.ai/proxy/v1/responses");
+    expect(firstFetchBody(mockFetch)).toMatchObject({
+      model: "grok-4.3",
+      store: false,
+      reasoning: { effort: "low" },
+      tools: [{ type: "web_search" }],
+    });
   });
 
   it("reports malformed xAI web search JSON as a provider error", async () => {
@@ -895,17 +906,17 @@ describe("xai web search config resolution", () => {
     );
   });
 
-  it("normalizes deprecated grok 4.20 beta model ids to GA ids", () => {
+  it("preserves provider-owned Grok 4.20 aliases", () => {
     expect(
       resolveXaiWebSearchModel({
         grok: { model: "grok-4.20-experimental-beta-0304-reasoning" },
       }),
-    ).toBe("grok-4.20-beta-latest-reasoning");
+    ).toBe("grok-4.20-experimental-beta-0304-reasoning");
     expect(
       resolveXaiWebSearchModel({
         grok: { model: "grok-4.20-experimental-beta-0304-non-reasoning" },
       }),
-    ).toBe("grok-4.20-beta-latest-non-reasoning");
+    ).toBe("grok-4.20-experimental-beta-0304-non-reasoning");
   });
 
   it("defaults inlineCitations to false", () => {
@@ -1022,8 +1033,8 @@ describe("xai provider models", () => {
       "grok-4.5",
       "grok-build-0.1",
       "grok-4.3",
-      "grok-4.20-beta-latest-reasoning",
-      "grok-4.20-beta-latest-non-reasoning",
+      "grok-4.20-0309-reasoning",
+      "grok-4.20-0309-non-reasoning",
     ]);
   });
 
@@ -1049,14 +1060,22 @@ describe("xai provider models", () => {
     });
   });
 
-  it("keeps Grok 4.3 selectable with its published metadata", () => {
-    expectCatalogEntry("grok-4.3", {
+  it("keeps Grok 4.3 selectable with current bundled metadata", () => {
+    const expected = {
       id: "grok-4.3",
       reasoning: true,
       input: ["text", "image"],
       contextWindow: 1_000_000,
       maxTokens: 64_000,
       cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+    };
+    expectCatalogEntry("grok-4.3", expected);
+    expectCatalogEntry("grok-4.3-latest", expected);
+    expectCatalogEntry("grok-latest", { ...expected, id: "grok-latest" });
+    expectCatalogEntry("grok-4-latest", {
+      ...expected,
+      id: "grok-4-latest",
+      input: ["text"],
     });
   });
 
@@ -1065,8 +1084,9 @@ describe("xai provider models", () => {
       id: "grok-4-1-fast",
       reasoning: true,
       input: ["text", "image"],
-      contextWindow: 2_000_000,
-      maxTokens: 30_000,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+      cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
     });
   });
 
@@ -1085,30 +1105,30 @@ describe("xai provider models", () => {
   });
 
   it("publishes Grok 4.20 reasoning and non-reasoning models", () => {
-    expectCatalogEntry("grok-4.20-beta-latest-reasoning", {
-      id: "grok-4.20-beta-latest-reasoning",
+    expectCatalogEntry("grok-4.20-0309-reasoning", {
+      id: "grok-4.20-0309-reasoning",
       reasoning: true,
       input: ["text", "image"],
-      contextWindow: 2_000_000,
+      contextWindow: 1_000_000,
     });
-    expectCatalogEntry("grok-4.20-beta-latest-non-reasoning", {
-      id: "grok-4.20-beta-latest-non-reasoning",
+    expectCatalogEntry("grok-4.20-0309-non-reasoning", {
+      id: "grok-4.20-0309-non-reasoning",
       reasoning: false,
-      contextWindow: 2_000_000,
+      contextWindow: 1_000_000,
     });
   });
 
   it("keeps older Grok aliases resolving with current limits", () => {
     expectCatalogEntry("grok-4-1-fast-reasoning", {
-      id: "grok-4-1-fast-reasoning",
+      id: "grok-4-1-fast",
       reasoning: true,
-      contextWindow: 2_000_000,
-      maxTokens: 30_000,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
     });
     expectCatalogEntry("grok-4.20-reasoning", {
       id: "grok-4.20-reasoning",
       reasoning: true,
-      contextWindow: 2_000_000,
+      contextWindow: 1_000_000,
       maxTokens: 30_000,
     });
   });
@@ -1117,14 +1137,22 @@ describe("xai provider models", () => {
     expectCatalogEntry("grok-3-mini-fast", {
       id: "grok-3-mini-fast",
       reasoning: true,
-      contextWindow: 131_072,
-      maxTokens: 8_192,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
     });
     expectCatalogEntry("grok-3-fast", {
       id: "grok-3-fast",
       reasoning: false,
-      contextWindow: 131_072,
-      maxTokens: 8_192,
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+    });
+    expectCatalogEntry("grok-3", {
+      id: "grok-3",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 1_000_000,
+      maxTokens: 64_000,
+      cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
     });
   });
 
@@ -1132,7 +1160,7 @@ describe("xai provider models", () => {
     expect(isModernXaiModel("grok-4.5")).toBe(true);
     expect(isModernXaiModel("grok-4.3")).toBe(true);
     expect(isModernXaiModel("grok-build-0.1")).toBe(true);
-    expect(isModernXaiModel("grok-4.20-beta-latest-reasoning")).toBe(true);
+    expect(isModernXaiModel("grok-4.20-0309-reasoning")).toBe(true);
     expect(isModernXaiModel("grok-build-latest")).toBe(true);
     expect(isModernXaiModel("grok-code-fast-1")).toBe(true);
     expect(isModernXaiModel("grok-3-mini-fast")).toBe(false);
@@ -1156,7 +1184,7 @@ describe("xai provider models", () => {
       providerId: "xai",
       ctx: {
         provider: "xai",
-        modelId: "grok-4.20-beta-latest-reasoning",
+        modelId: "grok-4.20-0309-reasoning",
         modelRegistry: { find: () => null } as never,
         providerConfig: {
           api: "openai-responses",
@@ -1206,11 +1234,11 @@ describe("xai provider models", () => {
     expect(grok41?.api).toBe("openai-responses");
     expect(grok41?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok41?.reasoning).toBe(true);
-    expect(grok41?.contextWindow).toBe(2_000_000);
-    expect(grok41?.maxTokens).toBe(30_000);
+    expect(grok41?.contextWindow).toBe(1_000_000);
+    expect(grok41?.maxTokens).toBe(64_000);
 
     expect(grok45Alias?.provider).toBe("xai");
-    expect(grok45Alias?.id).toBe("grok-4.5-latest");
+    expect(grok45Alias?.id).toBe("grok-4.5");
     expect(grok45Alias?.api).toBe("openai-responses");
     expect(grok45Alias?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok45Alias?.reasoning).toBe(true);
@@ -1227,12 +1255,12 @@ describe("xai provider models", () => {
     expect(grok45Alias?.maxTokens).toBe(64_000);
 
     expect(grok43Alias?.provider).toBe("xai");
-    expect(grok43Alias?.id).toBe("grok-4.3-latest");
+    expect(grok43Alias?.id).toBe("grok-4.3");
     expect(grok43Alias?.api).toBe("openai-responses");
     expect(grok43Alias?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok43Alias?.reasoning).toBe(true);
     expect(grok43Alias?.thinkingLevelMap).toEqual({
-      off: null,
+      off: "none",
       minimal: "low",
       low: "low",
       medium: "medium",
@@ -1244,12 +1272,12 @@ describe("xai provider models", () => {
     expect(grok43Alias?.maxTokens).toBe(64_000);
 
     expect(grok420?.provider).toBe("xai");
-    expect(grok420?.id).toBe("grok-4.20-beta-latest-reasoning");
+    expect(grok420?.id).toBe("grok-4.20-0309-reasoning");
     expect(grok420?.api).toBe("openai-responses");
     expect(grok420?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok420?.reasoning).toBe(true);
     expect(grok420?.input).toEqual(["text", "image"]);
-    expect(grok420?.contextWindow).toBe(2_000_000);
+    expect(grok420?.contextWindow).toBe(1_000_000);
     expect(grok420?.maxTokens).toBe(30_000);
 
     expect(grok3Mini?.provider).toBe("xai");
@@ -1257,8 +1285,8 @@ describe("xai provider models", () => {
     expect(grok3Mini?.api).toBe("openai-responses");
     expect(grok3Mini?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok3Mini?.reasoning).toBe(true);
-    expect(grok3Mini?.contextWindow).toBe(131_072);
-    expect(grok3Mini?.maxTokens).toBe(8_192);
+    expect(grok3Mini?.contextWindow).toBe(1_000_000);
+    expect(grok3Mini?.maxTokens).toBe(64_000);
   });
 
   it("refuses the unsupported multi-agent endpoint ids", () => {

--- a/extensions/xai/x-search.live.test.ts
+++ b/extensions/xai/x-search.live.test.ts
@@ -18,7 +18,6 @@ describeLive("xai x_search live", () => {
               config: {
                 xSearch: {
                   enabled: true,
-                  model: "grok-4-1-fast-non-reasoning",
                   maxTurns: 1,
                   timeoutSeconds: 60,
                 },
@@ -49,6 +48,7 @@ describeLive("xai x_search live", () => {
 
     const details = (result.details ?? {}) as {
       provider?: string;
+      model?: string;
       content?: string;
       citations?: string[];
       inlineCitations?: unknown[];
@@ -67,6 +67,7 @@ describeLive("xai x_search live", () => {
 
     expect(details.error, details.message).toBeUndefined();
     expect(details.provider).toBe("xai");
+    expect(details.model).toBe("grok-4.3");
     expect(details.content?.trim().length ?? 0).toBeGreaterThan(0);
 
     const citationCount =

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -179,7 +179,6 @@ describe("xai x_search tool", () => {
                   apiKey: "xai-config-test", // pragma: allowlist secret
                 },
                 xSearch: {
-                  model: "grok-4-1-fast-non-reasoning",
                   maxTurns: 2,
                 },
               },
@@ -201,7 +200,9 @@ describe("xai x_search tool", () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(firstFetchUrl(mockFetch)).toContain("api.x.ai/v1/responses");
     const body = parseFirstRequestBody(mockFetch);
-    expect(body.model).toBe("grok-4-1-fast-non-reasoning");
+    expect(body.model).toBe("grok-4.3");
+    expect(body.store).toBe(false);
+    expect(body.reasoning).toEqual({ effort: "none" });
     expect(body.max_turns).toBe(2);
     expect(body.tools).toEqual([
       {

--- a/extensions/xai/xai.live.test.ts
+++ b/extensions/xai/xai.live.test.ts
@@ -15,6 +15,7 @@ import {
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { isBillingErrorMessage } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
+import { createCodeExecutionTool } from "./code-execution.js";
 import plugin from "./index.js";
 import { XAI_DEFAULT_STT_MODEL } from "./stt.js";
 
@@ -91,6 +92,41 @@ function isRealtimeOpenBillingDrift(error: Error): boolean {
 }
 
 describeLive("xai plugin live", () => {
+  it("runs remote code execution with the current default model", async () => {
+    await runXaiLiveCase("code-execution", async () => {
+      const tool = createCodeExecutionTool({
+        config: {
+          plugins: {
+            entries: {
+              xai: {
+                config: {
+                  webSearch: { apiKey: XAI_API_KEY },
+                  codeExecution: { enabled: true, maxTurns: 1, timeoutSeconds: 90 },
+                },
+              },
+            },
+          },
+        },
+      });
+      if (!tool) {
+        throw new Error("expected code_execution tool to be registered");
+      }
+
+      const result = await tool.execute("code-execution:xai-live", {
+        task: "Use the code interpreter to calculate the sum of the integers from 1 through 100.",
+      });
+      const details = (result.details ?? {}) as {
+        content?: string;
+        model?: string;
+        usedCodeExecution?: boolean;
+      };
+
+      expect(details.model).toBe("grok-4.3");
+      expect(details.usedCodeExecution).toBe(true);
+      expect(details.content).toContain("5050");
+    });
+  }, 120_000);
+
   it("synthesizes TTS through the registered speech provider", async () => {
     await runXaiLiveCase("tts", async () => {
       const { speechProviders } = await registerXaiPlugin();

--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -815,7 +815,7 @@ function normalizeToolParameterSchemaUncached(
   // - OpenAI rejects function tool schemas unless the *top-level* is `type: "object"`.
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
   // - Anthropic expects full JSON Schema draft 2020-12 compliance.
-  // - xAI rejects validation-constraint keywords (minLength, maxLength, etc.) outright.
+  // - xAI's documented tool-schema contract rejects contains-count bounds.
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -93,7 +93,7 @@ describe("OpenAI reasoning effort support", () => {
   it("honors compat metadata that disables reasoning effort payloads", () => {
     const model = {
       provider: "xai",
-      id: "grok-4.20-beta-latest-reasoning",
+      id: "grok-4.20-0309-reasoning",
       compat: { supportsReasoningEffort: false },
     };
 
@@ -101,14 +101,14 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBeUndefined();
   });
 
-  it("does not turn disabled reasoning into a fallback effort when compat omits none", () => {
+  it("passes disabled reasoning when xAI compat explicitly supports none", () => {
     const model = {
       provider: "xai",
       id: "grok-4.3",
-      compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
+      compat: { supportedReasoningEfforts: ["none", "low", "medium", "high"] },
     };
 
-    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBe("none");
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
   });
 });

--- a/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.test.ts
@@ -88,6 +88,23 @@ describe("provider model id policy normalization", () => {
     ).toBe("vercel-ai-gateway/opus-4.6");
   });
 
+  it("preserves provider-owned xAI Grok 4.20 aliases", () => {
+    expect(
+      normalizeStaticProviderModelIdWithPolicies("xai", "grok-4.20-beta-latest-reasoning"),
+    ).toBe("grok-4.20-beta-latest-reasoning");
+    expect(
+      normalizeStaticProviderModelIdWithPolicies(
+        "xai",
+        "grok-4.20-experimental-beta-0304-non-reasoning",
+      ),
+    ).toBe("grok-4.20-experimental-beta-0304-non-reasoning");
+  });
+
+  it("preserves the global xAI flagship alias without manifest metadata", () => {
+    expect(normalizeStaticProviderModelIdWithPolicies("xai", "grok-latest")).toBe("grok-latest");
+    expect(normalizeStaticProviderModelIdWithPolicies("xai", "grok-4.5-latest")).toBe("grok-4.5");
+  });
+
   it("strips self provider model prefixes before runtime provider calls", () => {
     expect(stripSelfProviderModelPrefix("google", "google/gemini-2.0-flash")).toBe(
       "gemini-2.0-flash",

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -174,12 +174,11 @@ export function normalizeBuiltInProviderModelId(provider: string, model: string)
   }
   if (normalizedProvider === "xai") {
     const xaiAliases: Record<string, string> = {
+      "grok-4.3-latest": "grok-4.3",
+      "grok-4.5-latest": "grok-4.5",
+      "grok-build-latest": "grok-4.5",
       "grok-4-fast-reasoning": "grok-4-fast",
       "grok-4-1-fast-reasoning": "grok-4-1-fast",
-      "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-beta-latest-reasoning",
-      "grok-4.20-experimental-beta-0304-non-reasoning": "grok-4.20-beta-latest-non-reasoning",
-      "grok-4.20-reasoning": "grok-4.20-beta-latest-reasoning",
-      "grok-4.20-non-reasoning": "grok-4.20-beta-latest-non-reasoning",
     };
     return xaiAliases[normalizeLowercaseStringOrEmpty(model)] ?? model;
   }

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -37,15 +37,7 @@ const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
   "base64",
 );
-const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
-  "minLength",
-  "maxLength",
-  "minItems",
-  "maxItems",
-  "minContains",
-  "maxContains",
-]);
-
+const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["minContains", "maxContains"]);
 function collectActionValues(schema: unknown, values: Set<string>): void {
   if (!schema || typeof schema !== "object") {
     return;
@@ -1520,12 +1512,7 @@ describe("createOpenClawCodingTools", () => {
         `${tool.name}.parameters`,
         XAI_UNSUPPORTED_SCHEMA_KEYWORDS,
       );
-      expect(
-        violations.filter((violation) => {
-          const keyword = violation.split(".").at(-1) ?? "";
-          return XAI_UNSUPPORTED_SCHEMA_KEYWORDS.has(keyword);
-        }),
-      ).toStrictEqual([]);
+      expect(violations).toStrictEqual([]);
     }
   });
 

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -1067,14 +1067,14 @@ describe("applyExtraParamsToAgent", () => {
   it("strips xai Responses reasoning payload fields", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "xai",
-      applyModelId: "grok-4.20-beta-latest-reasoning",
+      applyModelId: "grok-4.20-0309-reasoning",
       model: {
         api: "openai-responses",
         provider: "xai",
-        id: "grok-4.20-beta-latest-reasoning",
+        id: "grok-4.20-0309-reasoning",
       } as unknown as Model<"openai-responses">,
       payload: {
-        model: "grok-4.20-beta-latest-reasoning",
+        model: "grok-4.20-0309-reasoning",
         input: [],
         reasoning: { effort: "high", summary: "auto" },
         reasoningEffort: "high",

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -4252,22 +4252,22 @@ describe("resolveModel", () => {
   it("normalizes stale native xai completions transport to responses", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "xai",
-      modelId: "grok-4.20-beta-latest-reasoning",
+      modelId: "grok-4.20-0309-reasoning",
       templateModel: buildForwardCompatTemplate({
-        id: "grok-4.20-beta-latest-reasoning",
-        name: "Grok 4.20 Beta Latest (Reasoning)",
+        id: "grok-4.20-0309-reasoning",
+        name: "Grok 4.20 0309 (Reasoning)",
         provider: "xai",
         api: "openai-completions",
         baseUrl: "https://api.x.ai/v1",
       }),
     });
 
-    const result = resolveModelForTest("xai", "grok-4.20-beta-latest-reasoning", "/tmp/agent");
+    const result = resolveModelForTest("xai", "grok-4.20-0309-reasoning", "/tmp/agent");
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
       provider: "xai",
-      id: "grok-4.20-beta-latest-reasoning",
+      id: "grok-4.20-0309-reasoning",
       api: "openai-responses",
       baseUrl: "https://api.x.ai/v1",
     });
@@ -4276,17 +4276,17 @@ describe("resolveModel", () => {
   it("normalizes stale native xai completions transport after plugin model normalization", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "xai",
-      modelId: "grok-4.20-beta-latest-reasoning",
+      modelId: "grok-4.3",
       templateModel: buildForwardCompatTemplate({
-        id: "grok-4.20-beta-latest-reasoning",
-        name: "Grok 4.20 Beta Latest (Reasoning)",
+        id: "grok-4.3",
+        name: "Grok 4.3",
         provider: "xai",
         api: "openai-completions",
         baseUrl: "https://api.x.ai/v1",
       }),
     });
 
-    const result = resolveModel("xai", "grok-4.20-beta-latest-reasoning", "/tmp/agent", undefined, {
+    const result = resolveModel("xai", "grok-4.3-latest", "/tmp/agent", undefined, {
       authStorage: { mocked: true } as never,
       modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
       runtimeHooks: {
@@ -4311,7 +4311,7 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
       provider: "xai",
-      id: "grok-4.20-beta-latest-reasoning",
+      id: "grok-4.3",
       api: "openai-responses",
       baseUrl: "https://api.x.ai/v1",
     });

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -74,12 +74,12 @@ describe("normalizeStaticProviderModelId", () => {
     ).toBe("openrouter/auto");
   });
 
-  it("normalizes retired XAI beta ids without manifest lookup", () => {
+  it("preserves provider-owned XAI beta aliases without manifest lookup", () => {
     expect(
       normalizeStaticProviderModelId("xai", "grok-4.20-experimental-beta-0304-reasoning", {
         allowManifestNormalization: false,
       }),
-    ).toBe("grok-4.20-beta-latest-reasoning");
+    ).toBe("grok-4.20-experimental-beta-0304-reasoning");
   });
 
   it("normalizes the shipped retired Together default without manifest lookup", () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -63,11 +63,7 @@ const manifestNormalizationSnapshot = vi.hoisted(() => ({
               "gemini-3.1-flash-preview": "gemini-3-flash-preview",
             },
           },
-          xai: {
-            aliases: {
-              "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-beta-latest-reasoning",
-            },
-          },
+          xai: { aliases: {} },
           openrouter: {
             prefixWhenBare: "openrouter",
           },
@@ -427,13 +423,13 @@ describe("model-selection", () => {
         expected: { provider: "google", model: "gemini-3.1-flash-lite" },
       },
       {
-        name: "normalizes deprecated xai grok 4.20 beta ids",
+        name: "preserves provider-owned xai grok 4.20 beta ids",
         variants: [
           "xai/grok-4.20-experimental-beta-0304-reasoning",
           "grok-4.20-experimental-beta-0304-reasoning",
         ],
         defaultProvider: "xai",
-        expected: { provider: "xai", model: "grok-4.20-beta-latest-reasoning" },
+        expected: { provider: "xai", model: "grok-4.20-experimental-beta-0304-reasoning" },
       },
       {
         name: "keeps OpenAI codex refs on the openai provider",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2000,15 +2000,15 @@ describe("openai transport stream", () => {
 
   it("does not emit thinking streams when reasoning is disabled", () => {
     const model = {
-      id: "grok-4.20-beta-latest-reasoning",
-      name: "Grok 4.20 Beta Latest (Reasoning)",
+      id: "grok-4.20-0309-reasoning",
+      name: "Grok 4.20 0309 (Reasoning)",
       api: "openai-completions",
       provider: "xai",
       baseUrl: "https://api.x.ai/v1",
       reasoning: true,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 2_000_000,
+      contextWindow: 1_000_000,
       maxTokens: 30_000,
     } satisfies Model<"openai-completions">;
 
@@ -3750,15 +3750,15 @@ describe("openai transport stream", () => {
   it("omits Responses reasoning params when model compat disables reasoning effort", () => {
     const params = buildOpenAIResponsesParams(
       {
-        id: "grok-4.20-beta-latest-reasoning",
-        name: "Grok 4.20 Beta Latest (Reasoning)",
+        id: "grok-4.20-0309-reasoning",
+        name: "Grok 4.20 0309 (Reasoning)",
         api: "openai-responses",
         provider: "xai",
         baseUrl: "https://api.x.ai/v1",
         reasoning: true,
         input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 2_000_000,
+        contextWindow: 1_000_000,
         maxTokens: 30_000,
         compat: { supportsReasoningEffort: false },
       } as unknown as Model<"openai-responses">,
@@ -3791,7 +3791,7 @@ describe("openai transport stream", () => {
         maxTokens: 128_000,
         compat: {
           supportsReasoningEffort: true,
-          supportedReasoningEfforts: ["low", "medium", "high"],
+          supportedReasoningEfforts: ["none", "low", "medium", "high"],
         },
       } as unknown as Model<"openai-responses">,
       {
@@ -3821,7 +3821,7 @@ describe("openai transport stream", () => {
         maxTokens: 128_000,
         compat: {
           supportsReasoningEffort: true,
-          supportedReasoningEfforts: ["low", "medium", "high"],
+          supportedReasoningEfforts: ["none", "low", "medium", "high"],
         },
       } as unknown as Model<"openai-responses">,
       {

--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -1,130 +1,47 @@
-// xAI schema cleaner tests cover provider-specific keyword stripping for tool
-// schemas before they are sent to Grok/xAI endpoints.
+// xAI schema tests lock the live-supported JSON Schema bounds used by tools.
+import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
 import { describe, expect, it } from "vitest";
-import { stripUnsupportedSchemaKeywords } from "../../plugin-sdk/provider-tools.js";
 
-const XAI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
-  "minLength",
-  "maxLength",
-  "minItems",
-  "maxItems",
-  "minContains",
-  "maxContains",
-]);
-
-function stripXaiUnsupportedKeywords(schema: unknown): unknown {
-  return stripUnsupportedSchemaKeywords(schema, XAI_UNSUPPORTED_SCHEMA_KEYWORDS);
-}
-
-describe("stripXaiUnsupportedKeywords", () => {
-  it("strips minLength and maxLength from string properties", () => {
+describe("xAI tool schema compatibility", () => {
+  it("preserves supported bounds while stripping documented contains-count bounds", () => {
     const schema = {
       type: "object",
       properties: {
-        name: { type: "string", minLength: 1, maxLength: 64, description: "A name" },
-      },
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as {
-      properties: { name: Record<string, unknown> };
-    };
-    expect(result.properties.name.minLength).toBeUndefined();
-    expect(result.properties.name.maxLength).toBeUndefined();
-    expect(result.properties.name.type).toBe("string");
-    expect(result.properties.name.description).toBe("A name");
-  });
-
-  it("strips minItems and maxItems from array properties", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        items: { type: "array", minItems: 1, maxItems: 50, items: { type: "string" } },
-      },
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as {
-      properties: { items: Record<string, unknown> };
-    };
-    expect(result.properties.items.minItems).toBeUndefined();
-    expect(result.properties.items.maxItems).toBeUndefined();
-    expect(result.properties.items.type).toBe("array");
-  });
-
-  it("strips minContains and maxContains", () => {
-    const schema = {
-      type: "array",
-      minContains: 1,
-      maxContains: 5,
-      contains: { type: "string" },
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as Record<string, unknown>;
-    expect(result.minContains).toBeUndefined();
-    expect(result.maxContains).toBeUndefined();
-    expect(result.contains).toEqual({ type: "string" });
-  });
-
-  it("strips keywords recursively inside nested objects", () => {
-    // Attachment schemas can contain large string bounds deep in nested objects;
-    // xAI rejects those bounds unless the cleaner recurses.
-    const schema = {
-      type: "object",
-      properties: {
-        attachment: {
-          type: "object",
-          properties: {
-            content: { type: "string", maxLength: 6_700_000 },
-          },
+        name: { type: "string", minLength: 1, maxLength: 64 },
+        tags: {
+          type: "array",
+          minItems: 1,
+          maxItems: 5,
+          items: { type: "string", minLength: 2, maxLength: 20 },
+          contains: { const: "required" },
+          minContains: 1,
+          maxContains: 1,
         },
       },
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as {
-      properties: { attachment: { properties: { content: Record<string, unknown> } } };
-    };
-    expect(result.properties.attachment.properties.content.maxLength).toBeUndefined();
-    expect(result.properties.attachment.properties.content.type).toBe("string");
-  });
-
-  it("strips keywords inside anyOf/oneOf/allOf variants", () => {
-    const schema = {
-      anyOf: [{ type: "string", minLength: 1 }, { type: "null" }],
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as {
-      anyOf: Array<Record<string, unknown>>;
-    };
-    expect(result.anyOf[0].minLength).toBeUndefined();
-    expect(result.anyOf[0].type).toBe("string");
-  });
-
-  it("strips keywords inside array item schemas", () => {
-    const schema = {
-      type: "array",
-      items: { type: "string", maxLength: 100 },
-    };
-    const result = stripXaiUnsupportedKeywords(schema) as {
-      items: Record<string, unknown>;
-    };
-    expect(result.items.maxLength).toBeUndefined();
-    expect(result.items.type).toBe("string");
-  });
-
-  it("preserves all other schema keywords", () => {
-    const schema = {
-      type: "object",
-      description: "A tool schema",
-      required: ["name"],
-      properties: {
-        name: { type: "string", description: "The name", enum: ["foo", "bar"] },
-      },
+      required: ["name", "tags"],
       additionalProperties: false,
     };
-    const result = stripXaiUnsupportedKeywords(schema) as Record<string, unknown>;
-    expect(result.type).toBe("object");
-    expect(result.description).toBe("A tool schema");
-    expect(result.required).toEqual(["name"]);
-    expect(result.additionalProperties).toBe(false);
-  });
 
-  it("passes through primitives and null unchanged", () => {
-    expect(stripXaiUnsupportedKeywords(null)).toBeNull();
-    expect(stripXaiUnsupportedKeywords("string")).toBe("string");
-    expect(stripXaiUnsupportedKeywords(42)).toBe(42);
+    expect(
+      normalizeToolParameterSchema(schema, {
+        modelProvider: "xai",
+        modelCompat: {
+          toolSchemaProfile: "xai",
+          unsupportedToolSchemaKeywords: ["minContains", "maxContains"],
+        },
+      }),
+    ).toEqual({
+      ...schema,
+      properties: {
+        ...schema.properties,
+        tags: {
+          type: "array",
+          minItems: 1,
+          maxItems: 5,
+          items: { type: "string", minLength: 2, maxLength: 20 },
+          contains: { const: "required" },
+        },
+      },
+    });
   });
 });

--- a/src/agents/xai.live.test.ts
+++ b/src/agents/xai.live.test.ts
@@ -1,6 +1,6 @@
 // xAI live tests verify Grok completions, tool payload wrapping, and Grok web
 // search against the real provider when live credentials are enabled.
-import { completeSimple, type Model, streamSimple } from "openclaw/plugin-sdk/llm";
+import { completeSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import {
@@ -13,6 +13,7 @@ import {
   extractNonEmptyAssistantText,
   isLiveTestEnabled,
 } from "./live-test-helpers.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-transport-stream.js";
 import { createWebSearchTool } from "./tools/web-search.js";
 
 const XAI_KEY = process.env.XAI_API_KEY ?? "";
@@ -27,6 +28,7 @@ type AssistantLikeMessage = {
     type?: string;
     text?: string;
     id?: string;
+    name?: string;
     function?: {
       strict?: unknown;
     };
@@ -44,20 +46,23 @@ function getToolFunction(tool: Record<string, unknown>): Record<string, unknown>
   return undefined;
 }
 
-function resolveLiveXaiModel() {
+function resolveLiveXaiModel(modelId: "grok-4.3" | "grok-4.5") {
+  const isGrok45 = modelId === "grok-4.5";
   return {
-    id: "grok-4.5",
-    name: "Grok 4.5",
+    id: modelId,
+    name: isGrok45 ? "Grok 4.5" : "Grok 4.3",
     api: "openai-responses",
     provider: "xai",
     baseUrl: "https://api.x.ai/v1",
     reasoning: true,
     input: ["text", "image"],
-    cost: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
-    contextWindow: 500_000,
+    cost: isGrok45
+      ? { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 }
+      : { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
+    contextWindow: isGrok45 ? 500_000 : 1_000_000,
     maxTokens: 64_000,
     thinkingLevelMap: {
-      off: null,
+      off: isGrok45 ? null : "none",
       minimal: "low",
       low: "low",
       medium: "medium",
@@ -110,82 +115,95 @@ async function collectDoneMessage(
 }
 
 describeLive("xai live", () => {
-  it(
-    "returns assistant text for Grok 4.5",
-    async () => {
-      await runXaiLiveCase("complete", async () => {
-        const model = requireLiveValue(resolveLiveXaiModel(), "xAI model");
-        const res = await completeSimple(
-          model,
-          {
-            messages: createSingleUserPromptMessage(),
-          },
-          {
-            apiKey: XAI_KEY,
-            maxTokens: 64,
-          },
-        );
+  for (const modelId of ["grok-4.3", "grok-4.5"] as const) {
+    it(
+      `returns assistant text for ${modelId}`,
+      async () => {
+        await runXaiLiveCase("complete", async () => {
+          const model = requireLiveValue(resolveLiveXaiModel(modelId), "xAI model");
+          const res = await completeSimple(
+            model,
+            {
+              messages: createSingleUserPromptMessage(),
+            },
+            {
+              apiKey: XAI_KEY,
+              maxTokens: 64,
+            },
+          );
 
-        expect(extractNonEmptyAssistantText(res.content).length).toBeGreaterThan(0);
-      });
-    },
-    XAI_COMPLETE_LIVE_TIMEOUT_MS,
-  );
+          expect(extractNonEmptyAssistantText(res.content).length).toBeGreaterThan(0);
+        });
+      },
+      XAI_COMPLETE_LIVE_TIMEOUT_MS,
+    );
+  }
 
-  it("sends wrapped xAI tool payloads live", async () => {
-    await runXaiLiveCase("tool-call", async () => {
-      const model = requireLiveValue(resolveLiveXaiModel(), "xAI model");
-      const agent = { streamFn: streamSimple };
-      applyExtraParamsToAgent(agent, undefined, "xai", model.id);
+  for (const modelId of ["grok-4.3", "grok-4.5"] as const) {
+    it(`sends wrapped ${modelId} tool payloads live`, async () => {
+      await runXaiLiveCase("tool-call", async () => {
+        const model = requireLiveValue(resolveLiveXaiModel(modelId), "xAI model");
+        const agent = { streamFn: createOpenAIResponsesTransportStreamFn() };
+        applyExtraParamsToAgent(agent, undefined, "xai", model.id);
 
-      const noopTool = {
-        name: "noop",
-        description: "Return ok.",
-        parameters: Type.Object({}, { additionalProperties: false }),
-      };
+        const noopTool = {
+          name: "noop",
+          description: "Return ok.",
+          parameters: Type.Object({}, { additionalProperties: false }),
+        };
 
-      let capturedPayload: Record<string, unknown> | undefined;
-      const stream = agent.streamFn(
-        model,
-        {
-          messages: createSingleUserPromptMessage(
-            "Call the tool `noop` with {} if needed, then finish.",
-          ),
-          tools: [noopTool],
-        },
-        {
+        let capturedPayload: Record<string, unknown> | undefined;
+        const streamOptions = {
           apiKey: XAI_KEY,
           maxTokens: 128,
           reasoning: "low",
-          onPayload: (payload) => {
+          toolChoice: { type: "function", name: "noop" },
+          onPayload: (payload: unknown) => {
             capturedPayload = payload as Record<string, unknown>;
           },
-        },
-      );
+        } satisfies Parameters<typeof agent.streamFn>[2] & {
+          reasoning: "low";
+          toolChoice: { type: "function"; name: string };
+        };
+        const stream = agent.streamFn(
+          model,
+          {
+            messages: createSingleUserPromptMessage(
+              "You must call the tool `noop` exactly once with {}.",
+            ),
+            tools: [noopTool],
+          },
+          streamOptions,
+        );
 
-      const doneMessage = await collectDoneMessage(
-        stream as AsyncIterable<{ type: string; message?: AssistantLikeMessage }>,
-      );
-      expect(Array.isArray(doneMessage.content)).toBe(true);
-      const payload = requireLiveValue(capturedPayload, "captured xAI payload");
-      expect(payload.reasoning).toMatchObject({ effort: "low" });
-      if ("tool_stream" in payload) {
-        expect(payload.tool_stream).toBe(true);
-      }
+        const doneMessage = await collectDoneMessage(
+          stream as AsyncIterable<{ type: string; message?: AssistantLikeMessage }>,
+        );
+        const content = requireLiveValue(doneMessage.content, "done message content");
+        expect(Array.isArray(content)).toBe(true);
+        expect(content.some((block) => block.type === "toolCall" && block.name === "noop")).toBe(
+          true,
+        );
+        const payload = requireLiveValue(capturedPayload, "captured xAI payload");
+        expect(payload.reasoning).toMatchObject({ effort: "low" });
+        if ("tool_stream" in payload) {
+          expect(payload.tool_stream).toBe(true);
+        }
 
-      const payloadTools = Array.isArray(payload.tools)
-        ? (payload.tools as Array<Record<string, unknown>>)
-        : [];
-      expect(payloadTools.length).toBeGreaterThan(0);
-      const firstFunction = requireLiveValue(
-        payloadTools[0] ? getToolFunction(payloadTools[0]) : undefined,
-        "first xAI tool function",
-      );
-      expect(typeof firstFunction).toBe("object");
-      expect(Array.isArray(firstFunction)).toBe(false);
-      expect([undefined, false]).toContain(firstFunction.strict);
-    });
-  }, 90_000);
+        const payloadTools = Array.isArray(payload.tools)
+          ? (payload.tools as Array<Record<string, unknown>>)
+          : [];
+        expect(payloadTools.length).toBeGreaterThan(0);
+        const firstFunction = requireLiveValue(
+          payloadTools[0] ? getToolFunction(payloadTools[0]) : undefined,
+          "first xAI tool function",
+        );
+        expect(typeof firstFunction).toBe("object");
+        expect(Array.isArray(firstFunction)).toBe(false);
+        expect([undefined, false]).toContain(firstFunction.strict);
+      });
+    }, 90_000);
+  }
 
   it("runs Grok web_search live", async () => {
     await runXaiLiveCase("web-search", async () => {
@@ -196,9 +214,7 @@ describeLive("xai live", () => {
               search: {
                 provider: "grok",
                 timeoutSeconds: XAI_WEB_SEARCH_LIVE_TIMEOUT_SECONDS,
-                grok: {
-                  model: "grok-4-1-fast",
-                },
+                grok: { model: "grok-4.3" },
               },
             },
           },
@@ -213,6 +229,7 @@ describeLive("xai live", () => {
 
       const details = (result.details ?? {}) as {
         provider?: string;
+        model?: string;
         content?: string;
         citations?: string[];
         inlineCitations?: Array<unknown>;
@@ -231,6 +248,7 @@ describeLive("xai live", () => {
 
       expect(details.error, details.message).toBeUndefined();
       expect(details.provider).toBe("grok");
+      expect(details.model).toBe("grok-4.3");
       expect(details.content?.trim().length ?? 0).toBeGreaterThan(0);
 
       const citationCount =

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -990,7 +990,7 @@ describe("createModelSelectionState respects session model override", () => {
     expect(state.model).toBe("qwen2.5-coder:7b");
   });
 
-  it("normalizes deprecated xai beta session overrides before allowlist checks", async () => {
+  it("preserves xai beta session overrides during allowlist checks", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -1025,7 +1025,7 @@ describe("createModelSelectionState respects session model override", () => {
     });
 
     expect(state.provider).toBe("xai");
-    expect(state.model).toBe("grok-4.20-beta-latest-reasoning");
+    expect(state.model).toBe("grok-4.20-experimental-beta-0304-reasoning");
     expect(state.resetModelOverride).toBe(false);
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1941,6 +1941,37 @@ describe("legacy migrate x_search auth", () => {
       "Moved tools.web.x_search.apiKey → plugins.entries.xai.config.webSearch.apiKey.",
     ]);
   });
+
+  it("detects and repairs retired xAI model-only tool config without plugin discovery", () => {
+    const raw = {
+      tools: {
+        web: {
+          search: { grok: { model: "grok-4-1-fast" } },
+          x_search: { model: "grok-4-1-fast-non-reasoning" },
+        },
+      },
+    };
+
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toEqual(
+      expect.arrayContaining(["tools.web.search", "tools.web.x_search.model"]),
+    );
+
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.plugins?.entries?.xai).toEqual({
+      enabled: true,
+      config: { webSearch: { model: "grok-4.3" } },
+    });
+    expect((res.config?.tools?.web as Record<string, unknown> | undefined)?.x_search).toEqual({
+      model: "grok-4.3",
+    });
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        'Updated tools.web.search.grok.model from "grok-4-1-fast" to "grok-4.3".',
+        'Updated tools.web.x_search.model from "grok-4-1-fast-non-reasoning" to "grok-4.3".',
+      ]),
+    );
+  });
 });
 
 describe("legacy bundled provider discovery migrate", () => {
@@ -2295,6 +2326,43 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
 });
 
 describe("legacy model compat migrate", () => {
+  it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
+    const raw = {
+      agents: {
+        defaults: {
+          imageGenerationModel: {
+            primary: "xai/grok-imagine-image-pro",
+            fallbacks: ["xai/grok-imagine-image"],
+          },
+          model: {
+            primary: "xai/grok-4.20-beta-latest-reasoning",
+          },
+          models: {
+            "xai/grok-imagine-image-pro": { alias: "quality" },
+          },
+        },
+      },
+    };
+
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toContain("agents");
+    const res = migrateLegacyConfigForTest(raw);
+
+    expect(res.config?.agents?.defaults?.imageGenerationModel).toEqual({
+      primary: "xai/grok-imagine-image-quality",
+      fallbacks: ["xai/grok-imagine-image"],
+    });
+    expect(res.config?.agents?.defaults?.model).toEqual({
+      primary: "xai/grok-4.20-beta-latest-reasoning",
+    });
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "xai/grok-imagine-image-quality": { alias: "quality" },
+    });
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'config.agents.defaults.imageGenerationModel.primary from "xai/grok-imagine-image-pro" to "xai/grok-imagine-image-quality"',
+      'config.agents.defaults.models key from "xai/grok-imagine-image-pro" to "xai/grok-imagine-image-quality"',
+    ]);
+  });
+
   it("upgrades retired model refs", () => {
     const res = migrateLegacyConfigForTest({
       agents: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts
@@ -35,6 +35,31 @@ describe("stale contextWindow migration", () => {
     expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
   });
 
+  it("repairs Grok 4.20 canonical and shipped alias context windows from 2M to 1M", () => {
+    const changes: string[] = [];
+    const raw = {
+      models: {
+        providers: {
+          xai: {
+            models: [
+              { id: "grok-4.20-0309-reasoning", contextWindow: 2_000_000 },
+              { id: "grok-4.20-beta-latest-non-reasoning", contextWindow: 2_000_000 },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(true);
+    migration!.apply(raw, changes);
+
+    expect(raw.models.providers.xai.models.map((model) => model.contextWindow)).toEqual([
+      1_000_000, 1_000_000,
+    ]);
+    expect(changes).toHaveLength(2);
+    expect(migration!.legacyRules?.[0]?.match?.(raw.models.providers, raw)).toBe(false);
+  });
+
   it("does not modify correct contextWindow values", () => {
     const changes: string[] = [];
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -15,6 +15,20 @@ import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadat
 
 const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
   "deepseek/deepseek-v4-flash": { stale: 200_000, correct: 1_000_000 },
+  "xai/grok-4.20-0309-reasoning": { stale: 2_000_000, correct: 1_000_000 },
+  "xai/grok-4.20-0309-non-reasoning": { stale: 2_000_000, correct: 1_000_000 },
+  "xai/grok-4.20-beta-latest-reasoning": { stale: 2_000_000, correct: 1_000_000 },
+  "xai/grok-4.20-beta-latest-non-reasoning": { stale: 2_000_000, correct: 1_000_000 },
+  "xai/grok-4.20-experimental-beta-0304-reasoning": {
+    stale: 2_000_000,
+    correct: 1_000_000,
+  },
+  "xai/grok-4.20-experimental-beta-0304-non-reasoning": {
+    stale: 2_000_000,
+    correct: 1_000_000,
+  },
+  "xai/grok-4.20-reasoning": { stale: 2_000_000, correct: 1_000_000 },
+  "xai/grok-4.20-non-reasoning": { stale: 2_000_000, correct: 1_000_000 },
 } as const;
 
 function resolveStaleContextWindowFix(params: {
@@ -22,12 +36,13 @@ function resolveStaleContextWindowFix(params: {
   modelId: string;
   contextWindow: number;
 }): { stale: number; correct: number } | undefined {
-  if (params.providerId !== "deepseek") {
-    return undefined;
-  }
-  const scopedModelId = params.modelId.includes("/")
-    ? params.modelId
-    : `deepseek/${params.modelId}`;
+  const providerId = params.providerId.trim().toLowerCase();
+  const modelId = params.modelId.trim().toLowerCase();
+  const providerPrefix = `${providerId}/`;
+  const unprefixedModelId = modelId.startsWith(providerPrefix)
+    ? modelId.slice(providerPrefix.length)
+    : modelId;
+  const scopedModelId = `${providerId}/${unprefixedModelId}`;
   const fix = STALE_CONTEXT_WINDOW_FIXES[scopedModelId];
   return fix && params.contextWindow === fix.stale ? fix : undefined;
 }
@@ -546,7 +561,10 @@ function upgradeRetiredXaiModelId(model: string): string | null {
       return "grok-build-0.1";
     case "grok-4-fast-reasoning":
     case "grok-4-1-fast-reasoning":
+    case "grok-4-0709":
       return "grok-4.3";
+    case "grok-imagine-image-pro":
+      return "grok-imagine-image-quality";
     default:
       return null;
   }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
@@ -5,7 +5,10 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isRecord } from "./legacy-config-record-shared.js";
-import { migrateLegacyXSearchConfig } from "./legacy-x-search-migrate.js";
+import {
+  migrateLegacyXSearchConfig,
+  resolveLegacyXSearchModelTarget,
+} from "./legacy-x-search-migrate.js";
 
 const LEGACY_OPENAI_CODEX_PLUGIN_ID = "openai-codex";
 const OPENAI_PLUGIN_ID = "openai";
@@ -28,6 +31,14 @@ const X_SEARCH_RULE: LegacyConfigRule = {
   path: ["tools", "web", "x_search", "apiKey"],
   message:
     'tools.web.x_search.apiKey moved to the xAI plugin; use plugins.entries.xai.config.webSearch.apiKey instead. Run "openclaw doctor --fix".',
+};
+
+const X_SEARCH_MODEL_RULE: LegacyConfigRule = {
+  path: ["tools", "web", "x_search", "model"],
+  message:
+    'tools.web.x_search.model uses a retired xAI model; run "openclaw doctor --fix" to repair it.',
+  requireSourceLiteral: true,
+  match: (value) => resolveLegacyXSearchModelTarget(value) !== undefined,
 };
 
 function rewritePluginIdList(value: unknown): { next: unknown; changed: boolean } {
@@ -141,8 +152,8 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_PROVIDERS: LegacyConfigMigrationSp
   }),
   defineLegacyConfigMigration({
     id: "tools.web.x_search.apiKey->plugins.entries.xai.config.webSearch.apiKey",
-    describe: "Move legacy x_search auth into the xAI plugin webSearch config",
-    legacyRules: [X_SEARCH_RULE],
+    describe: "Move legacy x_search auth and repair retired xAI model defaults",
+    legacyRules: [X_SEARCH_RULE, X_SEARCH_MODEL_RULE],
     apply: (raw, changes) => {
       const migrated = migrateLegacyXSearchConfig(raw);
       if (!migrated.changes.length) {

--- a/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
@@ -16,7 +16,7 @@ describe("legacy web search config", () => {
             apiKey: "brave-key",
             grok: {
               apiKey: "xai-key",
-              model: "grok-4-search",
+              model: "grok-4-1-fast",
             },
             kimi: {
               apiKey: "kimi-key",
@@ -43,7 +43,7 @@ describe("legacy web search config", () => {
       config: {
         webSearch: {
           apiKey: "xai-key",
-          model: "grok-4-search",
+          model: "grok-4.3",
         },
       },
     });
@@ -58,9 +58,38 @@ describe("legacy web search config", () => {
     });
     expect(res.changes).toEqual([
       "Moved tools.web.search.apiKey → plugins.entries.brave.config.webSearch.apiKey.",
+      'Updated tools.web.search.grok.model from "grok-4-1-fast" to "grok-4.3".',
       "Moved tools.web.search.grok → plugins.entries.xai.config.webSearch.",
       "Moved tools.web.search.kimi → plugins.entries.moonshot.config.webSearch.",
     ]);
+  });
+
+  it("repairs retired Grok code aliases while preserving current aliases", () => {
+    const retired = migrateLegacyWebSearchConfig<OpenClawConfig>({
+      tools: {
+        web: {
+          search: { grok: { model: "grok-code-fast-1" } },
+        },
+      },
+    });
+    const current = migrateLegacyWebSearchConfig<OpenClawConfig>({
+      tools: {
+        web: {
+          search: { grok: { model: "grok-latest" } },
+        },
+      },
+    });
+
+    expect(retired.config.plugins?.entries?.xai?.config?.webSearch).toEqual({
+      model: "grok-build-0.1",
+    });
+    expect(retired.changes).toEqual([
+      'Updated tools.web.search.grok.model from "grok-code-fast-1" to "grok-build-0.1".',
+      "Moved tools.web.search.grok → plugins.entries.xai.config.webSearch.",
+    ]);
+    expect(current.config.plugins?.entries?.xai?.config?.webSearch).toEqual({
+      model: "grok-latest",
+    });
   });
 
   it("does not mutate the caller's original config", () => {

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -35,6 +35,32 @@ const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set([
   "tavily",
 ]);
 const LEGACY_GLOBAL_WEB_SEARCH_PROVIDER_ID = "brave";
+const RETIRED_GROK_WEB_SEARCH_MODELS = new Set([
+  "grok-4-1-fast",
+  "grok-4-1-fast-reasoning",
+  "grok-4-fast",
+  "grok-4-fast-reasoning",
+  "grok-4-0709",
+]);
+const RETIRED_GROK_CODE_MODELS = new Set([
+  "grok-code-fast-1",
+  "grok-code-fast",
+  "grok-code-fast-1-0825",
+]);
+
+export function resolveLegacyGrokWebSearchModelTarget(model: unknown): string | undefined {
+  if (typeof model !== "string") {
+    return undefined;
+  }
+  const normalized = model.trim().toLowerCase();
+  if (RETIRED_GROK_WEB_SEARCH_MODELS.has(normalized)) {
+    return "grok-4.3";
+  }
+  if (RETIRED_GROK_CODE_MODELS.has(normalized)) {
+    return "grok-build-0.1";
+  }
+  return undefined;
+}
 
 function getBundledLegacyWebSearchOwners(): ReadonlyMap<string, string> {
   return BUNDLED_LEGACY_WEB_SEARCH_OWNERS;
@@ -246,6 +272,16 @@ function normalizeLegacyWebSearchConfigRecord<T extends JsonRecord>(
     const pluginId = owners.get(providerId);
     if (!pluginId) {
       continue;
+    }
+    if (providerId === "grok") {
+      const targetModel = resolveLegacyGrokWebSearchModelTarget(scoped.model);
+      if (targetModel) {
+        const previousModel = scoped.model;
+        scoped.model = targetModel;
+        changes.push(
+          `Updated tools.web.search.grok.model from ${JSON.stringify(previousModel)} to ${JSON.stringify(targetModel)}.`,
+        );
+      }
     }
     migratePluginWebSearchConfig({
       root: nextRoot,

--- a/src/commands/doctor/shared/legacy-x-search-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-x-search-migrate.test.ts
@@ -114,13 +114,13 @@ describe("legacy x_search config migration", () => {
     ]);
   });
 
-  it("does nothing for knob-only x_search config without a legacy apiKey", () => {
+  it("repairs a retired knob-only x_search model without creating plugin config", () => {
     const config = {
       tools: {
         web: {
           x_search: {
             enabled: true,
-            model: "grok-4-1-fast",
+            model: "grok-4-1-fast-non-reasoning",
           },
         } as Record<string, unknown>,
       },
@@ -128,9 +128,36 @@ describe("legacy x_search config migration", () => {
 
     const res = migrateLegacyXSearchConfig(config);
 
-    expect(res.config).toEqual(config);
-    expect(res.changes).toStrictEqual([]);
+    expect((res.config.tools?.web as Record<string, unknown> | undefined)?.x_search).toEqual({
+      enabled: true,
+      model: "grok-4.3",
+    });
+    expect(res.changes).toEqual([
+      'Updated tools.web.x_search.model from "grok-4-1-fast-non-reasoning" to "grok-4.3".',
+    ]);
     expect(res.config.plugins?.entries?.xai).toBeUndefined();
+    expect(config.tools?.web).toEqual({
+      x_search: { enabled: true, model: "grok-4-1-fast-non-reasoning" },
+    });
   });
 
+  it("repairs retired Grok code aliases and preserves current aliases", () => {
+    const retired = migrateLegacyXSearchConfig({
+      tools: { web: { x_search: { model: "grok-code-fast-1" } } },
+    } as OpenClawConfig);
+    const current = migrateLegacyXSearchConfig({
+      tools: { web: { x_search: { model: "grok-latest" } } },
+    } as OpenClawConfig);
+
+    expect((retired.config.tools?.web as Record<string, unknown> | undefined)?.x_search).toEqual({
+      model: "grok-build-0.1",
+    });
+    expect(retired.changes).toEqual([
+      'Updated tools.web.x_search.model from "grok-code-fast-1" to "grok-build-0.1".',
+    ]);
+    expect(current).toEqual({
+      config: { tools: { web: { x_search: { model: "grok-latest" } } } },
+      changes: [],
+    });
+  });
 });

--- a/src/commands/doctor/shared/legacy-x-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-x-search-migrate.ts
@@ -6,6 +6,16 @@ type JsonRecord = Record<string, unknown>;
 const XAI_PLUGIN_ID = "xai";
 const X_SEARCH_LEGACY_PATH = "tools.web.x_search";
 const XAI_WEB_SEARCH_PLUGIN_KEY_PATH = `plugins.entries.${XAI_PLUGIN_ID}.config.webSearch.apiKey`;
+const RETIRED_X_SEARCH_MODELS = new Set([
+  "grok-4-1-fast-non-reasoning",
+  "grok-4-fast-non-reasoning",
+  "grok-3",
+]);
+const RETIRED_CODE_MODELS = new Set([
+  "grok-code-fast-1",
+  "grok-code-fast",
+  "grok-code-fast-1-0825",
+]);
 
 function cloneRecord<T extends JsonRecord | undefined>(value: T): T {
   if (!value) {
@@ -37,13 +47,29 @@ function resolveLegacyXSearchAuth(legacy: JsonRecord): unknown {
   return legacy.apiKey;
 }
 
-/** Move legacy X search API key config into plugins.entries.xai.config.webSearch. */
+export function resolveLegacyXSearchModelTarget(modelValue: unknown): string | undefined {
+  if (typeof modelValue !== "string") {
+    return undefined;
+  }
+  const model = modelValue.trim().toLowerCase();
+  if (RETIRED_X_SEARCH_MODELS.has(model)) {
+    return "grok-4.3";
+  }
+  if (RETIRED_CODE_MODELS.has(model)) {
+    return "grok-build-0.1";
+  }
+  return undefined;
+}
+
+/** Move legacy X search auth and repair retired legacy model defaults. */
 export function migrateLegacyXSearchConfig<T>(raw: T): { config: T; changes: string[] } {
   if (!isRecord(raw)) {
     return { config: raw, changes: [] };
   }
   const legacy = resolveLegacyXSearchConfig(raw);
-  if (!legacy || !Object.hasOwn(legacy, "apiKey")) {
+  const hasLegacyAuth = legacy ? Object.hasOwn(legacy, "apiKey") : false;
+  const modelTarget = legacy ? resolveLegacyXSearchModelTarget(legacy.model) : undefined;
+  if (!legacy || (!hasLegacyAuth && !modelTarget)) {
     return { config: raw, changes: [] };
   }
 
@@ -51,25 +77,34 @@ export function migrateLegacyXSearchConfig<T>(raw: T): { config: T; changes: str
   const tools = ensureRecord(nextRoot, "tools");
   const web = ensureRecord(tools, "web");
   const nextLegacy = cloneRecord(legacy) ?? {};
-  delete nextLegacy.apiKey;
+  if (hasLegacyAuth) {
+    delete nextLegacy.apiKey;
+  }
+  const changes: string[] = [];
+  if (modelTarget) {
+    nextLegacy.model = modelTarget;
+    changes.push(
+      `Updated ${X_SEARCH_LEGACY_PATH}.model from ${JSON.stringify(legacy.model)} to ${JSON.stringify(modelTarget)}.`,
+    );
+  }
   if (Object.keys(nextLegacy).length === 0) {
     delete web.x_search;
   } else {
     web.x_search = nextLegacy;
   }
 
-  const plugins = ensureRecord(nextRoot, "plugins");
-  const entries = ensureRecord(plugins, "entries");
-  const entry = ensureRecord(entries, XAI_PLUGIN_ID);
-  const hadEnabled = entry.enabled !== undefined;
-  if (!hadEnabled) {
-    entry.enabled = true;
-  }
-  const config = ensureRecord(entry, "config");
   const auth = resolveLegacyXSearchAuth(legacy);
-  const changes: string[] = [];
 
-  if (auth !== undefined) {
+  let hadEnabled = true;
+  if (hasLegacyAuth) {
+    const plugins = ensureRecord(nextRoot, "plugins");
+    const entries = ensureRecord(plugins, "entries");
+    const entry = ensureRecord(entries, XAI_PLUGIN_ID);
+    hadEnabled = entry.enabled !== undefined;
+    if (!hadEnabled) {
+      entry.enabled = true;
+    }
+    const config = ensureRecord(entry, "config");
     const existingWebSearch = isRecord(config.webSearch)
       ? cloneRecord(config.webSearch)
       : undefined;
@@ -89,7 +124,7 @@ export function migrateLegacyXSearchConfig<T>(raw: T): { config: T; changes: str
     }
   }
 
-  if (auth !== undefined && Object.keys(nextLegacy).length === 0 && !hadEnabled) {
+  if (hasLegacyAuth && Object.keys(nextLegacy).length === 0 && !hadEnabled) {
     changes.push(`Removed empty ${X_SEARCH_LEGACY_PATH}.`);
   }
 

--- a/src/flows/search-setup.test.ts
+++ b/src/flows/search-setup.test.ts
@@ -77,7 +77,7 @@ const mockGrokProvider = vi.hoisted(() => ({
     }
     const model = await prompter.select({
       message: "Grok model",
-      options: [{ value: "grok-4-1-fast", label: "grok-4-1-fast" }],
+      options: [{ value: "grok-4.3", label: "grok-4.3" }],
     });
     const pluginEntries = (config.plugins as { entries?: Record<string, unknown> } | undefined)
       ?.entries;
@@ -227,7 +227,7 @@ describe("runSearchSetupFlow", () => {
       .fn()
       .mockResolvedValueOnce("grok")
       .mockResolvedValueOnce("yes")
-      .mockResolvedValueOnce("grok-4-1-fast");
+      .mockResolvedValueOnce("grok-4.3");
     const text = vi.fn().mockResolvedValue("xai-test-key");
     const prompter = createWizardPrompter({
       select: select as never,
@@ -247,7 +247,7 @@ describe("runSearchSetupFlow", () => {
     expect(next.tools?.web?.search?.provider).toBe("grok");
     expect(next.tools?.web?.search?.enabled).toBe(true);
     expect(xaiConfig?.xSearch?.enabled).toBe(true);
-    expect(xaiConfig?.xSearch?.model).toBe("grok-4-1-fast");
+    expect(xaiConfig?.xSearch?.model).toBe("grok-4.3");
   });
 
   it("shows provider notes in every search provider row label", async () => {
@@ -434,7 +434,7 @@ describe("runSearchSetupFlow", () => {
       .fn()
       .mockResolvedValueOnce("grok")
       .mockResolvedValueOnce("yes")
-      .mockResolvedValueOnce("grok-4-1-fast");
+      .mockResolvedValueOnce("grok-4.3");
     const prompter = createWizardPrompter({
       select: select as never,
     });
@@ -473,7 +473,7 @@ describe("runSearchSetupFlow", () => {
     expect(next.tools?.web?.search?.provider).toBe("grok");
     expect(next.tools?.web?.search?.enabled).toBe(false);
     expect(xaiConfig?.xSearch?.enabled).toBe(true);
-    expect(xaiConfig?.xSearch?.model).toBe("grok-4-1-fast");
+    expect(xaiConfig?.xSearch?.model).toBe("grok-4.3");
   });
 
   it("allows an explicit setup flow to reenable credential-ready web_search", async () => {


### PR DESCRIPTION
Closes #103242

AI-assisted: yes (Codex). The implementation and live-provider behavior were reviewed and validated before publication.

## What Problem This Solves

Fixes an issue where xAI users would see stale Grok 4.20 catalog metadata and retired Grok Fast server-tool defaults, while current reasoning and tool-schema behavior was applied inconsistently across xAI models.

## Why This Change Was Made

This updates the bundled xAI catalog to the current canonical language models, preserves provider-owned moving aliases, and gives Grok 4.3, Grok 4.5, Grok Build, and Grok 4.20 their verified reasoning behavior. It also moves xAI server tools to Grok 4.3, adds safe doctor repairs for generated legacy config, keeps native schema features that xAI accepts, and removes stale request workarounds without exposing the incompatible multi-agent family.

## User Impact

Users can select the current Grok 4.20 dated models with correct 1M context metadata, use current xAI server-tool defaults, and keep intentional moving aliases. Existing OpenClaw-generated stale rows and retired tool defaults are repaired by `openclaw doctor --fix`; customized model rows are preserved.

## Evidence

- Official contract audit: current xAI model pages, Grok 4.3/4.5/Build/4.20 reasoning matrix, May 15 retirement guide, and structured-output schema support.
- Exact-ID live probe: 24/24 tested current and compatibility language IDs returned HTTP 200 and resolved to the documented current family.
- Application live suite: 12/12 passed, including Grok 4.3 and 4.5 completion/tool calls, web search, X search, and code execution.
- Gateway live suite: 112/112 passed across `grok-4.5`, `grok-build-0.1`, `grok-4.3`, `grok-4.20-0309-reasoning`, and `grok-4.20-0309-non-reasoning`, including prompt, read, exec, and image probes.
- Exact rebased head on Blacksmith Testbox through Crabbox `tbx_01kx4w3awbrq1z128hp2mnj2qp`: 1,237 focused assertions passed across catalog, provider, agent, doctor, and model-selection surfaces; core and extension production/test tsgo lanes passed.
- `git diff --check` passed.

Official references:

- https://docs.x.ai/developers/models
- https://docs.x.ai/developers/models/grok-4.3
- https://docs.x.ai/developers/models/grok-4.20-0309-reasoning
- https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning
- https://docs.x.ai/developers/models/grok-build-0.1
- https://docs.x.ai/developers/migration/may-15-retirement
