### PR TITLE
fix(qqbot): require own account credential entries

### DIFF
--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -21,6 +21,17 @@ interface QQBotChannelConfig extends QQBotAccountConfig {
   defaultAccount?: string;
 }
 
+function readOwnAccountConfig(
+  qqbot: QQBotChannelConfig | undefined,
+  accountId: string,
+): QQBotAccountConfig | undefined {
+  if (!qqbot?.accounts || !Object.hasOwn(qqbot.accounts, accountId)) {
+    return undefined;
+  }
+  const account = qqbot.accounts[accountId];
+  return account && typeof account === "object" ? { ...account } : {};
+}
+
 function assertNotLegacySecretRefMarker(value: unknown, path: string): void {
   const normalized = normalizeSecretInputString(value);
   if (!normalized || !/^secretref(?:-env)?:/i.test(normalized)) {
@@ -112,9 +123,9 @@ export function resolveQQBotAccount(
     base.accountId === DEFAULT_ACCOUNT_ID
       ? {
           ...qqbot,
-          ...qqbot?.accounts?.[DEFAULT_ACCOUNT_ID],
+          ...readOwnAccountConfig(qqbot, DEFAULT_ACCOUNT_ID),
         }
-      : (qqbot?.accounts?.[base.accountId] ?? {});
+      : (readOwnAccountConfig(qqbot, base.accountId) ?? {});
 
   let clientSecret = "";
   let secretSource: "config" | "file" | "env" | "none" = "none";

--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -16,22 +16,6 @@ import type { ResolvedQQBotAccount, QQBotAccountConfig } from "../types.js";
 
 export const DEFAULT_ACCOUNT_ID = ENGINE_DEFAULT_ACCOUNT_ID;
 
-interface QQBotChannelConfig extends QQBotAccountConfig {
-  accounts?: Record<string, QQBotAccountConfig>;
-  defaultAccount?: string;
-}
-
-function readOwnAccountConfig(
-  qqbot: QQBotChannelConfig | undefined,
-  accountId: string,
-): QQBotAccountConfig | undefined {
-  if (!qqbot?.accounts || !Object.hasOwn(qqbot.accounts, accountId)) {
-    return undefined;
-  }
-  const account = qqbot.accounts[accountId];
-  return account && typeof account === "object" ? { ...account } : {};
-}
-
 function assertNotLegacySecretRefMarker(value: unknown, path: string): void {
   const normalized = normalizeSecretInputString(value);
   if (!normalized || !/^secretref(?:-env)?:/i.test(normalized)) {
@@ -112,20 +96,9 @@ export function resolveQQBotAccount(
 ): ResolvedQQBotAccount {
   const raw = cfg as unknown as Record<string, unknown>;
   const base = resolveAccountBase(raw, accountId);
-
-  const qqbot = cfg.channels?.qqbot as QQBotChannelConfig | undefined;
-  /**
-   * Legacy top-level account uses `channels.qqbot` as the base, but per-account
-   * fields (allowFrom, streaming, …) often live under `accounts.default`.
-   * Merge that slice so runtime sees `config.streaming` etc.
-   */
-  const accountConfig: QQBotAccountConfig =
-    base.accountId === DEFAULT_ACCOUNT_ID
-      ? {
-          ...qqbot,
-          ...readOwnAccountConfig(qqbot, DEFAULT_ACCOUNT_ID),
-        }
-      : (readOwnAccountConfig(qqbot, base.accountId) ?? {});
+  // Identity, secret, and authorization fields must use the same own-container
+  // and own-entry projection as account discovery and default selection.
+  const accountConfig = base.config as QQBotAccountConfig;
 
   let clientSecret = "";
   let secretSource: "config" | "file" | "env" | "none" = "none";

--- a/extensions/qqbot/src/channel.logout.test.ts
+++ b/extensions/qqbot/src/channel.logout.test.ts
@@ -1,0 +1,157 @@
+// QQBot logout tests cover gateway-level credential cleanup behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setQQBotRuntime } from "./bridge/runtime.js";
+import { qqbotPlugin } from "./channel.js";
+import type { QQBotAccountConfig, ResolvedQQBotAccount } from "./types.js";
+
+type QQBotRuntimeMocks = {
+  replaceConfigFile: ReturnType<typeof vi.fn>;
+};
+
+type QQBotLogoutAccount = NonNullable<NonNullable<typeof qqbotPlugin.gateway>["logoutAccount"]>;
+
+function createRuntime(): { runtime: PluginRuntime; mocks: QQBotRuntimeMocks } {
+  const replaceConfigFile = vi.fn(async () => {});
+  const runtime = {
+    version: "test",
+    config: { replaceConfigFile },
+  } as unknown as PluginRuntime;
+  return { runtime, mocks: { replaceConfigFile } };
+}
+
+async function runLogoutScenario(params: { cfg: OpenClawConfig; accountId: string }): Promise<{
+  result: Awaited<ReturnType<QQBotLogoutAccount>>;
+  account: ResolvedQQBotAccount;
+  mocks: QQBotRuntimeMocks;
+}> {
+  const { runtime, mocks } = createRuntime();
+  setQQBotRuntime(runtime);
+  const logoutAccount = qqbotPlugin.gateway?.logoutAccount;
+  if (!logoutAccount) {
+    throw new Error("QQBot gateway logoutAccount missing");
+  }
+  const account = qqbotPlugin.config.resolveAccount(params.cfg, params.accountId);
+  const result = await logoutAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    account,
+    runtime: createRuntimeEnv(),
+  });
+  return { result, account, mocks };
+}
+
+describe("qqbotPlugin gateway.logoutAccount", () => {
+  afterEach(() => {
+    setQQBotRuntime({ version: "test" } as PluginRuntime);
+  });
+
+  it("ignores inherited named accounts during logout cleanup", async () => {
+    const inheritedAccount = {
+      appId: "app-id",
+      clientSecret: "secret",
+      clientSecretFile: "/tmp/secret",
+    };
+    const accounts = Object.create({ bot2: inheritedAccount }) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts,
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const { result, account, mocks } = await runLogoutScenario({ cfg, accountId: "bot2" });
+
+    expect(account.secretSource).toBe("none");
+    expect(result).toStrictEqual({
+      ok: true,
+      cleared: false,
+      envToken: false,
+      loggedOut: true,
+    });
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(Object.hasOwn(accounts, "bot2")).toBe(false);
+    expect(inheritedAccount).toEqual({
+      appId: "app-id",
+      clientSecret: "secret",
+      clientSecretFile: "/tmp/secret",
+    });
+  });
+
+  it("ignores inherited credentials on an own named account during logout", async () => {
+    const ownAccount = Object.assign(
+      Object.create({
+        clientSecret: "secret",
+        clientSecretFile: "/tmp/secret",
+      }) as QQBotAccountConfig,
+      { appId: "app-id" },
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: { bot2: ownAccount },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const { result, account, mocks } = await runLogoutScenario({ cfg, accountId: "bot2" });
+
+    expect(account.secretSource).toBe("none");
+    expect(result).toStrictEqual({
+      ok: true,
+      cleared: false,
+      envToken: false,
+      loggedOut: true,
+    });
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(Object.hasOwn(ownAccount, "clientSecret")).toBe(false);
+    expect(Object.hasOwn(ownAccount, "clientSecretFile")).toBe(false);
+  });
+
+  it("clears own named account credentials through the gateway logout entry point", async () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: {
+            bot2: {
+              appId: "app-id",
+              clientSecret: "secret",
+              clientSecretFile: "/tmp/secret",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const { result, account, mocks } = await runLogoutScenario({ cfg, accountId: "bot2" });
+
+    expect(account.secretSource).toBe("config");
+    expect(result).toStrictEqual({
+      ok: true,
+      cleared: true,
+      envToken: false,
+      loggedOut: true,
+    });
+    expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(1);
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        channels: {
+          qqbot: {
+            accounts: {
+              bot2: {
+                appId: "app-id",
+              },
+            },
+          },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
+  });
+});

--- a/extensions/qqbot/src/channel.logout.test.ts
+++ b/extensions/qqbot/src/channel.logout.test.ts
@@ -84,6 +84,36 @@ describe("qqbotPlugin gateway.logoutAccount", () => {
     });
   });
 
+  it("ignores an inherited accounts container during logout", async () => {
+    const inheritedAccounts = {
+      bot2: {
+        appId: "app-id",
+        clientSecret: "secret",
+        clientSecretFile: "/tmp/secret",
+      },
+    };
+    const qqbot = Object.create({ accounts: inheritedAccounts }) as Record<string, unknown>;
+    const cfg = { channels: { qqbot } } as unknown as OpenClawConfig;
+
+    const { result, account, mocks } = await runLogoutScenario({ cfg, accountId: "bot2" });
+
+    expect(account.appId).toBe("");
+    expect(account.secretSource).toBe("none");
+    expect(result).toStrictEqual({
+      ok: true,
+      cleared: false,
+      envToken: false,
+      loggedOut: true,
+    });
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(Object.hasOwn(qqbot, "accounts")).toBe(false);
+    expect(inheritedAccounts.bot2).toEqual({
+      appId: "app-id",
+      clientSecret: "secret",
+      clientSecretFile: "/tmp/secret",
+    });
+  });
+
   it("ignores inherited credentials on an own named account during logout", async () => {
     const ownAccount = Object.assign(
       Object.create({

--- a/extensions/qqbot/src/engine/config/credentials.test.ts
+++ b/extensions/qqbot/src/engine/config/credentials.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { clearAccountCredentials } from "./credentials.js";
+import { DEFAULT_ACCOUNT_ID } from "./resolve.js";
+
+describe("engine/config/credentials", () => {
+  it("ignores inherited account entries when clearing named-account credentials", () => {
+    const inheritedAccount = { clientSecret: "secret", clientSecretFile: "/tmp/secret" };
+    const accounts = Object.create({ bot2: inheritedAccount }) as Record<string, unknown>;
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts,
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    const result = clearAccountCredentials(cfg, "bot2");
+
+    expect(result.cleared).toBe(false);
+    expect(result.changed).toBe(false);
+    expect(Object.hasOwn(accounts, "bot2")).toBe(false);
+    expect(inheritedAccount).toEqual({
+      clientSecret: "secret",
+      clientSecretFile: "/tmp/secret",
+    });
+  });
+
+  it("ignores inherited credential properties on an own account entry", () => {
+    const account = Object.assign(
+      Object.create({
+        clientSecret: "secret",
+        clientSecretFile: "/tmp/secret",
+      }),
+      { appId: "app-id" },
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: { bot2: account },
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    const result = clearAccountCredentials(cfg, "bot2");
+
+    expect(result.cleared).toBe(false);
+    expect(result.changed).toBe(false);
+    expect(account).toEqual({ appId: "app-id" });
+    expect(account.clientSecret).toBe("secret");
+    expect(account.clientSecretFile).toBe("/tmp/secret");
+  });
+
+  it("clears own named-account credential properties and drops empty entries", () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: {
+            bot2: {
+              clientSecret: "secret",
+              clientSecretFile: "/tmp/secret",
+            },
+          },
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    const result = clearAccountCredentials(cfg, "bot2");
+    const nextAccounts = (
+      (result.nextCfg.channels as Record<string, unknown>).qqbot as Record<string, unknown>
+    ).accounts as Record<string, unknown>;
+
+    expect(result.cleared).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(nextAccounts.bot2).toBeUndefined();
+  });
+
+  it("clears own default-account credential properties", () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          appId: "app-id",
+          clientSecret: "",
+          clientSecretFile: "",
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    const result = clearAccountCredentials(cfg, DEFAULT_ACCOUNT_ID);
+    const nextQQBot = (result.nextCfg.channels as Record<string, unknown>).qqbot as Record<
+      string,
+      unknown
+    >;
+
+    expect(result.cleared).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(Object.hasOwn(nextQQBot, "clientSecret")).toBe(false);
+    expect(Object.hasOwn(nextQQBot, "clientSecretFile")).toBe(false);
+  });
+});

--- a/extensions/qqbot/src/engine/config/credentials.ts
+++ b/extensions/qqbot/src/engine/config/credentials.ts
@@ -37,26 +37,26 @@ export function clearAccountCredentials(
   if (nextQQBot) {
     const qqbot = nextQQBot as Record<string, unknown>;
     if (accountId === DEFAULT_ACCOUNT_ID) {
-      if (qqbot.clientSecret) {
+      if (Object.hasOwn(qqbot, "clientSecret")) {
         delete qqbot.clientSecret;
         cleared = true;
         changed = true;
       }
-      if (qqbot.clientSecretFile) {
+      if (Object.hasOwn(qqbot, "clientSecretFile")) {
         delete qqbot.clientSecretFile;
         cleared = true;
         changed = true;
       }
     }
     const accounts = qqbot.accounts as Record<string, Record<string, unknown>> | undefined;
-    if (accounts && accountId in accounts) {
+    if (accounts && Object.hasOwn(accounts, accountId)) {
       const entry = accounts[accountId] as Record<string, unknown> | undefined;
-      if (entry && "clientSecret" in entry) {
+      if (entry && Object.hasOwn(entry, "clientSecret")) {
         delete entry.clientSecret;
         cleared = true;
         changed = true;
       }
-      if (entry && "clientSecretFile" in entry) {
+      if (entry && Object.hasOwn(entry, "clientSecretFile")) {
         delete entry.clientSecretFile;
         cleared = true;
         changed = true;

--- a/extensions/qqbot/src/engine/config/resolve.test.ts
+++ b/extensions/qqbot/src/engine/config/resolve.test.ts
@@ -169,6 +169,34 @@ describe("engine/config/resolve", () => {
     expect(base.enabled).toBe(false);
   });
 
+  it("ignores inherited fields on an own named account entry", () => {
+    const account = Object.assign(
+      Object.create({
+        appId: "inherited-app-id",
+        clientSecret: "placeholder",
+        clientSecretFile: "/tmp/placeholder",
+      }) as Record<string, unknown>,
+      { name: "Owned Bot", enabled: false },
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: { bot2: account },
+        },
+      },
+    };
+
+    const base = resolveAccountBase(cfg, "bot2");
+
+    expect(account.appId).toBe("inherited-app-id");
+    expect(base.appId).toBe("");
+    expect(base.name).toBe("Owned Bot");
+    expect(base.enabled).toBe(false);
+    expect(base.config).toEqual({ name: "Owned Bot", enabled: false });
+    expect(base.config.clientSecret).toBeUndefined();
+    expect(base.config.clientSecretFile).toBeUndefined();
+  });
+
   it("uses configured defaultAccount when accountId is omitted", () => {
     const cfg = {
       channels: {

--- a/extensions/qqbot/src/engine/config/resolve.test.ts
+++ b/extensions/qqbot/src/engine/config/resolve.test.ts
@@ -1,6 +1,7 @@
 // Qqbot tests cover resolve plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  applyAccountConfig,
   DEFAULT_ACCOUNT_ID,
   listAccountIds,
   resolveDefaultAccountId,
@@ -82,6 +83,21 @@ describe("engine/config/resolve", () => {
 
     expect(listAccountIds(cfg)).toStrictEqual([]);
     expect(resolveDefaultAccountId(cfg)).toBe(DEFAULT_ACCOUNT_ID);
+  });
+
+  it("ignores an inherited accounts container", () => {
+    const inheritedAccounts = {
+      bot2: { appId: "inherited-app-id", name: "Inherited Bot" },
+    };
+    const qqbot = Object.create({ accounts: inheritedAccounts }) as Record<string, unknown>;
+    const cfg = { channels: { qqbot } };
+    const base = resolveAccountBase(cfg, "bot2");
+
+    expect(listAccountIds(cfg)).toStrictEqual([]);
+    expect(resolveDefaultAccountId(cfg)).toBe(DEFAULT_ACCOUNT_ID);
+    expect(base.appId).toBe("");
+    expect(base.config).toEqual({});
+    expect(Object.hasOwn(qqbot, "accounts")).toBe(false);
   });
 
   it("resolves default account id to 'default' when top-level appId exists", () => {
@@ -212,6 +228,30 @@ describe("engine/config/resolve", () => {
     expect(base.config).toEqual({ name: "Owned Bot", enabled: false });
     expect(base.config.clientSecret).toBeUndefined();
     expect(base.config.clientSecretFile).toBeUndefined();
+  });
+
+  it("does not copy an inherited accounts container during named-account setup", () => {
+    const qqbot = Object.create({
+      accounts: {
+        inherited: { appId: "inherited-app-id" },
+      },
+    }) as Record<string, unknown>;
+
+    const next = applyAccountConfig({ channels: { qqbot } }, "bot2", {
+      appId: "owned-app-id",
+    });
+    const nextAccounts = (
+      (next.channels as Record<string, unknown>).qqbot as Record<string, unknown>
+    ).accounts as Record<string, unknown>;
+
+    expect(Object.hasOwn(nextAccounts, "inherited")).toBe(false);
+    expect(nextAccounts).toEqual({
+      bot2: {
+        enabled: true,
+        allowFrom: ["*"],
+        appId: "owned-app-id",
+      },
+    });
   });
 
   it("uses configured defaultAccount when accountId is omitted", () => {

--- a/extensions/qqbot/src/engine/config/resolve.test.ts
+++ b/extensions/qqbot/src/engine/config/resolve.test.ts
@@ -67,6 +67,23 @@ describe("engine/config/resolve", () => {
     expect(ids).toContain("bot3");
   });
 
+  it("ignores inherited appId on a named account when listing IDs", () => {
+    const account = Object.assign(
+      Object.create({ appId: "inherited-app-id" }) as Record<string, unknown>,
+      { name: "Owned Bot" },
+    );
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: { bot2: account },
+        },
+      },
+    };
+
+    expect(listAccountIds(cfg)).toStrictEqual([]);
+    expect(resolveDefaultAccountId(cfg)).toBe(DEFAULT_ACCOUNT_ID);
+  });
+
   it("resolves default account id to 'default' when top-level appId exists", () => {
     const cfg = {
       channels: {

--- a/extensions/qqbot/src/engine/config/resolve.ts
+++ b/extensions/qqbot/src/engine/config/resolve.ts
@@ -85,10 +85,20 @@ function readQQBotSection(cfg: Record<string, unknown>): QQBotChannelConfig | un
   return asRecord(channels?.qqbot) as QQBotChannelConfig | undefined;
 }
 
+function readOwnAccounts(
+  qqbot: Record<string, unknown> | undefined,
+): QQBotChannelConfig["accounts"] | undefined {
+  if (!qqbot || !Object.hasOwn(qqbot, "accounts")) {
+    return undefined;
+  }
+  return asRecord(qqbot.accounts) as QQBotChannelConfig["accounts"] | undefined;
+}
+
 function readOwnAccountConfig(
-  accounts: QQBotChannelConfig["accounts"] | undefined,
+  qqbot: Record<string, unknown> | undefined,
   accountId: string,
 ): Record<string, unknown> | undefined {
+  const accounts = readOwnAccounts(qqbot);
   if (!accounts || !Object.hasOwn(accounts, accountId)) {
     return undefined;
   }
@@ -108,9 +118,10 @@ export function listAccountIds(cfg: Record<string, unknown>): string[] {
     ids.add(DEFAULT_ACCOUNT_ID);
   }
 
-  if (qqbot?.accounts) {
-    for (const accountId of Object.keys(qqbot.accounts)) {
-      if (hasAppId(readOwnAccountConfig(qqbot.accounts, accountId)?.appId)) {
+  const accounts = readOwnAccounts(qqbot);
+  if (accounts) {
+    for (const accountId of Object.keys(accounts)) {
+      if (hasAppId(readOwnAccountConfig(qqbot, accountId)?.appId)) {
         ids.add(accountId);
       }
     }
@@ -125,22 +136,21 @@ export function listAccountIds(cfg: Record<string, unknown>): string[] {
  */
 export function resolveDefaultAccountId(cfg: Record<string, unknown>): string {
   const qqbot = readQQBotSection(cfg);
+  const accounts = readOwnAccounts(qqbot);
   const configuredDefaultAccountId = normalizeOptionalLowercaseString(qqbot?.defaultAccount);
   if (
     configuredDefaultAccountId &&
     (configuredDefaultAccountId === DEFAULT_ACCOUNT_ID ||
-      hasAppId(readOwnAccountConfig(qqbot?.accounts, configuredDefaultAccountId)?.appId))
+      hasAppId(readOwnAccountConfig(qqbot, configuredDefaultAccountId)?.appId))
   ) {
     return configuredDefaultAccountId;
   }
   if (hasAppId(qqbot?.appId) || hasAppId(process.env.QQBOT_APP_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }
-  if (qqbot?.accounts) {
-    const ids = Object.keys(qqbot.accounts);
-    const firstId = ids.find((id) =>
-      hasAppId(readOwnAccountConfig(qqbot.accounts, id)?.appId),
-    );
+  if (accounts) {
+    const ids = Object.keys(accounts);
+    const firstId = ids.find((id) => hasAppId(readOwnAccountConfig(qqbot, id)?.appId));
     if (firstId !== undefined) {
       return firstId;
     }
@@ -168,11 +178,11 @@ export function resolveAccountBase(
   if (resolvedAccountId === DEFAULT_ACCOUNT_ID) {
     accountConfig = normalizeAccountConfig({
       ...asRecord(qqbot),
-      ...readOwnAccountConfig(qqbot?.accounts, DEFAULT_ACCOUNT_ID),
+      ...readOwnAccountConfig(qqbot, DEFAULT_ACCOUNT_ID),
     });
     appId = normalizeAppId(accountConfig.appId);
   } else {
-    const account = readOwnAccountConfig(qqbot?.accounts, resolvedAccountId);
+    const account = readOwnAccountConfig(qqbot, resolvedAccountId);
     accountConfig = normalizeAccountConfig(account);
     appId = normalizeAppId(account?.appId);
   }
@@ -229,11 +239,8 @@ export function applyAccountConfig(
       },
     };
   } else {
-    const accounts = (asRecord(existingQQBot.accounts) ?? {}) as Record<
-      string,
-      Record<string, unknown>
-    >;
-    const existingAccount = readOwnAccountConfig(accounts, accountId) ?? {};
+    const accounts = readOwnAccounts(existingQQBot) ?? {};
+    const existingAccount = readOwnAccountConfig(existingQQBot, accountId) ?? {};
     const allowFrom = (existingAccount.allowFrom as unknown[]) ?? ["*"];
     next.channels = {
       ...channels,

--- a/extensions/qqbot/src/engine/config/resolve.ts
+++ b/extensions/qqbot/src/engine/config/resolve.ts
@@ -85,6 +85,17 @@ function readQQBotSection(cfg: Record<string, unknown>): QQBotChannelConfig | un
   return asRecord(channels?.qqbot) as QQBotChannelConfig | undefined;
 }
 
+function readOwnAccountConfig(
+  accounts: QQBotChannelConfig["accounts"] | undefined,
+  accountId: string,
+): Record<string, unknown> | undefined {
+  if (!accounts || !Object.hasOwn(accounts, accountId)) {
+    return undefined;
+  }
+  const account = asRecord(accounts[accountId]);
+  return account ? { ...account } : undefined;
+}
+
 /**
  * List all configured QQBot account IDs.
  * 列出所有已配置的 QQBot 账号 ID。
@@ -118,7 +129,7 @@ export function resolveDefaultAccountId(cfg: Record<string, unknown>): string {
   if (
     configuredDefaultAccountId &&
     (configuredDefaultAccountId === DEFAULT_ACCOUNT_ID ||
-      hasAppId(qqbot?.accounts?.[configuredDefaultAccountId]?.appId))
+      hasAppId(readOwnAccountConfig(qqbot?.accounts, configuredDefaultAccountId)?.appId))
   ) {
     return configuredDefaultAccountId;
   }
@@ -127,7 +138,9 @@ export function resolveDefaultAccountId(cfg: Record<string, unknown>): string {
   }
   if (qqbot?.accounts) {
     const ids = Object.keys(qqbot.accounts);
-    const firstId = ids.find((id) => hasAppId(qqbot.accounts?.[id]?.appId));
+    const firstId = ids.find((id) =>
+      hasAppId(readOwnAccountConfig(qqbot.accounts, id)?.appId),
+    );
     if (firstId !== undefined) {
       return firstId;
     }
@@ -155,13 +168,13 @@ export function resolveAccountBase(
   if (resolvedAccountId === DEFAULT_ACCOUNT_ID) {
     accountConfig = normalizeAccountConfig({
       ...asRecord(qqbot),
-      ...asRecord(qqbot?.accounts?.[DEFAULT_ACCOUNT_ID]),
+      ...readOwnAccountConfig(qqbot?.accounts, DEFAULT_ACCOUNT_ID),
     });
     appId = normalizeAppId(accountConfig.appId);
   } else {
-    const account = qqbot?.accounts?.[resolvedAccountId];
-    accountConfig = normalizeAccountConfig(asRecord(account));
-    appId = normalizeAppId(asRecord(account)?.appId);
+    const account = readOwnAccountConfig(qqbot?.accounts, resolvedAccountId);
+    accountConfig = normalizeAccountConfig(account);
+    appId = normalizeAppId(account?.appId);
   }
 
   if (!appId && hasAppId(process.env.QQBOT_APP_ID) && resolvedAccountId === DEFAULT_ACCOUNT_ID) {
@@ -216,8 +229,11 @@ export function applyAccountConfig(
       },
     };
   } else {
-    const accounts = (existingQQBot.accounts ?? {}) as Record<string, Record<string, unknown>>;
-    const existingAccount = accounts[accountId] ?? {};
+    const accounts = (asRecord(existingQQBot.accounts) ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const existingAccount = readOwnAccountConfig(accounts, accountId) ?? {};
     const allowFrom = (existingAccount.allowFrom as unknown[]) ?? ["*"];
     next.channels = {
       ...channels,

--- a/extensions/qqbot/src/engine/config/resolve.ts
+++ b/extensions/qqbot/src/engine/config/resolve.ts
@@ -110,7 +110,7 @@ export function listAccountIds(cfg: Record<string, unknown>): string[] {
 
   if (qqbot?.accounts) {
     for (const accountId of Object.keys(qqbot.accounts)) {
-      if (hasAppId(qqbot.accounts[accountId]?.appId)) {
+      if (hasAppId(readOwnAccountConfig(qqbot.accounts, accountId)?.appId)) {
         ids.add(accountId);
       }
     }

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
@@ -356,6 +356,72 @@ describe("createInteractionHandler approval buttons", () => {
     );
   });
 
+  it.each([
+    [
+      "an inherited accounts container",
+      () =>
+        Object.create({
+          accounts: {
+            bot2: { allowFrom: ["ATTACKER_OPENID"] },
+          },
+        }) as Record<string, unknown>,
+    ],
+    [
+      "an inherited account allowlist",
+      () => ({
+        accounts: {
+          bot2: Object.create({ allowFrom: ["ATTACKER_OPENID"] }) as Record<string, unknown>,
+        },
+      }),
+    ],
+  ] satisfies Array<[string, () => Record<string, unknown>]>)(
+    "rejects fallback approval buttons authorized only by %s",
+    async (_name, createQQBotConfig) => {
+      const namedAccount = { ...account, accountId: "bot2" };
+      const cfg = {
+        channels: {
+          qqbot: createQQBotConfig(),
+        },
+      } as unknown as OpenClawConfig;
+      const handler = createInteractionHandler(namedAccount, runtime, undefined, {
+        getActiveCfg: () => cfg,
+      });
+
+      handler(makeApprovalEvent());
+
+      await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+      expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+        { appId: "app", clientSecret: "secret" },
+        "interaction-1",
+        0,
+        { content: "You are not authorized to approve this request." },
+      );
+      expect(resolveApprovalMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses an own named-account allowlist for fallback approval buttons", async () => {
+    const namedAccount = { ...account, accountId: "bot2" };
+    const handler = createInteractionHandler(namedAccount, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          channels: {
+            qqbot: {
+              accounts: {
+                bot2: { allowFrom: ["ATTACKER_OPENID"] },
+              },
+            },
+          },
+        }) as OpenClawConfig,
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
   it("delegates fallback approval button auth to the gateway command resolver", async () => {
     const access = createSdkAccessAdapter();
     const handler = createInteractionHandler(account, runtime, undefined, {

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -454,10 +454,8 @@ function resolveApprovalButtonAccountConfig(
 ): QQBotAccountConfigView {
   // Approval authorization must use the same own-container and own-entry
   // projection as runtime account resolution or inherited allowlists can grant access.
-  return resolveAccountBase(
-    cfg as unknown as Record<string, unknown>,
-    accountId,
-  ).config as QQBotAccountConfigView;
+  return resolveAccountBase(cfg as unknown as Record<string, unknown>, accountId)
+    .config as QQBotAccountConfigView;
 }
 
 function resolveApprovalActorSenderIds(event: InteractionEvent): string[] {

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -452,21 +452,12 @@ function resolveApprovalButtonAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
 ): QQBotAccountConfigView {
-  const qqbot = readRecord(readRecord(cfg.channels)?.qqbot);
-  const accounts = readRecord(qqbot?.accounts);
-  if (accountId === "default") {
-    return {
-      ...qqbot,
-      ...readRecord(accounts?.default),
-    } as QQBotAccountConfigView;
-  }
-  return (readRecord(accounts?.[accountId]) ?? {}) as QQBotAccountConfigView;
-}
-
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
+  // Approval authorization must use the same own-container and own-entry
+  // projection as runtime account resolution or inherited allowlists can grant access.
+  return resolveAccountBase(
+    cfg as unknown as Record<string, unknown>,
+    accountId,
+  ).config as QQBotAccountConfigView;
 }
 
 function resolveApprovalActorSenderIds(event: InteractionEvent): string[] {


### PR DESCRIPTION
## What Problem This Solves

QQBot logout, setup, and account discovery could treat prototype-inherited named-account entries or credential fields as explicit user configuration. That could make cleanup report or resolve configuration the user did not own.

## Why This Change Was Made

QQBot credential handling now applies one own-property boundary across the `accounts` container, named account lookup, default-account selection, setup updates, bridge resolution, account listing, credential clearing, and approval-button authorization. Owned account objects are copied through their own enumerable properties before identity, secret, or authorization resolution.

The current-main account-ID contract is preserved: numeric app IDs remain valid, while blank string app IDs remain absent. Account listing and fallback default selection now combine that `hasAppId` normalization with the own-account lookup.

## User Impact

Normal owned-account logout still removes owned `clientSecret` / `clientSecretFile` values, retains non-secret configuration such as `appId`, and writes through the existing runtime path. Prototype-inherited account identity and credentials are ignored.

Programmatic configurations that intentionally depend on prototype-inherited QQBot properties are no longer supported. JSON/JSON5 configuration files cannot encode prototype inheritance.

## Evidence

- Exact PR head: `49a405a9c7a1f954cd4ef07b9256ef8e7c8629f2`.
- Current base: `6a8e11e63ceed04aed5476180b2a9a4dccea44a0` (`main`).
- Semantic conflict resolution preserved current-main blank/numeric app-ID normalization and applied the own-account boundary to account listing, configured-default lookup, and first-valid-account fallback.
- The [OpenClaw bot finding on `799f64d99`](https://github.com/openclaw/openclaw/pull/103371#issuecomment-4934451583) identified an inherited `qqbot.accounts` container and raw approval-account authorization as gaps in the same invariant. The follow-up requires the container itself to be owned, reuses the canonical `resolveAccountBase(...).config` projection in bridge and approval paths, and retains a positive control for owned named-account allowlists.
- Added regressions cover inherited containers in discovery/base resolution/setup/logout, inherited named-account allowlists in approval authorization, and normal owned named-account authorization.
- `git diff --check upstream/main..HEAD`: passed.
- Exact-head upstream CI and bot checks were automatically dispatched and are pending; this head includes only the oxfmt correction reported by the preceding exact-head run.
- No untrusted repository-controlled test or review tooling was executed locally; exact-head validation is delegated to GitHub.

Historical proof for the same inherited-object production path remains available in [fork run 29720907727](https://github.com/Alix-007/openclaw/actions/runs/29720907727). That run is immutable prior-head evidence; the current head is accepted only after its own GitHub checks complete.

Not tested locally: live QQBot API calls, a real gateway connection, or real credentials.
