### PR TITLE
fix(agents): agent runs survive rejected progress callbacks

### DIFF
--- a/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
+++ b/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
@@ -1,6 +1,7 @@
 // Block-reply rejection tests ensure async callback failures are contained and
 // do not escape as process-level unhandled rejections.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
 import {
   createSubscribedSessionHarness,
   emitAssistantTextDelta,
@@ -16,6 +17,27 @@ const waitForAsyncCallbacks = async () => {
     setImmediate(resolve);
   });
 };
+
+function emitToolRun(params: {
+  emit: (evt: unknown) => void;
+  toolName: string;
+  toolCallId: string;
+  result: unknown;
+}): void {
+  params.emit({
+    type: "tool_execution_start",
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    args: {},
+  });
+  params.emit({
+    type: "tool_execution_end",
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    isError: false,
+    result: params.result,
+  });
+}
 
 describe("subscribeEmbeddedAgentSession block reply rejections", () => {
   const unhandledRejections: unknown[] = [];
@@ -59,6 +81,85 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
     await waitForAsyncCallbacks();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("contains rejected assistant progress callbacks", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+    const rejectedCallback = vi.fn().mockRejectedValue(new Error("boom"));
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onAgentEvent: rejectedCallback,
+      onPartialReply: rejectedCallback,
+      onAssistantMessageStart: rejectedCallback,
+      onReasoningStream: rejectedCallback,
+      onReasoningEnd: rejectedCallback,
+      reasoningMode: "stream",
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "Hello" });
+    emitAssistantTextDelta({ emit, delta: "Hello" });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "thinking_delta", delta: "Because" },
+    });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "thinking_end" },
+    });
+    await waitForAsyncCallbacks();
+
+    expect(rejectedCallback).toHaveBeenCalled();
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("contains rejected tool presentation callbacks", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+    const onToolResult = vi.fn().mockRejectedValue(new Error("tool progress failed"));
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onToolResult,
+      verboseLevel: "full",
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "read",
+      toolCallId: "tool-1",
+      result: { content: [{ type: "text", text: "file contents" }] },
+    });
+    await waitForAsyncCallbacks();
+
+    expect(onToolResult).toHaveBeenCalled();
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("contains rejected heartbeat response callbacks", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+    const onHeartbeatToolResponse = vi.fn().mockRejectedValue(new Error("heartbeat failed"));
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onHeartbeatToolResponse,
+    });
+
+    emitToolRun({
+      emit,
+      toolName: HEARTBEAT_RESPONSE_TOOL_NAME,
+      toolCallId: "heartbeat-1",
+      result: {
+        details: {
+          status: "recorded",
+          outcome: "no_change",
+          notify: false,
+          summary: "Nothing needs attention.",
+        },
+      },
+    });
+    await waitForAsyncCallbacks();
+
+    expect(onHeartbeatToolResponse).toHaveBeenCalledTimes(1);
     expect(unhandledRejections).toHaveLength(0);
   });
 });

--- a/src/agents/embedded-agent-subscribe.callback-fatal.test.ts
+++ b/src/agents/embedded-agent-subscribe.callback-fatal.test.ts
@@ -1,0 +1,65 @@
+// Child-process proof uses OpenClaw's real fatal unhandled-rejection handler so
+// an accidentally detached callback rejection terminates the negative control.
+import { describe, expect, it } from "vitest";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
+
+const fatalHandlerImport = `
+  import { installUnhandledRejectionHandler } from "./src/infra/unhandled-rejections.ts";
+  installUnhandledRejectionHandler();
+`;
+
+describe("embedded agent callback rejection containment", () => {
+  it("proves the real process handler terminates an uncontained rejection", () => {
+    const result = spawnNodeEvalSync(
+      `${fatalHandlerImport}
+       void Promise.reject(new Error("negative-control-rejection"));
+       setTimeout(() => console.log("negative control survived"), 50);`,
+      { imports: ["tsx"], timeout: 20_000 },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Unhandled promise rejection");
+    expect(result.stderr).toContain("negative-control-rejection");
+    expect(result.stdout).not.toContain("negative control survived");
+  });
+
+  it("keeps the production assistant progress path alive when its callback rejects", () => {
+    const result = spawnNodeEvalSync(
+      `${fatalHandlerImport}
+       import { subscribeEmbeddedAgentSession } from "./src/agents/embedded-agent-subscribe.ts";
+       let emit = () => {};
+       let callbackCalls = 0;
+       const session = {
+         subscribe(handler) {
+           emit = handler;
+           return () => {};
+         },
+       };
+       subscribeEmbeddedAgentSession({
+         session,
+         runId: "fatal-handler-proof",
+         onAgentEvent: async () => {
+           callbackCalls += 1;
+           throw new Error("assistant-progress-rejection");
+         },
+       });
+       emit({
+         type: "message_update",
+         message: { role: "assistant" },
+         assistantMessageEvent: { type: "text_delta", delta: "hello" },
+       });
+       setTimeout(() => {
+         if (callbackCalls !== 1) {
+           console.error("unexpected callback count: " + callbackCalls);
+           process.exit(2);
+         }
+         console.log("assistant callback rejection contained");
+       }, 50);`,
+      { imports: ["tsx"], timeout: 20_000 },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("assistant callback rejection contained");
+    expect(result.stderr).not.toContain("Unhandled promise rejection");
+  });
+});

--- a/src/agents/embedded-agent-subscribe.callback.ts
+++ b/src/agents/embedded-agent-subscribe.callback.ts
@@ -1,0 +1,23 @@
+import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
+
+type CallbackLogger = {
+  warn(message: string): void;
+};
+
+/** Contains failures from untracked subscriber presentation and telemetry callbacks. */
+export function runBestEffortCallback(params: {
+  callback: () => void | Promise<void>;
+  label: string;
+  log: CallbackLogger;
+}): void {
+  try {
+    const result = params.callback();
+    if (isPromiseLike<void>(result)) {
+      void Promise.resolve(result).catch((error: unknown) => {
+        params.log.warn(`${params.label} callback failed: ${String(error)}`);
+      });
+    }
+  } catch (error) {
+    params.log.warn(`${params.label} callback failed: ${String(error)}`);
+  }
+}

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -7,6 +7,7 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { stripStaleAssistantUsageBeforeLatestCompaction } from "./compaction-usage.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
 
 type SessionCompactionStartEvent = Extract<AgentSessionEvent, { type: "compaction_start" }>;
@@ -63,9 +64,13 @@ export function handleCompactionStart(
     stream: "compaction",
     data: { phase: "start" },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "compaction",
-    data: { phase: "start" },
+  runBestEffortCallback({
+    label: "compaction agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "compaction",
+      data: { phase: "start" },
+    }),
   });
 
   // Hooks are fire-and-forget so compaction state updates and liveness pauses
@@ -153,9 +158,13 @@ export function handleCompactionEnd(ctx: EmbeddedAgentSubscribeContext, evt: Com
     stream: "compaction",
     data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+  runBestEffortCallback({
+    label: "compaction agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "compaction",
+      data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    }),
   });
 
   // after_compaction runs only once the run will not retry, matching the visible

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -31,7 +31,7 @@ vi.mock("../infra/agent-events.js", () => ({
 function createContext(
   lastAssistant: unknown,
   overrides?: {
-    onAgentEvent?: (event: unknown) => void;
+    onAgentEvent?: (event: unknown) => void | Promise<void>;
     onBeforeLifecycleTerminal?: () => void | Promise<void>;
     onBeforeTerminalDelivery?: () => void | Promise<void>;
     onBlockReply?: ((payload: unknown) => void) | undefined;
@@ -117,6 +117,18 @@ function firstWarnMeta(ctx: EmbeddedAgentSubscribeContext): Record<string, unkno
 }
 
 describe("handleAgentEnd", () => {
+  it("contains rejected lifecycle start event callbacks", async () => {
+    const onAgentEvent = vi.fn().mockRejectedValue(new Error("progress failed"));
+    const ctx = createContext(undefined, { onAgentEvent });
+
+    handleAgentStart(ctx);
+    await Promise.resolve();
+
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("lifecycle agent event callback failed"),
+    );
+  });
+
   it("keeps explicit session and agent identity on lifecycle start events", () => {
     emitAgentEventMock.mockClear();
     const ctx = createContext(undefined);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -25,6 +25,7 @@ import {
   hasAssistantVisibleReply,
 } from "./embedded-agent-subscribe.handlers.messages.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { isAssistantMessage } from "./embedded-agent-utils.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
@@ -51,9 +52,13 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
       startedAt: Date.now(),
     },
   });
-  void ctx.params.onAgentEvent?.({
-    stream: "lifecycle",
-    data: { phase: "start" },
+  runBestEffortCallback({
+    label: "lifecycle agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.({
+      stream: "lifecycle",
+      data: { phase: "start" },
+    }),
   });
 }
 
@@ -213,7 +218,10 @@ export function handleAgentEnd(
         endedAt: Date.now(),
       },
     });
-    void ctx.params.onAgentEvent?.({
+    runBestEffortCallback({
+      label: "lifecycle agent event",
+      log: ctx.log,
+      callback: () => ctx.params.onAgentEvent?.({
       stream: "lifecycle",
       data: {
         phase,
@@ -222,6 +230,7 @@ export function handleAgentEnd(
         ...(livenessState ? { livenessState } : {}),
         ...(replayInvalid ? { replayInvalid } : {}),
       },
+      }),
     });
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -29,6 +29,7 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedToolText } from "./embedded-agent-subscribe.tool-text-diagnostics.js";
@@ -220,7 +221,19 @@ function emitReasoningEnd(ctx: EmbeddedAgentSubscribeContext) {
     return;
   }
   ctx.state.reasoningStreamOpen = false;
-  void ctx.params.onReasoningEnd?.();
+  runBestEffortCallback({
+    label: "reasoning end",
+    log: ctx.log,
+    callback: () => ctx.params.onReasoningEnd?.(),
+  });
+}
+
+function emitAssistantMessageStart(ctx: EmbeddedAgentSubscribeContext) {
+  runBestEffortCallback({
+    label: "assistant message start",
+    log: ctx.log,
+    callback: () => ctx.params.onAssistantMessageStart?.(),
+  });
 }
 
 function openReasoningStream(ctx: EmbeddedAgentSubscribeContext) {
@@ -652,7 +665,7 @@ export function handleMessageStart(
   // re-trigger block replies.
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
   // Use assistant message_start as the earliest "writing" signal for typing.
-  void ctx.params.onAssistantMessageStart?.();
+  emitAssistantMessageStart(ctx);
 }
 
 /** Handles assistant message deltas, reasoning, directives, and block replies. */
@@ -791,7 +804,7 @@ export function handleMessageUpdate(
       streamItemChanged = true;
       void ctx.flushBlockReplyBuffer({ assistantMessageIndex: ctx.state.assistantMessageIndex });
       ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
-      void ctx.params.onAssistantMessageStart?.();
+      emitAssistantMessageStart(ctx);
     }
     ctx.state.lastAssistantStreamItemId = streamItemId;
   }

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -65,6 +65,7 @@ import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   collectMessagingMediaUrlsFromRecord,
@@ -317,35 +318,26 @@ function emitTrackedItemEvent(ctx: ToolHandlerContext, itemData: AgentItemEventD
   });
 }
 
-function warnBestEffortEventFailure(ctx: ToolHandlerContext, label: string, error: unknown): void {
-  ctx.log.warn(`${label} callback failed: ${String(error)}`);
-}
-
 function emitExecutionPhaseBestEffort(
   ctx: ToolHandlerContext,
   info: Parameters<NonNullable<ToolHandlerContext["params"]["onExecutionPhase"]>>[0],
 ): void {
-  try {
-    ctx.params.onExecutionPhase?.(info);
-  } catch (error) {
-    warnBestEffortEventFailure(ctx, "tool execution phase", error);
-  }
+  runBestEffortCallback({
+    label: "tool execution phase",
+    log: ctx.log,
+    callback: () => ctx.params.onExecutionPhase?.(info),
+  });
 }
 
 function emitAgentEventCallbackBestEffort(
   ctx: ToolHandlerContext,
   event: Parameters<NonNullable<ToolHandlerContext["params"]["onAgentEvent"]>>[0],
 ): void {
-  try {
-    const result = ctx.params.onAgentEvent?.(event);
-    if (isPromiseLike<void>(result)) {
-      void Promise.resolve(result).catch((error: unknown) => {
-        warnBestEffortEventFailure(ctx, "tool agent event", error);
-      });
-    }
-  } catch (error) {
-    warnBestEffortEventFailure(ctx, "tool agent event", error);
-  }
+  runBestEffortCallback({
+    label: "tool agent event",
+    log: ctx.log,
+    callback: () => ctx.params.onAgentEvent?.(event),
+  });
 }
 
 function applyCurrentMessageProvider(
@@ -1482,7 +1474,11 @@ export async function handleToolExecutionEnd(
       const isFirstHeartbeatResponse = ctx.state.heartbeatToolResponse === undefined;
       ctx.state.heartbeatToolResponse = response;
       if (isFirstHeartbeatResponse) {
-        void ctx.params.onHeartbeatToolResponse?.(response);
+        runBestEffortCallback({
+          label: "heartbeat tool response",
+          log: ctx.log,
+          callback: () => ctx.params.onHeartbeatToolResponse?.(response),
+        });
       }
     }
   }

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -47,6 +47,7 @@ import type {
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
+import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   buildToolLifecycleErrorResult,
@@ -279,12 +280,22 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       stream: "assistant",
       data,
     });
-    void params.onAgentEvent?.({
-      stream: "assistant",
-      data,
-    });
+    if (params.onAgentEvent) {
+      runBestEffortCallback({
+        label: "assistant agent event",
+        log,
+        callback: () => params.onAgentEvent?.({
+          stream: "assistant",
+          data,
+        }),
+      });
+    }
     if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-      void params.onPartialReply(data);
+      runBestEffortCallback({
+        label: "assistant partial reply",
+        log,
+        callback: () => params.onPartialReply?.(data),
+      });
     }
   };
   const emitAssistantStreamData = (
@@ -729,15 +740,15 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     if (!parsed.text && filteredMediaUrls.length === 0) {
       return;
     }
-    try {
-      void params.onToolResult({
+    runBestEffortCallback({
+      label: "tool result",
+      log,
+      callback: () => params.onToolResult?.({
         text: parsed.text,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
         ...(mediaArtifact?.audioAsVoice ? { audioAsVoice: true } : {}),
-      });
-    } catch {
-      // ignore tool result delivery failures
-    }
+      }),
+    });
   };
   const emitToolSummary = (toolName?: string, meta?: string) => {
     const agg = formatToolAggregate(toolName, meta ? [meta] : undefined, {
@@ -1210,9 +1221,13 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // render hook — uniformly, whether the thinking block rode in on a tool call
     // or arrived on its own. It still reaches the bus/archive above.
     if (state.streamReasoning && !hasMessageToolOnlySourceDelivery() && params.onReasoningStream) {
-      void params.onReasoningStream({
-        text: trimmed,
-        ...(state.reasoningMode === "stream" ? {} : { requiresReasoningProgressOptIn: true }),
+      runBestEffortCallback({
+        label: "reasoning stream",
+        log,
+        callback: () => params.onReasoningStream?.({
+          text: trimmed,
+          ...(state.reasoningMode === "stream" ? {} : { requiresReasoningProgressOptIn: true }),
+        }),
       });
     }
   };


### PR DESCRIPTION
Related: #103060

## What Problem This Solves

Fixes an issue where embedded agent runs could terminate when a best-effort progress or presentation callback returned a rejected promise. The process-wide unhandled-rejection handler treated those callback failures as fatal even though they were not part of the agent run's control flow.

## Why This Change Was Made

All fire-and-forget assistant, lifecycle, compaction, reasoning, tool, and heartbeat callbacks now use one shared best-effort callback boundary that contains both synchronous throws and asynchronous rejections. Awaited callbacks that control delivery, flushing, approvals, or terminal ordering remain awaited and retain their existing failure semantics.

This is the maintainer replacement for #103060. It preserves @NianJiuZst's contribution and co-author credit while incorporating the complete sibling-callback audit and regression proof.

## User Impact

Agent runs continue when an optional progress callback fails. The callback failure is logged for diagnosis instead of escaping as an unhandled rejection and terminating the process.

## Evidence

- Exact head: `18716942f5571cb0728e4db77a78a49f825c651e`.
- Blacksmith Testbox `tbx_01kx521whnmfap4nx97ta5fd4x`: 247 focused tests passed across two Vitest shards, including assistant, lifecycle, compaction, tool, heartbeat, and subscription paths.
- Child-process regression proof installs OpenClaw's real fatal unhandled-rejection handler: the negative control exits with status 1, while the production assistant callback rejection survives with status 0.
- Patch-identical broad `check:changed` proof passed core/core-test tsgo, full core oxlint, formatting, dependency, import-cycle, database-first, sidecar, webhook, pairing, and patch guards.
- Fresh whole-branch Codex autoreview: clean, no accepted or actionable findings, correctness confidence 0.86.
- The replacement's stable patch ID exactly matches the audited contributor patch.
