### PR TITLE
fix(feishu): route outbound media by case-insensitive MIME type

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1000,3 +1000,61 @@ describe("saveMessageResourceFeishu", () => {
     });
   });
 });
+
+describe("resolveFeishuOutboundMediaKind case-insensitive MIME", () => {
+  // MIME types are case-insensitive (RFC 2045); a relay may emit a mixed-case
+  // Content-Type header. resolveFeishuOutboundMediaKind must route by the
+  // lowercased value so audio/video/image are not misrouted to "file".
+  let resolveFeishuOutboundMediaKind: typeof import("./media.js").resolveFeishuOutboundMediaKind;
+  beforeAll(async () => {
+    ({ resolveFeishuOutboundMediaKind } = await import("./media.js"));
+  });
+
+  it("routes mixed-case audio MIME to audio", () => {
+    expect(resolveFeishuOutboundMediaKind({ fileName: "voice", contentType: "Audio/OGG" })).toEqual(
+      {
+        fileType: "opus",
+        msgType: "audio",
+      },
+    );
+    expect(
+      resolveFeishuOutboundMediaKind({ fileName: "voice", contentType: "Audio/Opus" }),
+    ).toEqual({ fileType: "opus", msgType: "audio" });
+  });
+
+  it("routes mixed-case video MIME to media", () => {
+    expect(resolveFeishuOutboundMediaKind({ fileName: "clip", contentType: "Video/MP4" })).toEqual({
+      fileType: "mp4",
+      msgType: "media",
+    });
+    expect(
+      resolveFeishuOutboundMediaKind({ fileName: "clip", contentType: "Video/QuickTime" }),
+    ).toEqual({ fileType: "mp4", msgType: "media" });
+  });
+
+  it("routes mixed-case image MIME to image", () => {
+    expect(resolveFeishuOutboundMediaKind({ fileName: "pic", contentType: "Image/PNG" })).toEqual({
+      msgType: "image",
+    });
+  });
+
+  it("still routes lowercase MIME correctly (regression)", () => {
+    expect(resolveFeishuOutboundMediaKind({ fileName: "voice", contentType: "audio/ogg" })).toEqual(
+      {
+        fileType: "opus",
+        msgType: "audio",
+      },
+    );
+    expect(resolveFeishuOutboundMediaKind({ fileName: "pic", contentType: "image/png" })).toEqual({
+      msgType: "image",
+    });
+  });
+
+  it("routes a non-media pdf to file (regression)", () => {
+    const result = resolveFeishuOutboundMediaKind({
+      fileName: "doc",
+      contentType: "Application/PDF",
+    });
+    expect(result.msgType).toBe("file");
+  });
+});

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -653,11 +653,20 @@ function detectFileType(
   }
 }
 
-function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?: string }): {
+/** @internal Exported for tests asserting case-insensitive MIME routing. */
+export function resolveFeishuOutboundMediaKind(params: {
+  fileName: string;
+  contentType?: string;
+}): {
   fileType?: "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream";
   msgType: "image" | "file" | "audio" | "media";
 } {
-  const { fileName, contentType } = params;
+  const { fileName } = params;
+  // MIME types are case-insensitive (RFC 2045) and the contentType arrives from
+  // a remote URL's Content-Type header, which relays may emit mixed-case. Lowercase
+  // once so every comparison below (and mediaKindFromMime) matches consistently;
+  // the sibling isFeishuNativeVoiceAudio already lowercases the same way.
+  const contentType = normalizeLowercaseStringOrEmpty(params.contentType);
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));
   const mimeKind = mediaKindFromMime(contentType);
 


### PR DESCRIPTION
## What Problem This Solves

`resolveFeishuOutboundMediaKind` (`extensions/feishu/src/media.ts`) compared the remote `Content-Type` with exact case-sensitive equality in its audio and video branches. MIME types are case-insensitive (RFC 2045), and `contentType` arrives from a remote URL's `Content-Type` header (`loadWebMedia`), which relays may emit mixed-case (e.g. `Audio/OGG`, `Video/MP4`). Such an outbound attachment was misrouted: a voice/audio clip became a generic `file` instead of `audio`, a video became `file` instead of `media`, and a mixed-case image header (`Image/PNG`) fell through `mediaKindFromMime` (also case-sensitive) to `file`. Feishu then renders the attachment as a flat file download instead of inline audio/video/image.

## Why This Change Was Made

- **Root cause:** `contentType` was compared raw (case-sensitive) in the audio/video branches, and `mediaKindFromMime(contentType)` is itself case-sensitive.
- **Fix:** lowercase `contentType` once at the top of `resolveFeishuOutboundMediaKind` via the already-imported `normalizeLowercaseStringOrEmpty`, so the image (`mediaKindFromMime`), audio, and video branches all match consistently. The sibling `isFeishuNativeVoiceAudio` in the same file already lowercases the same way — this aligns the two functions.

## User Impact

Outbound Feishu attachments served with a mixed-case `Content-Type` are now routed to the correct message type (audio/video/image) instead of degrading to a flat file. Lowercase content types are unchanged.

## Linked context

N/A (no existing issue). Same RFC 2045 case-insensitivity class as the qqbot inbound fix a49567cdfd.

## Evidence

Terminal capture of `node --import tsx` runtime verification calling the **patched router** `resolveFeishuOutboundMediaKind` (the function modified by this PR, imported from `extensions/feishu/src/media.ts`) on the exact PR head:

```
[PASS] mixed-case Audio/OGG: msgType=audio fileType=opus
[PASS] mixed-case Video/MP4: msgType=media fileType=mp4
[PASS] mixed-case Image/PNG: msgType=image fileType=-
[PASS] lowercase audio/ogg (regression): msgType=audio fileType=opus
[PASS] non-media pdf (regression): msgType=file fileType=stream
```

This calls the real `resolveFeishuOutboundMediaKind` (the function whose `contentType` comparison this PR lowercases), proving mixed-case MIME now routes to audio/media/image instead of degrading to file.

| # | Field | Value |
|---|-------|-------|
| 1 | Behavior or issue addressed | Mixed-case Content-Type misroutes outbound audio/video/image to file. |
| 2 | Real environment tested | Linux x64, Node 22; the patched `resolveFeishuOutboundMediaKind` invoked on the exact PR head (5a71dc80d3fe). |
| 3 | Exact steps or command run | `node --import tsx` script importing `resolveFeishuOutboundMediaKind` from `media.ts`, plus colocated vitest `node scripts/run-vitest.mjs extensions/feishu/src/media.test.ts`. |
| 4 | Evidence after fix | Terminal output above: mixed-case routes to audio/media/image; lowercase unchanged; pdf still file. |
| 5 | Observed result after fix | Mixed-case MIME classifies identically to lowercase via the patched router. |
| 6 | What was not tested | Live Feishu delivery (no tenant in this env); the router function itself is exercised directly. |

## Tests and validation

New resolveFeishuOutboundMediaKind case-insensitive MIME describe block: mixed-case audio/video/image routing, lowercase regression, non-media pdf regression.

## Risk checklist

- [x] One concern, one PR — only resolveFeishuOutboundMediaKind MIME normalization.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Backward compatible — lowercase inputs produce identical results; MIME is case-insensitive by spec so lowercasing only adds correct matches.
- [x] No new deps (reuses already-imported normalizeLowercaseStringOrEmpty).
- [x] No CHANGELOG edit (per release policy).
- [x] Tests added.

- [x] Allow edits by maintainers