### PR TITLE
fix(msteams): bound User Token service success-body JSON reads

### DIFF
--- a/extensions/msteams/src/monitor-handler.sso.test.ts
+++ b/extensions/msteams/src/monitor-handler.sso.test.ts
@@ -156,6 +156,62 @@ describe("handleSigninTokenExchangeInvoke", () => {
     }
     expect(calls).toHaveLength(0);
   });
+
+  it("bounds an oversized User Token service success body and fails soft", async () => {
+    // A buggy or hostile Bot Framework 200 response with a huge body must not be
+    // fully buffered by response.json(); the bounded reader cancels the stream.
+    const state = { canceled: false, enqueued: 0 };
+    const chunkBytes = 1024 * 1024;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (state.enqueued >= 64) {
+          controller.close();
+          return;
+        }
+        state.enqueued += 1;
+        controller.enqueue(new Uint8Array(chunkBytes).fill(0x61));
+      },
+      cancel() {
+        state.canceled = true;
+      },
+    });
+    const jsonSpy = vi.spyOn(Response.prototype, "json").mockImplementation(async () => {
+      throw new Error("raw response.json() should not be used");
+    });
+    const fetchImpl: MSTeamsSsoFetch = async () =>
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    try {
+      const { sso, tokenStore } = createSsoDeps({ fetchImpl });
+
+      const result = await handleSigninTokenExchangeInvoke({
+        value: { id: "flow-1", connectionName: "GraphConnection", token: "exchangeable-token" },
+        user: { userId: "aad-user-guid", channelId: "msteams" },
+        deps: sso,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("unexpected_response");
+        expect(result.message).toMatch(/invalid or oversized JSON from User Token service/);
+      }
+      expect(jsonSpy).not.toHaveBeenCalled();
+      // Enforced well before the 64 MiB test ceiling; an unbounded reader would keep pulling.
+      expect(state.enqueued).toBeLessThan(32);
+      expect(state.canceled).toBe(true);
+
+      const stored = await tokenStore.get({
+        connectionName: "GraphConnection",
+        userId: "aad-user-guid",
+      });
+      expect(stored).toBeNull();
+    } finally {
+      jsonSpy.mockRestore();
+    }
+  });
 });
 
 describe("handleSigninVerifyStateInvoke", () => {

--- a/extensions/msteams/src/sso.ts
+++ b/extensions/msteams/src/sso.ts
@@ -24,6 +24,7 @@
  * that ack; these helpers encapsulate token exchange and persistence.
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { readMSTeamsHttpErrorDetail } from "./http-error.js";
 import type { MSTeamsSsoTokenStore } from "./sso-token-store.js";
@@ -130,9 +131,12 @@ async function callUserTokenService(
   }
   let parsed: unknown;
   try {
-    parsed = await response.json();
+    // Bound the success body before parsing: the User Token service is an external
+    // Bot Framework endpoint, and a huge 200 body would otherwise OOM via response.json().
+    // Mirrors oauth.token.ts; the error path above already uses readMSTeamsHttpErrorDetail.
+    parsed = await readProviderJsonResponse<unknown>(response, "MSTeams User Token service");
   } catch {
-    return { error: "invalid JSON from User Token service", status: response.status };
+    return { error: "invalid or oversized JSON from User Token service", status: response.status };
   }
   if (!parsed || typeof parsed !== "object") {
     return { error: "empty response from User Token service", status: response.status };


### PR DESCRIPTION
## What Problem This Solves

`callUserTokenService` in `extensions/msteams/src/sso.ts` exchanges a Teams SSO
token with the Bot Framework User Token service (`token.botframework.com`,
`/api/usertoken/exchange` and `/api/usertoken/GetToken`). On the success path it
parsed the response with a bare `await response.json()`, which fully buffers the
body before parsing.

From openclaw's perspective the User Token service is an external endpoint: a
buggy intermediary (MITM proxy, cached CDN edge, misconfigured gateway) returning
`200 OK` with a large or never-ending body would be buffered into memory before
JSON parsing, an out-of-memory / DoS vector affecting any Teams SSO sign-in.

## Why This Change Was Made

The same plugin already bounds every other external JSON read:

- `oauth.token.ts` token exchange uses `readProviderJsonResponse`
- `graph.ts`, `graph-upload.ts`, `attachments/graph.ts`, `attachments/bot-framework.ts` all use `readProviderJsonResponse`
- the error path in this very function already uses `readMSTeamsHttpErrorDetail` (bounded via `extractProviderErrorDetail`)

`sso.ts` was the lone outlier still using raw `response.json()`. This aligns it
with the sibling `oauth.token.ts:98` call form (same reader, same default cap,
same label style). No new abstraction is introduced — it reuses the existing
`readProviderJsonResponse` helper from `openclaw/plugin-sdk/provider-http`.

The token-exchange response is tiny (`token`, `connectionName`, `channelId`,
`expiration`), so the helper's 16 MiB default cap never affects a normal flow.

## User Impact

Teams SSO sign-in (`signin/tokenExchange` and `signin/verifyState` invoke flows)
is unchanged for well-formed responses. An oversized success body that would
previously risk an unbounded buffer now fails soft: the caller still returns a
structured `{ ok: false, code, message, status }` result (message:
"invalid or oversized JSON from User Token service") instead of growing memory.

## Evidence

- **Behavior addressed**: oversized/huge success body from the Bot Framework User Token service no longer fully buffered via `response.json()`; bounded reader cancels the stream.
- **Real environment tested**: Linux x86_64, Node 22, local focused vitest run on `extensions/msteams/src/monitor-handler.sso.test.ts`.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs extensions/msteams/src/monitor-handler.sso.test.ts --run
  node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
  node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
  ```
- **Evidence after fix**:
  ```
  Test Files  1 passed (1)
       Tests  6 passed (6)
  tsgo:extensions exit: 0
  tsgo:extensions:test exit: 0
  ```
  New regression test `bounds an oversized User Token service success body and fails soft` constructs a 64 MiB ceiling ReadableStream (1 MiB chunks), asserts:
  - result is `{ ok: false }` with message matching `/invalid or oversized JSON from User Token service/`
  - raw `Response.prototype.json` is never called (spy throws if used)
  - stream cancelled (`state.canceled === true`)
  - reader stopped well before the 64 MiB ceiling (`state.enqueued < 32`)
- **Observed result after fix**: the bounded reader cancels the oversized stream and the handler returns a structured soft-failure result; no token is persisted (store stays null).
- **What was not tested**:
  - Did not exercise the live `token.botframework.com` endpoint (would not reproduce a hostile oversized body and would require real Teams SSO credentials).
  - Did not test the `signin/verifyState` (GetToken) path separately — it shares the same `callUserTokenService` success-body read, so the exchange-path regression covers the bounded-read contract for both callers.

## Risk checklist

- User-visible behavior change? No — well-formed token-exchange responses parse identically; only an oversized success body now fails soft instead of unbounded-buffering.
- Config/env/migration change? No.
- Security/auth/secrets/network/tool-execution change? Additive hardening only — bounds an external success-body read; no auth or request-shape change.
- Highest-risk area: an oversized but valid token response being rejected. Not plausible: real User Token responses are < 1 KiB, cap is 16 MiB.

Mirrors the merged bounded-reader pattern already used in `oauth.token.ts` / `graph.ts`. No new abstraction — reuses `readProviderJsonResponse`.

AI-assisted; reviewed before submission.
