### PR TITLE
fix(ios): replace dead-end discovered gateway connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **iOS discovered gateways:** replace dead-end Connect actions for TLS-less Bonjour gateways with consistent TLS, Tailscale Serve, and trusted-LAN manual-setup guidance across onboarding, Quick Setup, and Settings. (#99031) Thanks @odrobnik.
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS discovered gateways:** replace dead-end Connect actions for TLS-less Bonjour gateways with consistent TLS, Tailscale Serve, and trusted-LAN manual-setup guidance across onboarding, Quick Setup, and Settings. (#99031) Thanks @odrobnik.
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10875,7 +10875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1004,
+      "line": 1020,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
@@ -10883,7 +10883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1005,
+      "line": 1021,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -10891,7 +10891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 1022,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -10899,7 +10899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1010,
+      "line": 1026,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -10907,7 +10907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1013,
+      "line": 1029,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -10915,7 +10915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1014,
+      "line": 1030,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -10923,7 +10923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1017,
+      "line": 1033,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -10931,7 +10931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1029,
+      "line": 1045,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -10939,7 +10939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1059,
+      "line": 1075,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -10947,7 +10947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1060,
+      "line": 1076,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -10955,7 +10955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1061,
+      "line": 1077,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -10963,7 +10963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1066,
+      "line": 1082,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Custom Headers",
       "surface": "apple",
@@ -10971,7 +10971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1073,
+      "line": 1089,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -10979,7 +10979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 1116,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -10987,7 +10987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1119,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -10995,7 +10995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1111,
+      "line": 1127,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -11003,7 +11003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1118,
+      "line": 1134,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -11011,7 +11011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1122,
+      "line": 1138,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -11019,7 +11019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1143,
+      "line": 1159,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
@@ -11027,7 +11027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1144,
+      "line": 1160,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -11035,7 +11035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1151,
+      "line": 1167,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -11043,7 +11043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1152,
+      "line": 1168,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -11051,7 +11051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1159,
+      "line": 1175,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -11059,7 +11059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1160,
+      "line": 1176,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -11067,7 +11067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1162,
+      "line": 1178,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -11075,7 +11075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1164,
+      "line": 1180,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -11083,7 +11083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1165,
+      "line": 1181,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -11091,7 +11091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1172,
+      "line": 1188,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -11099,7 +11099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1173,
+      "line": 1189,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -11107,7 +11107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1180,
+      "line": 1196,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -11115,7 +11115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1213,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -11123,7 +11123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1216,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -11131,7 +11131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1220,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -11139,7 +11139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1210,
+      "line": 1226,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -11147,7 +11147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1211,
+      "line": 1227,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -11155,7 +11155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1213,
+      "line": 1229,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -11163,7 +11163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1236,
+      "line": 1252,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
@@ -11882,6 +11882,30 @@
       "id": "native.apple.09312ef7ca727f4b"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 82,
+      "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
+      "source": "Connect",
+      "surface": "apple",
+      "id": "native.apple.3cb1f1788ffb16e2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 84,
+      "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
+      "source": "TLS required",
+      "surface": "apple",
+      "id": "native.apple.b6ea004a3ef09501"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 93,
+      "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
+      "source": "Enable Gateway TLS or Tailscale Serve, or use Manual Setup with Unencrypted only on a trusted LAN.",
+      "surface": "apple",
+      "id": "native.apple.ecb492a642ab8df3"
+    },
+    {
       "kind": "ui-call",
       "line": 11,
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
@@ -12035,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 62,
+      "line": 64,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12043,7 +12067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 66,
+      "line": 68,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect to this Gateway",
       "surface": "apple",
@@ -12051,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 82,
+      "line": 99,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Not now",
       "surface": "apple",
@@ -12059,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 89,
+      "line": 106,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Don't show this again",
       "surface": "apple",
@@ -12067,7 +12091,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 99,
+      "line": 116,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Quick Setup",
       "surface": "apple",
@@ -12075,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 107,
+      "line": 124,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Close",
       "surface": "apple",
@@ -12083,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 196,
+      "line": 220,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
@@ -12091,7 +12115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 270,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
@@ -12099,7 +12123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 270,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
@@ -12107,7 +12131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 260,
+      "line": 284,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -12115,7 +12139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 261,
+      "line": 285,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -12123,7 +12147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 262,
+      "line": 286,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
@@ -12131,7 +12155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 263,
+      "line": 287,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
@@ -12139,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 369,
+      "line": 393,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
@@ -12147,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 395,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
@@ -12155,7 +12179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 378,
+      "line": 402,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
@@ -12163,7 +12187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 379,
+      "line": 403,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
@@ -12171,7 +12195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 380,
+      "line": 404,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",
@@ -13027,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 742,
+      "line": 745,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resolving…",
       "surface": "apple",
@@ -13035,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 758,
+      "line": 774,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Restart Discovery",
       "surface": "apple",
@@ -13043,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 764,
+      "line": 780,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -13051,7 +13075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 768,
+      "line": 784,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -13059,7 +13083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 773,
+      "line": 789,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -13067,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 784,
+      "line": 800,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -13075,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 803,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -13083,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 815,
+      "line": 831,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -13091,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 819,
+      "line": 835,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
@@ -13099,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 833,
+      "line": 849,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -13107,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 839,
+      "line": 855,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -13115,7 +13139,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 849,
+      "line": 865,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -13123,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 863,
+      "line": 879,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
@@ -13131,7 +13155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 892,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -13139,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 908,
+      "line": 924,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
@@ -13147,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 940,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
@@ -13155,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 942,
+      "line": 958,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -13163,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 945,
+      "line": 961,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
@@ -13171,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 957,
+      "line": 973,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -13179,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 958,
+      "line": 974,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -13187,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 961,
+      "line": 977,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -13195,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 966,
+      "line": 982,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -13203,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 970,
+      "line": 986,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -13211,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 999,
+      "line": 1015,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -13219,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1000,
+      "line": 1016,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -13227,7 +13251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1003,
+      "line": 1019,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -13235,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1074,
+      "line": 1090,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -13243,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1078,
+      "line": 1094,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11901,9 +11901,25 @@
       "kind": "ui-localized-call",
       "line": 93,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
-      "source": "Enable Gateway TLS or Tailscale Serve, or use Manual Setup with Unencrypted only on a trusted LAN.",
+      "source": "Enable Gateway TLS, or enter your Tailscale Serve HTTPS host in Manual Setup. Use Unencrypted only with a trusted private-LAN address.",
       "surface": "apple",
-      "id": "native.apple.ecb492a642ab8df3"
+      "id": "native.apple.16e06dae717734de"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1302,
+      "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
+      "source": "Can't reach gateway at \\(host):\\(port). Verify Tailscale Serve is enabled and publishes this Gateway.",
+      "surface": "apple",
+      "id": "native.apple.ccfde3d74305d096"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1305,
+      "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
+      "source": "Can't reach gateway at \\(host):\\(port). Check Tailscale or LAN.",
+      "surface": "apple",
+      "id": "native.apple.fe8f13e52e05ff77"
     },
     {
       "kind": "ui-call",
@@ -12059,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 64,
+      "line": 70,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12067,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 68,
+      "line": 74,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect to this Gateway",
       "surface": "apple",
@@ -12075,7 +12091,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 99,
+      "line": 100,
+      "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
+      "source": "Use Manual Setup",
+      "surface": "apple",
+      "id": "native.apple.91a0ab004066bacb"
+    },
+    {
+      "kind": "ui-call",
+      "line": 114,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Not now",
       "surface": "apple",
@@ -12083,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 106,
+      "line": 121,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Don't show this again",
       "surface": "apple",
@@ -12091,7 +12115,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 116,
+      "line": 131,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Quick Setup",
       "surface": "apple",
@@ -12099,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 124,
+      "line": 139,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Close",
       "surface": "apple",
@@ -12107,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 220,
+      "line": 233,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
@@ -12115,7 +12139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 270,
+      "line": 283,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
@@ -12123,7 +12147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 270,
+      "line": 283,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
@@ -12131,7 +12155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 284,
+      "line": 297,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -12139,7 +12163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 285,
+      "line": 298,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -12147,7 +12171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 286,
+      "line": 299,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
@@ -12155,7 +12179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 287,
+      "line": 300,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
@@ -12163,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 406,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
@@ -12171,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 408,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
@@ -12179,7 +12203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 402,
+      "line": 415,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
@@ -12187,7 +12211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 403,
+      "line": 416,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
@@ -12195,7 +12219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 404,
+      "line": 417,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",
@@ -13051,15 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 745,
-      "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
-      "source": "Resolving…",
-      "surface": "apple",
-      "id": "native.apple.17b900bb8b2fcced"
-    },
-    {
-      "kind": "ui-call",
-      "line": 774,
+      "line": 770,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Restart Discovery",
       "surface": "apple",
@@ -13067,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 780,
+      "line": 776,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -13075,7 +13091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 784,
+      "line": 780,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -13083,7 +13099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 789,
+      "line": 785,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -13091,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 796,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -13099,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 803,
+      "line": 799,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -13107,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 831,
+      "line": 827,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -13115,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 835,
+      "line": 831,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
@@ -13123,7 +13139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 849,
+      "line": 845,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -13131,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 855,
+      "line": 851,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -13139,7 +13155,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 865,
+      "line": 861,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -13147,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 879,
+      "line": 875,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
@@ -13155,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 892,
+      "line": 888,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -13163,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 920,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
@@ -13171,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 940,
+      "line": 936,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
@@ -13179,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 958,
+      "line": 954,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -13187,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 961,
+      "line": 957,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
@@ -13195,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 973,
+      "line": 969,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -13203,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 974,
+      "line": 970,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -13211,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 977,
+      "line": 973,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -13219,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 982,
+      "line": 978,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -13227,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 986,
+      "line": 982,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -13235,7 +13251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1015,
+      "line": 1011,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -13243,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1016,
+      "line": 1012,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -13251,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1019,
+      "line": 1015,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -13259,7 +13275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1090,
+      "line": 1086,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -13267,7 +13283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1090,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -13435,7 +13451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1017,
+      "line": 1020,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -13443,7 +13459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1017,
+      "line": 1020,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -13451,7 +13467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1053,
+      "line": 1056,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -13459,7 +13475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1053,
+      "line": 1056,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -974,29 +974,45 @@ extension SettingsProTab {
     }
 
     func discoveredGatewayRow(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(verbatim: gateway.name)
-                    .font(OpenClawType.subheadSemiBold)
-                Text(verbatim: self.gatewayDetailLines(gateway).joined(separator: " • "))
-                    .font(OpenClawType.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
-            Spacer(minLength: 8)
-            Button {
-                Task { await self.connect(gateway) }
-            } label: {
-                if self.connectingGatewayID == gateway.id {
-                    ProgressView().controlSize(.small)
+        let availability = self.gatewayController.discoveredGatewayConnectionAvailability(gateway)
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(verbatim: gateway.name)
+                        .font(OpenClawType.subheadSemiBold)
+                    Text(verbatim: self.gatewayDetailLines(gateway).joined(separator: " • "))
+                        .font(OpenClawType.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 8)
+                if availability.canConnect {
+                    Button {
+                        Task { await self.connect(gateway) }
+                    } label: {
+                        if self.connectingGatewayID == gateway.id {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text(availability.actionTitle)
+                                .font(OpenClawType.captionSemiBold)
+                        }
+                    }
+                    .font(OpenClawType.captionSemiBold)
+                    .buttonStyle(.bordered)
+                    .disabled(self.connectingGatewayID != nil)
                 } else {
-                    Text("Connect")
+                    Text(availability.actionTitle)
                         .font(OpenClawType.captionSemiBold)
+                        .foregroundStyle(OpenClawBrand.warn)
                 }
             }
-            .font(OpenClawType.captionSemiBold)
-            .buttonStyle(.bordered)
-            .disabled(self.connectingGatewayID != nil)
+
+            if let guidanceText = availability.guidanceText {
+                Text(guidanceText)
+                    .font(OpenClawType.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -1299,10 +1299,11 @@ final class GatewayConnectionController {
         switch failure {
         case .endpointUnreachable:
             if host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: ".")).hasSuffix(".ts.net") {
-                return String(
+                String(
                     localized: "Can't reach gateway at \(host):\(port). Verify Tailscale Serve is enabled and publishes this Gateway.")
+            } else {
+                String(localized: "Can't reach gateway at \(host):\(port). Check Tailscale or LAN.")
             }
-            return String(localized: "Can't reach gateway at \(host):\(port). Check Tailscale or LAN.")
         case .tlsHandshakeTimeout:
             "TLS fingerprint verification timed out for \(host):\(port). "
                 + "Secure endpoint was reached, but TLS did not finish in time."

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -91,7 +91,7 @@ final class GatewayConnectionController {
                 nil
             case .secureTransportRequired:
                 String(
-                    localized: "Enable Gateway TLS or Tailscale Serve, or use Manual Setup with Unencrypted only on a trusted LAN.")
+                    localized: "Enable Gateway TLS, or enter your Tailscale Serve HTTPS host in Manual Setup. Use Unencrypted only with a trusted private-LAN address.")
             }
         }
     }
@@ -286,6 +286,12 @@ final class GatewayConnectionController {
             return .available
         }
         return .secureTransportRequired
+    }
+
+    func preferredDiscoveredGateway() -> GatewayDiscoveryModel.DiscoveredGateway? {
+        self.gateways.first(where: {
+            self.discoveredGatewayConnectionAvailability($0).canConnect
+        }) ?? self.gateways.first
     }
 
     private func connectDiscoveredGateway(
@@ -1292,7 +1298,11 @@ final class GatewayConnectionController {
     {
         switch failure {
         case .endpointUnreachable:
-            "Can't reach gateway at \(host):\(port). Check Tailscale or LAN."
+            if host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: ".")).hasSuffix(".ts.net") {
+                return String(
+                    localized: "Can't reach gateway at \(host):\(port). Verify Tailscale Serve is enabled and publishes this Gateway.")
+            }
+            return String(localized: "Can't reach gateway at \(host):\(port). Check Tailscale or LAN.")
         case .tlsHandshakeTimeout:
             "TLS fingerprint verification timed out for \(host):\(port). "
                 + "Secure endpoint was reached, but TLS did not finish in time."

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -68,6 +68,34 @@ private func defaultGatewayTLSFingerprintProbe(url: URL) async -> GatewayTLSFing
 @MainActor
 @Observable
 final class GatewayConnectionController {
+    enum DiscoveredGatewayConnectionAvailability: Equatable {
+        case available
+        case secureTransportRequired
+
+        var canConnect: Bool {
+            self == .available
+        }
+
+        var actionTitle: String {
+            switch self {
+            case .available:
+                String(localized: "Connect")
+            case .secureTransportRequired:
+                String(localized: "TLS required")
+            }
+        }
+
+        var guidanceText: String? {
+            switch self {
+            case .available:
+                nil
+            case .secureTransportRequired:
+                String(
+                    localized: "Enable Gateway TLS or Tailscale Serve, or use Manual Setup with Unencrypted only on a trusted LAN.")
+            }
+        }
+    }
+
     static func resolvedManualPort(host: String, port: Int) -> Int? {
         if port > 0 {
             return port <= 65535 ? port : nil
@@ -251,10 +279,22 @@ final class GatewayConnectionController {
         await self.connectDiscoveredGateway(gateway)
     }
 
+    func discoveredGatewayConnectionAvailability(
+        _ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> DiscoveredGatewayConnectionAvailability
+    {
+        if gateway.tlsEnabled || GatewayTLSStore.loadFingerprint(stableID: gateway.stableID) != nil {
+            return .available
+        }
+        return .secureTransportRequired
+    }
+
     private func connectDiscoveredGateway(
         _ gateway: GatewayDiscoveryModel.DiscoveredGateway,
         forceReconnect: Bool = false) async -> String?
     {
+        let availability = self.discoveredGatewayConnectionAvailability(gateway)
+        guard availability.canConnect else { return availability.guidanceText }
+
         let connectAttempt = self.beginConnectAttempt()
         self.pendingConnectionStableID = gateway.stableID
         defer { self.finishConnectAttempt(connectAttempt.suppressionLease) }
@@ -284,10 +324,6 @@ final class GatewayConnectionController {
         // Discovery is a LAN operation; refuse unauthenticated plaintext connects.
         let tlsRequired = true
         let stored = GatewayTLSStore.loadFingerprint(stableID: stableID)
-
-        guard gateway.tlsEnabled || stored != nil else {
-            return "Discovered gateway is missing TLS and no trusted fingerprint is stored."
-        }
 
         if tlsRequired, stored == nil {
             guard let url = self.buildGatewayURL(host: target.host, port: target.port, useTLS: true)

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -10,10 +10,16 @@ struct GatewayQuickSetupSheet: View {
     @Environment(GatewayConnectionController.self) private var gatewayController
     @Environment(\.dismiss) private var dismiss
 
+    let onUseManualSetup: () -> Void
+
     @AppStorage("onboarding.quickSetupDismissed") private var quickSetupDismissed: Bool = false
     @State private var connecting: Bool = false
     @State private var connectError: String?
     @State private var showGatewayProblemDetails: Bool = false
+
+    init(onUseManualSetup: @escaping () -> Void = {}) {
+        self.onUseManualSetup = onUseManualSetup
+    }
 
     var body: some View {
         NavigationStack {
@@ -87,6 +93,15 @@ struct GatewayQuickSetupSheet: View {
                                 }
                             }
                             .accessibilityElement(children: .combine)
+
+                            Button {
+                                self.onUseManualSetup()
+                            } label: {
+                                Text("Use Manual Setup")
+                                    .font(OpenClawType.subheadSemiBold)
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(OpenClawSecondaryActionButtonStyle())
                         }
 
                         if let connectError {
@@ -141,9 +156,7 @@ struct GatewayQuickSetupSheet: View {
     }
 
     private var bestCandidate: GatewayDiscoveryModel.DiscoveredGateway? {
-        self.gatewayController.gateways.first(where: {
-            self.gatewayController.discoveredGatewayConnectionAvailability($0).canConnect
-        }) ?? self.gatewayController.gateways.first
+        self.gatewayController.preferredDiscoveredGateway()
     }
 
     private func fullRowToggle(_ title: LocalizedStringKey, isOn: Binding<Bool>) -> some View {

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -34,6 +34,7 @@ struct GatewayQuickSetupSheet: View {
                     }
 
                     if let candidate = self.bestCandidate {
+                        let availability = self.gatewayController.discoveredGatewayConnectionAvailability(candidate)
                         GatewayQuickSetupCandidatePanel(
                             name: candidate.name,
                             debugID: candidate.debugID,
@@ -44,33 +45,49 @@ struct GatewayQuickSetupSheet: View {
                             nodeStatusText: self.appModel.nodeStatusText,
                             operatorStatusText: self.appModel.operatorStatusText)
 
-                        Button {
-                            self.connectError = nil
-                            self.connecting = true
-                            Task {
-                                let err = await self.gatewayController.connectWithDiagnostics(candidate)
-                                await MainActor.run {
-                                    self.connecting = false
-                                    self.connectError = err
+                        if availability.canConnect {
+                            Button {
+                                self.connectError = nil
+                                self.connecting = true
+                                Task {
+                                    let err = await self.gatewayController.connectWithDiagnostics(candidate)
+                                    await MainActor.run {
+                                        self.connecting = false
+                                        self.connectError = err
+                                    }
                                 }
-                            }
-                        } label: {
-                            Group {
-                                if self.connecting {
-                                    HStack(spacing: 8) {
-                                        ProgressView().progressViewStyle(.circular)
-                                        Text("Connecting…")
+                            } label: {
+                                Group {
+                                    if self.connecting {
+                                        HStack(spacing: 8) {
+                                            ProgressView().progressViewStyle(.circular)
+                                            Text("Connecting…")
+                                                .font(OpenClawType.subheadSemiBold)
+                                        }
+                                    } else {
+                                        Text("Connect to this Gateway")
                                             .font(OpenClawType.subheadSemiBold)
                                     }
-                                } else {
-                                    Text("Connect to this Gateway")
+                                }
+                                .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(OpenClawPrimaryActionButtonStyle())
+                            .disabled(self.connecting)
+                        } else if let guidanceText = availability.guidanceText {
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: "lock.shield.fill")
+                                    .foregroundStyle(OpenClawBrand.warn)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(availability.actionTitle)
                                         .font(OpenClawType.subheadSemiBold)
+                                    Text(guidanceText)
+                                        .font(OpenClawType.caption)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 }
                             }
-                            .frame(maxWidth: .infinity)
+                            .accessibilityElement(children: .combine)
                         }
-                        .buttonStyle(OpenClawPrimaryActionButtonStyle())
-                        .disabled(self.connecting)
 
                         if let connectError {
                             GatewayQuickSetupErrorView(message: connectError)
@@ -124,7 +141,9 @@ struct GatewayQuickSetupSheet: View {
     }
 
     private var bestCandidate: GatewayDiscoveryModel.DiscoveredGateway? {
-        self.gatewayController.gateways.first
+        self.gatewayController.gateways.first(where: {
+            self.gatewayController.discoveredGatewayConnectionAvailability($0).canConnect
+        }) ?? self.gatewayController.gateways.first
     }
 
     private func fullRowToggle(_ title: LocalizedStringKey, isOn: Binding<Bool>) -> some View {
@@ -160,6 +179,11 @@ struct GatewayQuickSetupSheet: View {
         }
         guard problem.retryable else { return }
         guard let candidate = self.bestCandidate else { return }
+        let availability = self.gatewayController.discoveredGatewayConnectionAvailability(candidate)
+        guard availability.canConnect else {
+            self.connectError = availability.guidanceText
+            return
+        }
         self.connectError = nil
         self.connecting = true
         let err = await self.gatewayController.connectWithDiagnostics(candidate)

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -719,7 +719,6 @@ struct OnboardingWizardView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(self.gatewayController.gateways) { gateway in
-                        let hasHost = self.gatewayHasResolvableHost(gateway)
                         let availability = self.gatewayController.discoveredGatewayConnectionAvailability(gateway)
 
                         VStack(alignment: .leading, spacing: 6) {
@@ -741,16 +740,13 @@ struct OnboardingWizardView: View {
                                         if self.connectingGatewayID == gateway.id {
                                             ProgressView()
                                                 .progressViewStyle(.circular)
-                                        } else if !hasHost {
-                                            Text("Resolving…")
-                                                .font(OpenClawType.subheadSemiBold)
                                         } else {
                                             Text(availability.actionTitle)
                                                 .font(OpenClawType.subheadSemiBold)
                                         }
                                     }
                                     .font(OpenClawType.subheadSemiBold)
-                                    .disabled(self.connectingGatewayID != nil || !hasHost)
+                                    .disabled(self.connectingGatewayID != nil)
                                 } else {
                                     Text(availability.actionTitle)
                                         .font(OpenClawType.subheadSemiBold)
@@ -1674,13 +1670,6 @@ extension OnboardingWizardView {
             self.manualTLS = false
             if self.manualPort <= 0 || self.manualPort > 65535 { self.manualPort = 18789 }
         }
-    }
-
-    private func gatewayHasResolvableHost(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> Bool {
-        let lanHost = gateway.lanHost?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !lanHost.isEmpty { return true }
-        let tailnetDns = gateway.tailnetDns?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return !tailnetDns.isEmpty
     }
 
     private func connectManual(setupAttemptID: UUID? = nil) async {

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -720,34 +720,50 @@ struct OnboardingWizardView: View {
                 } else {
                     ForEach(self.gatewayController.gateways) { gateway in
                         let hasHost = self.gatewayHasResolvableHost(gateway)
+                        let availability = self.gatewayController.discoveredGatewayConnectionAvailability(gateway)
 
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(gateway.name)
-                                    .font(OpenClawType.body)
-                                if let host = gateway.lanHost ?? gateway.tailnetDns {
-                                    Text(host)
-                                        .font(OpenClawType.footnote)
-                                        .foregroundStyle(.secondary)
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(gateway.name)
+                                        .font(OpenClawType.body)
+                                    if let host = gateway.lanHost ?? gateway.tailnetDns {
+                                        Text(host)
+                                            .font(OpenClawType.footnote)
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
-                            }
-                            Spacer()
-                            Button {
-                                Task { await self.connectDiscoveredGateway(gateway) }
-                            } label: {
-                                if self.connectingGatewayID == gateway.id {
-                                    ProgressView()
-                                        .progressViewStyle(.circular)
-                                } else if !hasHost {
-                                    Text("Resolving…")
-                                        .font(OpenClawType.subheadSemiBold)
+                                Spacer()
+                                if availability.canConnect {
+                                    Button {
+                                        Task { await self.connectDiscoveredGateway(gateway) }
+                                    } label: {
+                                        if self.connectingGatewayID == gateway.id {
+                                            ProgressView()
+                                                .progressViewStyle(.circular)
+                                        } else if !hasHost {
+                                            Text("Resolving…")
+                                                .font(OpenClawType.subheadSemiBold)
+                                        } else {
+                                            Text(availability.actionTitle)
+                                                .font(OpenClawType.subheadSemiBold)
+                                        }
+                                    }
+                                    .font(OpenClawType.subheadSemiBold)
+                                    .disabled(self.connectingGatewayID != nil || !hasHost)
                                 } else {
-                                    Text("Connect")
+                                    Text(availability.actionTitle)
                                         .font(OpenClawType.subheadSemiBold)
+                                        .foregroundStyle(OpenClawBrand.warn)
                                 }
                             }
-                            .font(OpenClawType.subheadSemiBold)
-                            .disabled(self.connectingGatewayID != nil || !hasHost)
+
+                            if let guidanceText = availability.guidanceText {
+                                Text(guidanceText)
+                                    .font(OpenClawType.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
                         }
                     }
                 }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -909,10 +909,13 @@ struct RootTabs: View {
             .sheet(item: self.$presentedSheet) { sheet in
                 switch sheet {
                 case .quickSetup:
-                    GatewayQuickSetupSheet()
-                        .environment(self.appModel)
-                        .environment(self.gatewayController)
-                        .openClawSheetChrome()
+                    GatewayQuickSetupSheet(onUseManualSetup: {
+                        self.presentedSheet = nil
+                        self.selectSettingsRoute(.gateway)
+                    })
+                    .environment(self.appModel)
+                    .environment(self.gatewayController)
+                    .openClawSheetChrome()
                 }
             }
             .fullScreenCover(isPresented: self.$showOnboarding) {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -16,7 +16,8 @@ import Testing
         lanHost: String?,
         tailnetDns: String?,
         gatewayPort: Int?,
-        fingerprint: String?) -> GatewayDiscoveryModel.DiscoveredGateway
+        fingerprint: String?,
+        tlsEnabled: Bool = true) -> GatewayDiscoveryModel.DiscoveredGateway
     {
         let endpoint: NWEndpoint = .service(name: "Test", type: "_openclaw-gw._tcp", domain: "local.", interface: nil)
         return GatewayDiscoveryModel.DiscoveredGateway(
@@ -28,7 +29,7 @@ import Testing
             tailnetDns: tailnetDns,
             gatewayPort: gatewayPort,
             canvasPort: nil,
-            tlsEnabled: true,
+            tlsEnabled: tlsEnabled,
             tlsFingerprintSha256: fingerprint,
             cliPath: nil)
     }
@@ -73,6 +74,48 @@ import Testing
         let params = controller._test_resolveDiscoveredTLSParams(gateway: gateway)
         #expect(params?.expectedFingerprint == nil)
         #expect(params?.allowTOFU == false)
+    }
+
+    @Test @MainActor func `discovered gateway availability requires advertised TLS or a stored pin`() {
+        let unpinnedID = "test|\(UUID().uuidString)"
+        let pinnedID = "test|\(UUID().uuidString)"
+        defer {
+            clearTLSFingerprint(stableID: unpinnedID)
+            clearTLSFingerprint(stableID: pinnedID)
+        }
+        self.clearTLSFingerprint(stableID: unpinnedID)
+        self.clearTLSFingerprint(stableID: pinnedID)
+
+        let controller = self.makeController()
+        let unavailable = self.makeDiscoveredGateway(
+            stableID: unpinnedID,
+            lanHost: "gateway.local",
+            tailnetDns: nil,
+            gatewayPort: 18789,
+            fingerprint: "untrusted-txt-fingerprint",
+            tlsEnabled: false)
+        let advertisedTLS = self.makeDiscoveredGateway(
+            stableID: unpinnedID,
+            lanHost: "gateway.local",
+            tailnetDns: nil,
+            gatewayPort: 18789,
+            fingerprint: nil)
+        let pinned = self.makeDiscoveredGateway(
+            stableID: pinnedID,
+            lanHost: "gateway.local",
+            tailnetDns: nil,
+            gatewayPort: 18789,
+            fingerprint: nil,
+            tlsEnabled: false)
+
+        #expect(controller.discoveredGatewayConnectionAvailability(unavailable) == .secureTransportRequired)
+        #expect(controller.discoveredGatewayConnectionAvailability(unavailable).canConnect == false)
+        #expect(controller.discoveredGatewayConnectionAvailability(unavailable).guidanceText?
+            .contains("trusted LAN") == true)
+        #expect(controller.discoveredGatewayConnectionAvailability(advertisedTLS) == .available)
+
+        GatewayTLSStore.saveFingerprint("stored-pin", stableID: pinnedID)
+        #expect(controller.discoveredGatewayConnectionAvailability(pinned) == .available)
     }
 
     @Test @MainActor func `autoconnect requires stored pin for discovered gateways`() {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -111,11 +111,80 @@ import Testing
         #expect(controller.discoveredGatewayConnectionAvailability(unavailable) == .secureTransportRequired)
         #expect(controller.discoveredGatewayConnectionAvailability(unavailable).canConnect == false)
         #expect(controller.discoveredGatewayConnectionAvailability(unavailable).guidanceText?
-            .contains("trusted LAN") == true)
+            .contains("trusted private-LAN") == true)
         #expect(controller.discoveredGatewayConnectionAvailability(advertisedTLS) == .available)
 
         GatewayTLSStore.saveFingerprint("stored-pin", stableID: pinnedID)
         #expect(controller.discoveredGatewayConnectionAvailability(pinned) == .available)
+    }
+
+    @Test @MainActor func `blocked discovered gateway does no connection work`() async {
+        let stableID = "test|\(UUID().uuidString)"
+        defer { clearTLSFingerprint(stableID: stableID) }
+        self.clearTLSFingerprint(stableID: stableID)
+        let tcpCalls = OSAllocatedUnfairLock(initialState: 0)
+        let tlsCalls = OSAllocatedUnfairLock(initialState: 0)
+        let resolverCalls = OSAllocatedUnfairLock(initialState: 0)
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in
+                tcpCalls.withLock { $0 += 1 }
+                return true
+            },
+            tlsFingerprintProbe: { _ in
+                tlsCalls.withLock { $0 += 1 }
+                return .fingerprint("unexpected")
+            },
+            serviceEndpointResolver: { _ in
+                resolverCalls.withLock { $0 += 1 }
+                return (host: "unexpected.example", port: 443)
+            })
+        let gateway = self.makeDiscoveredGateway(
+            stableID: stableID,
+            lanHost: "untrusted-txt.example",
+            tailnetDns: nil,
+            gatewayPort: 18789,
+            fingerprint: "untrusted-txt-fingerprint",
+            tlsEnabled: false)
+
+        let message = await controller.connectWithDiagnostics(gateway)
+
+        #expect(message?.contains("Manual Setup") == true)
+        #expect(resolverCalls.withLock { $0 } == 0)
+        #expect(tcpCalls.withLock { $0 } == 0)
+        #expect(tlsCalls.withLock { $0 } == 0)
+        #expect(controller.pendingTrustPrompt == nil)
+        #expect(appModel.activeGatewayConnectConfig == nil)
+    }
+
+    @Test @MainActor func `quick setup prefers an eligible discovered gateway`() {
+        let blockedID = "test|\(UUID().uuidString)"
+        let eligibleID = "test|\(UUID().uuidString)"
+        defer {
+            clearTLSFingerprint(stableID: blockedID)
+            clearTLSFingerprint(stableID: eligibleID)
+        }
+        self.clearTLSFingerprint(stableID: blockedID)
+        self.clearTLSFingerprint(stableID: eligibleID)
+        let controller = self.makeController()
+        let blocked = self.makeDiscoveredGateway(
+            stableID: blockedID,
+            lanHost: nil,
+            tailnetDns: nil,
+            gatewayPort: nil,
+            fingerprint: nil,
+            tlsEnabled: false)
+        let eligible = self.makeDiscoveredGateway(
+            stableID: eligibleID,
+            lanHost: nil,
+            tailnetDns: nil,
+            gatewayPort: nil,
+            fingerprint: nil)
+        controller._test_setGateways([blocked, eligible])
+
+        #expect(controller.preferredDiscoveredGateway()?.stableID == eligibleID)
     }
 
     @Test @MainActor func `autoconnect requires stored pin for discovered gateways`() {
@@ -329,6 +398,24 @@ import Testing
         #expect(tlsProbeCalls.withLock { $0 } == 0)
         #expect(controller.pendingTrustPrompt == nil)
         #expect(appModel.gatewayStatusText == "Can't reach gateway at \(host):\(port). Check Tailscale or LAN.")
+    }
+
+    @Test @MainActor func `unreachable tailscale host explains serve publishing`() async {
+        let host = "gateway-\(UUID().uuidString).example.ts.net"
+        let port = 443
+        let stableID = "manual|\(host.lowercased())|\(port)"
+        defer { clearTLSFingerprint(stableID: stableID) }
+        self.clearTLSFingerprint(stableID: stableID)
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in false })
+
+        await controller.connectManual(host: host, port: port, useTLS: true)
+
+        #expect(appModel.gatewayStatusText ==
+            "Can't reach gateway at \(host):\(port). Verify Tailscale Serve is enabled and publishes this Gateway.")
     }
 
     @Test @MainActor func `manual first use TLS probe reports handshake timeout without trust prompt`() async {

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -1094,13 +1094,19 @@ struct RootTabsSourceGuardTests {
         let onboardingSource = try String(
             contentsOf: Self.onboardingWizardSourceURL(),
             encoding: .utf8)
+        let rootSource = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
 
         #expect(controllerSource.contains("enum DiscoveredGatewayConnectionAvailability"))
         #expect(controllerSource.contains("gateway.tlsEnabled || GatewayTLSStore.loadFingerprint"))
-        #expect(controllerSource.contains("Enable Gateway TLS or Tailscale Serve"))
+        #expect(controllerSource.contains("enter your Tailscale Serve HTTPS host in Manual Setup"))
         #expect(settingsSource.contains("discoveredGatewayConnectionAvailability(gateway)"))
         #expect(quickSetupSource.contains("discoveredGatewayConnectionAvailability(candidate)"))
+        #expect(quickSetupSource.contains("Text(\"Use Manual Setup\")"))
+        #expect(quickSetupSource.contains("self.gatewayController.preferredDiscoveredGateway()"))
         #expect(onboardingSource.contains("discoveredGatewayConnectionAvailability(gateway)"))
+        #expect(!onboardingSource.contains("gatewayHasResolvableHost"))
+        #expect(rootSource.contains("GatewayQuickSetupSheet(onUseManualSetup:"))
+        #expect(rootSource.contains("self.selectSettingsRoute(.gateway)"))
     }
 
     @Test func `gateway credential fields update before endpoint persistence is available`() throws {
@@ -1132,7 +1138,7 @@ struct RootTabsSourceGuardTests {
         let modeDefaults = try Self.extract(
             source,
             from: "private func applyModeDefaults(_ mode: OnboardingConnectionMode)",
-            to: "private func gatewayHasResolvableHost")
+            to: "private func connectManual")
 
         #expect(modeDefaults.contains("let previousStableID = self.currentManualGatewayStableID"))
         #expect(modeDefaults.contains("previousStableID != self.currentManualGatewayStableID"))

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -1081,6 +1081,28 @@ struct RootTabsSourceGuardTests {
         #expect(!modelSource.contains("expectedGeneration: UInt64?"))
     }
 
+    @Test func `discovered gateway surfaces share secure connection availability`() throws {
+        let controllerSource = try String(
+            contentsOf: Self.gatewayConnectionControllerSourceURL(),
+            encoding: .utf8)
+        let settingsSource = try String(
+            contentsOf: Self.settingsProTabSectionsSourceURL(),
+            encoding: .utf8)
+        let quickSetupSource = try String(
+            contentsOf: Self.gatewayQuickSetupSourceURL(),
+            encoding: .utf8)
+        let onboardingSource = try String(
+            contentsOf: Self.onboardingWizardSourceURL(),
+            encoding: .utf8)
+
+        #expect(controllerSource.contains("enum DiscoveredGatewayConnectionAvailability"))
+        #expect(controllerSource.contains("gateway.tlsEnabled || GatewayTLSStore.loadFingerprint"))
+        #expect(controllerSource.contains("Enable Gateway TLS or Tailscale Serve"))
+        #expect(settingsSource.contains("discoveredGatewayConnectionAvailability(gateway)"))
+        #expect(quickSetupSource.contains("discoveredGatewayConnectionAvailability(candidate)"))
+        #expect(onboardingSource.contains("discoveredGatewayConnectionAvailability(gateway)"))
+    }
+
     @Test func `gateway credential fields update before endpoint persistence is available`() throws {
         let onboardingSource = try String(contentsOf: Self.onboardingWizardSourceURL(), encoding: .utf8)
         let settingsSource = try String(contentsOf: Self.settingsProTabActionsSourceURL(), encoding: .utf8)
@@ -1538,6 +1560,13 @@ struct RootTabsSourceGuardTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/Onboarding/OnboardingWizardView.swift")
+    }
+
+    private static func gatewayQuickSetupSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Gateway/GatewayQuickSetupSheet.swift")
     }
 
     private static func qrScannerSourceURL() -> URL {


### PR DESCRIPTION
Fixes #99031

## What Problem This Solves

Fixes an issue where iOS users selecting a Bonjour-discovered Gateway would see a Connect action that could only fail when the Gateway had neither advertised TLS nor an existing trusted certificate pin.

## Why This Change Was Made

The app now classifies discovered Gateways once at the connection-controller boundary and reuses that result in onboarding, Quick Setup, and Settings. TLS-capable and previously pinned Gateways remain connectable; TLS-less unpinned Gateways instead explain how to enable Gateway TLS or enter a Tailscale Serve HTTPS host in Manual Setup. Unencrypted remains an explicit trusted private-LAN choice.

Quick Setup now links directly to Manual Setup when discovery is blocked. Onboarding no longer treats unauthenticated Bonjour TXT host hints as a separate eligibility gate; the controller-owned service resolver remains authoritative. Unreachable `.ts.net` endpoints now identify missing Tailscale Serve publication rather than giving generic LAN advice.

The existing secure transport guard remains intact, and an untrusted Bonjour TXT fingerprint does not supply routing or bypass trust.

## User Impact

Discovered Gateways no longer present a dead-end Connect button. Users get consistent, actionable setup guidance before attempting a connection, without weakening the app's transport-security policy.

## Evidence

- Exact head: `937718659022c59dcdc11aa5f28537b2f253829e`.
- `swiftformat --lint --config config/swiftformat` passed for all touched Swift files.
- `pnpm native:i18n:check` passed with 2,860 inventoried native strings.
- Blacksmith Testbox-through-Crabbox `tbx_01kx51y6pz5d6fdhdnjswhgka0`: remote `pnpm check:changed` passed after rebasing onto current main.
- Regression coverage verifies TLS-advertised, stored-pin, and TLS-less/unpinned states; blocked discovery performs no resolver, TCP, TLS, trust, or connection work; Quick Setup prefers an eligible candidate; and `.ts.net` reachability errors identify Tailscale Serve publication.
- Fresh full-branch Codex autoreview reported no accepted or actionable findings.
