### PR TITLE
fix(infra): verify managed update handoff startup

### DIFF
--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -539,6 +539,26 @@ describe("update.run restart scheduling", () => {
     expect(payload?.ok).toBe(true);
   });
 
+  it("does not restart or report success when the handoff helper cannot spawn", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    mockGlobalInstallSurface();
+    startManagedServiceUpdateHandoffMock.mockRejectedValueOnce(
+      Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+    );
+
+    const payload = await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
+      captureUpdateRunPayload(),
+    );
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(payload?.ok).toBe(false);
+    expect(payload?.result).toMatchObject({
+      status: "error",
+      reason: "managed-service-handoff-failed",
+    });
+    expect(payload?.handoff).toBeUndefined();
+  });
+
   it("keeps a startup grace before restarting after systemd handoff spawn", async () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("systemd");
     mockGlobalInstallSurface();

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests managed-service update handoff behavior exposed by gateway methods.
  */
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -24,11 +26,23 @@ import {
 } from "./update-managed-service-handoff-cleanup.js";
 
 const { spawnMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn(() => ({
-    pid: 24680,
-    unref: vi.fn(),
-  })),
+  spawnMock: vi.fn(),
 }));
+
+function createSpawnMock(params?: { pid?: number }) {
+  const child = Object.assign(new EventEmitter(), {
+    pid: params?.pid ?? 24680,
+    exitCode: null,
+    signalCode: null,
+    stdout: new PassThrough(),
+    unref: vi.fn(),
+  });
+  return child;
+}
+
+function signalHandoffReady(child: ReturnType<typeof createSpawnMock>): void {
+  child.stdout.write("OPENCLAW_UPDATE_HANDOFF_READY\n");
+}
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessModule } =
@@ -41,9 +55,19 @@ vi.mock("node:child_process", async () => {
 const tempDirs = new Set<string>();
 type GatewayRestartSentinelDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_sentinel">;
 
+beforeEach(() => {
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(() => {
+    const child = createSpawnMock();
+    process.nextTick(() => {
+      signalHandoffReady(child);
+    });
+    return child;
+  });
+});
+
 afterEach(async () => {
   closeOpenClawStateDatabaseForTest();
-  spawnMock.mockClear();
   await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
   tempDirs.clear();
 });
@@ -340,6 +364,105 @@ exit 1
 }
 
 describe("managed service update handoff", () => {
+  it("reports started only after the detached helper signals readiness", async () => {
+    const child = createSpawnMock();
+    spawnMock.mockReturnValueOnce(child);
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+
+    const resultPromise = startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      restartDrainTimeoutMs: 300_000,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      meta: {},
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+
+    const pending = Symbol("pending");
+    await expect(
+      Promise.race([
+        resultPromise,
+        new Promise((resolve) => {
+          setImmediate(() => resolve(pending));
+        }),
+      ]),
+    ).resolves.toBe(pending);
+
+    signalHandoffReady(child);
+    await expect(resultPromise).resolves.toMatchObject({ status: "started", pid: 24680 });
+    expect(child.unref).toHaveBeenCalledTimes(1);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.stdout.destroyed).toBe(true);
+  });
+
+  it("rejects failed helper spawns and removes the sensitive handoff directory", async () => {
+    const child = createSpawnMock();
+    spawnMock.mockReturnValueOnce(child);
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+
+    const resultPromise = startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      restartDrainTimeoutMs: 300_000,
+      parentPid: 12345,
+      execPath: "/definitely/missing/openclaw-node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      meta: { sessionKey: "agent:test:webchat:dm:user-123" },
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    const handoffDir = path.dirname(args[0] ?? "");
+    tempDirs.add(handoffDir);
+
+    child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+    await expect(resultPromise).rejects.toMatchObject({ code: "ENOENT" });
+    expect(child.unref).not.toHaveBeenCalled();
+    await expect(pathExists(handoffDir)).resolves.toBe(false);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.stdout.destroyed).toBe(true);
+  });
+
+  it("rejects a systemd-run launcher that exits before the helper is ready", async () => {
+    const child = createSpawnMock();
+    spawnMock.mockReturnValueOnce(child);
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
+    tempDirs.add(binDir);
+    await fs.writeFile(path.join(binDir, "systemd-run"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+
+    const resultPromise = startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      restartDrainTimeoutMs: 300_000,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      supervisor: "systemd",
+      env: { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
+      meta: {},
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    const handoffDir = path.dirname(args.at(-2) ?? "");
+    tempDirs.add(handoffDir);
+
+    child.emit("exit", 1, null);
+
+    await expect(resultPromise).rejects.toThrow(
+      "managed update handoff exited before signaling readiness (code=1, signal=null)",
+    );
+    expect(child.unref).not.toHaveBeenCalled();
+    await expect(pathExists(handoffDir)).resolves.toBe(false);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.stdout.destroyed).toBe(true);
+  });
+
   it("strips process supervisor hints while preserving service identity for the CLI handoff", async () => {
     const { startManagedServiceUpdateHandoff, stripSupervisorHintEnv } =
       await import("./update-managed-service-handoff.js");
@@ -386,7 +509,7 @@ describe("managed service update handoff", () => {
     const [execPath, args, options] = spawnMock.mock.calls[0] as unknown as [
       string,
       string[],
-      { env: NodeJS.ProcessEnv; detached?: boolean; cwd?: string },
+      { env: NodeJS.ProcessEnv; detached?: boolean; cwd?: string; stdio?: unknown },
     ];
     expect(execPath).toBe("/usr/local/bin/node");
     expect(args).toHaveLength(2);
@@ -401,6 +524,7 @@ describe("managed service update handoff", () => {
     expect(options.cwd).toBe(os.homedir());
     expect(helperParams.cwd).toBe(os.homedir());
     expect(options.detached).toBe(true);
+    expect(options.stdio).toEqual(["ignore", "pipe", "ignore"]);
     expect(options.env.KEEP_ME).toBe("1");
     for (const [key, value] of Object.entries(serviceIdentityEnv)) {
       expect(options.env[key]).toBe(value);

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -25,7 +25,8 @@ import {
   MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX,
 } from "./update-managed-service-handoff-cleanup.js";
 
-const { spawnMock } = vi.hoisted(() => ({
+const { forceKillChildProcessTreeMock, spawnMock } = vi.hoisted(() => ({
+  forceKillChildProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
 }));
 
@@ -52,10 +53,18 @@ vi.mock("node:child_process", async () => {
   });
 });
 
+vi.mock("../process/child-process-tree.js", async () => {
+  const actual = await vi.importActual<typeof import("../process/child-process-tree.js")>(
+    "../process/child-process-tree.js",
+  );
+  return { ...actual, forceKillChildProcessTree: forceKillChildProcessTreeMock };
+});
+
 const tempDirs = new Set<string>();
 type GatewayRestartSentinelDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_sentinel">;
 
 beforeEach(() => {
+  forceKillChildProcessTreeMock.mockReset();
   spawnMock.mockReset();
   spawnMock.mockImplementation(() => {
     const child = createSpawnMock();
@@ -67,6 +76,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   closeOpenClawStateDatabaseForTest();
   await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
   tempDirs.clear();
@@ -456,6 +466,40 @@ describe("managed service update handoff", () => {
     await expect(resultPromise).rejects.toThrow(
       "managed update handoff exited before signaling readiness (code=1, signal=null)",
     );
+    expect(child.unref).not.toHaveBeenCalled();
+    await expect(pathExists(handoffDir)).resolves.toBe(false);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.stdout.destroyed).toBe(true);
+  });
+
+  it("terminates a detached helper that misses the readiness deadline", async () => {
+    vi.useFakeTimers();
+    const child = createSpawnMock();
+    spawnMock.mockReturnValueOnce(child);
+    const { startManagedServiceUpdateHandoff } =
+      await import("./update-managed-service-handoff.js");
+
+    const resultPromise = startManagedServiceUpdateHandoff({
+      root: "/tmp/openclaw",
+      restartDrainTimeoutMs: undefined,
+      parentPid: 12345,
+      execPath: "/usr/local/bin/node",
+      argv1: "/opt/openclaw/openclaw.mjs",
+      meta: {},
+    });
+    const rejection = resultPromise.catch((err: unknown) => err);
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1));
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    const handoffDir = path.dirname(args[0] ?? "");
+    tempDirs.add(handoffDir);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(rejection).resolves.toMatchObject({
+      message: "managed update handoff did not signal readiness within 30 seconds",
+    });
+    expect(forceKillChildProcessTreeMock).toHaveBeenCalledExactlyOnceWith(child);
     expect(child.unref).not.toHaveBeenCalled();
     await expect(pathExists(handoffDir)).resolves.toBe(false);
     expect(child.listenerCount("exit")).toBe(0);

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
 } from "../daemon/constants.js";
+import { forceKillChildProcessTree } from "../process/child-process-tree.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { SUPERVISOR_HINT_ENV_VARS, type RespawnSupervisor } from "./supervisor-markers.js";
 import type { UpdateChannel } from "./update-channels.js";
@@ -655,7 +656,18 @@ async function waitForHandoffReady(child: HandoffChild): Promise<void> {
           `managed update handoff exited before signaling readiness (code=${code ?? "null"}, signal=${signal ?? "null"})`,
         ),
       );
-    const onOutputError = (err: Error) => finish(err);
+    const terminateBeforeFailure = () => {
+      if (typeof child.pid !== "number" || child.pid <= 0) {
+        return;
+      }
+      // A helper that loaded its parameters is armed even if its readiness
+      // marker is lost. Stop the detached tree before reporting failure.
+      forceKillChildProcessTree(child);
+    };
+    const onOutputError = (err: Error) => {
+      terminateBeforeFailure();
+      finish(err);
+    };
     const onData = (chunk: Buffer | string) => {
       buffered = `${buffered}${chunk.toString()}`.slice(-HANDOFF_READY_MARKER.length * 2);
       if (buffered.includes(HANDOFF_READY_MARKER)) {
@@ -663,7 +675,7 @@ async function waitForHandoffReady(child: HandoffChild): Promise<void> {
       }
     };
     const timeout = setTimeout(() => {
-      child.unref();
+      terminateBeforeFailure();
       finish(new Error("managed update handoff did not signal readiness within 30 seconds"));
     }, HANDOFF_READY_TIMEOUT_MS);
 

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -1,6 +1,6 @@
 // Managed-service update handoff starts a detached process that can finish an
 // update after the gateway exits under launchd/systemd-style supervisors.
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -22,12 +22,15 @@ import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payloa
 // The Gateway may spend its full restart-drain budget before entering the
 // bounded shutdown phase. Keep the helper alive through both phases. (#99666)
 const PARENT_EXIT_SHUTDOWN_RESERVE_MS = 30_000;
+const HANDOFF_READY_TIMEOUT_MS = 30_000;
+const HANDOFF_READY_MARKER = "OPENCLAW_UPDATE_HANDOFF_READY\n";
 const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
 const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
   "OPENCLAW_LAUNCHD_LABEL",
   "OPENCLAW_SYSTEMD_UNIT",
   "OPENCLAW_WINDOWS_TASK_NAME",
 ] as const);
+type HandoffChild = ChildProcess & { stdout: NonNullable<ChildProcess["stdout"]> };
 
 const HANDOFF_SCRIPT = String.raw`
 const { spawn, spawnSync } = require("node:child_process");
@@ -47,6 +50,8 @@ function appendLog(line) {
     // Best effort only.
   }
 }
+
+fs.writeSync(1, ${JSON.stringify(HANDOFF_READY_MARKER)});
 
 function isPidAlive(pid) {
   if (!pid || typeof pid !== "number") {
@@ -617,6 +622,58 @@ function buildSystemdHandoffUnitName(handoffId: string | undefined): string {
   return `openclaw-update-${suffix}.scope`;
 }
 
+async function waitForHandoffReady(child: HandoffChild): Promise<void> {
+  const output = child.stdout;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let buffered = "";
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+      output.removeListener("data", onData);
+      output.removeListener("error", onOutputError);
+      output.destroy();
+    };
+    const finish = (err?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+    const onError = (err: Error) => finish(err);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+      finish(
+        new Error(
+          `managed update handoff exited before signaling readiness (code=${code ?? "null"}, signal=${signal ?? "null"})`,
+        ),
+      );
+    const onOutputError = (err: Error) => finish(err);
+    const onData = (chunk: Buffer | string) => {
+      buffered = `${buffered}${chunk.toString()}`.slice(-HANDOFF_READY_MARKER.length * 2);
+      if (buffered.includes(HANDOFF_READY_MARKER)) {
+        finish();
+      }
+    };
+    const timeout = setTimeout(() => {
+      child.unref();
+      finish(new Error("managed update handoff did not signal readiness within 30 seconds"));
+    }, HANDOFF_READY_TIMEOUT_MS);
+
+    child.once("error", onError);
+    child.once("exit", onExit);
+    output.once("error", onOutputError);
+    output.on("data", onData);
+  });
+}
+
 async function resolveHandoffSpawn(params: {
   supervisor?: RespawnSupervisor | null;
   env: NodeJS.ProcessEnv;
@@ -711,29 +768,38 @@ export async function startManagedServiceUpdateHandoff(params: {
     serviceRecovery: resolveGatewayServiceRecovery(params.supervisor, params.env ?? process.env),
   };
 
-  await fs.writeFile(scriptPath, `${HANDOFF_SCRIPT}\n`, { mode: 0o700 });
-  await fs.writeFile(paramsPath, `${JSON.stringify(helperParams, null, 2)}\n`, { mode: 0o600 });
-  await fs.writeFile(metaPath, `${JSON.stringify(metaFile, null, 2)}\n`, { mode: 0o600 });
+  let child: HandoffChild;
+  try {
+    await fs.writeFile(scriptPath, `${HANDOFF_SCRIPT}\n`, { mode: 0o700 });
+    await fs.writeFile(paramsPath, `${JSON.stringify(helperParams, null, 2)}\n`, { mode: 0o600 });
+    await fs.writeFile(metaPath, `${JSON.stringify(metaFile, null, 2)}\n`, { mode: 0o600 });
 
-  const env = {
-    ...stripSupervisorHintEnv(params.env ?? process.env),
-    [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
-    OPENCLAW_UPDATE_RUN_HANDOFF: "1",
-  };
-  const spawnTarget = await resolveHandoffSpawn({
-    supervisor: params.supervisor,
-    env,
-    execPath: params.execPath ?? process.execPath,
-    scriptPath,
-    paramsPath,
-    handoffId: params.handoffId,
-  });
-  const child = spawn(spawnTarget.command, spawnTarget.args, {
-    cwd: handoffCwd,
-    env,
-    detached: true,
-    stdio: "ignore",
-  });
+    const env = {
+      ...stripSupervisorHintEnv(params.env ?? process.env),
+      [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]: metaPath,
+      OPENCLAW_UPDATE_RUN_HANDOFF: "1",
+    };
+    const spawnTarget = await resolveHandoffSpawn({
+      supervisor: params.supervisor,
+      env,
+      execPath: params.execPath ?? process.execPath,
+      scriptPath,
+      paramsPath,
+      handoffId: params.handoffId,
+    });
+    child = spawn(spawnTarget.command, spawnTarget.args, {
+      cwd: handoffCwd,
+      env,
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // systemd-run can spawn before the user manager accepts the scope. Only let
+    // callers terminate the Gateway after the helper itself loads its params.
+    await waitForHandoffReady(child);
+  } catch (err) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
   child.unref();
 
   return {

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -1104,6 +1104,31 @@ describe("update-startup", () => {
     });
   });
 
+  it("does not restart after a managed auto-update handoff spawn failure", async () => {
+    mockPackageInstallStatus();
+    mockNpmChannelTag("beta", "2.0.0-beta.1");
+    detectRespawnSupervisorMock.mockReturnValue("launchd");
+    startManagedServiceUpdateHandoffMock.mockRejectedValueOnce(
+      Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
+    );
+    const log = { info: vi.fn() };
+
+    await runGatewayUpdateCheck({
+      cfg: createBetaAutoUpdateConfig(),
+      log,
+      isNixMode: false,
+      allowInTests: true,
+    });
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith("auto-update attempt failed", {
+      channel: "beta",
+      version: "2.0.0-beta.1",
+      tag: "beta",
+      reason: "Error: spawn ENOENT",
+    });
+  });
+
   it("uses managed systemd handoff for Linux gateway service auto-updates", async () => {
     mockPackageInstallStatus();
     mockNpmChannelTag("beta", "2.0.0-beta.1");


### PR DESCRIPTION
Supersedes #101524. GitHub rejected the contributor fork's far-behind full-tree update, so this replacement keeps the same focused patch on a maintainer branch with the original contributor credited as co-author.

## What Problem This Solves

Managed-service updates could crash the live Gateway when the detached handoff process failed to spawn. The original mitigation consumed the asynchronous child-process error, but then incorrectly reported the handoff as started and allowed the Gateway to shut down without a running updater.

This also affected the Linux systemd path: Node starts `systemd-run` first, while the requested helper is executed only after the user manager accepts the transient scope.

## Why This Change Was Made

The handoff helper now emits a small readiness marker after loading its private parameter file. The parent waits for that marker before reporting `started`, closes the readiness pipe, and then unreferences the detached helper. Direct spawn errors, systemd launcher exits, output errors, and readiness timeouts reject through the existing failed-handoff paths.

If startup fails, OpenClaw removes the complete temporary handoff directory so the helper script, parameters, and restart metadata do not remain on disk. RPC and automatic-update callers retain their existing error handling and no longer schedule Gateway shutdown after failure.

## User Impact

Managed updates now fail visibly and leave the running Gateway intact when the updater cannot start. Successful launchd, systemd, and Windows handoffs retain detached behavior.

## Evidence

- Node contract: inspected Node v22.19.0, v24.0.0, and v24.x child-process source and current type declarations; failed spawns report an asynchronous `error` and successful process creation emits `spawn` first.
- systemd contract: inspected current `src/run/run.c`; scope mode completes `StartTransientUnit` and its start job before replacing `systemd-run` with the requested command.
- Original untrusted head: sanitized AWS Crabbox `cbx_1089f9628131`, run `run_bdad6b34bb5a`, passed 124 focused tests.
- Repaired head: Testbox-through-Crabbox `tbx_01kx4v4zx7ecf61amvq5yf9742` passed 131 focused Gateway/infra tests and the full `check:changed` gate.
- Real direct failure: missing executable rejected with `ENOENT`; zero new handoff directories remained.
- Real direct success: helper returned `started` with a numeric PID, removed all three sensitive inputs, and retained its normal log.
- Real systemd success: actual `systemd-run --user --scope` reached helper readiness and left zero residual test directories.
- Real systemd failure: an invalid user-bus endpoint made the real launcher exit; OpenClaw rejected before reporting started and left zero residual directories.
- Real timeout failure: a process that loaded its parameter file but missed readiness for 30 seconds was terminated before rejection and left zero residual directories.
- Behavior contract: direct failure, direct success, systemd success, systemd-manager failure, cleanup, and caller no-restart clauses all passed.
- Fresh autoreview: no accepted/actionable findings.

Exact pushed-head CI passed for `f3a13fc10869f7386baf173672694805eace2bdb` in [run 29065636575](https://github.com/openclaw/openclaw/actions/runs/29065636575), including the required Windows coverage selected by the workflow.

## Merge Risk

Low-to-moderate and bounded to managed update handoff startup. The readiness wait has a 30-second fail-closed bound; after success the only parent pipe is destroyed before the child is unreferenced. No config, protocol, dependency, or steady-state storage surface changes.

AI-assisted: maintainer repair and validation performed with Codex; contributor credit preserved.
