### PR TITLE
fix(ui): refresh profile and agent selector after language changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI live translations:** refresh Profile and agent selector copy immediately when the locale changes while those Lit components remain mounted. (#103270)
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI live translations:** refresh Profile and agent selector copy immediately when the locale changes while those Lit components remain mounted. (#103270)
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -2,6 +2,7 @@
 
 import { expect, it, vi } from "vitest";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
+import { i18n, t } from "../i18n/index.ts";
 import "./agent-select.ts";
 
 type AgentSelectElement = HTMLElement & {
@@ -321,5 +322,24 @@ it("renders a disabled trigger with the empty-state label", async () => {
     expect(element.querySelector(".agent-select__label")?.textContent?.trim()).toBe("No agents");
   } finally {
     element.remove();
+  }
+});
+
+it("refreshes translated labels when the locale changes while mounted", async () => {
+  await i18n.setLocale("en");
+  const element = await createAgentSelect({ agents: [], selectedId: null });
+
+  try {
+    const label = element.querySelector(".agent-select__label");
+    const englishLabel = label?.textContent?.trim();
+
+    await i18n.setLocale("zh-CN");
+    await element.updateComplete;
+
+    expect(label?.textContent?.trim()).toBe(t("agents.noAgents"));
+    expect(label?.textContent?.trim()).not.toBe(englishLabel);
+  } finally {
+    element.remove();
+    await i18n.setLocale("en");
   }
 });

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
@@ -8,13 +8,10 @@ import {
   resolveAgentTextAvatar,
 } from "../lib/agents/display.ts";
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
+import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 
-class AgentSelect extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
+class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) agents: GatewayAgentRow[] = [];
   @property({ attribute: false }) selectedId: string | null = null;
   @property({ attribute: false }) defaultId: string | null = null;

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -1,0 +1,79 @@
+/* @vitest-environment jsdom */
+
+import { ContextProvider } from "@lit/context";
+import { LitElement } from "lit";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import type { RouteId } from "../../app-route-paths.ts";
+import {
+  applicationContext,
+  type ApplicationContext,
+  type ApplicationGatewaySnapshot,
+} from "../../app/context.ts";
+import { i18n, t } from "../../i18n/index.ts";
+import "./profile-page.ts";
+
+const PROVIDER_ELEMENT_NAME = "test-profile-page-context-provider";
+
+class ProfilePageContextProvider extends LitElement {
+  private readonly contextProvider = new ContextProvider(this, {
+    context: applicationContext,
+  });
+
+  setContext(context: ApplicationContext<RouteId>) {
+    this.contextProvider.setValue(context);
+  }
+}
+
+if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
+  customElements.define(PROVIDER_ELEMENT_NAME, ProfilePageContextProvider);
+}
+
+type ProfilePageElement = HTMLElement & {
+  updateComplete: Promise<boolean>;
+};
+
+function createContext(): ApplicationContext<RouteId> {
+  const snapshot: ApplicationGatewaySnapshot = {
+    client: null,
+    connected: false,
+    reconnecting: false,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "agent:main:main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const subscribe = () => () => undefined;
+  return {
+    gateway: { snapshot, subscribe },
+    agents: { subscribe },
+    agentIdentity: { subscribe },
+  } as unknown as ApplicationContext<RouteId>;
+}
+
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+
+afterEach(async () => {
+  document.body.replaceChildren();
+  await i18n.setLocale("en");
+});
+
+it("refreshes translated copy when the locale changes while mounted", async () => {
+  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as ProfilePageContextProvider;
+  const page = document.createElement("openclaw-profile-page") as ProfilePageElement;
+  provider.setContext(createContext());
+  provider.append(page);
+  document.body.append(provider);
+  await page.updateComplete;
+
+  const note = page.querySelector(".profile-note");
+  const englishNote = note?.textContent?.trim();
+
+  await i18n.setLocale("de");
+  await page.updateComplete;
+
+  expect(note?.textContent?.trim()).toBe(t("profilePage.offline"));
+  expect(note?.textContent?.trim()).not.toBe(englishNote);
+});

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, LitElement, nothing, svg } from "lit";
+import { html, nothing, svg } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { CostUsageSummary, SessionsUsageResult } from "../../api/types.ts";
@@ -19,6 +19,7 @@ import {
   isMissingOperatorReadScopeError,
 } from "../../lib/gateway-errors.ts";
 import { buildSessionUsageDateParams, requestSessionsUsage } from "../../lib/sessions/index.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import {
   buildHeatmap,
   buildInsights,
@@ -84,11 +85,7 @@ function toErrorMessage(error: unknown): string {
   return typeof error === "string" ? error : "request failed";
 }
 
-class ProfilePage extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
+class ProfilePage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ApplicationContext;
 


### PR DESCRIPTION
Closes #103270

## What Problem This Solves

Fixes an issue where users changing the Control UI language would keep seeing stale translated copy in the Profile page and agent selector while those surfaces remained mounted.

## Why This Change Was Made

Profile and agent selection now use the existing locale-aware OpenClaw light-DOM Lit base instead of duplicating raw `LitElement` light-DOM setup. This preserves their DOM and styling behavior, adds the shared locale invalidation lifecycle, and leaves the untranslated decorative lobster component as the intentional raw-Lit exception.

## User Impact

Profile labels and agent-selector copy update immediately after a language change without requiring navigation, remounting, or an unrelated state update.

## Evidence

- Before-fix regression proof: AWS Crabbox `run_51540d3f293b` — both new tests failed with English copy remaining after locale changes.
- Focused latest-main proof: AWS Crabbox `run_86a1758963c7` — 3 files and 16 tests passed, covering AgentSelect, ProfilePage, and the shared Lit base lifecycle.
- Full latest-main changed gate: AWS Crabbox `run_13e03575a5ff` — typecheck, lint, dependency/structure guards, and runtime import-cycle validation passed.
- Production Control UI build: AWS Crabbox `run_4054ffc72c31` — Vite built 1,025 modules successfully.
- Fresh pre-commit Codex autoreview: no accepted or actionable findings.
