### PR TITLE
fix(agents): prevent retained-writer CI race

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -4097,8 +4097,12 @@ describe("embedded attempt session lock lifecycle", () => {
   it("waits for active retained writers before releasing a takeover lock", async () => {
     const sessionFile = await createTempSessionFile();
     const events: string[] = [];
-    let releaseActiveWrite!: () => void;
+    let markActiveWriteStarted!: () => void;
     const activeWriteStarted = new Promise<void>((resolve) => {
+      markActiveWriteStarted = resolve;
+    });
+    let releaseActiveWrite!: () => void;
+    const activeWriteCanFinish = new Promise<void>((resolve) => {
       releaseActiveWrite = () => {
         events.push("active-finish");
         resolve();
@@ -4117,24 +4121,25 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await controller.releaseForPrompt();
     await controller.reacquireAfterPrompt();
-    const activeWrite = controller.withSessionWriteLock(async () => {
-      events.push("active-start");
-      await activeWriteStarted;
-    });
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
+    const activeWriteResult = Promise.allSettled([
+      controller.withSessionWriteLock(async () => {
+        events.push("active-start");
+        markActiveWriteStarted();
+        await activeWriteCanFinish;
+      }),
+    ]).then(([result]) => result);
+    await activeWriteStarted;
     await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
 
     let takeoverSettled = false;
-    const takeoverWrite = controller
-      .withSessionWriteLock(async () => {
+    const takeoverWriteResult = Promise.allSettled([
+      controller.withSessionWriteLock(async () => {
         events.push("late-write");
-      })
-      .catch((error: unknown) => error)
-      .finally(() => {
-        takeoverSettled = true;
-      });
+      }),
+    ]).then(([result]) => {
+      takeoverSettled = true;
+      return result;
+    });
     await waitUntil(
       () => controller.hasSessionTakeover(),
       "expected takeover detection while active retained writer was still running",
@@ -4144,8 +4149,18 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releaseRetained).not.toHaveBeenCalled();
 
     releaseActiveWrite();
-    await expect(activeWrite).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
-    await expect(takeoverWrite).resolves.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    const [activeResult, takeoverResult] = await Promise.all([
+      activeWriteResult,
+      takeoverWriteResult,
+    ]);
+    expect(activeResult.status).toBe("rejected");
+    expect(takeoverResult.status).toBe("rejected");
+    if (activeResult.status === "rejected") {
+      expect(activeResult.reason).toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    }
+    if (takeoverResult.status === "rejected") {
+      expect(takeoverResult.reason).toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    }
 
     expect(releaseRetained).toHaveBeenCalledTimes(1);
     expect(events).toEqual(["prep-release", "active-start", "active-finish", "retained-release"]);


### PR DESCRIPTION
Closes #103277

## What Problem This Solves

Fixes an issue where maintainers running the embedded-agent CI shard could see a false-red session-lock failure when runner scheduling let the takeover edit happen before the retained writer entered its callback.

## Why This Change Was Made

The regression test now handshakes the retained writer's callback entry, keeps its completion behind a separate gate, and observes both expected rejection paths immediately. Production session-lock behavior is unchanged.

## User Impact

Maintainers get deterministic retained-writer takeover coverage instead of an intermittent release-blocking CI failure. There is no runtime behavior change.

## Evidence

- Before: [CI run 29064197569](https://github.com/openclaw/openclaw/actions/runs/29064197569), [failed job 86272252320](https://github.com/openclaw/openclaw/actions/runs/29064197569/job/86272252320): 1 failed / 1,702 passed plus one unhandled takeover rejection.
- Testbox-through-Crabbox `tbx_01kx4x61tfbmrpvfvamwf6k92z`:
  - focused regression: passed
  - repeated focused regression: 20/20 passed
  - complete `attempt.session-lock.test.ts`: 111/111 passed
  - targeted oxfmt check: passed
  - `pnpm check:changed`: passed (`coreTests` typecheck and lint included)
- Fresh autoreview: clean, no actionable findings, confidence 0.98.

AI-assisted by Codex. The patch and failure path were reviewed and verified by the maintainer workflow.
