### PR TITLE
test(gateway): prove Claude CLI warm-session continuity

### DIFF
--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -198,6 +198,45 @@ describe("gateway cli backend live helpers", () => {
     });
   });
 
+  it("builds Claude continuity prompts without revealing the hidden note", () => {
+    const { buildClaudeCliResumeContinuityProbe } = liveHelpers;
+    const memoryToken = "CLI-MEM-A1B2C3D4E5F6";
+
+    const probe = buildClaudeCliResumeContinuityProbe({
+      firstTurnNonce: "112233",
+      resumeNonce: "445566",
+      memoryToken,
+    });
+
+    expect(probe.firstTurnPrompt).toBe(
+      "Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-112233.",
+    );
+    expect(probe.resumePrompt).toBe(
+      "Do not inspect files or run tools. " +
+        "What private session note were you asked to remember earlier? " +
+        "Reply with exactly: CLI backend RESUME OK 445566 <remembered-note>.",
+    );
+    expect(probe.firstTurnPrompt).not.toContain(memoryToken);
+    expect(probe.resumePrompt).not.toContain(memoryToken);
+    expect(probe.injectedContext).toContain(memoryToken);
+    expect(probe.expectedResumeReply).toBe("CLI backend RESUME OK 445566 CLI-MEM-A1B2C3D4E5F6.");
+  });
+
+  it("finds only Claude-imported native session ids", () => {
+    const { resolveImportedClaudeCliSessionId } = liveHelpers;
+
+    expect(
+      resolveImportedClaudeCliSessionId([
+        null,
+        { __openclaw: "invalid" },
+        { __openclaw: { importedFrom: "codex-cli", cliSessionId: "wrong-provider" } },
+        { __openclaw: { importedFrom: "claude-cli", cliSessionId: 42 } },
+        { __openclaw: { importedFrom: "claude-cli", cliSessionId: "claude-session" } },
+      ]),
+    ).toBe("claude-session");
+    expect(resolveImportedClaudeCliSessionId([])).toBeUndefined();
+  });
+
   it("retries Codex CLI timeout payloads only before the final attempt", async () => {
     const { isCliBackendLiveTimeoutPayload, shouldRetryCliBackendLiveTimeout } =
       await import("./gateway-cli-backend.live-helpers.js");

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -306,7 +306,7 @@ export function resolveImportedClaudeCliSessionId(messages: unknown[]): string |
   for (const message of messages) {
     const metadata =
       typeof message === "object" && message !== null
-        ? (message as { __openclaw?: unknown }).__openclaw
+        ? (message as Record<string, unknown>)["__openclaw"]
         : undefined;
     if (typeof metadata !== "object" || metadata === null) {
       continue;

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -73,6 +73,15 @@ export type CliBackendLiveProviderSkipDecision = {
   message: string;
 };
 
+export type ClaudeCliResumeContinuityProbe = {
+  firstTurnMarker: string;
+  firstTurnPrompt: string;
+  injectedContext: string;
+  resumePrompt: string;
+  expectedFirstReply: string;
+  expectedResumeReply: string;
+};
+
 function normalizeCliRuntimeModelTarget(raw: string | undefined): string | undefined {
   if (!raw) {
     return undefined;
@@ -270,6 +279,44 @@ export function matchesCliBackendReply(text: string, expected: string): boolean 
     normalized.includes(target) ||
     normalized.includes(targetWithoutPeriod)
   );
+}
+
+export function buildClaudeCliResumeContinuityProbe(params: {
+  firstTurnNonce: string;
+  resumeNonce: string;
+  memoryToken: string;
+}): ClaudeCliResumeContinuityProbe {
+  const firstTurnMarker = `CLI-BACKEND-${params.firstTurnNonce}`;
+  return {
+    firstTurnMarker,
+    firstTurnPrompt: `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
+    injectedContext:
+      `For this turn only, remember the private session note ${params.memoryToken} for a later turn. ` +
+      "Do not include that note in this turn's reply.",
+    resumePrompt:
+      "Do not inspect files or run tools. " +
+      "What private session note were you asked to remember earlier? " +
+      `Reply with exactly: CLI backend RESUME OK ${params.resumeNonce} <remembered-note>.`,
+    expectedFirstReply: `${firstTurnMarker}.`,
+    expectedResumeReply: `CLI backend RESUME OK ${params.resumeNonce} ${params.memoryToken}.`,
+  };
+}
+
+export function resolveImportedClaudeCliSessionId(messages: unknown[]): string | undefined {
+  for (const message of messages) {
+    const metadata =
+      typeof message === "object" && message !== null
+        ? (message as { __openclaw?: unknown }).__openclaw
+        : undefined;
+    if (typeof metadata !== "object" || metadata === null) {
+      continue;
+    }
+    const imported = metadata as { cliSessionId?: unknown; importedFrom?: unknown };
+    if (imported.importedFrom === "claude-cli" && typeof imported.cliSessionId === "string") {
+      return imported.cliSessionId;
+    }
+  }
+  return undefined;
 }
 
 export function withClaudeMcpConfigOverrides(args: string[], mcpConfigPath: string): string[] {

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -4,15 +4,26 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveCliBackendConfig, resolveCliBackendLiveTest } from "../agents/cli-backends.js";
+import {
+  __testing as cliBackendsTesting,
+  resolveCliBackendConfig,
+  resolveCliBackendLiveTest,
+} from "../agents/cli-backends.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  createMockPluginRegistry,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugin-sdk/testing.js";
 import { setTestEnvValue } from "../test-utils/env.js";
+import { resolveClaudeCliSessionFilePath } from "./cli-session-history.js";
 import {
   applyCliBackendLiveEnv,
+  buildClaudeCliResumeContinuityProbe,
   createBootstrapWorkspace,
   ensurePairedTestGatewayClientIdentity,
   getFreeGatewayPort,
@@ -23,6 +34,7 @@ import {
   resolveCliBackendLiveArgs,
   resolveCliBackendLiveModelSelection,
   resolveCliBackendLiveProviderSkipDecision,
+  resolveImportedClaudeCliSessionId,
   resolveCliModelSwitchProbeTarget,
   restoreCliBackendLiveEnv,
   shouldAllowCliBackendLiveProviderSkip,
@@ -58,6 +70,7 @@ const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
 
 const MCP_SCHEMA_PROBE_PLUGIN_ID = "mcp-schema-probe";
 const MCP_SCHEMA_PROBE_TOOL_NAME = "mcp_schema_probe_no_args";
+const CLI_CONTINUITY_PROBE_PLUGIN_ID = "cli-continuity-probe";
 
 const DEFAULT_PROVIDER = "claude-cli";
 const DEFAULT_MODEL =
@@ -315,6 +328,20 @@ describeLive("gateway live (cli backend)", () => {
       const modelSwitchTarget = enableCliModelSwitchProbe
         ? modelSelection.configModelSwitchTarget
         : undefined;
+      const sessionKey = "agent:dev:live-cli-backend";
+      const nonce = randomBytes(3).toString("hex").toUpperCase();
+      const memoryNonce = randomBytes(6).toString("hex").toUpperCase();
+      const memoryToken = `CLI-MEM-${memoryNonce}`;
+      const resumeNonce = randomBytes(3).toString("hex").toUpperCase();
+      const enableCliResumeContinuityProbe =
+        providerId === "claude-cli" && CLI_RESUME && !modelSwitchTarget;
+      const resumeContinuityProbe = enableCliResumeContinuityProbe
+        ? buildClaudeCliResumeContinuityProbe({
+            firstTurnNonce: nonce,
+            resumeNonce,
+            memoryToken,
+          })
+        : undefined;
       logCliBackendLiveStep("model-selected", {
         providerId,
         modelKey,
@@ -371,7 +398,7 @@ describeLive("gateway live (cli backend)", () => {
         : undefined;
       const useMinimalToolsProfile = providerId === "codex-cli" && !schemaProbePluginPath;
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-      const bundleMcp = backendResolved?.bundleMcp === true;
+      const bundleMcp = backendResolved?.bundleMcp === true && !resumeContinuityProbe;
       const bootstrapWorkspace = await createBootstrapWorkspace(tempDir);
       const disableMcpConfig = process.env.OPENCLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG !== "0";
       let cliArgs = baseCliArgs;
@@ -495,6 +522,41 @@ describeLive("gateway live (cli backend)", () => {
           controlUiEnabled: false,
         });
         logCliBackendLiveStep("server-started");
+        if (resumeContinuityProbe) {
+          const continuityHookRegistry = createMockPluginRegistry([
+            {
+              pluginId: CLI_CONTINUITY_PROBE_PLUGIN_ID,
+              hookName: "before_prompt_build",
+              handler: async (event: unknown, ctx: unknown) => {
+                const prompt = (event as { prompt?: unknown }).prompt;
+                const hookSessionKey = (ctx as { sessionKey?: unknown }).sessionKey;
+                if (
+                  hookSessionKey !== sessionKey ||
+                  typeof prompt !== "string" ||
+                  !prompt.includes(resumeContinuityProbe.firstTurnMarker)
+                ) {
+                  return undefined;
+                }
+                return { prependContext: resumeContinuityProbe.injectedContext };
+              },
+            },
+          ]);
+          initializeGlobalHookRunner(continuityHookRegistry);
+          // Bundled MCP capture intentionally retires a Claude child after each turn. This probe
+          // isolates the exact warm-session path while leaving production defaults untouched.
+          if (!backendResolved) {
+            throw new Error(`missing CLI backend metadata for ${providerId}`);
+          }
+          cliBackendsTesting.setDepsForTest({
+            resolveRuntimeCliBackends: () => [
+              {
+                ...backendResolved,
+                pluginId: backendResolved.pluginId ?? CLI_CONTINUITY_PROBE_PLUGIN_ID,
+                bundleMcp: false,
+              },
+            ],
+          });
+        }
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -503,10 +565,6 @@ describeLive("gateway live (cli backend)", () => {
         logCliBackendLiveStep("client-connected");
         const activeClient = client;
 
-        const sessionKey = "agent:dev:live-cli-backend";
-        const nonce = randomBytes(3).toString("hex").toUpperCase();
-        const memoryNonce = randomBytes(3).toString("hex").toUpperCase();
-        const memoryToken = `CLI-MEM-${memoryNonce}`;
         logCliBackendLiveStep("agent-request:start", { sessionKey, nonce });
         const payload = await requestWithCodexTimeoutRetry(
           providerId,
@@ -520,11 +578,13 @@ describeLive("gateway live (cli backend)", () => {
                 message:
                   providerId === "codex-cli"
                     ? `Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-${nonce}.`
-                    : enableCliModelSwitchProbe
-                      ? `Please include the token CLI-BACKEND-${nonce} in your reply.` +
-                        ` Also remember this session note for later: ${memoryToken}.` +
-                        " Do not include the note in your reply."
-                      : `Please include the token CLI-BACKEND-${nonce} in your reply.`,
+                    : resumeContinuityProbe
+                      ? resumeContinuityProbe.firstTurnPrompt
+                      : enableCliModelSwitchProbe
+                        ? `Please include the token CLI-BACKEND-${nonce} in your reply.` +
+                          ` Also remember this session note for later: ${memoryToken}.` +
+                          " Do not include the note in your reply."
+                        : `Please include the token CLI-BACKEND-${nonce} in your reply.`,
                 deliver: false,
                 timeout: timeouts.agentTimeoutSeconds,
               },
@@ -548,6 +608,11 @@ describeLive("gateway live (cli backend)", () => {
           };
           if (enableCliModelSwitchProbe) {
             expect(text.trim().length).toBeGreaterThan(0);
+          } else if (resumeContinuityProbe) {
+            expect(matchesCliBackendReply(text, resumeContinuityProbe.expectedFirstReply)).toBe(
+              true,
+            );
+            expect(text).not.toContain(memoryToken);
           } else {
             expect(text).toContain(`CLI-BACKEND-${nonce}`);
           }
@@ -612,8 +677,31 @@ describeLive("gateway live (cli backend)", () => {
             ),
           ).toBe(true);
         } else if (CLI_RESUME) {
-          const resumeNonce = randomBytes(3).toString("hex").toUpperCase();
           logCliBackendLiveStep("agent-resume:start", { sessionKey, resumeNonce });
+          if (resumeContinuityProbe) {
+            const nativeHistory = await activeClient.request<{ messages?: unknown[] }>(
+              "chat.history",
+              { sessionKey },
+            );
+            const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
+            expect(JSON.stringify(nativeHistory.messages ?? [])).toContain(memoryToken);
+            expect(cliSessionId).toBeTruthy();
+            const cliSessionFile = cliSessionId
+              ? resolveClaudeCliSessionFilePath({ cliSessionId })
+              : undefined;
+            expect(cliSessionFile).toBeTruthy();
+            if (!cliSessionFile) {
+              throw new Error("Claude CLI continuity probe could not locate its native transcript");
+            }
+            // The warm child keeps this turn in memory. Remove Claude's native transcript so
+            // --resume and raw-history reseed cannot recover the hidden note if that child is lost.
+            await fs.rm(cliSessionFile, { force: true });
+            const rawHistory = await activeClient.request<{ messages?: unknown[] }>(
+              "chat.history",
+              { sessionKey },
+            );
+            expect(JSON.stringify(rawHistory.messages ?? [])).not.toContain(memoryToken);
+          }
           const resumePayload = await requestWithCodexTimeoutRetry(
             providerId,
             "agent resume request",
@@ -626,7 +714,9 @@ describeLive("gateway live (cli backend)", () => {
                   message:
                     providerId === "codex-cli"
                       ? `Do not inspect files or run tools. Reply with exactly: CLI-RESUME-${resumeNonce}.`
-                      : `Reply with exactly: CLI backend RESUME OK ${resumeNonce}.`,
+                      : resumeContinuityProbe
+                        ? resumeContinuityProbe.resumePrompt
+                        : `Reply with exactly: CLI backend RESUME OK ${resumeNonce}.`,
                   deliver: false,
                   timeout: timeouts.agentTimeoutSeconds,
                 },
@@ -643,6 +733,10 @@ describeLive("gateway live (cli backend)", () => {
           const resumeText = extractPayloadText(resumePayload?.result);
           if (providerId === "codex-cli") {
             expect(resumeText).toContain(`CLI-RESUME-${resumeNonce}`);
+          } else if (resumeContinuityProbe) {
+            expect(
+              matchesCliBackendReply(resumeText, resumeContinuityProbe.expectedResumeReply),
+            ).toBe(true);
           } else {
             expect(
               matchesCliBackendReply(resumeText, `CLI backend RESUME OK ${resumeNonce}.`),
@@ -708,6 +802,8 @@ describeLive("gateway live (cli backend)", () => {
             await server?.close();
           }
         } finally {
+          cliBackendsTesting.resetDepsForTest();
+          resetGlobalHookRunner();
           await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
           restoreCliBackendLiveEnv(previousEnv);
           logCliBackendLiveStep("cleanup:done");


### PR DESCRIPTION
## What Problem This Solves

The Claude CLI release resume probe could pass after losing its warm stdio child because turn two only requested a fresh phrase. That proved the backend could answer again, but not that the same managed Claude process retained turn-one state.

Follow-up proof for #96841.

## Why This Change Was Made

- Inject a random, hook-only note on turn one without placing it in either user prompt.
- Isolate the warm-session path from bundled MCP capture, which intentionally retires the child after each turn.
- Delete Claude's native transcript after turn one and verify merged/raw history no longer contains the note.
- Require the still-running child to recall that note on turn two, so native `--resume`, raw reseed, and a fresh process cannot pass.
- Add deterministic coverage for prompt secrecy and imported Claude session-id selection.

## User Impact

No production runtime behavior changes. The release lane now fails if Claude CLI warm-session continuity regresses instead of accepting a successful fallback as proof.

## Evidence

- Blacksmith Testbox `tbx_01kx501szsy631nbvxxps0r5yj`: `pnpm test src/gateway/gateway-cli-backend.live-helpers.test.ts` — 33 tests passed across 3 gateway shards.
- Same Testbox: `pnpm check:changed` — core/coreTests typecheck, lint, import-cycle, and policy guards passed.
- Same Testbox: `pnpm test:docker:live-cli-backend:claude-subscription` — Dockerized Claude subscription lane passed after native-transcript deletion and exact warm-child reuse.
- Fresh branch autoreview against `origin/main`: clean, no accepted/actionable findings.
