### PR TITLE
fix(ci): build iOS without a named simulator device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1631,7 +1631,7 @@
     "gen:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --write",
     "ghsa:patch": "node scripts/ghsa-patch.mjs",
     "ios:app-review-notes:pdf": "xcrun swift scripts/ios-app-review-notes-pdf.swift apps/ios/APP-REVIEW-NOTES.md apps/ios/build/app-review/APP-REVIEW-NOTES.pdf",
-    "ios:build": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-platform=iOS Simulator,name=iPhone 17}\" -configuration Debug build'",
+    "ios:build": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination \"${IOS_DEST:-generic/platform=iOS Simulator}\" -configuration Debug build'",
     "ios:filelist:gen": "node scripts/ios-write-swift-filelist.mjs",
     "ios:gen": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate'",
     "ios:open": "bash -lc './scripts/ios-configure-signing.sh && ./scripts/ios-write-version-xcconfig.sh && node scripts/ios-write-swift-filelist.mjs && cd apps/ios && xcodegen generate && open OpenClaw.xcodeproj'",

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -152,6 +152,13 @@ describe("package scripts", () => {
     expect(readPackageJson().scripts.start).toBe("node openclaw.mjs");
   });
 
+  it("builds iOS without requiring an installed simulator device", () => {
+    const script = readPackageJson().scripts["ios:build"];
+
+    expect(script).toContain('-destination "${IOS_DEST:-generic/platform=iOS Simulator}"');
+    expect(script).not.toMatch(/\$\{IOS_DEST:-[^}]*,name=/u);
+  });
+
   it("runs generated module formatting coverage in Windows CI", () => {
     expect(readPackageJson().scripts["test:windows:ci"]).toContain(
       "test/scripts/format-generated-module.test.ts",


### PR DESCRIPTION
Closes #103257

## What Problem This Solves

Fixes an issue where release-gate and full-CI iOS builds could fail before compilation when a macOS runner exposed the simulator SDK but no concrete simulator devices. The build-only lane required `iPhone 17`, so Xcode rejected an otherwise valid generic simulator build environment.

## Why This Change Was Made

The canonical `ios:build` command now defaults to Xcode's generic iOS Simulator destination while retaining `IOS_DEST` for explicit overrides. Concrete simulator selection remains unchanged in `ios:run` and UI/screenshot test lanes, which actually boot, install, or launch an app. A package-script regression guard prevents the build-only default from regaining a named-device dependency.

## User Impact

Maintainers can run release and exact-head CI without depending on the runner's pre-created CoreSimulator device inventory. There is no product runtime or UI behavior change.

## Evidence

- Before: exact-head CI run 29063344821, job 86269735564 failed with exit 70; Xcode listed only `Any iOS Simulator Device`. A rerun on a healthy allocation passed, confirming runner-state sensitivity: https://github.com/openclaw/openclaw/actions/runs/29063344821/job/86269735564
- Focused regression proof on Blacksmith Testbox through Crabbox (`tbx_01kx4wjv47htrnw0b92jg1waan`): 17/17 tests passed (`test/package-scripts.test.ts` and `test/scripts/ios-run.test.ts`), and the touched-surface changed gate passed: https://github.com/openclaw/openclaw/actions/runs/29064019785
- Platform proof: Xcode 26.6 successfully built the complete OpenClaw scheme with `-destination 'generic/platform=iOS Simulator'`, including the app, share extension, activity widget, and watch app.
- Exact-head release-gate CI passed with 111 successful jobs, 3 expected skips, and no failures; the Xcode 26.5 iOS job used the generic destination and ended `BUILD SUCCEEDED`: https://github.com/openclaw/openclaw/actions/runs/29064214024/job/86272299014
- Fresh structured autoreview: no accepted or actionable findings.

AI-assisted: yes. The implementation, owner boundaries, tests, Xcode behavior, and CI evidence were reviewed before opening.
