### PR TITLE
fix(slack): log typing reaction errors instead of silently swallowing them

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -28,6 +28,7 @@ const stopSlackStreamMock = vi.fn(async (_params?: unknown) => ({}) as { message
 const emitSlackMessageSentHooksMock = vi.fn(() => {});
 const reactSlackMessageMock = vi.fn(async () => {});
 const removeSlackReactionMock = vi.fn(async () => {});
+const logVerboseMock = vi.fn();
 class TestSlackStreamNotDeliveredError extends Error {
   readonly pendingText: string;
   readonly slackCode: string;
@@ -198,6 +199,14 @@ function requireCapturedTyping() {
     throw new Error("expected Slack typing callback");
   }
   return capturedTyping;
+}
+
+function createSlackPlatformError(error: string, details?: { needed?: string; provided?: string }) {
+  // Mirrors @slack/web-api 7.18.0 platformErrorFromResult: message plus structured result data.
+  return Object.assign(new Error(`An API error occurred: ${error}`), {
+    code: "slack_webapi_platform_error",
+    data: { ok: false, error, ...details },
+  });
 }
 
 function requireCapturedItemEventHandler() {
@@ -819,7 +828,7 @@ vi.mock("openclaw/plugin-sdk/reply-payload", () => ({
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   danger: (message: string) => message,
-  logVerbose: () => {},
+  logVerbose: logVerboseMock,
   shouldLogVerbose: () => false,
 }));
 
@@ -1258,6 +1267,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     stopSlackStreamMock.mockReset();
     reactSlackMessageMock.mockReset();
     removeSlackReactionMock.mockReset();
+    logVerboseMock.mockReset();
     for (const value of Object.values(statusReactionControllerMock)) {
       value.mockClear();
     }
@@ -1979,6 +1989,39 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(removeReactionCall[2]).toBe("hourglass_flowing_sand");
     expect(requireRecord(removeReactionCall[3], "remove Slack reaction options").token).toBe(
       "xoxb-test",
+    );
+  });
+
+  it("logs the formatted Slack error when adding the typing reaction fails", async () => {
+    reactSlackMessageMock.mockRejectedValueOnce(
+      createSlackPlatformError("missing_scope", {
+        needed: "reactions:write",
+        provided: "chat:write",
+      }),
+    );
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({ typingReaction: "hourglass_flowing_sand" }),
+    );
+    await expect(requireCapturedTyping().start()).resolves.toBeUndefined();
+
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "slack send: typing reaction failed: An API error occurred: missing_scope; code: slack_webapi_platform_error; slack error: missing_scope; needed: reactions:write; provided: chat:write",
+    );
+  });
+
+  it("logs the formatted Slack error when removing the typing reaction fails", async () => {
+    removeSlackReactionMock.mockRejectedValueOnce(createSlackPlatformError("invalid_auth"));
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({ typingReaction: "hourglass_flowing_sand" }),
+    );
+    const typing = requireCapturedTyping();
+    await typing.start();
+    await expect(typing.stop?.()).resolves.toBeUndefined();
+
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "slack send: typing reaction removal failed: An API error occurred: invalid_auth; code: slack_webapi_platform_error; slack error: invalid_auth",
     );
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -614,7 +614,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           await reactSlackMessage(message.channel, message.ts, typingReaction, {
             token: ctx.botToken,
             client: slackClient,
-          }).catch(() => {});
+          }).catch((err: unknown) => {
+            logVerbose(`slack send: typing reaction failed: ${formatSlackError(err)}`);
+          });
         }
       },
       stop: async () => {
@@ -632,7 +634,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           await removeSlackReaction(message.channel, message.ts, typingReaction, {
             token: ctx.botToken,
             client: slackClient,
-          }).catch(() => {});
+          }).catch((err: unknown) => {
+            logVerbose(`slack send: typing reaction removal failed: ${formatSlackError(err)}`);
+          });
         }
       },
       onStartError: (err) => {


### PR DESCRIPTION
## What Problem This Solves

Slack typing-reaction add and remove calls silently discard every rejected promise. Operators therefore cannot diagnose a missing `reactions:write` scope, invalid authentication, or another Slack API failure when `typingReaction` is configured.

## Why This Change Was Made

The shared reaction helpers already treat Slack's idempotent `already_reacted` and `no_reaction` results as success. This change keeps typing feedback best-effort while logging every remaining rejection through the existing redacting Slack error formatter.

## User Impact

Reply delivery remains non-fatal when typing feedback fails. Verbose logs now contain the actual pinned-SDK shape, for example:

```text
slack send: typing reaction failed: An API error occurred: missing_scope; code: slack_webapi_platform_error; slack error: missing_scope; needed: reactions:write; provided: chat:write
```

Removal failures use the corresponding `slack send: typing reaction removal failed:` prefix.

## Evidence

- Current-main source proof: both callback branches used empty catch handlers before this patch.
- Pinned dependency proof: `@slack/web-api` 7.18.0 constructs platform errors with the `An API error occurred: <code>` message, `slack_webapi_platform_error` code, and the complete Slack result on `data`; the regression fixture mirrors that contract.
- Focused regression proof: add and remove rejection tests assert the exact formatted diagnostic and verify each callback still resolves. The dispatch, formatter, and reaction-helper suites pass 102 tests.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29184901554
- Real-Slack rejection proof is not claimed. A source-blind run requires a valid fixture credential intentionally lacking `reactions:write`; that credential was unavailable during maintainer validation.

## Review

- Maintainer autoreview: clean, no actionable findings.
- AI-assisted: Yes.
