### PR TITLE
fix(ui): derive ProfilePage and AgentSelect from OpenClawLightDomElement for locale reactivity

### DIFF
--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
@@ -8,13 +8,10 @@ import {
   resolveAgentTextAvatar,
 } from "../lib/agents/display.ts";
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
+import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 
-class AgentSelect extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
+class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) agents: GatewayAgentRow[] = [];
   @property({ attribute: false }) selectedId: string | null = null;
   @property({ attribute: false }) defaultId: string | null = null;

--- a/ui/src/lit/openclaw-element.test.ts
+++ b/ui/src/lit/openclaw-element.test.ts
@@ -90,4 +90,21 @@ describe("OpenClaw Lit elements", () => {
     expect(element.textContent).toContain("Refresh");
     expect(element.renderCount).toBe(disconnectedRenderCount + 1);
   });
+
+  it("re-renders a light-DOM element when the active locale changes without disconnect", async () => {
+    // Regression for #103270: components extending OpenClawLightDomElement
+    // must refresh translated labels after a locale change while still mounted.
+    const element = document.createElement(LIGHT_ELEMENT_NAME) as TestLightDomElement;
+    document.body.append(element);
+    await element.updateComplete;
+
+    const renderCountBefore = element.renderCount;
+    expect(element.textContent).toContain("Refresh");
+
+    await i18n.setLocale("zh-CN");
+    await element.updateComplete;
+
+    expect(element.renderCount).toBeGreaterThan(renderCountBefore);
+    expect(element.textContent).toContain("刷新");
+  });
 });

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { html, LitElement, nothing, svg } from "lit";
+import { html, nothing, svg } from "lit";
 import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { CostUsageSummary, SessionsUsageResult } from "../../api/types.ts";
@@ -19,6 +19,7 @@ import {
   isMissingOperatorReadScopeError,
 } from "../../lib/gateway-errors.ts";
 import { buildSessionUsageDateParams, requestSessionsUsage } from "../../lib/sessions/index.ts";
+import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import {
   buildHeatmap,
   buildInsights,
@@ -84,11 +85,7 @@ function toErrorMessage(error: unknown): string {
   return typeof error === "string" ? error : "request failed";
 }
 
-class ProfilePage extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
+class ProfilePage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ApplicationContext;
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI profile page and agent selector extended raw `LitElement`, bypassing the `I18nController` that `OpenClawLightDomElement` uses to refresh mounted components when the active locale changes. After a locale switch, translated labels in these two surfaces could stay stale until an unrelated property update triggered a re-render.

Fixes #103270

## Why This Change Was Made

`OpenClawLitElement` (parent of `OpenClawLightDomElement`) registers an `I18nController` that calls `requestUpdate()` on `i18n.subscribe` notifications and on reconnect. `ProfilePage` and `AgentSelect` both manually overrode `createRenderRoot()` to return `this` (light DOM) — exactly what `OpenClawLightDomElement` already does — but inherited from raw `LitElement` instead, missing the locale controller.

The fix is mechanical: replace `extends LitElement` + manual `createRenderRoot` with `extends OpenClawLightDomElement` (which provides both light DOM and the locale controller).

## Evidence

- Exact head: `b0cdffe507` (3 files, +23/-12)
- `pnpm test:unit ui/src/lit/openclaw-element.test.ts` — 3 tests passed
  - Existing: light/shadow DOM structure, disconnect/reconnect locale tracking
  - New: "re-renders a light-DOM element when the active locale changes without disconnect"
- `pnpm check:changed` (core, coreTests lanes) — prod/test typechecks and lint passed
- The new regression test proves an `OpenClawLightDomElement` re-renders with updated translations on `i18n.setLocale("zh-CN")` while still mounted — before the fix, `ProfilePage` and `AgentSelect` (as raw `LitElement`) would not have this behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)