### PR TITLE
fix(doctor): strip C1 control characters from doctor error messages

### DIFF
--- a/src/flows/doctor-error-message.test.ts
+++ b/src/flows/doctor-error-message.test.ts
@@ -1,0 +1,35 @@
+// Regression tests for doctor error-message sanitization, focused on the C1
+// control range (U+0080-U+009F) added on top of the existing C0/DEL stripping.
+import { describe, expect, it } from "vitest";
+import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
+
+const CSI = String.fromCharCode(0x9b); // C1 CSI introducer, alt ANSI escape prefix
+const NUL = String.fromCharCode(0x00);
+const BEL = String.fromCharCode(0x07);
+const DEL = String.fromCharCode(0x7f);
+
+describe("scrubDoctorErrorMessage", () => {
+  it("strips the CSI introducer U+009B while keeping surrounding text", () => {
+    const input = new Error(`boot ${CSI}31mfailed${CSI}0m`);
+    expect(scrubDoctorErrorMessage(input)).toBe("boot 31mfailed0m");
+  });
+
+  it("removes the full C1 range 0x80-0x9f", () => {
+    let raw = "";
+    for (let code = 0x80; code <= 0x9f; code += 1) {
+      raw += String.fromCharCode(code);
+    }
+    expect(scrubDoctorErrorMessage(new Error(`a${raw}b`))).toBe("ab");
+  });
+
+  it("preserves ordinary printable Unicode above the C1 range", () => {
+    // U+00A0 (NBSP) and beyond must survive; only 0x80-0x9f are stripped.
+    const input = new Error("café ☕ 日本語 \u{1f680}");
+    expect(scrubDoctorErrorMessage(input)).toBe("café ☕ 日本語 \u{1f680}");
+  });
+
+  it("still strips C0 controls and DEL", () => {
+    const input = new Error(`x${NUL}${BEL}${DEL}y`);
+    expect(scrubDoctorErrorMessage(input)).toBe("xy");
+  });
+});

--- a/src/flows/doctor-error-message.ts
+++ b/src/flows/doctor-error-message.ts
@@ -3,13 +3,13 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Shared sanitization for doctor/lint/repair errors shown in terminal output.
 const ERR_MESSAGE_MAX_LEN = 256;
 
-/** Removes control characters and caps error messages before doctor prints them. */
+/** Removes C0/C1 control characters and caps error messages before doctor prints them. */
 export function scrubDoctorErrorMessage(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
   let stripped = "";
   for (let index = 0; index < raw.length; index++) {
     const code = raw.charCodeAt(index);
-    if (code > 0x1f && code !== 0x7f) {
+    if (code > 0x1f && code !== 0x7f && (code < 0x80 || code > 0x9f)) {
       stripped += raw.charAt(index);
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`scrubDoctorErrorMessage()` in `src/flows/doctor-error-message.ts` strips control characters before doctor/lint/repair errors are printed to the terminal, but it only removed the C0 range (0x00-0x1f) and DEL (0x7f). It did **not** remove the C1 control range (0x80-0x9f), which includes the CSI introducer U+009B — an alternative ANSI escape prefix equivalent to `ESC [`. A C1-bearing error message could therefore reach the terminal and drive cursor/color escapes.

## Change

Extend the existing predicate to also drop 0x80-0x9f:

```ts
if (code > 0x1f && code !== 0x7f && (code < 0x80 || code > 0x9f)) {
  stripped += raw.charAt(index);
}
```

Same C1 completion Peter merged for `renderTerminalBufferText` in #103274 ("Extended the existing terminal-text residual filter through DEL/C1 while preserving tabs").

## Testing / Proof

Added a focused regression test `src/flows/doctor-error-message.test.ts` that calls the real `scrubDoctorErrorMessage` and asserts:

- U+009B (CSI) is removed while surrounding text is preserved
- the full C1 range 0x80-0x9f is removed
- printable Unicode above C1 (accented Latin, CJK, emoji) is preserved
- C0 controls and DEL are still stripped

```
$ node scripts/run-vitest.mjs run src/flows/doctor-error-message.test.ts

 RUN  v4.1.8 D:/IdeaWork/openclaw-repo

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  2.36s
```

The test exercises the modified function directly, so the passing run demonstrates the exact before/after behavior: on current `main` the U+009B and full-C1 cases fail (bytes retained), and with this change they are removed while ordinary Unicode survives.
