### PR TITLE
fix(proxy-capture): use decodeTextPrefix for UTF-8 safe body preview text

### DIFF
--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -5,6 +5,7 @@ import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import net from "node:net";
 import { URL } from "node:url";
+import { decodeTextPrefix } from "@openclaw/normalization-core";
 import { ensureDebugProxyCa } from "./ca.js";
 import type { DebugProxySettings } from "./env.js";
 import { getDebugProxyCaptureStore } from "./store.sqlite.js";
@@ -138,7 +139,9 @@ function finishBodyPreviewCapture(capture: BodyPreviewCapture): {
   metaJson?: string;
 } {
   return {
-    dataText: Buffer.concat(capture.chunks, capture.previewBytes).toString("utf8"),
+    dataText: decodeTextPrefix(Buffer.concat(capture.chunks, capture.previewBytes), {
+      truncated: capture.truncated,
+    }),
     metaJson: capture.truncated
       ? JSON.stringify({
           bodyBytes: capture.totalBytes,


### PR DESCRIPTION
## What Problem This Solves

`finishBodyPreviewCapture()` in `src/proxy-capture/proxy-server.ts` uses `Buffer.concat(...).toString("utf8")` to produce the inline text preview for captured HTTP bodies. When `CAPTURE_BODY_PREVIEW_BYTES` (8192) falls inside a multi-byte UTF-8 character (emoji, CJK), `.toString("utf8")` silently replaces the incomplete trailing sequence with **U+FFFD replacement characters (�)**.

This is the same pattern as the `store.sqlite.ts` fix in #103276 — both files are in the same `proxy-capture` package and both decode truncated UTF-8 byte sequences for inline previews.

## Why This Change Was Made

Replace `Buffer.concat(...).toString("utf8")` with `decodeTextPrefix(Buffer.concat(...), { truncated: capture.truncated })` — the standard UTF-8 safe decoding helper already used in:
- `src/proxy-capture/store.sqlite.ts` (#103276, same package)
- `src/infra/http-error-body.ts:16`
- `src/agents/tools/web-shared.ts:222`

The `{ truncated: true }` option tells `decodeTextPrefix` to discard incomplete trailing multi-byte sequences. When `capture.truncated` is false (body fits within the limit), the behavior is identical to `.toString("utf8")`.

## User Impact

HTTP body previews in proxy capture listings no longer show U+FFFD replacement characters when the 8192-byte boundary falls inside a multi-byte UTF-8 character. Preview text is clean, valid UTF-8.

## Evidence

### Existing codebase pattern (same package)

```typescript
// src/proxy-capture/store.sqlite.ts (#103276)
dataText: decodeTextPrefix(buffer.subarray(0, previewLimit), { truncated: true }),
```

### Behavior

```
// Before: Buffer.concat(chunks).toString("utf8")
// Multi-byte char split → U+FFFD in preview text ❌

// After: decodeTextPrefix(Buffer.concat(chunks), { truncated: true })
// Incomplete trailing sequence gracefully discarded ✅
```

### Files Changed (1 file, +4/-1)

```
 src/proxy-capture/proxy-server.ts | 5 ++++-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)