### PR TITLE
fix(nextcloud-talk): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -8,6 +8,7 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
 import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
@@ -201,6 +202,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
         chunkerMode: "markdown",
         textChunkLimit: 4000,
+        sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       },
       attachedResults: {
         channel: "nextcloud-talk",

--- a/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,42 @@
+// Nextcloud Talk outbound must strip assistant internal tool-trace scaffolding
+// before delivery, matching the sanitizeText hook shipped to sibling channels
+// (mattermost #98693, feishu #98705, twitch #103109, etc.).
+import { describe, expect, it } from "vitest";
+import { nextcloudTalkPlugin } from "./channel.js";
+
+function sanitizeOutboundText(text: string): string {
+  const base = nextcloudTalkPlugin.outbound?.base;
+  const sanitizeText = base?.sanitizeText;
+  if (!sanitizeText) {
+    throw new Error("Expected Nextcloud Talk outbound sanitizeText hook");
+  }
+  return sanitizeText({ text, payload: { text } });
+}
+
+describe("nextcloud-talk outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+    expect(sanitizeOutboundText(text)).toBe("Done.");
+  });
+
+  it("strips XML tool-call scaffolding leaked into assistant text", () => {
+    const text = '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.';
+    expect(sanitizeOutboundText(text)).toBe("Meeting notes sent.");
+  });
+
+  it("strips multiline tool-response scaffolding leaked into assistant text", () => {
+    const text = [
+      "Checking now.",
+      "<function_response>",
+      'Searching for: "agenda"',
+      "</function_response>",
+      "Meeting notes sent.",
+    ].join("\n");
+    expect(sanitizeOutboundText(text)).toBe("Checking now.\n\nMeeting notes sent.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The agenda has 3 open action items.";
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+});

--- a/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
@@ -5,8 +5,7 @@ import { describe, expect, it } from "vitest";
 import { nextcloudTalkPlugin } from "./channel.js";
 
 function sanitizeOutboundText(text: string): string {
-  const base = nextcloudTalkPlugin.outbound?.base;
-  const sanitizeText = base?.sanitizeText;
+  const sanitizeText = nextcloudTalkPlugin.outbound?.sanitizeText;
   if (!sanitizeText) {
     throw new Error("Expected Nextcloud Talk outbound sanitizeText hook");
   }


### PR DESCRIPTION
## What Problem This Solves

The Nextcloud Talk outbound adapter had no `sanitizeText` hook. Core delivery (`src/infra/outbound/deliver.ts:889-896`) only runs the per-channel assistant-text sanitizer when the adapter provides one; without it, internal assistant tool-trace scaffolding is delivered verbatim to the chat. Users see raw banners like `⚠️ 🛠️ `exec (agent)`` failed` and raw `<tool_call>`/`<function_response>` XML in their Nextcloud Talk messages.

## Why This Change Was Made

- **Root cause:** the outbound adapter omits the `sanitizeText` hook that strips internal runtime scaffolding before delivery.
- **Fix:** add `sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text)` to the outbound base adapter — the identical one-line hook already shipped to 13 sibling channels: mattermost (#98693), feishu (#98705), twitch (#103109), signal (#97360), slack (#97367), matrix (#97372), irc (#97214), telegram, googlechat (#90684), qqbot (#90132), discord, whatsapp (#71830), and sms.
- The hook runs in core delivery before chunk planning, so the markdown chunker only ever sees sanitized text.

## User Impact

Internal tool-trace banners and leaked XML scaffolding no longer reach Nextcloud Talk users. Ordinary assistant prose is preserved unchanged.

## Linked context

N/A (no existing issue). Sibling fixes: #103109, #98693, #98705.

## Evidence

Terminal capture of `node --import tsx` runtime verification calling the **patched adapter hook** `nextcloudTalkPlugin.outbound.sanitizeText` (the exact hook added by this PR) on the exact PR head:

```
sanitizeText hook exists: true
[PASS] tool-trace banner: "Done."
[PASS] xml tool-call: "Meeting notes sent."
[PASS] plain prose: "The agenda has 3 open action items."
```

This calls the real `nextcloudTalkPlugin.outbound.sanitizeText` (resolved from `{ base: { sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text) } }` via `resolveChatChannelOutbound`), proving the patched Nextcloud Talk adapter routes assistant text through the sanitizer before delivery.

| # | Field | Value |
|---|-------|-------|
| 1 | Behavior or issue addressed | Nextcloud Talk outbound delivers internal tool-trace scaffolding verbatim (no sanitizeText hook). |
| 2 | Real environment tested | Linux x64, Node 22; the patched adapter hook invoked on the exact PR head (fad7fab8f17b). |
| 3 | Exact steps or command run | `node --import tsx` script that imports `nextcloudTalkPlugin` and calls `outbound.sanitizeText` directly, plus colocated vitest `node scripts/run-vitest.mjs extensions/<channel>/src/outbound-tool-trace-sanitize.test.ts`. |
| 4 | Evidence after fix | Terminal output above: the patched adapter hook strips banners, XML tool-call scaffolding, while preserving ordinary prose. |
| 5 | Observed result after fix | The channel outbound hook removes tool-trace scaffolding; ordinary text unchanged. |
| 6 | What was not tested | Live channel server delivery (no server in this env); the adapter hook itself is exercised directly on the real plugin object. |

## Tests and validation

```
$ node scripts/run-vitest.mjs extensions/nextcloud-talk/src/channel.core.test.ts
✓ extensions/nextcloud-talk/src/channel.core.test.ts (3 tests)
Test Files  1 passed (1)
     Tests  3 passed (3)
```

New `outbound-tool-trace-sanitize.test.ts` mirrors the twitch #103109 test: asserts the hook strips banners, XML tool-call scaffolding, multiline function-response scaffolding, and preserves ordinary prose.

## Risk checklist

- [x] One concern, one PR — only the Nextcloud Talk outbound sanitizeText hook.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change (reuses an already-exported SDK helper).
- [x] Backward compatible — only internal scaffolding is removed; user-visible prose is unchanged.
- [x] No new deps (helper already in the SDK barrel).
- [x] No CHANGELOG edit (per release policy).
- [x] Tests added.

- [x] Allow edits by maintainers
