### PR TITLE
fix(clawrouter): support managed gateway configuration

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7382,6 +7382,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /providers/clawrouter
 - Headings:
   - H2: Getting started
+  - H2: Managed non-interactive deployment
+  - H2: Readiness and live proof
   - H2: Model discovery
   - H2: Protocol and provider plugins
   - H2: Quotas and usage

--- a/docs/providers/clawrouter.md
+++ b/docs/providers/clawrouter.md
@@ -69,6 +69,107 @@ you only need an issued ClawRouter credential.
   </Step>
 </Steps>
 
+## Managed non-interactive deployment
+
+Keep the proxy key in the workload's secret injection and store only a
+SecretRef in `openclaw.json`. The canonical managed fields are:
+
+| Purpose       | Config or environment field                                              |
+| ------------- | ------------------------------------------------------------------------ |
+| Router origin | `models.providers.clawrouter.baseUrl`                                    |
+| Credential    | `models.providers.clawrouter.apiKey` -> env SecretRef                    |
+| Secret value  | `CLAWROUTER_API_KEY` in the gateway process environment                  |
+| Default model | `agents.defaults.model.primary` -> `clawrouter/<provider>/<model>`       |
+| Workload tag  | `models.providers.clawrouter.headers.X-ClawRouter-Project-Id` (optional) |
+
+For example, a deployment controller can own this JSON5 patch:
+
+```json5
+{
+  plugins: {
+    entries: { clawrouter: { enabled: true } },
+  },
+  models: {
+    providers: {
+      clawrouter: {
+        baseUrl: "https://clawrouter.internal.example",
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "CLAWROUTER_API_KEY",
+        },
+        headers: {
+          "X-ClawRouter-Project-Id": "fakeco",
+        },
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "clawrouter/openai/gpt-5.5" },
+    },
+  },
+}
+```
+
+If the deployment sets `plugins.allow`, preserve its existing entries and add
+`clawrouter`. Validate and apply without an interactive wizard:
+
+```bash
+openclaw config patch --file ./clawrouter.patch.json5 --dry-run --json
+openclaw config patch --file ./clawrouter.patch.json5
+```
+
+The dry run resolves the SecretRef but never prints its value. To rotate the
+credential, update the external Secret that supplies `CLAWROUTER_API_KEY` and
+restart the gateway workload so the new process environment is loaded. The
+config file and model reference do not change.
+
+## Readiness and live proof
+
+These checks prove different boundaries; do not substitute one for another:
+
+```bash
+# ClawRouter process health only; no credential or upstream model is exercised.
+curl -fsS https://clawrouter.internal.example/v1/health
+
+# OpenClaw gateway startup readiness only; no model call is made.
+curl -fsS http://127.0.0.1:18789/readyz
+
+# Credential-scoped catalog discovery.
+openclaw models list --all --provider clawrouter --json
+
+# Minimal real inference probe through the configured ClawRouter provider.
+openclaw models status --probe --probe-provider clawrouter --probe-max-tokens 8 --json
+
+# Workload canary using an exact granted model ref.
+openclaw agent --agent main \
+  --model clawrouter/openai/gpt-5.5 \
+  --message "Reply exactly: CLAWROUTER_CANARY_OK" \
+  --json
+```
+
+Use a model returned by the scoped catalog instead of copying the example
+model blindly. A successful `/readyz` response means the gateway can serve
+requests; it does not claim that ClawRouter, its credential, or an upstream
+provider is ready. The model probe and agent canary are the inference proofs.
+
+For live diagnosis, issue the canary and inspect the gateway's standard logs.
+The existing metadata-only model transport diagnostics emit lines shaped like:
+
+```text
+[model-fetch] start provider=clawrouter api=openai-responses model=openai/gpt-5.5 method=POST url=https://clawrouter.internal.example/v1/responses
+[model-fetch] response provider=clawrouter api=openai-responses model=openai/gpt-5.5 status=200
+```
+
+The plugin sends bounded `X-ClawRouter-Client`, `X-ClawRouter-Agent-Id`, and
+`X-ClawRouter-Session-Id` headers when those identifiers are available. Static
+deployment metadata such as `X-ClawRouter-Project-Id` can be set in the
+provider `headers` map. Explicit configured headers win over automatic values.
+The transport diagnostic records routing and response metadata; it does not log
+credentials, request ids, prompts, or completions. ClawRouter's own audit event
+provides the selected upstream provider and content-retention state.
+
 ## Model discovery
 
 `GET /v1/catalog` returns `{ providers: [...] }`, where each provider entry
@@ -141,6 +242,8 @@ the same ClawRouter policy can change the remaining percentage.
 
 - Catalog discovery is scoped to the configured proxy key and cached per credential scope (agent dir, workspace dir, auth profile id, and base URL).
 - The proxy key is attached only at request dispatch; it is not stored in model metadata.
+- Automatic attribution values are trimmed, control-character rejected, and bounded to 256 characters before dispatch.
+- Model transport diagnostics contain metadata only and never include the proxy key or model content.
 - Native Anthropic and Gemini model ids are rewritten to their upstream ids only at dispatch.
 - Unsupported or ungranted catalog rows fail closed and are not selectable.
 

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -10,6 +10,7 @@ const providerAuthRuntimeMocks = vi.hoisted(() => ({
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => providerAuthRuntimeMocks);
 
 import plugin from "./index.js";
+import { wrapClawRouterProviderStream } from "./stream.js";
 
 const LIVE_CATALOG = {
   providers: [
@@ -101,10 +102,79 @@ describe("ClawRouter plugin", () => {
 
     expect(calls[0]?.headers).toEqual({
       "X-Request-ID": "request-1",
+      "X-ClawRouter-Client": "openclaw",
       Authorization: "Bearer runtime-proxy-key",
     });
     expect(calls[0]?.id).toBe("claude-sonnet-4-6");
     expect(calls[0]?.params).toBeUndefined();
+  });
+
+  it("attaches bounded attribution without overriding configured metadata", () => {
+    const calls: Array<Parameters<StreamFn>[0]> = [];
+    const baseStreamFn: StreamFn = (model) => {
+      calls.push(model);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = wrapClawRouterProviderStream({
+      provider: "clawrouter",
+      modelId: "openai/gpt-5.5",
+      agentId: "main",
+      streamFn: baseStreamFn,
+    } as never);
+
+    void wrapped?.(
+      {
+        provider: "clawrouter",
+        api: "openai-responses",
+        id: "openai/gpt-5.5",
+        headers: {
+          "x-clawrouter-client": "managed-openclaw",
+          "X-ClawRouter-Project-Id": "fakeco",
+        },
+      } as never,
+      {} as never,
+      {
+        apiKey: "runtime-proxy-key",
+        sessionId: `session-${"x".repeat(300)}`,
+      } as never,
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "x-clawrouter-client": "managed-openclaw",
+      "X-ClawRouter-Agent-Id": "main",
+      "X-ClawRouter-Project-Id": "fakeco",
+      Authorization: "Bearer runtime-proxy-key",
+    });
+    expect(calls[0]?.headers?.["X-ClawRouter-Session-Id"]).toHaveLength(256);
+  });
+
+  it("omits unsafe attribution header values", () => {
+    const calls: Array<Parameters<StreamFn>[0]> = [];
+    const baseStreamFn: StreamFn = (model) => {
+      calls.push(model);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = wrapClawRouterProviderStream({
+      provider: "clawrouter",
+      modelId: "openai/gpt-5.5",
+      agentId: "bad\nagent",
+      streamFn: baseStreamFn,
+    } as never);
+
+    void wrapped?.(
+      {
+        provider: "clawrouter",
+        api: "openai-responses",
+        id: "openai/gpt-5.5",
+      } as never,
+      {} as never,
+      { apiKey: "runtime-proxy-key", sessionId: "bad\rsession" } as never,
+    );
+
+    expect(calls[0]?.headers).toEqual({
+      "X-ClawRouter-Client": "openclaw",
+      Authorization: "Bearer runtime-proxy-key",
+    });
   });
 
   it("resolves managed secret refs before scoped discovery", async () => {

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -3,35 +3,84 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 import { prepareClawRouterRequestModel } from "./provider-catalog.js";
 
 const ENV_API_KEY_MARKER = "CLAWROUTER_API_KEY";
+const ATTRIBUTION_VALUE_MAX_LENGTH = 256;
+const CLIENT_HEADER = "X-ClawRouter-Client";
+const AGENT_HEADER = "X-ClawRouter-Agent-Id";
+const SESSION_HEADER = "X-ClawRouter-Session-Id";
 
-function withBearerAuthorization(
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sanitizeAttributionValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized || hasControlCharacter(normalized)) {
+    return undefined;
+  }
+  return normalized.slice(0, ATTRIBUTION_VALUE_MAX_LENGTH);
+}
+
+function findHeader(headers: Record<string, string>, target: string): string | undefined {
+  const normalizedTarget = target.toLowerCase();
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === normalizedTarget) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function setHeaderDefault(
+  headers: Record<string, string>,
+  name: string,
+  value: string | undefined,
+): void {
+  if (value !== undefined && findHeader(headers, name) === undefined) {
+    headers[name] = value;
+  }
+}
+
+function withClawRouterHeaders(
   headers: Record<string, string> | undefined,
-  apiKey: string,
+  params: { agentId?: string; apiKey?: string; sessionId?: string },
 ): Record<string, string> {
   const next: Record<string, string> = {};
   for (const [name, value] of Object.entries(headers ?? {})) {
-    if (name.toLowerCase() !== "authorization") {
+    if (name.toLowerCase() !== "authorization" || !params.apiKey) {
       next[name] = value;
     }
   }
-  next.Authorization = `Bearer ${apiKey}`;
+  setHeaderDefault(next, CLIENT_HEADER, "openclaw");
+  setHeaderDefault(next, AGENT_HEADER, sanitizeAttributionValue(params.agentId));
+  setHeaderDefault(next, SESSION_HEADER, sanitizeAttributionValue(params.sessionId));
+  if (params.apiKey) {
+    next.Authorization = `Bearer ${params.apiKey}`;
+  }
   return next;
 }
 
-function createClawRouterStreamWrapper(underlying: StreamFn | undefined): StreamFn | undefined {
+function createClawRouterStreamWrapper(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
+  const underlying = ctx.streamFn;
   if (!underlying) {
     return undefined;
   }
   return (model, context, options) => {
     const apiKey = options?.apiKey?.trim();
     const preparedModel = prepareClawRouterRequestModel(model);
-    if (!apiKey || apiKey === ENV_API_KEY_MARKER) {
-      return underlying(preparedModel, context, options);
-    }
     return underlying(
       {
         ...preparedModel,
-        headers: withBearerAuthorization(preparedModel.headers, apiKey),
+        headers: withClawRouterHeaders(preparedModel.headers, {
+          agentId: ctx.agentId,
+          apiKey: apiKey && apiKey !== ENV_API_KEY_MARKER ? apiKey : undefined,
+          sessionId: options?.sessionId,
+        }),
       },
       context,
       options,
@@ -42,5 +91,5 @@ function createClawRouterStreamWrapper(underlying: StreamFn | undefined): Stream
 export function wrapClawRouterProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
-  return createClawRouterStreamWrapper(ctx.streamFn);
+  return createClawRouterStreamWrapper(ctx);
 }

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -444,6 +444,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "cerebras",
   "chutes",
   "claude-cli",
+  "clawrouter",
   "cloudflare-ai-gateway",
   "codex",
   "comfy",

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -6,6 +6,7 @@ describe("ModelsConfigSchema", () => {
   it.each([
     "claude-cli",
     "azure-openai-responses",
+    "clawrouter",
     "gmi",
     "gmi-cloud",
     "gmicloud",

--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -1,0 +1,409 @@
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const API_KEY = "clawrouter-e2e-secret";
+const MODEL_ID = "openai/gpt-5.5";
+const MODEL_REF = `clawrouter/${MODEL_ID}`;
+const SUCCESS_MARKER = "CLAWROUTER_E2E_OK";
+
+type CapturedRequest = {
+  method: string;
+  path: string;
+  authorization?: string;
+  headers: Record<string, string | string[] | undefined>;
+  body?: Record<string, unknown>;
+};
+
+type FakeClawRouter = {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+};
+
+const instances: OpenClawTestInstance[] = [];
+const routers: FakeClawRouter[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
+  await Promise.allSettled(routers.splice(0).map((router) => router.close()));
+});
+
+describe("ClawRouter managed gateway contract", () => {
+  it("boots from a SecretRef, reports truthful readiness, and routes an attributed agent turn", async () => {
+    const router = await startFakeClawRouter();
+    routers.push(router);
+    const instance = await createOpenClawTestInstance({
+      name: "clawrouter-managed-gateway",
+      env: {
+        CLAWROUTER_API_KEY: API_KEY,
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_TEST_FAST: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      },
+    });
+    instances.push(instance);
+
+    const patchPath = await instance.state.writeText(
+      "clawrouter.patch.json5",
+      JSON.stringify(
+        {
+          plugins: {
+            allow: ["clawrouter"],
+            entries: { clawrouter: { enabled: true } },
+          },
+          models: {
+            providers: {
+              clawrouter: {
+                baseUrl: router.baseUrl,
+                apiKey: { source: "env", provider: "default", id: "CLAWROUTER_API_KEY" },
+                headers: { "X-ClawRouter-Project-Id": "fakeco-e2e" },
+              },
+            },
+          },
+          agents: { defaults: { model: { primary: MODEL_REF } } },
+        },
+        null,
+        2,
+      ),
+    );
+    const dryRun = await instance.cli(
+      ["config", "patch", "--file", patchPath, "--dry-run", "--json"],
+      { timeoutMs: 120_000 },
+    );
+    expect(dryRun.code, dryRun.stderr).toBe(0);
+    expect(dryRun.stdout).toMatch(/"ok"\s*:\s*true/u);
+
+    const bootstrap = await instance.cli(["config", "patch", "--file", patchPath], {
+      timeoutMs: 120_000,
+    });
+    expect(bootstrap.code, bootstrap.stderr).toBe(0);
+
+    const configText = await fs.readFile(instance.configPath, "utf8");
+    const config = JSON.parse(configText) as {
+      agents?: { defaults?: { model?: { primary?: string } } };
+      models?: {
+        providers?: Record<
+          string,
+          {
+            apiKey?: unknown;
+            baseUrl?: string;
+            headers?: Record<string, string>;
+          }
+        >;
+      };
+      plugins?: { allow?: string[]; entries?: Record<string, { enabled?: boolean }> };
+    };
+    expect(config.models?.providers?.clawrouter).toMatchObject({
+      apiKey: { source: "env", provider: "default", id: "CLAWROUTER_API_KEY" },
+      baseUrl: router.baseUrl,
+      headers: { "X-ClawRouter-Project-Id": "fakeco-e2e" },
+    });
+    expect(config.agents?.defaults?.model?.primary).toBe(MODEL_REF);
+    expect(config.plugins?.allow).toContain("clawrouter");
+    expect(config.plugins?.entries?.clawrouter?.enabled).toBe(true);
+    expect(configText).not.toContain(API_KEY);
+
+    const routerHealth = await fetch(`${router.baseUrl}/v1/health`);
+    expect(routerHealth.status).toBe(200);
+    await expect(routerHealth.json()).resolves.toMatchObject({
+      ok: true,
+      environment: "fakeco",
+      observability: {
+        mode: "metadata_only",
+        requestContentRetentionDefault: false,
+      },
+    });
+    const rejectedCatalog = await fetch(`${router.baseUrl}/v1/catalog`, {
+      headers: { Authorization: "Bearer wrong-secret" },
+    });
+    expect(rejectedCatalog.status).toBe(401);
+
+    await instance.startGateway();
+    const gatewayReadiness = await waitForGatewayReadiness(instance);
+    expect(gatewayReadiness).toMatchObject({ ready: true, failing: [] });
+
+    const catalog = await instance.cli(
+      ["models", "list", "--all", "--provider", "clawrouter", "--json"],
+      { timeoutMs: 120_000 },
+    );
+    expect(catalog.code, catalog.stderr).toBe(0);
+    expect(catalog.stdout).toContain(MODEL_REF);
+
+    const probe = await instance.cli(
+      [
+        "models",
+        "status",
+        "--probe",
+        "--probe-provider",
+        "clawrouter",
+        "--probe-max-tokens",
+        "8",
+        "--json",
+      ],
+      { timeoutMs: 120_000 },
+    );
+    expect(probe.code, probe.stderr).toBe(0);
+    expect(probe.stdout).toMatch(/"provider"\s*:\s*"clawrouter"/u);
+    expect(probe.stdout).toMatch(/"status"\s*:\s*"ok"/u);
+
+    const agent = await instance.cli(
+      [
+        "agent",
+        "--agent",
+        "main",
+        "--model",
+        MODEL_REF,
+        "--message",
+        `Reply exactly: ${SUCCESS_MARKER}`,
+        "--json",
+      ],
+      { timeoutMs: 120_000 },
+    );
+    expect(agent.code, agent.stderr).toBe(0);
+    expect(agent.stdout).toContain(SUCCESS_MARKER);
+
+    const inferenceRequests = router.requests.filter(
+      (request) => request.method === "POST" && request.path === "/v1/responses",
+    );
+    expect(inferenceRequests.length).toBeGreaterThanOrEqual(2);
+    expect(inferenceRequests.at(-1)).toMatchObject({
+      authorization: `Bearer ${API_KEY}`,
+      body: { model: MODEL_ID, stream: true },
+      headers: {
+        "x-clawrouter-agent-id": "main",
+        "x-clawrouter-client": "openclaw",
+        "x-clawrouter-project-id": "fakeco-e2e",
+      },
+    });
+    const sessionId = inferenceRequests.at(-1)?.headers["x-clawrouter-session-id"];
+    expect(JSON.stringify(inferenceRequests.at(-1)?.body)).toContain(SUCCESS_MARKER);
+    expect(typeof sessionId).toBe("string");
+    expect(String(sessionId).length).toBeGreaterThan(0);
+    expect(String(sessionId).length).toBeLessThanOrEqual(256);
+
+    expect(instance.logs()).toContain(
+      `[model-fetch] start provider=clawrouter api=openai-responses model=${MODEL_ID} method=POST url=${router.baseUrl}/v1/responses`,
+    );
+    expect(instance.logs()).toContain(
+      `[model-fetch] response provider=clawrouter api=openai-responses model=${MODEL_ID} status=200`,
+    );
+    expect(
+      [
+        bootstrap.stdout,
+        bootstrap.stderr,
+        dryRun.stdout,
+        dryRun.stderr,
+        catalog.stdout,
+        catalog.stderr,
+        probe.stdout,
+        probe.stderr,
+        agent.stdout,
+        agent.stderr,
+        instance.logs(),
+      ].join("\n"),
+    ).not.toContain(API_KEY);
+  }, 240_000);
+});
+
+async function waitForGatewayReadiness(
+  instance: OpenClawTestInstance,
+): Promise<{ ready: boolean; failing: string[] }> {
+  const url = `http://127.0.0.1:${instance.port}/readyz`;
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return (await response.json()) as { ready: boolean; failing: string[] };
+      }
+    } catch {
+      // The listener can open before startup readiness settles.
+    }
+    await delay(50);
+  }
+  throw new Error(`gateway did not become ready: ${instance.logs()}`);
+}
+
+async function startFakeClawRouter(): Promise<FakeClawRouter> {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((req, res) => {
+    void handleClawRouterRequest(req, res, requests).catch((error) => {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: String(error) } }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("fake ClawRouter did not bind a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${(address as AddressInfo).port}`,
+    requests,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function handleClawRouterRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  requests: CapturedRequest[],
+): Promise<void> {
+  const method = req.method ?? "GET";
+  const path = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+  const bodyText = await readRequestBody(req);
+  const body = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : undefined;
+  const authorization = req.headers.authorization;
+  requests.push({ method, path, authorization, headers: { ...req.headers }, body });
+
+  if (method === "GET" && path === "/v1/health") {
+    writeJson(res, 200, {
+      ok: true,
+      environment: "fakeco",
+      observability: {
+        mode: "metadata_only",
+        requestContentRetentionDefault: false,
+      },
+    });
+    return;
+  }
+
+  if (authorization !== `Bearer ${API_KEY}`) {
+    writeJson(res, 401, { error: { message: "unauthorized" } });
+    return;
+  }
+
+  if (method === "GET" && path === "/v1/catalog") {
+    writeJson(res, 200, {
+      providers: [
+        {
+          id: "openai",
+          displayName: "OpenAI",
+          openaiCompatible: true,
+          nativeBaseUrl: "/v1/native/openai",
+          routes: [],
+          models: [
+            {
+              id: MODEL_ID,
+              upstream: "gpt-5.5",
+              capabilities: ["llm.responses"],
+            },
+          ],
+        },
+      ],
+    });
+    return;
+  }
+
+  if (method === "GET" && path === "/v1/usage") {
+    writeJson(res, 200, {
+      budget: { configured: false, ledger: "unmetered" },
+      usage: { summary: { requestCount: 0, totalTokens: 0, actualCostMicros: 0 } },
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/v1/responses") {
+    writeResponsesStream(res, resolveResponseText(body));
+    return;
+  }
+
+  writeJson(res, 404, { error: { message: `unexpected ${method} ${path}` } });
+}
+
+function resolveResponseText(body: Record<string, unknown> | undefined): string {
+  const matches = JSON.stringify(body ?? {}).match(/CLAWROUTER_[A-Z0-9_]+/gu);
+  return matches?.at(-1) ?? "CLAWROUTER_PROBE_OK";
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function writeResponsesStream(res: ServerResponse, text: string): void {
+  const itemId = "msg_clawrouter_e2e";
+  const events = [
+    {
+      type: "response.output_item.added",
+      item: { type: "message", id: itemId, role: "assistant", content: [], status: "in_progress" },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: itemId,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: itemId,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "message",
+        id: itemId,
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text, annotations: [] }],
+      },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_clawrouter_e2e",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: itemId,
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+          },
+        ],
+        usage: {
+          input_tokens: 11,
+          output_tokens: 7,
+          total_tokens: 18,
+          input_tokens_details: { cached_tokens: 0 },
+        },
+      },
+    },
+  ];
+  res.writeHead(200, {
+    "cache-control": "no-store",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+    "x-clawrouter-content-retention": "off",
+    "x-clawrouter-upstream-provider": "openai",
+    "x-request-id": "clawrouter-e2e-request",
+  });
+  for (const event of events) {
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+  }
+  res.end("data: [DONE]\n\n");
+}


### PR DESCRIPTION
Closes #103298

## What Problem This Solves

Fixes an issue where operators configuring an isolated ClawRouter endpoint with `models.providers.clawrouter.baseUrl` and an `apiKey` SecretRef could not validate the configuration unless they added a redundant static `models` list, despite ClawRouter owning a credential-scoped dynamic catalog.

Managed deployments also lacked one exact, secret-safe proof path from declarative bootstrap through gateway readiness, model probing, and an attributed agent turn.

## Why This Change Was Made

The bundled ClawRouter provider now participates in the canonical built-in provider-overlay contract, while the plugin continues to own catalog and transport behavior. ClawRouter requests receive metadata-only OpenClaw client, agent, and session attribution at dispatch, with explicit configured headers retaining precedence; credentials remain SecretRefs until egress.

The provider guide and deterministic E2E use the same noninteractive config-patch workflow and separate router liveness, gateway readiness, model probing, and inference proof. No production deployment or real provider credential is part of this change.

AI-assisted implementation; the implementation and proof were reviewed against the repository's ownership and testing contracts.

## User Impact

Operators can declaratively bootstrap and rotate an isolated ClawRouter endpoint using `models.providers.clawrouter.baseUrl` plus an environment-backed `CLAWROUTER_API_KEY` SecretRef, without a `models: []` workaround or secret-bearing output.

Model refs remain `clawrouter/<catalog-provider>/<catalog-model>`. Health, readiness, catalog, probe, and agent-turn commands now make it explicit which layer is healthy and provide metadata-only evidence that inference traversed ClawRouter.

## Evidence

- Deterministic managed-gateway E2E: isolated config/state, mock `/v1/health`, `/v1/catalog`, `/v1/usage`, and `/v1/responses`, documented config patch dry-run/apply, invalid-auth 401, gateway `/readyz`, model probe, real gateway agent turn, attribution checks, and secret-absence assertions.
- Focused remote tests: 30 passed across `test/clawrouter-managed-gateway.e2e.test.ts`, `extensions/clawrouter/index.test.ts`, and `src/config/zod-schema.models.test.ts`.
- Remote `pnpm test:changed`: 626 tests passed.
- Remote `pnpm check:changed`: selected core, core tests, extensions, extension tests, docs, and tooling lanes passed.
- Remote `pnpm build`: passed.
- Targeted formatting and `git diff --check`: passed.
- Generated docs map check: passed after refreshing the two new ClawRouter headings.
- Source-blind behavior contract: passed for configuration, readiness, routing attribution, and secret redaction.
- Repo-local autoreview: clean with no accepted/actionable findings.
- Exact head: `cb53e0825f8f7217eeade6330ad4dcf9adcc9f19`.
- Exact-head CI: [run 29066481099](https://github.com/openclaw/openclaw/actions/runs/29066481099), completed successfully; docs, build artifacts, lint/types, plugin contracts, tests, security, CodeQL, OpenGrep, and workflow checks passed.
- Repo-native preparation: `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 103299` passed with `gates_mode=hosted_exact_or_recent_rebase`; prep head and PR head both resolved to the exact head above.
- Live external ClawRouter inference was not run because no credential/environment is available; the deterministic gateway E2E and documented live runbook cover that explicit remaining proof boundary.
