### PR TITLE
fix(agents): detect C1 control characters in attachment name validation

### DIFF
--- a/src/agents/subagent-attachments.test.ts
+++ b/src/agents/subagent-attachments.test.ts
@@ -1,0 +1,76 @@
+// Regression tests for attachment-name validation, focused on C1 control
+// rejection and on not leaking raw control bytes back into the diagnostic.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAcpSessionsSpawnImageAttachments } from "./subagent-attachments.js";
+
+const CONFIG = {
+  tools: { sessions_spawn: { attachments: { enabled: true } } },
+} as unknown as OpenClawConfig;
+
+// base64 for "hello" (5 bytes), well under the default per-file limit.
+const HELLO_B64 = "aGVsbG8=";
+
+function errorOf(result: ReturnType<typeof resolveAcpSessionsSpawnImageAttachments>): string {
+  return result && result.status === "error" ? result.error : "";
+}
+
+describe("resolveAcpSessionsSpawnImageAttachments name validation", () => {
+  it("rejects a C1-bearing name and escapes it in the diagnostic", () => {
+    // U+009B is the C1 CSI introducer (alternative ANSI escape prefix, ESC [).
+    const CSI = String.fromCharCode(0x9b);
+    const result = resolveAcpSessionsSpawnImageAttachments({
+      config: CONFIG,
+      attachments: [
+        {
+          name: `bad${CSI}name.png`,
+          content: HELLO_B64,
+          encoding: "base64",
+          mimeType: "image/png",
+        },
+      ],
+    });
+
+    expect(result?.status).toBe("error");
+    const error = errorOf(result);
+    expect(error).toContain("attachments_invalid_name");
+    // The rejected name is echoed with the C1 byte escaped, not raw.
+    expect(error).toContain("\\x9b");
+    expect(error).not.toContain(CSI);
+  });
+
+  it("rejects every byte across the full C1 range 0x80-0x9f", () => {
+    for (let code = 0x80; code <= 0x9f; code += 1) {
+      const result = resolveAcpSessionsSpawnImageAttachments({
+        config: CONFIG,
+        attachments: [
+          {
+            name: `n${String.fromCharCode(code)}m.png`,
+            content: HELLO_B64,
+            encoding: "base64",
+            mimeType: "image/png",
+          },
+        ],
+      });
+      expect(result?.status).toBe("error");
+      expect(errorOf(result)).toContain("attachments_invalid_name");
+      // No raw C1 byte survives into the returned diagnostic.
+      expect(errorOf(result)).not.toContain(String.fromCharCode(code));
+    }
+  });
+
+  it("accepts an ordinary image attachment name", () => {
+    const result = resolveAcpSessionsSpawnImageAttachments({
+      config: CONFIG,
+      attachments: [
+        {
+          name: "photo.png",
+          content: HELLO_B64,
+          encoding: "base64",
+          mimeType: "image/png",
+        },
+      ],
+    });
+    expect(result?.status).toBe("ok");
+  });
+});

--- a/src/agents/subagent-attachments.ts
+++ b/src/agents/subagent-attachments.ts
@@ -162,7 +162,7 @@ function validateAttachmentName(name: string): void {
   if (
     Array.from(name).some((char) => {
       const code = char.codePointAt(0) ?? 0;
-      return code < 0x20 || code === 0x7f;
+      return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
     })
   ) {
     failAttachment(`attachments_invalid_name (${name})`);

--- a/src/agents/subagent-attachments.ts
+++ b/src/agents/subagent-attachments.ts
@@ -152,12 +152,28 @@ function failAttachment(error: string): never {
   throw new Error(error);
 }
 
+// Renders a rejected, untrusted attachment name for diagnostics without
+// leaking raw control bytes: C0 (0x00-0x1f), DEL (0x7f), and C1 (0x80-0x9f)
+// are escaped to visible \xNN sequences (C1 includes the U+009B CSI
+// introducer), and the result is capped by code point so it stays single-line
+// and bounded even for adversarial names.
+function describeRejectedName(name: string): string {
+  const chars = Array.from(name, (char) => {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      return `\\x${code.toString(16).padStart(2, "0")}`;
+    }
+    return char;
+  });
+  return chars.length > 80 ? `${chars.slice(0, 80).join("")}...` : chars.join("");
+}
+
 function validateAttachmentName(name: string): void {
   if (!name) {
     failAttachment("attachments_invalid_name (empty)");
   }
   if (name.includes("/") || name.includes("\\") || name.includes("\u0000")) {
-    failAttachment(`attachments_invalid_name (${name})`);
+    failAttachment(`attachments_invalid_name (${describeRejectedName(name)})`);
   }
   if (
     Array.from(name).some((char) => {
@@ -165,10 +181,10 @@ function validateAttachmentName(name: string): void {
       return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
     })
   ) {
-    failAttachment(`attachments_invalid_name (${name})`);
+    failAttachment(`attachments_invalid_name (${describeRejectedName(name)})`);
   }
   if (name === "." || name === ".." || name === ".manifest.json") {
-    failAttachment(`attachments_invalid_name (${name})`);
+    failAttachment(`attachments_invalid_name (${describeRejectedName(name)})`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`validateAttachmentName()` in `src/agents/subagent-attachments.ts` rejects unsafe `sessions_spawn` attachment names. It checked for control characters but only covered the C0 range (0x00-0x1f) and DEL (0x7f), missing the C1 control range (0x80-0x9f). The C1 range includes the CSI introducer U+009B, an alternative ANSI escape prefix equivalent to `ESC [`.

Two issues, both addressed here:

1. **Detection gap** — a name carrying a C1 byte was accepted.
2. **Diagnostic leak** (raised by ClawSweeper) — the rejection error `attachments_invalid_name (${name})` interpolated the **raw** untrusted name, so even after rejection the same control bytes were re-introduced into an error string that can reach a terminal or log.

## Change

- Extend the control-character predicate to cover 0x80-0x9f (C1).
- Add `describeRejectedName()` which escapes C0/DEL/C1 to visible `\xNN` sequences and caps the name by code point, and use it in every `attachments_invalid_name (...)` diagnostic. The rejected name is now safe to display and never carries raw control bytes.

## Testing / Proof

Added `src/agents/subagent-attachments.test.ts` driving the real exported `resolveAcpSessionsSpawnImageAttachments` path:

- a C1-bearing name (`bad<U+009B>name.png`) returns `status: "error"` with `attachments_invalid_name`, the byte rendered as escaped `\x9b`, and **no raw C1 byte** in the returned error;
- every byte across the full 0x80-0x9f range is rejected with no raw byte leaking;
- an ordinary image attachment (`photo.png`) still succeeds (`status: "ok"`).

```
$ node scripts/run-vitest.mjs run src/agents/subagent-attachments.test.ts

 RUN  v4.1.8 D:/IdeaWork/openclaw-repo

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  1.64s
```

The test exercises the real validation + diagnostic path, so the passing run is the before/after proof: on current `main` the C1 name is accepted and, once other checks reject it, the raw byte is echoed back in the error; with this change the name is rejected and the diagnostic is escaped.
