### PR TITLE
fix(codex): handle stdout/stderr stream errors in sandbox process execution

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts
@@ -1,0 +1,133 @@
+// Codex tests cover sandbox exec-server child-process stream error handling.
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { createSandboxContext } from "../sandbox-exec-server.test-helpers.js";
+import { startProcess } from "./processes.js";
+import type { ManagedProcess, OpenClawExecServer } from "./types.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+type FakeChild = EventEmitter & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+// Realistic child: stdout/stderr/stdin are real streams so the production close
+// path's `stdin.destroy()` runs and `finalizeExec` is actually reached (a bare
+// EventEmitter stdin would throw inside finalize and silently skip finalization).
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+function sentMethods(sendMock: ReturnType<typeof vi.fn>): string[] {
+  return sendMock.mock.calls
+    .map((call) => {
+      try {
+        return (JSON.parse(String(call[0])) as { method?: string }).method ?? "";
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+}
+
+const flush = () =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
+async function startFakeProcess(
+  processId: string,
+  overrides: { finalizeExec?: ReturnType<typeof vi.fn> } = {},
+): Promise<{
+  managed: ManagedProcess;
+  child: FakeChild;
+  send: ReturnType<typeof vi.fn>;
+}> {
+  const child = makeFakeChild();
+  spawnMock.mockReturnValueOnce(child);
+  const send = vi.fn();
+  const socket = { readyState: 1, send } as unknown as WebSocket;
+  const execServer = {
+    sandbox: createSandboxContext({ finalizeExec: overrides.finalizeExec }),
+  } as unknown as OpenClawExecServer;
+  const processes = new Map<string, ManagedProcess>();
+  await startProcess(execServer, processes, socket, {
+    processId,
+    argv: ["echo", "hi"],
+    cwd: "/workspace",
+  });
+  const managed = processes.get(processId);
+  if (!managed) {
+    throw new Error("managed process was not registered");
+  }
+  return { managed, child, send };
+}
+
+describe("sandbox exec-server child stream error handling", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("terminates the child on stdout error and finalizes through the close path", async () => {
+    const finalizeExec = vi.fn(async () => undefined);
+    const { managed, child, send } = await startFakeProcess("stdout-fail", { finalizeExec });
+
+    child.stdout.emit("error", new Error("EPIPE stdout broken"));
+
+    // Failure is recorded and the child is terminated, but the process is NOT
+    // reported closed yet — the real "close" event owns finalization.
+    expect(managed.failure).toBe("EPIPE stdout broken");
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(managed.closed).toBe(false);
+    expect(finalizeExec).not.toHaveBeenCalled();
+
+    // The subsequent close finalizes exactly once, in exited-then-closed order,
+    // and the backend finalizer runs with a failed status.
+    child.emit("close", null);
+    await flush();
+
+    expect(managed.closed).toBe(true);
+    expect(finalizeExec).toHaveBeenCalledTimes(1);
+    expect(finalizeExec).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+
+    const methods = sentMethods(send);
+    const exitedIdx = methods.indexOf("process/exited");
+    const closedIdx = methods.indexOf("process/closed");
+    expect(exitedIdx).toBeGreaterThanOrEqual(0);
+    expect(closedIdx).toBeGreaterThan(exitedIdx);
+  });
+
+  it("logs a warning on a stderr stream error and keeps the process alive", async () => {
+    const warnSpy = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const finalizeExec = vi.fn(async () => undefined);
+    const { managed, child } = await startFakeProcess("stderr-fail", { finalizeExec });
+
+    child.stderr.emit("error", new Error("EPIPE stderr broken"));
+    await flush();
+
+    expect(warnSpy).toHaveBeenCalledWith("codex sandbox stderr stream failed", {
+      error: expect.any(Error),
+    });
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(managed.closed).toBe(false);
+    expect(managed.failure).toBeNull();
+    expect(finalizeExec).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts
@@ -2,11 +2,14 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { SandboxBackendHandle } from "openclaw/plugin-sdk/sandbox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { createSandboxContext } from "../sandbox-exec-server.test-helpers.js";
 import { startProcess } from "./processes.js";
 import type { ManagedProcess, OpenClawExecServer } from "./types.js";
+
+type FinalizeExec = NonNullable<SandboxBackendHandle["finalizeExec"]>;
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -53,7 +56,7 @@ const flush = () =>
 
 async function startFakeProcess(
   processId: string,
-  overrides: { finalizeExec?: ReturnType<typeof vi.fn> } = {},
+  overrides: { finalizeExec?: FinalizeExec } = {},
 ): Promise<{
   managed: ManagedProcess;
   child: FakeChild;
@@ -86,7 +89,7 @@ describe("sandbox exec-server child stream error handling", () => {
   });
 
   it("terminates the child on stdout error and finalizes through the close path", async () => {
-    const finalizeExec = vi.fn(async () => undefined);
+    const finalizeExec = vi.fn<FinalizeExec>(async () => undefined);
     const { managed, child, send } = await startFakeProcess("stdout-fail", { finalizeExec });
 
     child.stdout.emit("error", new Error("EPIPE stdout broken"));
@@ -116,7 +119,7 @@ describe("sandbox exec-server child stream error handling", () => {
 
   it("logs a warning on a stderr stream error and keeps the process alive", async () => {
     const warnSpy = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const finalizeExec = vi.fn(async () => undefined);
+    const finalizeExec = vi.fn<FinalizeExec>(async () => undefined);
     const { managed, child } = await startFakeProcess("stderr-fail", { finalizeExec });
 
     child.stderr.emit("error", new Error("EPIPE stderr broken"));

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -128,7 +128,20 @@ async function runProcess(
   child.stdout.on("data", (chunk: Buffer) =>
     appendProcessChunk(managed, managed.tty ? "pty" : "stdout", chunk),
   );
+  child.stdout.on("error", (error) => {
+    // A dead stdout pipe means the process output channel is gone. Preserve the
+    // failure and terminate the child, but leave terminal notifications and
+    // finalization to the existing "close" handler so we never report the
+    // process closed while the child is still running.
+    managed.failure = error.message;
+    child.kill("SIGTERM");
+  });
   child.stderr.on("data", (chunk: Buffer) => appendProcessChunk(managed, "stderr", chunk));
+  child.stderr.on("error", (error) => {
+    // stderr is diagnostic-only; a broken stderr pipe must not kill an
+    // otherwise healthy sandbox process.
+    embeddedAgentLog.warn("codex sandbox stderr stream failed", { error });
+  });
   child.once("error", (error) => {
     // Node can report an abort or transport error before the child exits. The
     // backend lease and Codex terminal notifications stay owned until close.


### PR DESCRIPTION
## What Problem This Solves

`runProcess()` in the sandbox exec server listens on `child.stdout.on("data")` and `child.stderr.on("data")` but does not register `child.stdout.on("error")` / `child.stderr.on("error")` handlers. Node.js does not forward pipe stream errors to `child.on("error")` — an unhandled `error` event on a readable stream crashes the process with `ERR_UNHANDLED_ERROR`. A broken sandbox stdout/stderr pipe takes down the codex sandbox exec server.

## Why This Change Was Made

- **`child.stdout.on("error")`**: preserve the failure message and kill the child with `SIGTERM`. Terminal notifications and backend finalization stay owned by the existing `child.once("close")` handler, so the process is never reported closed while the child is still running.
- **`child.stderr.on("error")`**: stderr is diagnostic-only; a broken stderr pipe must not kill a healthy process — logged via `embeddedAgentLog.warn`.

## User Impact

A broken sandbox stdout/stderr pipe no longer crashes the exec server. Stdout failures terminate the managed process through the normal close lifecycle; stderr failures are logged without disrupting execution.

## Evidence

### Negative control — without handler, process crashes (current main)

Real `child_process.spawn`, stdout pipe destroyed without an `error` handler:

```
$ node -e "
import('node:child_process').then(({spawn}) => {
  const child = spawn('sh', ['-c', 'echo hello; sleep 0.2']);
  child.stdout.on('data', () => {});
  // Deliberately NO stdout.on('error') — matching current main code
  child.stdout.destroy(new Error('EPIPE stdout broken'));
});
"
node:events:486
      throw er; // Unhandled 'error' event
      ^

Error: EPIPE stdout broken
    at [eval]:6:24
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    ...
```

→ **ERR_UNHANDLED_ERROR — process crashes.** This is the exact failure mode in the sandbox exec server.

### After fix — with handler, caught gracefully (this PR)

Same real `spawn`, plus production-pattern `stdout.on("error")` + `stderr.on("error")` handlers — proof 2 destoys stdout mid-stream, proof 3 registers and verifies both handlers fire with the exact destroy pattern:

```
── Proof 2: stdout error WITH handler → caught gracefully
  [stdout] chunk #1: chunk0
  [stdout] → destroying stream: EPIPE stdout broken (simulated)
  [stdout/error] caught: EPIPE stdout broken (simulated)
  [close] exit=0 signal=null
  ✓ stdout "error" handler fired and prevented ERR_UNHANDLED_ERROR

── Proof 3: production handler pattern (matching processes.ts)
  [stdout/error] production handler: EPIPE stdout broken (production pattern)
  [stderr/error] production handler (warn): EPIPE stderr broken (production pattern)
  ✓ stdout "error" listener registered (1 listener(s))
  ✓ stderr "error" listener registered (1 listener(s))

ALL PROOF CASES PASSED
```

**Before**: `ERR_UNHANDLED_ERROR` → exec server dies
**After**: error caught → `managed.failure` recorded → `SIGTERM` → close path finalizes normally

### Observed result

- The production-pattern handler catches the stream error and prevents the crash
- stdout error records failure + signals the child (close lifecycle finalizes)
- stderr error is warning-only, does not kill an otherwise healthy process

### What was not tested

Live Codex sandbox pipe failure in a running exec-server process (requires resource-exhaustion repro).

## Regression Test Plan

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts
Test Files  1 passed (1)
     Tests  2 passed (2)
```

```
$ oxlint extensions/codex/src/app-server/sandbox-exec-server/processes.stream-errors.test.ts — exit 0
$ oxfmt --check — clean
```

- Realistic-stream tests with `PassThrough` stdout/stderr/stdin exercise the production close path, including `finalizeProcess()` → `stdin.destroy()` → `finalizeExec`.
- `finalizeExec` type now uses `NonNullable<SandboxBackendHandle["finalizeExec"]>` imported from `openclaw/plugin-sdk/sandbox` — `check-test-types` passes.
- Branch rebased on upstream main (f72e936f26).

## Root Cause

In `runProcess()` (`extensions/codex/src/app-server/sandbox-exec-server/processes.ts`), `child.stdout` and `child.stderr` are `Readable` streams returned by `child_process.spawn`. The code subscribes to `"data"` events on both but registers no `"error"` listener. Node.js does not forward readable-stream errors to the child process `"error"` event — per the Node.js docs, an unhandled `"error"` on a stream is a fatal `ERR_UNHANDLED_ERROR` that terminates the owning process. When a sandbox pipe breaks (e.g. EPIPE, ECONNRESET), the exec server process crashes entirely, taking down all concurrent sandbox sessions. The fix adds explicit error handlers: stdout errors record the failure and terminate the managed child via `SIGTERM` (letting the existing `"close"` handler own finalization), and stderr errors warn without disrupting execution — matching the adjacent Codex app-server client contract.

AI-assisted. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>