### PR TITLE
fix: Feishu post messages truncate URLs containing underscores

### DIFF
--- a/extensions/feishu/src/markdown-urls.test.ts
+++ b/extensions/feishu/src/markdown-urls.test.ts
@@ -1,0 +1,63 @@
+// Feishu tests cover post markdown URL normalization behavior.
+import { describe, expect, it } from "vitest";
+import { preserveFeishuBareMarkdownUrls } from "./markdown-urls.js";
+
+describe("preserveFeishuBareMarkdownUrls", () => {
+  it("wraps bare http(s) URLs with underscores so Feishu keeps the full link target", () => {
+    expect(
+      preserveFeishuBareMarkdownUrls(
+        "see https://example.com/path_with_under_score and http://x.test/a_b?c=d_e#f_g",
+      ),
+    ).toBe(
+      [
+        "see [https://example.com/path_with_under_score]",
+        "(https://example.com/path_with_under_score) and ",
+        "[http://x.test/a_b?c=d_e#f_g](http://x.test/a_b?c=d_e#f_g)",
+      ].join(""),
+    );
+  });
+
+  it("keeps markdown links, image links, angle autolinks, and code regions unchanged", () => {
+    const markdown = [
+      "[regular](https://example.com/already_linked_path)",
+      "![image](https://example.com/image_name.png)",
+      "<https://example.com/angle_link_path>",
+      "`https://example.com/inline_code_path`",
+      "```md",
+      "https://example.com/fenced_code_path",
+      "```",
+    ].join("\n");
+
+    expect(preserveFeishuBareMarkdownUrls(markdown)).toBe(markdown);
+  });
+
+  it("keeps nested-bracket markdown link destinations masked", () => {
+    expect(
+      preserveFeishuBareMarkdownUrls(
+        "[docs [v2]](https://example.com/already_linked_path) and https://example.com/live_path",
+      ),
+    ).toBe(
+      [
+        "[docs [v2]](https://example.com/already_linked_path) and ",
+        "[https://example.com/live_path](https://example.com/live_path)",
+      ].join(""),
+    );
+  });
+
+  it("keeps balanced URL parentheses but leaves trailing sentence punctuation outside", () => {
+    expect(
+      preserveFeishuBareMarkdownUrls("see https://example.com/releases/v1_(beta)_notes?file=a_b."),
+    ).toBe(
+      [
+        "see [https://example.com/releases/v1_(beta)_notes?file=a_b]",
+        "(https://example.com/releases/v1_(beta)_notes?file=a_b).",
+      ].join(""),
+    );
+  });
+
+  it("leaves bare URLs without underscores unchanged", () => {
+    expect(preserveFeishuBareMarkdownUrls("see https://example.com/plain")).toBe(
+      "see https://example.com/plain",
+    );
+  });
+});

--- a/extensions/feishu/src/markdown-urls.test.ts
+++ b/extensions/feishu/src/markdown-urls.test.ts
@@ -60,4 +60,12 @@ describe("preserveFeishuBareMarkdownUrls", () => {
       "see https://example.com/plain",
     );
   });
+
+  it("keeps reference-style link definitions unchanged", () => {
+    expect(
+      preserveFeishuBareMarkdownUrls(
+        "[docs]: https://example.com/path_with_under \"title\"",
+      ),
+    ).toBe("[docs]: https://example.com/path_with_under \"title\"");
+  });
 });

--- a/extensions/feishu/src/markdown-urls.ts
+++ b/extensions/feishu/src/markdown-urls.ts
@@ -129,6 +129,17 @@ function collectMarkdownLinkRanges(text: string, ranges: Range[]): void {
   }
 }
 
+function collectReferenceLinkDefinitionRanges(text: string, ranges: Range[]): void {
+  // Match reference-style link definitions: [label]: url ["title"]
+  const refDefPattern = /^ {0,3}\[([^\]]+)\]:\s*(?:<([^>\s]+)>|(\S+))(?:\s*(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = refDefPattern.exec(text)) !== null) {
+    if (!isInsideRanges(match.index, ranges)) {
+      ranges.push({ start: match.index, end: match.index + match[0].length });
+    }
+  }
+}
+
 function collectAngleAutolinkRanges(text: string, ranges: Range[]): void {
   const angleAutolinkPattern = /<https?:\/\/[^>\s]+>/g;
   let match: RegExpExecArray | null;
@@ -143,6 +154,7 @@ function collectProtectedRanges(text: string): Range[] {
   const ranges = collectFencedCodeRanges(text);
   collectInlineCodeRanges(text, ranges);
   collectMarkdownLinkRanges(text, ranges);
+  collectReferenceLinkDefinitionRanges(text, ranges);
   collectAngleAutolinkRanges(text, ranges);
   return ranges.sort((a, b) => a.start - b.start);
 }

--- a/extensions/feishu/src/markdown-urls.ts
+++ b/extensions/feishu/src/markdown-urls.ts
@@ -1,0 +1,224 @@
+// Feishu plugin module normalizes post markdown URL behavior.
+
+type Range = {
+  start: number;
+  end: number;
+};
+
+const URL_START_PATTERN = /https?:\/\//g;
+const TRAILING_URL_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+function isInsideRanges(index: number, ranges: Range[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+function collectFencedCodeRanges(text: string): Range[] {
+  const ranges: Range[] = [];
+  const fenceStartPattern = /^( {0,3})(`{3,}|~{3,})[^\n]*(?:\n|$)/gm;
+  let match: RegExpExecArray | null;
+  while ((match = fenceStartPattern.exec(text)) !== null) {
+    const marker = match[2];
+    const fenceChar = marker[0];
+    const minLength = marker.length;
+    const closePattern = new RegExp(`^ {0,3}\\${fenceChar}{${minLength},}[^\\n]*(?:\\n|$)`, "gm");
+    closePattern.lastIndex = fenceStartPattern.lastIndex;
+    const close = closePattern.exec(text);
+    const end = close ? close.index + close[0].length : text.length;
+    ranges.push({ start: match.index, end });
+    fenceStartPattern.lastIndex = end;
+  }
+  return ranges;
+}
+
+function collectInlineCodeRanges(text: string, ranges: Range[]): void {
+  for (let index = 0; index < text.length; ) {
+    if (text[index] !== "`" || isInsideRanges(index, ranges)) {
+      index++;
+      continue;
+    }
+
+    let runEnd = index + 1;
+    while (text[runEnd] === "`") {
+      runEnd++;
+    }
+    const marker = text.slice(index, runEnd);
+    const close = text.indexOf(marker, runEnd);
+    if (close === -1) {
+      index = runEnd;
+      continue;
+    }
+    ranges.push({ start: index, end: close + marker.length });
+    index = close + marker.length;
+  }
+}
+
+function parseBracketLabelEnd(text: string, labelStart: number): number | undefined {
+  let depth = 1;
+  for (let index = labelStart + 1; index < text.length; index++) {
+    const char = text[index];
+    if (isEscaped(text, index)) {
+      continue;
+    }
+    if (char === "[") {
+      depth++;
+      continue;
+    }
+    if (char === "]") {
+      depth--;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseLinkDestinationEnd(text: string, destinationStart: number): number | undefined {
+  let depth = 1;
+  for (let index = destinationStart + 1; index < text.length; index++) {
+    const char = text[index];
+    if (isEscaped(text, index)) {
+      continue;
+    }
+    if (char === "(") {
+      depth++;
+      continue;
+    }
+    if (char === ")") {
+      depth--;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseMarkdownLinkEnd(text: string, start: number): number | undefined {
+  const labelStart = text[start] === "!" ? start + 1 : start;
+  if (text[labelStart] !== "[") {
+    return undefined;
+  }
+  const labelEnd = parseBracketLabelEnd(text, labelStart);
+  if (labelEnd === undefined || text[labelEnd] !== "(") {
+    return undefined;
+  }
+  return parseLinkDestinationEnd(text, labelEnd);
+}
+
+function collectMarkdownLinkRanges(text: string, ranges: Range[]): void {
+  for (let index = 0; index < text.length; index++) {
+    if (isInsideRanges(index, ranges)) {
+      continue;
+    }
+    if (text[index] !== "[" && !(text[index] === "!" && text[index + 1] === "[")) {
+      continue;
+    }
+    const end = parseMarkdownLinkEnd(text, index);
+    if (end !== undefined) {
+      ranges.push({ start: index, end });
+      index = end - 1;
+    }
+  }
+}
+
+function collectAngleAutolinkRanges(text: string, ranges: Range[]): void {
+  const angleAutolinkPattern = /<https?:\/\/[^>\s]+>/g;
+  let match: RegExpExecArray | null;
+  while ((match = angleAutolinkPattern.exec(text)) !== null) {
+    if (!isInsideRanges(match.index, ranges)) {
+      ranges.push({ start: match.index, end: match.index + match[0].length });
+    }
+  }
+}
+
+function collectProtectedRanges(text: string): Range[] {
+  const ranges = collectFencedCodeRanges(text);
+  collectInlineCodeRanges(text, ranges);
+  collectMarkdownLinkRanges(text, ranges);
+  collectAngleAutolinkRanges(text, ranges);
+  return ranges.sort((a, b) => a.start - b.start);
+}
+
+function isBareUrlStart(text: string, index: number): boolean {
+  const previous = text[index - 1];
+  return previous === undefined || !/[A-Za-z0-9/]/.test(previous);
+}
+
+function findBareUrlEnd(text: string, start: number): number {
+  let index = start;
+  while (index < text.length) {
+    const char = text[index];
+    if (/\s/.test(char) || char === "<" || char === ">" || char === "`") {
+      break;
+    }
+    if (char === "[" || char === "]" || char === "{" || char === "}") {
+      break;
+    }
+    index++;
+  }
+  return index;
+}
+
+function trimBareUrl(rawUrl: string): { url: string; suffix: string } {
+  let end = rawUrl.length;
+  while (end > 0) {
+    const candidate = rawUrl.slice(0, end);
+    const last = rawUrl[end - 1];
+    if (TRAILING_URL_PUNCTUATION.has(last)) {
+      end--;
+      continue;
+    }
+    const openParens = (candidate.match(/\(/g) ?? []).length;
+    const closeParens = (candidate.match(/\)/g) ?? []).length;
+    if (last === ")" && closeParens > openParens) {
+      end--;
+      continue;
+    }
+    break;
+  }
+  return {
+    url: rawUrl.slice(0, end),
+    suffix: rawUrl.slice(end),
+  };
+}
+
+export function preserveFeishuBareMarkdownUrls(text: string): string {
+  if (!text.includes("_") || !URL_START_PATTERN.test(text)) {
+    URL_START_PATTERN.lastIndex = 0;
+    return text;
+  }
+
+  URL_START_PATTERN.lastIndex = 0;
+  const protectedRanges = collectProtectedRanges(text);
+  let output = "";
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = URL_START_PATTERN.exec(text)) !== null) {
+    const start = match.index;
+    if (start < cursor || isInsideRanges(start, protectedRanges) || !isBareUrlStart(text, start)) {
+      continue;
+    }
+
+    const rawEnd = findBareUrlEnd(text, start);
+    const { url, suffix } = trimBareUrl(text.slice(start, rawEnd));
+    if (!url.includes("_")) {
+      continue;
+    }
+
+    output += text.slice(cursor, start);
+    output += `[${url}](${url})${suffix}`;
+    cursor = rawEnd;
+    URL_START_PATTERN.lastIndex = rawEnd;
+  }
+  output += text.slice(cursor);
+  return output;
+}

--- a/extensions/feishu/src/markdown-urls.ts
+++ b/extensions/feishu/src/markdown-urls.ts
@@ -195,10 +195,11 @@ export function preserveFeishuBareMarkdownUrls(text: string): string {
     return text;
   }
 
-  const urlPattern = /https?:\/\//g;
-  if (!urlPattern.test(text)) {
+  if (!/https?:\/\//.test(text)) {
     return text;
   }
+
+  const urlPattern = /https?:\/\//g;
 
   const protectedRanges = collectProtectedRanges(text);
   let output = "";

--- a/extensions/feishu/src/markdown-urls.ts
+++ b/extensions/feishu/src/markdown-urls.ts
@@ -5,7 +5,6 @@ type Range = {
   end: number;
 };
 
-const URL_START_PATTERN = /https?:\/\//g;
 const TRAILING_URL_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
 
 function isEscaped(text: string, index: number): boolean {
@@ -192,17 +191,20 @@ function trimBareUrl(rawUrl: string): { url: string; suffix: string } {
 }
 
 export function preserveFeishuBareMarkdownUrls(text: string): string {
-  if (!text.includes("_") || !URL_START_PATTERN.test(text)) {
-    URL_START_PATTERN.lastIndex = 0;
+  if (!text.includes("_")) {
     return text;
   }
 
-  URL_START_PATTERN.lastIndex = 0;
+  const urlPattern = /https?:\/\//g;
+  if (!urlPattern.test(text)) {
+    return text;
+  }
+
   const protectedRanges = collectProtectedRanges(text);
   let output = "";
   let cursor = 0;
   let match: RegExpExecArray | null;
-  while ((match = URL_START_PATTERN.exec(text)) !== null) {
+  while ((match = urlPattern.exec(text)) !== null) {
     const start = match.index;
     if (start < cursor || isInsideRanges(start, protectedRanges) || !isBareUrlStart(text, start)) {
       continue;
@@ -217,7 +219,7 @@ export function preserveFeishuBareMarkdownUrls(text: string): string {
     output += text.slice(cursor, start);
     output += `[${url}](${url})${suffix}`;
     cursor = rawEnd;
-    URL_START_PATTERN.lastIndex = rawEnd;
+    urlPattern.lastIndex = rawEnd;
   }
   output += text.slice(cursor);
   return output;

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -10,6 +10,7 @@ import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
+import { preserveFeishuBareMarkdownUrls } from "./markdown-urls.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { resolveFeishuCardTemplate } from "./native-card.js";
@@ -564,7 +565,8 @@ export function buildFeishuPostMessagePayload(params: {
   content: string;
   msgType: string;
 } {
-  const { messageText, mentions } = params;
+  const messageText = preserveFeishuBareMarkdownUrls(params.messageText);
+  const { mentions } = params;
   const content: FeishuPostMessageElement[] = [
     ...buildFeishuPostMentionElements(mentions),
     {


### PR DESCRIPTION
Closes #41860

## What Problem This Solves

Fixes an issue where sending a message to Feishu containing a URL with underscores (e.g. `https://example.com/output_20260210_222435.png`) would cause the URL to be truncated or not fully clickable. Feishu's post message markdown parser interprets underscores as italics markers, breaking the URL display.

## Why This Change Was Made

A new `preserveFeishuBareMarkdownUrls()` function wraps bare URLs containing underscores in `[url](url)` markdown link syntax before sending, so Feishu's parser treats them as explicit links rather than applying italics formatting. The function protects already-formatted markdown links, reference-style link definitions, inline code, fenced code blocks, and angle autolinks from being modified.

## User Impact

Users sending messages to Feishu channels containing URLs with underscores will now see the full URL displayed as a single clickable link, matching the expected behavior.

## Evidence

- `pnpm test:extension feishu` — 76 test files, 1037 tests passed
- Codex review approved (4 rounds, all issues addressed)
- New `markdown-urls.test.ts` covers: basic underscore URL wrapping, already-formatted links (no-op), nested brackets, balanced parentheses, reference-style link definitions, and non-underscore URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>