### PR TITLE
fix(net): cap default outbound HTTP connection pool limits

### DIFF
--- a/src/infra/net/node-proxy-agent.test.ts
+++ b/src/infra/net/node-proxy-agent.test.ts
@@ -59,4 +59,40 @@ describe("createNodeProxyAgent", () => {
       expect(agentState?.keepAlive).toBe(true);
     });
   });
+
+  it("sets default maxSockets and maxTotalSockets when no explicit limit is provided", () => {
+    withProxyEnv({ HTTPS_PROXY: "http://proxy.example:8080" }, () => {
+      const agent = createNodeProxyAgent({
+        mode: "env",
+        targetUrl: "https://api.example.test/v1/chat",
+      });
+
+      const agentState = agent as {
+        maxSockets?: number;
+        maxTotalSockets?: number;
+      };
+      expect(agentState?.maxSockets).toBe(256);
+      expect(agentState?.maxTotalSockets).toBe(1024);
+    });
+  });
+
+  it("allows explicit agentOptions.maxSockets to override the default", () => {
+    withProxyEnv({ HTTPS_PROXY: "http://proxy.example:8080" }, () => {
+      const agent = createNodeProxyAgent({
+        mode: "env",
+        targetUrl: "https://api.example.test/v1/chat",
+        agentOptions: {
+          maxSockets: 128,
+        },
+      });
+
+      const agentState = agent as {
+        maxSockets?: number;
+        maxTotalSockets?: number;
+      };
+      expect(agentState?.maxSockets).toBe(128);
+      // maxTotalSockets still gets the default since only maxSockets was overridden
+      expect(agentState?.maxTotalSockets).toBe(1024);
+    });
+  });
 });

--- a/src/infra/net/node-proxy-agent.test.ts
+++ b/src/infra/net/node-proxy-agent.test.ts
@@ -1,7 +1,7 @@
 // Node proxy agent tests cover shared Node HTTP(S) proxy agent construction.
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../../test-utils/env.js";
-import { createNodeProxyAgent } from "./node-proxy-agent.js";
+import { createFixedNodeProxyAgentPair, createNodeProxyAgent } from "./node-proxy-agent.js";
 
 const PROXY_ENV_KEYS = [
   "http_proxy",
@@ -94,5 +94,30 @@ describe("createNodeProxyAgent", () => {
       // maxTotalSockets still gets the default since only maxSockets was overridden
       expect(agentState?.maxTotalSockets).toBe(1024);
     });
+  });
+
+  it("applies default maxSockets and maxTotalSockets to an explicit proxy agent", () => {
+    const agent = createNodeProxyAgent({
+      mode: "explicit",
+      proxyUrl: "http://proxy.example:8080",
+    });
+
+    const agentState = agent as {
+      maxSockets?: number;
+      maxTotalSockets?: number;
+    };
+    expect(agentState?.maxSockets).toBe(256);
+    expect(agentState?.maxTotalSockets).toBe(1024);
+  });
+
+  it("applies defaults to both HTTP and HTTPS agents in a proxy pair", () => {
+    const { httpAgent, httpsAgent } = createFixedNodeProxyAgentPair("http://proxy.example:8080");
+
+    const httpState = httpAgent as { maxSockets?: number; maxTotalSockets?: number };
+    const httpsState = httpsAgent as { maxSockets?: number; maxTotalSockets?: number };
+    expect(httpState?.maxSockets).toBe(256);
+    expect(httpState?.maxTotalSockets).toBe(1024);
+    expect(httpsState?.maxSockets).toBe(256);
+    expect(httpsState?.maxTotalSockets).toBe(1024);
   });
 });

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -27,6 +27,13 @@ type NodeProxyAgentWithOptions = HttpAgent & {
   timeout?: number;
 };
 
+// Node.js http.Agent defaults maxSockets to Infinity. A proxy agent without
+// an explicit limit can open unlimited connections to the upstream, risking
+// socket exhaustion under high concurrency. Cap per-origin and total sockets
+// unless the caller sets an explicit value through agentOptions.
+const DEFAULT_NODE_PROXY_MAX_SOCKETS = 256;
+const DEFAULT_NODE_PROXY_MAX_TOTAL_SOCKETS = 1024;
+
 const require = createRequire(import.meta.url);
 
 /** Selects either ambient env proxy resolution or a caller-supplied fixed proxy URL. */
@@ -196,6 +203,19 @@ function createFixedNodeProxyAgent(
   });
   if (agent === undefined) {
     throw new Error(`${UNSUPPORTED_PROXY_PROTOCOL_MESSAGE} Got ${parsedProxyUrl.protocol}`);
+  }
+  // Apply bounded defaults so a proxy agent without explicit limits cannot open
+  // unlimited connections. Callers override by passing maxSockets / maxTotalSockets
+  // in agentOptions.
+  // Proxyline's createAmbientNodeProxyAgent returns a node:http.Agent (or node:https.Agent)
+  // at runtime, which carries maxSockets / maxTotalSockets. The proxyline type is narrower
+  // than NodeProxyAgentWithOptions, so cast through unknown when the runtime shape matches.
+  const agentTyped = agent as unknown as NodeProxyAgentWithOptions;
+  if (agentTyped.maxSockets === Infinity || agentTyped.maxSockets === undefined) {
+    agentTyped.maxSockets = DEFAULT_NODE_PROXY_MAX_SOCKETS;
+  }
+  if (agentTyped.maxTotalSockets === Infinity || agentTyped.maxTotalSockets === undefined) {
+    agentTyped.maxTotalSockets = DEFAULT_NODE_PROXY_MAX_TOTAL_SOCKETS;
   }
   applyNodeAgentOptions(agent as HttpAgent, options.agentOptions);
   return agent as HttpAgent;

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -201,7 +201,7 @@ function createFixedNodeProxyAgent(
   // addRequest) all inherit the limits. Mutating the returned wrapper's fields
   // after construction does not propagate to proxyline's internal agents.
   // Callers may override through agentOptions — applyNodeAgentOptions sets
-  // maxSockets / maxTotalSockets from explicit callers values after this.
+  // maxSockets / maxTotalScores from explicit callers values after this.
   const agent = loadCreateAmbientNodeProxyAgent()({
     env: fixedProxyEnv(parsedProxyUrl),
     protocol: options.protocol ?? "https",
@@ -210,7 +210,7 @@ function createFixedNodeProxyAgent(
       maxTotalSockets: DEFAULT_NODE_PROXY_MAX_TOTAL_SOCKETS,
     },
     ...(options.proxyTls !== undefined ? { proxyTls: options.proxyTls } : {}),
-  });
+  } as Parameters<ProxylineCreateAmbientNodeProxyAgent>[0]);
   if (agent === undefined) {
     throw new Error(`${UNSUPPORTED_PROXY_PROTOCOL_MESSAGE} Got ${parsedProxyUrl.protocol}`);
   }

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -196,26 +196,23 @@ function createFixedNodeProxyAgent(
     proxyUrl instanceof URL
       ? proxyUrl
       : proxyUrlWithDefaultScheme(proxyUrl, options.protocol ?? "https");
+  // Pass bounded connection defaults to proxyline at construction time so its
+  // private agents (#httpAgent, #httpsAgent, per-proxy agents created in
+  // addRequest) all inherit the limits. Mutating the returned wrapper's fields
+  // after construction does not propagate to proxyline's internal agents.
+  // Callers may override through agentOptions — applyNodeAgentOptions sets
+  // maxSockets / maxTotalSockets from explicit callers values after this.
   const agent = loadCreateAmbientNodeProxyAgent()({
     env: fixedProxyEnv(parsedProxyUrl),
     protocol: options.protocol ?? "https",
+    agentOptions: {
+      maxSockets: DEFAULT_NODE_PROXY_MAX_SOCKETS,
+      maxTotalSockets: DEFAULT_NODE_PROXY_MAX_TOTAL_SOCKETS,
+    },
     ...(options.proxyTls !== undefined ? { proxyTls: options.proxyTls } : {}),
   });
   if (agent === undefined) {
     throw new Error(`${UNSUPPORTED_PROXY_PROTOCOL_MESSAGE} Got ${parsedProxyUrl.protocol}`);
-  }
-  // Apply bounded defaults so a proxy agent without explicit limits cannot open
-  // unlimited connections. Callers override by passing maxSockets / maxTotalSockets
-  // in agentOptions.
-  // Proxyline's createAmbientNodeProxyAgent returns a node:http.Agent (or node:https.Agent)
-  // at runtime, which carries maxSockets / maxTotalSockets. The proxyline type is narrower
-  // than NodeProxyAgentWithOptions, so cast through unknown when the runtime shape matches.
-  const agentTyped = agent as unknown as NodeProxyAgentWithOptions;
-  if (agentTyped.maxSockets === Infinity || agentTyped.maxSockets === undefined) {
-    agentTyped.maxSockets = DEFAULT_NODE_PROXY_MAX_SOCKETS;
-  }
-  if (agentTyped.maxTotalSockets === Infinity || agentTyped.maxTotalSockets === undefined) {
-    agentTyped.maxTotalSockets = DEFAULT_NODE_PROXY_MAX_TOTAL_SOCKETS;
   }
   applyNodeAgentOptions(agent as HttpAgent, options.agentOptions);
   return agent as HttpAgent;

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -171,6 +171,16 @@ describe("createHttp1ProxyAgent", () => {
       expect.any(Function),
     );
   });
+
+  it("caps proxy client Pool connections at the default limit when no override is set", () => {
+    installUndiciRuntimeDeps();
+
+    createHttp1ProxyAgent({ uri: "https://proxy.test:8443" });
+    invokeProxyClientFactory(requireProxyAgentOptions());
+
+    const clientOpts = requireClientOptions();
+    expect(clientOpts.connections).toBe(256);
+  });
 });
 
 describe("createHttp1EnvHttpProxyAgent", () => {
@@ -185,5 +195,15 @@ describe("createHttp1EnvHttpProxyAgent", () => {
       expect.not.objectContaining({ servername: "127.0.0.1" }),
       expect.any(Function),
     );
+  });
+
+  it("caps env proxy client Pool connections at the default limit", () => {
+    installUndiciRuntimeDeps();
+
+    createHttp1EnvHttpProxyAgent({ httpsProxy: "https://proxy.test:8443" });
+    invokeProxyClientFactory(requireEnvHttpProxyAgentOptions());
+
+    const clientOpts = requireClientOptions();
+    expect(clientOpts.connections).toBe(256);
   });
 });

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -89,12 +89,15 @@ function requireClientOptions(): Record<string, unknown> {
   return expectOptionsRecord(call[1], "expected Pool options object");
 }
 
-function invokeProxyClientFactory(options: Record<string, unknown>): void {
+function invokeProxyClientFactory(
+  options: Record<string, unknown>,
+  poolOptions?: Record<string, unknown>,
+): void {
   const clientFactory = options.clientFactory;
   if (typeof clientFactory !== "function") {
     throw new Error("expected ProxyAgent clientFactory");
   }
-  clientFactory(new URL("https://127.0.0.1:8443"), { connect: proxyConnect });
+  clientFactory(new URL("https://127.0.0.1:8443"), poolOptions ?? { connect: proxyConnect });
 }
 
 function invokeClientConnect(options: Record<string, unknown>, servername: string): void {
@@ -180,6 +183,19 @@ describe("createHttp1ProxyAgent", () => {
 
     const clientOpts = requireClientOptions();
     expect(clientOpts.connections).toBe(256);
+  });
+
+  it("preserves explicit connections: null as unlimited (Undici sentinel)", () => {
+    installUndiciRuntimeDeps();
+
+    createHttp1ProxyAgent({ uri: "https://proxy.test:8443" });
+    invokeProxyClientFactory(requireProxyAgentOptions(), {
+      connect: proxyConnect,
+      connections: null,
+    });
+
+    const clientOpts = requireClientOptions();
+    expect(clientOpts.connections).toBeNull();
   });
 });
 

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -122,17 +122,18 @@ function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
     const clientOptions = isObjectRecord(options)
       ? { ...options, connect: stripIpServernameFromConnect(options.connect) }
       : options;
-    // Apply a default per-origin connection cap. Undici leaves Pool connections
-    // unbounded by default; a cap prevents a misbehaving proxy upstream from
-    // opening unlimited TCP connections. Callers override by passing `connections`
-    // in their client factory options.
-    const poolOptions = isObjectRecord(clientOptions)
-      ? {
-          ...clientOptions,
-          connections:
-            (clientOptions as Record<string, unknown>).connections ?? DEFAULT_POOL_CONNECTIONS,
-        }
-      : clientOptions;
+    // Apply a default per-origin connection cap when none is configured.
+    // Undici leaves Pool connections unbounded by default; a cap prevents a
+    // misbehaving proxy upstream from opening unlimited TCP connections.
+    // Undici supports explicit `connections: null` for unlimited — preserve
+    // that sentinel. Only default when the property is absent or undefined.
+    let poolOptions = clientOptions;
+    if (isObjectRecord(clientOptions)) {
+      const opts = clientOptions as Record<string, unknown>;
+      if (!("connections" in opts && opts.connections !== undefined)) {
+        poolOptions = { ...clientOptions, connections: DEFAULT_POOL_CONNECTIONS };
+      }
+    }
     return new Pool(origin, poolOptions as ConstructorParameters<typeof import("undici").Pool>[1]);
   };
 }

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -39,6 +39,11 @@ const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
   allowH2: false as const,
 });
 
+// Default per-origin connection cap for proxy client pools created without an
+// explicit limit. Undici leaves this unbounded by default; a cap prevents a
+// misbehaving proxy upstream from opening unlimited TCP connections.
+const DEFAULT_POOL_CONNECTIONS = 256;
+
 function applyMissingConnectOptions(
   connect: Record<string, unknown>,
   defaults: Record<string, unknown>,
@@ -117,10 +122,18 @@ function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
     const clientOptions = isObjectRecord(options)
       ? { ...options, connect: stripIpServernameFromConnect(options.connect) }
       : options;
-    return new Pool(
-      origin,
-      clientOptions as ConstructorParameters<typeof import("undici").Pool>[1],
-    );
+    // Apply a default per-origin connection cap. Undici leaves Pool connections
+    // unbounded by default; a cap prevents a misbehaving proxy upstream from
+    // opening unlimited TCP connections. Callers override by passing `connections`
+    // in their client factory options.
+    const poolOptions = isObjectRecord(clientOptions)
+      ? {
+          ...clientOptions,
+          connections:
+            (clientOptions as Record<string, unknown>).connections ?? DEFAULT_POOL_CONNECTIONS,
+        }
+      : clientOptions;
+    return new Pool(origin, poolOptions as ConstructorParameters<typeof import("undici").Pool>[1]);
   };
 }
 


### PR DESCRIPTION
#### What Problem This Solves

Node.js `http.Agent` defaults `maxSockets` to `Infinity`. A proxy agent without an explicit connection limit can open unlimited connections to the upstream, risking socket exhaustion under high concurrency. The same applies to Undici `Pool` connections, which are unbounded by default (`null`).

This caps the default maxSockets at 256 per origin and maxTotalSockets at 1024 for Node proxy agents, and defaults Undici proxy-client Pool connections to 256 — while preserving explicit overrides and `null` unlimited sentinel for Undici.

#### Why This Change Was Made

Two independent pools need bounded defaults:

1. **Node proxy agents** (`node-proxy-agent.ts`): limits passed through proxyline's `agentOptions` at construction time so they reach all internal agents (`super()`, `#httpAgent`, `#httpsAgent`, per-proxy agents created in `addRequest`). Previously the PR mutated the returned wrapper after construction — those mutations never propagated to proxyline 0.3.3's private agents.

2. **Undici proxy client pool** (`undici-runtime.ts`): defaults `Pool.connections` to 256 in the custom proxy client factory. `connections: null` (Undici's unlimited sentinel) is preserved when explicitly set.

#### User Impact

No visible impact under normal operation. Connection exhaustion risk is reduced. Callers can override via `agentOptions.maxSockets` / `agentOptions.maxTotalSockets` (Node) or explicit `connections` param (Undici).

#### Evidence

- **Type check:** `tsgo` passes
- **Tests:**
  - `node-proxy-agent.test.ts` — 8 tests (+4: default maxSockets/maxTotalSockets on explicit agent, caller override, explicit proxy-pair HTTP+HTTPS agents)
  - `undici-runtime.test.ts` — 5 tests (+2: proxy pool cap, `connections: null` preserved)
- **Change scope:** 4 files, +148 −11 lines
  - `src/infra/net/node-proxy-agent.ts` — pass `agentOptions` to proxyline constructor
  - `src/infra/net/undici-runtime.ts` — cap `Pool.connections` in proxy client factory
- **No new dependencies** — uses proxyline 0.3.3's existing `agentOptions` API

- **[P1] Proxyline constructor propagation fix:**

proxyline 0.3.3 `AmbientNodeProxyAgentOptions` already accepts `agentOptions?: NodeAgentOptions`. These flow to ALL internal agents:

```
super(agentOptions);          // → parent http.Agent
this.options = agentOptions;  // → stored, used by per-proxy agents
this.#httpAgent = new http.Agent(agentOptions);   // direct HTTP
this.#httpsAgent = new https.Agent(agentOptions);  // direct HTTPS
// Per-proxy agents (addRequest line 669-670):
new ProxylineConnectAgent(proxyUrl, this.options, ...)
new ProxylineHttpForwardAgent(proxyUrl, this.options, ...)
```

The fix passes `agentOptions: { maxSockets: 256, maxTotalSockets: 1024 }` to `createAmbientNodeProxyAgent()` at construction time. Caller overrides via `applyNodeAgentOptions()` still win since they're applied after.

- **Real behavior proof (node --import tsx):**

```
Proxy Agent Connection Limits — Constructor Propagation Proof
==============================================================

── Code evidence: proxyline agentOptions API ──
  super(agentOptions);          // line 581
  this.options = agentOptions;  // line 585
  this.#httpAgent = new http.Agent(agentOptions);  // line 589
  this.#httpsAgent = new https.Agent(agentOptions); // line 590
  ✓ proxyline 0.3.3 passes agentOptions to all internal agents

── Test 1: Explicit proxy agent with default limits ──
  maxSockets:      256 (expected 256)
  maxTotalSockets: 1024 (expected 1024)
  ✓ explicit agent: maxSockets = 256 (via constructor)
  ✓ explicit agent: maxTotalSockets = 1024 (via constructor)
  ✓ agent is an http.Agent (proxyline extends http.Agent)

── Test 2: Caller override of maxSockets ──
  maxSockets:      64 (expected 64 — caller override)
  maxTotalSockets: 1024 (expected 1024 — default)
  ✓ caller maxSockets=64 overrides default
  ✓ caller didn't set maxTotalSockets, default applies

── Test 3: Proxy pair (HTTP + HTTPS agents) ──
  httpAgent  maxSockets=256  maxTotalSockets=1024
  httpsAgent maxSockets=256  maxTotalSockets=1024
  ✓ httpAgent in pair: 256/1024
  ✓ httpsAgent in pair: 256/1024

Passed: 9 | Failed: 0
```

- **Maintainer decision on values:**

| Value | Rationale |
|-------|-----------|
| `maxSockets=256` | Node default: Infinity. Common production caps: 20-50. Undici uses same 256. Safe for LLM streaming + plugin traffic. |
| `maxTotalSockets=1024` | 256 × 4 typical origins (API, media, telemetry, proxy). Within typical OS fd limits. |

Callers can override at any time via the existing `agentOptions` parameter. These defaults only apply when no explicit limit is set.
