### PR TITLE
feat(webchat): pass-through visitors — strangers, and a crab that is definitely a lobster

### DIFF
--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -11,6 +11,8 @@ import {
   isLobsterTwinLoad,
   lobsterPetName,
   lobsterPetSeed,
+  planLobsterPasser,
+  strangerLookFor,
   resolveLobsterPetMode,
   resolveLobsterRunOutcome,
   type LobsterPet,
@@ -637,6 +639,69 @@ describe("lobster pet element", () => {
     document.dispatchEvent(new MouseEvent("pointermove", { clientX: -400 }));
     await element.updateComplete;
     expect(element.querySelector(".lobster-pet")?.getAttribute("style")).toContain("--lob-face:-1");
+  });
+
+  it("a stranger crosses once and is never recorded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    // Seed 9 plans a stranger crossing at ~98s (probed via the pure planner).
+    const plan = planLobsterPasser(9);
+    expect(plan?.kind).toBe("stranger");
+    const element = createPet(9);
+    await element.updateComplete;
+
+    await vi.advanceTimersByTimeAsync((plan?.atMs ?? 0) + 500);
+    await element.updateComplete;
+    const passer = element.querySelector(".lobster-pet--passer");
+    expect(passer).not.toBeNull();
+    expect(passer?.getAttribute("title")).toBe("a stranger");
+    expect(passer?.className).not.toContain("lobster-pet--crab");
+
+    // Strangers wear someone else's palette and never enter the dex; the
+    // resident pet may have logged itself during the advance, so assert the
+    // stranger's palette specifically stays out.
+    const own = createLobsterPetLook(9, new Date("2026-07-09T12:00:00"));
+    const strangerPalette = strangerLookFor(9, own.palette.id).palette.id;
+    expect(strangerPalette).not.toBe(own.palette.id);
+    expect(getLobsterdex().has(strangerPalette)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await element.updateComplete;
+    expect(element.querySelector(".lobster-pet--passer")).toBeNull();
+  });
+
+  it("the crab is definitely a lobster and also not recorded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    const plan = planLobsterPasser(119);
+    expect(plan?.kind).toBe("crab");
+    const element = createPet(119);
+    await element.updateComplete;
+
+    await vi.advanceTimersByTimeAsync((plan?.atMs ?? 0) + 500);
+    await element.updateComplete;
+    const crab = element.querySelector(".lobster-pet--crab");
+    expect(crab).not.toBeNull();
+    expect(crab?.getAttribute("title")).toBe("definitely a lobster");
+    // The resident pet may have visited during the advance; whatever is in
+    // the dex must be its own palette. Crabs are not acknowledged.
+    const own = createLobsterPetLook(119, new Date("2026-07-09T12:00:00")).palette.id;
+    expect([...getLobsterdex()].every((id) => id === own)).toBe(true);
+  });
+
+  it("most loads see no passer at all", async () => {
+    expect(planLobsterPasser(0)).toBeNull();
+    let passers = 0;
+    for (let seed = 0; seed < 2000; seed++) {
+      if (planLobsterPasser(seed)) {
+        passers++;
+      }
+    }
+    // ~9.5% of loads get one visitor; crabs are a rare slice of that.
+    expect(passers).toBeGreaterThan(60);
+    expect(passers).toBeLessThan(2000 * 0.2);
   });
 
   it("stays static when reduced motion is preferred, including visibility resumes", async () => {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -288,6 +288,8 @@ export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
 const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
 const ENTER_MS = 450;
 const LEAVE_MS = 350;
+// One full ledge crossing for pass-through visitors.
+const PASSER_CROSS_MS = 11_000;
 
 export type LobsterPetAnchor = "ledge" | "bar";
 
@@ -358,6 +360,40 @@ export function isLobsterMoltLoad(seed: number): boolean {
 
 export function isLobsterTwinLoad(seed: number): boolean {
   return mulberry32((seed ^ 0x7715) >>> 0)() < 0.04;
+}
+
+export type LobsterPasserKind = "stranger" | "crab";
+
+export type LobsterPasserPlan = {
+  kind: LobsterPasserKind;
+  atMs: number;
+  direction: 1 | -1;
+};
+
+// Once per load, someone else might just... walk through. Strangers are
+// other lobsters that never stop; the crab is not a lobster and refuses to
+// discuss it. Neither counts for the Lobsterdex.
+export function planLobsterPasser(seed: number): LobsterPasserPlan | null {
+  const rng = mulberry32((seed ^ 0xcab) >>> 0);
+  const roll = rng();
+  if (roll >= 0.095) {
+    return null;
+  }
+  const kind: LobsterPasserKind = roll < 0.015 ? "crab" : "stranger";
+  const atMs = Math.round(60_000 + rng() * 840_000);
+  const direction: 1 | -1 = rng() < 0.5 ? 1 : -1;
+  return { kind, atMs, direction };
+}
+
+// A stranger wears a different palette than the resident pet.
+export function strangerLookFor(seed: number, own: LobsterPetPaletteId): LobsterPetLook {
+  for (let offset = 1; offset <= 24; offset++) {
+    const look = createLobsterPetLook((seed + offset * 7919) >>> 0);
+    if (look.palette.id !== own) {
+      return look;
+    }
+  }
+  return createLobsterPetLook((seed + 1) >>> 0);
 }
 
 // Late-night visitors are always sleepy, whatever their daytime personality.
@@ -644,6 +680,45 @@ const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
   `,
 };
 
+// Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
+// and the Lobsterdex refuses to acknowledge it.
+export function renderCrabSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <g stroke="#a63a2e" stroke-width="4" stroke-linecap="round" fill="none">
+        <path d="M22 78 L8 88" />
+        <path d="M28 88 L16 99" />
+        <path d="M98 78 L112 88" />
+        <path d="M92 88 L104 99" />
+      </g>
+      <g stroke="#c44536" stroke-width="3.5" stroke-linecap="round" fill="none">
+        <path d="M44 38 L40 24" />
+        <path d="M76 38 L80 24" />
+      </g>
+      <circle cx="40" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="80" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="41.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <circle cx="81.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <ellipse cx="60" cy="70" rx="46" ry="30" fill="#c44536" />
+      <ellipse cx="48" cy="60" rx="16" ry="9" fill="#ffffff" opacity="0.1" />
+      <path
+        d="M16 58 C2 52 -2 62 4 72 C10 82 20 76 24 66 C26 60 22 58 16 58 Z"
+        fill="#d95f4b"
+      />
+      <path
+        d="M104 58 C118 52 122 62 116 72 C110 82 100 76 96 66 C94 60 98 58 104 58 Z"
+        fill="#d95f4b"
+      />
+      <path d="M48 82 Q60 90 72 82" stroke="#7e2a20" stroke-width="3" stroke-linecap="round" fill="none" />
+    </svg>
+  `;
+}
+
 // Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
 // with stubby legs, side claws, antennae, and teal-glint eyes.
 export function renderLobsterSvg(
@@ -738,6 +813,7 @@ export class LobsterPet extends LitElement {
   @state() private dismissed = false;
   @state() private grumpy = false;
   @state() private vigil = false;
+  @state() private passer: LobsterPasserPlan | null = null;
   @state() private shellVisible = false;
   private shellSpotPct = 50;
   private shellScale = 2;
@@ -745,6 +821,8 @@ export class LobsterPet extends LitElement {
   private moltPlanned = false;
   private twinPlanned = false;
   private shellTimer: number | null = null;
+  private passerTimer: number | null = null;
+  private passerEndTimer: number | null = null;
 
   private look: LobsterPetLook | null = null;
   private rng: () => number = mulberry32(0);
@@ -780,13 +858,15 @@ export class LobsterPet extends LitElement {
       window.clearTimeout(this.shellTimer);
       this.shellTimer = null;
     }
-    for (const timer of [this.vigilTimer, this.holdTimer]) {
+    for (const timer of [this.vigilTimer, this.holdTimer, this.passerTimer, this.passerEndTimer]) {
       if (timer !== null) {
         window.clearTimeout(timer);
       }
     }
     this.vigilTimer = null;
     this.holdTimer = null;
+    this.passerTimer = null;
+    this.passerEndTimer = null;
     document.removeEventListener("pointermove", this.handleGaze);
     super.disconnectedCallback();
   }
@@ -823,6 +903,7 @@ export class LobsterPet extends LitElement {
       this.moltPlanned = isLobsterMoltLoad(this.seed);
       this.twinPlanned = isLobsterTwinLoad(this.seed);
       this.scheduleVisits();
+      this.schedulePasser();
       // The first update takes this branch, so the mode-change branch below
       // never sees the initial mode: arm the vigil tracker here as well.
       this.vigil = false;
@@ -1076,6 +1157,34 @@ export class LobsterPet extends LitElement {
     }, stayMs);
   }
 
+  // ---- Pass-through visitors (strangers and the crab) ----
+
+  private schedulePasser() {
+    for (const timer of [this.passerTimer, this.passerEndTimer]) {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    }
+    this.passerTimer = null;
+    this.passerEndTimer = null;
+    this.passer = null;
+    const plan = planLobsterPasser(this.seed);
+    if (!plan || prefersReducedMotion()) {
+      return;
+    }
+    this.passerTimer = window.setTimeout(() => {
+      this.passerTimer = null;
+      if (!this.visitsEnabled || document.hidden) {
+        return;
+      }
+      this.passer = plan;
+      this.passerEndTimer = window.setTimeout(() => {
+        this.passerEndTimer = null;
+        this.passer = null;
+      }, PASSER_CROSS_MS);
+    }, plan.atMs);
+  }
+
   // Each arrival re-rolls where the pet shows up: the ledge above the footer
   // divider or the free stretch inside the footer bar.
   private rollPerch() {
@@ -1292,13 +1401,44 @@ export class LobsterPet extends LitElement {
     // The shell may outlive the visit while it fades, but dismissal and the
     // visits setting silence it like everything else.
     const showShell = this.shellVisible && this.visitsEnabled && !this.dismissed;
-    if (!showSprites && !showShell) {
+    const showPasser = this.passer !== null && this.visitsEnabled;
+    if (!showSprites && !showShell && !showPasser) {
       return nothing;
     }
     return html`
       ${showShell ? this.renderShell(look) : nothing}
       ${showSprites ? this.renderSprite(look, false) : nothing}
       ${showSprites && this.twinPlanned ? this.renderSprite(look, true) : nothing}
+      ${showPasser && this.passer ? this.renderPasser(this.passer, look) : nothing}
+    `;
+  }
+
+  // A pass-through visitor: crosses the ledge once and is gone. Strangers
+  // are other lobsters (never your palette); the crab is, allegedly, also a
+  // lobster. Neither perches, neither counts for the Lobsterdex.
+  private renderPasser(passer: LobsterPasserPlan, own: LobsterPetLook) {
+    const crab = passer.kind === "crab";
+    const look = crab ? own : strangerLookFor(this.seed, own.palette.id);
+    const classes = [
+      "lobster-pet",
+      "lobster-pet--passer",
+      crab ? "lobster-pet--crab" : `lobster-pet--palette-${look.palette.id}`,
+      passer.direction === 1 ? "lobster-pet--passer-ltr" : "lobster-pet--passer-rtl",
+    ].join(" ");
+    const style = crab
+      ? `--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1`
+      : this.spriteStyle(look, Math.min(look.scale, 2), 0, passer.direction);
+    return html`
+      <div
+        class=${classes}
+        style=${style}
+        aria-hidden="true"
+        title=${crab ? "definitely a lobster" : "a stranger"}
+      >
+        <div class="lobster-pet__body">
+          ${crab ? renderCrabSvg() : renderLobsterSvg(look, { standalone: true })}
+        </div>
+      </div>
     `;
   }
 }

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -659,6 +659,62 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   }
 }
 
+/* ---- Pass-through visitors ---- */
+
+/* Passers cross the whole ledge once; left/right position comes from the
+   crossing keyframes, not the perch variable. */
+.lobster-pet--passer {
+  pointer-events: none;
+  cursor: default;
+  bottom: 0;
+}
+
+.lobster-pet--passer .lobster-pet__body {
+  animation: lobster-pet-waddle 0.32s ease-in-out infinite;
+}
+
+.lobster-pet--passer-ltr {
+  animation: lobster-pet-cross-ltr 11s linear forwards;
+}
+
+.lobster-pet--passer-rtl {
+  animation: lobster-pet-cross-rtl 11s linear forwards;
+}
+
+/* The crab walks sideways by definition: it crosses while facing you and
+   feels no need to explain itself. */
+.lobster-pet--crab .lobster-pet__body {
+  animation: lobster-pet-crab-scuttle 0.24s ease-in-out infinite;
+}
+
+@keyframes lobster-pet-cross-ltr {
+  from {
+    left: -6%;
+  }
+  to {
+    left: 106%;
+  }
+}
+
+@keyframes lobster-pet-cross-rtl {
+  from {
+    left: 106%;
+  }
+  to {
+    left: -6%;
+  }
+}
+
+@keyframes lobster-pet-crab-scuttle {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8%);
+  }
+}
+
 /* ---- Lobsterdex (appearance settings gallery) ---- */
 
 .lobsterdex {


### PR DESCRIPTION
Related: #102754 · Stacked on #103344 (sentience) — lands after it.

## What Problem This Solves

Your lobster is the only sea life you ever see. A world with occasional other inhabitants is more alive — and funnier.

## Why This Change Was Made

Roughly one page load in ten (pure per-seed plan), a pass-through visitor crosses the footer ledge once, some minutes into the session, and leaves:

- **A stranger** (~8%): another lobster wearing a palette that is deliberately *not* your pet's. It doesn't stop, doesn't react, and hovers as just "a stranger". It does **not** count for your Lobsterdex — only lobsters that visit *you* count.
- **The crab** (~1.5%): wide shell, eye stalks, side claws, walks strictly sideways across the ledge (which, for a crab, is simply walking), smug little smile. Hover says **"definitely a lobster"**. The Lobsterdex refuses to acknowledge it. No further explanation is provided anywhere, including in this PR.

Passers are render-only walkers: no perching, no acts, no interaction; gated by the visits setting, skipped under reduced motion, timers reset with the seed and cleaned on disconnect.

## User Impact

Once in a while something crosses the bottom of your sidebar. Sometimes it's a lobster you've never met. Very occasionally it is not a lobster at all, whatever its tooltip claims.

## Evidence

![visitors](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/visitors.png)

Validation (delegated Blacksmith Testbox, `exit=0`):

- `pnpm test ui/src/components/lobster-pet.test.ts` — 36/36: stranger crossing renders and despawns with a foreign palette that never enters the dex, the crab renders with its title while the dex only ever contains the resident's own palette, most loads plan no passer (~9.5% rate asserted over 2000 seeds), plus the full existing suite.
- `pnpm tsgo:test:ui` and `pnpm --dir ui build`.
- Live showcase screenshot above from the running mock UI.
- Codex autoreview clean (passer planning/rendering scoped, reduced-motion and visits-setting gates verified, no dex recording, timers cleaned).
