### PR TITLE
fix(ui): sidebar sessions show a link cursor instead of the default arrow

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6403,7 +6403,6 @@ details[open] > .ov-expandable-toggle::after {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   opacity: 0;
   pointer-events: none;
   transition:

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -801,7 +801,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--accent);
-  cursor: pointer;
   font: inherit;
   font-size: 13px;
   font-weight: 600;
@@ -869,6 +868,9 @@
   min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
+  /* Sessions are app chrome, not hyperlinks: the whole region uses the
+     default arrow cursor; the pointer hand is reserved for real links. */
+  cursor: default;
 }
 
 .sidebar-recent-sessions__group {
@@ -926,7 +928,6 @@
   background: transparent;
   color: inherit;
   text-align: left;
-  cursor: pointer;
 }
 
 .sidebar-session-group-toggle__icon {
@@ -979,7 +980,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1014,7 +1014,6 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   opacity: 0;
   pointer-events: none;
   transition:
@@ -1077,7 +1076,6 @@
   font-size: 11px;
   font-weight: 600;
   text-overflow: ellipsis;
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1130,6 +1128,8 @@
   opacity: 0.45;
 }
 
+/* Rows and row links are anchors (for middle-click/new-tab), but read as app
+   controls: override the UA link pointer back to the default arrow. */
 .sidebar-recent-session {
   display: flex;
   align-items: center;
@@ -1139,6 +1139,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   color: var(--muted);
+  cursor: default;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease,
@@ -1164,6 +1165,7 @@
   min-width: 0;
   padding: 5px 4px 5px 9px;
   color: inherit;
+  cursor: default;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where hovering session rows and session controls in the Control UI sidebar would show the hyperlink hand cursor (`cursor: pointer`) even though these elements are app controls rather than hyperlinks. Large parts of the sessions area — row links, pin/menu actions, group headers, the sort and agent-scope controls, and the New session button — all advertised themselves as links.

## Why This Change Was Made

Desktop-style app chrome should use the default arrow cursor and reserve the pointer hand for real hyperlinks. The sessions sidebar now uses `cursor: default` across the region; anchor-based rows/links (kept as anchors for middle-click/new-tab) explicitly override the browser's built-in link pointer. Non-link affordances are preserved: the group drag handle keeps `grab`/`grabbing` and disabled controls keep `not-allowed`. Menus, the nav rail, and the rest of the app are intentionally untouched.

## User Impact

Hovering the sidebar sessions list now shows the regular arrow cursor everywhere (rows, session names, pin/kebab actions, group headers, sort, agent scope, New session). Genuine hyperlinks elsewhere in the app still show the pointer hand.

## Evidence

Computed-style verification in a real browser (Chromium) against the changed stylesheets, using the exact sidebar markup:

| Element | Before | After |
| --- | --- | --- |
| Session row (`.sidebar-recent-session`) | `default` (div) / `pointer` (fallback anchor) | `default` |
| Session name link (`.sidebar-recent-session__link`) | `pointer` (UA anchor) | `default` |
| Pin / session menu (`.session-action`) | `pointer` | `default` |
| Group toggle / group kebab / sort / agent scope | `pointer` | `default` |
| New session button (`.sidebar-new-session`) | `pointer` | `default` |
| Disabled controls | `not-allowed` | `not-allowed` (unchanged) |
| Group drag handle | `grab`/`grabbing` | `grab`/`grabbing` (unchanged) |
| Control: real hyperlink (`a[href]` outside region) | `pointer` | `pointer` (unchanged) |

Codex autoreview (gpt-5.5, high): clean, no accepted/actionable findings.
