### PR TITLE
fix(xai): accept x-ai alias in thinking profile resolution

### DIFF
--- a/extensions/xai/provider-policy-api.test.ts
+++ b/extensions/xai/provider-policy-api.test.ts
@@ -37,6 +37,38 @@ describe("xai provider thinking policy", () => {
     },
   );
 
+  it("resolves x-ai alias to the same thinking profile as xai", () => {
+    // The x-ai alias must not fall through to off-only.
+    const profile = resolveThinkingProfile({
+      provider: "x-ai",
+      modelId: "grok-4.3",
+    });
+
+    expect(profile.defaultLevel).toBe("low");
+    expect(profile.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it.each(["grok-4.5", "grok-4.5-latest"])(
+    "resolves x-ai alias Grok 4.5 thinking levels for %s",
+    (modelId) => {
+      const profile = resolveThinkingProfile({
+        provider: "x-ai",
+        modelId,
+      });
+
+      expect(profile).toEqual({
+        levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+        defaultLevel: "high",
+      });
+    },
+  );
+
   it("keeps non-reasoning and non-xai routes off-only", () => {
     expect(
       resolveThinkingProfile({

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -6,11 +6,15 @@ import type {
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
 import { normalizeXaiModelId } from "./model-id.js";
 
+// The xAI plugin registers "x-ai" as a canonical alias of "xai".
+// Both provider IDs must resolve to the same thinking profile.
+const XAI_PROVIDER_IDS = new Set(["xai", "x-ai"]);
+
 export function resolveThinkingProfile(
   ctx: ProviderDefaultThinkingPolicyContext,
 ): ProviderThinkingProfile {
   const reasoning = ctx.reasoning ?? resolveXaiCatalogEntry(ctx.modelId)?.reasoning;
-  if (ctx.provider !== "xai" || !reasoning) {
+  if (!XAI_PROVIDER_IDS.has(ctx.provider) || !reasoning) {
     return { levels: [{ id: "off" }], defaultLevel: "off" };
   }
   const modelId = normalizeXaiModelId(ctx.modelId.trim().toLowerCase());


### PR DESCRIPTION
## What Problem This Solves

The shipped `x-ai` provider alias resolves Grok 4.5 with an off-only thinking policy even though the model supports `low`, `medium`, and `high`, causing a valid live gateway run to fail before provider transport.

Closes #103315

## Why This Change Was Made

The `resolveThinkingProfile` hook only matched the literal `"xai"` provider ID, but the xAI plugin registers `"x-ai"` as a canonical alias. When the gateway resolves a model through the alias path, the thinking-profile hook fell through to the off-only default, causing valid Grok 4.5 thinking levels to be rejected.

The fix replaces the strict equality check with a Set lookup that covers both `"xai"` and `"x-ai"` so alias-routed models receive the same thinking profile as canonical-routed models.

## User Impact

Users selecting Grok 4.5 through the `x-ai` alias will now correctly receive the supported thinking levels (low, medium, high) instead of an immediate validation error. This fixes the deterministic release-shard failure for the `x-ai/grok-4.5` route.

## Evidence

- Added test: verifies `x-ai` provider ID resolves to the same profile as `xai` for grok-4.3
- Added test: verifies `x-ai` provider ID correctly returns low/medium/high for grok-4.5 variants
- Existing tests for canonical `xai` provider path remain green