### PR TITLE
fix(signal): let controls bypass active debounce flush [AI-assisted]

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0d81b40bb07ac1cbf1d3e1ffb1f219907a4ae0e284a3c5b67343443a8c052235  plugin-sdk-api-baseline.json
-289650c203e232779e839b170e6c68616812c59b00f9083ca25776fbd2888fe6  plugin-sdk-api-baseline.jsonl
+7e1f207b6251a455c6f2384889aca4302bb16c55c792c60e5bfd56b20d64250c  plugin-sdk-api-baseline.json
+bf3f2d6dd704d2a3080cad41ac5dbaeb7edd05bbdfeb489e1f7e4b545c2e7eb3  plugin-sdk-api-baseline.jsonl

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -428,6 +428,95 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(context.UntrustedContext).toBeUndefined();
   });
 
+  it("dispatches an authorized stop while the same Signal debounce key is active", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    dispatchInboundMessageMock
+      .mockImplementationOnce(async (params: DispatchInboundMessageMockParams) => {
+        capture.ctx = params.ctx;
+        await firstGate;
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 1 } };
+      })
+      .mockImplementationOnce(async (params: DispatchInboundMessageMockParams) => {
+        capture.ctx = params.ctx;
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      });
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 5 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    const firstHandled = handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        sourceName: "Bob",
+        timestamp: 1700000000001,
+        dataMessage: { message: "start a long task", attachments: [] },
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    const stopHandled = handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        sourceName: "Bob",
+        timestamp: 1700000000002,
+        dataMessage: { message: "stop", attachments: [] },
+      }),
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      });
+      const stopContext = dispatchInboundMessageMock.mock.calls[1]?.[0].ctx;
+      expect(stopContext.CommandBody).toBe("stop");
+    } finally {
+      releaseFirst?.();
+      await Promise.allSettled([firstHandled, stopHandled]);
+    }
+  });
+
+  it("drops pending same-key Signal text when an authorized abort arrives", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 50 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: { message: "queued work", attachments: [] },
+      }),
+    );
+    await handler(
+      createSignalReceiveEvent({
+        timestamp: 1700000000001,
+        dataMessage: { message: "abort", attachments: [] },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundMessageMock.mock.calls[0]?.[0].ctx.CommandBody).toBe("abort");
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 75);
+    });
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+  });
+
   it("runs Telegram-parity Signal status reactions when explicitly enabled", async () => {
     dispatchInboundMessageMock.mockImplementationOnce(
       async (params: DispatchInboundMessageMockParams) => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -31,7 +31,8 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
-import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
+import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   createInternalHookEvent,
@@ -657,16 +658,20 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
   }
 
+  const buildSignalInboundDebounceKey = (entry: SignalInboundEntry): string | null => {
+    const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
+    if (!conversationId || !entry.senderPeerId) {
+      return null;
+    }
+    return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
+  };
+
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
-    buildKey: (entry) => {
-      const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
-      if (!conversationId || !entry.senderPeerId) {
-        return null;
-      }
-      return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
-    },
+    buildKey: buildSignalInboundDebounceKey,
+    shouldBypassKeyedChain: (entry) =>
+      entry.commandAuthorized && isControlCommandMessage(entry.commandBody, deps.cfg),
     shouldDebounce: (entry) => {
       return shouldDebounceTextInbound({
         text: entry.commandBody,
@@ -865,7 +870,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const messageText = normalizedMessage.trim();
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
-    const hasControlCommandInMessage = hasControlCommand(messageText, deps.cfg);
+    const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const { senderAccess, commandAccess } = await resolveSignalAccessState({
@@ -1190,7 +1195,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       typeof nativeReplyTargetTimestamp === "number"
         ? String(nativeReplyTargetTimestamp)
         : undefined;
-    await inboundDebouncer.enqueue({
+    const inboundEntry: SignalInboundEntry = {
       senderName,
       senderDisplay,
       senderRecipient,
@@ -1214,6 +1219,16 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
-    });
+    };
+    if (commandAuthorized && isAbortRequestText(messageText)) {
+      const debounceKey = buildSignalInboundDebounceKey(inboundEntry);
+      if (debounceKey) {
+        // Do not dispatch stale text that was still waiting in the debounce window when an
+        // authorized abort arrived. Active flushes cannot be cancelled, but the keyed-chain
+        // bypass above lets the abort reach reply admission immediately.
+        inboundDebouncer.cancelKey(debounceKey);
+      }
+    }
+    await inboundDebouncer.enqueue(inboundEntry);
   };
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -52,6 +52,7 @@ export type InboundDebounceCreateParams<T> = {
   maxTrackedKeys?: number;
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
+  shouldBypassKeyedChain?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
   serializeImmediate?: boolean;
   onFlush: (items: T[]) => Promise<void>;
@@ -217,6 +218,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     const key = params.buildKey(item);
     const debounceMs = resolveDebounceMs(item);
     const canDebounce = debounceMs > 0 && (params.shouldDebounce?.(item) ?? true);
+
+    if (params.shouldBypassKeyedChain?.(item) === true) {
+      // Urgent control work must be able to overtake a same-key flush that can encompass an
+      // entire agent run. Callers opt in explicitly; ordinary same-key ordering is unchanged.
+      await runFlush([item]);
+      return;
+    }
 
     if (!canDebounce || !key) {
       if (key) {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -635,6 +635,72 @@ describe("createInboundDebouncer", () => {
     }
   });
 
+  it("allows opted-in control work to bypass an active same-key flush", async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const debouncer = createInboundDebouncer<{
+      key: string;
+      id: string;
+      debounce: boolean;
+      bypass?: boolean;
+    }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      shouldDebounce: (item) => item.debounce,
+      shouldBypassKeyedChain: (item) => item.bypass === true,
+      onFlush: async (items) => {
+        const ids = items.map((entry) => entry.id).join(",");
+        started.push(ids);
+        if (ids === "1") {
+          await firstGate;
+        }
+        finished.push(ids);
+      },
+    });
+
+    try {
+      await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+
+      const timerIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 50);
+      expect(timerIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(setTimeoutSpy.mock.results[timerIndex]?.value as ReturnType<typeof setTimeout>);
+      const firstFlush = (
+        setTimeoutSpy.mock.calls[timerIndex]?.[0] as (() => Promise<void>) | undefined
+      )?.();
+
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1"]);
+      });
+
+      const controlEnqueue = debouncer.enqueue({
+        key: "a",
+        id: "stop",
+        debounce: false,
+        bypass: true,
+      });
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1", "stop"]);
+        expect(finished).toEqual(["stop"]);
+      });
+
+      if (!releaseFirst) {
+        throw new Error("Expected first inbound debounce release callback to be initialized");
+      }
+      releaseFirst();
+      await Promise.all([firstFlush, controlEnqueue]);
+
+      expect(finished).toEqual(["stop", "1"]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("keeps fire-and-forget keyed work ahead of a later buffered item", async () => {
     const started: string[] = [];
     const finished: string[] = [];


### PR DESCRIPTION
Fixes #103309

> **AI-assisted reference implementation:** this PR is intentionally written as a takeover-friendly implementation and design artifact. I understand the code path and verified the focused behavior locally; maintainers may prefer to rework or supersede it.

## What Problem This Solves

Fixes an issue where authorized Signal users cannot stop or control an active agent run from the same conversation because the later control message waits behind the active Signal inbound debounce flush.

The stop/control message is delayed before OpenClaw's fast-abort, reply-admission, queue, or steering logic can inspect it. As a result, `stop` or `/stop` is often handled only after the work it was meant to interrupt has already completed.

## Why This Change Was Made

This change adds an explicit, opt-in escape hatch for urgent work in the shared keyed inbound debouncer and enables it only for authorized Signal control messages.

Ordinary same-key message ordering remains unchanged. For authorized abort requests, Signal also drops normal text that is still waiting inside the debounce window, matching the intent of Telegram's existing stop bypass and preventing stale queued work from running after the abort.

## User Impact

Signal users can issue stop/abort and other authorized control messages while a previous same-conversation agent turn is still active. The control turn reaches existing command/abort handling immediately instead of waiting for the complete prior dispatch.

Normal Signal text still batches and preserves same-key FIFO ordering. Other channels are unchanged.

## Evidence

Focused local validation on the isolated source checkout:

- `pnpm test:extension signal` — 31 files, 483 tests passed
- `CI=true pnpm vitest run src/auto-reply/inbound.test.ts src/channels/inbound-debounce-policy.test.ts` — 2 files, 65 tests passed
- `pnpm check:changed` before the final upstream rebase — core, core-test, extension, and extension-test typechecks passed; its repository-wide core lint phase exceeded the 10-minute local command limit, so the final rebased four-file TypeScript diff was checked directly with `oxlint` instead
- `pnpm plugin-sdk:api:check` — passed after regenerating the checked-in API hash for the new optional parameter
- `pnpm exec oxlint <four touched TypeScript files>` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check` for the four changed files
- `git diff --check`

No live gateway, channel monitor, Nix profile, service, or OpenClaw configuration was rebuilt, reloaded, restarted, or switched during development. The running gateway remained on its existing Nix-store build.

## Detailed technical explanation

### Failure path before this change

Signal uses a debounce key containing account, conversation, and sender. The first buffered item reserves that key immediately; when its timer fires, Signal's `onFlush` awaits `handleSignalInboundMessage()`.

That await can cover the full agent/reply operation. A later control message is correctly marked non-debounced by `shouldDebounceTextInbound()`, but `createInboundDebouncer()` still sees the active `keyChains` entry and appends the control item behind it. The message therefore cannot reach the already-existing fast-abort or queue-policy code until the prior run settles.

This is why changing `messages.queue.mode` does not repair this Signal symptom: the later turn is blocked before queue policy.

### Generic change

`InboundDebounceCreateParams<T>` gains:

```ts
shouldBypassKeyedChain?: (item: T) => boolean;
```

When the predicate returns `true`, the debouncer calls the existing guarded `runFlush()` directly rather than joining or flushing the same-key chain. The option defaults to absent, so every existing caller retains current ordering semantics. The checked-in Plugin SDK API hash is regenerated because this optional parameter is part of the exported channel-inbound debounce surface.

This is deliberately separate from `shouldDebounce=false`:

- `shouldDebounce=false` means “do not wait for a debounce timer,” but still preserves same-key ordering.
- `shouldBypassKeyedChain=true` means “this item must not wait for an active same-key operation.”

Keeping the concepts separate avoids accidentally allowing media or ordinary immediate messages to overtake conversation work.

### Signal wiring

Signal opts into the bypass only when both conditions are true:

1. the ingress authorization result marks commands as authorized; and
2. `isControlCommandMessage(entry.commandBody, cfg)` identifies an exact control command or natural-language abort trigger.

`commandBody` is used rather than the rendered/enveloped body so detection matches command processing and is not confused by quote text, sender metadata, or media placeholders.

For `isAbortRequestText(messageText)`, Signal calls `cancelKey()` on the normal conversation key before enqueueing the control entry. This only removes work still inside the debounce buffer. It does not pretend to cancel an already-running flush; the bypass lets the existing abort handler perform that job at the reply/agent layer.

### Why this is opt-in rather than a global ordering change

The generic debouncer's same-key FIFO behavior is intentional and covered by existing tests. Removing it globally could reorder ordinary channel messages, attachments, or channel-specific immediate events.

The new predicate makes the exceptional concurrency explicit at the caller that owns the control semantics. This PR wires only Signal, leaving Telegram, Feishu, and other users unchanged.

## Tests added

1. **Generic debouncer regression**
   - Starts a timer-backed same-key flush and holds it open.
   - Enqueues an opted-in non-debounced control item.
   - Asserts that the control item starts and finishes before the first flush is released.

2. **Signal active-run regression**
   - Configures a non-zero Signal inbound debounce window.
   - Holds the first Signal dispatch open.
   - Sends authorized `stop` from the same sender/conversation.
   - Asserts the second dispatch starts while the first remains blocked.

3. **Signal pending-buffer cancellation**
   - Buffers ordinary Signal work.
   - Sends an authorized natural-language abort before the timer fires.
   - Asserts only the abort reaches dispatch and the stale buffered work does not fire later.

Existing same-key ordering tests continue to cover the non-bypass default.

## Prior art and related context

- #103309 — associated bug report and full reproduction/root-cause analysis.
- #83248 / `aa71f7fe15` — Telegram's authorized stop path cancels pending debounce buffers and bypasses its normal debounce key.
- #42803 — analogous control-lane problem in Feishu.
- #48003 and #48478 — broader active-turn queue/steering reports; this patch addresses the earlier Signal ingress boundary.
- `f5ebe63ecd` — made active same-key ordering unconditional in the generic debouncer, exposing the need for an explicit control escape hatch.

## Alternatives considered

### Return a null key for Signal controls

This mirrors part of Telegram's implementation and would be smaller, but it overloads key construction with control scheduling semantics and provides less reusable intent than an explicit predicate. The proposed API documents that the caller is bypassing an active chain, not merely disabling batching.

### Change all non-debounced items to bypass active chains

Rejected because media and other immediate same-key events may rely on FIFO ordering. `shouldDebounce=false` and “may overtake active work” are not equivalent.

### Fix only reply admission / queue mode

Insufficient for this reproduction. The Signal entry does not reach reply admission while it is waiting in the channel debouncer.

### Cancel the active debounce flush

The debounce layer does not own the active agent operation and should not attempt to cancel it. It should deliver the control message promptly so the existing abort layer can cancel the correct run.

## Boundaries and non-goals

- This PR does not change ordinary Signal batching, media ordering, reply admission, queue modes, or steering semantics.
- It does not modify Telegram or Feishu behavior.
- It does not add a new user-facing command.
- It does not bypass ingress or command authorization.
- It does not attempt to cancel an already-running agent directly from the Signal extension.
- It does not edit `CHANGELOG.md`.