### PR TITLE
improve: retry transient live image probe mismatches

### DIFF
--- a/src/agents/live-model-turn-probes.test.ts
+++ b/src/agents/live-model-turn-probes.test.ts
@@ -1,5 +1,5 @@
 // Covers live model extra-probe builders, matchers, and route skip lists.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   buildLiveModelFileProbeContext,
   buildLiveModelFileProbeRetryContext,
@@ -14,6 +14,21 @@ import {
   shouldSkipLiveModelFileProbe,
   shouldSkipLiveModelImageProbe,
 } from "./live-model-turn-probes.js";
+
+function createImageProbeRunner(responses: string[]) {
+  const attempts: Array<1 | 2> = [];
+  return {
+    attempts,
+    run: async (attempt: 1 | 2) => {
+      attempts.push(attempt);
+      const response = responses[attempt - 1];
+      if (response === undefined) {
+        throw new Error(`Unexpected image probe attempt ${attempt}`);
+      }
+      return response;
+    },
+  };
+}
 
 describe("live model turn probes", () => {
   it("defaults probes on and accepts common opt-out values", () => {
@@ -179,63 +194,61 @@ describe("live model turn probes", () => {
   });
 
   it("retries one mismatched image reply and accepts only a matching retry", async () => {
-    const run = vi
-      .fn<(attempt: 1 | 2) => Promise<string>>()
-      .mockResolvedValueOnce("blue")
-      .mockResolvedValueOnce("OK");
-    const onRetry = vi.fn();
+    const { attempts, run } = createImageProbeRunner(["blue", "OK"]);
+    const retries: string[] = [];
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry })).resolves.toBe("OK");
-    expect(run.mock.calls).toEqual([[1], [2]]);
-    expect(onRetry).toHaveBeenCalledWith("blue");
+    await expect(
+      runLiveModelImageProbeWithRetry({
+        run,
+        onRetry: (firstText) => retries.push(firstText),
+      }),
+    ).resolves.toBe("OK");
+    expect(attempts).toEqual([1, 2]);
+    expect(retries).toEqual(["blue"]);
   });
 
   it("does not retry an image reply that already matches", async () => {
-    const run = vi.fn<(attempt: 1 | 2) => Promise<string>>().mockResolvedValue("OK");
-    const onRetry = vi.fn();
+    const { attempts, run } = createImageProbeRunner(["OK"]);
+    const retries: string[] = [];
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry })).resolves.toBe("OK");
-    expect(run.mock.calls).toEqual([[1]]);
-    expect(onRetry).not.toHaveBeenCalled();
+    await expect(
+      runLiveModelImageProbeWithRetry({
+        run,
+        onRetry: (firstText) => retries.push(firstText),
+      }),
+    ).resolves.toBe("OK");
+    expect(attempts).toEqual([1]);
+    expect(retries).toEqual([]);
   });
 
   it("fails when the image retry also does not match", async () => {
-    const run = vi
-      .fn<(attempt: 1 | 2) => Promise<string>>()
-      .mockResolvedValueOnce("blue")
-      .mockResolvedValueOnce('" or "Reply with exactly');
+    const { attempts, run } = createImageProbeRunner(["blue", '" or "Reply with exactly']);
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).rejects.toThrow(
       "image probe did not return ok after retry",
     );
-    expect(run).toHaveBeenCalledTimes(2);
+    expect(attempts).toEqual([1, 2]);
   });
 
   it("does not turn a mismatched image reply into an empty-response skip", async () => {
-    const run = vi
-      .fn<(attempt: 1 | 2) => Promise<string>>()
-      .mockResolvedValueOnce("blue")
-      .mockResolvedValueOnce("");
+    const { run } = createImageProbeRunner(["blue", ""]);
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).rejects.toThrow(
       "attempt 2: <empty>",
     );
   });
 
   it("retains the empty-response skip only after two empty attempts", async () => {
-    const run = vi.fn<(attempt: 1 | 2) => Promise<string>>().mockResolvedValue("");
+    const { attempts, run } = createImageProbeRunner(["", ""]);
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).resolves.toBe("");
-    expect(run).toHaveBeenCalledTimes(2);
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).resolves.toBe("");
+    expect(attempts).toEqual([1, 2]);
   });
 
   it("fails when an empty image reply is followed by a mismatch", async () => {
-    const run = vi
-      .fn<(attempt: 1 | 2) => Promise<string>>()
-      .mockResolvedValueOnce("")
-      .mockResolvedValueOnce("blue");
+    const { run } = createImageProbeRunner(["", "blue"]);
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).rejects.toThrow(
       "attempt 1: <empty>",
     );
   });

--- a/src/agents/live-model-turn-probes.test.ts
+++ b/src/agents/live-model-turn-probes.test.ts
@@ -1,5 +1,5 @@
 // Covers live model extra-probe builders, matchers, and route skip lists.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildLiveModelFileProbeContext,
   buildLiveModelFileProbeRetryContext,
@@ -9,6 +9,7 @@ import {
   isLiveModelProbeEnabled,
   LIVE_MODEL_FILE_PROBE_TOKEN,
   modelSupportsImageInput,
+  runLiveModelImageProbeWithRetry,
   shouldSkipLiveModelExtraProbes,
   shouldSkipLiveModelFileProbe,
   shouldSkipLiveModelImageProbe,
@@ -174,5 +175,68 @@ describe("live model turn probes", () => {
     expect(fileProbeTextMatches("amber")).toBe(false);
     expect(imageProbeTextMatches("OK")).toBe(true);
     expect(imageProbeTextMatches("blue")).toBe(false);
+    expect(imageProbeTextMatches('" or "Reply with exactly')).toBe(false);
+  });
+
+  it("retries one mismatched image reply and accepts only a matching retry", async () => {
+    const run = vi
+      .fn<(attempt: 1 | 2) => Promise<string>>()
+      .mockResolvedValueOnce("blue")
+      .mockResolvedValueOnce("OK");
+    const onRetry = vi.fn();
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry })).resolves.toBe("OK");
+    expect(run.mock.calls).toEqual([[1], [2]]);
+    expect(onRetry).toHaveBeenCalledWith("blue");
+  });
+
+  it("does not retry an image reply that already matches", async () => {
+    const run = vi.fn<(attempt: 1 | 2) => Promise<string>>().mockResolvedValue("OK");
+    const onRetry = vi.fn();
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry })).resolves.toBe("OK");
+    expect(run.mock.calls).toEqual([[1]]);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("fails when the image retry also does not match", async () => {
+    const run = vi
+      .fn<(attempt: 1 | 2) => Promise<string>>()
+      .mockResolvedValueOnce("blue")
+      .mockResolvedValueOnce('" or "Reply with exactly');
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+      "image probe did not return ok after retry",
+    );
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not turn a mismatched image reply into an empty-response skip", async () => {
+    const run = vi
+      .fn<(attempt: 1 | 2) => Promise<string>>()
+      .mockResolvedValueOnce("blue")
+      .mockResolvedValueOnce("");
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+      "attempt 2: <empty>",
+    );
+  });
+
+  it("retains the empty-response skip only after two empty attempts", async () => {
+    const run = vi.fn<(attempt: 1 | 2) => Promise<string>>().mockResolvedValue("");
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).resolves.toBe("");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails when an empty image reply is followed by a mismatch", async () => {
+    const run = vi
+      .fn<(attempt: 1 | 2) => Promise<string>>()
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("blue");
+
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: vi.fn() })).rejects.toThrow(
+      "attempt 1: <empty>",
+    );
   });
 });

--- a/src/agents/live-model-turn-probes.test.ts
+++ b/src/agents/live-model-turn-probes.test.ts
@@ -221,6 +221,24 @@ describe("live model turn probes", () => {
     expect(retries).toEqual([]);
   });
 
+  it("does not retry provider errors", async () => {
+    const attempts: Array<1 | 2> = [];
+    const retries: string[] = [];
+    const run = async (attempt: 1 | 2): Promise<string> => {
+      attempts.push(attempt);
+      throw new Error("boom");
+    };
+
+    await expect(
+      runLiveModelImageProbeWithRetry({
+        run,
+        onRetry: (firstText) => retries.push(firstText),
+      }),
+    ).rejects.toThrow("boom");
+    expect(attempts).toEqual([1]);
+    expect(retries).toEqual([]);
+  });
+
   it("fails when the image retry also does not match", async () => {
     const { attempts, run } = createImageProbeRunner(["blue", '" or "Reply with exactly']);
 
@@ -238,10 +256,12 @@ describe("live model turn probes", () => {
     );
   });
 
-  it("retains the empty-response skip only after two empty attempts", async () => {
+  it("fails after two empty image replies", async () => {
     const { attempts, run } = createImageProbeRunner(["", ""]);
 
-    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).resolves.toBe("");
+    await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).rejects.toThrow(
+      "attempt 1: <empty>; attempt 2: <empty>",
+    );
     expect(attempts).toEqual([1, 2]);
   });
 
@@ -251,5 +271,15 @@ describe("live model turn probes", () => {
     await expect(runLiveModelImageProbeWithRetry({ run, onRetry: () => {} })).rejects.toThrow(
       "attempt 1: <empty>",
     );
+  });
+
+  it("redacts nonmatching image replies from failure diagnostics", async () => {
+    const { run } = createImageProbeRunner(["first private reply", "second private reply"]);
+
+    const error = await runLiveModelImageProbeWithRetry({ run, onRetry: () => {} }).catch(
+      (cause: unknown) => String(cause),
+    );
+    expect(error).toContain("<non-matching response:");
+    expect(error).not.toContain("private reply");
   });
 });

--- a/src/agents/live-model-turn-probes.ts
+++ b/src/agents/live-model-turn-probes.ts
@@ -158,3 +158,39 @@ export function fileProbeTextMatches(text: string): boolean {
 export function imageProbeTextMatches(text: string): boolean {
   return /\bok\b/i.test(text);
 }
+
+function formatImageProbeText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "<empty>";
+  }
+  const clipped = normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+  return JSON.stringify(clipped);
+}
+
+/** Retries one ambiguous image reply without weakening the strict OK matcher. */
+export async function runLiveModelImageProbeWithRetry(params: {
+  run: (attempt: 1 | 2) => Promise<string>;
+  onRetry: (firstText: string) => void;
+}): Promise<string> {
+  const firstText = await params.run(1);
+  if (imageProbeTextMatches(firstText)) {
+    return firstText;
+  }
+
+  params.onRetry(firstText);
+  const retryText = await params.run(2);
+  if (imageProbeTextMatches(retryText)) {
+    return retryText;
+  }
+
+  // Preserve the existing empty-response skip only when neither attempt produced a signal.
+  if (firstText.length === 0 && retryText.length === 0) {
+    return retryText;
+  }
+  throw new Error(
+    "image probe did not return ok after retry " +
+      `(attempt 1: ${formatImageProbeText(firstText)}; ` +
+      `attempt 2: ${formatImageProbeText(retryText)})`,
+  );
+}

--- a/src/agents/live-model-turn-probes.ts
+++ b/src/agents/live-model-turn-probes.ts
@@ -164,8 +164,7 @@ function formatImageProbeText(text: string): string {
   if (!normalized) {
     return "<empty>";
   }
-  const clipped = normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
-  return JSON.stringify(clipped);
+  return `<non-matching response: ${normalized.length} chars>`;
 }
 
 /** Retries one ambiguous image reply without weakening the strict OK matcher. */
@@ -184,10 +183,6 @@ export async function runLiveModelImageProbeWithRetry(params: {
     return retryText;
   }
 
-  // Preserve the existing empty-response skip only when neither attempt produced a signal.
-  if (firstText.length === 0 && retryText.length === 0) {
-    return retryText;
-  }
   throw new Error(
     "image probe did not return ok after retry " +
       `(attempt 1: ${formatImageProbeText(firstText)}; ` +

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -1688,7 +1688,7 @@ async function runExtraTurnProbes(params: {
     return;
   }
 
-  const imageText = await runLiveModelImageProbeWithRetry({
+  await runLiveModelImageProbeWithRetry({
     run: async (attempt) => {
       const attemptLabel = `${params.progressLabel}: image probe attempt ${attempt}/2`;
       logProgress(attemptLabel);
@@ -1699,8 +1699,12 @@ async function runExtraTurnProbes(params: {
         params.timeoutMs,
         attemptLabel,
       );
-      if (image.stopReason === "error") {
-        throw new Error(image.errorMessage || `${attemptLabel} returned error with no message`);
+      if (image.stopReason === "error" || image.stopReason === "aborted") {
+        const fallback =
+          image.stopReason === "aborted"
+            ? `${attemptLabel} was aborted`
+            : `${attemptLabel} returned error with no message`;
+        throw new Error(image.errorMessage || fallback);
       }
       return extractAssistantText(image);
     },
@@ -1709,9 +1713,6 @@ async function runExtraTurnProbes(params: {
       logProgress(`${params.progressLabel}: image probe attempt 1/2 ${reason}; retrying once`);
     },
   });
-  if (imageText.length === 0) {
-    logProgress(`${params.progressLabel}: image probe skipped (two empty responses)`);
-  }
 }
 
 describeLive("live models (profile keys)", () => {

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -40,12 +40,12 @@ import {
   buildLiveModelFileProbeRetryContext,
   buildLiveModelImageProbeContext,
   fileProbeTextMatches,
-  imageProbeTextMatches,
   isLiveModelProbeEnabled,
   LIVE_MODEL_FILE_PROBE_ENV,
   LIVE_MODEL_FILE_PROBE_TOKEN,
   LIVE_MODEL_IMAGE_PROBE_ENV,
   modelSupportsImageInput,
+  runLiveModelImageProbeWithRetry,
   shouldSkipLiveModelExtraProbes,
   shouldSkipLiveModelFileProbe,
   shouldSkipLiveModelImageProbe,
@@ -1688,24 +1688,29 @@ async function runExtraTurnProbes(params: {
     return;
   }
 
-  logProgress(`${params.progressLabel}: image probe`);
-  const image = await completeSimpleWithTimeout(
-    params.model,
-    buildLiveModelImageProbeContext({ systemPrompt: resolveLiveSystemPrompt(params.model) }),
-    options,
-    params.timeoutMs,
-    `${params.progressLabel}: image probe`,
-  );
-  if (image.stopReason === "error") {
-    throw new Error(image.errorMessage || "image probe returned error with no message");
-  }
-  const imageText = extractAssistantText(image);
-  if (!imageProbeTextMatches(imageText)) {
-    if (imageText.length === 0) {
-      logProgress(`${params.progressLabel}: image probe skipped (empty response)`);
-      return;
-    }
-    throw new Error(`image probe did not return ok: ${imageText}`);
+  const imageText = await runLiveModelImageProbeWithRetry({
+    run: async (attempt) => {
+      const attemptLabel = `${params.progressLabel}: image probe attempt ${attempt}/2`;
+      logProgress(attemptLabel);
+      const image = await completeSimpleWithTimeout(
+        params.model,
+        buildLiveModelImageProbeContext({ systemPrompt: resolveLiveSystemPrompt(params.model) }),
+        options,
+        params.timeoutMs,
+        attemptLabel,
+      );
+      if (image.stopReason === "error") {
+        throw new Error(image.errorMessage || `${attemptLabel} returned error with no message`);
+      }
+      return extractAssistantText(image);
+    },
+    onRetry: (firstText) => {
+      const reason = firstText.length === 0 ? "was empty" : "did not return ok";
+      logProgress(`${params.progressLabel}: image probe attempt 1/2 ${reason}; retrying once`);
+    },
+  });
+  if (imageText.length === 0) {
+    logProgress(`${params.progressLabel}: image probe skipped (two empty responses)`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure mode where one transient non-OK image-probe reply from an otherwise healthy live model aborts the mandatory provider lane and fail-fast cancels downstream Docker, package, and cross-OS proof.

## Why This Change Was Made

The live image probe now retries exactly once after an ambiguous reply while applying the same strict `OK` matcher to both attempts. Provider errors and aborted calls fail immediately, and every second nonmatch—including empty output—still fails. Known-empty routes remain owned by the existing explicit model exclusions. Attempt labels and bounded, content-redacted response classifications make failures attributable without adding a provider/model-specific skip.

## User Impact

No runtime or user-visible behavior changes. Release validation is less brittle to a single transient model-format wobble without hiding deterministic image regressions.

## Evidence

- Initial failure: Google credentials and primary prompts passed, but `google/gemini-3.1-pro-preview` returned a prompt-like image-probe fragment: https://github.com/openclaw/openclaw/actions/runs/29065324694/job/86277309475
- Same-SHA retry passed both Google models, showing the provider response was transient: https://github.com/openclaw/openclaw/actions/runs/29065324694/job/86279581212
- Independent pre-change route-health rerun at `6db586a388c639796e312811b4d9801ca6ce1806`: both Google models passed, 37/37 assertions: https://github.com/openclaw/openclaw/actions/runs/29066942234/job/86280888954
- Exact-head Testbox-through-Crabbox `tbx_01kx548xqy8t9qgzm4a9a0h8c8`: `src/agents/live-model-turn-probes.test.ts` passed 17/17 in the unit-fast shard: https://github.com/openclaw/openclaw/actions/runs/29068953955
- Exact-head `pnpm check:changed` passed core/coreTests typecheck, lint, and guards with zero warnings or errors.
- Fresh structured autoreview: no accepted/actionable findings.

AI-assisted with Codex; the final behavior, diagnostics, tests, and live evidence were inspected before submission.
