### PR TITLE
feat(webchat): lobster pet sentience — gaze, petting, honest run reactions, vigil

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -75,7 +75,7 @@ import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { pluginTabKey, pluginTabSearch } from "../pages/plugin/route.ts";
 import { icons, type IconName } from "./icons.ts";
-import { lobsterPetSeed, resolveLobsterPetMode } from "./lobster-pet.ts";
+import { lobsterPetSeed, resolveLobsterPetMode, resolveLobsterRunOutcome } from "./lobster-pet.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 
 type SidebarRecentSession = {
@@ -1731,6 +1731,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
             <openclaw-lobster-pet
               .seed=${lobsterPetSeed(this.sessionKey)}
               .mode=${resolveLobsterPetMode(this.connected, this.sessionsResult?.sessions)}
+              .runOutcome=${resolveLobsterRunOutcome(this.sessionsResult?.sessions)}
               .visitsEnabled=${this.lobsterPetVisits}
             ></openclaw-lobster-pet>
             <div class="sidebar-footer-bar">

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -12,6 +12,7 @@ import {
   lobsterPetName,
   lobsterPetSeed,
   resolveLobsterPetMode,
+  resolveLobsterRunOutcome,
   type LobsterPet,
   type LobsterPetMode,
   type LobsterPetPaletteId,
@@ -42,6 +43,12 @@ function createPet(seed: number, mode: LobsterPetMode = "idle"): LobsterPetEleme
   element.mode = mode;
   document.body.append(element);
   return element;
+}
+
+function poke(element: LobsterPetElement): void {
+  const sprite = element.querySelector(".lobster-pet");
+  sprite?.dispatchEvent(new Event("pointerdown"));
+  sprite?.dispatchEvent(new Event("pointerup"));
 }
 
 function spriteClasses(element: LobsterPetElement): string {
@@ -222,6 +229,35 @@ describe("resolveLobsterPetMode", () => {
   });
 });
 
+describe("resolveLobsterRunOutcome", () => {
+  it("uses the most recently active terminal session", () => {
+    expect(resolveLobsterRunOutcome(null)).toBe("ok");
+    expect(
+      resolveLobsterRunOutcome([
+        { status: "done", lastActivityAt: 10 },
+        { status: "failed", lastActivityAt: 20 },
+      ]),
+    ).toBe("error");
+    expect(
+      resolveLobsterRunOutcome([
+        { status: "failed", lastActivityAt: 10 },
+        { status: "done", lastActivityAt: 20 },
+      ]),
+    ).toBe("ok");
+    expect(resolveLobsterRunOutcome([{ status: "running", lastActivityAt: 99 }])).toBe("ok");
+    expect(resolveLobsterRunOutcome([{ status: "timeout", updatedAt: 5 }])).toBe("error");
+    // A user abort is neither success nor failure.
+    expect(resolveLobsterRunOutcome([{ status: "killed", endedAt: 50 }])).toBe("aborted");
+    // endedAt outranks activity stamps that unrelated events keep touching.
+    expect(
+      resolveLobsterRunOutcome([
+        { status: "failed", endedAt: 30, lastActivityAt: 10 },
+        { status: "done", endedAt: 20, lastActivityAt: 40 },
+      ]),
+    ).toBe("error");
+  });
+});
+
 describe("lobster pet element", () => {
   it("starts hidden and arrives on its seeded visit schedule", async () => {
     vi.useFakeTimers();
@@ -314,7 +350,7 @@ describe("lobster pet element", () => {
     const element = createPet(42);
     await arrive(element);
 
-    element.querySelector(".lobster-pet")?.dispatchEvent(new Event("pointerdown"));
+    poke(element);
     await element.updateComplete;
     expect(spriteClasses(element)).toContain("lobster-pet--act-startle");
   });
@@ -383,7 +419,7 @@ describe("lobster pet element", () => {
     await arrive(element);
 
     for (let i = 0; i < 3; i++) {
-      element.querySelector(".lobster-pet")?.dispatchEvent(new Event("pointerdown"));
+      poke(element);
       await element.updateComplete;
     }
     expect(spriteClasses(element)).toContain("lobster-pet--grumpy");
@@ -400,7 +436,7 @@ describe("lobster pet element", () => {
     await arrive(element);
 
     for (let i = 0; i < 10; i++) {
-      element.querySelector(".lobster-pet")?.dispatchEvent(new Event("pointerdown"));
+      poke(element);
       await element.updateComplete;
     }
     const gone = await advanceUntil(element, () => !spritePresent(element), 5_000);
@@ -531,6 +567,76 @@ describe("lobster pet element", () => {
     await arrive(element);
     const paletteId = createLobsterPetLook(42, new Date("2026-07-09T12:00:00")).palette.id;
     expect(getLobsterdex().has(paletteId)).toBe(true);
+  });
+
+  it("pets on press-and-hold instead of poking", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42);
+    await arrive(element);
+
+    const sprite = element.querySelector(".lobster-pet");
+    sprite?.dispatchEvent(new Event("pointerdown"));
+    await vi.advanceTimersByTimeAsync(700);
+    await element.updateComplete;
+    expect(spriteClasses(element)).toContain("lobster-pet--act-pet");
+
+    // Releasing after a completed pet must not fire a poke startle.
+    sprite?.dispatchEvent(new Event("pointerup"));
+    await vi.advanceTimersByTimeAsync(LOBSTER_PET_ACT_DURATION_MS.pet + 100);
+    await element.updateComplete;
+    expect(spriteClasses(element)).not.toContain("lobster-pet--act-startle");
+  });
+
+  it("droops instead of cheering when the finished run failed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42, "busy");
+    element.runOutcome = "error";
+    await arrive(element);
+
+    element.mode = "idle";
+    await element.updateComplete;
+    expect(spriteClasses(element)).toContain("lobster-pet--act-droop");
+    expect(spriteClasses(element)).not.toContain("lobster-pet--act-cheer");
+  });
+
+  it("keeps vigil during long runs and settles until the run ends", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42, "busy");
+    await arrive(element);
+
+    await vi.advanceTimersByTimeAsync(600_500);
+    await element.updateComplete;
+    expect(spriteClasses(element)).toContain("lobster-pet--vigil");
+
+    // No fidgeting while keeping vigil.
+    const act = await advanceUntilAct(element, 30_000);
+    expect(act).toBeNull();
+
+    element.mode = "idle";
+    await element.updateComplete;
+    expect(spriteClasses(element)).not.toContain("lobster-pet--vigil");
+  });
+
+  it("watches the pointer between acts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42);
+    await arrive(element);
+
+    // jsdom rects are zero, so any positive clientX is to the sprite's right
+    // and any negative clientX is to its left.
+    await vi.advanceTimersByTimeAsync(200);
+    document.dispatchEvent(new MouseEvent("pointermove", { clientX: 400 }));
+    await element.updateComplete;
+    expect(element.querySelector(".lobster-pet")?.getAttribute("style")).toContain("--lob-face:1");
+
+    await vi.advanceTimersByTimeAsync(200);
+    document.dispatchEvent(new MouseEvent("pointermove", { clientX: -400 }));
+    await element.updateComplete;
+    expect(element.querySelector(".lobster-pet")?.getAttribute("style")).toContain("--lob-face:-1");
   });
 
   it("stays static when reduced motion is preferred, including visibility resumes", async () => {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -19,7 +19,9 @@ export type LobsterPetAct =
   | "scuttle"
   | "startle"
   | "cheer"
-  | "molt";
+  | "molt"
+  | "pet"
+  | "droop";
 
 export type LobsterPetMode = "idle" | "busy" | "offline";
 
@@ -95,6 +97,8 @@ export const LOBSTER_PET_ACT_DURATION_MS: Record<LobsterPetAct, number> = {
   startle: 750,
   cheer: 1300,
   molt: 2600,
+  pet: 1500,
+  droop: 1600,
 };
 
 const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
@@ -456,6 +460,42 @@ export function createLobsterPetLook(seed: number, now: Date = new Date()): Lobs
   };
 }
 
+export type LobsterRunOutcome = "ok" | "error" | "aborted";
+
+// The most recently active session with a terminal status decides how the
+// pet reacts when the busy state clears: failures earn sympathy, not cheers.
+export function resolveLobsterRunOutcome(
+  sessions:
+    | ReadonlyArray<{
+        status?: "running" | "done" | "failed" | "killed" | "timeout";
+        endedAt?: number | null;
+        lastActivityAt?: number | null;
+        updatedAt?: number | null;
+      }>
+    | null
+    | undefined,
+): LobsterRunOutcome {
+  let latest: { at: number; outcome: LobsterRunOutcome } | null = null;
+  for (const row of sessions ?? []) {
+    if (!row.status || row.status === "running") {
+      continue;
+    }
+    // endedAt is the run-completion timestamp; activity/updated stamps also
+    // move on unrelated events (reads, renames) and only serve as fallbacks.
+    const at = row.endedAt ?? row.lastActivityAt ?? row.updatedAt ?? 0;
+    if (!latest || at > latest.at) {
+      const outcome: LobsterRunOutcome =
+        row.status === "failed" || row.status === "timeout"
+          ? "error"
+          : row.status === "killed"
+            ? "aborted"
+            : "ok";
+      latest = { at, outcome };
+    }
+  }
+  return latest?.outcome ?? "ok";
+}
+
 export function resolveLobsterPetMode(
   connected: boolean,
   sessions: ReadonlyArray<{ hasActiveRun?: boolean | null }> | null | undefined,
@@ -686,6 +726,7 @@ export class LobsterPet extends LitElement {
   @property({ attribute: false }) mode: LobsterPetMode = "idle";
 
   @property({ attribute: false }) visitsEnabled = true;
+  @property({ attribute: false }) runOutcome: LobsterRunOutcome = "ok";
 
   @state() private act: LobsterPetAct | null = null;
   @state() private spotPct = 80;
@@ -696,6 +737,7 @@ export class LobsterPet extends LitElement {
   @state() private scheduledVisiting = false;
   @state() private dismissed = false;
   @state() private grumpy = false;
+  @state() private vigil = false;
   @state() private shellVisible = false;
   private shellSpotPct = 50;
   private shellScale = 2;
@@ -713,12 +755,17 @@ export class LobsterPet extends LitElement {
   private visitTimer: number | null = null;
   private leaveTimer: number | null = null;
   private grumpyTimer: number | null = null;
+  private vigilTimer: number | null = null;
+  private holdTimer: number | null = null;
+  private holdPetted = false;
   private pokeTimes: number[] = [];
+  private lastGazeAt = 0;
   private restartPending = false;
 
   override connectedCallback() {
     super.connectedCallback();
     document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    document.addEventListener("pointermove", this.handleGaze, { passive: true });
   }
 
   override disconnectedCallback() {
@@ -733,12 +780,22 @@ export class LobsterPet extends LitElement {
       window.clearTimeout(this.shellTimer);
       this.shellTimer = null;
     }
+    for (const timer of [this.vigilTimer, this.holdTimer]) {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    }
+    this.vigilTimer = null;
+    this.holdTimer = null;
+    document.removeEventListener("pointermove", this.handleGaze);
     super.disconnectedCallback();
   }
 
   private wantsVisible(): boolean {
     return (
-      this.visitsEnabled && !this.dismissed && (this.mode === "offline" || this.scheduledVisiting)
+      this.visitsEnabled &&
+      !this.dismissed &&
+      (this.mode === "offline" || this.vigil || this.scheduledVisiting)
     );
   }
 
@@ -766,12 +823,29 @@ export class LobsterPet extends LitElement {
       this.moltPlanned = isLobsterMoltLoad(this.seed);
       this.twinPlanned = isLobsterTwinLoad(this.seed);
       this.scheduleVisits();
-    } else if (changed.has("mode") && this.presence === "in" && !prefersReducedMotion()) {
-      // Status flips get an immediate reaction; a finished run (busy -> idle)
-      // earns a celebration, everything else a startle. The act-end timer
-      // then reschedules from the new mode's pool.
-      const previousMode = changed.get("mode") as LobsterPetMode | undefined;
-      this.performAct(previousMode === "busy" && this.mode === "idle" ? "cheer" : "startle");
+      // The first update takes this branch, so the mode-change branch below
+      // never sees the initial mode: arm the vigil tracker here as well.
+      this.vigil = false;
+      this.trackVigil();
+    } else if (changed.has("mode")) {
+      this.trackVigil();
+      if (this.presence === "in" && !prefersReducedMotion()) {
+        // Status flips get an immediate reaction. A finished run (busy ->
+        // idle) earns a cheer when it succeeded and a sympathetic droop when
+        // it failed; everything else startles. The act-end timer then
+        // reschedules from the new mode's pool.
+        const previousMode = changed.get("mode") as LobsterPetMode | undefined;
+        const finished = previousMode === "busy" && this.mode === "idle";
+        // Success cheers, failure droops, a user abort is nothing to
+        // celebrate or mourn - just acknowledge the change.
+        const finishAct =
+          this.runOutcome === "error"
+            ? "droop"
+            : this.runOutcome === "aborted"
+              ? "startle"
+              : "cheer";
+        this.performAct(finished ? finishAct : "startle");
+      }
     }
     this.reconcilePresence();
   }
@@ -831,13 +905,46 @@ export class LobsterPet extends LitElement {
     }
   };
 
-  // Pokes are fun until they are not: 3 fast pokes turn it grumpy for a
-  // minute, 10 send it off in a huff until a later visit. Offline pets are
-  // on duty and never huff.
-  private readonly handlePoke = () => {
+  // Press-and-hold pets the lobster (content eyes, a floating heart); a
+  // quick tap is a poke. Pokes are fun until they are not: 3 fast pokes turn
+  // it grumpy for a minute, 10 send it off in a huff until a later visit.
+  // Offline pets are on duty and never huff.
+  private readonly handleHoldStart = () => {
     if (prefersReducedMotion()) {
       return;
     }
+    this.holdPetted = false;
+    if (this.holdTimer !== null) {
+      window.clearTimeout(this.holdTimer);
+    }
+    this.holdTimer = window.setTimeout(() => {
+      this.holdTimer = null;
+      this.holdPetted = true;
+      this.grumpy = false;
+      this.performAct("pet");
+    }, 600);
+  };
+
+  private readonly handleHoldEnd = () => {
+    if (this.holdTimer !== null) {
+      window.clearTimeout(this.holdTimer);
+      this.holdTimer = null;
+      if (!this.holdPetted) {
+        this.pokeNow();
+      }
+    }
+    this.holdPetted = false;
+  };
+
+  private readonly handleHoldCancel = () => {
+    if (this.holdTimer !== null) {
+      window.clearTimeout(this.holdTimer);
+      this.holdTimer = null;
+    }
+    this.holdPetted = false;
+  };
+
+  private pokeNow() {
     const now = Date.now();
     this.pokeTimes = [...this.pokeTimes.filter((at) => now - at < 6000), now];
     if (this.pokeTimes.length >= 10 && this.mode !== "offline") {
@@ -848,7 +955,7 @@ export class LobsterPet extends LitElement {
       this.enterGrumpy();
     }
     this.performAct("startle");
-  };
+  }
 
   private enterGrumpy() {
     this.grumpy = true;
@@ -870,6 +977,48 @@ export class LobsterPet extends LitElement {
     this.scheduledVisiting = false;
     this.armArrival(randomBetween(this.visitRng, VISIT_GAP_MS[0], VISIT_GAP_MS[1]));
   }
+
+  // Long runs earn solidarity: after 10 minutes of busy the pet settles
+  // into a quiet waiting pose until the run ends.
+  private trackVigil() {
+    if (this.vigilTimer !== null) {
+      window.clearTimeout(this.vigilTimer);
+      this.vigilTimer = null;
+    }
+    if (this.mode === "busy") {
+      this.vigilTimer = window.setTimeout(() => {
+        this.vigilTimer = null;
+        this.vigil = true;
+        this.clearActTimers();
+        this.act = null;
+      }, 600_000);
+    } else {
+      this.vigil = false;
+    }
+  }
+
+  // The pet watches your pointer: facing follows it between acts. Throttled,
+  // idle-only, and inert under reduced motion or while acting.
+  private readonly handleGaze = (event: PointerEvent) => {
+    if (this.presence !== "in" || this.act !== null || this.vigil || prefersReducedMotion()) {
+      return;
+    }
+    const now = Date.now();
+    if (now - this.lastGazeAt < 120) {
+      return;
+    }
+    this.lastGazeAt = now;
+    const sprite = this.querySelector(".lobster-pet:not(.lobster-pet--shell)");
+    if (!sprite) {
+      return;
+    }
+    const rect = sprite.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const facing: 1 | -1 = event.clientX < centerX ? -1 : 1;
+    if (facing !== this.facing) {
+      this.facing = facing;
+    }
+  };
 
   // Right-click shoos the pet away for the rest of this page load.
   private readonly handleShoo = (event: Event) => {
@@ -961,6 +1110,7 @@ export class LobsterPet extends LitElement {
     if (
       !this.look ||
       this.presence !== "in" ||
+      this.vigil ||
       this.idleTimer !== null ||
       this.actEndTimer !== null ||
       prefersReducedMotion()
@@ -1077,6 +1227,7 @@ export class LobsterPet extends LitElement {
       this.presence === "leaving" ? "lobster-pet--away" : "",
       this.entering ? "lobster-pet--entering" : "",
       this.grumpy ? "lobster-pet--grumpy" : "",
+      this.vigil ? "lobster-pet--vigil" : "",
       this.act ? `lobster-pet--act-${this.act}` : "",
     ]
       .filter(Boolean)
@@ -1098,7 +1249,9 @@ export class LobsterPet extends LitElement {
         style=${style}
         aria-hidden="true"
         title=${twin ? `${name} Jr.` : name}
-        @pointerdown=${this.handlePoke}
+        @pointerdown=${this.handleHoldStart}
+        @pointerup=${this.handleHoldEnd}
+        @pointerleave=${this.handleHoldCancel}
         @contextmenu=${this.handleShoo}
       >
         <div class="lobster-pet__body">
@@ -1109,6 +1262,7 @@ export class LobsterPet extends LitElement {
           <span class="lobster-pet__bubble" style="--i:0"></span>
           <span class="lobster-pet__bubble" style="--i:1"></span>
           <span class="lobster-pet__bubble" style="--i:2"></span>
+          <span class="lobster-pet__heart">♥</span>
         </div>
       </div>
     `;

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -179,12 +179,12 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
 
 /* Exclude the nap act: a running blink animation would out-cascade the nap
    opacity rules below and keep the eyes open mid-nap. */
-.lobster-pet:not(.lobster-pet--act-nap) .lob-eye-open {
+.lobster-pet:not(.lobster-pet--act-nap, .lobster-pet--act-pet) .lob-eye-open {
   animation: lobster-pet-blink-open 5.2s linear infinite;
   animation-delay: var(--lob-blink-delay, 0s);
 }
 
-.lobster-pet:not(.lobster-pet--act-nap) .lob-eye-closed {
+.lobster-pet:not(.lobster-pet--act-nap, .lobster-pet--act-pet) .lob-eye-closed {
   animation: lobster-pet-blink-closed 5.2s linear infinite;
   animation-delay: var(--lob-blink-delay, 0s);
 }
@@ -246,6 +246,48 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
 .lobster-pet--act-cheer .lob-claw {
   animation: lobster-pet-cheer-claws 1.3s ease-in-out;
   animation-delay: var(--lob-act-delay, 0s);
+}
+
+/* Petting: content closed eyes and a floating heart. */
+.lobster-pet--act-pet .lob-eye-open {
+  opacity: 0;
+}
+
+.lobster-pet--act-pet .lob-eye-closed {
+  opacity: 1;
+}
+
+.lobster-pet__heart {
+  position: absolute;
+  left: 46%;
+  bottom: 78%;
+  color: #ff5c8a;
+  font-size: calc(5px * var(--lob-scale, 2));
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lobster-pet--act-pet .lobster-pet__heart {
+  animation: lobster-pet-heart 1.4s ease-out;
+}
+
+/* Droop: a failed run earns sagging antennae and a slow, sad head shake. */
+.lobster-pet--act-droop .lobster-pet__body {
+  animation: lobster-pet-droop 1.6s ease-in-out;
+  animation-delay: var(--lob-act-delay, 0s);
+}
+
+.lobster-pet--act-droop .lob-antennae {
+  animation: lobster-pet-droop-antennae 1.6s ease-in-out;
+  transform-box: view-box;
+  transform-origin: 60px 14px;
+}
+
+/* Vigil: long runs earn a settled, patient waiting pose. Acts pause, so a
+   plain transform cannot fight the act animations. */
+.lobster-pet--vigil .lobster-pet__body {
+  transform: translateY(6%) scaleY(0.94);
 }
 
 /* Molt: shiver, squash, pop. */
@@ -472,6 +514,50 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   85%,
   100% {
     transform: translateY(0);
+  }
+}
+
+@keyframes lobster-pet-heart {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) scale(0.6);
+  }
+  25% {
+    opacity: 0.95;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(4px, -18px) scale(1.15);
+  }
+}
+
+@keyframes lobster-pet-droop {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  20% {
+    transform: translateY(4%) rotate(-2.5deg);
+  }
+  45% {
+    transform: translateY(4%) rotate(2.5deg);
+  }
+  70% {
+    transform: translateY(4%) rotate(-1.5deg);
+  }
+  90% {
+    transform: translateY(2%) rotate(0deg);
+  }
+}
+
+@keyframes lobster-pet-droop-antennae {
+  0%,
+  100% {
+    transform: translateY(0) scaleY(1);
+  }
+  30%,
+  75% {
+    transform: translateY(3px) scaleY(0.72);
   }
 }
 


### PR DESCRIPTION
Related: #102754 (lobster pet series, round 3)

## What Problem This Solves

The pet reacts to status but not to *you*, and its reactions are dishonest at the edges: a failed or user-aborted run currently earns the same cheer as a success.

## Why This Change Was Made

Four sentience behaviors, element-scoped:

- **Gaze:** between acts the pet watches your pointer — facing follows the cursor (120ms throttle, inert under reduced motion, during acts, and while keeping vigil).
- **Petting:** press-and-hold (600ms) pets it: content closed eyes and a floating heart, and it forgives any grumpiness. A quick tap remains a poke with all the existing mood consequences. Releasing after a completed pet does not double-fire a poke.
- **Honest run reactions:** a new `resolveLobsterRunOutcome` picks the most recently *ended* session (`endedAt` first — activity stamps move on unrelated events — with fallbacks) and the busy→idle reaction now branches: success cheers, failure/timeout earns a sympathetic droop (sagging antennae, slow sad head-shake), and a user-killed run gets a plain acknowledging startle rather than a celebration.
- **Vigil:** a run that passes ten minutes summons the pet into a settled waiting pose — visible for the duration, acts paused — until the run ends. Solidarity.

## User Impact

The lobster looks at your cursor, can be petted, reacts truthfully to how your run actually ended, and sits with you through the long ones. No config changes; reduced-motion stays fully inert on every new path.

## Evidence

![sentience](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/sentience.png)

Validation (delegated Blacksmith Testbox, `exit=0`):

- `pnpm test ui/src/components/lobster-pet.test.ts` — 33/33: outcome resolver units (latest-ended ordering, endedAt precedence, aborted classification), hold-pets vs tap-pokes without double-fire, droop on failed runs, vigil arming from the initial busy render + act pause + release, pointer-gaze facing flips, plus the full existing suite.
- `pnpm tsgo:test:ui` and `pnpm --dir ui build`.
- Live verification against `pnpm dev:ui:mock`: gaze both directions, hold-pet with heart animation, droop on error outcome, vigil class.
- Codex autoreview over four cycles accepted and led to fixes for: pet-act eyes losing the blink cascade (the nap lesson, reapplied), vigil never arming on initial busy render (the seedChanged branch swallows the first mode update), resolver ignoring `endedAt`, and killed runs being celebrated; final review clean.
