### PR TITLE
fix(onboarding): preserve plugin ownership from included config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS fresh AI onboarding:** open configured Gateways directly, keep Crestodian hidden until inference succeeds, reuse native Codex credentials on the effective default agent, reset stale route state, and preserve unrelated plugin install ownership while staging the Codex runtime. (#102637, #103347)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS fresh AI onboarding:** open configured Gateways directly, keep Crestodian hidden until inference succeeds, reuse native Codex credentials on the effective default agent, reset stale route state, and preserve unrelated plugin install ownership while staging the Codex runtime. (#102637, #103347)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/src/cli/plugins-install-record-commit.test.ts
+++ b/src/cli/plugins-install-record-commit.test.ts
@@ -14,11 +14,14 @@ import { withEnvAsync } from "../test-utils/env.js";
 const mocks = vi.hoisted(() => ({
   loadInstalledPluginIndexInstallRecords: vi.fn(),
   replaceConfigFile: vi.fn(),
+  transformConfigFileWithRetry: vi.fn(),
   writePersistedInstalledPluginIndexInstallRecords: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
   replaceConfigFile: mocks.replaceConfigFile,
+  resolveConfigWriteAfterWrite: (value?: unknown) => value ?? { mode: "auto" },
+  transformConfigFileWithRetry: mocks.transformConfigFileWithRetry,
 }));
 
 vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) => {
@@ -37,6 +40,7 @@ import {
   commitConfigWriteWithPendingPluginInstalls,
   commitPluginInstallRecordsWithConfig,
   stripPendingPluginInstallRecords,
+  transformConfigWithPendingPluginInstalls,
   unchangedPendingPluginInstallRecordIds,
 } from "./plugins-install-record-commit.js";
 
@@ -116,6 +120,91 @@ describe("commitConfigWithPendingPluginInstalls", () => {
       },
       movedInstallRecords: true,
       persistedHash: "test-config-hash",
+    });
+  });
+
+  it("migrates source records below the canonical index and explicit pending records", async () => {
+    const sourceConfig: OpenClawConfig = {
+      plugins: {
+        installs: {
+          stale: { source: "npm", spec: "stale@1.0.0" },
+          missing: { source: "npm", spec: "missing@1.0.0" },
+          codex: { source: "npm", spec: "codex@1.0.0" },
+        },
+      },
+    };
+    const existingRecords: Record<string, PluginInstallRecord> = {
+      stale: { source: "npm", spec: "stale@2.0.0" },
+      codex: { source: "npm", spec: "codex@2.0.0" },
+    };
+    const nextConfig: OpenClawConfig = {
+      plugins: {
+        installs: {
+          ...sourceConfig.plugins?.installs,
+          codex: { source: "npm", spec: "codex@3.0.0" },
+          concurrent: { source: "npm", spec: "concurrent@1.0.0" },
+        },
+      },
+    };
+    const commit = vi.fn(async () => undefined);
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(existingRecords);
+
+    const result = await commitConfigWriteWithPendingPluginInstalls({
+      nextConfig,
+      sourceConfig,
+      commit,
+    });
+
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({
+      stale: existingRecords.stale,
+      missing: sourceConfig.plugins?.installs?.missing,
+      codex: nextConfig.plugins?.installs?.codex,
+      concurrent: nextConfig.plugins?.installs?.concurrent,
+    });
+    expect(commit).toHaveBeenCalledWith({}, {
+      afterWrite: { mode: "restart", reason: "plugin source changed" },
+      unsetPaths: [["plugins", "installs"]],
+    });
+    expect(result.installRecords).toStrictEqual({
+      stale: existingRecords.stale,
+      missing: sourceConfig.plugins?.installs?.missing,
+      codex: nextConfig.plugins?.installs?.codex,
+      concurrent: nextConfig.plugins?.installs?.concurrent,
+    });
+  });
+
+  it("preserves source records omitted by a transform callback", async () => {
+    const sourceConfig: OpenClawConfig = {
+      plugins: {
+        installs: {
+          other: { source: "npm", spec: "other@1.0.0" },
+        },
+      },
+    };
+    const codexRecord: PluginInstallRecord = { source: "npm", spec: "codex@2.0.0" };
+    const snapshot = { sourceConfig };
+    mocks.transformConfigFileWithRetry.mockImplementationOnce(async (params: unknown) => {
+      const transformParams = params as {
+        transform: (
+          config: OpenClawConfig,
+          context: { snapshot: typeof snapshot },
+        ) => { nextConfig: OpenClawConfig };
+        commit: (input: unknown) => Promise<unknown>;
+      };
+      const transformed = transformParams.transform(sourceConfig, { snapshot });
+      await transformParams.commit({ nextConfig: transformed.nextConfig, snapshot });
+      return {};
+    });
+
+    await transformConfigWithPendingPluginInstalls({
+      transform: () => ({
+        nextConfig: { plugins: { installs: { codex: codexRecord } } },
+      }),
+    });
+
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({
+      other: sourceConfig.plugins?.installs?.other,
+      codex: codexRecord,
     });
   });
 

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -12,6 +12,7 @@ import {
   type TransformConfigFileWithRetryParams,
 } from "../config/config.js";
 import type { ConfigWriteOptions } from "../config/io.js";
+import { extractShippedPluginInstallConfigRecords } from "../config/plugin-install-config-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -359,11 +360,13 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
   movedInstallRecords: boolean;
   persistedHash: string | null;
 }> {
-  const sourceInstallRecords = params.sourceConfig?.plugins?.installs ?? {};
+  const sourceInstallRecords = extractShippedPluginInstallConfigRecords(params.sourceConfig);
   const nextPendingConfig = params.sourceConfig
     ? stripPendingPluginInstallRecords(
         params.nextConfig,
-        unchangedPendingPluginInstallRecordIds(params.nextConfig, params.sourceConfig),
+        unchangedPendingPluginInstallRecordIds(params.nextConfig, {
+          plugins: { installs: sourceInstallRecords },
+        }),
       )
     : params.nextConfig;
   if (

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -349,6 +349,8 @@ export async function commitPluginInstallRecordsWithConfig(params: {
 /** Commit config while migrating any pending install records into the install index. */
 export async function commitConfigWriteWithPendingPluginInstalls(params: {
   nextConfig: OpenClawConfig;
+  /** Source snapshot whose transient records migrate below the canonical index. */
+  sourceConfig?: OpenClawConfig;
   writeOptions?: ConfigWriteOptions;
   commit: ConfigCommit;
 }): Promise<{
@@ -357,7 +359,17 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
   movedInstallRecords: boolean;
   persistedHash: string | null;
 }> {
-  if (!hasPendingPluginInstallRecords(params.nextConfig)) {
+  const sourceInstallRecords = params.sourceConfig?.plugins?.installs ?? {};
+  const nextPendingConfig = params.sourceConfig
+    ? stripPendingPluginInstallRecords(
+        params.nextConfig,
+        unchangedPendingPluginInstallRecordIds(params.nextConfig, params.sourceConfig),
+      )
+    : params.nextConfig;
+  if (
+    Object.keys(sourceInstallRecords).length === 0 &&
+    !hasPendingPluginInstallRecords(nextPendingConfig)
+  ) {
     const committed = params.writeOptions
       ? await params.commit(params.nextConfig, params.writeOptions)
       : await params.commit(params.nextConfig);
@@ -369,9 +381,10 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
     };
   }
 
-  const pendingInstallRecords = params.nextConfig.plugins?.installs ?? {};
+  const pendingInstallRecords = nextPendingConfig.plugins?.installs ?? {};
   const previousInstallRecords = await loadInstalledPluginIndexInstallRecords();
   const nextInstallRecords = {
+    ...sourceInstallRecords,
     ...previousInstallRecords,
     ...pendingInstallRecords,
   };
@@ -423,6 +436,7 @@ export async function transformConfigWithPendingPluginInstalls<T = void>(
     const requestedAfterWrite = params.afterWrite ?? params.writeOptions?.afterWrite;
     const committed = await commitConfigWriteWithPendingPluginInstalls({
       nextConfig,
+      sourceConfig: snapshot.sourceConfig,
       ...(writeOptions ? { writeOptions: mergeAfterWrite(writeOptions, params.afterWrite) } : {}),
       commit: async (config, commitWriteOptions) => {
         return await replaceConfigFile({

--- a/src/crestodian/chat-engine.channel-hooks.test.ts
+++ b/src/crestodian/chat-engine.channel-hooks.test.ts
@@ -88,7 +88,7 @@ describe("Crestodian chat channel setup", () => {
     expect(reply.text).toContain("matrix is configured");
     expect(mocks.writeWizardConfigFile).toHaveBeenCalledWith(
       { channels: { matrix: { enabled: true } } },
-      { allowConfigSizeDrop: false },
+      { allowConfigSizeDrop: false, migrationBaseConfig: {} },
     );
     expect(mocks.runCollectedChannelOnboardingPostWriteHooks).toHaveBeenCalledWith({
       hooks: [mocks.hook],

--- a/src/crestodian/chat-engine.ts
+++ b/src/crestodian/chat-engine.ts
@@ -141,6 +141,7 @@ function defaultChannelSetupWizardRunner(
     });
     const committedConfig = await writeWizardConfigFile(nextConfig, {
       allowConfigSizeDrop: false,
+      migrationBaseConfig: baseConfig,
     });
     await runCollectedChannelOnboardingPostWriteHooks({
       hooks: postWriteHooks.drain(),

--- a/src/crestodian/setup-apply.ts
+++ b/src/crestodian/setup-apply.ts
@@ -183,7 +183,10 @@ export async function applyCrestodianSetup(
     command: "onboard",
     mode: "local",
   });
-  nextConfig = await writeWizardConfigFile(nextConfig, { allowConfigSizeDrop: false });
+  nextConfig = await writeWizardConfigFile(nextConfig, {
+    allowConfigSizeDrop: false,
+    migrationBaseConfig: baseConfig,
+  });
 
   await onboardHelpers.ensureWorkspaceAndSessions(workspace, runtime, {
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),

--- a/src/wizard/setup.shared.test.ts
+++ b/src/wizard/setup.shared.test.ts
@@ -34,7 +34,7 @@ describe("writeWizardConfigFile pending install ownership", () => {
 
     await expect(
       writeWizardConfigFile(config, { allowConfigSizeDrop: false }),
-    ).rejects.toThrow("require a migration base");
+    ).rejects.toThrow("declare migration ownership");
     expect(mocks.commitConfigWriteWithPendingPluginInstalls).not.toHaveBeenCalled();
   });
 
@@ -57,5 +57,21 @@ describe("writeWizardConfigFile pending install ownership", () => {
       }),
     );
     expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledTimes(2);
+  });
+
+  it("commits fresh pending records after baseline migration is complete", async () => {
+    const config: OpenClawConfig = {
+      plugins: { installs: { fresh: { source: "npm", spec: "fresh@1.0.0" } } },
+    };
+
+    await writeWizardConfigFile(config, {
+      allowConfigSizeDrop: false,
+      migrationBaseConfig: undefined,
+    });
+
+    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledOnce();
+    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledWith(
+      expect.objectContaining({ nextConfig: config }),
+    );
   });
 });

--- a/src/wizard/setup.shared.test.ts
+++ b/src/wizard/setup.shared.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
+
+const mocks = vi.hoisted(() => ({
+  commitConfigWriteWithPendingPluginInstalls: vi.fn(),
+}));
+
+vi.mock("../cli/plugins-install-record-commit.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../cli/plugins-install-record-commit.js")>()),
+  commitConfigWriteWithPendingPluginInstalls:
+    mocks.commitConfigWriteWithPendingPluginInstalls,
+}));
+
+import { writeWizardConfigFile } from "./setup.shared.js";
+
+describe("writeWizardConfigFile pending install ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.commitConfigWriteWithPendingPluginInstalls.mockImplementation(
+      async (params: { nextConfig: OpenClawConfig }) => ({
+        config: withoutPluginInstallRecords(params.nextConfig),
+        installRecords: {},
+        movedInstallRecords: true,
+        persistedHash: "test-hash",
+      }),
+    );
+  });
+
+  it("rejects a normal write with pending records but no migration base", async () => {
+    const config: OpenClawConfig = {
+      plugins: { installs: { demo: { source: "npm", spec: "demo@1.0.0" } } },
+    };
+
+    await expect(
+      writeWizardConfigFile(config, { allowConfigSizeDrop: false }),
+    ).rejects.toThrow("require a migration base");
+    expect(mocks.commitConfigWriteWithPendingPluginInstalls).not.toHaveBeenCalled();
+  });
+
+  it("migrates the baseline as source before the final wizard write", async () => {
+    const baseConfig: OpenClawConfig = {
+      plugins: { installs: { demo: { source: "npm", spec: "demo@1.0.0" } } },
+    };
+
+    await writeWizardConfigFile(baseConfig, {
+      allowConfigSizeDrop: false,
+      migrationBaseConfig: baseConfig,
+    });
+
+    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        nextConfig: baseConfig,
+        sourceConfig: baseConfig,
+        writeOptions: { allowConfigSizeDrop: true },
+      }),
+    );
+    expect(mocks.commitConfigWriteWithPendingPluginInstalls).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -63,11 +63,15 @@ export async function writeWizardConfigFile(
   let config = configInput;
   const allowConfigSizeDrop = opts.allowConfigSizeDrop === true;
   if (!allowConfigSizeDrop && hasPendingPluginInstallRecords(config)) {
-    const migrationBaseConfig = opts.migrationBaseConfig;
-    if (!migrationBaseConfig) {
-      throw new Error("Wizard config writes with pending plugin installs require a migration base.");
+    // Explicit undefined means this writer already migrated its baseline; an omitted
+    // key cannot distinguish fresh pending records from stale authored metadata.
+    if (!Object.hasOwn(opts, "migrationBaseConfig")) {
+      throw new Error(
+        "Wizard config writes with pending plugin installs must declare migration ownership.",
+      );
     }
-    if (hasPendingPluginInstallRecords(migrationBaseConfig)) {
+    const migrationBaseConfig = opts.migrationBaseConfig;
+    if (migrationBaseConfig && hasPendingPluginInstallRecords(migrationBaseConfig)) {
       await commitConfigWriteWithPendingPluginInstalls({
         nextConfig: migrationBaseConfig,
         sourceConfig: migrationBaseConfig,

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -64,9 +64,13 @@ export async function writeWizardConfigFile(
   const allowConfigSizeDrop = opts.allowConfigSizeDrop === true;
   if (!allowConfigSizeDrop && hasPendingPluginInstallRecords(config)) {
     const migrationBaseConfig = opts.migrationBaseConfig;
-    if (migrationBaseConfig && hasPendingPluginInstallRecords(migrationBaseConfig)) {
+    if (!migrationBaseConfig) {
+      throw new Error("Wizard config writes with pending plugin installs require a migration base.");
+    }
+    if (hasPendingPluginInstallRecords(migrationBaseConfig)) {
       await commitConfigWriteWithPendingPluginInstalls({
         nextConfig: migrationBaseConfig,
+        sourceConfig: migrationBaseConfig,
         writeOptions: { allowConfigSizeDrop: true },
         commit: async (nextConfig, writeOptions) => {
           return await replaceConfigFile({


### PR DESCRIPTION
Closes #103347

## What Problem This Solves

Fixes an issue where fresh AI onboarding through a detected Codex CLI could silently drop another plugin's install ownership metadata when the plugin section came from an included config file.

## Why This Change Was Made

The shared config-transform commit now migrates source install records beneath the canonical installed-plugin index, then applies explicit pending updates above it. This preserves included source records, keeps newer canonical records ahead of stale authored metadata, and lets the freshly installed Codex record win only its own key.

## User Impact

Users can complete Codex-backed onboarding without losing update, doctor, or uninstall ownership metadata for another concurrently staged plugin.

## Evidence

- Blacksmith Testbox focused regressions: `corepack pnpm test src/cli/plugins-install-record-commit.test.ts src/crestodian/setup-inference.test.ts` — 36 tests passed on the owner-boundary patch before the final source-schema validation guard.
- Exact pushed-head hosted PR CI and Testbox landing gates: pending.
- Fresh autoreview: clean; no accepted or actionable findings.
- Regression proves source-only records survive an omitting transform, canonical records beat stale source metadata, and explicit pending updates beat both.

AI assistance: Codex implemented and reviewed the patch under maintainer direction. No agent transcript is attached.
