### PR TITLE
feat(memory-wiki): isolate vaults per agent

### DIFF
--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -47,11 +47,33 @@ openclaw wiki obsidian command workspace:quick-switcher
 openclaw wiki obsidian daily
 ```
 
+## Agent selection
+
+When `plugins.entries.memory-wiki.config.vault.scope` is `agent`, select the
+vault with the top-level `--agent <id>` option:
+
+```bash
+openclaw wiki --agent support status
+openclaw wiki --agent support search "refund policy"
+openclaw wiki --agent marketing ingest ./campaign-notes.md
+```
+
+In a setup with multiple configured agents, `--agent` is required for CLI
+operations so a command cannot read or write an arbitrary default vault. If
+only one agent is configured, that agent remains the default. Unknown agent ids
+fail before the vault operation starts. The option does not change the selected
+path when `vault.scope` is `global`.
+
+Gateway clients follow the same rule: pass `agentId` on vault-backed `wiki.*`
+requests in an agent-scoped multi-agent setup. A missing or unknown id is an
+error. Agent turns, wiki tools, memory corpus supplements, and compiled prompt
+digests already carry the active runtime agent context.
+
 ## Commands
 
 ### `wiki status`
 
-Show vault mode, health, and Obsidian CLI availability. Use this first to check whether the vault is initialized, bridge mode is healthy, or Obsidian integration is available.
+Show vault mode and scope, resolved agent, health, and Obsidian CLI availability. Use this first to check whether the intended vault is initialized, bridge mode is healthy, or Obsidian integration is available.
 
 When bridge mode is active and configured to read memory artifacts, this command queries the running Gateway so it sees the same active memory plugin context as agent/runtime memory.
 
@@ -198,6 +220,11 @@ Roll back a previously applied ChatGPT import run, removing pages it created and
 
 Obsidian helper commands for vaults running in Obsidian-friendly mode: `status`, `search`, `open`, `command`, `daily`. These require the official `obsidian` CLI on `PATH` when `obsidian.useOfficialCli` is enabled.
 
+Configuration validation rejects `obsidian.useOfficialCli: true` when
+`vault.scope` is `agent` because `obsidian.vaultName` is one global setting,
+not a per-agent mapping. Obsidian-friendly Markdown rendering remains
+available.
+
 ## Practical usage guidance
 
 - Use `wiki search` + `wiki get` when provenance and page identity matter.
@@ -212,6 +239,8 @@ Obsidian helper commands for vaults running in Obsidian-friendly mode: `status`,
 `openclaw wiki` behavior is shaped by:
 
 - `plugins.entries.memory-wiki.config.vaultMode`
+- `plugins.entries.memory-wiki.config.vault.scope`
+- `plugins.entries.memory-wiki.config.vault.path`
 - `plugins.entries.memory-wiki.config.search.backend`
 - `plugins.entries.memory-wiki.config.search.corpus`
 - `plugins.entries.memory-wiki.config.bridge.*`

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -122,6 +122,7 @@ A plugin can register a context engine using the plugin API:
 
 ```ts
 import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
+import { resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 
 export default function register(api) {
   api.registerContextEngine("my-engine", (ctx) => ({
@@ -136,7 +137,14 @@ export default function register(api) {
       return { ingested: true };
     },
 
-    async assemble({ sessionId, messages, tokenBudget, availableTools, citationsMode }) {
+    async assemble({
+      sessionId,
+      sessionKey,
+      messages,
+      tokenBudget,
+      availableTools,
+      citationsMode,
+    }) {
       // Return messages that fit the budget
       return {
         messages: buildContext(messages, tokenBudget),
@@ -144,6 +152,8 @@ export default function register(api) {
         systemPromptAddition: buildMemorySystemPromptAddition({
           availableTools: availableTools ?? new Set(),
           citationsMode,
+          agentId: resolveSessionAgentId({ config: ctx.config, sessionKey }),
+          agentSessionKey: sessionKey,
         }),
       };
     },

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -1,12 +1,12 @@
 ---
-summary: "Multi-agent routing: isolated agents, channel accounts, and bindings"
+summary: "Multi-agent routing: agent boundaries, channel accounts, and bindings"
 title: "Multi-agent routing"
 sidebarTitle: "Multi-agent routing"
-read_when: "You want multiple isolated agents (workspaces + auth) in one gateway process."
+read_when: "You want multiple agents with separate workspaces, auth, and sessions in one Gateway process."
 status: active
 ---
 
-Run multiple _isolated_ agents in one Gateway process, each with its own workspace, state directory (`agentDir`), and session store, plus multiple channel accounts (e.g. two WhatsApp numbers). Inbound messages route to the right agent through **bindings**.
+Run multiple agents in one Gateway process, each with its own workspace, state directory (`agentDir`), and session store, plus multiple channel accounts (e.g. two WhatsApp numbers). Inbound messages route to the right agent through **bindings**.
 
 An **agent** is the full per-persona scope: workspace files, auth profiles, model registry, and session store. A **binding** maps a channel account (a Slack workspace, a WhatsApp number, etc.) to one of those agents.
 
@@ -33,6 +33,11 @@ Never reuse `agentDir` across agents — it causes auth/session state collisions
 </Warning>
 
 Skills load from each agent workspace plus shared roots such as `~/.openclaw/skills`, then filter by the effective agent skill allowlist. Use `agents.defaults.skills` for a shared baseline and `agents.list[].skills` for a per-agent replacement (explicit entries replace the default, they do not merge). See [Skills: per-agent vs shared](/tools/skills#per-agent-vs-shared-skills) and [Skills: agent allowlists](/tools/skills#agent-allowlists).
+
+Plugin-owned storage follows that plugin's configuration; adding a second agent
+does not automatically split every global plugin store. For example, configure
+[Memory Wiki per-agent vaults](/concepts/multi-agent#per-agent-memory-wiki-vaults)
+when personas must not share compiled wiki knowledge.
 
 <Note>
 **Workspace note:** each agent's workspace is the **default cwd**, not a hard sandbox. Relative paths resolve inside the workspace, but absolute paths can reach other host locations unless sandboxing is enabled. See [Sandboxing](/gateway/sandboxing).
@@ -114,13 +119,44 @@ openclaw agents list --bindings
 
 ## Multiple agents, multiple personas
 
-Each configured `agentId` is a fully isolated persona:
+Each configured `agentId` is a distinct persona boundary for core agent state:
 
 - Different accounts per channel (per `accountId`).
 - Different personalities (per-agent `AGENTS.md`/`SOUL.md`).
-- Separate auth and sessions, with no cross-talk unless explicitly enabled.
+- Separate auth and sessions, with cross-agent access enabled only through explicit features or plugin configuration.
 
-This lets multiple people share one Gateway while keeping their agent state isolated.
+This lets multiple people share one Gateway while keeping core agent state separate.
+
+## Per-agent Memory Wiki vaults
+
+Memory Wiki uses one global vault by default. To keep a support agent's
+compiled knowledge separate from a marketing agent's, set
+`plugins.entries.memory-wiki.config.vault.scope` to `agent`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "memory-wiki": {
+        enabled: true,
+        config: {
+          vault: {
+            scope: "agent",
+            path: "~/.openclaw/wiki",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+The configured path is the parent directory. OpenClaw appends the normalized
+agent id, producing paths such as `~/.openclaw/wiki/support` and
+`~/.openclaw/wiki/marketing`. Agent-scoped CLI and Gateway operations require
+an explicit agent when multiple agents are configured. See
+[Memory Wiki per-agent vaults](/plugins/memory-wiki#per-agent-vaults) for bridge
+filtering, migration, and trust-boundary details.
 
 ## Cross-agent QMD memory search
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2089,6 +2089,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H1: openclaw wiki
   - H2: Common commands
+  - H2: Agent selection
   - H2: Commands
   - H3: wiki status
   - H3: wiki doctor
@@ -2640,6 +2641,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Agent helper
   - H2: Quick start
   - H2: Multiple agents, multiple personas
+  - H2: Per-agent Memory Wiki vaults
   - H2: Cross-agent QMD memory search
   - H2: One WhatsApp number, multiple people (DM split)
   - H2: Routing rules
@@ -5664,6 +5666,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Agent tools
   - H2: Prompt and context behavior
   - H2: Configuration
+  - H3: Per-agent vaults
   - H3: Example: QMD + bridge mode
   - H2: CLI
   - H2: Obsidian support

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -1063,6 +1063,7 @@ pipeline rather than just add memory search or hooks.
 
 ```ts
 import { buildMemorySystemPromptAddition } from "openclaw/plugin-sdk/core";
+import { resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 
 export default function (api) {
   api.registerContextEngine("lossless-claw", (ctx) => ({
@@ -1070,13 +1071,15 @@ export default function (api) {
     async ingest() {
       return { ingested: true };
     },
-    async assemble({ messages, availableTools, citationsMode }) {
+    async assemble({ messages, sessionKey, availableTools, citationsMode }) {
       return {
         messages,
         estimatedTokens: 0,
         systemPromptAddition: buildMemorySystemPromptAddition({
           availableTools: availableTools ?? new Set(),
           citationsMode,
+          agentId: resolveSessionAgentId({ config: ctx.config, sessionKey }),
+          agentSessionKey: sessionKey,
         }),
       };
     },
@@ -1108,6 +1111,7 @@ import {
   buildMemorySystemPromptAddition,
   delegateCompactionToRuntime,
 } from "openclaw/plugin-sdk/core";
+import { resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 
 export default function (api) {
   api.registerContextEngine("my-memory-engine", (ctx) => ({
@@ -1119,13 +1123,15 @@ export default function (api) {
     async ingest() {
       return { ingested: true };
     },
-    async assemble({ messages, availableTools, citationsMode }) {
+    async assemble({ messages, sessionKey, availableTools, citationsMode }) {
       return {
         messages,
         estimatedTokens: 0,
         systemPromptAddition: buildMemorySystemPromptAddition({
           availableTools: availableTools ?? new Set(),
           citationsMode,
+          agentId: resolveSessionAgentId({ config: ctx.config, sessionKey }),
+          agentSessionKey: sessionKey,
         }),
       };
     },

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -3,6 +3,7 @@ summary: "memory-wiki: compiled knowledge vault with provenance, claims, dashboa
 read_when:
   - You want persistent knowledge beyond plain MEMORY.md notes
   - You are configuring the bundled memory-wiki plugin
+  - You need separate wiki vaults for agents in one Gateway
   - You want to understand wiki_search, wiki_get, or bridge mode
 title: "Memory wiki"
 ---
@@ -40,6 +41,18 @@ then confirm the active memory plugin supports public artifacts.
 - `isolated` (default): own vault, own sources, no dependency on the active memory plugin. Use this for a self-contained curated knowledge store.
 - `bridge`: reads public memory artifacts and event logs from the active memory plugin through public plugin SDK seams. Use this to compile the memory plugin's exported artifacts without reaching into private plugin internals.
 - `unsafe-local`: explicit same-machine escape hatch for local private paths. Intentionally experimental and non-portable; use only when you understand the trust boundary and specifically need local filesystem access bridge mode cannot provide.
+
+Vault mode and vault scope are separate choices:
+
+- `vaultMode` chooses where wiki inputs come from.
+- `vault.scope` chooses whether all agents use one vault or each agent gets a child vault.
+
+`vault.scope: "global"` is the default and preserves the existing single-vault
+behavior. Use `vault.scope: "agent"` with `isolated` or `bridge` mode when
+agents must not share wiki pages, compiled digests, search results, or writes.
+Agent scope cannot be combined with `unsafe-local` mode because those configured
+private paths are not agent-owned inputs. Configuration validation rejects this
+combination.
 
 Bridge mode can index, per `bridge.*` config toggle:
 
@@ -244,7 +257,7 @@ includes compact `Claim:` and `Evidence:` lines when available.
 
 | Tool          | Purpose                                                                                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wiki_status` | current vault mode, health, Obsidian CLI availability                                                                                                         |
+| `wiki_status` | current vault mode and scope, resolved agent, health, Obsidian CLI availability                                                                               |
 | `wiki_search` | search wiki pages and, when configured, the shared memory corpus; accepts `mode` for person lookup, question routing, source evidence, or raw claim drilldown |
 | `wiki_get`    | read a wiki page by id/path, falling back to the shared memory corpus when shared search is enabled and the lookup misses                                     |
 | `wiki_apply`  | narrow synthesis/metadata mutations without freeform page surgery                                                                                             |
@@ -276,6 +289,7 @@ Put config under `plugins.entries.memory-wiki.config`:
         config: {
           vaultMode: "isolated",
           vault: {
+            scope: "global",
             path: "~/.openclaw/wiki/main",
             renderMode: "obsidian",
           },
@@ -323,20 +337,83 @@ Put config under `plugins.entries.memory-wiki.config`:
 
 Key toggles:
 
-| Key                                        | Values / default                               | Notes                                                    |
-| ------------------------------------------ | ---------------------------------------------- | -------------------------------------------------------- |
-| `vaultMode`                                | `isolated` (default), `bridge`, `unsafe-local` |                                                          |
-| `vault.path`                               | default `~/.openclaw/wiki/main`                |                                                          |
-| `vault.renderMode`                         | `native` (default), `obsidian`                 |                                                          |
-| `bridge.readMemoryArtifacts`               | default `true`                                 | import active memory plugin public artifacts             |
-| `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                        |
-| `unsafeLocal.allowPrivateMemoryCoreAccess` | default `false`                                | required to run `unsafe-local` imports                   |
-| `unsafeLocal.paths`                        | default `[]`                                   | explicit local paths to import in `unsafe-local` mode    |
-| `search.backend`                           | `shared` (default), `local`                    |                                                          |
-| `search.corpus`                            | `wiki` (default), `memory`, `all`              |                                                          |
-| `context.includeCompiledDigestPrompt`      | default `false`                                | append compact digest snapshot to memory prompt sections |
-| `render.createBacklinks`                   | default `true`                                 | generate deterministic related blocks                    |
-| `render.createDashboards`                  | default `true`                                 | generate dashboard pages                                 |
+| Key                                        | Values / default                               | Notes                                                                         |
+| ------------------------------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| `vaultMode`                                | `isolated` (default), `bridge`, `unsafe-local` | chooses input and integration behavior                                        |
+| `vault.scope`                              | `global` (default), `agent`                    | one shared vault or one child vault per agent                                 |
+| `vault.path`                               | global default `~/.openclaw/wiki/main`         | exact vault globally; agent-scope parent defaults to `~/.openclaw/wiki`       |
+| `vault.renderMode`                         | `native` (default), `obsidian`                 |                                                                               |
+| `bridge.readMemoryArtifacts`               | default `true`                                 | import active memory plugin public artifacts                                  |
+| `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                                             |
+| `unsafeLocal.allowPrivateMemoryCoreAccess` | default `false`                                | required to run `unsafe-local` imports                                        |
+| `unsafeLocal.paths`                        | default `[]`                                   | explicit local paths to import in `unsafe-local` mode                         |
+| `search.backend`                           | `shared` (default), `local`                    |                                                                               |
+| `search.corpus`                            | `wiki` (default), `memory`, `all`              |                                                                               |
+| `context.includeCompiledDigestPrompt`      | default `false`                                | append the selected agent's compact digest snapshot to memory prompt sections |
+| `render.createBacklinks`                   | default `true`                                 | generate deterministic related blocks                                         |
+| `render.createDashboards`                  | default `true`                                 | generate dashboard pages                                                      |
+
+### Per-agent vaults
+
+Set `vault.scope` to `agent` to give every configured agent a separate wiki.
+In this scope, `vault.path` is a parent directory and OpenClaw appends the
+normalized agent id:
+
+```json5
+{
+  agents: {
+    list: [{ id: "support" }, { id: "marketing" }],
+  },
+  plugins: {
+    entries: {
+      "memory-wiki": {
+        enabled: true,
+        config: {
+          vaultMode: "bridge",
+          vault: {
+            scope: "agent",
+            path: "~/.openclaw/wiki",
+          },
+          bridge: {
+            enabled: true,
+            readMemoryArtifacts: true,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+This resolves to `~/.openclaw/wiki/support` and
+`~/.openclaw/wiki/marketing`. If `vault.path` is omitted in agent scope, the
+parent defaults to `~/.openclaw/wiki`. The default `main` agent therefore keeps
+the existing `~/.openclaw/wiki/main` path.
+
+Agent tools, compiled prompt digests, and the wiki supplement exposed through
+`memory_search` / `memory_get` resolve the vault from the active agent context.
+For CLI and Gateway calls in a setup with multiple configured agents, provide
+the agent explicitly with `openclaw wiki --agent <agentId> ...` or the Gateway
+request's `agentId`. A single configured agent remains the default when no id is
+provided.
+
+In bridge mode, agent-scoped imports accept a public memory artifact only when
+its `agentIds` includes the selected agent. Artifacts owned by another agent,
+without ownership metadata, or with an unknown owner are skipped. Global scope
+keeps the existing shared-artifact behavior.
+
+<Warning>
+Changing `vault.scope` does not copy or split an existing vault. In agent scope,
+an explicitly configured `vault.path` becomes a parent directory, so move or
+import existing pages deliberately before switching production agents. Back up
+the vault first.
+
+Per-agent vaults are a same-process knowledge boundary, not an operating-system
+security boundary. Plugins and unsandboxed tools with host filesystem access can
+still read another agent's directory. Use [sandboxing](/gateway/sandboxing) or
+[separate Gateway profiles](/gateway/multiple-gateways) when agents do not trust
+each other.
+</Warning>
 
 ### Example: QMD + bridge mode
 
@@ -410,6 +487,12 @@ Markdown and can optionally use the official `obsidian` CLI for status
 probing, vault search, opening a page, invoking a command, and jumping to the
 daily note. This is optional; the wiki still works in native mode without
 Obsidian.
+
+Agent-scoped vaults can still use Obsidian-friendly Markdown, but configuration
+validation rejects `obsidian.useOfficialCli: true` with `vault.scope: "agent"`.
+The current `obsidian.vaultName` setting is global and cannot select a distinct
+Obsidian vault for each agent. Use the wiki tools and CLI operations instead,
+or keep an Obsidian-operated wiki in global scope.
 
 ## Recommended workflow
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -187,6 +187,14 @@ guidance remain available to non-Codex prompt surfaces for compatibility.
 | `api.registerNodeInvokePolicy(policy)`          | Allowlist/approval policy for node-invoked commands          |
 | `api.registerSecurityAuditCollector(collector)` | Findings collector for `openclaw security audit`             |
 
+Memory prompt supplement builders receive optional `agentId`,
+`agentSessionKey`, and `sandboxed` context. Memory corpus supplement `search`
+and `get` calls receive optional `agentId` and `sandboxed` context. Plugins with
+agent-owned storage should resolve that storage for each call instead of
+capturing one global path during registration. If an agent id is required but
+missing in a multi-agent operation, fail closed rather than choosing an
+arbitrary agent.
+
 Telegram interactive handlers can return `{ submitText }` to route text through
 Telegram's normal inbound agent path after the handler succeeds. OpenClaw keeps
 the callback button when inbound policy skips the text or processing fails, so

--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -6,6 +6,10 @@ import {
   embeddedAgentLog,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-host-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexWorkspaceBootstrapContext,
@@ -20,6 +24,7 @@ import type { CodexAppServerContextEngineBinding } from "./session-binding.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  clearMemoryPluginState();
 });
 
 describe("Codex app-server attempt context", () => {
@@ -141,6 +146,54 @@ describe("Codex app-server attempt context", () => {
     expect(context.memoryReferenceFiles).toEqual([]);
     expect(context.promptContext).toContain(memorySummary);
     expect(context.memoryToolRouted).toBe(false);
+  });
+
+  it("passes agent context to Codex memory collaboration guidance", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agent-memory-"));
+    let observedContext:
+      | { agentId?: string; agentSessionKey?: string; sandboxed?: boolean }
+      | undefined;
+    registerMemoryCapability("memory-core", {
+      promptBuilder: (context) => {
+        observedContext = context;
+        return [
+          "## Agent Memory",
+          `agent=${context.agentId} session=${context.agentSessionKey}`,
+          "",
+        ];
+      },
+    });
+
+    try {
+      const context = await buildCodexWorkspaceBootstrapContext({
+        params: {
+          sessionId: "session-1",
+          sessionKey: "agent:marketing-agent:session-1",
+          config: {
+            agents: {
+              defaults: { workspace: workspaceDir },
+              list: [{ id: "marketing-agent", default: true, workspace: workspaceDir }],
+            },
+          },
+        } as EmbeddedRunAttemptParams,
+        resolvedWorkspace: workspaceDir,
+        effectiveWorkspace: workspaceDir,
+        sessionKey: "agent:marketing-agent:session-1",
+        sessionAgentId: "marketing-agent",
+        memoryToolNames: ["memory_search", "memory_get"],
+      });
+
+      expect(context.memoryToolRouted).toBe(true);
+      expect(observedContext).toMatchObject({
+        agentId: "marketing-agent",
+        agentSessionKey: "agent:marketing-agent:session-1",
+      });
+      expect(context.memoryCollaborationInstructions).toContain(
+        "agent=marketing-agent session=agent:marketing-agent:session-1",
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("remaps Codex bootstrap files under dot-prefixed workspace directories", () => {

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -260,6 +260,8 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
             toolNames: params.memoryToolNames,
             memoryToolRouted: memoryToolsAvailable,
             citationsMode: params.params.config?.memory?.citations,
+            agentId: params.params.agentId ?? params.sessionAgentId,
+            agentSessionKey: params.sessionKey,
           })
         : undefined,
       heartbeatCollaborationInstructions:
@@ -858,11 +860,15 @@ function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
   toolNames: readonly string[];
   memoryToolRouted: boolean;
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+  agentId?: string;
+  agentSessionKey?: string;
 }): string | undefined {
   const memoryRecallInstructions = params.memoryToolRouted
     ? renderCodexMemoryRecallInstructions({
         toolNames: params.toolNames,
         citationsMode: params.citationsMode,
+        agentId: params.agentId,
+        agentSessionKey: params.agentSessionKey,
       })
     : undefined;
   const memoryReferenceInstructions = renderCodexWorkspaceMemoryReference({
@@ -876,11 +882,15 @@ function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
 function renderCodexMemoryRecallInstructions(params: {
   toolNames: readonly string[];
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+  agentId?: string;
+  agentSessionKey?: string;
 }): string | undefined {
   const availableTools = new Set(params.toolNames);
   const memoryPrompt = buildMemorySystemPromptAddition({
     availableTools,
     citationsMode: params.citationsMode,
+    agentId: params.agentId,
+    agentSessionKey: params.agentSessionKey,
   });
   if (!memoryPrompt) {
     // Memory recall policy belongs to the active memory plugin.

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -20,7 +20,11 @@ import {
 } from "./memory-tool-manager.test-mocks.js";
 import { testing as shortTermPromotionTesting } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
-import { testing as memoryToolsTesting } from "./tools.js";
+import {
+  createMemoryGetTool,
+  createMemorySearchTool,
+  testing as memoryToolsTesting,
+} from "./tools.js";
 import {
   asOpenClawConfig,
   createAutoCitationsMemorySearchTool,
@@ -393,6 +397,51 @@ describe("memory tools", () => {
     expect(getMemorySearchManagerMockCalls()).toBe(0);
   });
 
+  it.each(["wiki", "all"] as const)(
+    "forwards effective agent context to memory_search corpus=%s supplements",
+    async (corpus) => {
+      const search = vi.fn(async () => [
+        {
+          corpus: "wiki" as const,
+          path: "entities/alpha.md",
+          score: 4,
+          snippet: "Alpha wiki entry",
+        },
+      ]);
+      registerMemoryCorpusSupplement("memory-wiki", {
+        search,
+        get: async () => null,
+      });
+      const config = asOpenClawConfig({
+        agents: { list: [{ id: "marketing-agent", default: true }] },
+      });
+      const tool = createMemorySearchTool({
+        config,
+        agentId: " Marketing Agent ",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+      });
+      if (!tool) {
+        throw new Error("expected memory_search tool");
+      }
+
+      await tool.execute(`call_search_${corpus}`, {
+        query: "alpha",
+        maxResults: 3,
+        corpus,
+      });
+
+      expect(search).toHaveBeenCalledWith({
+        query: "alpha",
+        maxResults: 3,
+        agentId: "marketing-agent",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+        corpus,
+      });
+    },
+  );
+
   it("includes memory results in corpus=all even when wiki scores are numerically higher (#77337)", async () => {
     // Wiki uses integer point scores (up to ~100+); memory uses cosine similarity (0-1).
     // Raw-score sort would starve memory hits when maxResults <= number of wiki hits.
@@ -629,6 +678,57 @@ describe("memory tools", () => {
       lineCount: 5,
     });
   });
+
+  it.each(["wiki", "all"] as const)(
+    "forwards effective agent context to memory_get corpus=%s supplements",
+    async (corpus) => {
+      if (corpus === "all") {
+        setMemoryReadFileImpl(async () => {
+          throw new Error("memory path missing");
+        });
+      }
+      const get = vi.fn(async () => ({
+        corpus: "wiki" as const,
+        path: "entities/alpha.md",
+        content: "Alpha wiki entry",
+        fromLine: 2,
+        lineCount: 4,
+      }));
+      registerMemoryCorpusSupplement("memory-wiki", {
+        search: async () => [],
+        get,
+      });
+      const config = asOpenClawConfig({
+        agents: { list: [{ id: "marketing-agent", default: true }] },
+      });
+      const tool = createMemoryGetTool({
+        config,
+        agentId: " Marketing Agent ",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+      });
+      if (!tool) {
+        throw new Error("expected memory_get tool");
+      }
+
+      await tool.execute(`call_get_${corpus}`, {
+        path: "entities/alpha.md",
+        from: 2,
+        lines: 4,
+        corpus,
+      });
+
+      expect(get).toHaveBeenCalledWith({
+        lookup: "entities/alpha.md",
+        fromLine: 2,
+        lineCount: 4,
+        agentId: "marketing-agent",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+        corpus,
+      });
+    },
+  );
 
   it("falls back to a wiki corpus supplement when memory_get corpus=all misses memory without throwing", async () => {
     setMemoryReadFileImpl(async (params: MemoryReadParams) => ({

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -19,6 +19,7 @@ type MemoryToolOptions = {
   getConfig?: () => OpenClawConfig | undefined;
   agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
   oneShotCliRun?: boolean;
 };
 
@@ -154,7 +155,9 @@ export function buildMemorySearchUnavailableResult(
 export async function searchMemoryCorpusSupplements(params: {
   query: string;
   maxResults?: number;
+  agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
@@ -183,7 +186,9 @@ export async function getMemoryCorpusSupplementResult(params: {
   lookup: string;
   fromLine?: number;
   lineCount?: number;
+  agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
 }) {
   if (params.corpus === "memory" || params.corpus === "sessions") {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -319,14 +319,18 @@ async function getSupplementMemoryReadResult(params: {
   relPath: string;
   from?: number;
   lines?: number;
+  agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all";
 }) {
   const supplement = await getMemoryCorpusSupplementResult({
     lookup: params.relPath,
     fromLine: params.from,
     lineCount: params.lines,
+    agentId: params.agentId,
     agentSessionKey: params.agentSessionKey,
+    sandboxed: params.sandboxed,
     corpus: params.corpus,
   });
   if (!supplement) {
@@ -345,7 +349,9 @@ async function resolveMemoryReadFailureResult(params: {
   relPath: string;
   from?: number;
   lines?: number;
+  agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
 }) {
   if (params.requestedCorpus === "all") {
     try {
@@ -353,7 +359,9 @@ async function resolveMemoryReadFailureResult(params: {
         relPath: params.relPath,
         from: params.from,
         lines: params.lines,
+        agentId: params.agentId,
         agentSessionKey: params.agentSessionKey,
+        sandboxed: params.sandboxed,
         corpus: params.requestedCorpus,
       });
       if (supplement) {
@@ -378,7 +386,9 @@ async function executeMemoryReadResult(params: {
   relPath: string;
   from?: number;
   lines?: number;
+  agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
 }) {
   try {
     const result = await params.read();
@@ -387,7 +397,9 @@ async function executeMemoryReadResult(params: {
         relPath: params.relPath,
         from: params.from,
         lines: params.lines,
+        agentId: params.agentId,
         agentSessionKey: params.agentSessionKey,
+        sandboxed: params.sandboxed,
         corpus: params.requestedCorpus,
       });
       if (supplement) {
@@ -402,7 +414,9 @@ async function executeMemoryReadResult(params: {
       relPath: params.relPath,
       from: params.from,
       lines: params.lines,
+      agentId: params.agentId,
       agentSessionKey: params.agentSessionKey,
+      sandboxed: params.sandboxed,
     });
   }
 }
@@ -677,7 +691,9 @@ export function createMemorySearchTool(options: {
                       await searchMemoryCorpusSupplements({
                         query,
                         maxResults,
+                        agentId,
                         agentSessionKey: options.agentSessionKey,
+                        sandboxed: options.sandboxed,
                         corpus: requestedCorpus,
                       }),
                   )
@@ -733,6 +749,7 @@ export function createMemoryGetTool(options: {
   getConfig?: () => OpenClawConfig | undefined;
   agentId?: string;
   agentSessionKey?: string;
+  sandboxed?: boolean;
 }) {
   return createMemoryTool({
     options,
@@ -759,7 +776,9 @@ export function createMemoryGetTool(options: {
             relPath,
             from: from ?? undefined,
             lines: lines ?? undefined,
+            agentId,
             agentSessionKey: options.agentSessionKey,
+            sandboxed: options.sandboxed,
             corpus: requestedCorpus,
           });
           return jsonResult(
@@ -786,7 +805,9 @@ export function createMemoryGetTool(options: {
             relPath,
             from: from ?? undefined,
             lines: lines ?? undefined,
+            agentId,
             agentSessionKey: options.agentSessionKey,
+            sandboxed: options.sandboxed,
           });
         }
         const memory = await getMemoryManagerContextWithPurpose({
@@ -808,7 +829,9 @@ export function createMemoryGetTool(options: {
           relPath,
           from: from ?? undefined,
           lines: lines ?? undefined,
+          agentId,
           agentSessionKey: options.agentSessionKey,
+          sandboxed: options.sandboxed,
         });
       },
   });

--- a/extensions/memory-wiki/README.md
+++ b/extensions/memory-wiki/README.md
@@ -14,6 +14,10 @@ When the active memory plugin exposes shared recall, agents can use `memory_sear
 
 Default mode is `isolated`.
 
+`vaultMode` controls the wiki's inputs. `vault.scope` separately controls
+whether agents share one vault (`global`, the default) or resolve separate
+vaults (`agent`).
+
 ## Config
 
 Put config under `plugins.entries.memory-wiki.config`:
@@ -23,6 +27,7 @@ Put config under `plugins.entries.memory-wiki.config`:
   vaultMode: "isolated",
 
   vault: {
+    scope: "global", // or "agent"
     path: "~/.openclaw/wiki/main",
     renderMode: "obsidian", // or "native"
   },
@@ -70,6 +75,51 @@ Put config under `plugins.entries.memory-wiki.config`:
   },
 }
 ```
+
+### Per-agent vaults
+
+In agent scope, `vault.path` is a parent directory. OpenClaw appends the
+normalized agent id:
+
+```json5
+{
+  vaultMode: "bridge",
+  vault: {
+    scope: "agent",
+    path: "~/.openclaw/wiki",
+  },
+  bridge: {
+    enabled: true,
+    readMemoryArtifacts: true,
+  },
+  obsidian: {
+    useOfficialCli: false,
+  },
+}
+```
+
+This resolves agents such as `support` and `marketing` to
+`~/.openclaw/wiki/support` and `~/.openclaw/wiki/marketing`. With no explicit
+path, the parent defaults to `~/.openclaw/wiki`; the default `main` agent
+therefore keeps the existing `~/.openclaw/wiki/main` path. In global scope,
+`vault.path` remains the exact shared vault path.
+
+Wiki tools and compiled prompt/corpus supplements resolve the active runtime
+agent on each call. In bridge mode, an agent vault imports only public memory
+artifacts whose `agentIds` includes that agent; unowned and other-agent
+artifacts are skipped. CLI and Gateway operations require an explicit agent in
+multi-agent setups; use `openclaw wiki --agent <agentId> ...` or pass `agentId`
+to the `wiki.*` RPC request. A single configured agent may remain implicit.
+
+Configuration validation rejects agent scope with either
+`vaultMode: "unsafe-local"` or `obsidian.useOfficialCli: true`. Obsidian-friendly
+Markdown rendering still works with agent vaults when official CLI actions are
+disabled.
+
+Changing scope does not copy or split existing pages. Back up the vault and
+move or import content deliberately. Per-agent paths are a same-process
+knowledge boundary, not an operating-system security boundary; unsandboxed
+plugins and tools can still access another agent's host files.
 
 ## Vault shape
 
@@ -130,6 +180,10 @@ openclaw wiki obsidian search "alpha"
 openclaw wiki obsidian open syntheses/alpha-summary.md
 openclaw wiki obsidian command workspace:quick-switcher
 openclaw wiki obsidian daily
+
+# Agent-scoped vault
+openclaw wiki --agent support status
+openclaw wiki --agent support search "refund policy"
 ```
 
 ## Agent tools
@@ -170,10 +224,14 @@ Write methods:
 - `wiki.obsidian.command`
 - `wiki.obsidian.daily`
 
+For agent-scoped vaults, pass `agentId` to vault-backed RPC methods. Missing or
+unknown ids fail in multi-agent setups.
+
 ## Notes
 
 - `unsafe-local` is intentionally experimental and non-portable.
 - Bridge mode reads the active memory plugin through public seams only.
+- Agent scope is incompatible with `unsafe-local` and official Obsidian CLI actions.
 - Wiki pages are compiled artifacts, not the ultimate source of truth. Keep provenance attached to raw sources, memory artifacts, and daily notes.
 - The compiled agent digests in `.openclaw-wiki/cache/agent-digest.json` and `.openclaw-wiki/cache/claims.jsonl` are the stable machine-facing view of the wiki.
 - Obsidian CLI support requires the official `obsidian` CLI to be installed and available on `PATH`.

--- a/extensions/memory-wiki/cli-metadata.test.ts
+++ b/extensions/memory-wiki/cli-metadata.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   registerWikiCli: vi.fn(),
+  resolveMemoryWikiAgentConfig: vi.fn(),
   resolveMemoryWikiConfig: vi.fn(),
 }));
 
@@ -13,6 +14,7 @@ vi.mock("./src/cli.js", () => ({
 }));
 
 vi.mock("./src/config.js", () => ({
+  resolveMemoryWikiAgentConfig: mocks.resolveMemoryWikiAgentConfig,
   resolveMemoryWikiConfig: mocks.resolveMemoryWikiConfig,
 }));
 
@@ -73,6 +75,13 @@ describe("memory-wiki cli metadata entry", () => {
     expect(mocks.resolveMemoryWikiConfig).toHaveBeenCalledWith(
       appConfig.plugins.entries["memory-wiki"].config,
     );
-    expect(mocks.registerWikiCli).toHaveBeenCalledWith(program, resolvedConfig, appConfig);
+    expect(mocks.registerWikiCli).toHaveBeenCalledWith(
+      program,
+      expect.objectContaining({
+        config: resolvedConfig,
+        getAppConfig: expect.any(Function),
+        resolveConfig: expect.any(Function),
+      }),
+    );
   });
 });

--- a/extensions/memory-wiki/cli-metadata.ts
+++ b/extensions/memory-wiki/cli-metadata.ts
@@ -8,12 +8,20 @@ export default definePluginEntry({
   register(api) {
     api.registerCli(
       async ({ program, config: appConfig }) => {
-        const [{ registerWikiCli }, { resolveMemoryWikiConfig }] = await Promise.all([
-          import("./src/cli.js"),
-          import("./src/config.js"),
-        ]);
+        const [{ registerWikiCli }, { resolveMemoryWikiAgentConfig, resolveMemoryWikiConfig }] =
+          await Promise.all([import("./src/cli.js"), import("./src/config.js")]);
         const pluginConfig = appConfig.plugins?.entries?.["memory-wiki"]?.config;
-        registerWikiCli(program, resolveMemoryWikiConfig(pluginConfig), appConfig);
+        const config = resolveMemoryWikiConfig(pluginConfig);
+        registerWikiCli(program, {
+          config,
+          getAppConfig: () => appConfig,
+          resolveConfig: (agentId, currentAppConfig) =>
+            resolveMemoryWikiAgentConfig({
+              config,
+              appConfig: currentAppConfig ?? appConfig,
+              ...(agentId ? { agentId } : {}),
+            }),
+        });
       },
       {
         descriptors: [

--- a/extensions/memory-wiki/doctor-contract-api.test.ts
+++ b/extensions/memory-wiki/doctor-contract-api.test.ts
@@ -31,15 +31,19 @@ function resolveLegacyImportRunRecordPath(vaultRoot: string, runId: string): str
   return path.join(vaultRoot, ".openclaw-wiki", "import-runs", `${runId}.json`);
 }
 
-function migrationParams(params: { stateDir: string; vaultRoot: string }) {
+function migrationParams(params: { stateDir: string; vaultRoot: string; agentIds?: string[] }) {
   const env = { ...process.env, HOME: params.stateDir, OPENCLAW_STATE_DIR: params.stateDir };
   return {
     config: {
+      ...(params.agentIds ? { agents: { list: params.agentIds.map((id) => ({ id })) } } : {}),
       plugins: {
         entries: {
           "memory-wiki": {
             config: {
-              vault: { path: params.vaultRoot },
+              vault: {
+                path: params.vaultRoot,
+                ...(params.agentIds ? { scope: "agent" as const } : {}),
+              },
             },
           },
         },
@@ -266,5 +270,49 @@ describe("memory-wiki doctor source sync migration", () => {
       },
     });
     await expect(fs.stat(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("migrates legacy state from every configured agent vault", async () => {
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vaults");
+    const agentIds = ["support", "marketing"];
+    for (const agentId of agentIds) {
+      const legacyPath = resolveMemoryWikiSourceSyncStatePath(path.join(vaultRoot, agentId));
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({
+          version: 1,
+          entries: {
+            [agentId]: {
+              group: "bridge",
+              pagePath: `sources/${agentId}.md`,
+              sourcePath: `/tmp/${agentId}.md`,
+              sourceUpdatedAtMs: 100,
+              sourceSize: 200,
+              renderFingerprint: agentId,
+            },
+          },
+        })}\n`,
+      );
+    }
+
+    const params = migrationParams({ stateDir, vaultRoot, agentIds });
+    await expect(stateMigrations[0].detectLegacyState(params)).resolves.toEqual({
+      preview: [
+        expect.stringContaining(path.join(vaultRoot, "support")),
+        expect.stringContaining(path.join(vaultRoot, "marketing")),
+      ],
+    });
+    await expect(stateMigrations[0].migrateLegacyState(params)).resolves.toMatchObject({
+      warnings: [],
+    });
+
+    const store = createMemoryWikiSourceSyncStateStore(params.context.openPluginStateKeyedStore);
+    for (const agentId of agentIds) {
+      await expect(
+        readMemoryWikiSourceSyncState(path.join(vaultRoot, agentId), store),
+      ).resolves.toMatchObject({ entries: { [agentId]: { renderFingerprint: agentId } } });
+    }
   });
 });

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -7,7 +7,12 @@ import {
   legacyStateFileExists,
   type PluginDoctorStateMigration,
 } from "openclaw/plugin-sdk/runtime-doctor";
-import { resolveMemoryWikiConfig, type MemoryWikiPluginConfig } from "./src/config.js";
+import {
+  resolveMemoryWikiAgentConfig,
+  resolveMemoryWikiConfig,
+  resolveMemoryWikiConfiguredAgentIds,
+  type MemoryWikiPluginConfig,
+} from "./src/config.js";
 export { legacyConfigRules, normalizeCompatibilityConfig } from "./src/config-compat.js";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -50,7 +55,17 @@ function resolveConfiguredVaultRoots(params: {
   const resolved = resolveMemoryWikiConfig(readConfiguredPluginConfig(params.config), {
     homedir: homeDir,
   });
-  return [resolved.vault.path];
+  if (resolved.vault.scope === "global") {
+    return [resolved.vault.path];
+  }
+  return resolveMemoryWikiConfiguredAgentIds(params.config).map(
+    (agentId) =>
+      resolveMemoryWikiAgentConfig({
+        config: resolved,
+        appConfig: params.config,
+        agentId,
+      }).vault.path,
+  );
 }
 
 async function archiveLegacyImportRunRecords(params: {

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -1,9 +1,24 @@
 // Memory Wiki tests cover index plugin behavior.
-import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "./api.js";
 import plugin from "./index.js";
 import { createMemoryWikiTestHarness } from "./src/test-helpers.js";
 
-const { createPluginApi } = createMemoryWikiTestHarness();
+const toolMocks = vi.hoisted(() => {
+  const createTool = (name: string) => vi.fn((config: unknown) => ({ name, testConfig: config }));
+  return {
+    createWikiApplyTool: createTool("wiki_apply"),
+    createWikiGetTool: createTool("wiki_get"),
+    createWikiLintTool: createTool("wiki_lint"),
+    createWikiSearchTool: createTool("wiki_search"),
+    createWikiStatusTool: createTool("wiki_status"),
+  };
+});
+
+vi.mock("./src/tool.js", () => toolMocks);
+
+const { createPluginApi, createTempDir } = createMemoryWikiTestHarness();
 
 describe("memory-wiki plugin", () => {
   it("registers prompt supplement, gateway methods, tools, and wiki cli surface", () => {
@@ -49,6 +64,13 @@ describe("memory-wiki plugin", () => {
       "wiki_search",
       "wiki_get",
     ]);
+    expect(registerTool.mock.calls.map((call) => typeof call[0])).toEqual([
+      "function",
+      "function",
+      "function",
+      "function",
+      "function",
+    ]);
     expect(registerCli).toHaveBeenCalledTimes(1);
     expect(registerCli.mock.calls[0]?.[1]).toStrictEqual({
       descriptors: [
@@ -59,5 +81,46 @@ describe("memory-wiki plugin", () => {
         },
       ],
     });
+  });
+
+  it("resolves every tool factory from the invocation agent", async () => {
+    const rootDir = await createTempDir("memory-wiki-index-agents-");
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    } as OpenClawConfig;
+    const { api, registerTool } = createPluginApi();
+    api.config = appConfig;
+    api.pluginConfig = {
+      vault: { scope: "agent", path: rootDir },
+    };
+    Object.assign(api.runtime, {
+      config: {
+        current: () => appConfig,
+      },
+    });
+
+    plugin.register(api);
+
+    for (const [factory, registration] of registerTool.mock.calls) {
+      expect(factory).toEqual(expect.any(Function));
+      expect(factory({})).toBeNull();
+      const supportTool = factory({ agentId: "support" });
+      const marketingTool = factory({ agentId: "marketing" });
+      expect(supportTool).toMatchObject({
+        name: registration.name,
+        testConfig: {
+          agentId: "support",
+          vault: { scope: "agent", path: path.join(rootDir, "support") },
+        },
+      });
+      expect(marketingTool).toMatchObject({
+        name: registration.name,
+        testConfig: {
+          agentId: "marketing",
+          vault: { scope: "agent", path: path.join(rootDir, "marketing") },
+        },
+      });
+      expect(() => factory({ agentId: "finance" })).toThrow("Unknown memory-wiki agentId: finance");
+    }
   });
 });

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -6,7 +6,12 @@ import plugin from "./index.js";
 import { createMemoryWikiTestHarness } from "./src/test-helpers.js";
 
 const toolMocks = vi.hoisted(() => {
-  const createTool = (name: string) => vi.fn((config: unknown) => ({ name, testConfig: config }));
+  const createTool = (name: string) =>
+    vi.fn((config: unknown, _appConfig?: unknown, memoryContext?: unknown) => ({
+      name,
+      testConfig: config,
+      testMemoryContext: memoryContext,
+    }));
   return {
     createWikiApplyTool: createTool("wiki_apply"),
     createWikiGetTool: createTool("wiki_get"),
@@ -120,6 +125,10 @@ describe("memory-wiki plugin", () => {
           vault: { scope: "agent", path: path.join(rootDir, "marketing") },
         },
       });
+      if (registration.name === "wiki_status") {
+        expect(supportTool).toMatchObject({ testMemoryContext: { agentId: "support" } });
+        expect(marketingTool).toMatchObject({ testMemoryContext: { agentId: "marketing" } });
+      }
       expect(() => factory({ agentId: "finance" })).toThrow("Unknown memory-wiki agentId: finance");
     }
   });

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -69,7 +69,11 @@ export default definePluginEntry({
     api.registerTool(
       (ctx) => {
         const resolved = resolveToolContext(ctx.agentId);
-        return resolved ? createWikiStatusTool(resolved.config, resolved.appConfig) : null;
+        return resolved
+          ? createWikiStatusTool(resolved.config, resolved.appConfig, {
+              agentId: resolved.config.agentId ?? ctx.agentId,
+            })
+          : null;
       },
       { name: "wiki_status" },
     );

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,7 +1,13 @@
 // Memory Wiki plugin entrypoint registers its OpenClaw integration.
-import { definePluginEntry } from "./api.js";
+import { definePluginEntry, type OpenClawConfig } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
-import { memoryWikiConfigSchema, resolveMemoryWikiConfig } from "./src/config.js";
+import {
+  memoryWikiConfigSchema,
+  resolveMemoryWikiAgentConfig,
+  resolveMemoryWikiConfig,
+  resolveMemoryWikiConfiguredAgentIds,
+  type MemoryWikiConfigResolver,
+} from "./src/config.js";
 import { createWikiCorpusSupplement } from "./src/corpus-supplement.js";
 import { registerMemoryWikiGatewayMethods } from "./src/gateway.js";
 import {
@@ -28,6 +34,22 @@ export default definePluginEntry({
   configSchema: memoryWikiConfigSchema,
   register(api) {
     const config = resolveMemoryWikiConfig(api.pluginConfig);
+    const getAppConfig = () =>
+      (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig | undefined;
+    const resolveConfig: MemoryWikiConfigResolver = (agentId, appConfig = getAppConfig()) =>
+      resolveMemoryWikiAgentConfig({ config, appConfig, agentId });
+    const resolveToolContext = (agentId?: string) => {
+      const appConfig = getAppConfig();
+      if (
+        config.vault.scope === "agent" &&
+        !agentId &&
+        resolveMemoryWikiConfiguredAgentIds(appConfig).length > 1
+      ) {
+        // Context-free tool discovery cannot safely choose one agent's vault.
+        return null;
+      }
+      return { appConfig, config: resolveConfig(agentId, appConfig) };
+    };
     configureMemoryWikiSourceSyncStateStore(
       createMemoryWikiSourceSyncStateStore(api.runtime.state.openKeyedStore),
     );
@@ -35,35 +57,67 @@ export default definePluginEntry({
       createMemoryWikiImportRunStateStore(api.runtime.state.openKeyedStore),
     );
 
-    api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder(config));
-    api.registerMemoryCorpusSupplement(
-      createWikiCorpusSupplement({ config, appConfig: api.config }),
-    );
-    registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
-    api.registerTool(createWikiStatusTool(config, api.config), { name: "wiki_status" });
-    api.registerTool(createWikiLintTool(config, api.config), { name: "wiki_lint" });
-    api.registerTool(createWikiApplyTool(config, api.config), { name: "wiki_apply" });
+    api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder({ config, resolveConfig }));
+    api.registerMemoryCorpusSupplement(createWikiCorpusSupplement({ resolveConfig, getAppConfig }));
+    registerMemoryWikiGatewayMethods({
+      api,
+      config,
+      appConfig: api.config,
+      getAppConfig,
+      resolveConfig,
+    });
     api.registerTool(
-      (ctx) =>
-        createWikiSearchTool(config, api.config, {
-          agentId: ctx.agentId,
+      (ctx) => {
+        const resolved = resolveToolContext(ctx.agentId);
+        return resolved ? createWikiStatusTool(resolved.config, resolved.appConfig) : null;
+      },
+      { name: "wiki_status" },
+    );
+    api.registerTool(
+      (ctx) => {
+        const resolved = resolveToolContext(ctx.agentId);
+        return resolved ? createWikiLintTool(resolved.config, resolved.appConfig) : null;
+      },
+      { name: "wiki_lint" },
+    );
+    api.registerTool(
+      (ctx) => {
+        const resolved = resolveToolContext(ctx.agentId);
+        return resolved ? createWikiApplyTool(resolved.config, resolved.appConfig) : null;
+      },
+      { name: "wiki_apply" },
+    );
+    api.registerTool(
+      (ctx) => {
+        const resolved = resolveToolContext(ctx.agentId);
+        if (!resolved) {
+          return null;
+        }
+        return createWikiSearchTool(resolved.config, resolved.appConfig, {
+          agentId: resolved.config.agentId ?? ctx.agentId,
           agentSessionKey: ctx.sessionKey,
           sandboxed: ctx.sandboxed,
-        }),
+        });
+      },
       { name: "wiki_search" },
     );
     api.registerTool(
-      (ctx) =>
-        createWikiGetTool(config, api.config, {
-          agentId: ctx.agentId,
+      (ctx) => {
+        const resolved = resolveToolContext(ctx.agentId);
+        if (!resolved) {
+          return null;
+        }
+        return createWikiGetTool(resolved.config, resolved.appConfig, {
+          agentId: resolved.config.agentId ?? ctx.agentId,
           agentSessionKey: ctx.sessionKey,
           sandboxed: ctx.sandboxed,
-        }),
+        });
+      },
       { name: "wiki_get" },
     );
     api.registerCli(
       ({ program }) => {
-        registerWikiCli(program, config, api.config);
+        registerWikiCli(program, { config, resolveConfig, getAppConfig });
       },
       {
         descriptors: [

--- a/extensions/memory-wiki/openclaw.plugin.json
+++ b/extensions/memory-wiki/openclaw.plugin.json
@@ -16,7 +16,11 @@
     },
     "vault.path": {
       "label": "Vault Path",
-      "help": "Filesystem path for the wiki vault root."
+      "help": "Exact vault path in global scope, or the parent directory for per-agent vaults."
+    },
+    "vault.scope": {
+      "label": "Vault Scope",
+      "help": "Use one global vault or a separate child vault for each agent."
     },
     "vault.renderMode": {
       "label": "Render Mode",
@@ -46,6 +50,49 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
+    "allOf": [
+      {
+        "not": {
+          "required": ["vaultMode", "vault"],
+          "properties": {
+            "vaultMode": {
+              "const": "unsafe-local"
+            },
+            "vault": {
+              "required": ["scope"],
+              "properties": {
+                "scope": {
+                  "const": "agent"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "not": {
+          "required": ["vault", "obsidian"],
+          "properties": {
+            "vault": {
+              "required": ["scope"],
+              "properties": {
+                "scope": {
+                  "const": "agent"
+                }
+              }
+            },
+            "obsidian": {
+              "required": ["useOfficialCli"],
+              "properties": {
+                "useOfficialCli": {
+                  "const": true
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
     "properties": {
       "vaultMode": {
         "type": "string",
@@ -55,6 +102,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "scope": {
+            "type": "string",
+            "enum": ["global", "agent"]
+          },
           "path": {
             "type": "string"
           },

--- a/extensions/memory-wiki/src/agent-vault-isolation.test.ts
+++ b/extensions/memory-wiki/src/agent-vault-isolation.test.ts
@@ -1,0 +1,265 @@
+// Memory Wiki tests cover agent-scoped vault isolation through the public tools.
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  clearMemoryPluginState,
+  registerMemoryCorpusSupplement,
+} from "openclaw/plugin-sdk/memory-host-core";
+import type { AnyAgentTool, OpenClawPluginToolFactory } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it } from "vitest";
+import memoryCorePlugin from "../../memory-core/index.js";
+import type { OpenClawConfig } from "../api.js";
+import {
+  resolveMemoryWikiAgentConfig,
+  resolveMemoryWikiConfig,
+  type ResolvedMemoryWikiConfig,
+} from "./config.js";
+import { createWikiCorpusSupplement } from "./corpus-supplement.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+import { createWikiApplyTool, createWikiGetTool, createWikiSearchTool } from "./tool.js";
+
+const { createTempDir } = createMemoryWikiTestHarness();
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected tool details object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function textContent(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+function registerMemoryCoreToolFactories(
+  appConfig: OpenClawConfig,
+): Map<string, OpenClawPluginToolFactory> {
+  const factories = new Map<string, OpenClawPluginToolFactory>();
+  memoryCorePlugin.register(
+    createTestPluginApi({
+      id: "memory-core",
+      config: appConfig,
+      registerTool(tool, options) {
+        if (typeof tool !== "function") {
+          return;
+        }
+        for (const name of options?.names ?? []) {
+          factories.set(name, tool);
+        }
+      },
+    }),
+  );
+  return factories;
+}
+
+function createMemoryCoreTool(params: {
+  factories: Map<string, OpenClawPluginToolFactory>;
+  name: "memory_search" | "memory_get";
+  appConfig: OpenClawConfig;
+  agentId: string;
+}): AnyAgentTool {
+  const factory = params.factories.get(params.name);
+  if (!factory) {
+    throw new Error(`Expected memory-core to register ${params.name}`);
+  }
+  const tool = factory({
+    config: params.appConfig,
+    runtimeConfig: params.appConfig,
+    getRuntimeConfig: () => params.appConfig,
+    agentId: params.agentId,
+    sessionKey: `agent:${params.agentId}:main`,
+  });
+  if (!tool || Array.isArray(tool)) {
+    throw new Error(`Expected one ${params.name} tool`);
+  }
+  return tool;
+}
+
+describe("agent-scoped memory-wiki tools", () => {
+  it("keeps apply, search, and get behavior isolated by configured agent", async () => {
+    const vaultParent = await createTempDir("memory-wiki-agent-vaults-");
+    const appConfig = {
+      agents: {
+        list: [{ id: "support", default: true }, { id: "marketing" }],
+      },
+    } as OpenClawConfig;
+    const baseConfig = resolveMemoryWikiConfig({
+      vault: { scope: "agent", path: vaultParent },
+      search: { backend: "local", corpus: "wiki" },
+    });
+
+    const agents: Array<{
+      id: string;
+      title: string;
+      sentinel: string;
+      config: ResolvedMemoryWikiConfig;
+      pagePath?: string;
+    }> = [
+      {
+        id: "support",
+        title: "Support Private Synthesis",
+        sentinel: "SUPPORT_ONLY_7f3c21",
+        config: resolveMemoryWikiAgentConfig({
+          config: baseConfig,
+          appConfig,
+          agentId: "support",
+        }),
+      },
+      {
+        id: "marketing",
+        title: "Marketing Private Synthesis",
+        sentinel: "MARKETING_ONLY_8e4d62",
+        config: resolveMemoryWikiAgentConfig({
+          config: baseConfig,
+          appConfig,
+          agentId: "marketing",
+        }),
+      },
+    ];
+
+    for (const agent of agents) {
+      const result = await createWikiApplyTool(agent.config, appConfig).execute(
+        `apply-${agent.id}`,
+        {
+          op: "create_synthesis",
+          title: agent.title,
+          body: `Private synthesis marker: ${agent.sentinel}`,
+          sourceIds: [`source.${agent.id}`],
+        },
+      );
+      const pagePath = asRecord(result.details).pagePath;
+      if (typeof pagePath !== "string") {
+        throw new Error("Expected wiki_apply to return pagePath");
+      }
+      agent.pagePath = pagePath;
+    }
+
+    expect(agents[0]?.config.vault.path).toBe(path.join(vaultParent, "support"));
+    expect(agents[1]?.config.vault.path).toBe(path.join(vaultParent, "marketing"));
+    expect(agents[0]?.config.vault.path).not.toBe(agents[1]?.config.vault.path);
+
+    for (const agent of agents) {
+      const foreignAgent = agents.find((candidate) => candidate.id !== agent.id);
+      if (!agent.pagePath || !foreignAgent?.pagePath) {
+        throw new Error("Expected both agent synthesis paths");
+      }
+
+      expect((await fs.stat(agent.config.vault.path)).isDirectory()).toBe(true);
+      await expect(
+        fs.readFile(path.join(agent.config.vault.path, agent.pagePath), "utf8"),
+      ).resolves.toContain(agent.sentinel);
+      await expect(
+        fs.access(path.join(agent.config.vault.path, foreignAgent.pagePath)),
+      ).rejects.toThrow();
+
+      const searchTool = createWikiSearchTool(agent.config, appConfig, {
+        agentId: agent.id,
+      });
+      const ownSearch = await searchTool.execute(`search-own-${agent.id}`, {
+        query: agent.sentinel,
+      });
+      expect(textContent(ownSearch)).toContain(agent.sentinel);
+      expect(asRecord(ownSearch.details).results).toEqual([
+        expect.objectContaining({ path: agent.pagePath }),
+      ]);
+
+      const foreignSearch = await searchTool.execute(`search-foreign-${agent.id}`, {
+        query: foreignAgent.sentinel,
+      });
+      expect(textContent(foreignSearch)).toBe("No wiki or memory results.");
+      expect(asRecord(foreignSearch.details).results).toEqual([]);
+
+      const getTool = createWikiGetTool(agent.config, appConfig, { agentId: agent.id });
+      const ownGet = await getTool.execute(`get-own-${agent.id}`, { lookup: agent.pagePath });
+      expect(textContent(ownGet)).toContain(agent.sentinel);
+      expect(asRecord(ownGet.details).found).toBe(true);
+
+      const foreignGet = await getTool.execute(`get-foreign-${agent.id}`, {
+        lookup: foreignAgent.pagePath,
+      });
+      expect(textContent(foreignGet)).toBe(`Wiki page not found: ${foreignAgent.pagePath}`);
+      expect(asRecord(foreignGet.details).found).toBe(false);
+    }
+
+    clearMemoryPluginState();
+    try {
+      registerMemoryCorpusSupplement(
+        "memory-wiki",
+        createWikiCorpusSupplement({
+          resolveConfig: (agentId, currentAppConfig) =>
+            resolveMemoryWikiAgentConfig({
+              config: baseConfig,
+              appConfig: currentAppConfig,
+              agentId,
+            }),
+          getAppConfig: () => appConfig,
+        }),
+      );
+      const memoryCoreFactories = registerMemoryCoreToolFactories(appConfig);
+
+      for (const agent of agents) {
+        const foreignAgent = agents.find((candidate) => candidate.id !== agent.id);
+        if (!agent.pagePath || !foreignAgent?.pagePath) {
+          throw new Error("Expected both agent synthesis paths");
+        }
+
+        const memorySearch = createMemoryCoreTool({
+          factories: memoryCoreFactories,
+          name: "memory_search",
+          appConfig,
+          agentId: agent.id,
+        });
+        const ownMemorySearch = await memorySearch.execute(`memory-search-own-${agent.id}`, {
+          query: agent.sentinel,
+          corpus: "wiki",
+        });
+        expect(asRecord(ownMemorySearch.details).results).toEqual([
+          expect.objectContaining({
+            corpus: "wiki",
+            path: agent.pagePath,
+            snippet: expect.stringContaining(agent.sentinel),
+          }),
+        ]);
+
+        const foreignMemorySearch = await memorySearch.execute(
+          `memory-search-foreign-${agent.id}`,
+          {
+            query: foreignAgent.sentinel,
+            corpus: "wiki",
+          },
+        );
+        expect(asRecord(foreignMemorySearch.details).results).toEqual([]);
+
+        const memoryGet = createMemoryCoreTool({
+          factories: memoryCoreFactories,
+          name: "memory_get",
+          appConfig,
+          agentId: agent.id,
+        });
+        const ownMemoryGet = await memoryGet.execute(`memory-get-own-${agent.id}`, {
+          path: agent.pagePath,
+          corpus: "wiki",
+        });
+        expect(asRecord(ownMemoryGet.details)).toMatchObject({
+          corpus: "wiki",
+          path: agent.pagePath,
+          text: expect.stringContaining(agent.sentinel),
+        });
+
+        const foreignMemoryGet = await memoryGet.execute(`memory-get-foreign-${agent.id}`, {
+          path: foreignAgent.pagePath,
+          corpus: "wiki",
+        });
+        expect(asRecord(foreignMemoryGet.details)).toMatchObject({
+          path: foreignAgent.pagePath,
+          text: "",
+          disabled: true,
+          error: "wiki corpus result not found",
+        });
+      }
+    } finally {
+      clearMemoryPluginState();
+    }
+  });
+});

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -262,6 +262,120 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(page).toContain("- Agents: unknown");
   });
 
+  it("isolates agent-scoped bridge artifacts while preserving shared ownership", async () => {
+    const supportWorkspace = await createBridgeWorkspace("support-workspace");
+    const marketingWorkspace = await createBridgeWorkspace("marketing-workspace");
+    const sharedWorkspace = await createBridgeWorkspace("shared-workspace");
+    const unknownWorkspace = await createBridgeWorkspace("unknown-workspace");
+    const supportMemory = path.join(supportWorkspace, "MEMORY.md");
+    const marketingMemory = path.join(marketingWorkspace, "MEMORY.md");
+    const sharedMemory = path.join(sharedWorkspace, "MEMORY.md");
+    const unknownMemory = path.join(unknownWorkspace, "MEMORY.md");
+    await fs.writeFile(supportMemory, "# Support Sentinel\n", "utf8");
+    await fs.writeFile(marketingMemory, "# Marketing Sentinel\n", "utf8");
+    await fs.writeFile(sharedMemory, "# Shared Sentinel\n", "utf8");
+    await fs.writeFile(unknownMemory, "# Unknown Sentinel\n", "utf8");
+
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir: supportWorkspace,
+        relativePath: "MEMORY.md",
+        absolutePath: supportMemory,
+        agentIds: [" SUPPORT "],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: marketingWorkspace,
+        relativePath: "MEMORY.md",
+        absolutePath: marketingMemory,
+        agentIds: ["marketing"],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: sharedWorkspace,
+        relativePath: "MEMORY.md",
+        absolutePath: sharedMemory,
+        agentIds: ["support", "MARKETING"],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: unknownWorkspace,
+        relativePath: "MEMORY.md",
+        absolutePath: unknownMemory,
+        contentType: "markdown",
+      } as Omit<MemoryPluginPublicArtifact, "agentIds"> as MemoryPluginPublicArtifact,
+    ]);
+
+    const { rootDir: supportVault, config: unresolvedSupportConfig } = await createVault({
+      rootDir: nextCaseRoot("support-vault"),
+      config: {
+        vaultMode: "bridge",
+        vault: { scope: "agent" },
+        bridge: { enabled: true, indexMemoryRoot: true },
+      },
+    });
+    const { rootDir: marketingVault, config: unresolvedMarketingConfig } = await createVault({
+      rootDir: nextCaseRoot("marketing-vault"),
+      config: {
+        vaultMode: "bridge",
+        vault: { scope: "agent" },
+        bridge: { enabled: true, indexMemoryRoot: true },
+      },
+    });
+    const supportConfig = { ...unresolvedSupportConfig, agentId: "support" };
+    const marketingConfig = { ...unresolvedMarketingConfig, agentId: "marketing" };
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "support", default: true, workspace: supportWorkspace },
+          { id: "marketing", workspace: marketingWorkspace },
+        ],
+      },
+    };
+
+    const supportResult = await syncMemoryWikiBridgeSources({ config: supportConfig, appConfig });
+    const marketingResult = await syncMemoryWikiBridgeSources({
+      config: marketingConfig,
+      appConfig,
+    });
+
+    expect(supportResult).toMatchObject({ artifactCount: 2, importedCount: 2, workspaces: 2 });
+    expect(marketingResult).toMatchObject({ artifactCount: 2, importedCount: 2, workspaces: 2 });
+    const supportPages = await Promise.all(
+      supportResult.pagePaths.map((pagePath) =>
+        fs.readFile(path.join(supportVault, pagePath), "utf8"),
+      ),
+    );
+    const marketingPages = await Promise.all(
+      marketingResult.pagePaths.map((pagePath) =>
+        fs.readFile(path.join(marketingVault, pagePath), "utf8"),
+      ),
+    );
+    expect(supportPages.join("\n")).toContain("Support Sentinel");
+    expect(supportPages.join("\n")).toContain("Shared Sentinel");
+    expect(supportPages.join("\n")).not.toContain("Marketing Sentinel");
+    expect(supportPages.join("\n")).not.toContain("Unknown Sentinel");
+    expect(marketingPages.join("\n")).toContain("Marketing Sentinel");
+    expect(marketingPages.join("\n")).toContain("Shared Sentinel");
+    expect(marketingPages.join("\n")).not.toContain("Support Sentinel");
+    expect(marketingPages.join("\n")).not.toContain("Unknown Sentinel");
+  });
+
+  it("rejects an unresolved agent-scoped bridge config", async () => {
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("unresolved-agent-vault"),
+      config: { vault: { scope: "agent" } },
+    });
+
+    await expect(syncMemoryWikiBridgeSources({ config })).rejects.toThrow(
+      "Memory Wiki agent-scoped vault requires a resolved agent id",
+    );
+  });
+
   it("returns a no-op result outside bridge mode", async () => {
     const { config } = await createVault({ rootDir: nextCaseRoot("isolated") });
 

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -7,6 +7,7 @@ import {
   listActiveMemoryPublicArtifacts,
   type MemoryPluginPublicArtifact,
 } from "openclaw/plugin-sdk/memory-host-core";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type { OpenClawConfig } from "../api.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
@@ -43,6 +44,40 @@ export type BridgeMemoryWikiResult = {
   workspaces: number;
   pagePaths: string[];
 };
+
+export function resolveMemoryWikiVaultAgentId(
+  config: Pick<ResolvedMemoryWikiConfig, "agentId" | "vault">,
+): string | null {
+  if (config.vault.scope === "global") {
+    return null;
+  }
+  const agentId = config.agentId?.trim();
+  if (!agentId) {
+    throw new Error("Memory Wiki agent-scoped vault requires a resolved agent id");
+  }
+  return normalizeAgentId(agentId);
+}
+
+export function filterMemoryWikiBridgeArtifacts(params: {
+  config: Pick<ResolvedMemoryWikiConfig, "agentId" | "vault">;
+  artifacts: MemoryPluginPublicArtifact[];
+}): MemoryPluginPublicArtifact[] {
+  const agentId = resolveMemoryWikiVaultAgentId(params.config);
+  if (!agentId) {
+    return params.artifacts;
+  }
+  // Ownership metadata is mandatory only in agent scope. Global scope keeps
+  // accepting legacy providers that omit agentIds.
+  return params.artifacts.filter((artifact) => {
+    const artifactAgentIds = Array.isArray(artifact.agentIds) ? artifact.agentIds : [];
+    return artifactAgentIds.some(
+      (artifactAgentId) =>
+        typeof artifactAgentId === "string" &&
+        artifactAgentId.trim().length > 0 &&
+        normalizeAgentId(artifactAgentId) === agentId,
+    );
+  });
+}
 
 function shouldImportArtifact(
   artifact: MemoryPluginPublicArtifact,
@@ -219,6 +254,7 @@ export async function syncMemoryWikiBridgeSources(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
 }): Promise<BridgeMemoryWikiResult> {
+  resolveMemoryWikiVaultAgentId(params.config);
   await initializeMemoryWikiVault(params.config);
   if (
     params.config.vaultMode !== "bridge" ||
@@ -237,7 +273,12 @@ export async function syncMemoryWikiBridgeSources(params: {
     };
   }
 
-  const publicArtifacts = await listActiveMemoryPublicArtifacts({ cfg: params.appConfig });
+  // Filter before building active keys so each vault's pruning state tracks
+  // only artifacts that are visible to its resolved agent.
+  const publicArtifacts = filterMemoryWikiBridgeArtifacts({
+    config: params.config,
+    artifacts: await listActiveMemoryPublicArtifacts({ cfg: params.appConfig }),
+  });
   const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
   const activeKeys = new Set<string>();
   const artifacts = await collectBridgeArtifacts(

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -61,8 +61,13 @@ export function resolveMemoryWikiVaultAgentId(
 export function filterMemoryWikiBridgeArtifacts(params: {
   config: Pick<ResolvedMemoryWikiConfig, "agentId" | "vault">;
   artifacts: MemoryPluginPublicArtifact[];
+  callerAgentId?: string;
 }): MemoryPluginPublicArtifact[] {
-  const agentId = resolveMemoryWikiVaultAgentId(params.config);
+  const vaultAgentId = resolveMemoryWikiVaultAgentId(params.config);
+  const callerAgentId = params.callerAgentId?.trim();
+  // Agent-scoped vault ownership is authoritative. Global vaults remain shared,
+  // but agent tools still scope diagnostic metadata to their calling agent.
+  const agentId = vaultAgentId ?? (callerAgentId ? normalizeAgentId(callerAgentId) : null);
   if (!agentId) {
     return params.artifacts;
   }

--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -112,10 +112,13 @@ describe("memory-wiki cli", () => {
   }
 
   function createGatewayStatus(config: {
-    vault: { path: string };
+    agentId?: string;
+    vault: { path: string; scope?: MemoryWikiStatus["vaultScope"] };
     bridge: MemoryWikiStatus["bridge"];
   }): MemoryWikiStatus {
     return {
+      vaultScope: config.vault.scope ?? "global",
+      agentId: config.agentId ?? null,
       vaultMode: "bridge",
       renderMode: "native",
       vaultPath: config.vault.path,
@@ -154,7 +157,7 @@ describe("memory-wiki cli", () => {
     const { rootDir, config } = await createCliVault();
     const program = new Command();
     program.name("test");
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await program.parseAsync(
       [
@@ -177,6 +180,92 @@ describe("memory-wiki cli", () => {
     expect(page).toContain("source.alpha");
     await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toContain(
       "[CLI Alpha](syntheses/cli-alpha.md)",
+    );
+  });
+
+  it("resolves --agent for local commands and requires it with multiple agent vaults", async () => {
+    const { rootDir, config } = await createCliVault({
+      config: { vault: { scope: "agent" } },
+    });
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+    const program = new Command();
+    program.name("test");
+    program.exitOverride();
+    registerWikiCli(program, { config, getAppConfig: () => appConfig });
+
+    await program.parseAsync(["wiki", "--agent", "marketing", "init", "--json"], {
+      from: "user",
+    });
+
+    await expect(fs.stat(path.join(rootDir, "marketing", "index.md"))).resolves.toBeDefined();
+
+    const missingAgentProgram = new Command();
+    missingAgentProgram.name("test");
+    missingAgentProgram.exitOverride();
+    registerWikiCli(missingAgentProgram, { config, getAppConfig: () => appConfig });
+    await expect(
+      missingAgentProgram.parseAsync(["wiki", "status", "--json"], { from: "user" }),
+    ).rejects.toThrow("agentId is required for memory-wiki when vault.scope=agent.");
+  });
+
+  it("forwards --agent through every bridge Gateway call", async () => {
+    const { config } = await createCliVault({
+      config: {
+        vaultMode: "bridge",
+        vault: { scope: "agent" },
+        bridge: { enabled: true, readMemoryArtifacts: true },
+      },
+    });
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+    const status = createGatewayStatus(config);
+    const report: MemoryWikiDoctorReport = {
+      healthy: true,
+      warningCount: 0,
+      status,
+      fixes: [],
+    };
+    callGatewayFromCliMock
+      .mockResolvedValueOnce(status)
+      .mockResolvedValueOnce(report)
+      .mockResolvedValueOnce({
+        importedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        removedCount: 0,
+        artifactCount: 0,
+        workspaces: 0,
+        pagePaths: [],
+        indexesRefreshed: false,
+        indexUpdatedFiles: [],
+        indexRefreshReason: "no-import-changes",
+      });
+    const register = () => {
+      const program = new Command();
+      program.name("test");
+      registerWikiCli(program, { config, getAppConfig: () => appConfig });
+      return program;
+    };
+
+    await register().parseAsync(["wiki", "--agent", "marketing", "status", "--json"], {
+      from: "user",
+    });
+    await register().parseAsync(["wiki", "--agent", "marketing", "doctor", "--json"], {
+      from: "user",
+    });
+    await register().parseAsync(["wiki", "--agent", "marketing", "bridge", "import", "--json"], {
+      from: "user",
+    });
+
+    expect(callGatewayFromCliMock.mock.calls.map(([method, , params]) => [method, params])).toEqual(
+      [
+        ["wiki.status", { agentId: "marketing" }],
+        ["wiki.doctor", { agentId: "marketing" }],
+        ["wiki.bridge.import", { agentId: "marketing" }],
+      ],
     );
   });
 
@@ -211,7 +300,7 @@ Orders join to [customers](/tables/customers.md).
 
     const program = new Command();
     program.name("test");
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await program.parseAsync(["wiki", "okf", "import", bundlePath, "--json"], { from: "user" });
 
@@ -248,7 +337,7 @@ Orders join to [customers](/tables/customers.md).
       writeErr: () => {},
       writeOut: () => {},
     });
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await expect(
       program.parseAsync(
@@ -290,7 +379,7 @@ Orders join to [customers](/tables/customers.md).
       writeErr: () => {},
       writeOut: () => {},
     });
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await expect(
       program.parseAsync(["wiki", "search", "alpha", "--max-results", "0x10"], {
@@ -312,7 +401,7 @@ Orders join to [customers](/tables/customers.md).
     await fs.writeFile(targetPath, "# CLI Lines\n\nfirst\nsecond\n", "utf8");
     const program = new Command();
     program.name("test");
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await program.parseAsync(
       ["wiki", "get", "syntheses/cli-lines.md", "--from", "+01", "--lines", "02"],
@@ -349,7 +438,7 @@ cli note
 
     const program = new Command();
     program.name("test");
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
 
     await program.parseAsync(
       [
@@ -389,7 +478,7 @@ cli note
     });
     const program = new Command();
     program.name("test");
-    registerWikiCli(program, config);
+    registerWikiCli(program, { config });
     await fs.rm(rootDir, { recursive: true, force: true });
 
     await program.parseAsync(["wiki", "doctor", "--json"], { from: "user" });

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -18,10 +18,10 @@ import {
 } from "./chatgpt-import.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import {
-  resolveMemoryWikiConfig,
+  resolveMemoryWikiAgentConfig,
   WIKI_SEARCH_BACKENDS,
   WIKI_SEARCH_CORPORA,
-  type MemoryWikiPluginConfig,
+  type MemoryWikiConfigResolver,
   type ResolvedMemoryWikiConfig,
 } from "./config.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
@@ -164,18 +164,15 @@ type WikiObsidianDailyCommandOptions = {
   json?: boolean;
 };
 
-function isResolvedMemoryWikiConfig(
-  config: MemoryWikiPluginConfig | ResolvedMemoryWikiConfig | undefined,
-): config is ResolvedMemoryWikiConfig {
-  return Boolean(
-    config &&
-    "vaultMode" in config &&
-    "vault" in config &&
-    "bridge" in config &&
-    "obsidian" in config &&
-    "unsafeLocal" in config,
-  );
-}
+type WikiCommandOptions = {
+  agent?: string;
+};
+
+export type MemoryWikiCliRegistration = {
+  config: ResolvedMemoryWikiConfig;
+  resolveConfig?: MemoryWikiConfigResolver;
+  getAppConfig?: () => OpenClawConfig | undefined;
+};
 
 function sanitizeGatewayStringForTerminal(value: string): string {
   const truncated =
@@ -253,6 +250,9 @@ function isMemoryWikiStatus(value: unknown): value is MemoryWikiStatus {
   const pageCounts = value.pageCounts;
   const sourceCounts = value.sourceCounts;
   return (
+    isBoundedGatewayString(value.vaultScope, GATEWAY_RESPONSE_MAX_CODE_CHARS) &&
+    (isBoundedGatewayString(value.agentId, GATEWAY_RESPONSE_MAX_CODE_CHARS) ||
+      value.agentId === null) &&
     isBoundedGatewayString(value.vaultMode, GATEWAY_RESPONSE_MAX_CODE_CHARS) &&
     isBoundedGatewayString(value.renderMode, GATEWAY_RESPONSE_MAX_CODE_CHARS) &&
     isBoundedGatewayString(value.vaultPath) &&
@@ -328,15 +328,25 @@ function validateWikiGatewayResult(
   throw new Error(`Invalid Gateway response for ${method}.`);
 }
 
-async function callWikiGateway(method: "wiki.status"): Promise<MemoryWikiStatus>;
-async function callWikiGateway(method: "wiki.doctor"): Promise<MemoryWikiDoctorReport>;
+async function callWikiGateway(method: "wiki.status", agentId?: string): Promise<MemoryWikiStatus>;
+async function callWikiGateway(
+  method: "wiki.doctor",
+  agentId?: string,
+): Promise<MemoryWikiDoctorReport>;
 async function callWikiGateway(
   method: "wiki.bridge.import",
+  agentId?: string,
 ): Promise<MemoryWikiImportedSourceSyncResult>;
-async function callWikiGateway(method: "wiki.status" | "wiki.doctor" | "wiki.bridge.import") {
-  const result = await callGatewayFromCli(method, { timeout: WIKI_GATEWAY_TIMEOUT_MS }, undefined, {
-    progress: false,
-  });
+async function callWikiGateway(
+  method: "wiki.status" | "wiki.doctor" | "wiki.bridge.import",
+  agentId?: string,
+) {
+  const result = await callGatewayFromCli(
+    method,
+    { timeout: WIKI_GATEWAY_TIMEOUT_MS },
+    agentId ? { agentId } : undefined,
+    { progress: false },
+  );
   return validateWikiGatewayResult(method, result);
 }
 
@@ -476,12 +486,13 @@ function addWikiApplyMutationOptions<T extends Command>(command: T): T {
 export async function runWikiStatus(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  agentId?: string;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const routeThroughGateway = shouldRouteBridgeRuntimeThroughGateway(params.config);
   const status = routeThroughGateway
-    ? await callWikiGateway("wiki.status")
+    ? await callWikiGateway("wiki.status", params.agentId)
     : await (async () => {
         await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
         return await resolveMemoryWikiStatus(params.config, {
@@ -500,12 +511,13 @@ export async function runWikiStatus(params: {
 export async function runWikiDoctor(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  agentId?: string;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const routeThroughGateway = shouldRouteBridgeRuntimeThroughGateway(params.config);
   const report = routeThroughGateway
-    ? await callWikiGateway("wiki.doctor")
+    ? await callWikiGateway("wiki.doctor", params.agentId)
     : await (async () => {
         await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
         return buildMemoryWikiDoctorReport(
@@ -616,6 +628,7 @@ export async function runWikiOkfImport(params: {
 async function runWikiSearch(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  agentId?: string;
   query: string;
   maxResults?: number;
   searchBackend?: ResolvedMemoryWikiConfig["search"]["backend"];
@@ -631,6 +644,7 @@ async function runWikiSearch(params: {
   const results = await searchMemoryWiki({
     config: params.config,
     appConfig: params.appConfig,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     query: params.query,
     maxResults: params.maxResults,
     searchBackend: params.searchBackend,
@@ -654,6 +668,7 @@ async function runWikiSearch(params: {
 async function runWikiGet(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  agentId?: string;
   lookup: string;
   fromLine?: number;
   lineCount?: number;
@@ -666,6 +681,7 @@ async function runWikiGet(params: {
   const result = await getMemoryWikiPage({
     config: params.config,
     appConfig: params.appConfig,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     lookup: params.lookup,
     fromLine: params.fromLine,
     lineCount: params.lineCount,
@@ -763,13 +779,14 @@ async function runWikiApplyMetadata(params: {
 export async function runWikiBridgeImport(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  agentId?: string;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const render = (value: MemoryWikiImportedSourceSyncResult) =>
     `Bridge import synced ${value.artifactCount} artifacts across ${value.workspaces} workspaces (${value.importedCount} new, ${value.updatedCount} updated, ${value.skippedCount} unchanged, ${value.removedCount} removed). Indexes ${value.indexesRefreshed ? `refreshed (${value.indexUpdatedFiles.length} files)` : `not refreshed (${value.indexRefreshReason})`}.`;
   if (shouldRouteBridgeRuntimeThroughGateway(params.config)) {
-    const result = await callWikiGateway("wiki.bridge.import");
+    const result = await callWikiGateway("wiki.bridge.import", params.agentId);
     writeOutput(formatGatewayJsonOrText(result, params.json, render), params.stdout);
     return result;
   }
@@ -791,6 +808,9 @@ async function runWikiUnsafeLocalImport(params: {
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
+  if (params.config.vault.scope === "agent") {
+    throw new Error("Unsafe-local import does not support memory-wiki vault.scope=agent.");
+  }
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
@@ -820,12 +840,19 @@ async function runWikiObsidianStatus(params: {
   });
 }
 
+function assertOfficialObsidianCliSupported(config: ResolvedMemoryWikiConfig) {
+  if (config.vault.scope === "agent") {
+    throw new Error("Official Obsidian CLI actions do not support memory-wiki vault.scope=agent.");
+  }
+}
+
 async function runWikiObsidianSearch(params: {
   config: ResolvedMemoryWikiConfig;
   query: string;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
+  assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
@@ -840,6 +867,7 @@ async function runWikiObsidianOpenCli(params: {
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
+  assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
@@ -854,6 +882,7 @@ async function runWikiObsidianCommandCli(params: {
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
+  assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
@@ -867,6 +896,7 @@ async function runWikiObsidianDailyCli(params: {
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
+  assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
     stdout: params.stdout,
@@ -928,22 +958,47 @@ export async function runWikiChatGptRollback(params: {
   });
 }
 
-export function registerWikiCli(
-  program: Command,
-  pluginConfig?: MemoryWikiPluginConfig | ResolvedMemoryWikiConfig,
-  appConfig?: OpenClawConfig,
-) {
-  const config = isResolvedMemoryWikiConfig(pluginConfig)
-    ? pluginConfig
-    : resolveMemoryWikiConfig(pluginConfig);
-  const wiki = program.command("wiki").description("Inspect and initialize the memory wiki vault");
+export function registerWikiCli(program: Command, registration: MemoryWikiCliRegistration) {
+  const resolveConfig: MemoryWikiConfigResolver =
+    registration.resolveConfig ??
+    ((agentId, currentAppConfig) =>
+      resolveMemoryWikiAgentConfig({
+        config: registration.config,
+        appConfig: currentAppConfig,
+        ...(agentId ? { agentId } : {}),
+      }));
+  let commandContext:
+    | { agentId?: string; appConfig?: OpenClawConfig; config: ResolvedMemoryWikiConfig }
+    | undefined;
+  const requireCommandContext = () => {
+    if (!commandContext) {
+      throw new Error("Memory Wiki CLI agent context was not resolved.");
+    }
+    return commandContext;
+  };
+  const wiki = program
+    .command("wiki")
+    .description("Inspect and initialize the memory wiki vault")
+    .option("--agent <id>", "Agent id for agent-scoped wiki vaults");
+  wiki.hook("preAction", () => {
+    const requestedAgentId = wiki.opts<WikiCommandOptions>().agent?.trim() || undefined;
+    const currentAppConfig = registration.getAppConfig?.();
+    const config = resolveConfig(requestedAgentId, currentAppConfig);
+    const agentId = config.agentId ?? requestedAgentId;
+    commandContext = {
+      config,
+      ...(currentAppConfig ? { appConfig: currentAppConfig } : {}),
+      ...(agentId ? { agentId } : {}),
+    };
+  });
 
   wiki
     .command("status")
     .description("Show wiki vault status")
     .option("--json", "Print JSON")
     .action(async (opts: WikiStatusCommandOptions) => {
-      await runWikiStatus({ config, appConfig, json: opts.json });
+      const { agentId, appConfig, config } = requireCommandContext();
+      await runWikiStatus({ config, appConfig, agentId, json: opts.json });
     });
 
   wiki
@@ -951,7 +1006,8 @@ export function registerWikiCli(
     .description("Audit wiki vault setup and report actionable fixes")
     .option("--json", "Print JSON")
     .action(async (opts: WikiDoctorCommandOptions) => {
-      await runWikiDoctor({ config, appConfig, json: opts.json });
+      const { agentId, appConfig, config } = requireCommandContext();
+      await runWikiDoctor({ config, appConfig, agentId, json: opts.json });
     });
 
   wiki
@@ -959,6 +1015,7 @@ export function registerWikiCli(
     .description("Initialize the wiki vault layout")
     .option("--json", "Print JSON")
     .action(async (opts: WikiInitCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiInit({ config, json: opts.json });
     });
 
@@ -967,6 +1024,7 @@ export function registerWikiCli(
     .description("Refresh generated wiki indexes")
     .option("--json", "Print JSON")
     .action(async (opts: WikiCompileCommandOptions) => {
+      const { appConfig, config } = requireCommandContext();
       await runWikiCompile({ config, appConfig, json: opts.json });
     });
 
@@ -975,6 +1033,7 @@ export function registerWikiCli(
     .description("Lint the wiki vault and write a report")
     .option("--json", "Print JSON")
     .action(async (opts: WikiLintCommandOptions) => {
+      const { appConfig, config } = requireCommandContext();
       await runWikiLint({ config, appConfig, json: opts.json });
     });
 
@@ -985,6 +1044,7 @@ export function registerWikiCli(
     .option("--title <title>", "Override the source title")
     .option("--json", "Print JSON")
     .action(async (inputPath: string, opts: WikiIngestCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiIngest({ config, inputPath, title: opts.title, json: opts.json });
     });
 
@@ -995,6 +1055,7 @@ export function registerWikiCli(
     .argument("<path>", "OKF bundle directory")
     .option("--json", "Print JSON")
     .action(async (bundlePath: string, opts: WikiOkfImportCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiOkfImport({ config, bundlePath, json: opts.json });
     });
 
@@ -1010,9 +1071,11 @@ export function registerWikiCli(
   )
     .option("--json", "Print JSON")
     .action(async (query: string, opts: WikiSearchCommandOptions) => {
+      const { agentId, appConfig, config } = requireCommandContext();
       await runWikiSearch({
         config,
         appConfig,
+        agentId,
         query,
         maxResults: opts.maxResults,
         searchBackend: opts.backend,
@@ -1036,9 +1099,11 @@ export function registerWikiCli(
   )
     .option("--json", "Print JSON")
     .action(async (lookup: string, opts: WikiGetCommandOptions) => {
+      const { agentId, appConfig, config } = requireCommandContext();
       await runWikiGet({
         config,
         appConfig,
+        agentId,
         lookup,
         fromLine: opts.from,
         lineCount: opts.lines,
@@ -1059,6 +1124,7 @@ export function registerWikiCli(
   )
     .option("--json", "Print JSON")
     .action(async (title: string, opts: WikiApplySynthesisCommandOptions) => {
+      const { appConfig, config } = requireCommandContext();
       await runWikiApplySynthesis({
         config,
         appConfig,
@@ -1082,6 +1148,7 @@ export function registerWikiCli(
     .option("--clear-confidence", "Remove any stored confidence value")
     .option("--json", "Print JSON")
     .action(async (lookup: string, opts: WikiApplyMetadataCommandOptions) => {
+      const { appConfig, config } = requireCommandContext();
       await runWikiApplyMetadata({
         config,
         appConfig,
@@ -1104,7 +1171,8 @@ export function registerWikiCli(
     .description("Sync bridge-backed memory artifacts into wiki source pages")
     .option("--json", "Print JSON")
     .action(async (opts: WikiBridgeImportCommandOptions) => {
-      await runWikiBridgeImport({ config, appConfig, json: opts.json });
+      const { agentId, appConfig, config } = requireCommandContext();
+      await runWikiBridgeImport({ config, appConfig, agentId, json: opts.json });
     });
 
   const unsafeLocal = wiki
@@ -1115,6 +1183,7 @@ export function registerWikiCli(
     .description("Sync unsafe-local configured paths into wiki source pages")
     .option("--json", "Print JSON")
     .action(async (opts: WikiUnsafeLocalImportCommandOptions) => {
+      const { appConfig, config } = requireCommandContext();
       await runWikiUnsafeLocalImport({ config, appConfig, json: opts.json });
     });
 
@@ -1128,6 +1197,7 @@ export function registerWikiCli(
     .option("--dry-run", "Preview changes without writing", false)
     .option("--json", "Print JSON")
     .action(async (opts: WikiChatGptImportCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiChatGptImport({
         config,
         exportPath: opts.export!,
@@ -1141,6 +1211,7 @@ export function registerWikiCli(
     .argument("<run-id>", "Import run id")
     .option("--json", "Print JSON")
     .action(async (runId: string, opts: WikiChatGptRollbackCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiChatGptRollback({
         config,
         runId,
@@ -1154,6 +1225,7 @@ export function registerWikiCli(
     .description("Probe the Obsidian CLI")
     .option("--json", "Print JSON")
     .action(async (opts: WikiStatusCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiObsidianStatus({ config, json: opts.json });
     });
   obsidian
@@ -1162,6 +1234,7 @@ export function registerWikiCli(
     .argument("<query>", "Search query")
     .option("--json", "Print JSON")
     .action(async (query: string, opts: WikiObsidianSearchCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiObsidianSearch({ config, query, json: opts.json });
     });
   obsidian
@@ -1170,6 +1243,7 @@ export function registerWikiCli(
     .argument("<path>", "Vault-relative path")
     .option("--json", "Print JSON")
     .action(async (vaultPath: string, opts: WikiObsidianOpenCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiObsidianOpenCli({ config, vaultPath, json: opts.json });
     });
   obsidian
@@ -1178,6 +1252,7 @@ export function registerWikiCli(
     .argument("<id>", "Obsidian command id")
     .option("--json", "Print JSON")
     .action(async (id: string, opts: WikiObsidianCommandCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiObsidianCommandCli({ config, id, json: opts.json });
     });
   obsidian
@@ -1185,6 +1260,7 @@ export function registerWikiCli(
     .description("Open today's daily note in Obsidian")
     .option("--json", "Print JSON")
     .action(async (opts: WikiObsidianDailyCommandOptions) => {
+      const { config } = requireCommandContext();
       await runWikiObsidianDailyCli({ config, json: opts.json });
     });
 }

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -6,12 +6,17 @@ import {
   type JsonSchemaObject,
 } from "openclaw/plugin-sdk/json-schema-runtime";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../api.js";
 import {
   DEFAULT_WIKI_RENDER_MODE,
   DEFAULT_WIKI_SEARCH_BACKEND,
   DEFAULT_WIKI_SEARCH_CORPUS,
   DEFAULT_WIKI_VAULT_MODE,
+  DEFAULT_WIKI_VAULT_SCOPE,
+  memoryWikiConfigSchema,
   resolveDefaultMemoryWikiVaultPath,
+  resolveDefaultMemoryWikiVaultRoot,
+  resolveMemoryWikiAgentConfig,
   resolveMemoryWikiConfig,
 } from "./config.js";
 
@@ -33,6 +38,7 @@ describe("resolveMemoryWikiConfig", () => {
     const config = resolveMemoryWikiConfig(undefined, { homedir: "/Users/tester" });
 
     expect(config.vaultMode).toBe(DEFAULT_WIKI_VAULT_MODE);
+    expect(config.vault.scope).toBe(DEFAULT_WIKI_VAULT_SCOPE);
     expect(config.vault.renderMode).toBe(DEFAULT_WIKI_RENDER_MODE);
     expect(config.vault.path).toBe(resolveDefaultMemoryWikiVaultPath("/Users/tester"));
     expect(config.search.backend).toBe(DEFAULT_WIKI_SEARCH_BACKEND);
@@ -65,6 +71,118 @@ describe("resolveMemoryWikiConfig", () => {
     });
 
     expect(canonical.bridge.readMemoryArtifacts).toBe(false);
+  });
+
+  it("resolves normalized agent ids to distinct vault roots", () => {
+    const base = resolveMemoryWikiConfig(
+      {
+        vault: {
+          scope: "agent",
+          path: "~/vaults/wiki",
+        },
+      },
+      { homedir: "/Users/tester" },
+    );
+    const appConfig = {
+      agents: {
+        list: [{ id: "Support Team", default: true }, { id: "Marketing" }],
+      },
+    } as OpenClawConfig;
+
+    const support = resolveMemoryWikiAgentConfig({
+      config: base,
+      appConfig,
+      agentId: " SUPPORT TEAM ",
+    });
+    const marketing = resolveMemoryWikiAgentConfig({
+      config: base,
+      appConfig,
+      agentId: "MARKETING",
+    });
+
+    expect(base.vault.path).toBe(path.join("/Users/tester", "vaults", "wiki"));
+    expect(support).toMatchObject({
+      agentId: "support-team",
+      vault: { scope: "agent", path: path.join(base.vault.path, "support-team") },
+    });
+    expect(marketing).toMatchObject({
+      agentId: "marketing",
+      vault: { scope: "agent", path: path.join(base.vault.path, "marketing") },
+    });
+    expect(support.vault.path).not.toBe(marketing.vault.path);
+  });
+
+  it("uses the wiki root before appending the single configured agent", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { scope: "agent" } },
+      { homedir: "/Users/tester" },
+    );
+
+    const resolved = resolveMemoryWikiAgentConfig({
+      config: base,
+      appConfig: { agents: { list: [{ id: "support", default: true }] } },
+    });
+
+    expect(base.vault.path).toBe(resolveDefaultMemoryWikiVaultRoot("/Users/tester"));
+    expect(resolved.vault.path).toBe(
+      path.join(resolveDefaultMemoryWikiVaultRoot("/Users/tester"), "support"),
+    );
+  });
+
+  it("fails closed when a multi-agent scoped vault has no agent context", () => {
+    const config = resolveMemoryWikiConfig({ vault: { scope: "agent" } });
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    } as OpenClawConfig;
+
+    expect(() => resolveMemoryWikiAgentConfig({ config, appConfig })).toThrow(
+      "agentId is required",
+    );
+  });
+
+  it("fails closed for unknown scoped agents", () => {
+    const config = resolveMemoryWikiConfig({ vault: { scope: "agent" } });
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    } as OpenClawConfig;
+
+    expect(() => resolveMemoryWikiAgentConfig({ config, appConfig, agentId: "finance" })).toThrow(
+      "Unknown memory-wiki agentId: finance",
+    );
+  });
+
+  it("rejects unsafe-local access for agent-scoped vaults", () => {
+    const parsed = memoryWikiConfigSchema.safeParse?.({
+      vaultMode: "unsafe-local",
+      vault: { scope: "agent" },
+    });
+
+    expect(parsed?.success).toBe(false);
+    if (parsed?.success === false) {
+      expect(parsed.error?.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["vaultMode"],
+          message: "vaultMode=unsafe-local cannot be combined with vault.scope=agent",
+        }),
+      );
+    }
+  });
+
+  it("rejects the global Obsidian CLI selector for agent-scoped vaults", () => {
+    const parsed = memoryWikiConfigSchema.safeParse?.({
+      vault: { scope: "agent" },
+      obsidian: { useOfficialCli: true },
+    });
+
+    expect(parsed?.success).toBe(false);
+    if (parsed?.success === false) {
+      expect(parsed.error?.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["obsidian", "useOfficialCli"],
+          message: "obsidian.useOfficialCli cannot be enabled with vault.scope=agent",
+        }),
+      );
+    }
   });
 });
 
@@ -100,5 +218,27 @@ describe("memory-wiki manifest config schema", () => {
     };
 
     expect(validate(config)).toBe(true);
+  });
+
+  it("rejects unsafe-local access for agent-scoped vaults", () => {
+    const validate = compileManifestConfigSchema();
+
+    expect(
+      validate({
+        vaultMode: "unsafe-local",
+        vault: { scope: "agent" },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects the global Obsidian CLI selector for agent-scoped vaults", () => {
+    const validate = compileManifestConfigSchema();
+
+    expect(
+      validate({
+        vault: { scope: "agent" },
+        obsidian: { useOfficialCli: true },
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -2,14 +2,18 @@
 import os from "node:os";
 import path from "node:path";
 import { mapPluginConfigIssues } from "openclaw/plugin-sdk/extension-shared";
+import { resolveDefaultAgentId, resolveSessionAgentId } from "openclaw/plugin-sdk/memory-host-core";
 import { buildPluginConfigSchema, z, type OpenClawPluginConfigSchema } from "../api.js";
+import type { OpenClawConfig } from "../api.js";
 
 const WIKI_VAULT_MODES = ["isolated", "bridge", "unsafe-local"] as const;
+const WIKI_VAULT_SCOPES = ["global", "agent"] as const;
 const WIKI_RENDER_MODES = ["native", "obsidian"] as const;
 export const WIKI_SEARCH_BACKENDS = ["shared", "local"] as const;
 export const WIKI_SEARCH_CORPORA = ["wiki", "memory", "all"] as const;
 
 type WikiVaultMode = (typeof WIKI_VAULT_MODES)[number];
+export type WikiVaultScope = (typeof WIKI_VAULT_SCOPES)[number];
 type WikiRenderMode = (typeof WIKI_RENDER_MODES)[number];
 export type WikiSearchBackend = (typeof WIKI_SEARCH_BACKENDS)[number];
 export type WikiSearchCorpus = (typeof WIKI_SEARCH_CORPORA)[number];
@@ -17,6 +21,7 @@ export type WikiSearchCorpus = (typeof WIKI_SEARCH_CORPORA)[number];
 export type MemoryWikiPluginConfig = {
   vaultMode?: WikiVaultMode;
   vault?: {
+    scope?: WikiVaultScope;
     path?: string;
     renderMode?: WikiRenderMode;
   };
@@ -58,8 +63,10 @@ export type MemoryWikiPluginConfig = {
 };
 
 export type ResolvedMemoryWikiConfig = {
+  agentId?: string;
   vaultMode: WikiVaultMode;
   vault: {
+    scope: WikiVaultScope;
     path: string;
     renderMode: WikiRenderMode;
   };
@@ -100,69 +107,93 @@ export type ResolvedMemoryWikiConfig = {
   };
 };
 
+export type MemoryWikiConfigResolver = (
+  agentId?: string,
+  appConfig?: OpenClawConfig,
+) => ResolvedMemoryWikiConfig;
+
 export const DEFAULT_WIKI_VAULT_MODE: WikiVaultMode = "isolated";
+export const DEFAULT_WIKI_VAULT_SCOPE: WikiVaultScope = "global";
 export const DEFAULT_WIKI_RENDER_MODE: WikiRenderMode = "native";
 export const DEFAULT_WIKI_SEARCH_BACKEND: WikiSearchBackend = "shared";
 export const DEFAULT_WIKI_SEARCH_CORPUS: WikiSearchCorpus = "wiki";
 
-const MemoryWikiConfigSource = z.strictObject({
-  vaultMode: z.enum(WIKI_VAULT_MODES).optional(),
-  vault: z
-    .strictObject({
-      path: z.string().optional(),
-      renderMode: z.enum(WIKI_RENDER_MODES).optional(),
-    })
-    .optional(),
-  obsidian: z
-    .strictObject({
-      enabled: z.boolean().optional(),
-      useOfficialCli: z.boolean().optional(),
-      vaultName: z.string().optional(),
-      openAfterWrites: z.boolean().optional(),
-    })
-    .optional(),
-  bridge: z
-    .strictObject({
-      enabled: z.boolean().optional(),
-      readMemoryArtifacts: z.boolean().optional(),
-      indexDreamReports: z.boolean().optional(),
-      indexDailyNotes: z.boolean().optional(),
-      indexMemoryRoot: z.boolean().optional(),
-      followMemoryEvents: z.boolean().optional(),
-    })
-    .optional(),
-  unsafeLocal: z
-    .strictObject({
-      allowPrivateMemoryCoreAccess: z.boolean().optional(),
-      paths: z.array(z.string()).optional(),
-    })
-    .optional(),
-  ingest: z
-    .strictObject({
-      autoCompile: z.boolean().optional(),
-      maxConcurrentJobs: z.number().int().min(1).optional(),
-      allowUrlIngest: z.boolean().optional(),
-    })
-    .optional(),
-  search: z
-    .strictObject({
-      backend: z.enum(WIKI_SEARCH_BACKENDS).optional(),
-      corpus: z.enum(WIKI_SEARCH_CORPORA).optional(),
-    })
-    .optional(),
-  context: z
-    .strictObject({
-      includeCompiledDigestPrompt: z.boolean().optional(),
-    })
-    .optional(),
-  render: z
-    .strictObject({
-      preserveHumanBlocks: z.boolean().optional(),
-      createBacklinks: z.boolean().optional(),
-      createDashboards: z.boolean().optional(),
-    })
-    .optional(),
-});
+const MemoryWikiConfigSource = z
+  .strictObject({
+    vaultMode: z.enum(WIKI_VAULT_MODES).optional(),
+    vault: z
+      .strictObject({
+        scope: z.enum(WIKI_VAULT_SCOPES).optional(),
+        path: z.string().optional(),
+        renderMode: z.enum(WIKI_RENDER_MODES).optional(),
+      })
+      .optional(),
+    obsidian: z
+      .strictObject({
+        enabled: z.boolean().optional(),
+        useOfficialCli: z.boolean().optional(),
+        vaultName: z.string().optional(),
+        openAfterWrites: z.boolean().optional(),
+      })
+      .optional(),
+    bridge: z
+      .strictObject({
+        enabled: z.boolean().optional(),
+        readMemoryArtifacts: z.boolean().optional(),
+        indexDreamReports: z.boolean().optional(),
+        indexDailyNotes: z.boolean().optional(),
+        indexMemoryRoot: z.boolean().optional(),
+        followMemoryEvents: z.boolean().optional(),
+      })
+      .optional(),
+    unsafeLocal: z
+      .strictObject({
+        allowPrivateMemoryCoreAccess: z.boolean().optional(),
+        paths: z.array(z.string()).optional(),
+      })
+      .optional(),
+    ingest: z
+      .strictObject({
+        autoCompile: z.boolean().optional(),
+        maxConcurrentJobs: z.number().int().min(1).optional(),
+        allowUrlIngest: z.boolean().optional(),
+      })
+      .optional(),
+    search: z
+      .strictObject({
+        backend: z.enum(WIKI_SEARCH_BACKENDS).optional(),
+        corpus: z.enum(WIKI_SEARCH_CORPORA).optional(),
+      })
+      .optional(),
+    context: z
+      .strictObject({
+        includeCompiledDigestPrompt: z.boolean().optional(),
+      })
+      .optional(),
+    render: z
+      .strictObject({
+        preserveHumanBlocks: z.boolean().optional(),
+        createBacklinks: z.boolean().optional(),
+        createDashboards: z.boolean().optional(),
+      })
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.vault?.scope === "agent" && value.vaultMode === "unsafe-local") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["vaultMode"],
+        message: "vaultMode=unsafe-local cannot be combined with vault.scope=agent",
+      });
+    }
+    if (value.vault?.scope === "agent" && value.obsidian?.useOfficialCli === true) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["obsidian", "useOfficialCli"],
+        message: "obsidian.useOfficialCli cannot be enabled with vault.scope=agent",
+      });
+    }
+  });
 
 const memoryWikiConfigSchemaBase = buildPluginConfigSchema(MemoryWikiConfigSource, {
   safeParse(value: unknown) {
@@ -198,6 +229,10 @@ export function resolveDefaultMemoryWikiVaultPath(homedir = os.homedir()): strin
   return path.join(homedir, ".openclaw", "wiki", "main");
 }
 
+export function resolveDefaultMemoryWikiVaultRoot(homedir = os.homedir()): string {
+  return path.join(homedir, ".openclaw", "wiki");
+}
+
 export function resolveMemoryWikiConfig(
   config: MemoryWikiPluginConfig | undefined,
   options?: { homedir?: string },
@@ -205,12 +240,17 @@ export function resolveMemoryWikiConfig(
   const homedir = options?.homedir ?? os.homedir();
   const parsed = config ? MemoryWikiConfigSource.safeParse(config) : null;
   const safeConfig = parsed?.success ? parsed.data : (config ?? {});
+  const vaultScope = safeConfig.vault?.scope ?? DEFAULT_WIKI_VAULT_SCOPE;
 
   return {
     vaultMode: safeConfig.vaultMode ?? DEFAULT_WIKI_VAULT_MODE,
     vault: {
+      scope: vaultScope,
       path: expandHomePath(
-        safeConfig.vault?.path ?? resolveDefaultMemoryWikiVaultPath(homedir),
+        safeConfig.vault?.path ??
+          (vaultScope === "agent"
+            ? resolveDefaultMemoryWikiVaultRoot(homedir)
+            : resolveDefaultMemoryWikiVaultPath(homedir)),
         homedir,
       ),
       renderMode: safeConfig.vault?.renderMode ?? DEFAULT_WIKI_RENDER_MODE,
@@ -249,6 +289,56 @@ export function resolveMemoryWikiConfig(
       preserveHumanBlocks: safeConfig.render?.preserveHumanBlocks ?? true,
       createBacklinks: safeConfig.render?.createBacklinks ?? true,
       createDashboards: safeConfig.render?.createDashboards ?? true,
+    },
+  };
+}
+
+export function resolveMemoryWikiConfiguredAgentIds(
+  appConfig: OpenClawConfig | undefined,
+): string[] {
+  const configured = appConfig?.agents?.list ?? [];
+  const ids = configured.flatMap((entry) => {
+    const rawId = entry?.id?.trim();
+    if (!rawId) {
+      return [];
+    }
+    return [resolveSessionAgentId({ config: appConfig, agentId: rawId })];
+  });
+  return [...new Set(ids.length > 0 ? ids : [resolveDefaultAgentId(appConfig ?? {})])];
+}
+
+/** Resolve the exact vault for one trusted runtime agent context. */
+export function resolveMemoryWikiAgentConfig(params: {
+  config: ResolvedMemoryWikiConfig;
+  appConfig?: OpenClawConfig;
+  agentId?: string;
+}): ResolvedMemoryWikiConfig {
+  if (params.config.vault.scope === "global") {
+    return params.config;
+  }
+  if (params.config.vaultMode === "unsafe-local") {
+    throw new Error("memory-wiki vault.scope=agent does not support vaultMode=unsafe-local.");
+  }
+
+  const configuredAgentIds = resolveMemoryWikiConfiguredAgentIds(params.appConfig);
+  const requestedAgentId = params.agentId?.trim();
+  if (!requestedAgentId && configuredAgentIds.length > 1) {
+    throw new Error("agentId is required for memory-wiki when vault.scope=agent.");
+  }
+  const agentId = resolveSessionAgentId({
+    config: params.appConfig,
+    agentId: requestedAgentId ?? resolveDefaultAgentId(params.appConfig ?? {}),
+  });
+  if (!configuredAgentIds.includes(agentId)) {
+    throw new Error(`Unknown memory-wiki agentId: ${requestedAgentId ?? agentId}.`);
+  }
+
+  return {
+    ...params.config,
+    agentId,
+    vault: {
+      ...params.config.vault,
+      path: path.join(params.config.vault.path, agentId),
     },
   };
 }

--- a/extensions/memory-wiki/src/corpus-supplement.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.test.ts
@@ -1,0 +1,107 @@
+// Memory Wiki tests cover corpus supplement agent routing.
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../api.js";
+import {
+  resolveMemoryWikiAgentConfig,
+  resolveMemoryWikiConfig,
+  type MemoryWikiConfigResolver,
+} from "./config.js";
+import { createWikiCorpusSupplement } from "./corpus-supplement.js";
+
+const queryMocks = vi.hoisted(() => ({
+  getMemoryWikiPage: vi.fn(),
+  searchMemoryWiki: vi.fn(),
+}));
+
+vi.mock("./query.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./query.js")>()),
+  ...queryMocks,
+}));
+
+describe("memory-wiki corpus supplement", () => {
+  const appConfig = {
+    agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+  } as OpenClawConfig;
+  const config = resolveMemoryWikiConfig({
+    vault: { scope: "agent", path: "/tmp/memory-wiki-agents" },
+  });
+
+  beforeEach(() => {
+    queryMocks.searchMemoryWiki.mockReset().mockResolvedValue([]);
+    queryMocks.getMemoryWikiPage.mockReset().mockResolvedValue(null);
+  });
+
+  it("resolves search and get from each invocation's agent context", async () => {
+    const resolveConfig = vi.fn<MemoryWikiConfigResolver>((agentId, currentAppConfig) =>
+      resolveMemoryWikiAgentConfig({ config, appConfig: currentAppConfig, agentId }),
+    );
+    const getAppConfig = vi.fn(() => appConfig);
+    const supplement = createWikiCorpusSupplement({ resolveConfig, getAppConfig });
+
+    await supplement.search({
+      query: "support handbook",
+      maxResults: 4,
+      agentId: "support",
+      agentSessionKey: "agent:support:main",
+      sandboxed: true,
+    });
+    await supplement.get({
+      lookup: "marketing-plan",
+      fromLine: 3,
+      lineCount: 8,
+      agentId: "marketing",
+      agentSessionKey: "agent:marketing:main",
+      sandboxed: false,
+    });
+
+    expect(resolveConfig).toHaveBeenNthCalledWith(1, "support", appConfig);
+    expect(resolveConfig).toHaveBeenNthCalledWith(2, "marketing", appConfig);
+    expect(queryMocks.searchMemoryWiki).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        agentId: "support",
+        vault: expect.objectContaining({
+          path: path.join(config.vault.path, "support"),
+        }),
+      }),
+      appConfig,
+      agentId: "support",
+      agentSessionKey: "agent:support:main",
+      sandboxed: true,
+      query: "support handbook",
+      maxResults: 4,
+      searchBackend: "local",
+      searchCorpus: "wiki",
+    });
+    expect(queryMocks.getMemoryWikiPage).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        agentId: "marketing",
+        vault: expect.objectContaining({
+          path: path.join(config.vault.path, "marketing"),
+        }),
+      }),
+      appConfig,
+      agentId: "marketing",
+      agentSessionKey: "agent:marketing:main",
+      sandboxed: false,
+      lookup: "marketing-plan",
+      fromLine: 3,
+      lineCount: 8,
+      searchBackend: "local",
+      searchCorpus: "wiki",
+    });
+  });
+
+  it("fails closed before querying when multi-agent context is missing", async () => {
+    const supplement = createWikiCorpusSupplement({
+      resolveConfig: (agentId, currentAppConfig) =>
+        resolveMemoryWikiAgentConfig({ config, appConfig: currentAppConfig, agentId }),
+      getAppConfig: () => appConfig,
+    });
+
+    await expect(supplement.search({ query: "shared data" })).rejects.toThrow(
+      "agentId is required",
+    );
+    expect(queryMocks.searchMemoryWiki).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-wiki/src/corpus-supplement.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.ts
@@ -1,38 +1,56 @@
 // Memory Wiki plugin module implements corpus supplement behavior.
 import type { OpenClawConfig } from "../api.js";
-import type { ResolvedMemoryWikiConfig } from "./config.js";
+import type { MemoryWikiConfigResolver } from "./config.js";
 import { getMemoryWikiPage, searchMemoryWiki } from "./query.js";
 
 export function createWikiCorpusSupplement(params: {
-  config: ResolvedMemoryWikiConfig;
-  appConfig?: OpenClawConfig;
+  resolveConfig: MemoryWikiConfigResolver;
+  getAppConfig: () => OpenClawConfig | undefined;
 }) {
   return {
-    search: async (input: { query: string; maxResults?: number; agentSessionKey?: string }) =>
-      await searchMemoryWiki({
-        config: params.config,
-        appConfig: params.appConfig,
+    search: async (input: {
+      query: string;
+      maxResults?: number;
+      agentId?: string;
+      agentSessionKey?: string;
+      sandboxed?: boolean;
+    }) => {
+      const appConfig = params.getAppConfig();
+      const config = params.resolveConfig(input.agentId, appConfig);
+      return await searchMemoryWiki({
+        config,
+        appConfig,
+        agentId: config.agentId ?? input.agentId,
         agentSessionKey: input.agentSessionKey,
+        sandboxed: input.sandboxed,
         query: input.query,
         maxResults: input.maxResults,
         searchBackend: "local",
         searchCorpus: "wiki",
-      }),
+      });
+    },
     get: async (input: {
       lookup: string;
       fromLine?: number;
       lineCount?: number;
+      agentId?: string;
       agentSessionKey?: string;
-    }) =>
-      await getMemoryWikiPage({
-        config: params.config,
-        appConfig: params.appConfig,
+      sandboxed?: boolean;
+    }) => {
+      const appConfig = params.getAppConfig();
+      const config = params.resolveConfig(input.agentId, appConfig);
+      return await getMemoryWikiPage({
+        config,
+        appConfig,
+        agentId: config.agentId ?? input.agentId,
         agentSessionKey: input.agentSessionKey,
+        sandboxed: input.sandboxed,
         lookup: input.lookup,
         fromLine: input.fromLine,
         lineCount: input.lineCount,
         searchBackend: "local",
         searchCorpus: "wiki",
-      }),
+      });
+    },
   };
 }

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -1,4 +1,5 @@
 // Memory Wiki tests cover gateway plugin behavior.
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyMemoryWikiMutation,
@@ -105,6 +106,27 @@ function readRespondError(respond: { mock: { calls: Array<Array<unknown>> } }): 
   return call?.[2];
 }
 
+const VAULT_BACKED_GATEWAY_CASES = [
+  ["wiki.status", {}],
+  ["wiki.importRuns", {}],
+  ["wiki.importInsights", {}],
+  ["wiki.palace", {}],
+  ["wiki.init", {}],
+  ["wiki.doctor", {}],
+  ["wiki.compile", {}],
+  ["wiki.ingest", { inputPath: "/tmp/alpha-notes.txt" }],
+  ["wiki.lint", {}],
+  ["wiki.bridge.import", {}],
+  ["wiki.unsafeLocal.import", {}],
+  ["wiki.search", { query: "alpha" }],
+  ["wiki.apply", { op: "create_synthesis" }],
+  ["wiki.get", { lookup: "alpha" }],
+  ["wiki.obsidian.search", { query: "alpha" }],
+  ["wiki.obsidian.open", { path: "syntheses/alpha.md" }],
+  ["wiki.obsidian.command", { id: "workspace:save-file" }],
+  ["wiki.obsidian.daily", {}],
+] as const satisfies ReadonlyArray<readonly [string, Record<string, unknown>]>;
+
 describe("memory-wiki gateway methods", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -120,10 +142,15 @@ describe("memory-wiki gateway methods", () => {
       indexUpdatedFiles: [],
       indexRefreshReason: "no-import-changes",
     });
-    vi.mocked(resolveMemoryWikiStatus).mockResolvedValue({
-      vaultMode: "isolated",
-      vaultExists: true,
-    } as never);
+    vi.mocked(resolveMemoryWikiStatus).mockImplementation(
+      async (config) =>
+        ({
+          vaultScope: config.vault.scope,
+          agentId: config.agentId ?? null,
+          vaultMode: "isolated",
+          vaultExists: true,
+        }) as never,
+    );
     vi.mocked(ingestMemoryWikiSource).mockResolvedValue({
       pagePath: "sources/alpha-notes.md",
     } as never);
@@ -183,6 +210,84 @@ describe("memory-wiki gateway methods", () => {
     });
   });
 
+  it.each(VAULT_BACKED_GATEWAY_CASES)(
+    "%s resolves its request agent exactly once",
+    async (method, methodParams) => {
+      const { config, rootDir } = await createVault({
+        prefix: "memory-wiki-gateway-agent-",
+        config: { vault: { scope: "agent" } },
+      });
+      const { api, registerGatewayMethod } = createPluginApi();
+      const appConfig = {
+        agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+      };
+      const agentConfig = {
+        ...config,
+        agentId: "marketing",
+        vault: { ...config.vault, path: path.join(rootDir, "marketing") },
+      };
+      const resolveConfig = vi.fn(() => agentConfig);
+
+      registerMemoryWikiGatewayMethods({ api, config, appConfig, resolveConfig });
+      const handler = findGatewayHandler(registerGatewayMethod, method);
+      if (!handler) {
+        throw new Error(`${method} handler missing`);
+      }
+
+      await handler({
+        params: { ...methodParams, agentId: "marketing" },
+        respond: vi.fn(),
+      });
+
+      expect(resolveConfig).toHaveBeenCalledOnce();
+      expect(resolveConfig).toHaveBeenCalledWith("marketing", appConfig);
+    },
+  );
+
+  it("keeps only the Obsidian executable probe outside vault resolution", async () => {
+    const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const resolveConfig = vi.fn(() => config);
+
+    registerMemoryWikiGatewayMethods({ api, config, resolveConfig });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.obsidian.status");
+    if (!handler) {
+      throw new Error("wiki.obsidian.status handler missing");
+    }
+
+    await handler({ params: { agentId: "marketing" }, respond: vi.fn() });
+
+    expect(resolveConfig).not.toHaveBeenCalled();
+    expect(
+      registerGatewayMethod.mock.calls
+        .map(([method]) => method)
+        .filter((method) => method !== "wiki.obsidian.status"),
+    ).toEqual(VAULT_BACKED_GATEWAY_CASES.map(([method]) => method));
+  });
+
+  it("rejects official Obsidian CLI actions for agent-scoped vaults", async () => {
+    const { config } = await createVault({
+      prefix: "memory-wiki-gateway-agent-",
+      config: { vault: { scope: "agent" } },
+    });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const appConfig = { agents: { list: [{ id: "support", default: true }] } };
+
+    registerMemoryWikiGatewayMethods({ api, config, appConfig });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.obsidian.search");
+    if (!handler) {
+      throw new Error("wiki.obsidian.search handler missing");
+    }
+    const respond = vi.fn();
+
+    await handler({ params: { agentId: "support", query: "alpha" }, respond });
+
+    expect(readRespondError(respond)).toEqual({
+      code: "internal_error",
+      message: "Official Obsidian CLI actions do not support memory-wiki vault.scope=agent.",
+    });
+  });
+
   it("returns wiki status over the gateway", async () => {
     const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
     const { api, registerGatewayMethod } = createPluginApi();
@@ -204,9 +309,94 @@ describe("memory-wiki gateway methods", () => {
       appConfig: undefined,
     });
     expect(readRespondPayload(respond)).toEqual({
+      vaultScope: "global",
+      agentId: null,
       vaultMode: "isolated",
       vaultExists: true,
     });
+  });
+
+  it("keeps global vault requests on the shared base config", async () => {
+    const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+
+    registerMemoryWikiGatewayMethods({ api, config, appConfig });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.status");
+    if (!handler) {
+      throw new Error("wiki.status handler missing");
+    }
+
+    await handler({ params: { agentId: "marketing" }, respond: vi.fn() });
+
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig });
+    expect(resolveMemoryWikiStatus).toHaveBeenCalledWith(config, { appConfig });
+  });
+
+  it("resolves an agent-scoped vault once from each request and live app config", async () => {
+    const { config, rootDir } = await createVault({
+      prefix: "memory-wiki-gateway-agent-",
+      config: { vault: { scope: "agent" } },
+    });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+    const getAppConfig = vi.fn(() => appConfig);
+
+    registerMemoryWikiGatewayMethods({ api, config, getAppConfig });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.status");
+    if (!handler) {
+      throw new Error("wiki.status handler missing");
+    }
+    const respond = vi.fn();
+
+    await handler({ params: { agentId: "marketing" }, respond });
+
+    const resolvedConfig = expect.objectContaining({
+      agentId: "marketing",
+      vault: expect.objectContaining({ path: path.join(rootDir, "marketing") }),
+    });
+    expect(getAppConfig).toHaveBeenCalledTimes(1);
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config: resolvedConfig,
+      appConfig,
+    });
+    expect(resolveMemoryWikiStatus).toHaveBeenCalledWith(resolvedConfig, { appConfig });
+    expect(readRespondPayload(respond)).toEqual({
+      vaultScope: "agent",
+      agentId: "marketing",
+      vaultMode: "isolated",
+      vaultExists: true,
+    });
+  });
+
+  it.each([
+    [{}, "agentId is required for memory-wiki when vault.scope=agent."],
+    [{ agentId: "unknown" }, "Unknown memory-wiki agentId: unknown."],
+  ])("fails closed for invalid agent-scoped requests", async (requestParams, message) => {
+    const { config } = await createVault({
+      prefix: "memory-wiki-gateway-agent-",
+      config: { vault: { scope: "agent" } },
+    });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    };
+
+    registerMemoryWikiGatewayMethods({ api, config, appConfig });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.status");
+    if (!handler) {
+      throw new Error("wiki.status handler missing");
+    }
+    const respond = vi.fn();
+
+    await handler({ params: requestParams, respond });
+
+    expect(syncMemoryWikiImportedSources).not.toHaveBeenCalled();
+    expect(readRespondError(respond)).toEqual({ code: "internal_error", message });
   });
 
   it("returns recent import runs over the gateway", async () => {

--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig, OpenClawPluginApi } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import {
+  resolveMemoryWikiAgentConfig,
   WIKI_SEARCH_BACKENDS,
   WIKI_SEARCH_CORPORA,
   type ResolvedMemoryWikiConfig,
@@ -77,16 +78,6 @@ function respondError(respond: GatewayRespond, error: unknown) {
   respond(false, undefined, { code: "internal_error", message });
 }
 
-function resolveGatewayAgentId(
-  requestParams: Record<string, unknown>,
-  appConfig: OpenClawConfig | undefined,
-): string | undefined {
-  return (
-    readStringParam(requestParams, "agentId") ??
-    (appConfig ? resolveDefaultAgentId(appConfig) : undefined)
-  );
-}
-
 async function syncImportedSourcesIfNeeded(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
@@ -98,13 +89,50 @@ export function registerMemoryWikiGatewayMethods(params: {
   api: OpenClawPluginApi;
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  getAppConfig?: () => OpenClawConfig | undefined;
+  resolveConfig?: (agentId?: string, appConfig?: OpenClawConfig) => ResolvedMemoryWikiConfig;
 }) {
-  const { api, config, appConfig } = params;
+  const { api, config: baseConfig } = params;
+
+  const getAppConfig = () => {
+    if (params.getAppConfig) {
+      return params.getAppConfig();
+    }
+    if (typeof api.runtime.config?.current === "function") {
+      return api.runtime.config.current() as OpenClawConfig;
+    }
+    return params.appConfig;
+  };
+  const resolveRequestContext = (requestParams: Record<string, unknown>) => {
+    const appConfig = getAppConfig();
+    const requestedAgentId = readStringParam(requestParams, "agentId");
+    const config = params.resolveConfig
+      ? params.resolveConfig(requestedAgentId, appConfig)
+      : resolveMemoryWikiAgentConfig({
+          config: baseConfig,
+          appConfig,
+          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
+        });
+    const agentId =
+      config.agentId ??
+      requestedAgentId ??
+      (appConfig ? resolveDefaultAgentId(appConfig) : undefined);
+    return { agentId, appConfig, config };
+  };
+
+  const assertOfficialObsidianCliSupported = (config: ResolvedMemoryWikiConfig) => {
+    if (config.vault.scope === "agent") {
+      throw new Error(
+        "Official Obsidian CLI actions do not support memory-wiki vault.scope=agent.",
+      );
+    }
+  };
 
   api.registerGatewayMethod(
     "wiki.status",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(
           true,
@@ -123,6 +151,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.importRuns",
     async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
         const limit = readPositiveIntegerParam(requestParams, "limit");
         respond(true, await listMemoryWikiImportRuns(config, limit !== undefined ? { limit } : {}));
       } catch (error) {
@@ -134,8 +163,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.importInsights",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(true, await listMemoryWikiImportInsights(config));
       } catch (error) {
@@ -147,8 +177,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.palace",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(true, await listMemoryWikiPalace(config));
       } catch (error) {
@@ -160,8 +191,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.init",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
         respond(true, await initializeMemoryWikiVault(config));
       } catch (error) {
         respondError(respond, error);
@@ -172,8 +204,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.doctor",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         const status = await resolveMemoryWikiStatus(config, {
           appConfig,
@@ -188,8 +221,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.compile",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(true, await compileMemoryWikiVault(config));
       } catch (error) {
@@ -203,6 +237,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.ingest",
     async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
         const inputPath = readStringParam(requestParams, "inputPath", { required: true });
         const title = readStringParam(requestParams, "title");
         respond(
@@ -222,8 +257,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.lint",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(true, await lintMemoryWikiVault(config));
       } catch (error) {
@@ -235,8 +271,9 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.bridge.import",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         respond(
           true,
           await syncMemoryWikiImportedSources({
@@ -253,8 +290,12 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.unsafeLocal.import",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
+        if (config.vault.scope === "agent") {
+          throw new Error("Unsafe-local import does not support memory-wiki vault.scope=agent.");
+        }
         respond(
           true,
           await syncMemoryWikiImportedSources({
@@ -273,13 +314,13 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.search",
     async ({ params: requestParams, respond }) => {
       try {
+        const { agentId, appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         const query = readStringParam(requestParams, "query", { required: true });
         const maxResults = readPositiveIntegerParam(requestParams, "maxResults");
         const searchBackend = readEnumParam(requestParams, "backend", WIKI_SEARCH_BACKENDS);
         const searchCorpus = readEnumParam(requestParams, "corpus", WIKI_SEARCH_CORPORA);
         const mode = readEnumParam(requestParams, "mode", WIKI_SEARCH_MODES);
-        const agentId = resolveGatewayAgentId(requestParams, appConfig);
         respond(
           true,
           await searchMemoryWiki({
@@ -304,6 +345,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.apply",
     async ({ params: requestParams, respond }) => {
       try {
+        const { appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         respond(
           true,
@@ -323,13 +365,13 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.get",
     async ({ params: requestParams, respond }) => {
       try {
+        const { agentId, appConfig, config } = resolveRequestContext(requestParams);
         await syncImportedSourcesIfNeeded(config, appConfig);
         const lookup = readStringParam(requestParams, "lookup", { required: true });
         const fromLine = readPositiveIntegerParam(requestParams, "fromLine");
         const lineCount = readPositiveIntegerParam(requestParams, "lineCount");
         const searchBackend = readEnumParam(requestParams, "backend", WIKI_SEARCH_BACKENDS);
         const searchCorpus = readEnumParam(requestParams, "corpus", WIKI_SEARCH_CORPORA);
-        const agentId = resolveGatewayAgentId(requestParams, appConfig);
         respond(
           true,
           await getMemoryWikiPage({
@@ -366,6 +408,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.obsidian.search",
     async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
+        assertOfficialObsidianCliSupported(config);
         const query = readStringParam(requestParams, "query", { required: true });
         respond(true, await runObsidianSearch({ config, query }));
       } catch (error) {
@@ -379,6 +423,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.obsidian.open",
     async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
+        assertOfficialObsidianCliSupported(config);
         const vaultPath = readStringParam(requestParams, "path", { required: true });
         respond(true, await runObsidianOpen({ config, vaultPath }));
       } catch (error) {
@@ -392,6 +438,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.obsidian.command",
     async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
+        assertOfficialObsidianCliSupported(config);
         const id = readStringParam(requestParams, "id", { required: true });
         respond(true, await runObsidianCommand({ config, id }));
       } catch (error) {
@@ -403,8 +451,10 @@ export function registerMemoryWikiGatewayMethods(params: {
 
   api.registerGatewayMethod(
     "wiki.obsidian.daily",
-    async ({ respond }) => {
+    async ({ params: requestParams, respond }) => {
       try {
+        const { config } = resolveRequestContext(requestParams);
+        assertOfficialObsidianCliSupported(config);
         respond(true, await runObsidianDaily({ config }));
       } catch (error) {
         respondError(respond, error);

--- a/extensions/memory-wiki/src/prompt-section.test.ts
+++ b/extensions/memory-wiki/src/prompt-section.test.ts
@@ -3,7 +3,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { resolveMemoryWikiConfig } from "./config.js";
+import type { OpenClawConfig } from "../api.js";
+import {
+  resolveMemoryWikiAgentConfig,
+  resolveMemoryWikiConfig,
+  type ResolvedMemoryWikiConfig,
+} from "./config.js";
 import { createWikiPromptSectionBuilder } from "./prompt-section.js";
 
 let suiteRoot = "";
@@ -18,7 +23,11 @@ afterAll(async () => {
   }
 });
 
-const buildDefaultWikiPromptSection = createWikiPromptSectionBuilder(
+function createStaticWikiPromptSectionBuilder(config: ResolvedMemoryWikiConfig) {
+  return createWikiPromptSectionBuilder({ config, resolveConfig: () => config });
+}
+
+const buildDefaultWikiPromptSection = createStaticWikiPromptSectionBuilder(
   resolveMemoryWikiConfig({
     vault: { path: "" },
     context: { includeCompiledDigestPrompt: false },
@@ -74,7 +83,7 @@ describe("default wiki prompt section", () => {
       ),
       "utf8",
     );
-    const builder = createWikiPromptSectionBuilder(
+    const builder = createStaticWikiPromptSectionBuilder(
       resolveMemoryWikiConfig({
         vault: { path: rootDir },
         context: { includeCompiledDigestPrompt: true },
@@ -101,7 +110,7 @@ describe("default wiki prompt section", () => {
       }),
       "utf8",
     );
-    const builder = createWikiPromptSectionBuilder(
+    const builder = createStaticWikiPromptSectionBuilder(
       resolveMemoryWikiConfig({
         vault: { path: rootDir },
       }),
@@ -115,7 +124,7 @@ describe("default wiki prompt section", () => {
     const digestPath = path.join(rootDir, ".openclaw-wiki", "cache", "agent-digest.json");
     await fs.mkdir(path.dirname(digestPath), { recursive: true });
 
-    const builder = createWikiPromptSectionBuilder(
+    const builder = createStaticWikiPromptSectionBuilder(
       resolveMemoryWikiConfig({
         vault: { path: rootDir },
         context: { includeCompiledDigestPrompt: true },
@@ -185,5 +194,60 @@ describe("default wiki prompt section", () => {
     expect(firstLines.join("\n")).toContain(
       "Alpha was renamed in 2026. (confidence 0.42, freshness aging)",
     );
+  });
+
+  it("reads only the invoking agent's compiled digest", async () => {
+    const rootDir = path.join(suiteRoot, "agent-digests");
+    const appConfig = {
+      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+    } as OpenClawConfig;
+    const config = resolveMemoryWikiConfig({
+      vault: { scope: "agent", path: rootDir },
+      context: { includeCompiledDigestPrompt: true },
+    });
+    for (const [agentId, marker] of [
+      ["support", "SUPPORT_SENTINEL"],
+      ["marketing", "MARKETING_SENTINEL"],
+    ] as const) {
+      const digestPath = path.join(
+        rootDir,
+        agentId,
+        ".openclaw-wiki",
+        "cache",
+        "agent-digest.json",
+      );
+      await fs.mkdir(path.dirname(digestPath), { recursive: true });
+      await fs.writeFile(
+        digestPath,
+        JSON.stringify({
+          claimCount: 1,
+          pages: [
+            {
+              title: agentId,
+              kind: "entity",
+              claimCount: 1,
+              topClaims: [{ text: marker }],
+            },
+          ],
+        }),
+        "utf8",
+      );
+    }
+    const builder = createWikiPromptSectionBuilder({
+      config,
+      resolveConfig: (agentId) => resolveMemoryWikiAgentConfig({ config, appConfig, agentId }),
+    });
+
+    const support = builder({ availableTools: new Set(["web_search"]), agentId: "support" });
+    const marketing = builder({
+      availableTools: new Set(["web_search"]),
+      agentId: "marketing",
+    });
+
+    expect(support.join("\n")).toContain("SUPPORT_SENTINEL");
+    expect(support.join("\n")).not.toContain("MARKETING_SENTINEL");
+    expect(marketing.join("\n")).toContain("MARKETING_SENTINEL");
+    expect(marketing.join("\n")).not.toContain("SUPPORT_SENTINEL");
+    expect(builder({ availableTools: new Set(["web_search"]) })).toStrictEqual([]);
   });
 });

--- a/extensions/memory-wiki/src/prompt-section.ts
+++ b/extensions/memory-wiki/src/prompt-section.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-host-core";
-import type { ResolvedMemoryWikiConfig } from "./config.js";
+import type { MemoryWikiConfigResolver, ResolvedMemoryWikiConfig } from "./config.js";
 
 const AGENT_DIGEST_PATH = ".openclaw-wiki/cache/agent-digest.json";
 const DIGEST_MAX_PAGES = 4;
@@ -214,11 +214,16 @@ function buildWikiToolGuidance(availableTools: Set<string>): string[] {
   return lines;
 }
 
-export function createWikiPromptSectionBuilder(
-  config: ResolvedMemoryWikiConfig,
-): MemoryPromptSectionBuilder {
-  return ({ availableTools }) => {
-    const digestLines = buildDigestPromptSection(config);
+export function createWikiPromptSectionBuilder(params: {
+  config: ResolvedMemoryWikiConfig;
+  resolveConfig: MemoryWikiConfigResolver;
+}): MemoryPromptSectionBuilder {
+  return ({ availableTools, agentId }) => {
+    // Prompt contexts without an agent must not fall back to another agent's digest.
+    const digestLines =
+      params.config.vault.scope === "agent" && !agentId
+        ? []
+        : buildDigestPromptSection(params.resolveConfig(agentId));
     const toolGuidance = buildWikiToolGuidance(availableTools);
     if (digestLines.length === 0 && toolGuidance.length === 0) {
       return [];

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -188,6 +188,67 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.bridgePublicArtifactCount).toBe(2);
   });
 
+  it("scopes global-vault status metadata when called by an agent tool", async () => {
+    const config = resolveMemoryWikiConfig(
+      {
+        vaultMode: "bridge",
+        bridge: { enabled: true, readMemoryArtifacts: true },
+      },
+      { homedir: "/Users/tester" },
+    );
+    const artifacts: MemoryPluginPublicArtifact[] = [
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/support",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/support/MEMORY.md",
+        agentIds: ["support"],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/marketing",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/marketing/MEMORY.md",
+        agentIds: ["marketing"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir: "/tmp/shared",
+        relativePath: "memory/2026-07-09.md",
+        absolutePath: "/tmp/shared/memory/2026-07-09.md",
+        agentIds: ["support", "marketing"],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/legacy",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/legacy/MEMORY.md",
+        agentIds: [],
+        contentType: "markdown",
+      },
+    ];
+    const deps = {
+      appConfig: {} as OpenClawConfig,
+      listPublicArtifacts: async () => artifacts,
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    };
+
+    const agentStatus = await resolveMemoryWikiStatus(config, {
+      ...deps,
+      callerAgentId: " SUPPORT ",
+    });
+    const operatorStatus = await resolveMemoryWikiStatus(config, deps);
+
+    expect(agentStatus.vaultScope).toBe("global");
+    expect(agentStatus.agentId).toBeNull();
+    expect(agentStatus.bridgePublicArtifactCount).toBe(2);
+    expect(operatorStatus.bridgePublicArtifactCount).toBe(4);
+  });
+
   it("rejects status for an unresolved agent-scoped config", async () => {
     const config = resolveMemoryWikiConfig(
       { vault: { scope: "agent", path: "/tmp/wiki/support" } },

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -1,6 +1,7 @@
 // Memory Wiki tests cover status plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { MemoryPluginPublicArtifact } from "openclaw/plugin-sdk/memory-host-core";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { resolveMemoryWikiConfig } from "./config.js";
@@ -55,6 +56,8 @@ describe("resolveMemoryWikiStatus", () => {
     });
 
     expect(status.vaultExists).toBe(false);
+    expect(status.vaultScope).toBe("global");
+    expect(status.agentId).toBeNull();
     expect(status.obsidianCli.requested).toBe(true);
     expect(status.warnings.map((warning) => warning.code)).toEqual([
       "vault-missing",
@@ -124,6 +127,79 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.warnings.map((warning) => warning.code)).not.toContain(
       "bridge-artifacts-missing",
     );
+  });
+
+  it("counts only artifacts owned by the resolved agent in agent scope", async () => {
+    const unresolvedConfig = resolveMemoryWikiConfig(
+      {
+        vaultMode: "bridge",
+        vault: { scope: "agent", path: "/tmp/wiki/support" },
+        bridge: { enabled: true, readMemoryArtifacts: true },
+      },
+      { homedir: "/Users/tester" },
+    );
+    const config = { ...unresolvedConfig, agentId: "support" };
+    const artifacts: MemoryPluginPublicArtifact[] = [
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/support",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/support/MEMORY.md",
+        agentIds: [" SUPPORT "],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/marketing",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/marketing/MEMORY.md",
+        agentIds: ["marketing"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir: "/tmp/shared",
+        relativePath: "memory/2026-07-09.md",
+        absolutePath: "/tmp/shared/memory/2026-07-09.md",
+        agentIds: ["support", "marketing"],
+        contentType: "markdown",
+      },
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/unknown",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/unknown/MEMORY.md",
+        agentIds: [],
+        contentType: "markdown",
+      },
+    ];
+
+    const status = await resolveMemoryWikiStatus(config, {
+      appConfig: {
+        agents: { list: [{ id: "support", default: true, workspace: "/tmp/support" }] },
+      },
+      listPublicArtifacts: async () => artifacts,
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(status.vaultScope).toBe("agent");
+    expect(status.agentId).toBe("support");
+    expect(status.bridgePublicArtifactCount).toBe(2);
+  });
+
+  it("rejects status for an unresolved agent-scoped config", async () => {
+    const config = resolveMemoryWikiConfig(
+      { vault: { scope: "agent", path: "/tmp/wiki/support" } },
+      { homedir: "/Users/tester" },
+    );
+
+    await expect(
+      resolveMemoryWikiStatus(config, {
+        pathExists: async () => true,
+        resolveCommand: async () => null,
+      }),
+    ).rejects.toThrow("Memory Wiki agent-scoped vault requires a resolved agent id");
   });
 
   it("discovers pages in nested subdirectories", async () => {
@@ -269,6 +345,8 @@ describe("resolveMemoryWikiStatus", () => {
 describe("renderMemoryWikiStatus", () => {
   it("includes warnings in the text output", () => {
     const rendered = renderMemoryWikiStatus({
+      vaultScope: "global",
+      agentId: null,
       vaultMode: "isolated",
       renderMode: "native",
       vaultPath: "/tmp/wiki",
@@ -310,6 +388,7 @@ describe("renderMemoryWikiStatus", () => {
     });
 
     expect(rendered).toContain("Wiki vault mode: isolated");
+    expect(rendered).toContain("Vault scope: global");
     expect(rendered).toContain("Pages: 0 sources, 0 entities, 0 concepts, 0 syntheses, 0 reports");
     expect(rendered).toContain(
       "Source provenance: 0 native, 0 bridge, 0 bridge-events, 0 unsafe-local, 0 other",

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -65,6 +65,7 @@ export type MemoryWikiDoctorReport = {
 
 type ResolveMemoryWikiStatusDeps = {
   appConfig?: OpenClawConfig;
+  callerAgentId?: string;
   pathExists?: (inputPath: string) => Promise<boolean>;
   listPublicArtifacts?: typeof listActiveMemoryPublicArtifacts;
   resolveCommand?: (command: string) => Promise<string | null>;
@@ -221,6 +222,7 @@ export async function resolveMemoryWikiStatus(
     config.bridge.readMemoryArtifacts
       ? filterMemoryWikiBridgeArtifacts({
           config,
+          callerAgentId: deps.callerAgentId,
           artifacts: await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
             cfg: deps.appConfig,
           }),

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { listActiveMemoryPublicArtifacts } from "openclaw/plugin-sdk/memory-host-core";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenClawConfig } from "../api.js";
+import { filterMemoryWikiBridgeArtifacts, resolveMemoryWikiVaultAgentId } from "./bridge.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { toWikiPageSummary, type WikiPageKind } from "./markdown.js";
 import { probeObsidianCli } from "./obsidian.js";
@@ -21,6 +22,8 @@ type MemoryWikiStatusWarning = {
 };
 
 export type MemoryWikiStatus = {
+  vaultScope: ResolvedMemoryWikiConfig["vault"]["scope"];
+  agentId: string | null;
   vaultMode: ResolvedMemoryWikiConfig["vaultMode"];
   renderMode: ResolvedMemoryWikiConfig["vault"]["renderMode"];
   vaultPath: string;
@@ -208,6 +211,7 @@ export async function resolveMemoryWikiStatus(
   config: ResolvedMemoryWikiConfig,
   deps?: ResolveMemoryWikiStatusDeps,
 ): Promise<MemoryWikiStatus> {
+  const agentId = resolveMemoryWikiVaultAgentId(config);
   const exists = deps?.pathExists ?? pathExists;
   const vaultExists = await exists(config.vault.path);
   const bridgePublicArtifactCount =
@@ -215,11 +219,12 @@ export async function resolveMemoryWikiStatus(
     config.vaultMode === "bridge" &&
     config.bridge.enabled &&
     config.bridge.readMemoryArtifacts
-      ? (
-          await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
+      ? filterMemoryWikiBridgeArtifacts({
+          config,
+          artifacts: await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
             cfg: deps.appConfig,
-          })
-        ).length
+          }),
+        }).length
       : null;
   const obsidianProbe = await probeObsidianCli({ resolveCommand: deps?.resolveCommand });
   const counts = vaultExists
@@ -242,6 +247,8 @@ export async function resolveMemoryWikiStatus(
       };
 
   return {
+    vaultScope: config.vault.scope,
+    agentId,
     vaultMode: config.vaultMode,
     renderMode: config.vault.renderMode,
     vaultPath: config.vault.path,
@@ -298,6 +305,7 @@ export function buildMemoryWikiDoctorReport(status: MemoryWikiStatus): MemoryWik
 export function renderMemoryWikiStatus(status: MemoryWikiStatus): string {
   const lines = [
     `Wiki vault mode: ${status.vaultMode}`,
+    `Vault scope: ${status.vaultScope}${status.agentId ? ` (${status.agentId})` : ""}`,
     `Vault: ${status.vaultExists ? "ready" : "missing"} (${status.vaultPath})`,
     `Render mode: ${status.renderMode}`,
     `Obsidian CLI: ${status.obsidianCli.available ? "available" : "missing"}${status.obsidianCli.requested ? " (requested)" : ""}`,

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -117,6 +117,7 @@ type WikiToolMemoryContext = {
 export function createWikiStatusTool(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
+  memoryContext: WikiToolMemoryContext = {},
 ): AnyAgentTool {
   return {
     name: "wiki_status",
@@ -128,6 +129,7 @@ export function createWikiStatusTool(
       await syncImportedSourcesIfNeeded(config, appConfig);
       const status = await resolveMemoryWikiStatus(config, {
         appConfig,
+        callerAgentId: memoryContext.agentId,
       });
       return {
         content: [{ type: "text", text: renderMemoryWikiStatus(status) }],

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -323,6 +323,29 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
+  it("passes resolved agent context to compacted system prompt rebuilds", async () => {
+    resolveSessionAgentIdsMock.mockReturnValue({
+      defaultAgentId: "main",
+      sessionAgentId: "marketing-agent",
+    });
+
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:marketing-agent:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(buildEmbeddedSystemPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeInfo: expect.objectContaining({
+          agentId: "marketing-agent",
+          sessionKey: "agent:marketing-agent:session-1",
+        }),
+      }),
+    );
+  });
+
   it("keeps the embedded compaction system prompt after active tool selection", async () => {
     buildEmbeddedSystemPromptMock.mockReturnValueOnce("compaction system prompt");
 

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1098,6 +1098,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
       : undefined;
 
     const runtimeInfo = {
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
       host: machineName,
       os: resolveRuntimeOsLabel(),
       arch: os.arch(),

--- a/src/agents/system-prompt.memory.test.ts
+++ b/src/agents/system-prompt.memory.test.ts
@@ -23,4 +23,37 @@ describe("buildAgentSystemPrompt memory guidance", () => {
     expect(promptWithMemory).toContain("## Memory Recall");
     expect(promptWithoutMemory).not.toContain("## Memory Recall");
   });
+
+  it("passes the active agent context to memory prompt assembly", () => {
+    let observedContext:
+      | { agentId?: string; agentSessionKey?: string; sandboxed?: boolean }
+      | undefined;
+    registerMemoryPromptSection((context) => {
+      observedContext = context;
+      return [
+        "## Agent Memory",
+        `agent=${context.agentId} session=${context.agentSessionKey} sandboxed=${context.sandboxed}`,
+        "",
+      ];
+    });
+
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["memory_search", "memory_get"],
+      runtimeInfo: {
+        agentId: "marketing-agent",
+        sessionKey: "agent:marketing-agent:main",
+      },
+      sandboxInfo: { enabled: true },
+    });
+
+    expect(observedContext).toMatchObject({
+      agentId: "marketing-agent",
+      agentSessionKey: "agent:marketing-agent:main",
+      sandboxed: true,
+    });
+    expect(prompt).toContain(
+      "agent=marketing-agent session=agent:marketing-agent:main sandboxed=true",
+    );
+  });
 });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -289,6 +289,9 @@ function buildMemorySection(params: {
   includeMemorySection?: boolean;
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
+  agentId?: string;
+  agentSessionKey?: string;
+  sandboxed?: boolean;
 }) {
   if (params.isMinimal || params.includeMemorySection === false) {
     return [];
@@ -296,6 +299,9 @@ function buildMemorySection(params: {
   return buildMemoryPromptSection({
     availableTools: params.availableTools,
     citationsMode: params.citationsMode,
+    agentId: params.agentId,
+    agentSessionKey: params.agentSessionKey,
+    sandboxed: params.sandboxed,
   });
 }
 
@@ -975,6 +981,9 @@ export function buildAgentSystemPrompt(params: {
     includeMemorySection: params.includeMemorySection,
     availableTools,
     citationsMode: params.memoryCitationsMode,
+    agentId: params.runtimeInfo?.agentId,
+    agentSessionKey: params.runtimeInfo?.sessionKey,
+    sandboxed: params.sandboxInfo?.enabled === true,
   });
   const docsSection = buildDocsSection({
     docsPath: params.docsPath,

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -714,6 +714,25 @@ describe("Engine contract tests", () => {
     ).toBe("## Memory Recall\ncitations=off");
   });
 
+  it("passes agent context through delegated memory prompt assembly", () => {
+    registerMemoryPromptSection(({ agentId, agentSessionKey, sandboxed }) => [
+      "## Agent Memory",
+      `agent=${agentId} session=${agentSessionKey} sandboxed=${sandboxed}`,
+      "",
+    ]);
+
+    expect(
+      buildMemorySystemPromptAddition({
+        availableTools: new Set(["memory_search", "memory_get"]),
+        agentId: "marketing-agent",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+      }),
+    ).toBe(
+      "## Agent Memory\nagent=marketing-agent session=agent:marketing-agent:main sandboxed=true",
+    );
+  });
+
   it("returns undefined when the active memory prompt path contributes nothing", () => {
     expect(
       buildMemorySystemPromptAddition({

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -99,10 +99,16 @@ export async function delegateCompactionToRuntime(
 export function buildMemorySystemPromptAddition(params: {
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
+  agentId?: string;
+  agentSessionKey?: string;
+  sandboxed?: boolean;
 }): string | undefined {
   const lines = buildMemoryPromptSection({
     availableTools: params.availableTools,
     citationsMode: params.citationsMode,
+    agentId: params.agentId,
+    agentSessionKey: params.agentSessionKey,
+    sandboxed: params.sandboxed,
   });
   if (lines.length === 0) {
     return undefined;

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -1,5 +1,5 @@
 // Covers plugin-backed memory state registration and reset behavior.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildMemoryPromptSection,
   clearMemoryPluginState,
@@ -337,6 +337,33 @@ describe("memory plugin state", () => {
         citationsMode: "off",
       }),
     ).toEqual(["citations: off"]);
+  });
+
+  it("passes agent context through the primary and supplemental prompt builders", () => {
+    const primary = vi.fn(() => ["primary"]);
+    const supplemental = vi.fn(() => ["supplemental"]);
+    registerMemoryPromptSection(primary);
+    registerMemoryPromptSupplement("memory-wiki", supplemental);
+
+    const availableTools = new Set(["memory_search", "memory_get"]);
+    expect(
+      buildMemoryPromptSection({
+        availableTools,
+        citationsMode: "on",
+        agentId: "marketing-agent",
+        agentSessionKey: "agent:marketing-agent:main",
+        sandboxed: true,
+      }),
+    ).toEqual(["primary", "supplemental"]);
+    const expectedContext = {
+      availableTools,
+      citationsMode: "on",
+      agentId: "marketing-agent",
+      agentSessionKey: "agent:marketing-agent:main",
+      sandboxed: true,
+    };
+    expect(primary).toHaveBeenCalledWith(expectedContext);
+    expect(supplemental).toHaveBeenCalledWith(expectedContext);
   });
 
   it("appends prompt supplements in plugin-id order", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -9,6 +9,9 @@ const log = createSubsystemLogger("plugins/memory-state");
 export type MemoryPromptSectionBuilder = (params: {
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
+  agentId?: string;
+  agentSessionKey?: string;
+  sandboxed?: boolean;
 }) => string[];
 
 export type MemoryCorpusSearchResult = {
@@ -48,13 +51,17 @@ export type MemoryCorpusSupplement = {
   search(params: {
     query: string;
     maxResults?: number;
+    agentId?: string;
     agentSessionKey?: string;
+    sandboxed?: boolean;
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;
     fromLine?: number;
     lineCount?: number;
+    agentId?: string;
     agentSessionKey?: string;
+    sandboxed?: boolean;
   }): Promise<MemoryCorpusGetResult | null>;
 };
 
@@ -249,6 +256,9 @@ export function registerMemoryPromptSupplement(
 export function buildMemoryPromptSection(params: {
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
+  agentId?: string;
+  agentSessionKey?: string;
+  sandboxed?: boolean;
 }): string[] {
   const primary = normalizeMemoryPromptLines(
     memoryPluginState.capability?.capability.promptBuilder?.(params) ?? [],

--- a/ui/src/pages/dreams/dreaming.test.ts
+++ b/ui/src/pages/dreams/dreaming.test.ts
@@ -389,6 +389,57 @@ describe("dreaming controller", () => {
     expect(state.wikiImportInsightsLoading).toBe(false);
   });
 
+  it("loads wiki import insights for the selected agent", async () => {
+    const { state, request } = createState();
+    state.selectedAgentId = "support";
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.importInsights"] },
+    };
+    request.mockResolvedValue({ sourceType: "chatgpt", totalItems: 1, clusters: [] });
+
+    await loadWikiImportInsights(state);
+
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", { agentId: "support" });
+  });
+
+  it("starts a new selected-agent import load and ignores stale completions", async () => {
+    const { state, request } = createState();
+    const agentA = createDeferred<unknown>();
+    const agentB = createDeferred<unknown>();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.importInsights"] },
+    };
+    request.mockImplementation(async (_method: string, payload?: unknown) => {
+      const agentId =
+        typeof payload === "object" && payload !== null && "agentId" in payload
+          ? payload.agentId
+          : undefined;
+      return agentId === "agent-b" ? agentB.promise : agentA.promise;
+    });
+
+    state.selectedAgentId = "agent-a";
+    const firstLoad = loadWikiImportInsights(state);
+    state.selectedAgentId = "agent-b";
+    const secondLoad = loadWikiImportInsights(state);
+
+    agentB.resolve({ sourceType: "chatgpt", totalItems: 2, clusters: [] });
+    await secondLoad;
+    agentA.resolve({ sourceType: "chatgpt", totalItems: 1, clusters: [] });
+    await firstLoad;
+
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", { agentId: "agent-a" });
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", { agentId: "agent-b" });
+    expect(state.wikiImportInsights?.totalItems).toBe(2);
+    expect(state.wikiImportInsightsLoading).toBe(false);
+    expect(state.wikiImportInsightsError).toBeNull();
+  });
+
   it("falls back to config gating for wiki import insights when methods are not advertised", async () => {
     const { state, request } = createState();
     state.configSnapshot = {
@@ -556,6 +607,57 @@ describe("dreaming controller", () => {
     ]);
     expect(state.wikiMemoryPalaceError).toBeNull();
     expect(state.wikiMemoryPalaceLoading).toBe(false);
+  });
+
+  it("loads the wiki memory palace for the selected agent", async () => {
+    const { state, request } = createState();
+    state.selectedAgentId = "marketing";
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.palace"] },
+    };
+    request.mockResolvedValue({ totalItems: 1, clusters: [] });
+
+    await loadWikiMemoryPalace(state);
+
+    expect(request).toHaveBeenCalledWith("wiki.palace", { agentId: "marketing" });
+  });
+
+  it("starts a new selected-agent palace load and ignores stale completions", async () => {
+    const { state, request } = createState();
+    const agentA = createDeferred<unknown>();
+    const agentB = createDeferred<unknown>();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.palace"] },
+    };
+    request.mockImplementation(async (_method: string, payload?: unknown) => {
+      const agentId =
+        typeof payload === "object" && payload !== null && "agentId" in payload
+          ? payload.agentId
+          : undefined;
+      return agentId === "agent-b" ? agentB.promise : agentA.promise;
+    });
+
+    state.selectedAgentId = "agent-a";
+    const firstLoad = loadWikiMemoryPalace(state);
+    state.selectedAgentId = "agent-b";
+    const secondLoad = loadWikiMemoryPalace(state);
+
+    agentB.resolve({ totalItems: 2, clusters: [] });
+    await secondLoad;
+    agentA.resolve({ totalItems: 1, clusters: [] });
+    await firstLoad;
+
+    expect(request).toHaveBeenCalledWith("wiki.palace", { agentId: "agent-a" });
+    expect(request).toHaveBeenCalledWith("wiki.palace", { agentId: "agent-b" });
+    expect(state.wikiMemoryPalace?.totalItems).toBe(2);
+    expect(state.wikiMemoryPalaceLoading).toBe(false);
+    expect(state.wikiMemoryPalaceError).toBeNull();
   });
 
   it("derives legacy wiki memory palace page counts from clusters", async () => {

--- a/ui/src/pages/dreams/dreaming.ts
+++ b/ui/src/pages/dreams/dreaming.ts
@@ -232,9 +232,19 @@ export type DreamingState = {
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
+  // Agent switches can overlap RPCs; generations keep an old A -> B -> A response
+  // from replacing the current agent's wiki data.
+  wikiImportInsightsRequestAgentId?: string | null;
+  wikiImportInsightsRequestGeneration?: number;
+  wikiImportInsightsActiveRequestGeneration?: number | null;
+  wikiImportInsightsAgentId?: string | null;
   wikiImportInsightsLoading: boolean;
   wikiImportInsightsError: string | null;
   wikiImportInsights: WikiImportInsights | null;
+  wikiMemoryPalaceRequestAgentId?: string | null;
+  wikiMemoryPalaceRequestGeneration?: number;
+  wikiMemoryPalaceActiveRequestGeneration?: number | null;
+  wikiMemoryPalaceAgentId?: string | null;
   wikiMemoryPalaceLoading: boolean;
   wikiMemoryPalaceError: string | null;
   wikiMemoryPalace: WikiMemoryPalace | null;
@@ -939,47 +949,114 @@ export async function loadDreamDiary(state: DreamingState): Promise<void> {
 }
 
 export async function loadWikiImportInsights(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected || state.wikiImportInsightsLoading) {
+  if (!state.client || !state.connected) {
     return;
   }
+  const agentId = resolveSelectedAgentId(state);
+  if (state.wikiImportInsightsLoading && state.wikiImportInsightsRequestAgentId === agentId) {
+    return;
+  }
+  if (state.wikiImportInsightsAgentId !== agentId) {
+    state.wikiImportInsights = null;
+  }
   if (!canCallMemoryWikiMethod(state, "wiki.importInsights")) {
+    state.wikiImportInsightsActiveRequestGeneration = null;
+    state.wikiImportInsightsRequestAgentId = null;
+    state.wikiImportInsightsLoading = false;
     state.wikiImportInsights = null;
     state.wikiImportInsightsError = null;
     return;
   }
+  const requestGeneration = (state.wikiImportInsightsRequestGeneration ?? 0) + 1;
+  state.wikiImportInsightsRequestGeneration = requestGeneration;
+  state.wikiImportInsightsActiveRequestGeneration = requestGeneration;
+  state.wikiImportInsightsRequestAgentId = agentId;
   state.wikiImportInsightsLoading = true;
   state.wikiImportInsightsError = null;
   try {
     const payload = await state.client.request<WikiImportInsightsPayload>(
       "wiki.importInsights",
-      {},
+      buildSelectedAgentPayloadForAgentId(agentId),
     );
+    if (
+      state.wikiImportInsightsActiveRequestGeneration !== requestGeneration ||
+      state.wikiImportInsightsRequestAgentId !== agentId ||
+      resolveSelectedAgentId(state) !== agentId
+    ) {
+      return;
+    }
     state.wikiImportInsights = normalizeWikiImportInsights(payload);
+    state.wikiImportInsightsAgentId = agentId;
   } catch (err) {
-    state.wikiImportInsightsError = String(err);
+    if (
+      state.wikiImportInsightsActiveRequestGeneration === requestGeneration &&
+      state.wikiImportInsightsRequestAgentId === agentId &&
+      resolveSelectedAgentId(state) === agentId
+    ) {
+      state.wikiImportInsightsError = String(err);
+    }
   } finally {
-    state.wikiImportInsightsLoading = false;
+    if (state.wikiImportInsightsActiveRequestGeneration === requestGeneration) {
+      state.wikiImportInsightsLoading = false;
+      state.wikiImportInsightsRequestAgentId = null;
+      state.wikiImportInsightsActiveRequestGeneration = null;
+    }
   }
 }
 
 export async function loadWikiMemoryPalace(state: DreamingState): Promise<void> {
-  if (!state.client || !state.connected || state.wikiMemoryPalaceLoading) {
+  if (!state.client || !state.connected) {
     return;
   }
+  const agentId = resolveSelectedAgentId(state);
+  if (state.wikiMemoryPalaceLoading && state.wikiMemoryPalaceRequestAgentId === agentId) {
+    return;
+  }
+  if (state.wikiMemoryPalaceAgentId !== agentId) {
+    state.wikiMemoryPalace = null;
+  }
   if (!canCallMemoryWikiMethod(state, "wiki.palace")) {
+    state.wikiMemoryPalaceActiveRequestGeneration = null;
+    state.wikiMemoryPalaceRequestAgentId = null;
+    state.wikiMemoryPalaceLoading = false;
     state.wikiMemoryPalace = null;
     state.wikiMemoryPalaceError = null;
     return;
   }
+  const requestGeneration = (state.wikiMemoryPalaceRequestGeneration ?? 0) + 1;
+  state.wikiMemoryPalaceRequestGeneration = requestGeneration;
+  state.wikiMemoryPalaceActiveRequestGeneration = requestGeneration;
+  state.wikiMemoryPalaceRequestAgentId = agentId;
   state.wikiMemoryPalaceLoading = true;
   state.wikiMemoryPalaceError = null;
   try {
-    const payload = await state.client.request<WikiMemoryPalacePayload>("wiki.palace", {});
+    const payload = await state.client.request<WikiMemoryPalacePayload>(
+      "wiki.palace",
+      buildSelectedAgentPayloadForAgentId(agentId),
+    );
+    if (
+      state.wikiMemoryPalaceActiveRequestGeneration !== requestGeneration ||
+      state.wikiMemoryPalaceRequestAgentId !== agentId ||
+      resolveSelectedAgentId(state) !== agentId
+    ) {
+      return;
+    }
     state.wikiMemoryPalace = normalizeWikiMemoryPalace(payload);
+    state.wikiMemoryPalaceAgentId = agentId;
   } catch (err) {
-    state.wikiMemoryPalaceError = String(err);
+    if (
+      state.wikiMemoryPalaceActiveRequestGeneration === requestGeneration &&
+      state.wikiMemoryPalaceRequestAgentId === agentId &&
+      resolveSelectedAgentId(state) === agentId
+    ) {
+      state.wikiMemoryPalaceError = String(err);
+    }
   } finally {
-    state.wikiMemoryPalaceLoading = false;
+    if (state.wikiMemoryPalaceActiveRequestGeneration === requestGeneration) {
+      state.wikiMemoryPalaceLoading = false;
+      state.wikiMemoryPalaceRequestAgentId = null;
+      state.wikiMemoryPalaceActiveRequestGeneration = null;
+    }
   }
 }
 

--- a/ui/src/pages/dreams/dreams-page.test.ts
+++ b/ui/src/pages/dreams/dreams-page.test.ts
@@ -21,6 +21,7 @@ type TestDreamsPage = HTMLElement & {
   applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
   loadAll: () => Promise<void>;
   openWikiPage: (lookup: string) => Promise<unknown>;
+  selectAgent: (agentId: string) => void;
   render: () => unknown;
   requestUpdate: () => void;
   readonly updateComplete: Promise<boolean>;
@@ -194,6 +195,64 @@ describe("DreamsPage gateway lifecycle", () => {
 
     await expect(preview).resolves.toBeNull();
     expect(page.dreaming).not.toBe(previousState);
+    expect(page.viewState.wikiPreviewContent).toBe("");
+  });
+
+  it("loads wiki previews for the selected agent", async () => {
+    const request = vi.fn(async () => ({
+      title: "Support",
+      path: "support.md",
+      content: "support-only",
+    }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = createPage(contextWithGateway(client, true));
+    document.body.append(page);
+    await page.updateComplete;
+    page.dreaming.selectedAgentId = "support";
+
+    await page.openWikiPage("support.md");
+
+    expect(request).toHaveBeenCalledWith("wiki.get", {
+      lookup: "support.md",
+      fromLine: 1,
+      lineCount: 5000,
+      agentId: "support",
+    });
+  });
+
+  it("discards a wiki preview after the selected agent changes", async () => {
+    const pending = deferred<unknown>();
+    const client = {
+      request: vi.fn(() => pending.promise),
+    } as unknown as GatewayBrowserClient;
+    const page = createPage(contextWithGateway(client, true));
+    document.body.append(page);
+    await page.updateComplete;
+    page.dreaming.selectedAgentId = "support";
+
+    const preview = page.openWikiPage("support.md");
+    page.dreaming.selectedAgentId = "marketing";
+    pending.resolve({ title: "Support", path: "support.md", content: "stale" });
+
+    await expect(preview).resolves.toBeNull();
+  });
+
+  it("closes an open wiki preview when the selected agent changes", async () => {
+    const client = {
+      request: vi.fn(async () => ({})),
+    } as unknown as GatewayBrowserClient;
+    const page = createPage(contextWithGateway(client, true));
+    document.body.append(page);
+    await page.updateComplete;
+    page.dreaming.selectedAgentId = "support";
+    page.viewState.wikiPreviewOpen = true;
+    page.viewState.wikiPreviewLoading = true;
+    page.viewState.wikiPreviewContent = "support-only";
+
+    page.selectAgent("marketing");
+
+    expect(page.viewState.wikiPreviewOpen).toBe(false);
+    expect(page.viewState.wikiPreviewLoading).toBe(false);
     expect(page.viewState.wikiPreviewContent).toBe("");
   });
 });

--- a/ui/src/pages/dreams/dreams-page.ts
+++ b/ui/src/pages/dreams/dreams-page.ts
@@ -206,6 +206,13 @@ class DreamsPage extends OpenClawLightDomElement {
   }
 
   private resetTransientState() {
+    this.resetWikiPreview();
+    this.restartConfirmOpen = false;
+    this.restartConfirmLoading = false;
+    this.pendingEnabled = null;
+  }
+
+  private resetWikiPreview() {
     this.viewState.wikiPreviewRequestId += 1;
     this.viewState.wikiPreviewOpen = false;
     this.viewState.wikiPreviewLoading = false;
@@ -216,9 +223,6 @@ class DreamsPage extends OpenClawLightDomElement {
     this.viewState.wikiPreviewTotalLines = null;
     this.viewState.wikiPreviewTruncated = false;
     this.viewState.wikiPreviewError = null;
-    this.restartConfirmOpen = false;
-    this.restartConfirmLoading = false;
-    this.pendingEnabled = null;
   }
 
   private createGatewayState(snapshot = this.context.gateway.snapshot): DreamingState {
@@ -265,6 +269,7 @@ class DreamsPage extends OpenClawLightDomElement {
     const agentsList = this.context.agents.state.agentsList;
     const selected = this.dreaming.selectedAgentId;
     if (agentsList && (!selected || !agentsList.agents.some((agent) => agent.id === selected))) {
+      this.resetWikiPreview();
       this.dreaming.selectedAgentId = this.resolveSelectedAgentId();
       if (!this.awaitingRouteData) {
         this.routeDataEnabled = false;
@@ -366,6 +371,8 @@ class DreamsPage extends OpenClawLightDomElement {
     void Promise.all([
       this.runDreamingTask(loadDreamingStatus, scope),
       this.runDreamingTask(loadDreamDiary, scope),
+      this.runDreamingTask(loadWikiImportInsights, scope),
+      this.runDreamingTask(loadWikiMemoryPalace, scope),
     ]);
   }
 
@@ -374,6 +381,7 @@ class DreamsPage extends OpenClawLightDomElement {
       return;
     }
     this.routeDataEnabled = false;
+    this.resetWikiPreview();
     this.dreaming.selectedAgentId = agentId;
     this.loadSelectedAgentData();
   }
@@ -451,12 +459,17 @@ class DreamsPage extends OpenClawLightDomElement {
     if (!scope || !client || !scope.state.connected) {
       return null;
     }
+    const agentId = scope.state.selectedAgentId?.trim() || null;
     const payload = await client.request("wiki.get", {
       lookup,
       fromLine: 1,
       lineCount: 5000,
+      ...(agentId ? { agentId } : {}),
     });
-    if (!this.isTaskScopeCurrent(scope)) {
+    if (
+      !this.isTaskScopeCurrent(scope) ||
+      (scope.state.selectedAgentId?.trim() || null) !== agentId
+    ) {
       return null;
     }
     return readWikiPagePreview(payload, lookup);


### PR DESCRIPTION
Fixes #63829.
Fixes #81205.
Fixes #103088.

Related: #103196. This change folds in its caller-scoped status behavior and preserves contributor credit. Operator CLI/Gateway status remains global when no calling agent is supplied.

## What Problem This Solves

Resolves a problem where multiple agents on one OpenClaw instance had to share one Memory Wiki vault. A support agent and a marketing agent could therefore search, retrieve, import, or receive prompt context from the same knowledge store.

## Why This Change Was Made

Adds `vault.scope: "agent"` as an opt-in isolation mode. OpenClaw resolves one immutable effective vault per operation from the canonical agent id, then carries that identity through wiki tools, prompts and compaction, Memory Core corpus access, bridge imports, Gateway RPCs, CLI commands, the Dreams UI, and doctor migrations.

The existing global vault remains the default and keeps the exact `~/.openclaw/wiki/main` path. Agent scope fails closed when agent identity is ambiguous, filters bridge artifacts by ownership, and rejects `unsafe-local` plus official Obsidian CLI operation because those integrations cannot currently provide agent-safe source/vault selection. Existing mixed vaults are not split automatically.

## User Impact

Operators can configure one Memory Wiki parent and give every agent its own vault:

```json5
{
  vault: {
    scope: "agent",
    path: "~/.openclaw/wiki",
  },
}
```

For agents `support` and `marketing`, this resolves to `~/.openclaw/wiki/support` and `~/.openclaw/wiki/marketing`. Multi-agent CLI calls use `openclaw wiki --agent <id> ...`; single-agent setups may infer their only configured agent. This provides knowledge isolation inside one trusted Gateway process, not hostile-tenant OS isolation.

## Evidence

- Blacksmith Testbox: complete Memory Wiki suite, 35 files / 285 tests passed.
- Blacksmith Testbox: real two-agent apply/search/get and Memory Core corpus scenario passed with distinct disk roots and cross-agent denial.
- Source-blind Blacksmith Testbox validation passed all nine contract clauses: isolated writes/reads, reverse denial, persistence, missing/unknown agent failures, invalid integration combinations, historical global defaults, and no implicit data copy on scope changes.
- Blacksmith Testbox: focused context/prompt/compaction lane, 174 tests passed; Gateway lane, 39 tests passed; bridge/status lane, 26 tests passed; CLI/config/UI lane, 96 tests passed.
- Blacksmith Testbox: full `pnpm check:changed` passed, including core and plugin tests, TypeScript, UI/packages/plugin lint, import cycles, and storage/security guards.
- Docs: formatting, MDX, links, docs map, and docs listing checks passed with zero broken links.
- Fresh autoreview after the related status adaptation reported no actionable findings.
- Direct Codex contract audit confirmed per-turn collaboration-mode instructions are supported without a protocol change: `../codex/codex-rs/app-server-protocol/src/protocol/v2/turn.rs`, `../codex/codex-rs/app-server/src/request_processors/turn_processor.rs`, and `../codex/codex-rs/app-server/README.md`.

Config/default review metric: one additive config surface (`vault.scope`) with a backward-compatible `global` default; agent scope deliberately adds two validation failures for integrations that cannot preserve isolation. No runtime migration or fallback path is introduced.
