### PR TITLE
fix(sandbox): detect C1 control characters in hasUnsafeControlChars

### DIFF
--- a/src/agents/sandbox-explain.test.ts
+++ b/src/agents/sandbox-explain.test.ts
@@ -167,4 +167,39 @@ describe("sandbox explain helpers", () => {
     expect(msg).toContain('Tool "browser" blocked by sandbox tool policy');
     expect(toolPolicyAuditInfo).not.toHaveBeenCalled();
   });
+
+  it("escapes C1 controls in the Session line and falls back to agent-only explain", () => {
+    // U+009B is the C1 CSI introducer, an alternative ANSI escape prefix (ESC [).
+    const CSI = String.fromCharCode(0x9b);
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "non-main", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            deny: ["browser"],
+          },
+        },
+      },
+    };
+
+    // Session key carries a C1 byte within its trailing (visible) 6 chars.
+    const sessionKey = `agent:main:mobilechat:group:g1${CSI}`;
+    const msg = formatSandboxToolPolicyBlockedMessage({
+      cfg,
+      sessionKey,
+      toolName: "browser",
+    });
+
+    // Visible Session label escapes the C1 byte instead of emitting it raw.
+    expect(msg).toContain("\\x9b");
+    expect(msg).not.toContain(CSI);
+    // Unsafe (C1-bearing) keys use the agent-scoped explain command and never
+    // embed the raw key in a --session argument.
+    expect(msg).toContain("openclaw sandbox explain --agent");
+    expect(msg).not.toContain("--session");
+  });
 });

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -99,7 +99,7 @@ function sanitizeForSingleLineDisplay(value: string): string {
 function hasUnsafeControlChars(value: string): boolean {
   return Array.from(value).some((char) => {
     const codePoint = char.codePointAt(0) ?? 0;
-    return codePoint < 0x20 || codePoint === 0x7f;
+    return codePoint < 0x20 || codePoint === 0x7f || (codePoint >= 0x80 && codePoint <= 0x9f);
   });
 }
 

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -131,7 +131,10 @@ export function escapeControlCharsVisible(value: string): string {
       return "\\t";
     }
     const codePoint = char.codePointAt(0) ?? 0;
-    if (codePoint < 0x20 || codePoint === 0x7f) {
+    if (codePoint < 0x20 || codePoint === 0x7f || (codePoint >= 0x80 && codePoint <= 0x9f)) {
+      // Escape C0 (0x00-0x1f), DEL (0x7f), and C1 (0x80-0x9f) controls. The C1
+      // range includes the CSI introducer U+009B (an alt ANSI escape prefix),
+      // which must not reach single-line audit/session-label output raw.
       return `\\x${codePoint.toString(16).padStart(2, "0")}`;
     }
     return char;


### PR DESCRIPTION
## What Problem This Solves

When sandbox tool policy blocks a tool, `formatSandboxToolPolicyBlockedMessage()` in `src/agents/sandbox/runtime-status.ts` renders a single-line denial message that includes a redacted `Session:` label and a `openclaw sandbox explain ...` command. Two code paths handle an untrusted session key, and both must be hardened against the C1 control range (0x80-0x9f), which includes the CSI introducer U+009B (an alternative ANSI escape prefix equivalent to `ESC [`):

1. **Explain-command gating** — `hasUnsafeControlChars()` decides whether the command uses the raw key (`--session '<key>'`) or the agent-only fallback (`--agent <id>`). It only covered C0/DEL, so a C1-bearing key was still passed to `--session`.
2. **Visible Session label** — `redactSessionKey()` → `sanitizeForSingleLineDisplay()` → the shared `escapeControlCharsVisible()` (in `src/agents/tool-policy-audit.ts`). It only escaped C0/DEL, so a C1 byte in the redacted first/last-6 of the key reached the visible `Session:` line **raw**.

The first review pass only fixed path (1). This revision fixes **both**, matching ClawSweeper's recommended solution ("extend the shared visible-control escaping contract through C1, retain the agent-only fallback for unsafe keys, and test both outputs").

## Change

- `hasUnsafeControlChars` now treats 0x80-0x9f as unsafe → agent-only explain fallback for C1-bearing keys.
- `escapeControlCharsVisible` (shared) now escapes 0x80-0x9f as `\xNN` → the visible Session label no longer emits raw C1 bytes.

## Testing / Proof

Added an end-to-end regression in `src/agents/sandbox-explain.test.ts` that calls the real `formatSandboxToolPolicyBlockedMessage` with a session key whose trailing (visible) 6 chars contain U+009B, asserting both outputs:

- the `Session:` line contains the escaped `\x9b` and **not** the raw C1 byte;
- the explain command falls back to `openclaw sandbox explain --agent ...` and never emits `--session` with the raw key.

```
$ node scripts/run-vitest.mjs run src/agents/sandbox-explain.test.ts

 RUN  v4.1.8 D:/IdeaWork/openclaw-repo

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  2.79s
```

The test drives the real formatting path, so the passing run is the before/after proof: on current `main` the same input leaves the raw U+009B in the Session line and routes to `--session`; with this change it is escaped and routed to `--agent`.
