### PR TITLE
fix(zalo): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -38,7 +38,10 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 import {
   listZaloAccountIds,
   resolveDefaultZaloAccountId,
@@ -289,6 +292,9 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
       chunker: chunkTextForOutbound,
       chunkerMode: "text",
       textChunkLimit: zaloTextChunkLimit,
+      // Core strips only conservative runtime markers. This delivery profile also
+      // removes model/tool XML and failed-tool traces before Zalo chunking.
+      sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       sendPayload: async (ctx) =>
         await sendPayloadWithChunkedTextAndMedia({
           ctx,

--- a/extensions/zalo/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/zalo/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { zaloPlugin } from "./channel.js";
+
+function sanitizeOutboundText(text: string): string {
+  const sanitizeText = zaloPlugin.outbound?.sanitizeText;
+  if (!sanitizeText) {
+    throw new Error("Expected Zalo outbound sanitizeText hook");
+  }
+  return sanitizeText({ text, payload: { text } });
+}
+
+describe("zalo outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    expect(sanitizeOutboundText("Done.\n⚠️ 🛠️ `search repos (agent)` failed")).toBe("Done.");
+  });
+
+  it("strips XML tool-call scaffolding leaked into assistant text", () => {
+    expect(sanitizeOutboundText('<tool_call>{"name":"exec"}</tool_call>Message sent.')).toBe(
+      "Message sent.",
+    );
+  });
+
+  it("preserves ordinary assistant prose", () => {
+    const text = "The group has 5 active members.";
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+
+  it("preserves literal tool-call examples inside fenced code", () => {
+    const text = ["```xml", '<tool_call>{"name":"exec"}</tool_call>', "```"].join("\n");
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+
+  it("returns empty text when the payload contains only an internal trace", () => {
+    expect(sanitizeOutboundText("⚠️ 🛠️ `search repos (agent)` failed")).toBe("");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Zalo recipients could see internal assistant tool-failure banners or raw tool-call XML instead of only the user-visible response.

Related: #90684

## Why This Change Was Made

Zalo now opts into the existing shared assistant-visible-text sanitizer through the standard channel outbound `sanitizeText` hook. Core applies this hook before payload normalization, empty filtering, chunk planning, and the current attached-result Zalo transport adapter.

The branch was rebased onto current `main` and retains the newer `sendZaloDelivery`, `zaloSendResultAdapter`, and `createAttachedChannelResultAdapter` flow; no deprecated send-result path is restored.

## User Impact

Zalo users receive the intended assistant prose without internal tool traces or XML scaffolding. Ordinary messages are unchanged, and trace-only text is removed before outbound chunking and delivery.

## Evidence

- **Behavior or issue addressed:** Zalo's outbound adapter did not declare the shared assistant-visible-text sanitizer, allowing internal failed-tool banners and tool XML to reach channel delivery.
- **Real environment tested:** Linux x86_64, Node 24.14, original branch `fix/zalo-outbound-tool-trace-sanitize`, exact head `66dfdda620f9d0156ff3a621501910d198346503`, rebased onto `upstream/main` `370b5150c25961d6b46c32829b5f44a3a9b60557`.
- **Exact steps or command run:** `node --import tsx` with a runtime harness importing `zaloPlugin` from `extensions/zalo/src/channel.ts` and invoking the actual outbound `sanitizeText` hook for mixed, XML, ordinary, and trace-only payloads.
- **Evidence after fix:** Terminal capture of the `node` runtime verification (copied live output):

  ```text
  mixed: PASS output="Done."
  xml: PASS output="Message sent."
  ordinary: PASS output="The group has 5 active members."
  trace-only: PASS output=""
  ALL PASS
  ```

- **Observed result after fix:** Mixed visible/trace content retains only visible prose, tool-call XML is removed, ordinary prose is byte-equivalent, and trace-only input becomes empty before core's empty-payload suppression and transport delivery.

The shared final-delivery pass and the channel delivery profile were also compared directly on the current base. The shared `stripInternalRuntimeScaffolding` pass is intentionally conservative and leaves all four reported Zalo payload classes unchanged; `sanitizeAssistantVisibleText` removes them:

```text
banner shared="Done.\n⚠️ 🛠️ `search repos (agent)` failed"
banner delivery="Done."
tool-call shared="<tool_call>{\"name\":\"exec\"}</tool_call>Message sent."
tool-call delivery="Message sent."
function-response shared="Checking now.\n<function_response>..."
function-response delivery="Checking now.\n\nMessage sent."
trace-only shared="⚠️ 🛠️ `search repos (agent)` failed"
trace-only delivery=""
```

This establishes that the Zalo hook is the existing channel-owned full delivery profile layered after core's conservative runtime-marker pass, not a duplicate implementation of the same sanitizer.
- **What was not tested:** A live Zalo Bot API round trip. The actual rebased adapter hook, current payload/transport contracts, shared sanitizer semantics, and core delivery pipeline were exercised without Zalo credentials. SQLite-backed media cases and final build startup-metadata rendering require Node 24.15+ because Node 24.14 is explicitly outside the supported runtime; exact-head CI runs on the supported runtime.

### Tests and checks

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/zalo/src/outbound-tool-trace-sanitize.test.ts \
  extensions/zalo/src/outbound-payload.contract.test.ts \
  extensions/zalo/src/actions.test.ts \
  extensions/zalo/src/send.test.ts

Test Files  4 passed (4)
Tests       21 passed (21)
```

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/shared/text/assistant-visible-text.test.ts \
  src/infra/outbound/deliver.test.ts

Test Files  2 passed (2)
Tests       254 passed (254)
```

```text
OPENCLAW_LOCALE=en OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs extensions/zalo/src/setup-surface.test.ts

Test Files  1 passed (1)
Tests       6 passed (6)
```

Additional checks completed successfully:

- extensions production and test `tsgo` lanes
- scoped `oxfmt` and `oxlint`
- conflict-marker check
- runtime import-cycle check: 0 cycles
- build completed compilation, plugin SDK export checks, postbuild, and Control UI build; the final startup-metadata phase rejected unsupported local Node 24.14 before CLI rendering
- `git diff --check`
