### PR TITLE
fix(wizard): make failed Hermes imports safely retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 - **Discord voice participant context:** maintain the live Gateway voice-state roster and include current channel participants in authorized voice agent turns so agents can answer who is present.
 - **OC Path JSONC insertion:** patch object and array insertions through `jsonc-parser` so comments, trailing commas, and CRLF formatting survive. (#106847)
 - **Windows winget installs:** continue in the current PowerShell session when winget installs Node.js before the machine PATH update becomes visible, avoiding a false `Node.js not found` failure. (#106862)
-- **Hermes onboarding import recovery:** resume failed imports only when the source, plan, and target still match the recorded attempt, preventing partial imports from blocking safe retries. (#103290) Thanks @tzy-17.
 - **Control UI realtime Talk feedback:** request browser echo cancellation, noise suppression, and automatic gain control for every microphone transport, and keep PCM capture processors connected through zero-gain sinks so microphone input cannot play locally.
 - **Agent source-reply recovery:** preserve current-chat delivery evidence for message sends executed through Code Mode, preventing successful replies from triggering a redundant retry and misleading delivery-failure diagnostic.
 - **Gateway in-process restarts:** clear stale SIGUSR1 restart state and resume prepared host suspensions before rebuilding runtime admission, preventing restart cooldowns or paused scheduling from leaking into the next lifecycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - **Discord voice participant context:** maintain the live Gateway voice-state roster and include current channel participants in authorized voice agent turns so agents can answer who is present.
 - **OC Path JSONC insertion:** patch object and array insertions through `jsonc-parser` so comments, trailing commas, and CRLF formatting survive. (#106847)
 - **Windows winget installs:** continue in the current PowerShell session when winget installs Node.js before the machine PATH update becomes visible, avoiding a false `Node.js not found` failure. (#106862)
+- **Hermes onboarding import recovery:** resume failed imports only when the source, plan, and target still match the recorded attempt, preventing partial imports from blocking safe retries. (#103290) Thanks @tzy-17.
 - **Control UI realtime Talk feedback:** request browser echo cancellation, noise suppression, and automatic gain control for every microphone transport, and keep PCM capture processors connected through zero-gain sinks so microphone input cannot play locally.
 - **Agent source-reply recovery:** preserve current-chat delivery evidence for message sends executed through Code Mode, preventing successful replies from triggering a redundant retry and misleading delivery-failure diagnostic.
 - **Gateway in-process restarts:** clear stale SIGUSR1 restart state and resume prepared host suspensions before rebuilding runtime admission, preventing restart cooldowns or paused scheduling from leaking into the next lifecycle.

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1190,7 +1190,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/wizard/i18n/index.ts: resolveWizardLocale",
   "src/wizard/i18n/index.ts: resolveWizardLocaleFromEnv",
   "src/wizard/i18n/index.ts: WIZARD_SUPPORTED_LOCALES",
-  "src/wizard/setup.migration-import.ts: inspectSetupMigrationFreshness",
   "src/wizard/setup.official-plugins.ts: resolveOfficialPluginOnboardingInstallEntries",
   "src/wizard/setup.official-plugins.ts: testing",
 ];

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -1190,6 +1190,7 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/wizard/i18n/index.ts: resolveWizardLocale",
   "src/wizard/i18n/index.ts: resolveWizardLocaleFromEnv",
   "src/wizard/i18n/index.ts: WIZARD_SUPPORTED_LOCALES",
+  "src/wizard/setup.migration-recovery.ts: testing",
   "src/wizard/setup.official-plugins.ts: resolveOfficialPluginOnboardingInstallEntries",
   "src/wizard/setup.official-plugins.ts: testing",
 ];

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -49,6 +49,13 @@ async function runNonInteractiveMigrationImport(params: {
         `Non-interactive migration import needs explicit flags before prompting: ${message}`,
     ),
     runtime: params.runtime,
+    async readConfigFile() {
+      const snapshot = await readConfigFileSnapshot();
+      if (!snapshot.valid) {
+        throw new Error("Migration target config became invalid. Run `openclaw doctor`.");
+      }
+      return snapshot.exists ? (snapshot.sourceConfig ?? snapshot.config) : {};
+    },
     async commitConfigFile(config) {
       await replaceConfigFile({
         nextConfig: config,

--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -3,10 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { listSetupMigrationOptions } from "./setup.migration-import.js";
 import {
   inspectSetupMigrationFreshness,
-  listSetupMigrationOptions,
-} from "./setup.migration-import.js";
+  preserveSetupMigrationSecurityAcknowledgement,
+} from "./setup.migration-snapshot.js";
 
 const tempRoots = new Set<string>();
 
@@ -51,6 +52,15 @@ describe("setup migration import freshness", () => {
     });
 
     expect(result).toEqual({ fresh: true, reasons: [] });
+  });
+
+  it("preserves the first-launch acknowledgement across the lock-time config reread", () => {
+    expect(
+      preserveSetupMigrationSecurityAcknowledgement(
+        {},
+        { wizard: { securityAcknowledgedAt: "2026-06-30T00:00:00.000Z" } },
+      ),
+    ).toEqual({ wizard: { securityAcknowledgedAt: "2026-06-30T00:00:00.000Z" } });
   });
 
   it("rejects other wizard config during import freshness checks", async () => {

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -572,13 +572,15 @@ export async function runSetupMigrationImport(params: {
 
   const reportDir = buildMigrationReportDir(providerId, stateDir);
   const backupPath = await createPreMigrationBackup({});
-  // Commit base wizard metadata before applying migrations so generated reports
-  // can reference a concrete OpenClaw config target.
+  // Apply wizard metadata to the in-memory config so the apply context
+  // references a concrete target, but defer the disk commit until after
+  // the migration provider succeeds. Committing before apply would leave
+  // a wizard-stamped config on disk when apply fails, permanently blocking
+  // the next retry behind the fresh-setup gate (#103262).
   targetConfig = onboardHelpers.applyWizardMetadata(targetConfig, {
     command: "onboard",
     mode: "local",
   });
-  targetConfig = await params.commitConfigFile(targetConfig);
   const applyCtx = {
     ...ctx,
     config: targetConfig,
@@ -592,6 +594,9 @@ export async function runSetupMigrationImport(params: {
     reportDir: result.reportDir ?? reportDir,
   };
   assertApplySucceeded(withReport);
+  // Commit the config to disk only after apply succeeds, so a failed apply
+  // does not leave wizard metadata on disk that blocks retry.
+  targetConfig = await params.commitConfigFile(targetConfig);
   await params.prompter.note(
     formatMigrationResult(withReport).join("\n"),
     t("wizard.migration.appliedTitle"),

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -596,7 +596,7 @@ export async function runSetupMigrationImport(params: {
   assertApplySucceeded(withReport);
   // Commit the config to disk only after apply succeeds, so a failed apply
   // does not leave wizard metadata on disk that blocks retry.
-  targetConfig = await params.commitConfigFile(targetConfig);
+  await params.commitConfigFile(targetConfig);
   await params.prompter.note(
     formatMigrationResult(withReport).join("\n"),
     t("wizard.migration.appliedTitle"),

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -1,6 +1,3 @@
-// Setup migration import helpers read existing config during onboarding migration.
-import fs from "node:fs/promises";
-import path from "node:path";
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import {
   ensureOnboardingPluginInstalled,
@@ -29,46 +26,46 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { t } from "./i18n/index.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
+import {
+  createSetupMigrationAttempt,
+  prepareSetupMigrationRetryPlan,
+  resolveSetupMigrationRecovery,
+  runSetupMigrationAttempt,
+  setupMigrationAttemptMatchesSource,
+  setupMigrationProviderSupportsRecovery,
+} from "./setup.migration-recovery.js";
+import {
+  assertFreshSetupMigrationTarget,
+  buildSetupMigrationPlanSourceSnapshot,
+  buildSetupMigrationTargetSnapshot,
+  inspectSetupMigrationFreshness,
+  preserveSetupMigrationSecurityAcknowledgement,
+  prepareSetupMigrationAttemptBoundary,
+  withSetupMigrationTargetLock,
+} from "./setup.migration-snapshot.js";
 
-// Onboarding migration import helpers detect existing setups, select a plugin
-// migration provider, preview a plan, back up state, and apply into fresh setup.
+// Onboarding migration import: detect, preview, back up, and apply into a fresh setup.
 type SetupMigrationDetection = {
   providerId: string;
   label: string;
   source?: string;
   message?: string;
 };
-
 type SetupMigrationOption = {
   providerId: string;
   label: string;
   hint?: string;
 };
-
 type InstallableSetupMigrationProvider = {
   providerId: string;
   entry: OnboardingPluginInstallEntry;
   description?: string;
 };
-
 type ManifestSetupMigrationProvider = {
   providerId: string;
   label: string;
   description?: string;
 };
-
-const MEANINGFUL_CONFIG_IGNORED_KEYS = new Set(["$schema", "meta"]);
-const MEANINGFUL_WIZARD_CONFIG_IGNORED_KEYS = new Set(["securityAcknowledgedAt"]);
-const MEANINGFUL_WORKSPACE_ENTRIES = [
-  "AGENTS.md",
-  "SOUL.md",
-  "USER.md",
-  "IDENTITY.md",
-  "MEMORY.md",
-  "skills",
-] as const;
-const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
-
 const loadMigrationProviderRuntimeModule = createLazyRuntimeModule(
   () => import("../plugins/migration-provider-runtime.js"),
 );
@@ -78,86 +75,6 @@ const loadMigrationContextModule = createLazyRuntimeModule(
 );
 
 const loadConfigPathsModule = createLazyRuntimeModule(() => import("../config/paths.js"));
-
-async function exists(candidate: string): Promise<boolean> {
-  try {
-    await fs.access(candidate);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function hasDirectoryEntries(candidate: string): Promise<boolean> {
-  try {
-    return (await fs.readdir(candidate)).length > 0;
-  } catch {
-    return false;
-  }
-}
-
-function hasMeaningfulConfig(config: OpenClawConfig): boolean {
-  return Object.entries(config as Record<string, unknown>).some(([key, value]) => {
-    if (MEANINGFUL_CONFIG_IGNORED_KEYS.has(key)) {
-      return false;
-    }
-    if (key === "wizard") {
-      return hasMeaningfulWizardConfig(value);
-    }
-    return true;
-  });
-}
-
-function hasMeaningfulWizardConfig(value: unknown): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return true;
-  }
-  return Object.keys(value as Record<string, unknown>).some(
-    (key) => !MEANINGFUL_WIZARD_CONFIG_IGNORED_KEYS.has(key),
-  );
-}
-
-export async function inspectSetupMigrationFreshness(params: {
-  baseConfig: OpenClawConfig;
-  stateDir: string;
-  workspaceDir: string;
-}): Promise<{ fresh: boolean; reasons: string[] }> {
-  const reasons: string[] = [];
-  if (hasMeaningfulConfig(params.baseConfig)) {
-    reasons.push("existing config values are loaded");
-  }
-  for (const entry of MEANINGFUL_WORKSPACE_ENTRIES) {
-    if (await exists(path.join(params.workspaceDir, entry))) {
-      reasons.push(`workspace ${entry} exists`);
-    }
-  }
-  for (const entry of MEANINGFUL_STATE_ENTRIES) {
-    if (await hasDirectoryEntries(path.join(params.stateDir, entry))) {
-      reasons.push(`state ${entry}/ exists`);
-    }
-  }
-  return { fresh: reasons.length === 0, reasons };
-}
-
-function assertFreshSetupMigrationTarget(freshness: {
-  fresh: boolean;
-  reasons: readonly string[];
-}): void {
-  // Migration import is currently fresh-setup only unless an explicit env gate
-  // opts into existing-target behavior.
-  if (freshness.fresh || process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1") {
-    return;
-  }
-  throw new Error(
-    [
-      "Migration import during onboarding requires a fresh OpenClaw setup.",
-      "Create a fresh setup or reset config, credentials, sessions, and workspace before importing.",
-      "Backup plus overwrite/merge imports are feature-gated for now.",
-      "Existing setup:",
-      ...freshness.reasons.map((reason) => `- ${reason}`),
-    ].join("\n"),
-  );
-}
 
 export async function detectSetupMigrationSources(params: {
   config: OpenClawConfig;
@@ -448,6 +365,7 @@ export async function runSetupMigrationImport(params: {
   detections: readonly SetupMigrationDetection[];
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
+  readConfigFile: () => Promise<OpenClawConfig>;
   commitConfigFile: (config: OpenClawConfig) => Promise<OpenClawConfig>;
   continueOnboarding?: boolean;
 }): Promise<void> {
@@ -483,132 +401,207 @@ export async function runSetupMigrationImport(params: {
         }));
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
   const stateDir = resolveStateDir();
-  assertFreshSetupMigrationTarget(
-    await inspectSetupMigrationFreshness({
-      baseConfig: params.baseConfig,
+  await withSetupMigrationTargetLock(stateDir, async () => {
+    const lockedBaseConfig = preserveSetupMigrationSecurityAcknowledgement(
+      await params.readConfigFile(),
+      params.baseConfig,
+    );
+    const initialTargetSnapshotHash = await buildSetupMigrationTargetSnapshot({
+      config: lockedBaseConfig,
       stateDir,
       workspaceDir,
-    }),
-  );
-  const resolvedProvider = await resolveSetupMigrationProvider({
-    providerId,
-    baseConfig: params.baseConfig,
-    prompter: params.prompter,
-    runtime: params.runtime,
-    workspaceDir,
-  });
-  const migrationLogger = createMigrationLogger(params.runtime);
-  const selectedDetections = [...params.detections];
-  if (
-    resolvedProvider.provider.detect &&
-    !selectedDetections.some((detection) => detection.providerId === providerId)
-  ) {
-    try {
-      const detection = await resolvedProvider.provider.detect({
-        config: resolvedProvider.baseConfig,
-        stateDir,
-        logger: migrationLogger,
-      });
-      if (detection.found) {
-        selectedDetections.push({
-          providerId,
-          label: detection.label ?? resolvedProvider.provider.label,
-          ...(detection.source ? { source: detection.source } : {}),
-          ...(detection.message ? { message: detection.message } : {}),
-        });
-      }
-    } catch (error) {
-      migrationLogger.debug?.(
-        `Migration provider ${providerId} detection failed: ${formatErrorMessage(error)}`,
-      );
+    });
+    const freshness = await inspectSetupMigrationFreshness({
+      baseConfig: lockedBaseConfig,
+      stateDir,
+      workspaceDir,
+    });
+    const recoveryState =
+      !setupMigrationProviderSupportsRecovery(providerId) ||
+      process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1"
+        ? ({ kind: "none" } as const)
+        : await resolveSetupMigrationRecovery({
+            stateDir,
+            providerId,
+            workspaceDir,
+            targetSnapshotHash: initialTargetSnapshotHash,
+          });
+    const recoveryAttempt =
+      !freshness.fresh && recoveryState.kind === "recoverable" ? recoveryState.attempt : undefined;
+    if (!recoveryAttempt) {
+      assertFreshSetupMigrationTarget(freshness);
     }
-  }
-  const sourceDefault = resolveImportSourceDefault({ providerId, detections: selectedDetections });
-  const sourceDir =
-    params.opts.importSource?.trim() ||
-    sourceDefault ||
-    (params.opts.nonInteractive
-      ? (() => {
-          throw new Error("--import-source is required for non-interactive migration import.");
-        })()
-      : await params.prompter.text({
-          message: t("wizard.migration.sourceAgentHome"),
-          initialValue: providerId === "hermes" ? "~/.hermes" : undefined,
-        }));
-  let targetConfig = applyLocalSetupWorkspaceConfig(resolvedProvider.baseConfig, workspaceDir);
-  if (params.opts.skipBootstrap) {
-    targetConfig = applySkipBootstrapConfig(targetConfig);
-  }
-  const initialCtx = {
-    config: targetConfig,
-    stateDir,
-    source: sourceDir,
-    overwrite: false,
-    logger: migrationLogger,
-  };
-  const { ctx, plan } = await createSetupMigrationPlan({
-    provider: resolvedProvider.provider,
-    ctx: initialCtx,
-    importSecrets: Boolean(params.opts.importSecrets),
-    nonInteractive: Boolean(params.opts.nonInteractive),
-    prompter: params.prompter,
-  });
-  await params.prompter.note(
-    formatMigrationPreview(plan).join("\n"),
-    t("wizard.migration.previewTitle"),
-  );
-  assertConflictFreePlan(plan, providerId);
-
-  const confirmed =
-    params.opts.nonInteractive === true
-      ? true
-      : await params.prompter.confirm({
-          message: t("wizard.migration.apply"),
-          initialValue: true,
+    const resolvedProvider = await resolveSetupMigrationProvider({
+      providerId,
+      baseConfig: lockedBaseConfig,
+      prompter: params.prompter,
+      runtime: params.runtime,
+      workspaceDir,
+    });
+    const planningBaseConfig = await params.readConfigFile();
+    const planningTargetSnapshotHash = await buildSetupMigrationTargetSnapshot({
+      config: planningBaseConfig,
+      stateDir,
+      workspaceDir,
+    });
+    const migrationLogger = createMigrationLogger(params.runtime);
+    const selectedDetections = [...params.detections];
+    if (
+      resolvedProvider.provider.detect &&
+      !selectedDetections.some((detection) => detection.providerId === providerId)
+    ) {
+      try {
+        const detection = await resolvedProvider.provider.detect({
+          config: resolvedProvider.baseConfig,
+          stateDir,
+          logger: migrationLogger,
         });
-  if (!confirmed) {
-    throw new WizardCancelledError(t("wizard.migration.cancelled"));
-  }
-
-  const reportDir = buildMigrationReportDir(providerId, stateDir);
-  const backupPath = await createPreMigrationBackup({});
-  // Apply wizard metadata to the in-memory config so the apply context
-  // references a concrete target, but defer the disk commit until after
-  // the migration provider succeeds. Committing before apply would leave
-  // a wizard-stamped config on disk when apply fails, permanently blocking
-  // the next retry behind the fresh-setup gate (#103262).
-  targetConfig = onboardHelpers.applyWizardMetadata(targetConfig, {
-    command: "onboard",
-    mode: "local",
-  });
-  const applyCtx = {
-    ...ctx,
-    config: targetConfig,
-    ...(backupPath ? { backupPath } : {}),
-    reportDir,
-  };
-  const result = await resolvedProvider.provider.apply(applyCtx, plan);
-  const withReport = {
-    ...result,
-    ...((result.backupPath ?? backupPath) ? { backupPath: result.backupPath ?? backupPath } : {}),
-    reportDir: result.reportDir ?? reportDir,
-  };
-  assertApplySucceeded(withReport);
-  // Commit the config to disk only after apply succeeds. The returned config
-  // (which may include patches written by the provider during apply) is already
-  // persisted to disk by commitConfigFile; subsequent reads in this session
-  // re-read from disk, making the in-memory assignment unnecessary here.
-  await params.commitConfigFile(targetConfig);
-  await params.prompter.note(
-    formatMigrationResult(withReport).join("\n"),
-    t("wizard.migration.appliedTitle"),
-  );
-  if (params.continueOnboarding) {
+        if (detection.found) {
+          selectedDetections.push({
+            providerId,
+            label: detection.label ?? resolvedProvider.provider.label,
+            ...(detection.source ? { source: detection.source } : {}),
+            ...(detection.message ? { message: detection.message } : {}),
+          });
+        }
+      } catch (error) {
+        migrationLogger.debug?.(
+          `Migration provider ${providerId} detection failed: ${formatErrorMessage(error)}`,
+        );
+      }
+    }
+    const sourceDefault = resolveImportSourceDefault({
+      providerId,
+      detections: selectedDetections,
+    });
+    const sourceDir =
+      params.opts.importSource?.trim() ||
+      sourceDefault ||
+      (params.opts.nonInteractive
+        ? (() => {
+            throw new Error("--import-source is required for non-interactive migration import.");
+          })()
+        : await params.prompter.text({
+            message: t("wizard.migration.sourceAgentHome"),
+            initialValue: providerId === "hermes" ? "~/.hermes" : undefined,
+          }));
+    const retryingFailedAttempt =
+      recoveryAttempt !== undefined &&
+      setupMigrationAttemptMatchesSource(recoveryAttempt, sourceDir);
+    if (!retryingFailedAttempt) {
+      assertFreshSetupMigrationTarget(freshness);
+    } else if (planningTargetSnapshotHash !== initialTargetSnapshotHash) {
+      throw new Error("Migration target changed while preparing the retry. Review it and retry.");
+    }
+    let targetConfig = applyLocalSetupWorkspaceConfig(resolvedProvider.baseConfig, workspaceDir);
+    if (params.opts.skipBootstrap) {
+      targetConfig = applySkipBootstrapConfig(targetConfig);
+    }
+    const initialCtx = {
+      config: targetConfig,
+      stateDir,
+      source: sourceDir,
+      overwrite: false,
+      logger: migrationLogger,
+    };
+    const planned = await createSetupMigrationPlan({
+      provider: resolvedProvider.provider,
+      ctx: initialCtx,
+      importSecrets: Boolean(params.opts.importSecrets),
+      nonInteractive: Boolean(params.opts.nonInteractive),
+      prompter: params.prompter,
+    });
+    const plannedSourceSnapshotHash = await buildSetupMigrationPlanSourceSnapshot(planned.plan);
+    const ctx = planned.ctx;
+    const plan =
+      retryingFailedAttempt && recoveryAttempt
+        ? prepareSetupMigrationRetryPlan(planned.plan, recoveryAttempt, plannedSourceSnapshotHash)
+        : planned.plan;
     await params.prompter.note(
-      t("wizard.migration.continuing"),
+      formatMigrationPreview(plan).join("\n"),
+      t("wizard.migration.previewTitle"),
+    );
+    assertConflictFreePlan(plan, providerId);
+
+    const confirmed =
+      params.opts.nonInteractive === true
+        ? true
+        : await params.prompter.confirm({
+            message: t("wizard.migration.apply"),
+            initialValue: true,
+          });
+    if (!confirmed) {
+      throw new WizardCancelledError(t("wizard.migration.cancelled"));
+    }
+
+    const reportDir = buildMigrationReportDir(providerId, stateDir);
+    const backupPath = await createPreMigrationBackup({});
+    targetConfig = onboardHelpers.applyWizardMetadata(targetConfig, {
+      command: "onboard",
+      mode: "local",
+    });
+    const boundary = await prepareSetupMigrationAttemptBoundary({
+      currentConfig: await params.readConfigFile(),
+      targetConfig,
+      stateDir,
+      workspaceDir,
+      plan: planned.plan,
+      expectedTargetSnapshotHash: planningTargetSnapshotHash,
+      expectedSourceSnapshotHash: plannedSourceSnapshotHash,
+    });
+    const attempt = createSetupMigrationAttempt({
+      providerId,
+      source: sourceDir,
+      workspaceDir,
+      plan,
+      sourceSnapshotHash: boundary.sourceSnapshotHash,
+      preparedTargetSnapshotHash: boundary.preparedTargetSnapshotHash,
+      targetSnapshotHash: boundary.targetSnapshotHash,
+      ...(recoveryAttempt ? { previousAttempt: recoveryAttempt } : {}),
+    });
+    const withReport = await runSetupMigrationAttempt({
+      reportDir,
+      attempt,
+      assertSucceeded: assertApplySucceeded,
+      async readTargetSnapshot() {
+        return await buildSetupMigrationTargetSnapshot({
+          config: await params.readConfigFile(),
+          stateDir,
+          workspaceDir,
+        });
+      },
+      async apply() {
+        targetConfig = await params.commitConfigFile(targetConfig);
+        // Provider config mutations persist; recommitting targetConfig would overwrite them.
+        const result = await resolvedProvider.provider.apply(
+          {
+            ...ctx,
+            config: targetConfig,
+            ...(backupPath ? { backupPath } : {}),
+            reportDir,
+          },
+          plan,
+        );
+        return {
+          ...result,
+          ...((result.backupPath ?? backupPath)
+            ? { backupPath: result.backupPath ?? backupPath }
+            : {}),
+          reportDir: result.reportDir ?? reportDir,
+        };
+      },
+    });
+    await params.prompter.note(
+      formatMigrationResult(withReport).join("\n"),
       t("wizard.migration.appliedTitle"),
     );
-  } else {
-    await params.prompter.outro(t("wizard.migration.complete"));
-  }
+    if (params.continueOnboarding) {
+      await params.prompter.note(
+        t("wizard.migration.continuing"),
+        t("wizard.migration.appliedTitle"),
+      );
+    } else {
+      await params.prompter.outro(t("wizard.migration.complete"));
+    }
+  });
 }

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -595,8 +595,11 @@ export async function runSetupMigrationImport(params: {
   };
   assertApplySucceeded(withReport);
   // Commit the config to disk only after apply succeeds, so a failed apply
-  // does not leave wizard metadata on disk that blocks retry.
-  await params.commitConfigFile(targetConfig);
+  // does not leave wizard metadata on disk that blocks retry. Preserve the
+  // returned config so any patches written by the provider during apply
+  // (e.g. auth profile selections) are carried forward rather than silently
+  // replaced by the pre-apply snapshot.
+  targetConfig = await params.commitConfigFile(targetConfig);
   await params.prompter.note(
     formatMigrationResult(withReport).join("\n"),
     t("wizard.migration.appliedTitle"),

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -594,12 +594,11 @@ export async function runSetupMigrationImport(params: {
     reportDir: result.reportDir ?? reportDir,
   };
   assertApplySucceeded(withReport);
-  // Commit the config to disk only after apply succeeds, so a failed apply
-  // does not leave wizard metadata on disk that blocks retry. Preserve the
-  // returned config so any patches written by the provider during apply
-  // (e.g. auth profile selections) are carried forward rather than silently
-  // replaced by the pre-apply snapshot.
-  targetConfig = await params.commitConfigFile(targetConfig);
+  // Commit the config to disk only after apply succeeds. The returned config
+  // (which may include patches written by the provider during apply) is already
+  // persisted to disk by commitConfigFile; subsequent reads in this session
+  // re-read from disk, making the in-memory assignment unnecessary here.
+  await params.commitConfigFile(targetConfig);
   await params.prompter.note(
     formatMigrationResult(withReport).join("\n"),
     t("wizard.migration.appliedTitle"),

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -1,0 +1,439 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMigrationItem, summarizeMigrationItems } from "../plugin-sdk/migration.js";
+import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
+import {
+  createSetupMigrationAttempt,
+  prepareSetupMigrationRetryPlan,
+  resolveSetupMigrationRecovery,
+  setupMigrationAttemptMatchesSource,
+  setupMigrationProviderSupportsRecovery,
+  writeSetupMigrationAttempt,
+} from "./setup.migration-recovery.js";
+import {
+  buildSetupMigrationPlanSourceSnapshot,
+  buildSetupMigrationTargetSnapshot,
+} from "./setup.migration-snapshot.js";
+
+const tempRoots = new Set<string>();
+const BEFORE_HASH = "a".repeat(64);
+const AFTER_HASH = "b".repeat(64);
+const CHANGED_HASH = "c".repeat(64);
+const SOURCE_HASH = "d".repeat(64);
+
+async function makeTempRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-setup-recovery-"));
+  tempRoots.add(root);
+  return root;
+}
+
+function buildPlan(root: string): MigrationPlan {
+  const items = [
+    createMigrationItem({
+      id: "config:mcp",
+      kind: "config",
+      action: "merge",
+      status: "planned",
+      target: "mcp.servers.safe",
+      details: { path: ["mcp", "servers"], value: { safe: { command: "echo" } } },
+    }),
+    createMigrationItem({
+      id: "workspace:SOUL.md",
+      kind: "workspace",
+      action: "copy",
+      status: "planned",
+      source: path.join(root, "hermes", "SOUL.md"),
+      target: path.join(root, "workspace", "SOUL.md"),
+    }),
+    createMigrationItem({
+      id: "workspace:AGENTS.md",
+      kind: "workspace",
+      action: "copy",
+      status: "planned",
+      source: path.join(root, "hermes", "AGENTS.md"),
+      target: path.join(root, "workspace", "AGENTS.md"),
+    }),
+    createMigrationItem({
+      id: "archive:state.db",
+      kind: "archive",
+      action: "archive",
+      status: "planned",
+      source: path.join(root, "hermes", "state.db"),
+    }),
+  ];
+  return {
+    providerId: "hermes",
+    source: path.join(root, "hermes"),
+    target: path.join(root, "workspace"),
+    items,
+    summary: summarizeMigrationItems(items),
+  };
+}
+
+function buildFailedResult(plan: MigrationPlan): MigrationApplyResult {
+  const items = [
+    { ...plan.items[0]!, status: "migrated" as const },
+    { ...plan.items[1]!, status: "error" as const, reason: "permission denied" },
+    { ...plan.items[2]!, status: "skipped" as const, reason: "not attempted" },
+    { ...plan.items[3]!, status: "migrated" as const },
+  ];
+  return { ...plan, items, summary: summarizeMigrationItems(items) };
+}
+
+describe("setup migration recovery", () => {
+  afterEach(async () => {
+    for (const root of tempRoots) {
+      await fs.rm(root, { force: true, recursive: true });
+    }
+    tempRoots.clear();
+  });
+
+  it("limits recovery to the audited Hermes provider contract", () => {
+    expect(setupMigrationProviderSupportsRecovery("hermes")).toBe(true);
+    expect(setupMigrationProviderSupportsRecovery("other")).toBe(false);
+  });
+
+  it("retries only unchanged incomplete items against the exact failed target", async () => {
+    const stateDir = await makeTempRoot();
+    const identity = {
+      providerId: "hermes",
+      source: path.join(stateDir, "hermes"),
+      workspaceDir: path.join(stateDir, "workspace"),
+    };
+    const plan = buildPlan(stateDir);
+    const failed = createSetupMigrationAttempt(
+      {
+        ...identity,
+        plan,
+        sourceSnapshotHash: SOURCE_HASH,
+        targetSnapshotHash: BEFORE_HASH,
+      },
+      new Date("2026-07-13T10:00:00Z"),
+    );
+    const failedReportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z");
+    await writeSetupMigrationAttempt({
+      reportDir: failedReportDir,
+      attempt: failed,
+      status: "failed",
+      result: buildFailedResult(plan),
+      targetSnapshotHash: AFTER_HASH,
+    });
+
+    const recovery = await resolveSetupMigrationRecovery({
+      stateDir,
+      providerId: identity.providerId,
+      workspaceDir: identity.workspaceDir,
+      targetSnapshotHash: AFTER_HASH,
+    });
+    expect(recovery.kind).toBe("recoverable");
+    if (recovery.kind !== "recoverable") {
+      throw new Error("expected recoverable attempt");
+    }
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: CHANGED_HASH,
+      }),
+    ).resolves.toEqual({ kind: "none" });
+    expect(setupMigrationAttemptMatchesSource(recovery.attempt, identity.source)).toBe(true);
+    expect(
+      setupMigrationAttemptMatchesSource(recovery.attempt, path.join(stateDir, "other-hermes")),
+    ).toBe(false);
+
+    const retryItems = [
+      { ...plan.items[0]!, status: "conflict" as const, reason: "target exists" },
+      plan.items[1]!,
+      plan.items[2]!,
+      plan.items[3]!,
+    ];
+    const retryPlan = { ...plan, items: retryItems, summary: summarizeMigrationItems(retryItems) };
+    const prepared = prepareSetupMigrationRetryPlan(retryPlan, recovery.attempt, SOURCE_HASH);
+    expect(prepared.items.map((item) => item.status)).toEqual([
+      "skipped",
+      "planned",
+      "planned",
+      "planned",
+    ]);
+    expect(prepared.items[0]?.reason).toContain("previous onboarding import attempt");
+
+    const retry = createSetupMigrationAttempt({
+      ...identity,
+      plan: prepared,
+      sourceSnapshotHash: SOURCE_HASH,
+      targetSnapshotHash: AFTER_HASH,
+      previousAttempt: recovery.attempt,
+    });
+    expect(retry.items.map((item) => item.resultStatus)).toEqual([
+      "migrated",
+      "error",
+      "skipped",
+      "migrated",
+    ]);
+
+    const retryResultItems = [
+      prepared.items[0]!,
+      { ...prepared.items[1]!, status: "error" as const, reason: "still denied" },
+      { ...prepared.items[2]!, status: "skipped" as const, reason: "not attempted" },
+      { ...prepared.items[3]!, status: "migrated" as const },
+    ];
+    await writeSetupMigrationAttempt({
+      reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T10-30-00Z"),
+      attempt: retry,
+      status: "failed",
+      result: {
+        ...prepared,
+        items: retryResultItems,
+        summary: summarizeMigrationItems(retryResultItems),
+      },
+      targetSnapshotHash: CHANGED_HASH,
+    });
+    const repeatedRecovery = await resolveSetupMigrationRecovery({
+      stateDir,
+      providerId: identity.providerId,
+      workspaceDir: identity.workspaceDir,
+      targetSnapshotHash: CHANGED_HASH,
+    });
+    expect(repeatedRecovery.kind).toBe("recoverable");
+    if (repeatedRecovery.kind !== "recoverable") {
+      throw new Error("expected repeated recovery attempt");
+    }
+    expect(
+      prepareSetupMigrationRetryPlan(retryPlan, repeatedRecovery.attempt, SOURCE_HASH).items.map(
+        (item) => item.status,
+      ),
+    ).toEqual(["skipped", "planned", "planned", "planned"]);
+
+    const changedItems = [
+      plan.items[0]!,
+      { ...plan.items[1]!, target: path.join(stateDir, "other-workspace", "SOUL.md") },
+    ];
+    expect(() =>
+      prepareSetupMigrationRetryPlan(
+        { ...plan, items: changedItems, summary: summarizeMigrationItems(changedItems) },
+        recovery.attempt,
+        SOURCE_HASH,
+      ),
+    ).toThrow("Migration retry plan changed");
+    expect(() => prepareSetupMigrationRetryPlan(retryPlan, recovery.attempt, CHANGED_HASH)).toThrow(
+      "Migration source changed",
+    );
+    expect(() =>
+      prepareSetupMigrationRetryPlan(
+        { ...retryPlan, metadata: { changed: true } },
+        recovery.attempt,
+        SOURCE_HASH,
+      ),
+    ).toThrow("Migration retry plan context changed");
+
+    const succeeded = createSetupMigrationAttempt({
+      ...identity,
+      plan: prepared,
+      sourceSnapshotHash: SOURCE_HASH,
+      targetSnapshotHash: AFTER_HASH,
+      previousAttempt: recovery.attempt,
+    });
+    await writeSetupMigrationAttempt({
+      reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T11-00-00Z"),
+      attempt: succeeded,
+      status: "succeeded",
+    });
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: AFTER_HASH,
+      }),
+    ).resolves.toEqual({ kind: "none" });
+
+    const persisted = await fs.readFile(
+      path.join(failedReportDir, "onboarding-attempt.json"),
+      "utf8",
+    );
+    expect(persisted).not.toContain(identity.source);
+    expect(persisted).not.toContain(identity.workspaceDir);
+  });
+
+  it("recovers an interrupted applying attempt only before target side effects", async () => {
+    const stateDir = await makeTempRoot();
+    const identity = {
+      providerId: "hermes",
+      source: path.join(stateDir, "hermes"),
+      workspaceDir: path.join(stateDir, "workspace"),
+    };
+    const attempt = createSetupMigrationAttempt({
+      ...identity,
+      plan: buildPlan(stateDir),
+      sourceSnapshotHash: SOURCE_HASH,
+      preparedTargetSnapshotHash: BEFORE_HASH,
+      targetSnapshotHash: AFTER_HASH,
+    });
+    await writeSetupMigrationAttempt({
+      reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z"),
+      attempt,
+      status: "applying",
+    });
+
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: BEFORE_HASH,
+      }),
+    ).resolves.toMatchObject({ kind: "recoverable" });
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: AFTER_HASH,
+      }),
+    ).resolves.toMatchObject({ kind: "recoverable" });
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: CHANGED_HASH,
+      }),
+    ).resolves.toEqual({ kind: "none" });
+
+    const failedReportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T11-00-00Z");
+    await writeSetupMigrationAttempt({
+      reportDir: failedReportDir,
+      attempt,
+      status: "failed",
+      targetSnapshotHash: BEFORE_HASH,
+    });
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: BEFORE_HASH,
+      }),
+    ).resolves.toMatchObject({ kind: "recoverable" });
+
+    await writeSetupMigrationAttempt({
+      reportDir: failedReportDir,
+      attempt,
+      status: "failed",
+      targetSnapshotHash: CHANGED_HASH,
+    });
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: identity.providerId,
+        workspaceDir: identity.workspaceDir,
+        targetSnapshotHash: CHANGED_HASH,
+      }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+
+  it("binds retries to the planned source contents", async () => {
+    const root = await makeTempRoot();
+    const sourceDir = path.join(root, "hermes");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "SOUL.md"), "Original soul.\n");
+    await fs.writeFile(path.join(sourceDir, "AGENTS.md"), "Original agents.\n");
+    const plan = buildPlan(root);
+    const initial = await buildSetupMigrationPlanSourceSnapshot(plan);
+
+    await fs.writeFile(path.join(sourceDir, "SOUL.md"), "Changed soul.\n");
+    await expect(buildSetupMigrationPlanSourceSnapshot(plan)).resolves.not.toBe(initial);
+
+    const databasePath = path.join(sourceDir, "state.db");
+    await fs.writeFile(databasePath, "database");
+    const databaseItems = [
+      createMigrationItem({
+        id: "archive:state.db",
+        kind: "archive",
+        action: "archive",
+        source: databasePath,
+      }),
+    ];
+    const databasePlan = {
+      ...plan,
+      items: databaseItems,
+      summary: summarizeMigrationItems(databaseItems),
+    };
+    const databaseInitial = await buildSetupMigrationPlanSourceSnapshot(databasePlan);
+    await fs.writeFile(`${databasePath}-wal`, "committed rows");
+    await expect(buildSetupMigrationPlanSourceSnapshot(databasePlan)).resolves.not.toBe(
+      databaseInitial,
+    );
+  });
+
+  it.skipIf(process.platform === "win32")("hashes source symlink referent contents", async () => {
+    const root = await makeTempRoot();
+    const sourceDir = path.join(root, "hermes");
+    await fs.mkdir(sourceDir, { recursive: true });
+    const referent = path.join(sourceDir, "soul-source.md");
+    await fs.writeFile(referent, "Original soul.\n");
+    await fs.symlink(path.basename(referent), path.join(sourceDir, "SOUL.md"));
+    const initial = await buildSetupMigrationPlanSourceSnapshot(buildPlan(root));
+
+    await fs.writeFile(referent, "Changed soul.\n");
+    await expect(buildSetupMigrationPlanSourceSnapshot(buildPlan(root))).resolves.not.toBe(initial);
+  });
+
+  it("snapshots meaningful target changes but ignores migration reports", async () => {
+    const stateDir = await makeTempRoot();
+    const workspaceDir = path.join(stateDir, "workspace");
+    const initial = await buildSetupMigrationTargetSnapshot({
+      config: {},
+      stateDir,
+      workspaceDir,
+    });
+
+    await fs.mkdir(path.join(stateDir, "migration", "hermes", "report"), { recursive: true });
+    await fs.writeFile(path.join(stateDir, "migration", "hermes", "report", "result.json"), "{}");
+    await expect(
+      buildSetupMigrationTargetSnapshot({ config: {}, stateDir, workspaceDir }),
+    ).resolves.toBe(initial);
+    await expect(
+      buildSetupMigrationTargetSnapshot({
+        config: { meta: { lastTouchedAt: "2026-07-13T23:00:00.000Z" } },
+        stateDir,
+        workspaceDir,
+      }),
+    ).resolves.toBe(initial);
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Be useful.\n");
+    const workspaceChanged = await buildSetupMigrationTargetSnapshot({
+      config: {},
+      stateDir,
+      workspaceDir,
+    });
+    expect(workspaceChanged).not.toBe(initial);
+    await expect(
+      buildSetupMigrationTargetSnapshot({
+        config: { agents: { defaults: { workspace: workspaceDir } } },
+        stateDir,
+        workspaceDir,
+      }),
+    ).resolves.not.toBe(workspaceChanged);
+  });
+
+  it("fails closed when the newest recovery record is malformed", async () => {
+    const stateDir = await makeTempRoot();
+    const reportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z");
+    await fs.mkdir(reportDir, { recursive: true });
+    await fs.writeFile(path.join(reportDir, "onboarding-attempt.json"), "{}\n", "utf8");
+
+    await expect(
+      resolveSetupMigrationRecovery({
+        stateDir,
+        providerId: "hermes",
+        workspaceDir: path.join(stateDir, "workspace"),
+        targetSnapshotHash: BEFORE_HASH,
+      }),
+    ).rejects.toThrow("Invalid onboarding migration recovery record");
+  });
+});

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -403,6 +403,25 @@ describe("setup migration recovery", () => {
         workspaceDir,
       }),
     ).resolves.toBe(initial);
+    await expect(
+      buildSetupMigrationTargetSnapshot({
+        config: { wizard: { securityAcknowledgedAt: "2026-07-13T23:00:00.000Z" } },
+        stateDir,
+        workspaceDir,
+      }),
+    ).resolves.toBe(initial);
+    await expect(
+      buildSetupMigrationTargetSnapshot({
+        config: {
+          wizard: {
+            securityAcknowledgedAt: "2026-07-13T23:00:00.000Z",
+            lastRunCommand: "onboard",
+          },
+        },
+        stateDir,
+        workspaceDir,
+      }),
+    ).resolves.not.toBe(initial);
 
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Be useful.\n");

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -10,7 +10,7 @@ import {
   resolveSetupMigrationRecovery,
   setupMigrationAttemptMatchesSource,
   setupMigrationProviderSupportsRecovery,
-  writeSetupMigrationAttempt,
+  testing,
 } from "./setup.migration-recovery.js";
 import {
   buildSetupMigrationPlanSourceSnapshot,
@@ -22,6 +22,7 @@ const BEFORE_HASH = "a".repeat(64);
 const AFTER_HASH = "b".repeat(64);
 const CHANGED_HASH = "c".repeat(64);
 const SOURCE_HASH = "d".repeat(64);
+const { writeSetupMigrationAttempt } = testing;
 
 async function makeTempRoot(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-setup-recovery-"));

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createMigrationItem, summarizeMigrationItems } from "../plugin-sdk/migration.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
 import {
@@ -17,7 +17,7 @@ import {
   buildSetupMigrationTargetSnapshot,
 } from "./setup.migration-snapshot.js";
 
-const tempRoots = new Set<string>();
+const tempRoots = useAutoCleanupTempDirTracker(afterEach);
 const BEFORE_HASH = "a".repeat(64);
 const AFTER_HASH = "b".repeat(64);
 const CHANGED_HASH = "c".repeat(64);
@@ -25,9 +25,7 @@ const SOURCE_HASH = "d".repeat(64);
 const { writeSetupMigrationAttempt } = testing;
 
 async function makeTempRoot(): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-setup-recovery-"));
-  tempRoots.add(root);
-  return root;
+  return tempRoots.make("openclaw-setup-recovery-");
 }
 
 function buildPlan(root: string): MigrationPlan {
@@ -84,13 +82,6 @@ function buildFailedResult(plan: MigrationPlan): MigrationApplyResult {
 }
 
 describe("setup migration recovery", () => {
-  afterEach(async () => {
-    for (const root of tempRoots) {
-      await fs.rm(root, { force: true, recursive: true });
-    }
-    tempRoots.clear();
-  });
-
   it("limits recovery to the audited Hermes provider contract", () => {
     expect(setupMigrationProviderSupportsRecovery("hermes")).toBe(true);
     expect(setupMigrationProviderSupportsRecovery("other")).toBe(false);

--- a/src/wizard/setup.migration-recovery.ts
+++ b/src/wizard/setup.migration-recovery.ts
@@ -1,0 +1,398 @@
+// Onboarding migration recovery records live with the generated migration report.
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { readDurableJsonFile, writeJsonAtomic } from "../infra/json-files.js";
+import { summarizeMigrationItems } from "../plugin-sdk/migration.js";
+import type { MigrationApplyResult, MigrationItem, MigrationPlan } from "../plugins/types.js";
+import { resolveUserPath } from "../utils.js";
+
+const SETUP_MIGRATION_ATTEMPT_FILE = "onboarding-attempt.json";
+const SETUP_MIGRATION_ATTEMPT_VERSION = 1;
+
+export type SetupMigrationAttemptStatus = "applying" | "failed" | "succeeded";
+
+type SetupMigrationAttemptItem = {
+  id: string;
+  fingerprint: string;
+  resultStatus?: MigrationItem["status"];
+};
+
+export type SetupMigrationAttempt = {
+  version: typeof SETUP_MIGRATION_ATTEMPT_VERSION;
+  providerId: string;
+  sourceHash: string;
+  sourceSnapshotHash: string;
+  workspaceHash: string;
+  planFingerprint: string;
+  items: SetupMigrationAttemptItem[];
+  itemStatusesCaptured: boolean;
+  targetSnapshotHashPrepared: string;
+  targetSnapshotHashBefore: string;
+  targetSnapshotHashAfter?: string;
+  status: SetupMigrationAttemptStatus;
+  startedAt: string;
+  updatedAt: string;
+};
+
+export type SetupMigrationRecoveryState =
+  | { kind: "none" }
+  | { kind: "recoverable"; attempt: SetupMigrationAttempt };
+
+type SetupMigrationIdentity = {
+  providerId: string;
+  source: string;
+  workspaceDir: string;
+};
+
+/** Hermes enumerates its replay inputs and has idempotent or conflict-checked item writes. */
+export function setupMigrationProviderSupportsRecovery(providerId: string): boolean {
+  return providerId === "hermes";
+}
+
+function buildPathHash(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function buildSourceHash(source: string): string {
+  return buildPathHash(path.resolve(resolveUserPath(source.trim())));
+}
+
+function buildWorkspaceHash(workspaceDir: string): string {
+  return buildPathHash(path.resolve(workspaceDir));
+}
+
+function canonicalizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJsonValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => [key, canonicalizeJsonValue(record[key])]),
+  );
+}
+
+function buildMigrationItemFingerprint(item: MigrationItem): string {
+  const { status: _status, reason: _reason, ...identity } = item;
+  return buildPathHash(JSON.stringify(canonicalizeJsonValue(identity)));
+}
+
+function buildMigrationPlanFingerprint(plan: MigrationPlan): string {
+  return buildPathHash(
+    JSON.stringify(
+      canonicalizeJsonValue({
+        providerId: plan.providerId,
+        source: plan.source,
+        target: plan.target,
+        metadata: plan.metadata,
+      }),
+    ),
+  );
+}
+
+function isMigrationItemStatus(value: unknown): value is MigrationItem["status"] {
+  return (
+    value === "planned" ||
+    value === "migrated" ||
+    value === "skipped" ||
+    value === "warning" ||
+    value === "conflict" ||
+    value === "error"
+  );
+}
+
+function isSetupMigrationAttemptItem(value: unknown): value is SetupMigrationAttemptItem {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const item = value as Partial<SetupMigrationAttemptItem>;
+  return (
+    typeof item.id === "string" &&
+    typeof item.fingerprint === "string" &&
+    /^[a-f0-9]{64}$/.test(item.fingerprint) &&
+    (item.resultStatus === undefined || isMigrationItemStatus(item.resultStatus))
+  );
+}
+
+function isSetupMigrationAttempt(value: unknown): value is SetupMigrationAttempt {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Partial<SetupMigrationAttempt>;
+  return (
+    record.version === SETUP_MIGRATION_ATTEMPT_VERSION &&
+    typeof record.providerId === "string" &&
+    typeof record.sourceHash === "string" &&
+    /^[a-f0-9]{64}$/.test(record.sourceHash) &&
+    typeof record.sourceSnapshotHash === "string" &&
+    /^[a-f0-9]{64}$/.test(record.sourceSnapshotHash) &&
+    typeof record.workspaceHash === "string" &&
+    /^[a-f0-9]{64}$/.test(record.workspaceHash) &&
+    typeof record.planFingerprint === "string" &&
+    /^[a-f0-9]{64}$/.test(record.planFingerprint) &&
+    Array.isArray(record.items) &&
+    record.items.every(isSetupMigrationAttemptItem) &&
+    typeof record.itemStatusesCaptured === "boolean" &&
+    typeof record.targetSnapshotHashPrepared === "string" &&
+    /^[a-f0-9]{64}$/.test(record.targetSnapshotHashPrepared) &&
+    typeof record.targetSnapshotHashBefore === "string" &&
+    /^[a-f0-9]{64}$/.test(record.targetSnapshotHashBefore) &&
+    (record.targetSnapshotHashAfter === undefined ||
+      (typeof record.targetSnapshotHashAfter === "string" &&
+        /^[a-f0-9]{64}$/.test(record.targetSnapshotHashAfter))) &&
+    (record.status === "applying" || record.status === "failed" || record.status === "succeeded") &&
+    (record.status !== "failed" || record.targetSnapshotHashAfter !== undefined) &&
+    typeof record.startedAt === "string" &&
+    typeof record.updatedAt === "string"
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+export function createSetupMigrationAttempt(
+  params: SetupMigrationIdentity & {
+    plan: MigrationPlan;
+    sourceSnapshotHash: string;
+    preparedTargetSnapshotHash?: string;
+    targetSnapshotHash: string;
+    previousAttempt?: SetupMigrationAttempt;
+  },
+  now = new Date(),
+): SetupMigrationAttempt {
+  const timestamp = now.toISOString();
+  const previousItems = params.previousAttempt?.items;
+  return {
+    version: SETUP_MIGRATION_ATTEMPT_VERSION,
+    providerId: params.providerId,
+    sourceHash: buildSourceHash(params.source),
+    sourceSnapshotHash: params.sourceSnapshotHash,
+    workspaceHash: buildWorkspaceHash(params.workspaceDir),
+    planFingerprint: buildMigrationPlanFingerprint(params.plan),
+    items: params.plan.items.map((item, index) => {
+      const fingerprint = buildMigrationItemFingerprint(item);
+      const previous = previousItems?.[index];
+      return {
+        id: item.id,
+        fingerprint,
+        ...(previous?.id === item.id && previous.fingerprint === fingerprint
+          ? { resultStatus: previous.resultStatus }
+          : {}),
+      };
+    }),
+    itemStatusesCaptured: false,
+    targetSnapshotHashPrepared: params.preparedTargetSnapshotHash ?? params.targetSnapshotHash,
+    targetSnapshotHashBefore: params.targetSnapshotHash,
+    status: "applying",
+    startedAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export async function writeSetupMigrationAttempt(params: {
+  reportDir: string;
+  attempt: SetupMigrationAttempt;
+  status: SetupMigrationAttemptStatus;
+  result?: MigrationApplyResult;
+  targetSnapshotHash?: string;
+}): Promise<void> {
+  const resultItems = params.result?.items;
+  const itemStatusesCaptured =
+    resultItems?.length === params.attempt.items.length &&
+    resultItems.every((item, index) => item.id === params.attempt.items[index]?.id);
+  const items = itemStatusesCaptured
+    ? params.attempt.items.map((item, index) => ({
+        ...item,
+        resultStatus:
+          item.resultStatus === "migrated" && resultItems?.[index]?.status === "skipped"
+            ? "migrated"
+            : resultItems?.[index]?.status,
+      }))
+    : params.attempt.items;
+  await writeJsonAtomic(
+    path.join(params.reportDir, SETUP_MIGRATION_ATTEMPT_FILE),
+    {
+      ...params.attempt,
+      items,
+      itemStatusesCaptured,
+      ...(params.targetSnapshotHash ? { targetSnapshotHashAfter: params.targetSnapshotHash } : {}),
+      status: params.status,
+      updatedAt: new Date().toISOString(),
+    },
+    { mode: 0o600, dirMode: 0o700, trailingNewline: true },
+  );
+}
+
+/** Runs provider apply while durably recording completion or a safe retry boundary. */
+export async function runSetupMigrationAttempt(params: {
+  reportDir: string;
+  attempt: SetupMigrationAttempt;
+  apply: () => Promise<MigrationApplyResult>;
+  assertSucceeded: (result: MigrationApplyResult) => void;
+  readTargetSnapshot: () => Promise<string>;
+}): Promise<MigrationApplyResult> {
+  await writeSetupMigrationAttempt({
+    reportDir: params.reportDir,
+    attempt: params.attempt,
+    status: "applying",
+  });
+  let result: MigrationApplyResult | undefined;
+  try {
+    result = await params.apply();
+    params.assertSucceeded(result);
+  } catch (error) {
+    try {
+      await writeSetupMigrationAttempt({
+        reportDir: params.reportDir,
+        attempt: params.attempt,
+        status: "failed",
+        result,
+        targetSnapshotHash: await params.readTargetSnapshot(),
+      });
+    } catch (recoveryError) {
+      throw new AggregateError(
+        [error, recoveryError],
+        "Migration import failed and its retry record could not be updated.",
+      );
+    }
+    throw error;
+  }
+  await writeSetupMigrationAttempt({
+    reportDir: params.reportDir,
+    attempt: params.attempt,
+    status: "succeeded",
+    result,
+  });
+  return result;
+}
+
+async function findLatestSetupMigrationAttempt(params: {
+  stateDir: string;
+  providerId: string;
+  matches: (attempt: SetupMigrationAttempt) => boolean;
+}): Promise<SetupMigrationAttempt | undefined> {
+  const providerReportRoot = path.join(params.stateDir, "migration", params.providerId);
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(providerReportRoot, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+  for (const entry of entries
+    .filter((candidate) => candidate.isDirectory())
+    .toSorted((left, right) => (left.name < right.name ? 1 : left.name > right.name ? -1 : 0))) {
+    const recordPath = path.join(providerReportRoot, entry.name, SETUP_MIGRATION_ATTEMPT_FILE);
+    let value: unknown;
+    try {
+      value = await readDurableJsonFile<unknown>(recordPath);
+    } catch (error) {
+      throw new Error(`Invalid onboarding migration recovery record: ${recordPath}`, {
+        cause: error,
+      });
+    }
+    if (value === null) {
+      continue;
+    }
+    if (!isSetupMigrationAttempt(value)) {
+      throw new Error(`Invalid onboarding migration recovery record: ${recordPath}`);
+    }
+    if (value.providerId === params.providerId && params.matches(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/** Allows retry only while the target still matches the recorded attempt boundary. */
+export async function resolveSetupMigrationRecovery(params: {
+  stateDir: string;
+  providerId: string;
+  workspaceDir: string;
+  targetSnapshotHash: string;
+}): Promise<SetupMigrationRecoveryState> {
+  const workspaceHash = buildWorkspaceHash(params.workspaceDir);
+  const attempt = await findLatestSetupMigrationAttempt({
+    stateDir: params.stateDir,
+    providerId: params.providerId,
+    matches: (candidate) => candidate.workspaceHash === workspaceHash,
+  });
+  if (!attempt || attempt.status === "succeeded") {
+    return { kind: "none" };
+  }
+  if (attempt.status === "applying") {
+    return attempt.targetSnapshotHashPrepared === params.targetSnapshotHash ||
+      attempt.targetSnapshotHashBefore === params.targetSnapshotHash
+      ? { kind: "recoverable", attempt }
+      : { kind: "none" };
+  }
+  if (attempt.targetSnapshotHashAfter !== params.targetSnapshotHash) {
+    return { kind: "none" };
+  }
+  return attempt.itemStatusesCaptured ||
+    attempt.targetSnapshotHashPrepared === params.targetSnapshotHash ||
+    attempt.targetSnapshotHashBefore === params.targetSnapshotHash
+    ? { kind: "recoverable", attempt }
+    : { kind: "none" };
+}
+
+export function setupMigrationAttemptMatchesSource(
+  attempt: SetupMigrationAttempt,
+  source: string,
+): boolean {
+  return attempt.sourceHash === buildSourceHash(source);
+}
+
+/** Reuses an unchanged plan while suppressing items already completed by the failed run. */
+export function prepareSetupMigrationRetryPlan(
+  plan: MigrationPlan,
+  attempt: SetupMigrationAttempt,
+  sourceSnapshotHash: string,
+): MigrationPlan {
+  if (attempt.sourceSnapshotHash !== sourceSnapshotHash) {
+    throw new Error(
+      "Migration source changed since the failed attempt. Review it before starting a new import.",
+    );
+  }
+  if (attempt.planFingerprint !== buildMigrationPlanFingerprint(plan)) {
+    throw new Error(
+      "Migration retry plan context changed since the failed attempt. Review it before retrying.",
+    );
+  }
+  if (
+    plan.items.length !== attempt.items.length ||
+    plan.items.some((item, index) => {
+      const previous = attempt.items[index];
+      return (
+        !previous ||
+        previous.id !== item.id ||
+        previous.fingerprint !== buildMigrationItemFingerprint(item)
+      );
+    })
+  ) {
+    throw new Error(
+      "Migration retry plan changed since the failed attempt. Review the source and target before retrying.",
+    );
+  }
+  const items = plan.items.map((item, index) => {
+    const resultStatus = attempt.items[index]?.resultStatus;
+    if (resultStatus !== "migrated" || item.action === "archive") {
+      return item;
+    }
+    return {
+      ...item,
+      status: "skipped" as const,
+      reason: "already completed by the previous onboarding import attempt",
+    };
+  });
+  return { ...plan, items, summary: summarizeMigrationItems(items) };
+}

--- a/src/wizard/setup.migration-recovery.ts
+++ b/src/wizard/setup.migration-recovery.ts
@@ -10,7 +10,7 @@ import { resolveUserPath } from "../utils.js";
 const SETUP_MIGRATION_ATTEMPT_FILE = "onboarding-attempt.json";
 const SETUP_MIGRATION_ATTEMPT_VERSION = 1;
 
-export type SetupMigrationAttemptStatus = "applying" | "failed" | "succeeded";
+type SetupMigrationAttemptStatus = "applying" | "failed" | "succeeded";
 
 type SetupMigrationAttemptItem = {
   id: string;
@@ -18,7 +18,7 @@ type SetupMigrationAttemptItem = {
   resultStatus?: MigrationItem["status"];
 };
 
-export type SetupMigrationAttempt = {
+type SetupMigrationAttempt = {
   version: typeof SETUP_MIGRATION_ATTEMPT_VERSION;
   providerId: string;
   sourceHash: string;
@@ -35,7 +35,7 @@ export type SetupMigrationAttempt = {
   updatedAt: string;
 };
 
-export type SetupMigrationRecoveryState =
+type SetupMigrationRecoveryState =
   | { kind: "none" }
   | { kind: "recoverable"; attempt: SetupMigrationAttempt };
 
@@ -72,7 +72,7 @@ function canonicalizeJsonValue(value: unknown): unknown {
   const record = value as Record<string, unknown>;
   return Object.fromEntries(
     Object.keys(record)
-      .sort()
+      .toSorted()
       .filter((key) => record[key] !== undefined)
       .map((key) => [key, canonicalizeJsonValue(record[key])]),
   );
@@ -196,7 +196,7 @@ export function createSetupMigrationAttempt(
   };
 }
 
-export async function writeSetupMigrationAttempt(params: {
+async function writeSetupMigrationAttempt(params: {
   reportDir: string;
   attempt: SetupMigrationAttempt;
   status: SetupMigrationAttemptStatus;
@@ -257,10 +257,12 @@ export async function runSetupMigrationAttempt(params: {
         targetSnapshotHash: await params.readTargetSnapshot(),
       });
     } catch (recoveryError) {
-      throw new AggregateError(
+      const failure = new AggregateError(
         [error, recoveryError],
         "Migration import failed and its retry record could not be updated.",
+        { cause: recoveryError },
       );
+      throw failure;
     }
     throw error;
   }
@@ -396,3 +398,5 @@ export function prepareSetupMigrationRetryPlan(
   });
   return { ...plan, items, summary: summarizeMigrationItems(items) };
 }
+
+export const testing = { writeSetupMigrationAttempt };

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -1,0 +1,329 @@
+// Setup migration snapshots bind retries to unchanged source and target state.
+import crypto from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withFileLock } from "../infra/file-lock.js";
+import type { MigrationPlan } from "../plugins/types.js";
+import { resolveUserPath } from "../utils.js";
+
+const SETUP_MIGRATION_LOCK_OPTIONS = {
+  retries: { retries: 60, factor: 1, minTimeout: 500, maxTimeout: 500 },
+  stale: 30 * 60 * 1000,
+  staleRecovery: "remove-if-unchanged" as const,
+};
+const MEANINGFUL_CONFIG_IGNORED_KEYS = new Set(["$schema", "meta"]);
+const MEANINGFUL_WIZARD_CONFIG_IGNORED_KEYS = new Set(["securityAcknowledgedAt"]);
+const MEANINGFUL_WORKSPACE_ENTRIES = [
+  "AGENTS.md",
+  "SOUL.md",
+  "USER.md",
+  "IDENTITY.md",
+  "MEMORY.md",
+  "skills",
+] as const;
+const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
+
+function isMissingPathError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+function canonicalizeJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJsonValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .filter((key) => record[key] !== undefined)
+      .map((key) => [key, canonicalizeJsonValue(record[key])]),
+  );
+}
+
+async function exists(candidate: string): Promise<boolean> {
+  try {
+    await fs.access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hasDirectoryEntries(candidate: string): Promise<boolean> {
+  try {
+    return (await fs.readdir(candidate)).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function hasMeaningfulWizardConfig(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return true;
+  }
+  return Object.keys(value as Record<string, unknown>).some(
+    (key) => !MEANINGFUL_WIZARD_CONFIG_IGNORED_KEYS.has(key),
+  );
+}
+
+function hasMeaningfulConfig(config: OpenClawConfig): boolean {
+  return Object.entries(config as Record<string, unknown>).some(([key, value]) => {
+    if (MEANINGFUL_CONFIG_IGNORED_KEYS.has(key)) {
+      return false;
+    }
+    return key === "wizard" ? hasMeaningfulWizardConfig(value) : true;
+  });
+}
+
+export async function inspectSetupMigrationFreshness(params: {
+  baseConfig: OpenClawConfig;
+  stateDir: string;
+  workspaceDir: string;
+}): Promise<{ fresh: boolean; reasons: string[] }> {
+  const reasons: string[] = [];
+  if (hasMeaningfulConfig(params.baseConfig)) {
+    reasons.push("existing config values are loaded");
+  }
+  for (const entry of MEANINGFUL_WORKSPACE_ENTRIES) {
+    if (await exists(path.join(params.workspaceDir, entry))) {
+      reasons.push(`workspace ${entry} exists`);
+    }
+  }
+  for (const entry of MEANINGFUL_STATE_ENTRIES) {
+    if (await hasDirectoryEntries(path.join(params.stateDir, entry))) {
+      reasons.push(`state ${entry}/ exists`);
+    }
+  }
+  return { fresh: reasons.length === 0, reasons };
+}
+
+/** Preserves the acknowledgement accepted in-memory before the import lock is acquired. */
+export function preserveSetupMigrationSecurityAcknowledgement(
+  config: OpenClawConfig,
+  inMemoryConfig: OpenClawConfig,
+): OpenClawConfig {
+  const securityAcknowledgedAt = inMemoryConfig.wizard?.securityAcknowledgedAt;
+  if (!securityAcknowledgedAt || config.wizard?.securityAcknowledgedAt) {
+    return config;
+  }
+  return {
+    ...config,
+    wizard: { ...config.wizard, securityAcknowledgedAt },
+  };
+}
+
+async function hashTargetPath(
+  hash: crypto.Hash,
+  candidate: string,
+  snapshotPath: string,
+): Promise<void> {
+  let stat: import("node:fs").Stats;
+  try {
+    stat = await fs.lstat(candidate);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      hash.update(`missing:${snapshotPath}\0`);
+      return;
+    }
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    hash.update(`symlink:${snapshotPath}\0${await fs.readlink(candidate)}\0`);
+    return;
+  }
+  if (stat.isDirectory()) {
+    hash.update(`directory:${snapshotPath}\0`);
+    for (const entry of (await fs.readdir(candidate)).toSorted()) {
+      await hashTargetPath(hash, path.join(candidate, entry), `${snapshotPath}/${entry}`);
+    }
+    return;
+  }
+  if (stat.isFile()) {
+    hash.update(`file:${snapshotPath}\0${stat.size}\0`);
+    for await (const chunk of createReadStream(candidate)) {
+      hash.update(chunk);
+    }
+    hash.update("\0");
+    return;
+  }
+  hash.update(`other:${snapshotPath}\0`);
+}
+
+async function hashSourcePath(
+  hash: crypto.Hash,
+  candidate: string,
+  snapshotPath: string,
+  followedRealPaths = new Set<string>(),
+): Promise<void> {
+  let stat: import("node:fs").Stats;
+  try {
+    stat = await fs.lstat(candidate);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      hash.update(`missing:${snapshotPath}\0`);
+      return;
+    }
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    hash.update(`symlink:${snapshotPath}\0${await fs.readlink(candidate)}\0`);
+    let realPath: string;
+    try {
+      realPath = await fs.realpath(candidate);
+    } catch (error) {
+      hash.update(`unresolved:${(error as NodeJS.ErrnoException).code ?? "unknown"}\0`);
+      return;
+    }
+    if (followedRealPaths.has(realPath)) {
+      hash.update(`cycle:${snapshotPath}\0`);
+      return;
+    }
+    followedRealPaths.add(realPath);
+    await hashSourcePath(hash, realPath, `${snapshotPath}/referent`, followedRealPaths);
+    followedRealPaths.delete(realPath);
+    return;
+  }
+  if (stat.isDirectory()) {
+    hash.update(`directory:${snapshotPath}\0`);
+    for (const entry of (await fs.readdir(candidate)).toSorted()) {
+      await hashSourcePath(
+        hash,
+        path.join(candidate, entry),
+        `${snapshotPath}/${entry}`,
+        followedRealPaths,
+      );
+    }
+    return;
+  }
+  if (stat.isFile()) {
+    hash.update(`file:${snapshotPath}\0${stat.size}\0`);
+    for await (const chunk of createReadStream(candidate)) {
+      hash.update(chunk);
+    }
+    hash.update("\0");
+    return;
+  }
+  hash.update(`other:${snapshotPath}\0`);
+}
+
+/** Hashes migration-owned target state without persisting raw paths or values. */
+export async function buildSetupMigrationTargetSnapshot(params: {
+  config: OpenClawConfig;
+  stateDir: string;
+  workspaceDir: string;
+}): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const targetConfig = Object.fromEntries(
+    Object.entries(params.config as Record<string, unknown>).filter(
+      ([key]) => !MEANINGFUL_CONFIG_IGNORED_KEYS.has(key),
+    ),
+  );
+  hash.update(`config:${JSON.stringify(canonicalizeJsonValue(targetConfig))}\0`);
+  for (const entry of MEANINGFUL_WORKSPACE_ENTRIES) {
+    await hashTargetPath(hash, path.join(params.workspaceDir, entry), `workspace/${entry}`);
+  }
+  for (const entry of MEANINGFUL_STATE_ENTRIES) {
+    await hashTargetPath(hash, path.join(params.stateDir, entry), `state/${entry}`);
+  }
+  return hash.digest("hex");
+}
+
+/** Hashes only source paths represented by the provider's concrete migration plan. */
+export async function buildSetupMigrationPlanSourceSnapshot(plan: MigrationPlan): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const itemSources = [
+    ...new Set(
+      plan.items
+        .map((item) => item.source?.trim())
+        .filter((source): source is string => Boolean(source))
+        .map((source) => path.resolve(resolveUserPath(source))),
+    ),
+  ].toSorted();
+  const sources = [
+    ...new Set(
+      itemSources.flatMap((source) =>
+        path.extname(source) === ".db"
+          ? [source, `${source}-wal`, `${source}-shm`, `${source}-journal`]
+          : [source],
+      ),
+    ),
+  ].toSorted();
+  for (const [index, source] of sources.entries()) {
+    await hashSourcePath(hash, source, `source/${index}`);
+  }
+  return hash.digest("hex");
+}
+
+/** Verifies planning inputs and builds the exact provider-side-effect retry boundary. */
+export async function prepareSetupMigrationAttemptBoundary(params: {
+  currentConfig: OpenClawConfig;
+  targetConfig: OpenClawConfig;
+  stateDir: string;
+  workspaceDir: string;
+  plan: MigrationPlan;
+  expectedTargetSnapshotHash: string;
+  expectedSourceSnapshotHash: string;
+}): Promise<{
+  sourceSnapshotHash: string;
+  preparedTargetSnapshotHash: string;
+  targetSnapshotHash: string;
+}> {
+  const currentTargetSnapshotHash = await buildSetupMigrationTargetSnapshot({
+    config: params.currentConfig,
+    stateDir: params.stateDir,
+    workspaceDir: params.workspaceDir,
+  });
+  if (currentTargetSnapshotHash !== params.expectedTargetSnapshotHash) {
+    throw new Error("Migration target changed while preparing the import. Review it and retry.");
+  }
+  const sourceSnapshotHash = await buildSetupMigrationPlanSourceSnapshot(params.plan);
+  if (sourceSnapshotHash !== params.expectedSourceSnapshotHash) {
+    throw new Error("Migration source changed while preparing the import. Review it and retry.");
+  }
+  return {
+    sourceSnapshotHash,
+    preparedTargetSnapshotHash: currentTargetSnapshotHash,
+    targetSnapshotHash: await buildSetupMigrationTargetSnapshot({
+      config: params.targetConfig,
+      stateDir: params.stateDir,
+      workspaceDir: params.workspaceDir,
+    }),
+  };
+}
+
+/** Serializes all onboarding migration writes that share one OpenClaw state target. */
+export async function withSetupMigrationTargetLock<T>(
+  stateDir: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const migrationDir = path.join(stateDir, "migration");
+  await fs.mkdir(migrationDir, { recursive: true, mode: 0o700 });
+  return await withFileLock(
+    path.join(migrationDir, "onboarding.lock-target"),
+    SETUP_MIGRATION_LOCK_OPTIONS,
+    fn,
+  );
+}
+
+export function assertFreshSetupMigrationTarget(freshness: {
+  fresh: boolean;
+  reasons: readonly string[];
+}): void {
+  if (freshness.fresh || process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1") {
+    return;
+  }
+  throw new Error(
+    [
+      "Migration import during onboarding requires a fresh OpenClaw setup.",
+      "Create a fresh setup or reset config, credentials, sessions, and workspace before importing.",
+      "Backup plus overwrite/merge imports are feature-gated for now.",
+      "Existing setup:",
+      ...freshness.reasons.map((reason) => `- ${reason}`),
+    ].join("\n"),
+  );
+}

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -80,6 +80,29 @@ function hasMeaningfulConfig(config: OpenClawConfig): boolean {
   });
 }
 
+function buildSetupMigrationSnapshotConfig(config: OpenClawConfig): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config as Record<string, unknown>)) {
+    if (MEANINGFUL_CONFIG_IGNORED_KEYS.has(key)) {
+      continue;
+    }
+    if (key !== "wizard" || !value || typeof value !== "object" || Array.isArray(value)) {
+      snapshot[key] = value;
+      continue;
+    }
+    // Risk acknowledgement can be accepted between retries; freshness already ignores it.
+    const wizard = Object.fromEntries(
+      Object.entries(value).filter(
+        ([wizardKey]) => !MEANINGFUL_WIZARD_CONFIG_IGNORED_KEYS.has(wizardKey),
+      ),
+    );
+    if (Object.keys(wizard).length > 0) {
+      snapshot[key] = wizard;
+    }
+  }
+  return snapshot;
+}
+
 export async function inspectSetupMigrationFreshness(params: {
   baseConfig: OpenClawConfig;
   stateDir: string;
@@ -218,11 +241,7 @@ export async function buildSetupMigrationTargetSnapshot(params: {
   workspaceDir: string;
 }): Promise<string> {
   const hash = crypto.createHash("sha256");
-  const targetConfig = Object.fromEntries(
-    Object.entries(params.config as Record<string, unknown>).filter(
-      ([key]) => !MEANINGFUL_CONFIG_IGNORED_KEYS.has(key),
-    ),
-  );
+  const targetConfig = buildSetupMigrationSnapshotConfig(params.config);
   hash.update(`config:${JSON.stringify(canonicalizeJsonValue(targetConfig))}\0`);
   for (const entry of MEANINGFUL_WORKSPACE_ENTRIES) {
     await hashTargetPath(hash, path.join(params.workspaceDir, entry), `workspace/${entry}`);

--- a/src/wizard/setup.migration-snapshot.ts
+++ b/src/wizard/setup.migration-snapshot.ts
@@ -39,7 +39,7 @@ function canonicalizeJsonValue(value: unknown): unknown {
   const record = value as Record<string, unknown>;
   return Object.fromEntries(
     Object.keys(record)
-      .sort()
+      .toSorted()
       .filter((key) => record[key] !== undefined)
       .map((key) => [key, canonicalizeJsonValue(record[key])]),
   );

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -115,6 +115,14 @@ export async function readSetupConfigFileSnapshot() {
   return await createConfigIO({ pluginValidation: "skip" }).readConfigFileSnapshot();
 }
 
+export async function readValidSetupConfigFile(): Promise<OpenClawConfig> {
+  const snapshot = await readSetupConfigFileSnapshot();
+  if (!snapshot.valid) {
+    throw new Error("Migration target config became invalid. Run `openclaw doctor`.");
+  }
+  return snapshot.exists ? (snapshot.sourceConfig ?? snapshot.config) : {};
+}
+
 /** One-time security acknowledgement; persisted so reruns stay quiet. */
 export async function requireRiskAcknowledgement(params: {
   opts: OnboardOptions;

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,4 +1,3 @@
-// Setup wizard orchestrates onboarding prompts and generated OpenClaw config.
 import { formatCliCommand } from "../cli/command-format.js";
 import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { resolveGatewayPort } from "../config/config.js";
@@ -27,6 +26,7 @@ import { runSetupModelAuthStep } from "./setup.model-auth.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   readSetupConfigFileSnapshot,
+  readValidSetupConfigFile,
   requireRiskAcknowledgement,
   resolveQuickstartGatewayDefaults,
   writeWizardConfigFile,
@@ -295,6 +295,7 @@ async function runSetupWizardOnce(
       detections: migrationDetections,
       prompter,
       runtime,
+      readConfigFile: readValidSetupConfigFile,
       commitConfigFile: (cfg) => writeWizardConfigFile(cfg, { allowConfigSizeDrop: true }),
       continueOnboarding: true,
     });
@@ -611,7 +612,6 @@ async function runSetupWizardOnce(
     });
   }
 
-  // Plugin configuration (sandbox backends, tool plugins, etc.)
   if (flow !== "quickstart") {
     const { setupOfficialPluginInstalls } = await import("./setup.official-plugins.js");
     nextConfig = await setupOfficialPluginInstalls({


### PR DESCRIPTION
## What Problem This Solves

Failed Hermes onboarding imports can leave configuration, workspace files, credentials, or archives partially applied. The next onboarding attempt then sees a non-fresh target and refuses to retry, forcing users toward a manual reset or an undocumented override.

Closes #103262.

## Why This Change Was Made

A simple config-commit reorder is not sufficient: Hermes applies items sequentially, and successful earlier items remain when a later item fails. This change gives Hermes onboarding imports one durable recovery owner:

- serialize target-wide onboarding imports with a stale-safe file lock;
- record source, plan, workspace, and target identities without persisting raw paths or values;
- record per-item completion before allowing a retry;
- skip only previously migrated replay-safe items while rerunning archive output into the new report;
- fail closed when source, plan, or meaningful target state changes;
- ignore only transient writer metadata and the security acknowledgement already ignored by freshness checks;
- preserve provider-owned config mutations instead of overwriting them with a stale wizard snapshot.

Recovery is intentionally limited to the audited bundled Hermes provider. Other migration providers keep their existing behavior until they define equivalent replay and checkpoint contracts.

## User Impact

After a recoverable Hermes import failure, users can fix the underlying problem and rerun the same onboarding command. Completed work is preserved, incomplete work resumes, changed inputs are rejected, and no reset or existing-import override is required.

Release note: make failed Hermes onboarding imports safely retryable while rejecting changed source, plan, or target state.

## Evidence

- Testbox `tbx_01kxf1aryvyz671y7b6qb05v5q`, Actions run https://github.com/openclaw/openclaw/actions/runs/29296752877
- `pnpm test src/wizard/setup.migration-import.test.ts src/wizard/setup.migration-recovery.test.ts src/commands/onboard-non-interactive.gateway.test.ts`: 31 passed
- `pnpm check:changed`: conflict, LOC, attribution, export, duplicate, dependency, and format lanes passed. The Plugin SDK hash lane failed identically against a clean `origin/main` archive and this PR changes no SDK surface.
- `pnpm build`: passed
- Built CLI behavior proof: forced a real partial Hermes import with an unwritable workspace, added the transient security acknowledgement to model an interactive retry, fixed only the permission, reran the same import successfully, verified MCP config and `SOUL.md`, and observed durable `failed,succeeded` attempt states.
- Anti-cheat probe: changing `SOUL.md` after failure was rejected with the source-drift diagnostic.
- Fresh autoreview: no accepted or actionable findings, confidence 0.98.
