### PR TITLE
fix(whatsapp): honor account-level messagePrefix in inbound line [AI-assisted]

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
@@ -1,5 +1,6 @@
 // Whatsapp plugin module implements message line behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveMergedWhatsAppAccountConfig } from "../../account-config.js";
 import {
   getPrimaryIdentityId,
   getReplyContext,
@@ -31,14 +32,24 @@ export function buildInboundLine(params: {
   cfg: OpenClawConfig;
   msg: AdmittedWebInboundMessage;
   agentId: string;
+  accountId?: string;
   previousTimestamp?: number;
   envelope?: EnvelopeFormatOptions;
   visibleReplyTo?: WhatsAppReplyContext | null;
 }) {
-  const { cfg, msg, agentId, previousTimestamp, envelope } = params;
-  // WhatsApp inbound prefix: channels.whatsapp.messagePrefix > legacy messages.messagePrefix > identity/defaults
+  const { cfg, msg, agentId, accountId, previousTimestamp, envelope } = params;
+  // WhatsApp inbound prefix cascade: account > channel > legacy global
+  // messages.messagePrefix > identity/defaults. When an account context is
+  // available, resolve the prefix through the shared WhatsApp account merge so a
+  // per-account `messagePrefix` override wins over the channel-level value
+  // (mirroring how `responsePrefix` and `ackReaction` honor account/channel scope).
+  // `messagePrefix` is WhatsApp-only (the global `messages.messagePrefix` is
+  // deprecated in favor of `whatsapp.messagePrefix`), so this stays scoped to the
+  // WhatsApp inbound path rather than widening a generic channel contract.
   const messagePrefix = resolveMessagePrefix(cfg, agentId, {
-    configured: cfg.channels?.whatsapp?.messagePrefix,
+    configured: accountId
+      ? resolveMergedWhatsAppAccountConfig({ cfg, accountId }).messagePrefix
+      : cfg.channels?.whatsapp?.messagePrefix,
     hasAllowFrom: (cfg.channels?.whatsapp?.allowFrom?.length ?? 0) > 0,
   });
   const admission = requireWhatsAppInboundAdmission(msg);

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -307,6 +307,7 @@ export async function processMessage(params: {
     cfg: params.cfg,
     msg: msgForAgent,
     agentId: params.route.agentId,
+    accountId: account.accountId,
     previousTimestamp,
     envelope: envelopeOptions,
     visibleReplyTo,

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -801,6 +801,105 @@ describe("buildInboundLine", () => {
     expect(line).toContain("[PFX] ping");
   });
 
+  it("applies the account-level messagePrefix over the channel-level prefix", () => {
+    // Account-specific messagePrefix must win over the channel-level value so
+    // per-account inbound prefix customization is honored.
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/openclaw" } },
+      channels: {
+        whatsapp: {
+          messagePrefix: "[CH]",
+          accounts: {
+            work: { messagePrefix: "[ACCT]" },
+          },
+        },
+      },
+    } as never;
+    const line = buildInboundLine({
+      cfg,
+      agentId: "main",
+      accountId: "work",
+      msg: createDirectMessage({
+        admission: {
+          conversation: {
+            id: "+1555",
+          },
+        },
+        body: "ping",
+        to: "+2666",
+      }),
+      envelope: { includeTimestamp: false },
+    });
+
+    expect(line).toContain("[ACCT] ping");
+    expect(line).not.toContain("[CH]");
+  });
+
+  it("falls back to the channel-level messagePrefix when the account has none", () => {
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/openclaw" } },
+      channels: {
+        whatsapp: {
+          messagePrefix: "[CH]",
+          accounts: {
+            work: {},
+          },
+        },
+      },
+    } as never;
+    const line = buildInboundLine({
+      cfg,
+      agentId: "main",
+      accountId: "work",
+      msg: createDirectMessage({
+        admission: {
+          conversation: {
+            id: "+1555",
+          },
+        },
+        body: "ping",
+        to: "+2666",
+      }),
+      envelope: { includeTimestamp: false },
+    });
+
+    expect(line).toContain("[CH] ping");
+  });
+
+  it("treats an empty account-level messagePrefix as an explicit no-prefix override", () => {
+    // An empty string is an explicit operator choice: it must suppress the
+    // channel/global prefix rather than falling through to the channel value.
+    const cfg = {
+      agents: { defaults: { workspace: "/tmp/openclaw" } },
+      channels: {
+        whatsapp: {
+          messagePrefix: "[CH]",
+          accounts: {
+            work: { messagePrefix: "" },
+          },
+        },
+      },
+    } as never;
+    const line = buildInboundLine({
+      cfg,
+      agentId: "main",
+      accountId: "work",
+      msg: createDirectMessage({
+        admission: {
+          conversation: {
+            id: "+1555",
+          },
+        },
+        body: "ping",
+        to: "+2666",
+      }),
+      envelope: { includeTimestamp: false },
+    });
+
+    expect(line).not.toContain("[CH]");
+    expect(line).toContain("ping");
+  });
+
   it("normalizes direct from labels by stripping whatsapp: prefix", () => {
     const line = buildInboundLine({
       cfg: makeInboundCfg(""),


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #102937

## What Problem This Solves

Fixes an issue where WhatsApp operators who set a per-account `messagePrefix`
(`channels.whatsapp.accounts.<id>.messagePrefix`) would see their account-specific
inbound prefix **silently ignored**. The inbound line always fell back to the
channel-level (`channels.whatsapp.messagePrefix`) or global prefix, no matter what
the account override said.

This is a config-precedence bug: the sibling `responsePrefix` and `ackReaction`
resolvers already honor account > channel > global scope, but the WhatsApp inbound
`messagePrefix` path only read the channel-level value, so account-level
customization could never win.

## Why This Change Was Made

`buildInboundLine` resolved the inbound prefix with
`configured: cfg.channels?.whatsapp?.messagePrefix` - channel-level only. The
shared WhatsApp account-merge helper (`resolveMergedWhatsAppAccountConfig`) already
computes the correct account > channel precedence (and `resolveWhatsAppAccount`
already exposes `messagePrefix` with a global fallback), so the fix threads the
account context through: when an `accountId` is available, the prefix is resolved
through that merge so a per-account override wins; otherwise behavior is unchanged.

Scope is intentionally narrow and **WhatsApp-only**:

- `messagePrefix` is documented as a WhatsApp-only inbound prefix - the global
  `messages.messagePrefix` is `@deprecated Use whatsapp.messagePrefix`. The fix
  reuses the existing WhatsApp account/merge boundary rather than widening a
  generic core channel-config contract (which would risk breaking other channels).
- The core `src/agents/identity.ts` `resolveMessagePrefix` is **not** touched: a
  survey of its callers (`src/channels/reply-prefix.ts`,
  `extensions/tlon/src/monitor/index.ts`) shows they consume only `.responsePrefix`
  from `resolveEffectiveMessagesConfig`, so the core helper has no real
  `messagePrefix` consumer to fix there.

The empty-string case is preserved as an explicit operator choice (an account-level
`messagePrefix: ""` suppresses the channel/global prefix rather than falling
through), matching how `responsePrefix`/`ackReaction` treat empty strings and how
`hasConfiguredAccountValue` (`value !== undefined && value !== null`) already
treats `""` as set in the shared merge helper.

## User Impact

WhatsApp operators with multiple accounts (e.g. a `business` and a `personal`
account on the same install) can now give each account its own inbound
`messagePrefix`, and the agent-facing inbound line will honor it. Previously the
account-level value was ignored and the channel/global prefix was always used.
Accounts without an explicit `messagePrefix` keep the previous channel/global
behavior, so there is no change for existing single-account or channel-only setups.

## Evidence

Real behavior proof - calling the real `buildInboundLine` (the exact code path
`processMessage` uses to build the agent-facing inbound line) with a config that
sets both a channel-level and an account-level `messagePrefix`, account `work`,
body `ping`. Captured before (unpatched `upstream/main`) vs after (this PR):

**Before (unpatched main) - account-level `messagePrefix` is ignored, channel
`[CH]` wins:**

```
# account-level messagePrefix wins over channel-level  (EXPECTED [ACCT], GOT channel [CH])
[WhatsApp +1555] +1555: [CH] ping

# empty account-level messagePrefix should suppress, but channel [CH] still applied
[WhatsApp +1555] +1555: [CH] ping
```

Regression test on unpatched main failed exactly here:
`AssertionError: expected '[WhatsApp +1555] +1555: [CH] ping' to contain '[ACCT] ping'`

**After (this PR) - account-level `messagePrefix` now wins:**

```
# account-level messagePrefix wins over channel-level
[WhatsApp +1555] +1555: [ACCT] ping

# empty account-level messagePrefix suppresses channel prefix
[WhatsApp +1555] +1555: ping

# falls back to channel-level when account has no messagePrefix
[WhatsApp +1555] +1555: [CH] ping

# no accountId: preserves legacy channel-level behavior (backward compat)
[WhatsApp +1555] +1555: [CH] ping
```

Regression tests added to
`extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts`
(`buildInboundLine` block) cover: account-level wins over channel; fall back to
channel when account has none; empty account-level string suppresses the prefix.
All 26 tests in that file pass after the fix (2 failed before).

**Checks run locally on `upstream/main` (0d2db46956):**
- `oxlint` + `oxfmt --check` on the 3 changed files - clean.
- `tsgo:extensions` + `tsgo:extensions:test` (CI `check-prod-types` / `check-test-types`
  for extension changes) - pass.
- Scoped vitest `extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts` - 26/26 pass.

**Not tested:** No live WhatsApp account run was performed (no live Baileys/WhatsApp
connection available on this Windows machine). The proof is at the real
`buildInboundLine` function the inbound path calls, driven with the real account
config-merge resolver - the exact code path `processMessage` uses. macOS/iOS and
production deploy not tested.
