### PR TITLE
fix(logging): keep redacted token hints UTF-16 safe

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -309,6 +309,29 @@ describe("redactSensitiveText", () => {
     expect(redactSensitiveFieldValue("MONKEY", "banana")).toBe("banana");
   });
 
+  it("keeps Unicode token hints on valid UTF-16 boundaries", () => {
+    const cases = [
+      {
+        secret: `abcde😀${"x".repeat(9)}wxyz`,
+        expected: "abcde…wxyz",
+      },
+      {
+        secret: `abcdef${"x".repeat(9)}😀abc`,
+        expected: "abcdef…abc",
+      },
+      {
+        secret: `abcd😀${"x".repeat(9)}😀ab`,
+        expected: "abcd😀…😀ab",
+      },
+    ];
+
+    for (const { secret, expected } of cases) {
+      const redacted = redactSensitiveFieldValue("token", secret);
+      expect(redacted).toBe(expected);
+      expect(redacted).not.toMatch(/[\uD800-\uDFFF]/u);
+    }
+  });
+
   it("masks bearer tokens", () => {
     const input = "Authorization: Bearer abcdef1234567890ghij";
     const output = redactSensitiveText(input, { mode: "tools" });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,4 +1,5 @@
 // Redaction helpers scrub secrets and sensitive identifiers from log output.
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compileConfigRegex } from "../security/config-regex.js";
 import { readLoggingConfig } from "./config.js";
@@ -354,8 +355,8 @@ function maskToken(token: string): string {
   if (token.length < DEFAULT_REDACT_MIN_LENGTH) {
     return "***";
   }
-  const start = token.slice(0, DEFAULT_REDACT_KEEP_START);
-  const end = token.slice(-DEFAULT_REDACT_KEEP_END);
+  const start = sliceUtf16Safe(token, 0, DEFAULT_REDACT_KEEP_START);
+  const end = sliceUtf16Safe(token, -DEFAULT_REDACT_KEEP_END);
   return `${start}…${end}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators logging non-ASCII secrets could receive malformed redacted token hints when a surrogate pair crossed the retained first 6 or last 4 UTF-16 code units. The redaction step could introduce an unpaired surrogate into JSON-formatted log output even though the original secret was well-formed.

## Why This Change Was Made

This is a root-cause fix in the shared token hint constructor. It uses the repository's canonical surrogate-safe UTF-16 slicing helper for both retained edges, so every existing caller gets the same boundary guarantee.

ASCII hints keep the existing 6/4 code-unit budget, short tokens remain fully masked, and complete surrogate pairs that fit inside the budget remain visible. This does not change redaction patterns, logging configuration, public APIs, schemas, protocols, or persistence formats. A consumer sweep confirmed registered secrets, regex matches, URL/form values, authorization codes, and structured sensitive fields all converge on the same helper.

## User Impact

Unicode secrets now produce well-formed redacted hints, so JSON log consumers no longer receive surrogate halves introduced by redaction. Existing ASCII token hints are unchanged; when an emoji would straddle a hint edge, the output retains one fewer code unit instead of emitting half of the character.

## Evidence

Before the fix, the focused regression failed with:

```text
Expected: "abcde…wxyz"
Received: "abcde�…wxyz"
```

Local E2E live proof on the patched checkout:

- Started a real OpenClaw gateway and observed HTTP 200 from `/healthz`.
- Sent three synthetic Unicode token assignments through the production subsystem logger in JSON console mode.
- Parsed all three emitted JSON records and verified every output string was UTF-16 well-formed.
- Confirmed none of the raw synthetic secrets appeared in the output.

```json
{"level":"info","subsystem":"gateway/auth","message":"TOKEN=abcde…wxyz"}
{"level":"info","subsystem":"gateway/auth","message":"TOKEN=abcdef…abc"}
{"level":"info","subsystem":"gateway/auth","message":"TOKEN=abcd😀…😀ab"}
```

Focused regression:

```text
Test Files  1 passed (1)
Tests       117 passed (117)
```

Additional checks:

- `pnpm exec oxfmt --check --threads=1 src/logging/redact.ts src/logging/redact.test.ts`
- `node scripts/run-oxlint.mjs src/logging/redact.ts src/logging/redact.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- `git diff --check`

The pre-submit scan found no related open PR, and the refreshed main branch still used ordinary `String.prototype.slice` for both hint edges. The change is limited to the shared hint construction and its regression coverage.
