### PR TITLE
fix(agents): detect C1 control characters in hasControlCharacter

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1436,6 +1436,21 @@ describe("buildFailoverRemediationHint", () => {
     expect(buildProviderReauthCommand("custom\nprovider")).toBeUndefined();
   });
 
+  it("refuses C1 control characters (U+0080-U+009F) in provider ids", () => {
+    // U+009B is the CSI introducer, an alternative ANSI escape prefix (ESC [).
+    // Without the C1 range, buildProviderReauthCommand would emit a
+    // remediation command with the raw C1 byte embedded in the shell literal.
+    const CSI = String.fromCharCode(0x9b);
+    expect(buildProviderReauthCommand(`anthropic${CSI}[2J`)).toBeUndefined();
+    for (let code = 0x80; code <= 0x9f; code += 1) {
+      expect(buildProviderReauthCommand(`anthropic${String.fromCharCode(code)}`)).toBeUndefined();
+    }
+    // A clean provider id is still accepted.
+    expect(buildProviderReauthCommand("anthropic")).toBe(
+      "openclaw models auth login --provider 'anthropic' --force",
+    );
+  });
+
   it("wraps rendered provider commands in the standard CLI formatter", () => {
     expect(buildProviderReauthCommand("anthropic", { OPENCLAW_PROFILE: "work" })).toBe(
       "openclaw --profile work models auth login --provider 'anthropic' --force",

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -686,7 +686,7 @@ export function buildProviderReauthCommand(
 function hasControlCharacter(value: string): boolean {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
-    if (code < 0x20 || code === 0x7f) {
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
       return true;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`buildProviderReauthCommand()` in `src/agents/failover-error.ts` builds the copy-pasteable operator command shown in a failover **remediation hint** (`Re-authenticate with: openclaw models auth login --provider '<provider>' --force`). Before rendering, it rejects provider ids that contain control characters via `hasControlCharacter()`.

That guard only covered the C0 range (0x00-0x1f) and DEL (0x7f); it did **not** cover the C1 control range (0x80-0x9f). The C1 range includes the CSI introducer U+009B, an alternative ANSI escape prefix equivalent to `ESC [`. A provider id carrying a C1 byte therefore passed the guard and was rendered **inside the reauthentication command string**, so the C1 escape could reach a terminal that later prints/copies that remediation hint.

> Scope note: this change hardens the generated provider **reauth command** specifically. It does not claim to filter all failover error display text — only the `buildProviderReauthCommand` output.

## Change

Extend `hasControlCharacter()` to also flag 0x80-0x9f:

```ts
if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
  return true;
}
```

When the provider id contains any C1 byte, `buildProviderReauthCommand` now returns `undefined` (no command rendered), matching the existing behavior for C0/DEL. Same C1 completion as #103226 (`sanitizeForConsole`) and #103274 (`renderTerminalBufferText`).

## Testing / Proof

Extended the existing `buildProviderReauthCommand` coverage in `src/agents/failover-error.test.ts` with a focused C1 case: a provider id containing U+009B (and every byte across 0x80-0x9f) yields `undefined`, while a clean provider id still renders the expected command.

```
$ node scripts/run-vitest.mjs run src/agents/failover-error.test.ts

 RUN  v4.1.8 D:/IdeaWork/openclaw-repo

 Test Files  1 passed (1)
      Tests  98 passed (98)
   Duration  6.10s
```

The test calls the real exported `buildProviderReauthCommand`, so the passing run is the before/after proof: on current `main` `buildProviderReauthCommand("anthropic" + U+009B + "[2J")` renders a command with the raw C1 byte embedded in the shell literal; with this change it returns `undefined`.
