### PR TITLE
fix(queue): prevent applyQueueDropPolicy from selecting in-flight items as overflow victims

### DIFF
--- a/src/auto-reply/reply/queue.in-flight.test.ts
+++ b/src/auto-reply/reply/queue.in-flight.test.ts
@@ -1,0 +1,250 @@
+// Proves queue caps and depth describe pending work while active identities remain in shared state.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearFollowupQueue,
+  completeFollowupRunLifecycle,
+  enqueueFollowupRun,
+  getFollowupQueueDepth,
+  scheduleFollowupDrain,
+} from "./queue.js";
+import { createDeferred, createQueueTestRun as createRun } from "./queue.test-helpers.js";
+import { getExistingFollowupQueue } from "./queue/state.js";
+import type { FollowupRun, QueueDropPolicy, QueueSettings } from "./queue/types.js";
+
+describe("followup queue in-flight ownership", () => {
+  const keys = new Set<string>();
+
+  afterEach(() => {
+    for (const key of keys) {
+      clearFollowupQueue(key);
+    }
+    keys.clear();
+  });
+
+  const createKey = (suffix: string) => {
+    const key = `test-in-flight-${suffix}-${Date.now()}-${Math.random()}`;
+    keys.add(key);
+    return key;
+  };
+
+  const createSettings = (dropPolicy: QueueDropPolicy): QueueSettings => ({
+    mode: "followup",
+    debounceMs: 0,
+    cap: 1,
+    dropPolicy,
+  });
+
+  it.each(["old", "summarize"] as const)(
+    "keeps an active single delivery out of %s overflow victims",
+    async (dropPolicy) => {
+      const key = createKey(dropPolicy);
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const activeComplete = vi.fn();
+      const pendingComplete = vi.fn();
+      const calls: FollowupRun[] = [];
+      const active = {
+        ...createRun({ prompt: "active" }),
+        queuedLifecycle: { onComplete: activeComplete },
+      };
+      const runFollowup = async (run: FollowupRun) => {
+        calls.push(run);
+        run.queuedLifecycle?.onAdmitted?.();
+        if (run === active) {
+          entered.resolve();
+          await release.promise;
+        }
+        completeFollowupRunLifecycle(run);
+      };
+
+      try {
+        expect(
+          enqueueFollowupRun(key, active, createSettings(dropPolicy), "none", runFollowup),
+        ).toBe(true);
+        await entered.promise;
+
+        expect(getFollowupQueueDepth(key)).toBe(0);
+        expect(
+          enqueueFollowupRun(
+            key,
+            {
+              ...createRun({ prompt: "pending" }),
+              queuedLifecycle: { onComplete: pendingComplete },
+            },
+            createSettings(dropPolicy),
+            "none",
+          ),
+        ).toBe(true);
+        expect(
+          enqueueFollowupRun(
+            key,
+            createRun({ prompt: "survivor" }),
+            createSettings(dropPolicy),
+            "none",
+          ),
+        ).toBe(true);
+
+        const queue = getExistingFollowupQueue(key);
+        expect(queue?.inFlight.has(active)).toBe(true);
+        expect(queue?.items.map((item) => item.prompt)).toEqual(["active", "survivor"]);
+        expect(getFollowupQueueDepth(key)).toBe(1);
+        expect(activeComplete).not.toHaveBeenCalled();
+        expect(pendingComplete).toHaveBeenCalledTimes(dropPolicy === "old" ? 1 : 0);
+        expect(queue?.summarySources.map((item) => item.prompt)).toEqual(
+          dropPolicy === "summarize" ? ["pending"] : [],
+        );
+      } finally {
+        release.resolve();
+      }
+
+      await expect.poll(() => getExistingFollowupQueue(key)).toBeUndefined();
+      expect(activeComplete).toHaveBeenCalledOnce();
+      expect(pendingComplete).toHaveBeenCalledOnce();
+      expect(calls.at(-1)?.prompt).toBe("survivor");
+    },
+  );
+
+  it("admits one pending item under drop:new while another item is active", async () => {
+    const key = createKey("new");
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const rejectedEnqueued = vi.fn();
+    const rejectedComplete = vi.fn();
+    const active = createRun({ prompt: "active" });
+    const runFollowup = async (run: FollowupRun) => {
+      run.queuedLifecycle?.onAdmitted?.();
+      if (run === active) {
+        entered.resolve();
+        await release.promise;
+      }
+      completeFollowupRunLifecycle(run);
+    };
+
+    try {
+      expect(enqueueFollowupRun(key, active, createSettings("new"), "none", runFollowup)).toBe(
+        true,
+      );
+      await entered.promise;
+
+      expect(getFollowupQueueDepth(key)).toBe(0);
+      expect(
+        enqueueFollowupRun(key, createRun({ prompt: "pending" }), createSettings("new"), "none"),
+      ).toBe(true);
+      expect(
+        enqueueFollowupRun(
+          key,
+          {
+            ...createRun({ prompt: "rejected" }),
+            queuedLifecycle: {
+              onEnqueued: rejectedEnqueued,
+              onComplete: rejectedComplete,
+            },
+          },
+          createSettings("new"),
+          "none",
+        ),
+      ).toBe(false);
+
+      expect(getFollowupQueueDepth(key)).toBe(1);
+      expect(getExistingFollowupQueue(key)?.items.map((item) => item.prompt)).toEqual([
+        "active",
+        "pending",
+      ]);
+      expect(rejectedEnqueued).not.toHaveBeenCalled();
+      expect(rejectedComplete).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+    }
+
+    await expect.poll(() => getExistingFollowupQueue(key)).toBeUndefined();
+  });
+
+  it("protects a collect group and counts only active identities still present", async () => {
+    const key = createKey("collect");
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const groupCompletions = [vi.fn(), vi.fn()];
+    const pendingComplete = vi.fn();
+    const rejectedComplete = vi.fn();
+    let aggregate: FollowupRun | undefined;
+    const initialSettings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+    const group = groupCompletions.map((onComplete, index) => ({
+      ...createRun({
+        prompt: `group-${index + 1}`,
+        originatingChannel: "slack" as const,
+        originatingTo: "channel:A",
+        originatingChatType: "channel",
+      }),
+      queuedLifecycle: { onComplete },
+    }));
+    const runFollowup = async (run: FollowupRun) => {
+      if (!aggregate) {
+        aggregate = run;
+        entered.resolve();
+        await release.promise;
+      }
+      completeFollowupRunLifecycle(run);
+    };
+
+    for (const run of group) {
+      expect(enqueueFollowupRun(key, run, initialSettings, "none", undefined, false)).toBe(true);
+    }
+    scheduleFollowupDrain(key, runFollowup);
+
+    try {
+      await entered.promise;
+      const queue = getExistingFollowupQueue(key);
+      expect(queue?.inFlight.size).toBe(2);
+      expect(getFollowupQueueDepth(key)).toBe(0);
+
+      const oldSettings: QueueSettings = { ...initialSettings, cap: 1, dropPolicy: "old" };
+      expect(
+        enqueueFollowupRun(
+          key,
+          {
+            ...createRun({ prompt: "pending-old" }),
+            queuedLifecycle: { onComplete: pendingComplete },
+          },
+          oldSettings,
+          "none",
+        ),
+      ).toBe(true);
+      expect(enqueueFollowupRun(key, createRun({ prompt: "survivor" }), oldSettings, "none")).toBe(
+        true,
+      );
+
+      expect(queue?.items.map((item) => item.prompt)).toEqual(["group-1", "group-2", "survivor"]);
+      expect(pendingComplete).toHaveBeenCalledOnce();
+      expect(groupCompletions.map((complete) => complete.mock.calls.length)).toEqual([0, 0]);
+
+      aggregate?.queuedLifecycle?.onAdmitted?.();
+      expect(queue?.items.map((item) => item.prompt)).toEqual(["survivor"]);
+      expect(queue?.inFlight.size).toBe(2);
+      expect(getFollowupQueueDepth(key)).toBe(1);
+
+      expect(
+        enqueueFollowupRun(
+          key,
+          {
+            ...createRun({ prompt: "rejected-new" }),
+            queuedLifecycle: { onComplete: rejectedComplete },
+          },
+          { ...initialSettings, cap: 1, dropPolicy: "new" },
+          "none",
+        ),
+      ).toBe(false);
+      expect(rejectedComplete).toHaveBeenCalledOnce();
+      expect(getFollowupQueueDepth(key)).toBe(1);
+    } finally {
+      release.resolve();
+    }
+
+    await expect.poll(() => getExistingFollowupQueue(key)).toBeUndefined();
+    expect(groupCompletions.map((complete) => complete.mock.calls.length)).toEqual([1, 1]);
+  });
+});

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1106,6 +1106,7 @@ export function scheduleFollowupDrain(
             isCrossChannel,
             items: queue.items,
             run: effectiveRunFollowup,
+            inFlight: queue.inFlight,
           });
           if (collectDrainResult === "empty") {
             break;
@@ -1194,6 +1195,11 @@ export function scheduleFollowupDrain(
               });
             };
             try {
+              // Mark active group items as in-flight so the drop policy does not
+              // select them as overflow victims while the group drain is awaited.
+              for (const item of activeGroupItems) {
+                queue.inFlight.add(item);
+              }
               await drainGroup();
             } catch (err) {
               if (admitted) {
@@ -1201,6 +1207,9 @@ export function scheduleFollowupDrain(
               }
               throw err;
             } finally {
+              for (const item of activeGroupItems) {
+                queue.inFlight.delete(item);
+              }
               cancellation.dispose();
             }
             if (!admitted) {
@@ -1218,7 +1227,7 @@ export function scheduleFollowupDrain(
           continue;
         }
 
-        if (!(await drainNextQueueItem(queue.items, effectiveRunFollowup))) {
+        if (!(await drainNextQueueItem(queue.items, effectiveRunFollowup, queue.inFlight))) {
           break;
         }
       }

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -3,7 +3,11 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeChatType } from "../../../channels/chat-type.js";
 import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
-import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
+import {
+  applyQueueDropPolicy,
+  countPendingQueueItems,
+  shouldSkipQueueItem,
+} from "../../../utils/queue-helpers.js";
 import {
   createOverflowSummaryRetrySource,
   kickFollowupDrainIfIdle,
@@ -120,7 +124,8 @@ export function enqueueFollowupRun(
   }
   // drop:new rejects this source without mutating the existing queue. Do not
   // publish an external queued identity for work that will never be admitted.
-  if (queue.dropPolicy === "new" && queue.cap > 0 && queue.items.length >= queue.cap) {
+  const pendingCount = countPendingQueueItems(queue.items, queue.inFlight);
+  if (queue.dropPolicy === "new" && queue.cap > 0 && pendingCount >= queue.cap) {
     completeFollowupRunLifecycle(run);
     return false;
   }
@@ -202,7 +207,7 @@ export function getFollowupQueueDepth(key: string): number {
   if (!queue) {
     return 0;
   }
-  return queue.items.length;
+  return countPendingQueueItems(queue.items, queue.inFlight);
 }
 
 export function resetRecentQueuedMessageIdDedupe(): void {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -132,6 +132,7 @@ export function enqueueFollowupRun(
 
   const shouldEnqueue = applyQueueDropPolicy({
     queue,
+    inFlight: queue.inFlight,
     summarize: (item) => normalizeOptionalString(item.summaryLine) || item.prompt.trim(),
     onDrop: (dropped) => {
       if (queue.dropPolicy === "summarize") {

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -14,6 +14,8 @@ export type FollowupQueueState = {
   abortController: AbortController;
   items: FollowupRun[];
   draining: boolean;
+  /** Items currently checked out for in-flight delivery; drop policy must skip these. */
+  inFlight: Set<FollowupRun>;
   lastEnqueuedAt: number;
   mode: QueueMode;
   debounceMs: number;
@@ -112,6 +114,7 @@ export function getFollowupQueue(key: string, settings: QueueSettings): Followup
     abortController: new AbortController(),
     items: [],
     draining: false,
+    inFlight: new Set(),
     lastEnqueuedAt: 0,
     mode: settings.mode,
     debounceMs:
@@ -158,6 +161,7 @@ export function clearFollowupQueue(key: string): number {
     }
   }
   queue.items.length = 0;
+  queue.inFlight.clear();
   queue.droppedCount = 0;
   queue.summaryLines = [];
   queue.summarySources = [];

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -14,7 +14,7 @@ export type FollowupQueueState = {
   abortController: AbortController;
   items: FollowupRun[];
   draining: boolean;
-  /** Items currently checked out for in-flight delivery; drop policy must skip these. */
+  /** Identities retained in `items` while delivery awaits; pending cap and depth must exclude them. */
   inFlight: Set<FollowupRun>;
   lastEnqueuedAt: number;
   mode: QueueMode;

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   applyQueueDropPolicy,
   applyQueueRuntimeSettings,
   clearQueueSummaryState,
+  countPendingQueueItems,
   drainCollectQueueStep,
   drainNextQueueItem,
   hasCrossChannelItems,
@@ -165,6 +166,14 @@ describe("drainCollectQueueStep", () => {
 });
 
 describe("drainNextQueueItem", () => {
+  it("counts only in-flight identities that still intersect the queue", () => {
+    const active = { id: "active" };
+    const pending = { id: "pending" };
+    const alreadyRemoved = { id: "already-removed" };
+
+    expect(countPendingQueueItems([active, pending], new Set([active, alreadyRemoved]))).toBe(1);
+  });
+
   it("keeps overflow survivors when the queue mutates during an awaited drain", async () => {
     type Item = { id: string };
     const queue = {
@@ -219,33 +228,9 @@ describe("drainNextQueueItem", () => {
       )
     ) {}
 
-    // m1 is in-flight during the burst; drop policy must skip it.
     expect(delivered).toEqual(["m1", "m6", "m7", "m8"]);
     expect(dropped).toEqual(["m2", "m3", "m4", "m5"]);
     expect(queue.items).toEqual([]);
-  });
-
-  it("drops from the front when no in-flight set is provided", async () => {
-    type Item = { id: string };
-    const queue = {
-      items: [{ id: "m1" }, { id: "m2" }, { id: "m3" }, { id: "m4" }] as Item[],
-      cap: 2,
-      dropPolicy: "old" as const,
-      droppedCount: 0,
-      summaryLines: [] as string[],
-    };
-    const dropped: string[] = [];
-
-    applyQueueDropPolicy({
-      queue,
-      summarize: (item) => item.id,
-      onDrop: (items) => {
-        dropped.push(...items.map((item) => item.id));
-      },
-    });
-
-    expect(dropped).toEqual(["m1", "m2", "m3"]);
-    expect(queue.items).toEqual([{ id: "m4" }]);
   });
 
   it("skips in-flight items when selecting drop victims", () => {
@@ -273,7 +258,6 @@ describe("drainNextQueueItem", () => {
       },
     });
 
-    // m1 is in-flight so it is skipped; only m2 and m3 are dropped.
     expect(dropped).toEqual(["m2", "m3"]);
     expect(queue.items).toEqual([m1, m4]);
   });

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -168,11 +168,11 @@ describe("drainNextQueueItem", () => {
   it("keeps overflow survivors when the queue mutates during an awaited drain", async () => {
     type Item = { id: string };
     const queue = {
-      items: [{ id: "m1" }],
+      items: [{ id: "m1" }] as Item[],
       cap: 3,
       dropPolicy: "summarize" as const,
       droppedCount: 0,
-      summaryLines: [],
+      summaryLines: [] as string[],
     };
     const delivered: string[] = [];
     const dropped: string[] = [];
@@ -180,11 +180,16 @@ describe("drainNextQueueItem", () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
+    const inFlight = new Set<Item>();
 
-    const firstDrain = drainNextQueueItem(queue.items, async (item: Item) => {
-      delivered.push(item.id);
-      await gate;
-    });
+    const firstDrain = drainNextQueueItem(
+      queue.items,
+      async (item: Item) => {
+        delivered.push(item.id);
+        await gate;
+      },
+      inFlight,
+    );
     await Promise.resolve();
 
     for (let index = 2; index <= 8; index += 1) {
@@ -192,6 +197,7 @@ describe("drainNextQueueItem", () => {
       const shouldEnqueue = applyQueueDropPolicy({
         queue,
         summarize: (queued) => queued.id,
+        inFlight,
         onDrop: (items) => {
           dropped.push(...items.map((queued) => queued.id));
         },
@@ -204,14 +210,72 @@ describe("drainNextQueueItem", () => {
     release();
     await firstDrain;
     while (
-      await drainNextQueueItem(queue.items, async (item) => {
-        delivered.push(item.id);
-      })
+      await drainNextQueueItem(
+        queue.items,
+        async (item) => {
+          delivered.push(item.id);
+        },
+        inFlight,
+      )
     ) {}
 
+    // m1 is in-flight during the burst; drop policy must skip it.
     expect(delivered).toEqual(["m1", "m6", "m7", "m8"]);
-    expect(dropped).toEqual(["m1", "m2", "m3", "m4", "m5"]);
+    expect(dropped).toEqual(["m2", "m3", "m4", "m5"]);
     expect(queue.items).toEqual([]);
+  });
+
+  it("drops from the front when no in-flight set is provided", async () => {
+    type Item = { id: string };
+    const queue = {
+      items: [{ id: "m1" }, { id: "m2" }, { id: "m3" }, { id: "m4" }] as Item[],
+      cap: 2,
+      dropPolicy: "old" as const,
+      droppedCount: 0,
+      summaryLines: [] as string[],
+    };
+    const dropped: string[] = [];
+
+    applyQueueDropPolicy({
+      queue,
+      summarize: (item) => item.id,
+      onDrop: (items) => {
+        dropped.push(...items.map((item) => item.id));
+      },
+    });
+
+    expect(dropped).toEqual(["m1", "m2", "m3"]);
+    expect(queue.items).toEqual([{ id: "m4" }]);
+  });
+
+  it("skips in-flight items when selecting drop victims", () => {
+    type Item = { id: string };
+    const m1: Item = { id: "m1" };
+    const m2: Item = { id: "m2" };
+    const m3: Item = { id: "m3" };
+    const m4: Item = { id: "m4" };
+    const queue = {
+      items: [m1, m2, m3, m4],
+      cap: 2,
+      dropPolicy: "old" as const,
+      droppedCount: 0,
+      summaryLines: [] as string[],
+    };
+    const inFlight = new Set<Item>([m1]);
+    const dropped: string[] = [];
+
+    applyQueueDropPolicy({
+      queue,
+      inFlight,
+      summarize: (item) => item.id,
+      onDrop: (items) => {
+        dropped.push(...items.map((item) => item.id));
+      },
+    });
+
+    // m1 is in-flight so it is skipped; only m2 and m3 are dropped.
+    expect(dropped).toEqual(["m2", "m3"]);
+    expect(queue.items).toEqual([m1, m4]);
   });
 });
 

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -98,42 +98,40 @@ export function shouldSkipQueueItem<T>(params: {
   return params.dedupe(params.item, params.items);
 }
 
+/** Count identities that are still pending in the queue, excluding active deliveries. */
+export function countPendingQueueItems<T>(items: readonly T[], inFlight?: ReadonlySet<T>): number {
+  if (!inFlight || inFlight.size === 0) {
+    return items.length;
+  }
+  return items.reduce((count, item) => count + (inFlight.has(item) ? 0 : 1), 0);
+}
+
 /** Apply overflow policy before enqueueing another item. */
 export function applyQueueDropPolicy<T>(params: {
   queue: QueueState<T>;
   summarize: (item: T) => string;
   summaryLimit?: number;
   onDrop?: (items: T[]) => void;
-  /** Items currently mid-delivery that must not be selected as overflow drop victims. */
-  inFlight?: Set<T>;
+  inFlight?: ReadonlySet<T>;
 }): boolean {
   const cap = params.queue.cap;
-  if (cap <= 0 || params.queue.items.length < cap) {
+  const pendingCount = countPendingQueueItems(params.queue.items, params.inFlight);
+  if (cap <= 0 || pendingCount < cap) {
     return true;
   }
   if (params.queue.dropPolicy === "new") {
     return false;
   }
-  const inFlight = params.inFlight;
-  // Compute how many non-in-flight items must be dropped to make room.
-  // In-flight items stay in the shared items array while a drain awaits,
-  // so the effective queue length for cap purposes excludes them.
-  const inFlightCount = inFlight ? params.queue.items.reduce((n, item) => n + (inFlight.has(item) ? 1 : 0), 0) : 0;
-  const effectiveLength = params.queue.items.length - inFlightCount;
-  if (effectiveLength < cap) {
-    return true;
-  }
-  const dropCount = effectiveLength - cap + 1;
+  const dropCount = pendingCount - cap + 1;
   const dropped: T[] = [];
-  // Splice from the front, skipping in-flight items so they remain for their
-  // active delivery rather than being recorded as overflow victims.
-  for (let i = 0; dropped.length < dropCount && i < params.queue.items.length; ) {
-    const item = params.queue.items[i];
-    if (inFlight?.has(item)) {
-      i += 1;
+  // Active identities remain in the shared array until delivery succeeds; evict only pending work.
+  for (let index = 0; dropped.length < dropCount; ) {
+    const item = params.queue.items[index];
+    if (params.inFlight?.has(item)) {
+      index += 1;
       continue;
     }
-    dropped.push(...params.queue.items.splice(i, 1));
+    dropped.push(...params.queue.items.splice(index, 1));
   }
   params.onDrop?.(dropped);
   if (params.queue.dropPolicy === "summarize") {
@@ -213,10 +211,11 @@ export async function drainNextQueueItem<T>(
   inFlight?.add(next);
   try {
     await run(next);
+    // Keep the identity protected until its successful by-reference removal.
+    removeQueuedItemsByRef(items, [next]);
   } finally {
     inFlight?.delete(next);
   }
-  removeQueuedItemsByRef(items, [next]);
   return true;
 }
 

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -104,6 +104,8 @@ export function applyQueueDropPolicy<T>(params: {
   summarize: (item: T) => string;
   summaryLimit?: number;
   onDrop?: (items: T[]) => void;
+  /** Items currently mid-delivery that must not be selected as overflow drop victims. */
+  inFlight?: Set<T>;
 }): boolean {
   const cap = params.queue.cap;
   if (cap <= 0 || params.queue.items.length < cap) {
@@ -112,8 +114,27 @@ export function applyQueueDropPolicy<T>(params: {
   if (params.queue.dropPolicy === "new") {
     return false;
   }
-  const dropCount = params.queue.items.length - cap + 1;
-  const dropped = params.queue.items.splice(0, dropCount);
+  const inFlight = params.inFlight;
+  // Compute how many non-in-flight items must be dropped to make room.
+  // In-flight items stay in the shared items array while a drain awaits,
+  // so the effective queue length for cap purposes excludes them.
+  const inFlightCount = inFlight ? params.queue.items.reduce((n, item) => n + (inFlight.has(item) ? 1 : 0), 0) : 0;
+  const effectiveLength = params.queue.items.length - inFlightCount;
+  if (effectiveLength < cap) {
+    return true;
+  }
+  const dropCount = effectiveLength - cap + 1;
+  const dropped: T[] = [];
+  // Splice from the front, skipping in-flight items so they remain for their
+  // active delivery rather than being recorded as overflow victims.
+  for (let i = 0; dropped.length < dropCount && i < params.queue.items.length; ) {
+    const item = params.queue.items[i];
+    if (inFlight?.has(item)) {
+      i += 1;
+      continue;
+    }
+    dropped.push(...params.queue.items.splice(i, 1));
+  }
   params.onDrop?.(dropped);
   if (params.queue.dropPolicy === "summarize") {
     for (const item of dropped) {
@@ -181,12 +202,20 @@ export function removeQueuedItemsByRef<T>(items: T[], processed: readonly T[]): 
 export async function drainNextQueueItem<T>(
   items: T[],
   run: (item: T) => Promise<void>,
+  inFlight?: Set<T>,
 ): Promise<boolean> {
   const next = items[0];
   if (!next) {
     return false;
   }
-  await run(next);
+  // Mark the item as in-flight so applyQueueDropPolicy skips it during the
+  // await window when the shared items array is still mutated by enqueuers.
+  inFlight?.add(next);
+  try {
+    await run(next);
+  } finally {
+    inFlight?.delete(next);
+  }
   removeQueuedItemsByRef(items, [next]);
   return true;
 }
@@ -198,6 +227,7 @@ async function drainCollectItemIfNeeded<T>(params: {
   setForceIndividualCollect?: (next: boolean) => void;
   items: T[];
   run: (item: T) => Promise<void>;
+  inFlight?: Set<T>;
 }): Promise<"skipped" | "drained" | "empty"> {
   if (!params.forceIndividualCollect && !params.isCrossChannel) {
     return "skipped";
@@ -206,7 +236,7 @@ async function drainCollectItemIfNeeded<T>(params: {
     // Once cross-channel items appear, future collection stays individual to preserve ordering.
     params.setForceIndividualCollect?.(true);
   }
-  const drained = await drainNextQueueItem(params.items, params.run);
+  const drained = await drainNextQueueItem(params.items, params.run, params.inFlight);
   return drained ? "drained" : "empty";
 }
 
@@ -216,6 +246,7 @@ export async function drainCollectQueueStep<T>(params: {
   isCrossChannel: boolean;
   items: T[];
   run: (item: T) => Promise<void>;
+  inFlight?: Set<T>;
 }): Promise<"skipped" | "drained" | "empty"> {
   return await drainCollectItemIfNeeded({
     forceIndividualCollect: params.collectState.forceIndividualCollect,
@@ -225,6 +256,7 @@ export async function drainCollectQueueStep<T>(params: {
     },
     items: params.items,
     run: params.run,
+    inFlight: params.inFlight,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

While a followup is executing, its object stays in the shared queue array until delivery succeeds. Overflow eviction, `drop:new` admission, and reported queue depth previously treated that active object as pending work. Under a burst, the same message could therefore be delivered and also recorded as dropped; non-summary policies could complete its lifecycle before delivery finished.

Closes #103246

## Why This Change Was Made

The queue now owns one identity set for items currently being delivered. A shared intersection-based counter excludes only active identities that are still present in the queue array; this matters because collect admission can remove active group items before the awaited delivery settles. Old and summarize policies skip those identities when selecting victims, `drop:new` uses the same pending count before lifecycle publication, and public queue depth reports the same population.

Single-item removal remains by reference and still happens only after successful delivery, preserving the retry and concurrent-mutation fix from #91450. Collect groups receive the same protection for their full awaited delivery window.

## User Impact

- Active messages are no longer reported as unanswered overflow victims.
- Queue lifecycles do not complete early because of overflow eviction.
- `drop:new` admits up to the configured number of genuinely pending messages while another message is active.
- Queue status reports pending depth rather than counting work already executing.

## Evidence

- Exact reviewed head: `a557ff132ef88b144315ea5ccb25c5c8f2e67341`.
- Sanitized AWS Crabbox `cbx_76d796ba2956`, public networking, no Tailscale, no IAM instance profile:
  - `run_0e5b047f644f`: 31/31 tests passed across `queue-helpers.test.ts`, the production-owner `queue.in-flight.test.ts`, and `reply-flow.test.ts`.
  - `run_a4b0461ad81c`: `pnpm check:changed` passed the core/coreTests lanes, production and test tsgo checks, changed-file lint, and repository guards.
- GitHub CI run `29070791862` passed on the exact head, including build artifacts, lint, production/test types, and all Node shards (11,628 passed, 3 skipped in the full Node lane).
- Fresh full-branch autoreview: clean, no accepted/actionable findings, overall correctness 0.97.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
