### PR TITLE
fix(nostr): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -47,16 +47,17 @@ function createMockBus() {
   };
 }
 
-function createRuntimeHarness() {
+function createRuntimeHarness(deliveredText = "|a|b|") {
   const recordInboundSession = vi.fn(async () => {});
   const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions }) => {
-    await dispatcherOptions.deliver({ text: "**Table:** [docs](https://example.com)" });
+    await dispatcherOptions.deliver({ text: deliveredText });
   });
+  const convertMarkdownTables = vi.fn((text: string) => `converted:${text}`);
   const runtime = {
     channel: {
       text: {
         resolveMarkdownTableMode: vi.fn(() => "off"),
-        convertMarkdownTables: vi.fn((text: string) => text),
+        convertMarkdownTables,
       },
       commands: {
         shouldComputeCommandAuthorized: vi.fn(() => true),
@@ -91,14 +92,16 @@ function createRuntimeHarness() {
     runtime,
     recordInboundSession,
     dispatchReplyWithBufferedBlockDispatcher,
+    convertMarkdownTables,
   };
 }
 
 async function startGatewayHarness(params: {
   account: ReturnType<typeof buildResolvedNostrAccount>;
   cfg?: Parameters<typeof createStartAccountContext>[0]["cfg"];
+  deliveredText?: string;
 }) {
-  const harness = createRuntimeHarness();
+  const harness = createRuntimeHarness(params.deliveredText);
   const bus = createMockBus();
   setNostrRuntime(harness.runtime);
   mocks.startNostrBus.mockResolvedValueOnce(bus as never);
@@ -223,7 +226,52 @@ describe("nostr inbound gateway path", () => {
         turnAdoptionLifecycle: expect.objectContaining({ admission: "exclusive" }),
       }),
     );
-    expect(sendReply).toHaveBeenCalledWith("Table: docs (https://example.com)");
+    expect(sendReply).toHaveBeenCalledWith("converted:Table: docs (https://example.com)");
+
+    await cleanup.stop();
+  });
+
+  it.each([
+    {
+      name: "sanitizes mixed visible and tool-trace content before replying",
+      deliveredText: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
+      expectedText: "Done.",
+    },
+    {
+      name: "suppresses replies containing only tool-trace content",
+      deliveredText: "⚠️ 🛠️ `search repos (agent)` failed",
+      expectedText: null,
+    },
+  ])("$name", async ({ deliveredText, expectedText }) => {
+    const { harness, cleanup } = await startGatewayHarness({
+      account: buildResolvedNostrAccount({
+        publicKey: "bot-pubkey",
+        config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
+      }),
+      deliveredText,
+    });
+    const options = mockCallArg(mocks.startNostrBus) as {
+      onMessage: (
+        senderPubkey: string,
+        text: string,
+        reply: (text: string) => Promise<void>,
+        meta: { eventId: string; createdAt: number },
+      ) => Promise<void>;
+    };
+    const sendReply = vi.fn(async (_text: string) => {});
+
+    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
+      eventId: "event-123",
+      createdAt: 1_710_000_000,
+    });
+
+    if (expectedText === null) {
+      expect(harness.convertMarkdownTables).not.toHaveBeenCalled();
+      expect(sendReply).not.toHaveBeenCalled();
+    } else {
+      expect(harness.convertMarkdownTables).toHaveBeenCalledWith(expectedText, "off");
+      expect(sendReply).toHaveBeenCalledWith(`converted:${expectedText}`);
+    }
 
     await cleanup.stop();
   });

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -47,10 +47,10 @@ function createMockBus() {
   };
 }
 
-function createRuntimeHarness(deliveredText = "|a|b|") {
+function createRuntimeHarness() {
   const recordInboundSession = vi.fn(async () => {});
   const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions }) => {
-    await dispatcherOptions.deliver({ text: deliveredText });
+    await dispatcherOptions.deliver({ text: "|a|b|" });
   });
   const convertMarkdownTables = vi.fn((text: string) => `converted:${text}`);
   const runtime = {
@@ -99,9 +99,8 @@ function createRuntimeHarness(deliveredText = "|a|b|") {
 async function startGatewayHarness(params: {
   account: ReturnType<typeof buildResolvedNostrAccount>;
   cfg?: Parameters<typeof createStartAccountContext>[0]["cfg"];
-  deliveredText?: string;
 }) {
-  const harness = createRuntimeHarness(params.deliveredText);
+  const harness = createRuntimeHarness();
   const bus = createMockBus();
   setNostrRuntime(harness.runtime);
   mocks.startNostrBus.mockResolvedValueOnce(bus as never);
@@ -243,12 +242,16 @@ describe("nostr inbound gateway path", () => {
       expectedText: null,
     },
   ])("$name", async ({ deliveredText, expectedText }) => {
+    mocks.dispatchInboundDirectDm.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+        await params.deliver({ text: deliveredText });
+      },
+    );
     const { harness, cleanup } = await startGatewayHarness({
       account: buildResolvedNostrAccount({
         publicKey: "bot-pubkey",
         config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
       }),
-      deliveredText,
     });
     const options = mockCallArg(mocks.startNostrBus) as {
       onMessage: (
@@ -256,14 +259,28 @@ describe("nostr inbound gateway path", () => {
         text: string,
         reply: (text: string) => Promise<void>,
         meta: { eventId: string; createdAt: number },
+        lifecycle: NostrIngressLifecycle,
       ) => Promise<void>;
     };
     const sendReply = vi.fn(async (_text: string) => {});
+    const lifecycle: NostrIngressLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
 
-    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
-      eventId: "event-123",
-      createdAt: 1_710_000_000,
-    });
+    await options.onMessage(
+      "sender-pubkey",
+      "hello from nostr",
+      sendReply,
+      {
+        eventId: "event-123",
+        createdAt: 1_710_000_000,
+      },
+      lifecycle,
+    );
 
     if (expectedText === null) {
       expect(harness.convertMarkdownTables).not.toHaveBeenCalled();

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -23,9 +23,10 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText" | "sanitizeText"
+  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
+  sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
 };
 
 const activeBuses = new Map<string, NostrBusHandle>();

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -198,7 +198,7 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
               if (!outboundText.trim()) {
                 return;
               }
-// The gateway inbound reply path bypasses the outbound adapter, so
+              // The gateway inbound reply path bypasses the outbound adapter, so
               // strip internal tool-trace scaffolding here too — matching the
               // sanitizeText hook on nostrOutboundAdapter.
               const sanitizedText = sanitizeAssistantVisibleText(outboundText);

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -197,6 +197,9 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
               if (!outboundText.trim()) {
                 return;
               }
+// The gateway inbound reply path bypasses the outbound adapter, so
+              // strip internal tool-trace scaffolding here too — matching the
+              // sanitizeText hook on nostrOutboundAdapter.
               const sanitizedText = sanitizeAssistantVisibleText(outboundText);
               if (!sanitizedText.trim()) {
                 return;

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,7 +10,7 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { sanitizeAssistantVisibleText, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -23,7 +23,7 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
+  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText" | "sanitizeText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
 };
@@ -197,13 +197,17 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
               if (!outboundText.trim()) {
                 return;
               }
+              const sanitizedText = sanitizeAssistantVisibleText(outboundText);
+              if (!sanitizedText.trim()) {
+                return;
+              }
               const tableMode = runtime.channel.text.resolveMarkdownTableMode({
                 cfg: ctx.cfg,
                 channel: "nostr",
                 accountId: account.accountId,
               });
               const message = stripMarkdown(
-                runtime.channel.text.convertMarkdownTables(outboundText, tableMode),
+                runtime.channel.text.convertMarkdownTables(sanitizedText, tableMode),
               );
               if (message) {
                 await reply(message);
@@ -312,6 +316,7 @@ export const nostrPairingTextAdapter = {
 export const nostrOutboundAdapter: NostrOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 4000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   deliveryCapabilities: {
     durableFinal: {
       text: true,

--- a/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,41 @@
+// Nostr outbound must strip assistant internal tool-trace scaffolding before
+// delivery, matching the sanitizeText hook shipped to sibling channels
+// (twitch #103109, mattermost #98693, feishu #98705, etc.).
+import { describe, expect, it } from "vitest";
+import { nostrOutboundAdapter } from "./gateway.js";
+
+function sanitizeOutboundText(text: string): string {
+  const sanitizeText = nostrOutboundAdapter.sanitizeText;
+  if (!sanitizeText) {
+    throw new Error("Expected Nostr outbound sanitizeText hook");
+  }
+  return sanitizeText({ text, payload: { text } });
+}
+
+describe("nostr outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+    expect(sanitizeOutboundText(text)).toBe("Done.");
+  });
+
+  it("strips XML tool-call scaffolding leaked into assistant text", () => {
+    const text = '<tool_call>{"name":"exec"}</tool_call>DM delivered.';
+    expect(sanitizeOutboundText(text)).toBe("DM delivered.");
+  });
+
+  it("strips multiline tool-response scaffolding leaked into assistant text", () => {
+    const text = [
+      "Checking now.",
+      "<function_response>",
+      'Searching for: "contact"',
+      "</function_response>",
+      "DM delivered.",
+    ].join("\n");
+    expect(sanitizeOutboundText(text)).toBe("Checking now.\n\nDM delivered.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The relay has 2 active subscriptions.";
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Nostr direct messages could expose internal assistant tool-failure banners and tool-call XML instead of sending only user-visible reply text.

Related: #90684

## Why This Change Was Made

Nostr opts into the shared assistant-visible-text sanitizer through its standard outbound adapter hook. Its inbound DM reply callback also applies the same sanitizer because it delivers directly through the Nostr bus and bypasses the core outbound adapter pipeline.

The narrowed Nostr adapter type requires the sanitizer hook, preventing a later adapter refactor from silently dropping this delivery invariant while still type-checking. The direct callback suppresses trace-only output before Markdown conversion and relay delivery.

This rebase preserves current main's Nostr ingress architecture: `runPassiveAccountLifecycle`, `dispatchInboundDirectDm`, and its ingress lifecycle handoff remain intact. It does not restore the retired runtime dispatcher path.

## User Impact

Nostr recipients see intended assistant prose without internal tool traces or XML scaffolding. Ordinary prose remains unchanged, and a reply containing only internal trace content does not produce an empty DM.

## Evidence

- Standard outbound regression coverage verifies the adapter's shared sanitizer for mixed text, XML tool calls, multiline tool-response scaffolding, and ordinary prose.
- Inbound direct-reply regressions exercise the current lifecycle-aware dispatcher callback and verify mixed visible/trace content is sanitized before Markdown conversion while trace-only output invokes neither Markdown conversion nor the relay reply callback.
- Rebased exact head: `4947413d6f0e713700156323ec57948e4d0d563e`.
- Exact-head upstream CI: [success](https://github.com/openclaw/openclaw/actions/runs/29684297405).

## Risk checklist

- [x] One concern, one PR: prevent internal assistant scaffolding in Nostr outbound text.
- [x] Standard outbound and inbound direct-reply bypasses both use the same shared sanitizer.
- [x] Current ingress lifecycle and dispatcher contracts are preserved.
- [x] No config/env/default surface, SDK expansion, dependency, or CHANGELOG change.
- [x] Allow edits by maintainers.
