### PR TITLE
fix: claude-cli backend silently runs adaptive thinking at pinned medium effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Claude CLI adaptive effort:** remove configured `--effort` flags from adaptive-thinking runs instead of silently pinning medium or preserving a static override, allowing Claude Code to resolve effective effort from its own configuration and model defaults. (#103296) Thanks @dankorotin.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Claude CLI adaptive effort:** remove configured `--effort` flags from adaptive-thinking runs instead of silently pinning medium or preserving a static override, allowing Claude Code to resolve effective effort from its own configuration and model defaults. (#103296) Thanks @dankorotin.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -127,7 +127,7 @@ The bundled `claude-cli` backend prefers Claude Code's native skill resolver. Wh
 
 Claude CLI has its own noninteractive permission mode; OpenClaw maps that to the existing exec policy instead of adding Claude-specific config. For OpenClaw-managed Claude live sessions, the effective exec policy is authoritative: YOLO (`tools.exec.security: "full"` and `tools.exec.ask: "off"`) launches Claude with `--permission-mode bypassPermissions`, while a restrictive policy launches it with `--permission-mode default`. Per-agent `agents.list[].tools.exec` settings override the global `tools.exec` for that agent. Raw backend args may still include `--permission-mode`, but live Claude launches normalize that flag to match the effective policy.
 
-The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. `adaptive` omits `--effort` entirely so Claude Code uses its native adaptive-reasoning default for the model. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
+The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. `adaptive` removes configured `--effort` flags and supplies no replacement, so Claude Code resolves effective effort from its own environment, settings, and model defaults. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
 
 Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -127,7 +127,7 @@ The bundled `claude-cli` backend prefers Claude Code's native skill resolver. Wh
 
 Claude CLI has its own noninteractive permission mode; OpenClaw maps that to the existing exec policy instead of adding Claude-specific config. For OpenClaw-managed Claude live sessions, the effective exec policy is authoritative: YOLO (`tools.exec.security: "full"` and `tools.exec.ask: "off"`) launches Claude with `--permission-mode bypassPermissions`, while a restrictive policy launches it with `--permission-mode default`. Per-agent `agents.list[].tools.exec` settings override the global `tools.exec` for that agent. Raw backend args may still include `--permission-mode`, but live Claude launches normalize that flag to match the effective policy.
 
-The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `adaptive`/`medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
+The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. `adaptive` omits `--effort` entirely so Claude Code uses its native adaptive-reasoning default for the model. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
 
 Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -59,7 +59,7 @@ title: "Thinking levels"
 ## Application by agent
 
 - **Embedded OpenClaw**: the resolved level is passed to the in-process OpenClaw agent runtime.
-- **Claude CLI backend**: non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; see [CLI backends](/gateway/cli-backends).
+- **Claude CLI backend**: concrete non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; `adaptive` omits the flag so Claude Code uses its native adaptive default. See [CLI backends](/gateway/cli-backends).
 
 ## Fast mode (/fast)
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -59,7 +59,7 @@ title: "Thinking levels"
 ## Application by agent
 
 - **Embedded OpenClaw**: the resolved level is passed to the in-process OpenClaw agent runtime.
-- **Claude CLI backend**: concrete non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; `adaptive` omits the flag so Claude Code uses its native adaptive default. See [CLI backends](/gateway/cli-backends).
+- **Claude CLI backend**: concrete non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; `adaptive` removes configured effort flags and delegates effective effort to Claude Code's environment, settings, and model defaults. See [CLI backends](/gateway/cli-backends).
 
 ## Fast mode (/fast)
 

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -130,11 +130,21 @@ describe("resolveClaudeCliExecutionArgs", () => {
         workspaceDir: "/tmp",
         provider: "claude-cli",
         modelId: "claude-opus-4-7",
-        thinkingLevel: "adaptive",
+        thinkingLevel: "medium",
         useResume: false,
         baseArgs: ["-p"],
       }),
     ).toEqual(["-p", "--effort", "medium"]);
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-4-7",
+        thinkingLevel: "high",
+        useResume: false,
+        baseArgs: ["-p"],
+      }),
+    ).toEqual(["-p", "--effort", "high"]);
     expect(
       resolveClaudeCliExecutionArgs({
         workspaceDir: "/tmp",
@@ -145,6 +155,37 @@ describe("resolveClaudeCliExecutionArgs", () => {
         baseArgs: ["-p", "--resume", "{sessionId}"],
       }),
     ).toEqual(["-p", "--resume", "{sessionId}", "--effort", "xhigh"]);
+  });
+
+  it("omits effort args for adaptive so the Claude CLI's native default applies (issue #103245)", () => {
+    // Before fix, adaptive was silently pinned to `--effort medium`. Models
+    // without adaptive support get "adaptive" clamped to a concrete level on
+    // the spawn lanes first (see "maps unsupported adaptive to medium" in
+    // src/auto-reply/thinking.test.ts), which still yields a concrete
+    // `--effort` flag here.
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-4-8",
+        thinkingLevel: "adaptive",
+        useResume: false,
+        baseArgs: ["-p", "--output-format", "stream-json"],
+      }),
+    ).toEqual(["-p", "--output-format", "stream-json"]);
+  });
+
+  it("keeps operator-supplied effort args when thinking is adaptive", () => {
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-4-8",
+        thinkingLevel: "adaptive",
+        useResume: false,
+        baseArgs: ["-p", "--effort", "xhigh"],
+      }),
+    ).toEqual(["-p", "--effort", "xhigh"]);
   });
 
   it("replaces static effort args when a session thinking level is active", () => {

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -101,91 +101,65 @@ describe("Claude CLI model aliases", () => {
 });
 
 describe("resolveClaudeCliExecutionArgs", () => {
-  it("omits effort args when thinking is off", () => {
+  it.each(["off", undefined] as const)(
+    "preserves configured effort args when thinking is %s",
+    (thinkingLevel) => {
+      const baseArgs = ["-p", "--effort", "xhigh", "--effort=low"];
+
+      expect(
+        resolveClaudeCliExecutionArgs({
+          workspaceDir: "/tmp",
+          provider: "claude-cli",
+          modelId: "claude-sonnet-4-6",
+          thinkingLevel,
+          useResume: false,
+          baseArgs,
+        }),
+      ).toEqual(baseArgs);
+    },
+  );
+
+  it.each([
+    ["minimal", "low"],
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "high"],
+    ["xhigh", "xhigh"],
+    ["max", "max"],
+  ] as const)("maps %s thinking to --effort %s", (thinkingLevel, effort) => {
     expect(
       resolveClaudeCliExecutionArgs({
         workspaceDir: "/tmp",
         provider: "claude-cli",
-        modelId: "claude-sonnet-4-6",
-        thinkingLevel: "off",
+        modelId: "claude-opus-4-7",
+        thinkingLevel,
         useResume: false,
-        baseArgs: ["-p", "--output-format", "stream-json"],
+        baseArgs: ["-p"],
       }),
-    ).toEqual(["-p", "--output-format", "stream-json"]);
+    ).toEqual(["-p", "--effort", effort]);
   });
 
-  it("maps OpenClaw thinking levels to Claude effort args", () => {
+  it("strips configured effort args when thinking is adaptive", () => {
     expect(
       resolveClaudeCliExecutionArgs({
         workspaceDir: "/tmp",
         provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "minimal",
-        useResume: false,
-        baseArgs: ["-p"],
-      }),
-    ).toEqual(["-p", "--effort", "low"]);
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "medium",
-        useResume: false,
-        baseArgs: ["-p"],
-      }),
-    ).toEqual(["-p", "--effort", "medium"]);
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "high",
-        useResume: false,
-        baseArgs: ["-p"],
-      }),
-    ).toEqual(["-p", "--effort", "high"]);
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "xhigh",
+        modelId: "claude-opus-4-8",
+        thinkingLevel: "adaptive",
         useResume: true,
-        baseArgs: ["-p", "--resume", "{sessionId}"],
+        baseArgs: [
+          "-p",
+          "--effort",
+          "xhigh",
+          "--output-format",
+          "stream-json",
+          "--effort=low",
+          "--verbose",
+          "--resume",
+          "{sessionId}",
+        ],
       }),
-    ).toEqual(["-p", "--resume", "{sessionId}", "--effort", "xhigh"]);
-  });
-
-  it("omits effort args for adaptive so the Claude CLI's native default applies (issue #103245)", () => {
-    // Before fix, adaptive was silently pinned to `--effort medium`. Models
-    // without adaptive support get "adaptive" clamped to a concrete level on
-    // the spawn lanes first (see "maps unsupported adaptive to medium" in
-    // src/auto-reply/thinking.test.ts), which still yields a concrete
-    // `--effort` flag here.
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-8",
-        thinkingLevel: "adaptive",
-        useResume: false,
-        baseArgs: ["-p", "--output-format", "stream-json"],
-      }),
-    ).toEqual(["-p", "--output-format", "stream-json"]);
-  });
-
-  it("keeps operator-supplied effort args when thinking is adaptive", () => {
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-8",
-        thinkingLevel: "adaptive",
-        useResume: false,
-        baseArgs: ["-p", "--effort", "xhigh"],
-      }),
-    ).toEqual(["-p", "--effort", "xhigh"]);
+    ).toEqual(["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"]);
   });
 
   it("replaces static effort args when a session thinking level is active", () => {

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -89,6 +89,10 @@ const CLAUDE_NO_TOOLS_VALUE = "";
 const CLAUDE_DENY_MCP_TOOLS_VALUE = "mcp__*";
 
 type ClaudeCliEffort = "low" | "medium" | "high" | "xhigh" | "max";
+type ClaudeCliEffortArgAction =
+  | { mode: "preserve" }
+  | { mode: "omit" }
+  | { mode: "set"; effort: ClaudeCliEffort };
 
 /** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
 export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
@@ -205,31 +209,25 @@ export function normalizeClaudeSettingSourcesArgs(args?: string[]): string[] | u
   return normalized;
 }
 
-/** Map OpenClaw thinking levels to Claude CLI effort flags for a model id. */
-function mapClaudeCliThinkingLevelToEffort(
-  thinkingLevel?: string | null,
-): ClaudeCliEffort | undefined {
+/** Resolve whether a run preserves, removes, or sets a Claude CLI effort override. */
+function resolveClaudeCliEffortArgAction(thinkingLevel?: string | null): ClaudeCliEffortArgAction {
   switch (normalizeOptionalLowercaseString(thinkingLevel)) {
     case "minimal":
     case "low":
-      return "low";
-    // Adaptive reasoning is the Claude CLI's flagless default, so omit
-    // `--effort` instead of pinning a fixed level (#103245). The spawn lanes
-    // clamp "adaptive" to a concrete level for models without adaptive
-    // support, so this branch normally fires only for adaptive-capable models;
-    // a flagless invocation stays valid either way.
+      return { mode: "set", effort: "low" };
     case "adaptive":
-      return undefined;
+      // Adaptive runs delegate effort to Claude Code, so no static override may survive.
+      return { mode: "omit" };
     case "medium":
-      return "medium";
+      return { mode: "set", effort: "medium" };
     case "high":
-      return "high";
+      return { mode: "set", effort: "high" };
     case "xhigh":
-      return "xhigh";
+      return { mode: "set", effort: "xhigh" };
     case "max":
-      return "max";
+      return { mode: "set", effort: "max" };
     default:
-      return undefined;
+      return { mode: "preserve" };
   }
 }
 
@@ -339,11 +337,15 @@ export function resolveClaudeCliExecutionArgs(
   if (context.executionMode === "side-question") {
     return resolveClaudeCliSideQuestionExecutionArgs(context.baseArgs);
   }
-  const effort = mapClaudeCliThinkingLevelToEffort(context.thinkingLevel);
-  if (!effort) {
-    return [...context.baseArgs];
+  const action = resolveClaudeCliEffortArgAction(context.thinkingLevel);
+  switch (action.mode) {
+    case "preserve":
+      return [...context.baseArgs];
+    case "omit":
+      return stripClaudeEffortArgs(context.baseArgs);
+    case "set":
+      return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, action.effort];
   }
-  return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, effort];
 }
 
 /** Normalize Claude CLI backend config before registration or execution. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -213,7 +213,13 @@ function mapClaudeCliThinkingLevelToEffort(
     case "minimal":
     case "low":
       return "low";
+    // Adaptive reasoning is the Claude CLI's flagless default, so omit
+    // `--effort` instead of pinning a fixed level (#103245). The spawn lanes
+    // clamp "adaptive" to a concrete level for models without adaptive
+    // support, so this branch normally fires only for adaptive-capable models;
+    // a flagless invocation stays valid either way.
     case "adaptive":
+      return undefined;
     case "medium":
       return "medium";
     case "high":

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -338,14 +338,13 @@ export function resolveClaudeCliExecutionArgs(
     return resolveClaudeCliSideQuestionExecutionArgs(context.baseArgs);
   }
   const action = resolveClaudeCliEffortArgAction(context.thinkingLevel);
-  switch (action.mode) {
-    case "preserve":
-      return [...context.baseArgs];
-    case "omit":
-      return stripClaudeEffortArgs(context.baseArgs);
-    case "set":
-      return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, action.effort];
+  if (action.mode === "preserve") {
+    return [...context.baseArgs];
   }
+  if (action.mode === "omit") {
+    return stripClaudeEffortArgs(context.baseArgs);
+  }
+  return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, action.effort];
 }
 
 /** Normalize Claude CLI backend config before registration or execution. */


### PR DESCRIPTION
Closes #103245

## What Problem This Solves

Fixes an issue where agents on the `claude-cli` backend configured with `thinkingDefault: "adaptive"` would silently run every turn at pinned `--effort medium`. Validation and the model catalog accept `adaptive` for adaptive-capable Claude models (e.g. `claude-opus-4-8`), but at spawn time `mapClaudeCliThinkingLevelToEffort` flattened `adaptive` to `medium`, and `resolveClaudeCliExecutionArgs` stripped any operator-supplied `--effort` from `cliBackends.args` — so there was no config-level escape hatch and no log line indicating the substitution.

**Before:** `thinkingLevel: "adaptive"` → `claude … --effort medium` on every invocation (heartbeats, crons, and deep-reasoning tasks alike), with zero signal to the operator.
**After:** `thinkingLevel: "adaptive"` → no `--effort` flag, so the Claude CLI uses its native adaptive-reasoning default for that model; concrete levels (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`) map to explicit `--effort` flags exactly as before, and an operator-supplied `--effort` in `cliBackends.args` is now honored under adaptive instead of being stripped and overwritten.

## Why This Change Was Made

The Claude CLI (2.1.206) accepts only `--effort low|medium|high|xhigh|max`; true adaptive reasoning is its *flagless default* for models that support it. So the correct mapping for `adaptive` is to omit the flag: `mapClaudeCliThinkingLevelToEffort` now returns `undefined` for `adaptive`, which makes `resolveClaudeCliExecutionArgs` pass `baseArgs` through untouched — the same path already used for `off`/unknown levels. This is safe because the spawn lanes clamp unsupported levels via the catalog-resolved thinking profile (`resolveSupportedThinkingLevel`) before the CLI runner resolves execution args (verified in `src/agents/agent-command.ts`, `src/cron/isolated-agent/run.ts`, `src/auto-reply/reply/get-reply-run.ts`, `src/gateway/sessions-patch.ts`), and profiles only include `adaptive` when the model family supports it (`src/plugins/provider-claude-thinking.ts`). A downgraded `adaptive` arrives at the mapping as a concrete level (rank-clamped to `medium`) and still yields a concrete `--effort` flag — covered by the existing "maps unsupported adaptive to medium" test in `src/auto-reply/thinking.test.ts`.

One known edge (pre-existing, not introduced here): model-fallback candidates reuse the original run's thinking level without re-clamping to the candidate model (`src/auto-reply/reply/agent-runner-execution.ts` `resolveRunForFallbackCandidate`), so `adaptive` from an adaptive-capable primary can reach a non-adaptive fallback model. Pre-fix that lane silently got `--effort medium`; post-fix it gets a flagless invocation, which is always valid for the CLI and defers to its own default. The code comment is worded to match ("normally fires only for adaptive-capable models").

No refactoring; the diff is the one `case` branch, tests, and the two docs passages that documented the old `adaptive` → `medium` mapping (`docs/gateway/cli-backends.md`, `docs/tools/thinking.md`).

## User Impact

Operators who set `thinkingDefault: "adaptive"` (globally or per agent) on the `claude-cli` backend now actually get the CLI's adaptive reasoning instead of a silent pin to `medium` effort. All explicit thinking levels behave exactly as before.

## Evidence

- Updated `extensions/anthropic/cli-shared.test.ts`:
  - `adaptive` → no `--effort` flag (baseArgs pass through unchanged)
  - `medium`/`high` added alongside existing `minimal`/`xhigh`/`max` mapping assertions (all concrete levels unchanged)
  - operator-supplied `--effort` in baseArgs is preserved under `adaptive`
  - the previous assertion pinning `adaptive` → `--effort medium` is removed (it pinned the bug)
- `pnpm test:extension anthropic` passes locally (macOS arm64, Node 22.23.1):

```
[test-extension] Running 8 test files for anthropic
 RUN  v4.1.9

 Test Files  16 passed (16)
      Tests  204 passed (204)
   Duration  13.64s
```

- Scoped `oxfmt --check`, `oxlint`, and `tsc --noEmit -p tsconfig.extensions.json` are clean.
- Core clamp coverage for the downgrade path already exists and still passes: "maps unsupported adaptive to medium" (`src/auto-reply/thinking.test.ts`), so non-adaptive-capable models keep getting a concrete `--effort` flag.
- An independent adversarial review pass over the diff confirmed no other code, test, or snapshot depends on the old `adaptive` → `medium` mapping, and that operator-supplied `--effort` args cannot leak mid-session (baseArgs are rebuilt from config on every spawn; runtime-appended effort is never persisted back).

---

🤖 AI-assisted (Claude Code / Claude Fable 5): analysis, patch, and tests were model-authored and human-reviewed. I understand what the code does.
