### PR TITLE
fix(ci): restore DeepSeek live gateway coverage

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2099,7 +2099,7 @@ jobs:
             profiles: full
           - suite_id: native-live-src-gateway-profiles-deepseek
             label: Native live gateway profiles DeepSeek
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek OPENCLAW_LIVE_GATEWAY_MODELS=deepseek/deepseek-v4-flash,deepseek/deepseek-v4-pro node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 30
             profile_env_only: false
             advisory: true

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -56,6 +56,13 @@ type WorkflowStep = {
   with?: Record<string, string>;
 };
 
+type WorkflowMatrixEntry = {
+  advisory?: boolean;
+  command?: string;
+  profiles?: string;
+  suite_id?: string;
+};
+
 type WorkflowJob = {
   concurrency?: {
     group?: string;
@@ -67,6 +74,11 @@ type WorkflowJob = {
   needs?: string | string[];
   permissions?: Record<string, string>;
   "runs-on"?: string;
+  strategy?: {
+    matrix?: {
+      include?: WorkflowMatrixEntry[];
+    };
+  };
   "timeout-minutes"?: number | string;
   steps?: WorkflowStep[];
 };
@@ -104,6 +116,16 @@ function workflowStep(job: WorkflowJob, stepName: string): WorkflowStep {
     throw new Error(`Expected workflow step ${stepName}`);
   }
   return step;
+}
+
+function workflowMatrixEntry(path: string, jobName: string, suiteId: string): WorkflowMatrixEntry {
+  const entry = workflowJob(path, jobName).strategy?.matrix?.include?.find(
+    (candidate) => candidate.suite_id === suiteId,
+  );
+  if (!entry) {
+    throw new Error(`Expected workflow matrix entry ${suiteId} in ${jobName}`);
+  }
+  return entry;
 }
 
 function expectTextToIncludeAll(text: string | undefined, snippets: string[]): void {
@@ -1078,6 +1100,29 @@ describe("package artifact reuse", () => {
     expect(
       workflow.match(/moonshot\) require_any Moonshot MOONSHOT_API_KEY KIMI_API_KEY ;;/gu),
     ).toHaveLength(2);
+  });
+
+  it("pins DeepSeek live profiles to both current V4 model refs", () => {
+    const deepSeek = workflowMatrixEntry(
+      LIVE_E2E_WORKFLOW,
+      "validate_live_provider_suites",
+      "native-live-src-gateway-profiles-deepseek",
+    );
+    const openCodeGo = workflowMatrixEntry(
+      LIVE_E2E_WORKFLOW,
+      "validate_live_provider_suites",
+      "native-live-src-gateway-profiles-opencode-go-deepseek-glm",
+    );
+
+    expect(deepSeek).toMatchObject({
+      advisory: true,
+      command:
+        "OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek OPENCLAW_LIVE_GATEWAY_MODELS=deepseek/deepseek-v4-flash,deepseek/deepseek-v4-pro node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles",
+      profiles: "full",
+    });
+    expect(openCodeGo.command).toContain(
+      "OPENCLAW_LIVE_GATEWAY_MODELS=opencode-go/deepseek-v4-flash,opencode-go/deepseek-v4-pro",
+    );
   });
 
   it("runs Docker live harnesses from trusted helper scripts", () => {


### PR DESCRIPTION
Closes #103319

## What Problem This Solves

Fixes an issue where full-profile release validation would exercise no native DeepSeek gateway model when the source-test registry returned no DeepSeek rows.

## Why This Change Was Made

The dedicated DeepSeek lane now passes both current canonical refs, `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`, through the gateway harness's existing explicit-ref path. A structured workflow test binds those refs to the exact DeepSeek matrix entry and checks the sibling OpenCode Go V4 lane, preventing provider-only selection from yielding an empty lane.

## User Impact

Release maintainers regain real native DeepSeek V4 gateway coverage in the full profile. Product runtime behavior, provider metadata, and credentials are unchanged.

## Evidence

- Before: Release Checks job `86275900019` at `9ad38e77394f1fc14b54149e82b97182693e0777` reported `selected no high-signal live models ... from 0 registry model(s)`.
- Current contract: the DeepSeek plugin manifest, provider index, and official API docs all expose `deepseek-v4-flash` and `deepseek-v4-pro` through the OpenAI Chat Completions interface.
- Blacksmith Testbox `tbx_01kx51749nnvt41xhzkq4xfstv`: `corepack pnpm test test/scripts/package-acceptance-workflow.test.ts` passed 50/50.
- Blacksmith Testbox: `corepack pnpm check:workflows` passed actionlint, zizmor, and workflow interpolation guards.
- Blacksmith Testbox: `corepack pnpm check:changed` passed the tooling lane.
- `corepack pnpm format:check -- .github/workflows/openclaw-live-and-e2e-checks-reusable.yml test/scripts/package-acceptance-workflow.test.ts` passed before the exact-head rebase; the rebased diff is byte-identical.
- Fresh autoreview: no accepted/actionable findings.

AI-assisted implementation and review. No credentials were added or changed.
