### PR TITLE
fix(xai): align image and video capability contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **xAI media contracts:** align image edit reference limits and aspect ratios with the current API, default classic video generation to 480p, inherit source geometry for image-to-video, and stop advertising unsupported geometry overrides for video edit/extend. (#103360)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **xAI media contracts:** align image edit reference limits and aspect ratios with the current API, default classic video generation to 480p, inherit source geometry for image-to-video, and stop advertising unsupported geometry overrides for video edit/extend. (#103360)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -582,9 +582,11 @@ request. Plugin dependencies are expected to be present before runtime load.
   - Provider-specific Vydra coverage:
     - `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_VYDRA_VIDEO=1 pnpm test:live -- extensions/vydra/vydra.live.test.ts`
     - That file runs `veo3` text-to-video plus a `kling` image-to-video lane that uses a remote image URL fixture by default (`OPENCLAW_LIVE_VYDRA_KLING_IMAGE_URL` to override).
-  - Provider-specific xAI Video 1.5 coverage:
-    - `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO_15=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "Grok Imagine Video 1.5"`
-    - The case generates a local PNG first frame, requests a one-second 1080P image-to-video clip, polls to completion, and verifies the downloaded video buffer.
+  - Provider-specific xAI coverage:
+    - `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "classic Grok Imagine"`
+    - The classic case generates a square local PNG first frame, omits geometry, requests a one-second image-to-video clip, polls to completion, and verifies the downloaded buffer.
+    - `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "Grok Imagine Video 1.5"`
+    - The 1.5 case generates a local PNG first frame, requests a one-second 1080P image-to-video clip, polls to completion, and verifies the downloaded buffer.
   - Current `videoToVideo` live coverage:
     - `runway` only when the selected model resolves to `gen4_aleph`
   - Current declared-but-skipped `videoToVideo` providers in the shared sweep:

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -225,13 +225,16 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
       remote video edit, and remote video extension
     - Video 1.5 mode: image-to-video only, with exactly one first-frame image
     - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`;
-      Video 1.5 inherits the source image ratio when omitted
-    - Resolutions: classic `480P`/`720P`; Video 1.5 supports `480P`, `720P`,
-      and `1080P`, and defaults to `480P`
+      classic and Video 1.5 image-to-video inherit the source image ratio when
+      omitted
+    - Resolutions: classic `480P`/`720P`; Video 1.5 also supports `1080P`; all
+      generation modes default to `480P`
     - Duration: 1-15 seconds for generation/image-to-video, 1-10 seconds when
       using classic `reference_image` roles, 2-10 seconds for classic extension
     - Reference-image generation: set `imageRoles` to `reference_image` for
       every supplied image; xAI accepts up to 7 such images
+    - Video edit/extend inherit the input video's aspect ratio and resolution;
+      those operations do not accept geometry overrides
     - Default operation timeout: 600 seconds unless `video_generate.timeoutMs`
       or `agents.defaults.videoGenerationModel.timeoutMs` is set
 
@@ -273,8 +276,9 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     - Default image model: `xai/grok-imagine-image`
     - Additional model: `xai/grok-imagine-image-quality`
     - Modes: text-to-image and reference-image edit
-    - Reference inputs: one `image` or up to five `images`
-    - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `2:3`, `3:2`
+    - Reference inputs: one `image` or up to three `images`
+    - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`, `2:1`,
+      `1:2`, `19.5:9`, `9:19.5`, `20:9`, `9:20`
     - Resolutions: `1K`, `2K`
     - Count: up to 4 images
     - Default operation timeout: 600 seconds unless `image_generate.timeoutMs`
@@ -300,10 +304,9 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     ```
 
     <Note>
-    xAI also documents `quality`, `mask`, `user`, and additional native ratios
-    such as `1:2`, `2:1`, `9:20`, and `20:9`. OpenClaw forwards only the shared
-    cross-provider image controls today; these native-only knobs are not
-    exposed through `image_generate`.
+    xAI also documents `quality`, `mask`, `user`, and an `auto` aspect ratio.
+    OpenClaw forwards only the shared cross-provider image controls today;
+    these native-only knobs are not exposed through `image_generate`.
     </Note>
 
   </Accordion>
@@ -519,9 +522,9 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     - xAI Realtime voice is not registered as an OpenClaw provider yet. It
       needs a different bidirectional voice session contract than batch STT
       or streaming transcription.
-    - xAI image `quality`, image `mask`, and extra native-only aspect ratios
-      are not exposed until the shared `image_generate` tool has
-      corresponding cross-provider controls.
+    - xAI image `quality`, image `mask`, and the native `auto` aspect ratio are
+      not exposed until the shared `image_generate` tool has corresponding
+      cross-provider controls.
   </Accordion>
 
   <Accordion title="Advanced notes">
@@ -560,7 +563,8 @@ The xAI media paths are covered by unit tests and opt-in live suites. Export
 ```bash
 pnpm test extensions/xai
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 pnpm test:live -- extensions/xai/xai.live.test.ts
-OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO_15=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "Grok Imagine Video 1.5"
+OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "classic Grok Imagine"
+OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_XAI_VIDEO=1 pnpm test:live -- extensions/xai/xai.live.test.ts -t "Grok Imagine Video 1.5"
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 pnpm test:live -- extensions/xai/x-search.live.test.ts
 OPENCLAW_LIVE_GATEWAY_MODELS="xai/grok-4.5,xai/grok-build-0.1,xai/grok-4.3,xai/grok-4.20-0309-reasoning,xai/grok-4.20-0309-non-reasoning" OPENCLAW_LIVE_GATEWAY_MAX_MODELS=0 OPENCLAW_LIVE_GATEWAY_SMOKE=0 pnpm test:live -- src/gateway/gateway-models.profiles.live.test.ts
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=1 OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS=xai pnpm test:live -- test/image-generation.runtime.live.test.ts

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -108,7 +108,7 @@ backend emits it.
 | OpenAI            | `gpt-image-2`                           | Yes (up to 5 images)               | `OPENAI_API_KEY` or OpenAI ChatGPT/Codex OAuth        |
 | OpenRouter        | `google/gemini-3.1-flash-image-preview` | Yes (up to 5 input images)         | `OPENROUTER_API_KEY`                                  |
 | Vydra             | `grok-imagine`                          | No                                 | `VYDRA_API_KEY`                                       |
-| xAI               | `grok-imagine-image`                    | Yes (up to 5 images)               | `XAI_API_KEY`                                         |
+| xAI               | `grok-imagine-image`                    | Yes (up to 3 images)               | `XAI_API_KEY`                                         |
 
 Use `action: "list"` to inspect available providers and models at runtime:
 
@@ -128,7 +128,7 @@ current session:
 | Capability            | ComfyUI            | DeepInfra | fal                                            | Google         | Microsoft Foundry | MiniMax               | OpenAI         | Vydra | xAI            |
 | --------------------- | ------------------ | --------- | ---------------------------------------------- | -------------- | ----------------- | --------------------- | -------------- | ----- | -------------- |
 | Generate (max count)  | 1                  | 4         | 4                                              | 4              | 1                 | 9                     | 4              | 1     | 4              |
-| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; Krea style refs: 10; NB2: 14 | Up to 5 images | 1 image           | 1 image (subject ref) | Up to 5 images | -     | Up to 5 images |
+| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; Krea style refs: 10; NB2: 14 | Up to 5 images | 1 image           | 1 image (subject ref) | Up to 5 images | -     | Up to 3 images |
 | Size control          | -                  | ✓         | ✓                                              | ✓              | ✓                 | -                     | Up to 4K       | -     | -              |
 | Aspect ratio          | -                  | -         | ✓                                              | ✓              | -                 | ✓                     | -              | -     | ✓              |
 | Resolution (1K/2K/4K) | -                  | -         | ✓                                              | ✓              | -                 | -                     | -              | -     | 1K, 2K         |
@@ -271,11 +271,11 @@ inputs. Pass a reference image path or URL:
 "Generate a watercolor version of this photo" + image: "/path/to/photo.jpg"
 ```
 
-OpenAI, OpenRouter, Google, and xAI support up to 5 reference images via the
-`images` parameter. fal supports 1 reference image for Flux image-to-image,
-up to 10 for GPT Image 2 edits, up to 10 style references for Krea 2, and up
-to 14 for Nano Banana 2 edits. Microsoft Foundry, MiniMax, and ComfyUI
-support 1.
+OpenAI, OpenRouter, and Google support up to 5 reference images via the
+`images` parameter; xAI supports up to 3. fal supports 1 reference image for
+Flux image-to-image, up to 10 for GPT Image 2 edits, up to 10 style references
+for Krea 2, and up to 14 for Nano Banana 2 edits. Microsoft Foundry, MiniMax,
+and ComfyUI support 1.
 
 ## Provider deep dives
 
@@ -457,14 +457,15 @@ support 1.
 
     - Models: `xai/grok-imagine-image`, `xai/grok-imagine-image-quality`
     - Count: up to 4
-    - References: one `image` or up to five `images`
-    - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `2:3`, `3:2`
+    - References: one `image` or up to three `images`
+    - Aspect ratios: `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`, `2:1`,
+      `1:2`, `19.5:9`, `9:19.5`, `20:9`, `9:20`
     - Resolutions: `1K`, `2K`
     - Outputs: returned as OpenClaw-managed image attachments
 
     OpenClaw intentionally does not expose xAI-native `quality`, `mask`,
-    `user`, or extra native-only aspect ratios until those controls exist
-    in the shared cross-provider `image_generate` contract.
+    `user`, or the `auto` aspect ratio until those controls exist in the shared
+    cross-provider `image_generate` contract.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -425,7 +425,11 @@ only the explicit `model`, `primary`, and `fallbacks` entries.
   <Accordion title="xAI">
     The default `grok-imagine-video` model supports text-to-video, single
     first-frame image-to-video, up to 7 `reference_image` inputs through xAI
-    `reference_images`, and remote video edit/extend flows.
+    `reference_images`, and remote video edit/extend flows. Generation defaults
+    to `480P`; single-image image-to-video inherits the source ratio when
+    `aspectRatio` is omitted. Video edit/extend inherit the input geometry and
+    do not accept aspect-ratio or resolution overrides. Extension accepts 2-10
+    seconds.
 
     `grok-imagine-video-1.5` is image-to-video only: provide exactly one image.
     It supports 1-15 seconds and `480P`, `720P`, or `1080P`, defaulting to

--- a/extensions/xai/image-generation-provider.test.ts
+++ b/extensions/xai/image-generation-provider.test.ts
@@ -128,11 +128,17 @@ describe("xai image generation provider", () => {
       "9:16",
       "4:3",
       "3:4",
-      "2:3",
       "3:2",
+      "2:3",
+      "2:1",
+      "1:2",
+      "19.5:9",
+      "9:19.5",
+      "20:9",
+      "9:20",
     ]);
     expect(provider.capabilities.edit.enabled).toBe(true);
-    expect(provider.capabilities.edit.maxInputImages).toBe(5);
+    expect(provider.capabilities.edit.maxInputImages).toBe(3);
     const isConfigured = provider.isConfigured;
     if (!isConfigured) {
       throw new Error("expected XAI image provider config predicate");
@@ -157,7 +163,7 @@ describe("xai image generation provider", () => {
       provider: "xai",
       model: "grok-imagine-image",
       prompt: "test prompt",
-      aspectRatio: "2:3",
+      aspectRatio: "20:9",
       resolution: "2K",
       cfg: {
         models: {
@@ -190,7 +196,7 @@ describe("xai image generation provider", () => {
     expect(request.url).toContain("/images/generations");
     expect(provider.defaultTimeoutMs).toBe(600_000);
     expect(request.timeoutMs).toBe(600_000);
-    expect(request.body?.aspect_ratio).toBe("2:3");
+    expect(request.body?.aspect_ratio).toBe("20:9");
     expect(request.body?.resolution).toBe("2k");
     expect(resolveProviderOperationTimeoutMsMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -283,6 +289,7 @@ describe("xai image generation provider", () => {
       inputImages: [
         { buffer: Buffer.from("first"), mimeType: "image/png" },
         { buffer: Buffer.from("second"), mimeType: "image/jpeg" },
+        { buffer: Buffer.from("third"), mimeType: "image/webp" },
       ],
       cfg: {},
     } as any);
@@ -290,10 +297,30 @@ describe("xai image generation provider", () => {
     const request = requirePostJsonCall();
     expect(request.url).toContain("/images/edits");
     const images = request.body?.images as Array<{ url?: string; type?: string }> | undefined;
-    expect(images).toHaveLength(2);
+    expect(images).toHaveLength(3);
     expect(images?.[0]?.url).toContain("data:image/png;base64,");
     expect(images?.[0]?.type).toBe("image_url");
     expect(images?.[1]?.url).toContain("data:image/jpeg;base64,");
     expect(images?.[1]?.type).toBe("image_url");
+    expect(images?.[2]?.url).toContain("data:image/webp;base64,");
+    expect(images?.[2]?.type).toBe("image_url");
+  });
+
+  it("rejects more than three xAI edit references before HTTP", async () => {
+    const provider = buildXaiImageGenerationProvider();
+
+    await expect(
+      provider.generateImage({
+        provider: "xai",
+        model: "grok-imagine-image",
+        prompt: "Combine the references",
+        inputImages: Array.from({ length: 4 }, (_, index) => ({
+          buffer: Buffer.from(`reference-${index}`),
+          mimeType: "image/png",
+        })),
+        cfg: {},
+      } as any),
+    ).rejects.toThrow("xAI image editing supports up to 3 reference images");
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/xai/image-generation-provider.ts
+++ b/extensions/xai/image-generation-provider.ts
@@ -16,7 +16,21 @@ import { XAI_BASE_URL, XAI_DEFAULT_IMAGE_MODEL, XAI_IMAGE_MODELS } from "./model
 
 const DEFAULT_TIMEOUT_MS = 600_000;
 
-const XAI_SUPPORTED_ASPECT_RATIOS = ["1:1", "16:9", "9:16", "4:3", "3:4", "2:3", "3:2"] as const;
+const XAI_SUPPORTED_ASPECT_RATIOS = [
+  "1:1",
+  "16:9",
+  "9:16",
+  "4:3",
+  "3:4",
+  "3:2",
+  "2:3",
+  "2:1",
+  "1:2",
+  "19.5:9",
+  "9:19.5",
+  "20:9",
+  "9:20",
+] as const;
 
 function resolveImageForEdit(
   input: (ImageGenerationSourceImage & { url?: string }) | undefined,
@@ -94,7 +108,7 @@ export function buildXaiImageGenerationProvider(): ImageGenerationProvider {
       edit: {
         enabled: true,
         maxCount: 4,
-        maxInputImages: 5,
+        maxInputImages: 3,
         supportsAspectRatio: true,
         supportsResolution: true,
         supportsSize: false,

--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -163,7 +163,13 @@ function oversizedJsonResponse(): {
 
 describe("xai video generation provider", () => {
   it("declares explicit mode capabilities", () => {
-    expectExplicitVideoGenerationCapabilities(buildXaiVideoGenerationProvider());
+    const provider = buildXaiVideoGenerationProvider();
+    expectExplicitVideoGenerationCapabilities(provider);
+    expect(provider.capabilities.videoToVideo).toMatchObject({
+      maxDurationSeconds: 10,
+      supportsAspectRatio: false,
+      supportsResolution: false,
+    });
   });
 
   it("advertises canonical 1.5 and resolves capabilities for all API aliases", async () => {
@@ -644,6 +650,8 @@ describe("xai video generation provider", () => {
     expect(image?.url).toMatch(/^data:image\/png;base64,/u);
     const body = request.body ?? {};
     expect(body).not.toHaveProperty("reference_images");
+    expect(body).not.toHaveProperty("aspect_ratio");
+    expect(body.resolution).toBe("480p");
     expect(result.metadata?.mode).toBe("generate");
   });
 
@@ -746,13 +754,17 @@ describe("xai video generation provider", () => {
       model: "grok-imagine-video",
       prompt: "Continue the shot into a neon alleyway",
       cfg: {},
-      durationSeconds: 8,
+      durationSeconds: 15,
+      aspectRatio: "9:16",
+      resolution: "1080P",
       inputVideos: [{ url: "https://example.com/input.mp4" }],
     });
 
     const request = requirePostJsonCall();
     expect(request.url).toBe("https://api.x.ai/v1/videos/extensions");
     expect(request.body?.video).toEqual({ url: "https://example.com/input.mp4" });
-    expect(request.body?.duration).toBe(8);
+    expect(request.body?.duration).toBe(10);
+    expect(request.body).not.toHaveProperty("aspect_ratio");
+    expect(request.body).not.toHaveProperty("resolution");
   });
 });

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -58,8 +58,7 @@ const XAI_VIDEO_MALFORMED_RESPONSE = "xAI video generation response malformed";
 const XAI_VIDEO_TERMINAL_FAILURE_STATUSES = new Set(["failed", "error", "expired", "cancelled"]);
 const XAI_VIDEO_DEFAULT_DURATION_SECONDS = 8;
 const XAI_VIDEO_DEFAULT_ASPECT_RATIO = "16:9";
-const XAI_VIDEO_DEFAULT_RESOLUTION = "720p";
-const XAI_VIDEO_15_DEFAULT_RESOLUTION = "480p";
+const XAI_VIDEO_DEFAULT_RESOLUTION = "480p";
 const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
 
 type XaiVideoCreateResponse = {
@@ -320,15 +319,13 @@ function buildCreateBody(req: VideoGenerationRequest): Record<string, unknown> {
         max: 15,
       }) ?? XAI_VIDEO_DEFAULT_DURATION_SECONDS;
     const aspectRatio = resolveAspectRatio(req.aspectRatio);
-    // 1.5 inherits the source image ratio when callers do not choose one.
-    if (aspectRatio || !isVideo15) {
+    // Image-to-video inherits the source frame's ratio when callers omit it;
+    // text-to-video retains xAI's 16:9 default.
+    if (aspectRatio || !imageUrl) {
       body.aspect_ratio = aspectRatio ?? XAI_VIDEO_DEFAULT_ASPECT_RATIO;
     }
-    const defaultResolution = isVideo15
-      ? XAI_VIDEO_15_DEFAULT_RESOLUTION
-      : XAI_VIDEO_DEFAULT_RESOLUTION;
     body.resolution =
-      resolveResolution(req.resolution, { allow1080p: isVideo15 }) ?? defaultResolution;
+      resolveResolution(req.resolution, { allow1080p: isVideo15 }) ?? XAI_VIDEO_DEFAULT_RESOLUTION;
     return body;
   }
 
@@ -482,9 +479,9 @@ export function buildXaiVideoGenerationProvider(): VideoGenerationProvider {
         enabled: true,
         maxVideos: 1,
         maxInputVideos: 1,
-        maxDurationSeconds: 15,
-        supportsAspectRatio: true,
-        supportsResolution: true,
+        maxDurationSeconds: 10,
+        supportsAspectRatio: false,
+        supportsResolution: false,
       },
     },
     resolveModelCapabilities: ({ model }): VideoGenerationProviderCapabilities | undefined => {

--- a/extensions/xai/xai.live.test.ts
+++ b/extensions/xai/xai.live.test.ts
@@ -23,7 +23,7 @@ import { XAI_DEFAULT_STT_MODEL } from "./stt.js";
 
 const XAI_API_KEY = process.env.XAI_API_KEY ?? "";
 const LIVE_IMAGE_MODEL = process.env.OPENCLAW_LIVE_XAI_IMAGE_MODEL?.trim() || "grok-imagine-image";
-const ENABLE_VIDEO_15_LIVE = process.env.OPENCLAW_LIVE_XAI_VIDEO_15 === "1";
+const ENABLE_VIDEO_LIVE = process.env.OPENCLAW_LIVE_XAI_VIDEO === "1";
 const liveEnabled = XAI_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
 const describeLive = liveEnabled ? describe : describe.skip;
 const EMPTY_AUTH_STORE = { version: 1, profiles: {} } as const;
@@ -427,7 +427,7 @@ describeLive("xai plugin live", () => {
           authStore: EMPTY_AUTH_STORE,
           timeoutMs: 180_000,
           count: 1,
-          aspectRatio: "1:1",
+          aspectRatio: "20:9",
           resolution: "1K",
         });
 
@@ -439,8 +439,7 @@ describeLive("xai plugin live", () => {
         const edited = await imageProvider.generateImage({
           provider: "xai",
           model: LIVE_IMAGE_MODEL,
-          prompt:
-            "Render this image as a pencil sketch with detailed shading. Keep the same framing.",
+          prompt: "Combine these three references into one detailed pencil sketch.",
           cfg,
           agentDir,
           authStore: EMPTY_AUTH_STORE,
@@ -451,7 +450,17 @@ describeLive("xai plugin live", () => {
             {
               buffer: createReferencePng(),
               mimeType: "image/png",
-              fileName: "reference.png",
+              fileName: "reference-1.png",
+            },
+            {
+              buffer: createReferencePng(),
+              mimeType: "image/png",
+              fileName: "reference-2.png",
+            },
+            {
+              buffer: createReferencePng(),
+              mimeType: "image/png",
+              fileName: "reference-3.png",
             },
           ],
         });
@@ -466,7 +475,55 @@ describeLive("xai plugin live", () => {
     });
   }, 300_000);
 
-  it.skipIf(!ENABLE_VIDEO_15_LIVE)(
+  it.skipIf(!ENABLE_VIDEO_LIVE)(
+    "generates a classic Grok Imagine clip with inherited image geometry",
+    async () => {
+      await runXaiLiveCase("video-classic-i2v", async () => {
+        const { videoProviders } = await registerXaiPlugin();
+        const videoProvider = requireRegisteredProvider(videoProviders, "xai");
+        const cfg = createLiveConfig();
+        const agentDir = await createTempAgentDir();
+
+        try {
+          const generated = await videoProvider.generateVideo({
+            provider: "xai",
+            model: "grok-imagine-video",
+            prompt: "Animate the square gently while preserving the square framing.",
+            cfg,
+            agentDir,
+            authStore: EMPTY_AUTH_STORE,
+            timeoutMs: 10 * 60_000,
+            durationSeconds: 1,
+            inputImages: [
+              {
+                buffer: createVideoReferencePng(),
+                mimeType: "image/png",
+                fileName: "video-reference.png",
+              },
+            ],
+          });
+
+          expect(generated.model).toBe("grok-imagine-video");
+          expect(generated.videos).toHaveLength(1);
+          const video = generated.videos[0];
+          if (!video?.buffer) {
+            throw new Error("xAI classic image-to-video did not return a buffered video");
+          }
+          expect(video.mimeType.startsWith("video/")).toBe(true);
+          expect(video.buffer.byteLength).toBeGreaterThan(1_000);
+          const outputPath = process.env.OPENCLAW_LIVE_XAI_VIDEO_OUTPUT?.trim();
+          if (outputPath) {
+            await fs.writeFile(outputPath, video.buffer);
+          }
+        } finally {
+          await fs.rm(agentDir, { recursive: true, force: true });
+        }
+      });
+    },
+    12 * 60_000,
+  );
+
+  it.skipIf(!ENABLE_VIDEO_LIVE)(
     "generates a Grok Imagine Video 1.5 clip from one image",
     async () => {
       await runXaiLiveCase("video-1.5", async () => {


### PR DESCRIPTION
Closes #103360

## What Problem This Solves

Fixes an issue where xAI image/video users received stale provider limits and defaults: valid wide/tall image ratios were dropped, image edits advertised too many references, classic image-to-video forced 16:9, classic generation defaulted to 720p, and video edit/extend advertised geometry controls that xAI ignores.

## Why This Change Was Made

The xAI plugin now matches the current developer API contract while keeping every live media model and alias:

- image edit accepts at most three references and advertises all shared ratios xAI currently supports;
- classic video generation defaults to 480p;
- classic and Video 1.5 image-to-video omit an unspecified ratio so xAI inherits the source frame;
- classic video edit/extend advertise no aspect-ratio or resolution override, and extension caps at 10 seconds;
- provider docs and the xAI live lanes describe and exercise the same contract.

Native-only image controls such as `auto`, `quality`, and `mask`, the shared four-output cap, and local video-buffer edit support remain separate boundaries.

## User Impact

xAI image users can request six additional supported aspect ratios and get a correct three-reference limit. Classic video users get xAI's documented 480p default and source-ratio inheritance for image-to-video. Video edit/extend schemas no longer offer controls the API does not accept.

## Evidence

- Focused provider tests: 24/24 passed through the narrow Codex-worktree runner. Blacksmith reclaimed two fresh Testbox leases during checkout and the AWS fallback had no host credentials; exact-head hosted CI remains the broad landing gate.
- Live xAI image provider: one `20:9` generation and one three-reference edit passed.
- Live xAI classic video provider: omitted geometry on a square first frame returned one H.264 MP4, 544x544, 1.041667 seconds.
- Authenticated live catalog: both canonical image models, both canonical video models, and both Video 1.5 aliases returned HTTP 200; no model removal is needed.
- Fresh autoreview: clean, no actionable findings.
- `git diff --check`: passed.

Official contracts:

- https://docs.x.ai/developers/model-capabilities/images/generation
- https://docs.x.ai/developers/model-capabilities/images/multi-image-editing
- https://docs.x.ai/developers/model-capabilities/video/generation
- https://docs.x.ai/developers/model-capabilities/video/editing
- https://docs.x.ai/developers/model-capabilities/video/extension

## Release Note Context

Align xAI image edit reference limits and aspect ratios with the current API, default classic video generation to 480p, inherit source geometry for image-to-video, and stop advertising unsupported geometry overrides for video edit/extend. Related: #103360.
