### PR TITLE
fix(xai): preserve Grok thinking through the x-ai alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
+- **xAI provider aliases:** preserve Grok 4.3 and Grok 4.5 thinking profiles, fast-model routing, and encrypted reasoning replay when models use the shipped `x-ai` provider alias instead of clamping valid thinking requests to `minimal`. (#103315)
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)
 - **Google music generation:** retry one unblocked Lyria response that omits its contractually required audio while keeping prompt blocks and terminal generation stops non-retryable. (#103318)

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -503,6 +503,12 @@ describe("xai provider plugin", () => {
         expected: true,
       },
       {
+        label: "exposes by default for the shipped xAI provider alias with auth",
+        provider: "x-ai",
+        hasAuth: true,
+        expected: true,
+      },
+      {
         label: "exposes when explicitly enabled for an xAI model with auth",
         provider: "xai",
         enabled: true,

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -21,6 +21,7 @@ import {
   buildLiveXaiProvider,
   buildXaiProvider,
 } from "./provider-catalog.js";
+import { isXaiProviderId } from "./provider-id.js";
 import { isModernXaiModel, resolveXaiForwardCompatModel } from "./provider-models.js";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 import { buildXaiRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
@@ -103,7 +104,7 @@ function shouldExposeXaiBilledTool(params: {
   }
   // Cross-provider billing requires explicit consent; xAI models retain the
   // credential-backed default. Unknown providers fail closed.
-  return activeProvider === PROVIDER_ID || params.enabled === true;
+  return isXaiProviderId(activeProvider) || params.enabled === true;
 }
 
 function createLazyCodeExecutionTool(ctx: OpenClawPluginToolContext) {

--- a/extensions/xai/provider-id.ts
+++ b/extensions/xai/provider-id.ts
@@ -1,0 +1,8 @@
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+
+const XAI_PROVIDER_IDS = new Set(["xai", "x-ai"]);
+
+// Provider dispatch preserves the selected alias. Keep all xAI-owned runtime policy symmetric.
+export function isXaiProviderId(provider: unknown): boolean {
+  return typeof provider === "string" && XAI_PROVIDER_IDS.has(normalizeProviderId(provider));
+}

--- a/extensions/xai/provider-policy-api.test.ts
+++ b/extensions/xai/provider-policy-api.test.ts
@@ -3,39 +3,47 @@ import { describe, expect, it } from "vitest";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("xai provider thinking policy", () => {
-  it.each(["grok-4.3", "grok-4.3-latest", "grok-latest"])(
-    "exposes Grok 4.3 thinking levels for %s",
-    (modelId) => {
-      const profile = resolveThinkingProfile({
-        provider: "xai",
-        modelId,
-      });
+  it.each([
+    ["xai", "grok-4.3"],
+    ["xai", "grok-4.3-latest"],
+    ["xai", "grok-latest"],
+    ["x-ai", "grok-4.3"],
+    ["x-ai", "grok-4.3-latest"],
+    ["x-ai", "grok-latest"],
+  ])("exposes Grok 4.3 thinking levels for %s/%s", (provider, modelId) => {
+    const profile = resolveThinkingProfile({
+      provider,
+      modelId,
+    });
 
-      expect(profile.defaultLevel).toBe("low");
-      expect(profile.levels.map((level) => level.id)).toEqual([
-        "off",
-        "minimal",
-        "low",
-        "medium",
-        "high",
-      ]);
-    },
-  );
+    expect(profile.defaultLevel).toBe("low");
+    expect(profile.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
 
-  it.each(["grok-4.5", "grok-4.5-latest", "grok-build-latest"])(
-    "uses xAI's high reasoning default for %s",
-    (modelId) => {
-      const profile = resolveThinkingProfile({
-        provider: "xai",
-        modelId,
-      });
+  it.each([
+    ["xai", "grok-4.5"],
+    ["xai", "grok-4.5-latest"],
+    ["xai", "grok-build-latest"],
+    ["x-ai", "grok-4.5"],
+    ["x-ai", "grok-4.5-latest"],
+    ["x-ai", "grok-build-latest"],
+  ])("uses xAI's high reasoning default for %s/%s", (provider, modelId) => {
+    const profile = resolveThinkingProfile({
+      provider,
+      modelId,
+    });
 
-      expect(profile).toEqual({
-        levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
-        defaultLevel: "high",
-      });
-    },
-  );
+    expect(profile).toEqual({
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "high",
+    });
+  });
 
   it("keeps non-reasoning and non-xai routes off-only", () => {
     expect(
@@ -54,13 +62,17 @@ describe("xai provider thinking policy", () => {
     ).toEqual({ levels: [{ id: "off" }], defaultLevel: "off" });
   });
 
-  it.each(["grok-build-0.1", "grok-4.20-0309-reasoning", "grok-4.20-beta-latest-reasoning"])(
-    "does not advertise configurable reasoning for %s",
-    (modelId) => {
-      expect(resolveThinkingProfile({ provider: "xai", modelId })).toEqual({
-        levels: [{ id: "off" }],
-        defaultLevel: "off",
-      });
-    },
-  );
+  it.each([
+    ["xai", "grok-build-0.1"],
+    ["xai", "grok-4.20-0309-reasoning"],
+    ["xai", "grok-4.20-beta-latest-reasoning"],
+    ["x-ai", "grok-build-0.1"],
+    ["x-ai", "grok-4.20-0309-reasoning"],
+    ["x-ai", "grok-4.20-beta-latest-reasoning"],
+  ])("does not advertise configurable reasoning for %s/%s", (provider, modelId) => {
+    expect(resolveThinkingProfile({ provider, modelId })).toEqual({
+      levels: [{ id: "off" }],
+      defaultLevel: "off",
+    });
+  });
 });

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -5,12 +5,13 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
 import { normalizeXaiModelId } from "./model-id.js";
+import { isXaiProviderId } from "./provider-id.js";
 
 export function resolveThinkingProfile(
   ctx: ProviderDefaultThinkingPolicyContext,
 ): ProviderThinkingProfile {
   const reasoning = ctx.reasoning ?? resolveXaiCatalogEntry(ctx.modelId)?.reasoning;
-  if (ctx.provider !== "xai" || !reasoning) {
+  if (!isXaiProviderId(ctx.provider) || !reasoning) {
     return { levels: [{ id: "off" }], defaultLevel: "off" };
   }
   const modelId = normalizeXaiModelId(ctx.modelId.trim().toLowerCase());

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -52,6 +52,7 @@ function captureWrappedModelId(params: {
   modelId: string;
   fastMode: boolean | (() => boolean | undefined);
   api?: XaiStreamApi;
+  provider?: string;
 }): string {
   let capturedModelId = "";
   const baseStreamFn: StreamFn = (model) => {
@@ -63,7 +64,7 @@ function captureWrappedModelId(params: {
   void wrapped(
     {
       api: params.api ?? "openai-responses",
-      provider: "xai",
+      provider: params.provider ?? "xai",
       id: params.modelId,
     } as Model<Extract<Api, "openai-completions" | "openai-responses">>,
     { messages: [] } as Context,
@@ -78,6 +79,7 @@ function runXaiToolPayloadWrapper(params: {
   api?: XaiStreamApi;
   modelId?: string;
   input?: string[];
+  provider?: string;
 }) {
   const baseStreamFn: StreamFn = (_model, _context, options) => {
     options?.onPayload?.(params.payload, {} as Model<XaiStreamApi>);
@@ -89,7 +91,7 @@ function runXaiToolPayloadWrapper(params: {
   void wrapped(
     {
       api,
-      provider: "xai",
+      provider: params.provider ?? "xai",
       id:
         params.modelId ??
         (api === "openai-completions" ? "grok-4-1-fast-reasoning" : "grok-4-fast"),
@@ -160,6 +162,9 @@ describe("xai stream wrappers", () => {
         api: "openai-responses",
       }),
     ).toBe("grok-3-fast");
+    expect(captureWrappedModelId({ modelId: "grok-4", fastMode: true, provider: "x-ai" })).toBe(
+      "grok-4-fast",
+    );
   });
 
   it("leaves unsupported or disabled models unchanged", () => {
@@ -404,32 +409,35 @@ describe("xai stream wrappers", () => {
     expect(payload).not.toHaveProperty("reasoning_effort");
   });
 
-  it("still requests encrypted reasoning include when effort is unsupported", () => {
-    const payload: Record<string, unknown> = {
-      reasoning: { effort: "high" },
-      input: [],
-    };
-    const baseStreamFn: StreamFn = (model, _context, options) => {
-      options?.onPayload?.(payload, model);
-      return {} as ReturnType<StreamFn>;
-    };
-    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+  it.each(["xai", "x-ai"])(
+    "still requests encrypted reasoning include for %s when effort is unsupported",
+    (provider) => {
+      const payload: Record<string, unknown> = {
+        reasoning: { effort: "high" },
+        input: [],
+      };
+      const baseStreamFn: StreamFn = (model, _context, options) => {
+        options?.onPayload?.(payload, model);
+        return {} as ReturnType<StreamFn>;
+      };
+      const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
 
-    void wrapped(
-      {
-        api: "openai-responses",
-        provider: "xai",
-        id: "grok-build-0.1",
-        reasoning: true,
-        compat: { supportsReasoningEffort: false },
-      } as unknown as Model<"openai-responses">,
-      { messages: [] } as Context,
-      {},
-    );
+      void wrapped(
+        {
+          api: "openai-responses",
+          provider,
+          id: "grok-build-0.1",
+          reasoning: true,
+          compat: { supportsReasoningEffort: false },
+        } as unknown as Model<"openai-responses">,
+        { messages: [] } as Context,
+        {},
+      );
 
-    expect(payload).not.toHaveProperty("reasoning");
-    expect(payload.include).toEqual(["reasoning.encrypted_content"]);
-  });
+      expect(payload).not.toHaveProperty("reasoning");
+      expect(payload.include).toEqual(["reasoning.encrypted_content"]);
+    },
+  );
 
   it("merges encrypted reasoning include with existing include entries", () => {
     const payload: Record<string, unknown> = {

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -7,6 +7,7 @@ import {
   createPlainTextToolCallCompatWrapper,
   createToolStreamWrapper,
 } from "openclaw/plugin-sdk/provider-stream-shared";
+import { isXaiProviderId } from "./provider-id.js";
 
 const XAI_FAST_MODEL_IDS = new Map<string, string>([
   ["grok-3", "grok-3-fast"],
@@ -42,7 +43,11 @@ function ensureXaiResponsesEncryptedReasoningInclude(
   payloadObj: Record<string, unknown>,
   model: { api?: unknown; provider?: unknown; reasoning?: unknown },
 ): void {
-  if (model.provider !== "xai" || model.api !== "openai-responses" || model.reasoning !== true) {
+  if (
+    !isXaiProviderId(model.provider) ||
+    model.api !== "openai-responses" ||
+    model.reasoning !== true
+  ) {
     return;
   }
   const existing = payloadObj.include;
@@ -247,7 +252,7 @@ export function createXaiFastModeWrapper(
     if (
       (typeof fastMode === "function" ? fastMode() : fastMode) !== true ||
       !supportsFastAliasTransport ||
-      model.provider !== "xai"
+      !isXaiProviderId(model.provider)
     ) {
       return underlying(model, context, options);
     }

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1694,6 +1694,54 @@ describe("resolveGatewayLiveModelThinkingLevel", () => {
       }),
     ).toBe("off");
   });
+
+  it.each(["xai", "x-ai"])(
+    "preserves Grok 4.5 thinking support for the %s provider id",
+    (provider) => {
+      expect(
+        resolveGatewayLiveModelThinkingLevel({
+          cfg: {},
+          model: {
+            ...createGatewayLiveTestModel(provider, "grok-4.5"),
+            reasoning: true,
+            thinkingLevelMap: {
+              off: null,
+              minimal: "low",
+              low: "low",
+              medium: "medium",
+              high: "high",
+              xhigh: "high",
+            },
+          },
+          requestedLevel: "high",
+        }),
+      ).toBe("high");
+    },
+  );
+
+  it.each(["xai", "x-ai"])(
+    "keeps off-only xAI models disabled for the %s provider id",
+    (provider) => {
+      expect(
+        resolveGatewayLiveModelThinkingLevel({
+          cfg: {},
+          model: {
+            ...createGatewayLiveTestModel(provider, "grok-build-0.1"),
+            reasoning: true,
+            thinkingLevelMap: {
+              off: null,
+              minimal: null,
+              low: null,
+              medium: null,
+              high: null,
+              xhigh: null,
+            },
+          },
+          requestedLevel: "high",
+        }),
+      ).toBe("off");
+    },
+  );
 });
 
 describe("buildLiveGatewayConfig", () => {

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -157,13 +157,17 @@ describe("provider public artifacts", () => {
       throw new Error("unexpected manifest registry scan");
     });
     const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
-      if (dirName !== "openai") {
+      if (dirName !== "xai") {
         throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
       }
       return {
-        resolveThinkingProfile: ({ provider }: { provider: string }) => ({
-          levels: [{ id: provider }],
-        }),
+        resolveThinkingProfile: ({ provider, modelId }: { provider: string; modelId: string }) =>
+          provider === "x-ai" && modelId === "grok-4.5"
+            ? {
+                levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+                defaultLevel: "high",
+              }
+            : { levels: [{ id: "off" }], defaultLevel: "off" },
       };
     });
 
@@ -182,31 +186,32 @@ describe("provider public artifacts", () => {
       typeof import("./provider-public-artifacts.js")
     >(import.meta.url, "./provider-public-artifacts.js?scope=provider-auth-alias");
 
-    const surface = resolvePolicySurface("openai", {
+    const surface = resolvePolicySurface("x-ai", {
       manifestRegistry: {
         plugins: [
           {
-            id: "openai",
+            id: "xai",
             channels: [],
             cliBackends: [],
             hooks: [],
             origin: "bundled",
-            manifestPath: "/tmp/openai/openclaw.plugin.json",
-            providers: ["openai"],
-            providerAuthAliases: { openai: "openai" },
-            rootDir: "/tmp/openai",
+            manifestPath: "/tmp/xai/openclaw.plugin.json",
+            providers: ["xai"],
+            providerAuthAliases: { "x-ai": "xai" },
+            rootDir: "/tmp/xai",
             skills: [],
-            source: "/tmp/openai/index.js",
+            source: "/tmp/xai/index.js",
           },
         ],
       },
     });
 
-    expect(surface?.resolveThinkingProfile?.({ provider: "openai", modelId: "gpt-5.5" })).toEqual({
-      levels: [{ id: "openai" }],
+    expect(surface?.resolveThinkingProfile?.({ provider: "x-ai", modelId: "grok-4.5" })).toEqual({
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "high",
     });
     expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
-      dirName: "openai",
+      dirName: "xai",
       artifactBasename: "provider-policy-api.js",
     });
     expect(loadPluginManifestRegistry).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #103315

## What Problem This Solves

Fixes an issue where users selecting `x-ai/grok-4.5` could receive an unsupported `minimal` thinking-level error even though Grok 4.5 supports `low`, `medium`, and `high`. The same alias path also skipped xAI fast-model routing and encrypted reasoning replay.

## Why This Change Was Made

The xAI plugin now recognizes its shipped `xai` and `x-ai` runtime identities through one provider-owned predicate shared by thinking and stream policy. Generic plugin dispatch continues to preserve the selected provider identity, and off-only models plus non-xAI routes keep their existing behavior.

## User Impact

Users can run Grok 4.3 and Grok 4.5 through either xAI provider ID without valid thinking requests being clamped to an invalid level. Off-only Grok models remain off, and the alias now receives the same fast-mode and encrypted-reasoning handling as the canonical provider ID.

## Evidence

- Before: release validation job https://github.com/openclaw/openclaw/actions/runs/29065324694/job/86275900010 reported `Thinking level "minimal" is not supported for x-ai/grok-4.5. Use one of: off.` at exact head `9ad38e77394f1fc14b54149e82b97182693e0777`.
- Before on Blacksmith Testbox `tbx_01kx50k6fwbv6qh8jd0nsn3pj6`: all six `x-ai` Grok 4.3/4.5 policy cases failed while canonical and off-only cases passed; the gateway regression resolved requested `high` to `minimal`.
- After on the same Testbox: full `extensions/xai` suite passed, 23 files and 240 tests, including the Grok Imagine Video 1.5 coverage added on current `main`.
- After: bundled provider-artifact tests passed, 9 tests; focused gateway thinking tests passed, 7 tests with 113 unrelated cases skipped.
- `oxfmt --check` passed for all eight changed files.
- Fresh local Codex autoreview reported no accepted or actionable findings.

AI-assisted: yes. I reviewed the implementation and validation results. No agent transcript is attached.
