### PR TITLE
fix(ui): stabilize locale-reactivity tests across module resets

### DIFF
--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -3,7 +3,15 @@
 import { expect, it, vi } from "vitest";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
-import "./agent-select.ts";
+import { AgentSelect } from "./agent-select.ts";
+
+const AGENT_SELECT_TEST_TAG = "test-openclaw-agent-select";
+
+// The shared jsdom registry outlives Vitest's per-file module reset. Use the
+// freshly imported class so locale state and the element controller stay paired.
+if (!customElements.get(AGENT_SELECT_TEST_TAG)) {
+  customElements.define(AGENT_SELECT_TEST_TAG, class extends AgentSelect {});
+}
 
 type AgentSelectElement = HTMLElement & {
   agents: GatewayAgentRow[];
@@ -36,7 +44,7 @@ function createIdentity(
 async function createAgentSelect(
   overrides: Partial<Omit<AgentSelectElement, keyof HTMLElement>> = {},
 ): Promise<AgentSelectElement> {
-  const element = document.createElement("openclaw-agent-select") as AgentSelectElement;
+  const element = document.createElement(AGENT_SELECT_TEST_TAG) as AgentSelectElement;
   element.agents = agents;
   element.selectedId = "alpha";
   Object.assign(element, overrides);
@@ -336,8 +344,9 @@ it("refreshes translated labels when the locale changes while mounted", async ()
     await i18n.setLocale("zh-CN");
     await element.updateComplete;
 
-    expect(label?.textContent?.trim()).toBe(t("agents.noAgents"));
-    expect(label?.textContent?.trim()).not.toBe(englishLabel);
+    const translatedLabel = element.querySelector(".agent-select__label");
+    expect(translatedLabel?.textContent?.trim()).toBe(t("agents.noAgents"));
+    expect(translatedLabel?.textContent?.trim()).not.toBe(englishLabel);
   } finally {
     element.remove();
     await i18n.setLocale("en");

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -11,7 +11,7 @@ import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 
-class AgentSelect extends OpenClawLightDomElement {
+export class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) agents: GatewayAgentRow[] = [];
   @property({ attribute: false }) selectedId: string | null = null;
   @property({ attribute: false }) defaultId: string | null = null;

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -10,9 +10,10 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { i18n, t } from "../../i18n/index.ts";
-import "./profile-page.ts";
+import { ProfilePage } from "./profile-page.ts";
 
 const PROVIDER_ELEMENT_NAME = "test-profile-page-context-provider";
+const PROFILE_PAGE_TEST_TAG = "test-openclaw-profile-page";
 
 class ProfilePageContextProvider extends LitElement {
   private readonly contextProvider = new ContextProvider(this, {
@@ -26,6 +27,10 @@ class ProfilePageContextProvider extends LitElement {
 
 if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
   customElements.define(PROVIDER_ELEMENT_NAME, ProfilePageContextProvider);
+}
+// Keep the element class on the same post-reset i18n module as this test.
+if (!customElements.get(PROFILE_PAGE_TEST_TAG)) {
+  customElements.define(PROFILE_PAGE_TEST_TAG, class extends ProfilePage {});
 }
 
 type ProfilePageElement = HTMLElement & {
@@ -62,7 +67,7 @@ afterEach(async () => {
 
 it("refreshes translated copy when the locale changes while mounted", async () => {
   const provider = document.createElement(PROVIDER_ELEMENT_NAME) as ProfilePageContextProvider;
-  const page = document.createElement("openclaw-profile-page") as ProfilePageElement;
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
   provider.setContext(createContext());
   provider.append(page);
   document.body.append(provider);

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -85,7 +85,7 @@ function toErrorMessage(error: unknown): string {
   return typeof error === "string" ? error : "request failed";
 }
 
-class ProfilePage extends OpenClawLightDomElement {
+export class ProfilePage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ApplicationContext;
 
@@ -540,4 +540,6 @@ class ProfilePage extends OpenClawLightDomElement {
   }
 }
 
-customElements.define("openclaw-profile-page", ProfilePage);
+if (!customElements.get("openclaw-profile-page")) {
+  customElements.define("openclaw-profile-page", ProfilePage);
+}


### PR DESCRIPTION
Closes #103333

AI-assisted: Codex investigated, implemented, tested, and reviewed this fix.

## What Problem This Solves

Fixes an issue where Control UI locale-reactivity tests intermittently failed when another test file registered the same custom element first. The shared jsdom custom-element registry retained a class tied to the prior file's i18n module even though Vitest reset evaluated modules between files.

## Why This Change Was Made

The selector and profile tests now define test-only subclasses from their freshly imported component classes, keeping each mounted element and the test's i18n singleton on the same module generation. The profile page registration is also guarded for safe re-imports, and the selector assertion reads the live post-update DOM.

## User Impact

No user-visible product behavior changes. Maintainers get stable Control UI CI for locale changes instead of worker-order-dependent English/Chinese assertion failures.

## Evidence

Before the fix, the same `expected 'No agents' to be '无代理'` failure appeared in three independent jobs:

- Main CI: https://github.com/openclaw/openclaw/actions/runs/29066831874/job/86280297679
- PR CI: https://github.com/openclaw/openclaw/actions/runs/29067322022/job/86281613647
- PR CI after rebase: https://github.com/openclaw/openclaw/actions/runs/29067604370/job/86282443418

Deterministic Testbox reproduction:

- A preload test registered `openclaw-agent-select`, then the non-isolated runner reset modules before `agent-select.test.ts`.
- `--maxWorkers=1 --no-file-parallelism --sequence.shuffle --sequence.seed=1` forced preload-first order.
- Before: 1 failure / 14 tests with the exact English-vs-Chinese assertion.
- After: 14/14 passed in the same order.
- The analogous profile-page preload reproduced a duplicate-registration exception before the guard; 2/2 passed after the guard and fresh test subclass.

Validation for cleaned head `e54b37e7ee621258e50f887aad3b5213afc160d6`, based directly on `a2d5f32cef518cb89807cdf39ead2af846546bc5`:

- `pnpm check:changed -- ui/src/components/agent-select.test.ts ui/src/components/agent-select.ts ui/src/pages/profile/profile-page.test.ts ui/src/pages/profile/profile-page.ts` — passed, including tsgo, lint, import-cycle, and repository guards.
- `pnpm test ui/src -- --reporter=dot` — 188 files and 2,691 tests passed.
- Focused selector + profile tests — 14/14 passed.
- Fresh repository autoreview — clean, no actionable findings.
- Exact-head hosted CI target shard `checks-node-compact-large-whole-1` — passed: https://github.com/openclaw/openclaw/actions/runs/29068581251/job/86285277744
- Exact-head hosted `check-test-types` and `check-lint` — passed in the same run.
