### PR TITLE
fix(ci): reject skipped enabled Telegram package acceptance

### DIFF
--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -657,14 +657,15 @@ jobs:
     steps:
       - name: Verify package acceptance results
         env:
+          ADVISORY: ${{ inputs.advisory }}
           DOCKER_RESULT: ${{ needs.docker_acceptance.result }}
           PACKAGE_INTEGRITY_RESULT: ${{ needs.package_integrity.result }}
           PACKAGE_TELEGRAM_RESULT: ${{ needs.package_telegram.result }}
           RESOLVE_RESULT: ${{ needs.resolve_package.result }}
+          TELEGRAM_ENABLED: ${{ needs.resolve_package.outputs.telegram_enabled }}
         shell: bash
         run: |
           set -euo pipefail
-          advisory="${{ inputs.advisory }}"
           failed=0
           for item in \
             "resolve_package=${RESOLVE_RESULT}" \
@@ -674,8 +675,17 @@ jobs:
           do
             name="${item%%=*}"
             result="${item#*=}"
+            result_failed=false
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
-              if [[ "$advisory" == "true" && "$name" != "resolve_package" ]]; then
+              result_failed=true
+            fi
+            if [[ "$name" == "package_telegram" &&
+                  "$TELEGRAM_ENABLED" == "true" &&
+                  "$result" != "success" ]]; then
+              result_failed=true
+            fi
+            if [[ "$result_failed" == "true" ]]; then
+              if [[ "$ADVISORY" == "true" && "$name" != "resolve_package" ]]; then
                 echo "::warning::${name} ended with ${result}; package acceptance is advisory for this caller."
                 continue
               fi

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1,4 +1,5 @@
 // Package Acceptance Workflow tests cover package acceptance workflow script behavior.
+import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -112,6 +113,30 @@ function expectTextToIncludeAll(text: string | undefined, snippets: string[]): v
   for (const snippet of snippets) {
     expect(text).toContain(snippet);
   }
+}
+
+function runPackageAcceptanceSummary(params: {
+  advisory?: boolean;
+  telegramEnabled: boolean;
+  telegramResult: string;
+}) {
+  const summary = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "summary");
+  const script = workflowStep(summary, "Verify package acceptance results").run;
+  if (!script) {
+    throw new Error("Expected package acceptance summary script");
+  }
+  return spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      ADVISORY: String(params.advisory ?? false),
+      DOCKER_RESULT: "success",
+      PACKAGE_INTEGRITY_RESULT: "success",
+      PACKAGE_TELEGRAM_RESULT: params.telegramResult,
+      PATH: process.env.PATH,
+      RESOLVE_RESULT: "success",
+      TELEGRAM_ENABLED: String(params.telegramEnabled),
+    },
+  });
 }
 
 describe("package acceptance workflow", () => {
@@ -1771,6 +1796,42 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("PACKAGE_TELEGRAM_RESULT:");
     expect(workflow).toContain("package_telegram=${PACKAGE_TELEGRAM_RESULT}");
     expect(workflow).not.toContain("npm_telegram:");
+  });
+
+  it.each([
+    { telegramEnabled: true, telegramResult: "success" },
+    { telegramEnabled: false, telegramResult: "skipped" },
+  ])(
+    "accepts Telegram result $telegramResult when enabled=$telegramEnabled",
+    ({ telegramEnabled, telegramResult }) => {
+      const result = runPackageAcceptanceSummary({ telegramEnabled, telegramResult });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    },
+  );
+
+  it("rejects a skipped Telegram lane when package acceptance enabled it", () => {
+    const result = runPackageAcceptanceSummary({
+      telegramEnabled: true,
+      telegramResult: "skipped",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("::error::package_telegram ended with skipped");
+  });
+
+  it("preserves advisory handling for an unexpectedly skipped Telegram lane", () => {
+    const result = runPackageAcceptanceSummary({
+      advisory: true,
+      telegramEnabled: true,
+      telegramResult: "skipped",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "::warning::package_telegram ended with skipped; package acceptance is advisory for this caller.",
+    );
   });
 
   it("gives release build steps enough Node heap", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation gap where Package Acceptance could report success after the Telegram package job was unexpectedly skipped even though the selected profile enabled Telegram coverage.

## Why This Change Was Made

The final package verifier now reads the resolved Telegram-enabled state and requires the Telegram job to succeed when enabled. An intentional skip remains valid when Telegram is disabled, and advisory callers retain their existing warning-only behavior.

The regression tests execute the workflow's actual Bash verifier across enabled, disabled, failure, and advisory cases.

## User Impact

Release operators no longer receive a false-green Package Acceptance result when required Telegram package coverage never ran.

## Evidence

- Testbox-through-Crabbox `tbx_01kx4zsqtgtrfzeytwbexmnbkw`: `test/scripts/package-acceptance-workflow.test.ts`, 49/49 passed after rebasing onto current `main`.
- `pnpm check:changed`: tooling lane passed on Testbox-through-Crabbox.
- Fresh Codex autoreview after the current-main rebase: no accepted or actionable findings.

AI-assisted: yes. The change was reviewed and its decision table was verified directly.
