### PR TITLE
fix(agents): detect C1 control characters in sanitizeModelWarningValue

### DIFF
--- a/src/agents/model-selection-shared.test.ts
+++ b/src/agents/model-selection-shared.test.ts
@@ -1,0 +1,51 @@
+// Regression tests for sanitizeModelWarningValue's C1 boundary truncation,
+// exercised through the exported resolveConfiguredModelRef warning path.
+//
+// A providerless model value that contains a residual C1 control byte (one that
+// survives ANSI stripping, e.g. U+0080) must have the providerless-model
+// warning truncated at that byte, so trailing attacker-controlled text after a
+// C1 control cannot ride along into the logged warning.
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: warnMock,
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
+
+function warnFor(model: string): string {
+  warnMock.mockClear();
+  const cfg = { agents: { defaults: { model } } } as unknown as OpenClawConfig;
+  const ref = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: "openai",
+    defaultModel: "gpt-5",
+  });
+  // The resolved ref preserves the raw model; only the logged warning is sanitized.
+  expect(ref).toEqual({ provider: "openai", model });
+  return String(warnMock.mock.calls.at(-1)?.[0] ?? "");
+}
+
+describe("sanitizeModelWarningValue C1 boundary", () => {
+  it("truncates the providerless-model warning at a residual C1 byte", () => {
+    const PAD = String.fromCharCode(0x80); // C1 control that survives ANSI stripping
+    const warn = warnFor(`gpt4${PAD}EVIL`);
+    // Warning is truncated at the C1 boundary: the visible suffix is dropped.
+    expect(warn).toContain('Model "gpt4" specified without provider');
+    expect(warn).not.toContain("EVIL");
+    expect(warn).not.toContain(PAD);
+  });
+
+  it("keeps a clean providerless-model value intact in the warning", () => {
+    const warn = warnFor("gpt4");
+    expect(warn).toContain('Model "gpt4" specified without provider');
+  });
+});

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -157,7 +157,7 @@ function sanitizeModelWarningValue(value: string): string {
   let controlBoundary = -1;
   for (let index = 0; index < stripped.length; index += 1) {
     const code = stripped.charCodeAt(index);
-    if (code <= 0x1f || code === 0x7f) {
+    if (code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
       controlBoundary = index;
       break;
     }


### PR DESCRIPTION
## What Problem This Solves

`sanitizeModelWarningValue()` in `src/agents/model-selection-shared.ts` builds the value shown in the "providerless model" warning log (`Model "<value>" specified without provider. Falling back to ...`). It truncates the value at the first control character so attacker-controlled text after a control byte can't ride along into the log. The truncation boundary only covered the C0 range (0x00-0x1f) and DEL (0x7f), not the C1 control range (0x80-0x9f). C1 includes the CSI introducer U+009B (an alternative ANSI escape prefix equivalent to `ESC [`).

A **residual** C1 byte — one that survives the preceding `stripAnsi()` pass, e.g. U+0080 — was therefore not treated as a truncation boundary: `stripAnsi`/`sanitizeForLog` removed the byte itself but the visible suffix after it was retained in the warning.

## Change

Add `(code >= 0x80 && code <= 0x9f)` to the boundary predicate so a residual C1 byte truncates the warning value at that position.

## Testing / Proof

Added `src/agents/model-selection-shared.test.ts` driving the real exported `resolveConfiguredModelRef` providerless-model path (logger mocked) with `gpt4<U+0080>EVIL`, asserting the warning truncates to `Model "gpt4" ...` and drops the `EVIL` suffix (and carries no raw C1 byte).

Before/after on the exact same test, toggling only the one-line predicate:

**Before (current `main`, boundary = C0/DEL only):** test fails —
```
Received: Model "gpt4EVIL" specified without provider. Falling back to "openai/gpt4EVIL". ...
```
The residual C1 byte is dropped but the attacker suffix `EVIL` is retained.

**After (this change, boundary includes C1):** test passes —
```
$ node scripts/run-vitest.mjs run src/agents/model-selection-shared.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)
```
The warning is truncated to `Model "gpt4" ...`; the suffix after the C1 byte is dropped.
