### PR TITLE
fix(ui): prevent stale locale elements in shared test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
+- **Control UI live locale changes:** refresh mounted profile and agent-selector translations immediately after switching languages, with deterministic non-isolated coverage. (#103293, #103320)
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Browser node-proxy downloads:** transfer every action-produced download to the Gateway media store, align a 10 MiB per-file and 16 MiB aggregate transport budget, and rewrite plural download paths to Gateway-local files without traversing page-controlled result data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
-- **Control UI live locale changes:** refresh mounted profile and agent-selector translations immediately after switching languages, with deterministic non-isolated coverage. (#103293, #103320)
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Browser node-proxy downloads:** transfer every action-produced download to the Gateway media store, align a 10 MiB per-file and 16 MiB aggregate transport budget, and rewrite plural download paths to Gateway-local files without traversing page-controlled result data.

--- a/ui/src/components/native-link-menu.test.ts
+++ b/ui/src/components/native-link-menu.test.ts
@@ -5,7 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import { NativeLinkMenu, type NativeLinkMenuAction } from "./native-link-menu.ts";
 
+const NATIVE_LINK_MENU_ELEMENT_NAME = "test-openclaw-native-link-menu";
 const containers: HTMLElement[] = [];
+
+// The non-isolated UI runner resets modules but not customElements. Register
+// the current class graph so instanceof and locale updates share one module.
+class TestNativeLinkMenu extends NativeLinkMenu {}
+
+if (!customElements.get(NATIVE_LINK_MENU_ELEMENT_NAME)) {
+  customElements.define(NATIVE_LINK_MENU_ELEMENT_NAME, TestNativeLinkMenu);
+}
 
 beforeEach(async () => {
   await i18n.setLocale("en");
@@ -27,16 +36,16 @@ async function mountMenu(options: {
   containers.push(container);
   document.body.append(container);
   render(
-    html`<openclaw-native-link-menu
+    html`<test-openclaw-native-link-menu
       .x=${100}
       .y=${100}
       .trigger=${options.trigger ?? null}
       .onAction=${options.onAction ?? (() => {})}
       .onClose=${options.onClose ?? (() => {})}
-    ></openclaw-native-link-menu>`,
+    ></test-openclaw-native-link-menu>`,
     container,
   );
-  const menu = container.querySelector("openclaw-native-link-menu");
+  const menu = container.querySelector(NATIVE_LINK_MENU_ELEMENT_NAME);
   if (!(menu instanceof NativeLinkMenu)) {
     throw new Error("Expected native link menu");
   }

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -52,6 +52,16 @@ vi.mock("./terminal-runtime.ts", () => {
 
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 
+const TERMINAL_PANEL_ELEMENT_NAME = "test-openclaw-terminal-panel";
+
+// Keep the mounted panel and i18n manager in the current module graph when
+// the non-isolated runner has retained an earlier production registration.
+class TestTerminalPanel extends OpenClawTerminalPanel {}
+
+if (!customElements.get(TERMINAL_PANEL_ELEMENT_NAME)) {
+  customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
+}
+
 describe("OpenClawTerminalPanel", () => {
   beforeEach(async () => {
     await i18n.setLocale("en");
@@ -96,7 +106,7 @@ describe("OpenClawTerminalPanel", () => {
       },
       addEventListener: () => () => {},
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.agentId = "ops";
     panel.available = true;
@@ -164,7 +174,7 @@ describe("OpenClawTerminalPanel", () => {
       },
       addEventListener: () => () => {},
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.available = true;
     panel.fullscreen = true;
@@ -233,7 +243,7 @@ describe("OpenClawTerminalPanel", () => {
         };
       },
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.available = true;
     document.body.append(panel);
@@ -296,7 +306,7 @@ describe("OpenClawTerminalPanel", () => {
       },
       addEventListener: () => () => {},
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = oldClient;
     panel.available = true;
     document.body.append(panel);
@@ -332,7 +342,7 @@ describe("OpenClawTerminalPanel", () => {
       },
       addEventListener: () => () => {},
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.available = true;
     document.body.append(panel);
@@ -367,7 +377,7 @@ describe("OpenClawTerminalPanel", () => {
         (method === "terminal.open" ? terminalOpenResult("session-1") : {}) as T,
       addEventListener: () => () => {},
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.available = true;
     document.body.append(panel);
@@ -389,7 +399,7 @@ describe("OpenClawTerminalPanel", () => {
   });
 
   it("removes a tab host even when controller disposal throws", () => {
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     const host = document.createElement("div");
     document.body.append(host);
     const dispose = vi.fn(() => {
@@ -419,7 +429,7 @@ describe("OpenClawTerminalPanel", () => {
         };
       },
     };
-    const panel = document.createElement("openclaw-terminal-panel") as OpenClawTerminalPanel;
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
     panel.client = client;
     panel.available = true;
     document.body.append(panel);


### PR DESCRIPTION
Closes #103320

Complements #103338, which landed the same module-reset isolation for the agent selector and profile page.

## What Problem This Solves

The shared Control UI test worker resets evaluated modules between files while jsdom keeps its custom-element registry. Two sibling tests still mounted production tags that could therefore resolve to constructors retained from an earlier module graph:

- `native-link-menu.test.ts` could fail its current-class identity check before any assertion.
- `terminal-panel.test.ts` could mount a panel bound to stale i18n and mocked-runtime modules.

## Why This Change Was Made

Those tests now register test-only subclasses from their current imports and mount the test tags consistently. This keeps each mounted element, its i18n manager, its mocked dependencies, and the test's class identity on one module graph. Production tags and runtime behavior are unchanged.

## User Impact

No user-visible product behavior changes. Control UI CI remains deterministic when other test files register these production elements first.

## Evidence

- Before: on the prior `main`, the full UI suite reproduced the retained-constructor failure across all four native-link menu cases after another file registered the production tag first.
- Testbox-through-Crabbox `tbx_01kx52y0tmkngkj4cfgnrptkm9`: focused locale/component set 28/28, full UI suite 188 files and 2,691 tests, and `check:changed` all passed with this two-file hardening included: https://github.com/openclaw/openclaw/actions/runs/29068046843
- Refocused branch head `4a8c6768cfc4d5f135951dba9c05315b0edf8b16` is based on `d7d210f7e0b990478f290be49b0fb27d622d422e` and changes only the two test files above.
- Fresh repository autoreview on the refocused diff: clean, no accepted or actionable findings.
