### PR TITLE
fix(ci): pin Kova timeout signal contract

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -45,7 +45,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 6a1c20bf818f71f93d6d4cad7dabac74a2996bc0
+        default: a2dd84e7d65507e614afaff850d3932d18c859b6
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -148,7 +148,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '6a1c20bf818f71f93d6d4cad7dabac74a2996bc0' }}
+      KOVA_REF: ${{ inputs.kova_ref || 'a2dd84e7d65507e614afaff850d3932d18c859b6' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator that reads agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "6a1c20bf818f71f93d6d4cad7dabac74a2996bc0";
+    const kovaRef = "a2dd84e7d65507e614afaff850d3932d18c859b6";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the default OpenClaw Performance workflow could still use a Kova evaluator that treated successful `timeoutMs` transport diagnostics as provider/model timeout failures.

## Why This Change Was Made

Pin both the workflow input default and runtime fallback to Kova commit `a2dd84e7d65507e614afaff850d3932d18c859b6`, which landed the standalone timeout-outcome classifier in openclaw/Kova#20. Keep the existing workflow contract test aligned with that immutable ref.

## User Impact

Release performance validation keeps genuine provider/model timeout failures blocking while no longer failing on harmless timeout-budget metadata from successful requests.

## Evidence

- exact diff: three SHA substitutions across the workflow default, runtime fallback, and existing contract test
- Testbox `tbx_01kx4wvg160qkam7pjfzptqcvr`: `test/scripts/openclaw-performance-workflow.test.ts` 21/21 PASS on the rebased head
- earlier same-box proof: full `node scripts/check-workflows.mjs` PASS (`actionlint`, `zizmor`, composite-action interpolation guard)
- local `actionlint .github/workflows/openclaw-performance.yml`: PASS
- `git diff --check`: PASS
- fresh structured autoreview against current `origin/main`: no actionable findings, confidence 0.90
- Kova CI run 29063965394: Ubuntu and macOS full self-check plus package-install smoke PASS
- source failure evidence: OpenClaw Performance run 29063372172, where a successful HTTP 200 request was misclassified solely from `timeoutMs=undefined`
