### PR TITLE
fix(tmp): recognize sticky-bit directories as secure in tmp-openclaw-dir

### DIFF
--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -572,4 +572,55 @@ describe("resolvePreferredOpenClawTmpDir", () => {
 
     expect(result).toBe(POSIX_OPENCLAW_TMP_DIR);
   });
+
+  it("recognizes sticky-bit directories as secure and does not chmod them (#103190)", () => {
+    // /tmp on Linux has mode 0o41777 (sticky bit + world-writable).
+    // Without the sticky-bit check, isSecureDirForUser would classify it as
+    // insecure (0o1777 & 0o022 !== 0) and tryRepairWritableBits would chmod
+    // it to 0o700, corrupting system /tmp permissions.
+    const chmodSync = vi.fn();
+    const warn = vi.fn();
+    const stickyBitMode = 0o41777;
+
+    const result = resolvePreferredOpenClawTmpDir({
+      accessSync: vi.fn(),
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_OPENCLAW_TMP_DIR) {
+          return makeDirStat({ mode: stickyBitMode });
+        }
+        return secureDirStat();
+      }),
+      mkdirSync: vi.fn(),
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn,
+    });
+
+    expect(result).toBe(POSIX_OPENCLAW_TMP_DIR);
+    // chmod must NOT be called on a sticky-bit directory.
+    expect(chmodSync).not.toHaveBeenCalledWith(POSIX_OPENCLAW_TMP_DIR, 0o700);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still chmods non-sticky world-writable directories (#103190)", () => {
+    // A world-writable directory WITHOUT the sticky bit is genuinely insecure
+    // and should still be tightened to 0o700.
+    let preferredMode = 0o40777;
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === POSIX_OPENCLAW_TMP_DIR && mode === 0o700) {
+        preferredMode = 0o40700;
+      }
+    });
+    const warn = vi.fn();
+
+    const { resolved } = resolveWithMocks({
+      lstatSync: vi.fn(() => makeDirStat({ mode: preferredMode })),
+      chmodSync,
+      warn,
+    });
+
+    expect(resolved).toBe(POSIX_OPENCLAW_TMP_DIR);
+    expect(chmodSync).toHaveBeenCalledWith(POSIX_OPENCLAW_TMP_DIR, 0o700);
+  });
 });

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -66,6 +66,13 @@ export function resolvePreferredOpenClawTmpDir(
     if (typeof st.uid === "number" && st.uid !== uid) {
       return false;
     }
+    if (typeof st.mode === "number" && (st.mode & 0o1000) !== 0) {
+      // Sticky-bit directories like /tmp (mode 0o1777) are safe: only the
+      // file owner can delete or rename files inside, even though the
+      // directory itself is world-writable. Recognize the sticky bit as a
+      // safety mechanism rather than misclassifying the directory as insecure.
+      return true;
+    }
     return typeof st.mode !== "number" || (st.mode & 0o022) === 0;
   };
 
@@ -102,6 +109,12 @@ export function resolvePreferredOpenClawTmpDir(
       }
       if (typeof st.mode !== "number") {
         return false;
+      }
+      // Sticky-bit directories (e.g. /tmp with mode 0o1777) are safe as-is;
+      // chmod'ing them to 0o700 would corrupt system /tmp permissions and
+      // break every other process relying on the world-writable sticky-bit dir.
+      if ((st.mode & 0o1000) !== 0) {
+        return resolveDirState(candidatePath) === "available";
       }
       if ((st.mode & 0o022) === 0) {
         return resolveDirState(candidatePath) === "available";


### PR DESCRIPTION
## What Problem This Solves

`ensurePrivateDirectory` and `tryRepairWritableBits` in the temp directory resolution logic misclassify sticky-bit directories like `/tmp` (mode `0o1777`) as "insecure" because `(mode & 0o022) !== 0`. When OpenClaw's temp directory resolution runs against `/tmp`, `tryRepairWritableBits` chmod's it from `0o1777` to `0o0700`, immediately breaking MySQL, MariaDB, Postgres, tmux, X11, and every other process that relies on world-writable `/tmp`.

Additionally, `isSecureDirForUser` classifies `/tmp` as insecure because `0o1777 & 0o022 = 0o022 !== 0`, causing the resolver to reject `/tmp/openclaw` as a trusted path and fall back to a user-scoped directory unnecessarily.

Closes #103190

## Why This Change Was Made

The sticky bit (`0o1000`) is a well-established POSIX safety mechanism: on a world-writable directory, the sticky bit ensures that only the file owner (or the directory owner/root) can delete or rename files within it. `/tmp` with mode `0o1777` is the canonical example. The current code does not recognize this mechanism, treating the sticky-bit directory the same as a plain world-writable directory and attempting to tighten its permissions.

Two changes in `resolvePreferredOpenClawTmpDir`:
1. `isSecureDirForUser` now recognizes the sticky bit as a safety mechanism and returns `true` for sticky-bit directories owned by the current user.
2. `tryRepairWritableBits` now skips `chmod` entirely for sticky-bit directories, treating them as safe-as-is.

Non-sticky world-writable directories continue to be tightened to `0o700` as before.

## User Impact

Users running OpenClaw as a systemd user service or any setup where `os.tmpdir()` returns `/tmp` will no longer experience corrupted `/tmp` permissions after skill downloads, media transcoding, or any other operation that triggers temp workspace creation. The previous behavior could break the entire system silently.

## Evidence

- Added test `"recognizes sticky-bit directories as secure and does not chmod them (#103190)"` verifying that a directory with mode `0o41777` (sticky + world-writable) is accepted as secure without any `chmod` call.
- Added test `"still chmods non-sticky world-writable directories (#103190)"` verifying that world-writable directories without the sticky bit are still tightened to `0o700` as before.

Note: The `ensurePrivateDirectory` function in `@openclaw/fs-safe` has the same issue but lives in an external package. This PR fixes the OpenClaw-side `tmp-openclaw-dir.ts` which is the primary runtime path that resolves the temp root before it is passed to `@openclaw/fs-safe`. The external package fix should be addressed separately.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>