### PR TITLE
fix(agents): adopt orphaned managed worktrees left by a crash between git worktree add and registry insert

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1608,6 +1608,7 @@ public struct WorktreeRecord: Codable, Sendable {
     public let ownerkind: String
     public let ownerid: String?
     public let snapshotref: String?
+    public let readiness: String?
     public let createdat: Int
     public let lastactiveat: Int
     public let removedat: Int?
@@ -1623,6 +1624,7 @@ public struct WorktreeRecord: Codable, Sendable {
         ownerkind: String,
         ownerid: String? = nil,
         snapshotref: String? = nil,
+        readiness: String? = nil,
         createdat: Int,
         lastactiveat: Int,
         removedat: Int? = nil)
@@ -1637,6 +1639,7 @@ public struct WorktreeRecord: Codable, Sendable {
         self.ownerkind = ownerkind
         self.ownerid = ownerid
         self.snapshotref = snapshotref
+        self.readiness = readiness
         self.createdat = createdat
         self.lastactiveat = lastactiveat
         self.removedat = removedat
@@ -1653,6 +1656,7 @@ public struct WorktreeRecord: Codable, Sendable {
         case ownerkind = "ownerKind"
         case ownerid = "ownerId"
         case snapshotref = "snapshotRef"
+        case readiness
         case createdat = "createdAt"
         case lastactiveat = "lastActiveAt"
         case removedat = "removedAt"

--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -43,6 +43,18 @@ OPENCLAW_WORKTREE_PATH=<managed worktree>
 
 A nonzero exit aborts creation and removes the new worktree and branch. This is a repository-local contract; there is no OpenClaw config key for it.
 
+## Provisioning state and recovery
+
+A worktree record is registered the moment creation claims its path, before ignored-file provisioning and the setup script run. Until those finish, the record readiness is `provisioning`: the CLI list Status column shows `provisioning` (`readiness` in `--json` and gateway results), the record is never handed out as a usable checkout, and a same-name create reports that provisioning is in progress. An in-flight create heartbeats its record on a wall-clock interval, so a long file copy or setup script never looks like a crash.
+
+A `provisioning` record resolves in one of three ways:
+
+- The create completes and the record flips to `ready`.
+- The holding process died: once its heartbeat has been silent for 20 minutes, cleanup (`worktrees.gc` or the hourly pass) deletes the record, checkout, and branch, and the name becomes reusable.
+- Its directory vanished: the next cleanup or list removes the record and branch immediately.
+
+To recover by hand, wait for the hourly cleanup, run `openclaw worktrees gc`, or remove the record with `openclaw worktrees remove <id>`; afterward a fresh `openclaw worktrees create` with the same name provisions from scratch. A create that crashed before its record was registered is adopted directly by retrying the same named create. Restore refuses a snapshot taken from a `provisioning` record because it never contained a completed checkout; create the worktree again instead.
+
 ## Session worktrees
 
 Start an isolated chat from the active agent's git workspace with a worktree-backed session: enable **Worktree** on the Control UI's New session page (which also offers a base-branch picker and an optional worktree name), or use the Chat actions menu on iOS or the overflow action beside New Chat on Android. The option is available only for a git-backed agent where the client has that capability; clients that cannot preflight it surface the gateway error instead.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2433,6 +2433,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Layout and names
   - H2: Provision ignored files
   - H2: Run repository setup
+  - H2: Provisioning state and recovery
   - H2: Session worktrees
   - H2: Snapshots, cleanup, and restore
   - H2: CLI

--- a/packages/gateway-protocol/src/schema/worktrees.ts
+++ b/packages/gateway-protocol/src/schema/worktrees.ts
@@ -16,6 +16,9 @@ export const WorktreeRecordSchema = Type.Object(
     ownerKind: Type.String({ enum: ["manual", "workboard", "session"] }),
     ownerId: Type.Optional(NonEmptyString),
     snapshotRef: Type.Optional(NonEmptyString),
+    // Additive/optional: older clients ignore it; 'provisioning' rows are claimed but not
+    // yet usable checkouts (copy/setup still running or crashed before completion).
+    readiness: Type.Optional(Type.String({ enum: ["provisioning", "ready"] })),
     createdAt: Type.Integer({ minimum: 0 }),
     lastActiveAt: Type.Integer({ minimum: 0 }),
     removedAt: Type.Optional(Type.Integer({ minimum: 0 })),

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -14,6 +14,9 @@ export type GitResult = {
 type WorktreeListEntry = {
   path: string;
   lockedReason?: string;
+  // `refs/heads/<name>` from the porcelain `branch` field; undefined for detached HEAD.
+  // Adoption checks compare this against the managed `openclaw/<name>` scheme.
+  branch?: string;
 };
 
 export async function runGit(
@@ -73,6 +76,8 @@ function parseWorktreeList(output: string): WorktreeListEntry[] {
       current.lockedReason = "";
     } else if (current && field.startsWith("locked ")) {
       current.lockedReason = field.slice("locked ".length);
+    } else if (current && field.startsWith("branch ")) {
+      current.branch = field.slice("branch ".length);
     }
   }
   if (current) {

--- a/src/agents/worktrees/registry.test.ts
+++ b/src/agents/worktrees/registry.test.ts
@@ -8,7 +8,6 @@ import {
   findRegistryWorktreeByPath,
   findLiveRegistryWorktreeByPath,
   getRegistryWorktree,
-  insertRegistryWorktree,
   insertRegistryWorktreeIfPathFree,
   listRegistryWorktrees,
   updateRegistryWorktree,
@@ -45,8 +44,8 @@ describe("managed worktree registry", () => {
       createdAt: 10,
       lastActiveAt: 10,
     };
-    insertRegistryWorktree(env, record);
-    insertRegistryWorktree(env, {
+    expect(insertRegistryWorktreeIfPathFree(env, record)).toBe(true);
+    insertRegistryWorktreeIfPathFree(env, {
       ...record,
       id: "second",
       name: "task-2",

--- a/src/agents/worktrees/registry.test.ts
+++ b/src/agents/worktrees/registry.test.ts
@@ -9,6 +9,7 @@ import {
   findLiveRegistryWorktreeByPath,
   getRegistryWorktree,
   insertRegistryWorktree,
+  insertRegistryWorktreeIfPathFree,
   listRegistryWorktrees,
   updateRegistryWorktree,
 } from "./registry.js";
@@ -75,5 +76,33 @@ describe("managed worktree registry", () => {
 
     deleteRegistryWorktree(env, "first");
     expect(getRegistryWorktree(env, "first")).toBeUndefined();
+  });
+
+  it("claims a path atomically only while no live row exists", () => {
+    const record: ManagedWorktreeRecord = {
+      id: "claimant",
+      name: "task",
+      repoFingerprint: "0123456789abcdef",
+      repoRoot: path.join(root, "repo"),
+      path: path.join(root, "worktrees", "task"),
+      branch: "openclaw/task",
+      baseRef: "HEAD",
+      ownerKind: "manual",
+      createdAt: 10,
+      lastActiveAt: 10,
+    };
+
+    expect(insertRegistryWorktreeIfPathFree(env, record)).toBe(true);
+    expect(insertRegistryWorktreeIfPathFree(env, { ...record, id: "rival" })).toBe(false);
+    expect(listRegistryWorktrees(env).map((entry) => entry.id)).toEqual(["claimant"]);
+
+    // A removed row no longer blocks the path; the next claim wins again.
+    updateRegistryWorktree(env, "claimant", { removedAt: 50 });
+    expect(insertRegistryWorktreeIfPathFree(env, { ...record, id: "rival" })).toBe(true);
+    expect(
+      listRegistryWorktrees(env)
+        .map((entry) => entry.id)
+        .toSorted(),
+    ).toEqual(["claimant", "rival"]);
   });
 });

--- a/src/agents/worktrees/registry.test.ts
+++ b/src/agents/worktrees/registry.test.ts
@@ -41,6 +41,7 @@ describe("managed worktree registry", () => {
       baseRef: "HEAD",
       ownerKind: "workboard",
       ownerId: "card-1",
+      readiness: "ready",
       createdAt: 10,
       lastActiveAt: 10,
     };
@@ -88,13 +89,19 @@ describe("managed worktree registry", () => {
       branch: "openclaw/task",
       baseRef: "HEAD",
       ownerKind: "manual",
+      readiness: "provisioning",
       createdAt: 10,
       lastActiveAt: 10,
     };
 
     expect(insertRegistryWorktreeIfPathFree(env, record)).toBe(true);
+    // The claim persists the provisioning marker until the holder flips it to ready.
+    expect(getRegistryWorktree(env, "claimant")?.readiness).toBe("provisioning");
     expect(insertRegistryWorktreeIfPathFree(env, { ...record, id: "rival" })).toBe(false);
     expect(listRegistryWorktrees(env).map((entry) => entry.id)).toEqual(["claimant"]);
+
+    updateRegistryWorktree(env, "claimant", { readiness: "ready" });
+    expect(getRegistryWorktree(env, "claimant")?.readiness).toBe("ready");
 
     // A removed row no longer blocks the path; the next claim wins again.
     updateRegistryWorktree(env, "claimant", { removedAt: 50 });

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -140,6 +140,70 @@ export function insertRegistryWorktree(
   });
 }
 
+/**
+ * Atomically claims a worktree path: inserts the record only while no live row
+ * (removed_at IS NULL) exists for that path, as one INSERT ... SELECT ... WHERE NOT EXISTS
+ * statement so the check and insert cannot interleave with a concurrent registration.
+ * Returns whether this record won the claim. The schema is unique only by id, so this
+ * helper is what keeps orphan adoption from double-registering a path.
+ */
+export function insertRegistryWorktreeIfPathFree(
+  env: NodeJS.ProcessEnv,
+  record: ManagedWorktreeRecord,
+): boolean {
+  const db = dbFor(env);
+  const kysely = kyselyFor(db);
+  const row = recordToRow(record);
+  let claimed = false;
+  runOpenClawStateWriteTransaction(() => {
+    const query = kysely
+      .insertInto("worktrees")
+      .columns([
+        "id",
+        "repo_fingerprint",
+        "repo_root",
+        "path",
+        "branch",
+        "base_ref",
+        "owner_kind",
+        "owner_id",
+        "snapshot_ref",
+        "created_at",
+        "last_active_at",
+        "removed_at",
+      ])
+      .expression(
+        kysely
+          .selectNoFrom((eb) => [
+            eb.val(row.id).as("id"),
+            eb.val(row.repo_fingerprint).as("repo_fingerprint"),
+            eb.val(row.repo_root).as("repo_root"),
+            eb.val(row.path).as("path"),
+            eb.val(row.branch).as("branch"),
+            eb.val(row.base_ref).as("base_ref"),
+            eb.val(row.owner_kind).as("owner_kind"),
+            eb.val(row.owner_id).as("owner_id"),
+            eb.val(row.snapshot_ref).as("snapshot_ref"),
+            eb.val(row.created_at).as("created_at"),
+            eb.val(row.last_active_at).as("last_active_at"),
+            eb.val(row.removed_at).as("removed_at"),
+          ])
+          .where(({ not, exists, selectFrom }) =>
+            not(
+              exists(
+                selectFrom("worktrees")
+                  .select("id")
+                  .where("path", "=", row.path)
+                  .where("removed_at", "is", null),
+              ),
+            ),
+          ),
+      );
+    claimed = (executeSqliteQuerySync(db, query).numAffectedRows ?? 0n) > 0n;
+  });
+  return claimed;
+}
+
 export function updateRegistryWorktree(
   env: NodeJS.ProcessEnv,
   id: string,

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -188,10 +188,11 @@ export function insertRegistryWorktreeIfPathFree(
             eb.val(row.last_active_at).as("last_active_at"),
             eb.val(row.removed_at).as("removed_at"),
           ])
-          .where(({ not, exists, selectFrom }) =>
-            not(
-              exists(
-                selectFrom("worktrees")
+          .where((eb) =>
+            eb.not(
+              eb.exists(
+                eb
+                  .selectFrom("worktrees")
                   .select("id")
                   .where("path", "=", row.path)
                   .where("removed_at", "is", null),

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -139,16 +139,6 @@ export function findRegistryWorktreeByPath(
   return row ? rowToRecord(row) : undefined;
 }
 
-export function insertRegistryWorktree(
-  env: NodeJS.ProcessEnv,
-  record: ManagedWorktreeRecord,
-): void {
-  const db = dbFor(env);
-  runOpenClawStateWriteTransaction(() => {
-    executeSqliteQuerySync(db, kyselyFor(db).insertInto("worktrees").values(recordToRow(record)));
-  });
-}
-
 /**
  * Atomically claims a worktree path: inserts the record only while no live row
  * (removed_at IS NULL) exists for that path, as one INSERT ... SELECT ... WHERE NOT EXISTS

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -7,7 +7,11 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
-import type { ManagedWorktreeOwnerKind, ManagedWorktreeRecord } from "./types.js";
+import type {
+  ManagedWorktreeOwnerKind,
+  ManagedWorktreeReadiness,
+  ManagedWorktreeRecord,
+} from "./types.js";
 
 type WorktreesTable = OpenClawStateKyselyDatabase["worktrees"];
 type WorktreeRow = Selectable<WorktreesTable>;
@@ -38,6 +42,7 @@ function rowToRecord(row: WorktreeRow): ManagedWorktreeRecord {
     ownerKind: row.owner_kind as ManagedWorktreeOwnerKind,
     ...(row.owner_id ? { ownerId: row.owner_id } : {}),
     ...(row.snapshot_ref ? { snapshotRef: row.snapshot_ref } : {}),
+    readiness: row.readiness as ManagedWorktreeReadiness,
     createdAt: row.created_at,
     lastActiveAt: row.last_active_at,
     ...(row.removed_at == null ? {} : { removedAt: row.removed_at }),
@@ -55,6 +60,7 @@ function recordToRow(record: ManagedWorktreeRecord): Insertable<WorktreesTable> 
     owner_kind: record.ownerKind,
     owner_id: record.ownerId ?? null,
     snapshot_ref: record.snapshotRef ?? null,
+    readiness: record.readiness,
     created_at: record.createdAt,
     last_active_at: record.lastActiveAt,
     removed_at: record.removedAt ?? null,
@@ -103,12 +109,15 @@ export function findLiveRegistryWorktreeByOwner(
   ownerId: string,
 ): ManagedWorktreeRecord | undefined {
   const db = dbFor(env);
+  // Usable-record acquisition: callers run work inside the returned checkout, so a row
+  // still 'provisioning' (claimed, copy/setup unfinished) must stay invisible here.
   const query = kyselyFor(db)
     .selectFrom("worktrees")
     .selectAll()
     .where("owner_kind", "=", ownerKind)
     .where("owner_id", "=", ownerId)
     .where("removed_at", "is", null)
+    .where("readiness", "=", "ready")
     .orderBy("created_at", "desc")
     .limit(1);
   const row = executeSqliteQuerySync(db, query).rows[0];
@@ -168,6 +177,7 @@ export function insertRegistryWorktreeIfPathFree(
         "owner_kind",
         "owner_id",
         "snapshot_ref",
+        "readiness",
         "created_at",
         "last_active_at",
         "removed_at",
@@ -184,6 +194,7 @@ export function insertRegistryWorktreeIfPathFree(
             eb.val(row.owner_kind).as("owner_kind"),
             eb.val(row.owner_id).as("owner_id"),
             eb.val(row.snapshot_ref).as("snapshot_ref"),
+            eb.val(row.readiness).as("readiness"),
             eb.val(row.created_at).as("created_at"),
             eb.val(row.last_active_at).as("last_active_at"),
             eb.val(row.removed_at).as("removed_at"),
@@ -208,7 +219,9 @@ export function insertRegistryWorktreeIfPathFree(
 export function updateRegistryWorktree(
   env: NodeJS.ProcessEnv,
   id: string,
-  patch: Partial<Pick<ManagedWorktreeRecord, "lastActiveAt" | "removedAt" | "snapshotRef">>,
+  patch: Partial<
+    Pick<ManagedWorktreeRecord, "lastActiveAt" | "removedAt" | "snapshotRef" | "readiness">
+  >,
 ): void {
   const db = dbFor(env);
   const values: Partial<WorktreeRow> = {};
@@ -220,6 +233,9 @@ export function updateRegistryWorktree(
   }
   if ("snapshotRef" in patch) {
     values.snapshot_ref = patch.snapshotRef ?? null;
+  }
+  if (patch.readiness !== undefined) {
+    values.readiness = patch.readiness;
   }
   runOpenClawStateWriteTransaction(() => {
     executeSqliteQuerySync(

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -13,6 +13,7 @@ import {
   listRegistryWorktrees,
   updateRegistryWorktree,
 } from "./registry.js";
+import { acquireWorktreeRunLease } from "./run-lease.js";
 import {
   IDLE_GC_MS,
   ManagedWorktreeService,
@@ -1007,8 +1008,8 @@ describe("ManagedWorktreeService", () => {
     );
   });
 
-  it("the wall-clock lease heartbeat keeps any provisioning stall alive through gc", async () => {
-    // Fake only the interval APIs: the service's lease timer becomes deterministically
+  it("the wall-clock provisioning heartbeat keeps any provisioning stall alive through gc", async () => {
+    // Fake only the interval APIs: the service's heartbeat timer becomes deterministically
     // fireable while the test's own polling and the parked child process stay real.
     vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
     try {
@@ -1033,7 +1034,7 @@ describe("ManagedWorktreeService", () => {
       }
 
       // Far past the stale threshold relative to the claim (and to any pre-stall bump), a
-      // single timer tick re-proves liveness; gc must preserve the lease.
+      // single timer tick re-proves liveness; gc must preserve the claim.
       now += PROVISIONING_STALE_MS + 1;
       vi.advanceTimersByTime(PROVISIONING_HEARTBEAT_MS);
       const parked = listRegistryWorktrees(env).find((entry) => entry.name === "stalled");
@@ -1071,7 +1072,7 @@ describe("ManagedWorktreeService", () => {
     expect(recreated.readiness).toBe("ready");
   });
 
-  it("gc reaps silent provisioning leases and preserves heartbeating ones", async () => {
+  it("gc reaps silent provisioning claims and preserves heartbeating ones", async () => {
     await fs.mkdir(path.join(repo, ".openclaw"));
     await fs.writeFile(
       path.join(repo, ".openclaw", "worktree-setup.sh"),
@@ -1086,7 +1087,7 @@ describe("ManagedWorktreeService", () => {
     updateRegistryWorktree(env, autoNamed.id, { readiness: "provisioning" });
 
     // Liveness, not claim age, decides: well past the original claim's age a recent
-    // heartbeat still proves a live holder, so gc must not touch the lease.
+    // heartbeat still proves a live holder, so gc must not touch the claim.
     now += PROVISIONING_STALE_MS + 1;
     updateRegistryWorktree(env, named.id, { lastActiveAt: now });
     updateRegistryWorktree(env, autoNamed.id, { lastActiveAt: now });
@@ -1094,7 +1095,7 @@ describe("ManagedWorktreeService", () => {
     expect(getRegistryWorktree(env, named.id)?.readiness).toBe("provisioning");
     expect(await fs.stat(named.path)).toBeTruthy();
 
-    // A lease silent past the threshold has a dead holder: row, worktree, and branch go away.
+    // A claim silent past the threshold has a dead holder: row, worktree, and branch go away.
     now += PROVISIONING_STALE_MS + 1;
     await service.gc();
     expect(getRegistryWorktree(env, named.id)).toBeUndefined();
@@ -1124,6 +1125,24 @@ describe("ManagedWorktreeService", () => {
     expect(await git(repo, "branch", "--list", created.branch)).toBe("");
     const recreated = await service.create({ repoRoot: repo, name: "gone-dir" });
     expect(recreated.readiness).toBe("ready");
+  });
+
+  it("gc reap defers to a live run lease via the shared removal claim", async () => {
+    const created = await service.create({ repoRoot: repo, name: "leased-claim" });
+    const lease = await acquireWorktreeRunLease(created.id, { env });
+    // Constructed dead-holder state under a still-live run lease: the removal claim
+    // rejects, so reap must skip rather than destroy a checkout a run is using.
+    updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
+    now += PROVISIONING_STALE_MS + 1;
+
+    await service.gc();
+    expect(getRegistryWorktree(env, created.id)?.readiness).toBe("provisioning");
+    expect(await fs.stat(created.path)).toBeTruthy();
+
+    await lease.release();
+    await service.gc();
+    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -819,9 +819,10 @@ describe("ManagedWorktreeService", () => {
     deleteRegistryWorktree(env, created.id);
     const winner: ManagedWorktreeRecord = { ...created, id: "race-winner" };
     let raced = false;
-    // The first now() read inside the retried create() lands before the atomic claim; the
-    // trapdoor inserts the competing row there, deterministically simulating a concurrent
-    // create() winning the path after this call's registry lookup.
+    // The first now() read inside the retried create() is adoptOrphan's createdAt, taken
+    // right before the atomic claim (which precedes provisioning); the trapdoor inserts the
+    // competing row there, deterministically simulating a concurrent create() winning the
+    // path after this call's registry lookup.
     const racingService = new ManagedWorktreeService({
       env,
       now: () => {
@@ -838,6 +839,66 @@ describe("ManagedWorktreeService", () => {
     expect(retried.id).toBe("race-winner");
     const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
     expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
+  });
+
+  it("a losing retried create() does not provision or destroy the winner's worktree", async () => {
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      "#!/bin/sh\necho ran >> setup-marker.txt\n",
+      { mode: 0o755 },
+    );
+    const created = await service.create({ repoRoot: repo, name: "race-loser" });
+    deleteRegistryWorktree(env, created.id);
+    // Pre-setup crash signature: the marker the initial create() wrote is gone.
+    await fs.rm(path.join(created.path, "setup-marker.txt"));
+    const winner: ManagedWorktreeRecord = { ...created, id: "race-winner" };
+    let raced = false;
+    const racingService = new ManagedWorktreeService({
+      env,
+      now: () => {
+        if (!raced) {
+          raced = true;
+          insertRegistryWorktree(env, winner);
+        }
+        return now;
+      },
+    });
+
+    const retried = await racingService.create({ repoRoot: repo, name: "race-loser" });
+
+    expect(retried.id).toBe("race-winner");
+    // Claim-before-provision: the loser ran no setup, no copy, and no cleanup on the
+    // winner's path, and left the registry row set untouched.
+    await expect(fs.stat(path.join(created.path, "setup-marker.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await fs.stat(created.path)).toBeTruthy();
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
+    expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
+  });
+
+  it("binds a gc-adopted name to the manual record until removed", async () => {
+    const created = await service.create({ repoRoot: repo, name: "gc-owned" });
+    deleteRegistryWorktree(env, created.id);
+    await service.gc();
+    const adopted = (await service.list()).find((entry) => entry.path === created.path);
+    expect(adopted?.ownerKind).toBe("manual");
+
+    // An owner-carrying retry hits the owner guard against gc's manual record...
+    await expect(
+      service.create({
+        repoRoot: repo,
+        name: "gc-owned",
+        ownerKind: "workboard",
+        ownerId: "card-9",
+      }),
+    ).rejects.toThrow(/already in use by manual/);
+
+    // ...while an ownerless retry reuses it.
+    const reused = await service.create({ repoRoot: repo, name: "gc-owned" });
+    expect(reused.id).toBe(adopted?.id);
+    expect(reused.ownerKind).toBe("manual");
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -1006,7 +1006,7 @@ describe("ManagedWorktreeService", () => {
     );
   });
 
-  it("gc reaps stale provisioning rows and preserves fresh ones", async () => {
+  it("gc reaps silent provisioning leases and preserves heartbeating ones", async () => {
     await fs.mkdir(path.join(repo, ".openclaw"));
     await fs.writeFile(
       path.join(repo, ".openclaw", "worktree-setup.sh"),
@@ -1020,14 +1020,17 @@ describe("ManagedWorktreeService", () => {
     updateRegistryWorktree(env, named.id, { readiness: "provisioning" });
     updateRegistryWorktree(env, autoNamed.id, { readiness: "provisioning" });
 
-    // At the threshold the rows are still considered in-flight and stay untouched.
-    now += PROVISIONING_STALE_MS;
+    // Liveness, not claim age, decides: well past the original claim's age a recent
+    // heartbeat still proves a live holder, so gc must not touch the lease.
+    now += PROVISIONING_STALE_MS + 1;
+    updateRegistryWorktree(env, named.id, { lastActiveAt: now });
+    updateRegistryWorktree(env, autoNamed.id, { lastActiveAt: now });
     await service.gc();
     expect(getRegistryWorktree(env, named.id)?.readiness).toBe("provisioning");
     expect(await fs.stat(named.path)).toBeTruthy();
 
-    // Past the threshold the holder is dead by contract: row, worktree, and branch go away.
-    now += 1;
+    // A lease silent past the threshold has a dead holder: row, worktree, and branch go away.
+    now += PROVISIONING_STALE_MS + 1;
     await service.gc();
     expect(getRegistryWorktree(env, named.id)).toBeUndefined();
     expect(getRegistryWorktree(env, autoNamed.id)).toBeUndefined();
@@ -1040,6 +1043,22 @@ describe("ManagedWorktreeService", () => {
     const recreated = await service.create({ repoRoot: repo, name: "stale-prov" });
     expect(recreated.readiness).toBe("ready");
     expect(await fs.readFile(path.join(recreated.path, "setup-marker.txt"), "utf8")).toBe("ran\n");
+  });
+
+  it("gc hard-deletes provisioning claims whose directory vanished, keeping the name retriable", async () => {
+    const created = await service.create({ repoRoot: repo, name: "gone-dir" });
+    // Constructed: a provisioning claim whose directory is gone (crash + manual cleanup).
+    updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
+    await fs.rm(created.path, { recursive: true, force: true });
+
+    await service.gc();
+
+    // No hidden retired row and no surviving branch — retiring instead would strand the
+    // name forever (row invisible to adoption, branch collides with the next create).
+    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
+    expect(await git(repo, "branch", "--list", created.branch)).toBe("");
+    const recreated = await service.create({ repoRoot: repo, name: "gone-dir" });
+    expect(recreated.readiness).toBe("ready");
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   IDLE_GC_MS,
   ManagedWorktreeService,
+  PROVISIONING_HEARTBEAT_MS,
   PROVISIONING_STALE_MS,
   SNAPSHOT_RETENTION_MS,
 } from "./service.js";
@@ -1006,58 +1007,68 @@ describe("ManagedWorktreeService", () => {
     );
   });
 
-  it("per-file copy heartbeats keep a long-running copy's lease alive through gc", async () => {
-    const syncDir = path.join(root, "sync");
-    await fs.mkdir(syncDir, { recursive: true });
-    const startedFlag = path.join(syncDir, "setup-started");
-    const releaseFlag = path.join(syncDir, "setup-release");
-    await fs.writeFile(path.join(repo, ".gitignore"), "a.env\nb.env\n");
-    await fs.writeFile(path.join(repo, ".worktreeinclude"), "a.env\nb.env\n");
-    await fs.writeFile(path.join(repo, "a.env"), "a\n");
-    await fs.writeFile(path.join(repo, "b.env"), "b\n");
-    await fs.mkdir(path.join(repo, ".openclaw"));
-    await fs.writeFile(
-      path.join(repo, ".openclaw", "worktree-setup.sh"),
-      `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
-      { mode: 0o755 },
-    );
-    let nowCalls = 0;
-    // The first per-file heartbeat's now() read (call #2, after the claim's createdAt) jumps
-    // the clock past the stale threshold — simulating a first include-file copy that took far
-    // longer than PROVISIONING_STALE_MS while the holder stayed alive.
-    const racingService = new ManagedWorktreeService({
-      env,
-      now: () => {
-        nowCalls += 1;
-        if (nowCalls === 2) {
-          now += PROVISIONING_STALE_MS + 1;
-        }
-        return now;
-      },
-    });
+  it("the wall-clock lease heartbeat keeps any provisioning stall alive through gc", async () => {
+    // Fake only the interval APIs: the service's lease timer becomes deterministically
+    // fireable while the test's own polling and the parked child process stay real.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    try {
+      const syncDir = path.join(root, "sync");
+      await fs.mkdir(syncDir, { recursive: true });
+      const startedFlag = path.join(syncDir, "setup-started");
+      const releaseFlag = path.join(syncDir, "setup-release");
+      await fs.mkdir(path.join(repo, ".openclaw"));
+      // The parked setup script stands in for any provisioning stall (one huge include-file
+      // copy, a slow setup, ...): nothing but the timer proves the holder is alive.
+      await fs.writeFile(
+        path.join(repo, ".openclaw", "worktree-setup.sh"),
+        `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
+        { mode: 0o755 },
+      );
 
-    const createPromise = racingService.create({ repoRoot: repo, name: "slow-copy" });
-    while (!(await fs.stat(startedFlag).catch(() => undefined))) {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 20);
-      });
+      const createPromise = service.create({ repoRoot: repo, name: "stalled" });
+      while (!(await fs.stat(startedFlag).catch(() => undefined))) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 20);
+        });
+      }
+
+      // Far past the stale threshold relative to the claim (and to any pre-stall bump), a
+      // single timer tick re-proves liveness; gc must preserve the lease.
+      now += PROVISIONING_STALE_MS + 1;
+      vi.advanceTimersByTime(PROVISIONING_HEARTBEAT_MS);
+      const parked = listRegistryWorktrees(env).find((entry) => entry.name === "stalled");
+      expect(parked?.readiness).toBe("provisioning");
+      expect(now - parked!.createdAt).toBeGreaterThan(PROVISIONING_STALE_MS);
+      // Pins that the timer fired: only its bump can have written the advanced clock.
+      expect(parked?.lastActiveAt).toBe(now);
+      await service.gc();
+      expect(getRegistryWorktree(env, parked!.id)?.readiness).toBe("provisioning");
+      expect(await fs.stat(parked!.path)).toBeTruthy();
+
+      await fs.writeFile(releaseFlag, "");
+      const created = await createPromise;
+      expect(created.readiness).toBe("ready");
+    } finally {
+      vi.useRealTimers();
     }
+  });
 
-    // Mid-provisioning and far past the CLAIM's age, the fresh per-file heartbeat is what
-    // keeps gc from reaping the live holder.
-    const parked = listRegistryWorktrees(env).find((entry) => entry.name === "slow-copy");
-    expect(parked?.readiness).toBe("provisioning");
-    expect(now - parked!.createdAt).toBeGreaterThan(PROVISIONING_STALE_MS);
-    expect(parked?.lastActiveAt).toBe(now);
-    await service.gc();
-    expect(getRegistryWorktree(env, parked!.id)?.readiness).toBe("provisioning");
-    expect(await fs.stat(parked!.path)).toBeTruthy();
+  it("list() hard-deletes a missing-path provisioning claim instead of retiring it", async () => {
+    const created = await service.create({ repoRoot: repo, name: "list-heal" });
+    // Constructed: a provisioning claim whose directory vanished, discovered via list()
+    // before any gc runs (the door that previously retired it into a permanent dead end).
+    updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
+    await fs.rm(created.path, { recursive: true, force: true });
 
-    await fs.writeFile(releaseFlag, "");
-    const created = await createPromise;
-    expect(created.readiness).toBe("ready");
-    // now() reads: claim createdAt + one heartbeat per copied file (2) + the ready flip.
-    expect(nowCalls).toBe(4);
+    const listed = await service.list();
+
+    // Hard-deleted, not retired: no removed row lingers to collide with the surviving
+    // branch, and the branch itself is gone — the name is genuinely retriable.
+    expect(listed.find((entry) => entry.id === created.id)).toBeUndefined();
+    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
+    expect(await git(repo, "branch", "--list", created.branch)).toBe("");
+    const recreated = await service.create({ repoRoot: repo, name: "list-heal" });
+    expect(recreated.readiness).toBe("ready");
   });
 
   it("gc reaps silent provisioning leases and preserves heartbeating ones", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -693,6 +693,8 @@ describe("ManagedWorktreeService", () => {
       ownerKind: "workboard",
       ownerId: "card-42",
     });
+    // Deleting the row reproduces the only remaining no-row crash window (between
+    // `git worktree add` and the claim, which runs no user code) and pre-fix orphans.
     deleteRegistryWorktree(env, created.id);
 
     const retried = await service.create({
@@ -835,7 +837,7 @@ describe("ManagedWorktreeService", () => {
     const releaseFlag = path.join(syncDir, "setup-release");
     await fs.mkdir(path.join(repo, ".openclaw"));
     // The setup script parks create() mid-provisioning until released, so gc deterministically
-    // observes the live-worktree/no-registry-row window of a normal create().
+    // observes an in-flight create (live worktree + live claim-time row) and must preserve it.
     await fs.writeFile(
       path.join(repo, ".openclaw", "worktree-setup.sh"),
       `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
@@ -868,9 +870,9 @@ describe("ManagedWorktreeService", () => {
       branch: "openclaw/race-normal",
     };
     let raced = false;
-    // Normal create()'s first now() read is the record's createdAt, taken right before its
-    // final claim; the trapdoor inserts the competing row there, simulating a concurrent
-    // create() that registered the same path during this call's provisioning window.
+    // Normal create()'s first now() read is the record's createdAt, taken right after
+    // `git worktree add` and before the claim; the trapdoor inserts the competing row there,
+    // simulating a concurrent registration winning the tiny post-add window.
     const racingService = new ManagedWorktreeService({
       env,
       now: () => {
@@ -887,6 +889,46 @@ describe("ManagedWorktreeService", () => {
     expect(created.id).toBe("race-winner");
     const rows = listRegistryWorktrees(env).filter((entry) => entry.path === winner.path);
     expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
+  });
+
+  it("a parked in-flight create() cannot be adopted, reprovisioned, or destroyed by a same-name retry", async () => {
+    const syncDir = path.join(root, "sync");
+    await fs.mkdir(syncDir, { recursive: true });
+    const startedFlag = path.join(syncDir, "setup-started");
+    const releaseFlag = path.join(syncDir, "setup-release");
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    // The marker counts setup executions; the park keeps create #1 in its provisioning
+    // window while same-name retries run against the live claim-time row.
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      `#!/bin/sh\necho ran >> setup-marker.txt\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const firstPromise = service.create({ repoRoot: repo, name: "parked" });
+    while (!(await fs.stat(startedFlag).catch(() => undefined))) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+
+    // Same-owner retry returns the in-flight record without touching the worktree...
+    const retry = await service.create({ repoRoot: repo, name: "parked" });
+    // ...and a foreign-owner retry is rejected instead of adopting it.
+    await expect(
+      service.create({ repoRoot: repo, name: "parked", ownerKind: "session", ownerId: "s1" }),
+    ).rejects.toThrow(/already in use by manual/);
+    expect(listRegistryWorktrees(env).filter((entry) => entry.path === retry.path)).toHaveLength(1);
+
+    await fs.writeFile(releaseFlag, "");
+    const first = await firstPromise;
+
+    expect(retry.id).toBe(first.id);
+    // Only #1's setup execution ever ran; no retry adopted, re-provisioned, or cleaned up.
+    expect(await fs.readFile(path.join(first.path, "setup-marker.txt"), "utf8")).toBe("ran\n");
+    expect(await fs.stat(first.path)).toBeTruthy();
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === first.path);
+    expect(rows.map((entry) => entry.id)).toEqual([first.id]);
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { deleteRegistryWorktree, getRegistryWorktree } from "./registry.js";
+import {
+  deleteRegistryWorktree,
+  findRegistryWorktreeByPath,
+  getRegistryWorktree,
+} from "./registry.js";
 import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 
 const execFileAsync = promisify(execFile);
@@ -724,6 +728,54 @@ describe("ManagedWorktreeService", () => {
     });
     expect(service.findLiveByOwner("workboard", "card-42")?.id).toBe(retried.id);
     expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
+  });
+
+  it("re-runs provisioning when a retried create() adopts a pre-setup crash orphan", async () => {
+    await fs.writeFile(path.join(repo, ".gitignore"), "included.env\n");
+    await fs.writeFile(path.join(repo, ".worktreeinclude"), "included.env\n");
+    await fs.writeFile(path.join(repo, "included.env"), "provisioned\n");
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      "#!/bin/sh\necho ran > setup-marker.txt\n",
+      { mode: 0o755 },
+    );
+    const created = await service.create({ repoRoot: repo, name: "orphan-setup", baseRef: "main" });
+    // Simulates a crash after `git worktree add` but before copy/setup and the registry insert:
+    // undo the provisioning artifacts the initial create() produced and drop its registry row.
+    deleteRegistryWorktree(env, created.id);
+    await fs.rm(path.join(created.path, "included.env"));
+    await fs.rm(path.join(created.path, "setup-marker.txt"));
+
+    const retried = await service.create({ repoRoot: repo, name: "orphan-setup", baseRef: "main" });
+
+    expect(retried.path).toBe(created.path);
+    expect(retried.baseRef).toBe("main");
+    expect(await fs.readFile(path.join(retried.path, "included.env"), "utf8")).toBe(
+      "provisioned\n",
+    );
+    expect(await fs.readFile(path.join(retried.path, "setup-marker.txt"), "utf8")).toBe("ran\n");
+  });
+
+  it("cleans up instead of adopting when provisioning fails on the retried create()", async () => {
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      '#!/bin/sh\nif [ -f "$OPENCLAW_SOURCE_TREE_PATH/fail-setup" ]; then\n  echo setup-broke >&2\n  exit 9\nfi\nexit 0\n',
+      { mode: 0o755 },
+    );
+    const created = await service.create({ repoRoot: repo, name: "orphan-refail" });
+    deleteRegistryWorktree(env, created.id);
+    await fs.writeFile(path.join(repo, "fail-setup"), "");
+
+    await expect(service.create({ repoRoot: repo, name: "orphan-refail" })).rejects.toThrow(
+      "setup-broke",
+    );
+
+    expect(await git(repo, "worktree", "list", "--porcelain")).not.toContain(created.path);
+    expect(await git(repo, "branch", "--list", "openclaw/orphan-refail")).toBe("");
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(findRegistryWorktreeByPath(env, created.path)).toBeUndefined();
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -953,6 +953,59 @@ describe("ManagedWorktreeService", () => {
     expect(rows.map((entry) => [entry.id, entry.readiness])).toEqual([[first.id, "ready"]]);
   });
 
+  it("restore() revives a removed provisioning row as ready", async () => {
+    const created = await service.create({
+      repoRoot: repo,
+      name: "restore-prov",
+      ownerKind: "workboard",
+      ownerId: "card-restore",
+    });
+    // Constructed post-claim crash: the row is left 'provisioning' over a real checkout,
+    // then the operator recovers it via the normal remove -> restore path.
+    updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
+    await service.remove({ id: created.id, reason: "operator-recovery" });
+
+    const restored = await service.restore({ id: created.id });
+
+    expect(restored.readiness).toBe("ready");
+    expect(getRegistryWorktree(env, created.id)?.readiness).toBe("ready");
+    // The revived row must not be reapable via its original claim timestamp.
+    now += PROVISIONING_STALE_MS + 1;
+    await service.gc();
+    expect(getRegistryWorktree(env, created.id)?.removedAt).toBeUndefined();
+    expect(await fs.stat(restored.path)).toBeTruthy();
+    expect(service.findLiveByOwner("workboard", "card-restore")?.id).toBe(created.id);
+  });
+
+  it("create() fails closed when its provisioning row is reaped mid-flight", async () => {
+    const syncDir = path.join(root, "sync-reap");
+    await fs.mkdir(syncDir, { recursive: true });
+    const startedFlag = path.join(syncDir, "setup-started");
+    const releaseFlag = path.join(syncDir, "setup-release");
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
+      { mode: 0o755 },
+    );
+
+    const firstPromise = service.create({ repoRoot: repo, name: "reaped" });
+    while (!(await fs.stat(startedFlag).catch(() => undefined))) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+    // Simulates gc reaping the claim while the (suspended/overlong) holder still runs:
+    // the ready flip then updates zero rows and create() must not return a dead record.
+    const parked = listRegistryWorktrees(env).find((entry) => entry.name === "reaped");
+    deleteRegistryWorktree(env, parked!.id);
+    await fs.writeFile(releaseFlag, "");
+
+    await expect(firstPromise).rejects.toThrow(
+      "worktree provisioning exceeded its window and was reclaimed: reaped",
+    );
+  });
+
   it("gc reaps stale provisioning rows and preserves fresh ones", async () => {
     await fs.mkdir(path.join(repo, ".openclaw"));
     await fs.writeFile(

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -9,7 +9,7 @@ import {
   deleteRegistryWorktree,
   findRegistryWorktreeByPath,
   getRegistryWorktree,
-  insertRegistryWorktree,
+  insertRegistryWorktreeIfPathFree,
   listRegistryWorktrees,
   updateRegistryWorktree,
 } from "./registry.js";
@@ -788,7 +788,7 @@ describe("ManagedWorktreeService", () => {
       now: () => {
         if (!raced) {
           raced = true;
-          insertRegistryWorktree(env, winner);
+          insertRegistryWorktreeIfPathFree(env, winner);
         }
         return now;
       },
@@ -819,7 +819,7 @@ describe("ManagedWorktreeService", () => {
       now: () => {
         if (!raced) {
           raced = true;
-          insertRegistryWorktree(env, winner);
+          insertRegistryWorktreeIfPathFree(env, winner);
         }
         return now;
       },
@@ -886,7 +886,7 @@ describe("ManagedWorktreeService", () => {
       now: () => {
         if (!raced) {
           raced = true;
-          insertRegistryWorktree(env, winner);
+          insertRegistryWorktreeIfPathFree(env, winner);
         }
         return now;
       },

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -955,28 +955,42 @@ describe("ManagedWorktreeService", () => {
     expect(rows.map((entry) => [entry.id, entry.readiness])).toEqual([[first.id, "ready"]]);
   });
 
-  it("restore() revives a removed provisioning row as ready", async () => {
-    const created = await service.create({
-      repoRoot: repo,
-      name: "restore-prov",
-      ownerKind: "workboard",
-      ownerId: "card-restore",
-    });
+  it("restore() refuses a snapshot taken from a provisioning row", async () => {
+    const created = await service.create({ repoRoot: repo, name: "restore-prov" });
     // Constructed post-claim crash: the row is left 'provisioning' over a real checkout,
-    // then the operator recovers it via the normal remove -> restore path.
+    // then an operator removes it; its snapshot captured an unprovisioned tree.
     updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
     await service.remove({ id: created.id, reason: "operator-recovery" });
 
-    const restored = await service.restore({ id: created.id });
+    await expect(service.restore({ id: created.id })).rejects.toThrow(
+      "cannot restore a worktree that never finished provisioning: restore-prov",
+    );
+    // The row keeps its removed state; nothing was rematerialized.
+    expect(getRegistryWorktree(env, created.id)?.removedAt).toBeDefined();
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
-    expect(restored.readiness).toBe("ready");
-    expect(getRegistryWorktree(env, created.id)?.readiness).toBe("ready");
-    // The revived row must not be reapable via its original claim timestamp.
-    now += PROVISIONING_STALE_MS + 1;
-    await service.gc();
-    expect(getRegistryWorktree(env, created.id)?.removedAt).toBeUndefined();
-    expect(await fs.stat(restored.path)).toBeTruthy();
-    expect(service.findLiveByOwner("workboard", "card-restore")?.id).toBe(created.id);
+  it("create() after removing a provisioning row provisions fresh instead of restoring", async () => {
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    const script = path.join(repo, ".openclaw", "worktree-setup.sh");
+    await fs.writeFile(script, "#!/bin/sh\necho one > setup-marker.txt\n", { mode: 0o755 });
+    const created = await service.create({ repoRoot: repo, name: "prov-recreate" });
+    updateRegistryWorktree(env, created.id, { readiness: "provisioning" });
+    const removed = await service.remove({ id: created.id, reason: "operator-recovery" });
+    // A snapshot restore would resurrect the OLD marker; only a fresh full provision runs
+    // the updated setup script.
+    await fs.writeFile(script, "#!/bin/sh\necho two > setup-marker.txt\n", { mode: 0o755 });
+
+    const recreated = await service.create({ repoRoot: repo, name: "prov-recreate" });
+
+    expect(recreated.id).not.toBe(created.id);
+    expect(recreated.readiness).toBe("ready");
+    expect(await fs.readFile(path.join(recreated.path, "setup-marker.txt"), "utf8")).toBe("two\n");
+    // The stale removed provisioning row and its snapshot ref are gone.
+    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
+    await expect(git(repo, "show-ref", "--verify", removed.snapshotRef!)).rejects.toThrow();
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === recreated.path);
+    expect(rows.map((entry) => entry.id)).toEqual([recreated.id]);
   });
 
   it("create() fails closed when its provisioning row is reaped mid-flight", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -11,8 +11,14 @@ import {
   getRegistryWorktree,
   insertRegistryWorktree,
   listRegistryWorktrees,
+  updateRegistryWorktree,
 } from "./registry.js";
-import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
+import {
+  IDLE_GC_MS,
+  ManagedWorktreeService,
+  PROVISIONING_STALE_MS,
+  SNAPSHOT_RETENTION_MS,
+} from "./service.js";
 import type { ManagedWorktreeRecord } from "./types.js";
 
 const execFileAsync = promisify(execFile);
@@ -891,7 +897,7 @@ describe("ManagedWorktreeService", () => {
     expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
   });
 
-  it("a parked in-flight create() cannot be adopted, reprovisioned, or destroyed by a same-name retry", async () => {
+  it("a parked in-flight create() is invisible as a usable record and untouchable by retries", async () => {
     const syncDir = path.join(root, "sync");
     await fs.mkdir(syncDir, { recursive: true });
     const startedFlag = path.join(syncDir, "setup-started");
@@ -905,30 +911,82 @@ describe("ManagedWorktreeService", () => {
       { mode: 0o755 },
     );
 
-    const firstPromise = service.create({ repoRoot: repo, name: "parked" });
+    const firstPromise = service.create({
+      repoRoot: repo,
+      name: "parked",
+      ownerKind: "session",
+      ownerId: "agent:parked",
+    });
     while (!(await fs.stat(startedFlag).catch(() => undefined))) {
       await new Promise((resolve) => {
         setTimeout(resolve, 20);
       });
     }
 
-    // Same-owner retry returns the in-flight record without touching the worktree...
-    const retry = await service.create({ repoRoot: repo, name: "parked" });
-    // ...and a foreign-owner retry is rejected instead of adopting it.
+    // The claim-time row is observable but not usable: list() shows it provisioning, while
+    // usable-record acquisition (findLiveByOwner, same-name create) refuses to hand it out.
+    const parkedRows = listRegistryWorktrees(env).filter((entry) => entry.name === "parked");
+    expect(parkedRows.map((entry) => entry.readiness)).toEqual(["provisioning"]);
+    expect(service.findLiveByOwner("session", "agent:parked")).toBeUndefined();
     await expect(
-      service.create({ repoRoot: repo, name: "parked", ownerKind: "session", ownerId: "s1" }),
-    ).rejects.toThrow(/already in use by manual/);
-    expect(listRegistryWorktrees(env).filter((entry) => entry.path === retry.path)).toHaveLength(1);
+      service.create({
+        repoRoot: repo,
+        name: "parked",
+        ownerKind: "session",
+        ownerId: "agent:parked",
+      }),
+    ).rejects.toThrow("worktree provisioning in progress: parked");
+    await expect(service.create({ repoRoot: repo, name: "parked" })).rejects.toThrow(
+      "worktree provisioning in progress: parked",
+    );
+    expect(listRegistryWorktrees(env).filter((entry) => entry.name === "parked")).toHaveLength(1);
 
     await fs.writeFile(releaseFlag, "");
     const first = await firstPromise;
 
-    expect(retry.id).toBe(first.id);
+    expect(first.readiness).toBe("ready");
+    expect(service.findLiveByOwner("session", "agent:parked")?.id).toBe(first.id);
     // Only #1's setup execution ever ran; no retry adopted, re-provisioned, or cleaned up.
     expect(await fs.readFile(path.join(first.path, "setup-marker.txt"), "utf8")).toBe("ran\n");
     expect(await fs.stat(first.path)).toBeTruthy();
     const rows = listRegistryWorktrees(env).filter((entry) => entry.path === first.path);
-    expect(rows.map((entry) => entry.id)).toEqual([first.id]);
+    expect(rows.map((entry) => [entry.id, entry.readiness])).toEqual([[first.id, "ready"]]);
+  });
+
+  it("gc reaps stale provisioning rows and preserves fresh ones", async () => {
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      "#!/bin/sh\necho ran > setup-marker.txt\n",
+      { mode: 0o755 },
+    );
+    const named = await service.create({ repoRoot: repo, name: "stale-prov" });
+    const autoNamed = await service.create({ repoRoot: repo });
+    // Constructed post-claim crash state: live worktree + branch with a row still marked
+    // 'provisioning' — exactly what a create() killed mid-setup leaves behind.
+    updateRegistryWorktree(env, named.id, { readiness: "provisioning" });
+    updateRegistryWorktree(env, autoNamed.id, { readiness: "provisioning" });
+
+    // At the threshold the rows are still considered in-flight and stay untouched.
+    now += PROVISIONING_STALE_MS;
+    await service.gc();
+    expect(getRegistryWorktree(env, named.id)?.readiness).toBe("provisioning");
+    expect(await fs.stat(named.path)).toBeTruthy();
+
+    // Past the threshold the holder is dead by contract: row, worktree, and branch go away.
+    now += 1;
+    await service.gc();
+    expect(getRegistryWorktree(env, named.id)).toBeUndefined();
+    expect(getRegistryWorktree(env, autoNamed.id)).toBeUndefined();
+    await expect(fs.stat(named.path)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(autoNamed.path)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await git(repo, "branch", "--list", named.branch)).toBe("");
+    expect(await git(repo, "branch", "--list", autoNamed.branch)).toBe("");
+
+    // Background recovery is complete: the same name (and any auto name) provisions fresh.
+    const recreated = await service.create({ repoRoot: repo, name: "stale-prov" });
+    expect(recreated.readiness).toBe("ready");
+    expect(await fs.readFile(path.join(recreated.path, "setup-marker.txt"), "utf8")).toBe("ran\n");
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -686,23 +686,6 @@ describe("ManagedWorktreeService", () => {
     await git(repo, "worktree", "remove", "--force", foreign);
   });
 
-  it("adopts a worktree orphaned when create() crashed before the registry insert, during gc()", async () => {
-    const created = await service.create({ repoRoot: repo, name: "orphan-gc" });
-    // Simulates a create() that crashed between `git worktree add` and insertRegistryWorktree():
-    // the live worktree + branch stay on disk exactly as create() left them, but the row that
-    // would name them in the registry never landed.
-    deleteRegistryWorktree(env, created.id);
-    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
-
-    const result = await service.gc();
-
-    expect(result.orphansDeleted).toBe(0);
-    const adopted = (await service.list()).find((entry) => entry.path === created.path);
-    expect(adopted).toMatchObject({ path: created.path, branch: created.branch });
-    expect(await fs.stat(created.path)).toBeTruthy();
-    expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
-  });
-
   it("adopts an orphaned worktree instead of throwing on a retried create() with the same name", async () => {
     const created = await service.create({
       repoRoot: repo,
@@ -781,39 +764,6 @@ describe("ManagedWorktreeService", () => {
     expect(findRegistryWorktreeByPath(env, created.path)).toBeUndefined();
   });
 
-  it("gc adoption loses to a concurrent create() registration without duplicating the row", async () => {
-    const created = await service.create({ repoRoot: repo, name: "race-gc" });
-    deleteRegistryWorktree(env, created.id);
-    // A protected idle session record makes gc call isOwnerActive AFTER its registry snapshot
-    // but BEFORE reconcileOrphans, deterministically simulating a create() that registers the
-    // orphan path inside that window — the exact interleaving the atomic claim guards.
-    await service.create({
-      repoRoot: repo,
-      name: "race-idle",
-      ownerKind: "session",
-      ownerId: "agent:race",
-    });
-    now += IDLE_GC_MS + 1;
-    const winner: ManagedWorktreeRecord = {
-      ...created,
-      id: "race-winner",
-      createdAt: now,
-      lastActiveAt: now,
-    };
-
-    const result = await service.gc({
-      isOwnerActive: () => {
-        insertRegistryWorktree(env, winner);
-        return true;
-      },
-    });
-
-    expect(result.orphansDeleted).toBe(0);
-    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
-    expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
-    expect(await fs.stat(created.path)).toBeTruthy();
-  });
-
   it("retried create() returns the concurrent winner's record instead of double-registering", async () => {
     const created = await service.create({ repoRoot: repo, name: "race-retry" });
     deleteRegistryWorktree(env, created.id);
@@ -878,27 +828,65 @@ describe("ManagedWorktreeService", () => {
     expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
   });
 
-  it("binds a gc-adopted name to the manual record until removed", async () => {
-    const created = await service.create({ repoRoot: repo, name: "gc-owned" });
-    deleteRegistryWorktree(env, created.id);
-    await service.gc();
-    const adopted = (await service.list()).find((entry) => entry.path === created.path);
-    expect(adopted?.ownerKind).toBe("manual");
+  it("gc during a normal create() preserves the in-flight worktree and leaves one live row", async () => {
+    const syncDir = path.join(root, "sync");
+    await fs.mkdir(syncDir, { recursive: true });
+    const startedFlag = path.join(syncDir, "setup-started");
+    const releaseFlag = path.join(syncDir, "setup-release");
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    // The setup script parks create() mid-provisioning until released, so gc deterministically
+    // observes the live-worktree/no-registry-row window of a normal create().
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
+      { mode: 0o755 },
+    );
 
-    // An owner-carrying retry hits the owner guard against gc's manual record...
-    await expect(
-      service.create({
-        repoRoot: repo,
-        name: "gc-owned",
-        ownerKind: "workboard",
-        ownerId: "card-9",
-      }),
-    ).rejects.toThrow(/already in use by manual/);
+    const createPromise = service.create({ repoRoot: repo, name: "during-gc" });
+    while (!(await fs.stat(startedFlag).catch(() => undefined))) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+    const result = await service.gc();
+    await fs.writeFile(releaseFlag, "");
+    const created = await createPromise;
 
-    // ...while an ownerless retry reuses it.
-    const reused = await service.create({ repoRoot: repo, name: "gc-owned" });
-    expect(reused.id).toBe(adopted?.id);
-    expect(reused.ownerKind).toBe("manual");
+    expect(result.orphansDeleted).toBe(0);
+    expect(await fs.stat(created.path)).toBeTruthy();
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
+    expect(rows.map((entry) => entry.id)).toEqual([created.id]);
+  });
+
+  it("normal create() returns the concurrent winner's record instead of double-registering", async () => {
+    const sibling = await service.create({ repoRoot: repo, name: "sibling" });
+    const winner: ManagedWorktreeRecord = {
+      ...sibling,
+      id: "race-winner",
+      name: "race-normal",
+      path: path.join(path.dirname(sibling.path), "race-normal"),
+      branch: "openclaw/race-normal",
+    };
+    let raced = false;
+    // Normal create()'s first now() read is the record's createdAt, taken right before its
+    // final claim; the trapdoor inserts the competing row there, simulating a concurrent
+    // create() that registered the same path during this call's provisioning window.
+    const racingService = new ManagedWorktreeService({
+      env,
+      now: () => {
+        if (!raced) {
+          raced = true;
+          insertRegistryWorktree(env, winner);
+        }
+        return now;
+      },
+    });
+
+    const created = await racingService.create({ repoRoot: repo, name: "race-normal" });
+
+    expect(created.id).toBe("race-winner");
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === winner.path);
+    expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -9,8 +9,11 @@ import {
   deleteRegistryWorktree,
   findRegistryWorktreeByPath,
   getRegistryWorktree,
+  insertRegistryWorktree,
+  listRegistryWorktrees,
 } from "./registry.js";
 import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
+import type { ManagedWorktreeRecord } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -776,6 +779,65 @@ describe("ManagedWorktreeService", () => {
     expect(await git(repo, "branch", "--list", "openclaw/orphan-refail")).toBe("");
     await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
     expect(findRegistryWorktreeByPath(env, created.path)).toBeUndefined();
+  });
+
+  it("gc adoption loses to a concurrent create() registration without duplicating the row", async () => {
+    const created = await service.create({ repoRoot: repo, name: "race-gc" });
+    deleteRegistryWorktree(env, created.id);
+    // A protected idle session record makes gc call isOwnerActive AFTER its registry snapshot
+    // but BEFORE reconcileOrphans, deterministically simulating a create() that registers the
+    // orphan path inside that window — the exact interleaving the atomic claim guards.
+    await service.create({
+      repoRoot: repo,
+      name: "race-idle",
+      ownerKind: "session",
+      ownerId: "agent:race",
+    });
+    now += IDLE_GC_MS + 1;
+    const winner: ManagedWorktreeRecord = {
+      ...created,
+      id: "race-winner",
+      createdAt: now,
+      lastActiveAt: now,
+    };
+
+    const result = await service.gc({
+      isOwnerActive: () => {
+        insertRegistryWorktree(env, winner);
+        return true;
+      },
+    });
+
+    expect(result.orphansDeleted).toBe(0);
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
+    expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
+    expect(await fs.stat(created.path)).toBeTruthy();
+  });
+
+  it("retried create() returns the concurrent winner's record instead of double-registering", async () => {
+    const created = await service.create({ repoRoot: repo, name: "race-retry" });
+    deleteRegistryWorktree(env, created.id);
+    const winner: ManagedWorktreeRecord = { ...created, id: "race-winner" };
+    let raced = false;
+    // The first now() read inside the retried create() lands before the atomic claim; the
+    // trapdoor inserts the competing row there, deterministically simulating a concurrent
+    // create() winning the path after this call's registry lookup.
+    const racingService = new ManagedWorktreeService({
+      env,
+      now: () => {
+        if (!raced) {
+          raced = true;
+          insertRegistryWorktree(env, winner);
+        }
+        return now;
+      },
+    });
+
+    const retried = await racingService.create({ repoRoot: repo, name: "race-retry" });
+
+    expect(retried.id).toBe("race-winner");
+    const rows = listRegistryWorktrees(env).filter((entry) => entry.path === created.path);
+    expect(rows.map((entry) => entry.id)).toEqual(["race-winner"]);
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { getRegistryWorktree } from "./registry.js";
+import { deleteRegistryWorktree, getRegistryWorktree } from "./registry.js";
 import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 
 const execFileAsync = promisify(execFile);
@@ -677,6 +677,36 @@ describe("ManagedWorktreeService", () => {
     await expect(fs.stat(debris)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await fs.stat(foreign)).toBeTruthy();
     await git(repo, "worktree", "remove", "--force", foreign);
+  });
+
+  it("adopts a worktree orphaned when create() crashed before the registry insert, during gc()", async () => {
+    const created = await service.create({ repoRoot: repo, name: "orphan-gc" });
+    // Simulates a create() that crashed between `git worktree add` and insertRegistryWorktree():
+    // the live worktree + branch stay on disk exactly as create() left them, but the row that
+    // would name them in the registry never landed.
+    deleteRegistryWorktree(env, created.id);
+    expect(getRegistryWorktree(env, created.id)).toBeUndefined();
+
+    const result = await service.gc();
+
+    expect(result.orphansDeleted).toBe(0);
+    const adopted = (await service.list()).find((entry) => entry.path === created.path);
+    expect(adopted).toMatchObject({ path: created.path, branch: created.branch });
+    expect(await fs.stat(created.path)).toBeTruthy();
+    expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
+  });
+
+  it("adopts an orphaned worktree instead of throwing on a retried create() with the same name", async () => {
+    const created = await service.create({ repoRoot: repo, name: "orphan-retry" });
+    deleteRegistryWorktree(env, created.id);
+
+    const retried = await service.create({ repoRoot: repo, name: "orphan-retry" });
+
+    expect(retried.path).toBe(created.path);
+    expect(retried.branch).toBe(created.branch);
+    expect(retried.id).not.toBe(created.id);
+    expect(getRegistryWorktree(env, retried.id)).toBeDefined();
+    expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
   });
 
   it("prunes expired snapshot refs and registry rows", async () => {

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -1006,6 +1006,60 @@ describe("ManagedWorktreeService", () => {
     );
   });
 
+  it("per-file copy heartbeats keep a long-running copy's lease alive through gc", async () => {
+    const syncDir = path.join(root, "sync");
+    await fs.mkdir(syncDir, { recursive: true });
+    const startedFlag = path.join(syncDir, "setup-started");
+    const releaseFlag = path.join(syncDir, "setup-release");
+    await fs.writeFile(path.join(repo, ".gitignore"), "a.env\nb.env\n");
+    await fs.writeFile(path.join(repo, ".worktreeinclude"), "a.env\nb.env\n");
+    await fs.writeFile(path.join(repo, "a.env"), "a\n");
+    await fs.writeFile(path.join(repo, "b.env"), "b\n");
+    await fs.mkdir(path.join(repo, ".openclaw"));
+    await fs.writeFile(
+      path.join(repo, ".openclaw", "worktree-setup.sh"),
+      `#!/bin/sh\n: > "${startedFlag}"\ni=0\nwhile [ ! -f "${releaseFlag}" ]; do\n  i=$((i + 1))\n  [ "$i" -gt 400 ] && exit 9\n  sleep 0.1\ndone\nexit 0\n`,
+      { mode: 0o755 },
+    );
+    let nowCalls = 0;
+    // The first per-file heartbeat's now() read (call #2, after the claim's createdAt) jumps
+    // the clock past the stale threshold — simulating a first include-file copy that took far
+    // longer than PROVISIONING_STALE_MS while the holder stayed alive.
+    const racingService = new ManagedWorktreeService({
+      env,
+      now: () => {
+        nowCalls += 1;
+        if (nowCalls === 2) {
+          now += PROVISIONING_STALE_MS + 1;
+        }
+        return now;
+      },
+    });
+
+    const createPromise = racingService.create({ repoRoot: repo, name: "slow-copy" });
+    while (!(await fs.stat(startedFlag).catch(() => undefined))) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+
+    // Mid-provisioning and far past the CLAIM's age, the fresh per-file heartbeat is what
+    // keeps gc from reaping the live holder.
+    const parked = listRegistryWorktrees(env).find((entry) => entry.name === "slow-copy");
+    expect(parked?.readiness).toBe("provisioning");
+    expect(now - parked!.createdAt).toBeGreaterThan(PROVISIONING_STALE_MS);
+    expect(parked?.lastActiveAt).toBe(now);
+    await service.gc();
+    expect(getRegistryWorktree(env, parked!.id)?.readiness).toBe("provisioning");
+    expect(await fs.stat(parked!.path)).toBeTruthy();
+
+    await fs.writeFile(releaseFlag, "");
+    const created = await createPromise;
+    expect(created.readiness).toBe("ready");
+    // now() reads: claim createdAt + one heartbeat per copied file (2) + the ready flip.
+    expect(nowCalls).toBe(4);
+  });
+
   it("gc reaps silent provisioning leases and preserves heartbeating ones", async () => {
     await fs.mkdir(path.join(repo, ".openclaw"));
     await fs.writeFile(

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -697,15 +697,32 @@ describe("ManagedWorktreeService", () => {
   });
 
   it("adopts an orphaned worktree instead of throwing on a retried create() with the same name", async () => {
-    const created = await service.create({ repoRoot: repo, name: "orphan-retry" });
+    const created = await service.create({
+      repoRoot: repo,
+      name: "orphan-retry",
+      ownerKind: "workboard",
+      ownerId: "card-42",
+    });
     deleteRegistryWorktree(env, created.id);
 
-    const retried = await service.create({ repoRoot: repo, name: "orphan-retry" });
+    const retried = await service.create({
+      repoRoot: repo,
+      name: "orphan-retry",
+      ownerKind: "workboard",
+      ownerId: "card-42",
+    });
 
     expect(retried.path).toBe(created.path);
     expect(retried.branch).toBe(created.branch);
     expect(retried.id).not.toBe(created.id);
-    expect(getRegistryWorktree(env, retried.id)).toBeDefined();
+    // The retry's owner must survive adoption so findLiveByOwner() and idle-gc still apply.
+    expect(retried.ownerKind).toBe("workboard");
+    expect(retried.ownerId).toBe("card-42");
+    expect(getRegistryWorktree(env, retried.id)).toMatchObject({
+      ownerKind: "workboard",
+      ownerId: "card-42",
+    });
+    expect(service.findLiveByOwner("workboard", "card-42")?.id).toBe(retried.id);
     expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
   });
 

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -25,6 +25,7 @@ import {
   findLiveRegistryWorktreeByPath,
   getRegistryWorktree,
   insertRegistryWorktree,
+  insertRegistryWorktreeIfPathFree,
   listRegistryWorktrees,
   updateRegistryWorktree,
 } from "./registry.js";
@@ -92,6 +93,12 @@ function recordOwnerMatches(
   return (
     record.ownerKind === (params.ownerKind ?? "manual") &&
     (record.ownerId ?? undefined) === (params.ownerId ?? undefined)
+  );
+}
+
+function worktreeNameInUseError(record: ManagedWorktreeRecord, name: string): Error {
+  return new Error(
+    `worktree name is already in use by ${record.ownerKind}${record.ownerId ? ` ${record.ownerId}` : ""}: ${name}`,
   );
 }
 
@@ -354,9 +361,7 @@ export class ManagedWorktreeService {
     // caller-chosen name could bind a new owner to another session's or a
     // manual checkout and run inside it.
     if (existing?.name === name && !existing.removedAt && !recordOwnerMatches(existing, params)) {
-      throw new Error(
-        `worktree name is already in use by ${existing.ownerKind}${existing.ownerId ? ` ${existing.ownerId}` : ""}: ${name}`,
-      );
+      throw worktreeNameInUseError(existing, name);
     }
     if (existing?.name === name && existing.removedAt === undefined) {
       if (await pathExists(existing.path)) {
@@ -366,9 +371,7 @@ export class ManagedWorktreeService {
     }
     if (existing?.name === name && existing.removedAt !== undefined && existing.snapshotRef) {
       if (!recordOwnerMatches(existing, params)) {
-        throw new Error(
-          `worktree name is already in use by ${existing.ownerKind}${existing.ownerId ? ` ${existing.ownerId}` : ""}: ${name}`,
-        );
+        throw worktreeNameInUseError(existing, name);
       }
       return await this.restore({ id: existing.id });
     }
@@ -404,7 +407,7 @@ export class ManagedWorktreeService {
           }
           throw error;
         }
-        return this.adoptOrphan({
+        const adopted = this.adoptOrphan({
           repoFingerprint: repository.fingerprint,
           repoRoot: repository.repoRoot,
           path: worktreePath,
@@ -413,6 +416,19 @@ export class ManagedWorktreeService {
           ...(params.ownerKind ? { ownerKind: params.ownerKind } : {}),
           ...(params.ownerId ? { ownerId: params.ownerId } : {}),
         });
+        if (adopted) {
+          return adopted;
+        }
+        // Claim lost: a concurrent registration won the path while we re-provisioned; the
+        // winner owns the worktree (the re-run above is idempotent). Mirror create()'s
+        // live-row-at-path shortcut for the row we lost to.
+        const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
+        if (winner) {
+          if (!recordOwnerMatches(winner, params)) {
+            throw worktreeNameInUseError(winner, name);
+          }
+          return winner;
+        }
       }
       throw new Error(`branch already exists: ${branch}`);
     }
@@ -839,7 +855,7 @@ export class ManagedWorktreeService {
     baseRef?: string;
     ownerKind?: ManagedWorktreeOwnerKind;
     ownerId?: string;
-  }): ManagedWorktreeRecord {
+  }): ManagedWorktreeRecord | undefined {
     const createdAt = this.now();
     const record: ManagedWorktreeRecord = {
       id: randomUUID(),
@@ -857,7 +873,11 @@ export class ManagedWorktreeService {
       createdAt,
       lastActiveAt: createdAt,
     };
-    insertRegistryWorktree(this.env, record);
+    // Atomic path claim: a concurrent create()/gc() may have registered this path after the
+    // caller's registry snapshot; the loser must never add a second row for the same path.
+    if (!insertRegistryWorktreeIfPathFree(this.env, record)) {
+      return undefined;
+    }
     return record;
   }
 
@@ -896,6 +916,7 @@ export class ManagedWorktreeService {
             // instead of deleting a live worktree or leaving it invisible to list()/gc() forever.
             // Registration-only: background gc must not execute repo setup scripts, so a possibly
             // half-provisioned worktree becomes visible/removable rather than silently trusted.
+            // A lost claim means a concurrent create() registered the path first; skip either way.
             this.adoptOrphan({
               repoFingerprint: repository.fingerprint,
               repoRoot: repository.repoRoot,

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -48,10 +48,10 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
-// Lease contract: provisioning rows carry a heartbeat (lastActiveAt bumps at claim, after
-// the include-file copy, and at the ready flip), and setup is hard-bounded by
-// SETUP_SCRIPT_TIMEOUT_MS. A lease silent for 10x the setup bound has a dead holder and gc
-// may reclaim the path and branch for the next create().
+// Lease contract: provisioning rows carry a heartbeat (lastActiveAt bumps at claim, per
+// copied include-file, and at the ready flip), so the longest legitimate silent gap is the
+// SETUP_SCRIPT_TIMEOUT_MS-bounded setup script plus a single file copy. A lease silent for
+// 10x the setup bound has a dead holder and gc may reclaim the path and branch.
 export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -171,7 +171,13 @@ async function ensureNoSymlinkDirectory(root: string, relativePath: string): Pro
   return true;
 }
 
-async function copyIncludedFiles(repoRoot: string, worktreePath: string): Promise<void> {
+async function copyIncludedFiles(
+  repoRoot: string,
+  worktreePath: string,
+  // Invoked once per copied file so provisioning callers can heartbeat their lease
+  // through arbitrarily long multi-file copies; stays clock/env-free itself.
+  heartbeat?: () => void,
+): Promise<void> {
   const includePath = path.join(repoRoot, ".worktreeinclude");
   if (!(await pathExists(includePath))) {
     return;
@@ -218,6 +224,7 @@ async function copyIncludedFiles(repoRoot: string, worktreePath: string): Promis
       }
     });
     await fs.chmod(destination, sourceStat.mode);
+    heartbeat?.();
   }
 }
 
@@ -916,10 +923,11 @@ export class ManagedWorktreeService {
     // The row is visible as 'provisioning' (list()) while copy/setup run; that is what makes
     // in-flight creates unadoptable and observable. Failed creates still end with no row.
     try {
-      await copyIncludedFiles(repository.sourceRoot, worktreePath);
-      // Lease heartbeat between phases: gc treats a lease silent past PROVISIONING_STALE_MS
-      // as dead, and setup alone is bounded well under that (SETUP_SCRIPT_TIMEOUT_MS).
-      updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
+      // Per-file lease heartbeats: a long multi-file copy must keep proving a live holder,
+      // or gc would reap the lease mid-copy after PROVISIONING_STALE_MS of silence.
+      await copyIncludedFiles(repository.sourceRoot, worktreePath, () => {
+        updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
+      });
       if (params.runSetupScript !== false) {
         await runSetupScript(repository.sourceRoot, worktreePath);
       }

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -261,6 +261,25 @@ async function canResetFailedWorktreeAdd(
   return branchExists.code === 1;
 }
 
+/**
+ * A crash between `git worktree add` and `insertRegistryWorktree()` (or an orphan directory
+ * found during gc) can leave a live git worktree + managed branch with no registry row.
+ * Adoption requires an exact match on both path and branch so foreign or detached worktrees
+ * are never silently claimed.
+ */
+async function findAdoptableOrphan(
+  repoRoot: string,
+  worktreePath: string,
+  branch: string,
+): Promise<boolean> {
+  const listed = await listGitWorktrees(repoRoot).catch(() => []);
+  return listed.some(
+    (entry) =>
+      path.resolve(entry.path) === path.resolve(worktreePath) &&
+      entry.branch === `refs/heads/${branch}`,
+  );
+}
+
 async function runSetupScript(repoRoot: string, worktreePath: string): Promise<void> {
   const setupScript = path.join(repoRoot, ".openclaw", "worktree-setup.sh");
   const stat = await fs.stat(setupScript).catch(() => undefined);
@@ -361,6 +380,20 @@ export class ManagedWorktreeService {
       `refs/heads/${branch}`,
     ]);
     if (branchExists.code === 0) {
+      // No registry row was found above for this exact path, yet the managed branch already
+      // exists: this is the crashed-create() signature. Adopt only on an exact live-worktree +
+      // branch match; a bare branch collision (no worktree) keeps the throw below.
+      if (
+        existing === undefined &&
+        (await findAdoptableOrphan(repository.repoRoot, worktreePath, branch))
+      ) {
+        return this.adoptOrphan({
+          repoFingerprint: repository.fingerprint,
+          repoRoot: repository.repoRoot,
+          path: worktreePath,
+          branch,
+        });
+      }
       throw new Error(`branch already exists: ${branch}`);
     }
     if (branchExists.code !== 1) {
@@ -778,6 +811,29 @@ export class ManagedWorktreeService {
     return { removed, orphansDeleted, snapshotsPruned };
   }
 
+  private adoptOrphan(params: {
+    repoFingerprint: string;
+    repoRoot: string;
+    path: string;
+    branch: string;
+  }): ManagedWorktreeRecord {
+    const createdAt = this.now();
+    const record: ManagedWorktreeRecord = {
+      id: randomUUID(),
+      name: path.basename(params.path),
+      repoFingerprint: params.repoFingerprint,
+      repoRoot: params.repoRoot,
+      path: params.path,
+      branch: params.branch,
+      baseRef: "HEAD",
+      ownerKind: "manual",
+      createdAt,
+      lastActiveAt: createdAt,
+    };
+    insertRegistryWorktree(this.env, record);
+    return record;
+  }
+
   private requireLiveRecord(id: string): ManagedWorktreeRecord {
     const record = getRegistryWorktree(this.env, id);
     if (!record || record.removedAt !== undefined) {
@@ -807,6 +863,18 @@ export class ManagedWorktreeService {
         }
         const repository = await resolveRepository(candidate).catch(() => undefined);
         if (repository) {
+          const managedBranch = `openclaw/${name.name}`;
+          if (await findAdoptableOrphan(repository.repoRoot, candidate, managedBranch)) {
+            // Orphaned by a create() that crashed before insertRegistryWorktree(); reclaim it
+            // instead of deleting a live worktree or leaving it invisible to list()/gc() forever.
+            this.adoptOrphan({
+              repoFingerprint: repository.fingerprint,
+              repoRoot: repository.repoRoot,
+              path: candidate,
+              branch: managedBranch,
+            });
+            continue;
+          }
           const listed = await listGitWorktrees(repository.repoRoot).catch(() => []);
           if (listed.some((entry) => path.resolve(entry.path) === path.resolve(candidate))) {
             continue;

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -48,10 +48,11 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
-// Lease contract: a provisioning holder bumps lastActiveAt on a wall-clock interval for the
-// whole provisioning phase, so no stall class (large include-file copy, slow setup, ...)
-// leaves a silence gap while the process lives. A lease silent for PROVISIONING_STALE_MS
-// has a dead holder and gc may reclaim the path and branch.
+// Provisioning heartbeat contract (distinct from run leases in run-lease.ts): a provisioning
+// holder bumps lastActiveAt on a wall-clock interval for the whole provisioning phase, so no
+// stall class (large include-file copy, slow setup, ...) leaves a silence gap while the
+// process lives. A claim silent for PROVISIONING_STALE_MS has a dead holder and gc may
+// reclaim the path and branch.
 export const PROVISIONING_HEARTBEAT_MS = 30_000; // 40x inside the stale threshold.
 export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
@@ -514,16 +515,35 @@ export class ManagedWorktreeService {
    */
   private async healMissingPathRecord(record: ManagedWorktreeRecord): Promise<boolean> {
     if (record.readiness === "provisioning") {
-      // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
-      // (unlisted dir, missing branch).
-      await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
-      deleteRegistryWorktree(this.env, record.id);
+      await this.reapProvisioningRecord(record);
       return true;
     }
     const removedAt = this.now();
     updateRegistryWorktree(this.env, record.id, { removedAt });
     record.removedAt = removedAt;
     return false;
+  }
+
+  /**
+   * Destroys a dead provisioning claim (worktree, branch, row). Every remover — this reap
+   * included — serializes through the removal claim: a provisioning row cannot hold a run
+   * lease by construction (sessions are only ever handed 'ready' records), but the uniform
+   * claim keeps one serialization point with remove()/removeIfLossless() and excludes
+   * competing removers; a live run lease rejects the claim and the caller skips the record.
+   */
+  private async reapProvisioningRecord(record: ManagedWorktreeRecord): Promise<void> {
+    const claimToken = randomUUID();
+    claimWorktreeRemoval(this.env, { worktreeId: record.id, token: claimToken, force: false });
+    try {
+      // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
+      // (unlisted dir, missing branch), unlike the happy-path cleanupFailedCreate.
+      await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
+      deleteRegistryWorktree(this.env, record.id);
+      finalizeWorktreeRemoval(this.env, record.id);
+    } catch (error) {
+      abortWorktreeRemoval(this.env, record.id, claimToken);
+      throw error;
+    }
   }
 
   findLiveByOwner(
@@ -821,18 +841,15 @@ export class ManagedWorktreeService {
             continue;
           }
         }
-        // A 'provisioning' lease silent past PROVISIONING_STALE_MS has a dead holder; reap
-        // worktree+branch+row so the next create() — including auto-named orphans no retry
-        // will ever reach — starts fresh. Recently heartbeating leases stay untouched.
+        // A provisioning claim whose heartbeat is silent past PROVISIONING_STALE_MS has a
+        // dead holder; reap worktree+branch+row so the next create() — including auto-named
+        // orphans no retry will ever reach — starts fresh. Heartbeating claims stay untouched.
         if (
           record.removedAt === undefined &&
           record.readiness === "provisioning" &&
           now - record.lastActiveAt > PROVISIONING_STALE_MS
         ) {
-          // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
-          // (unlisted dir, missing branch), unlike the happy-path cleanupFailedCreate.
-          await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
-          deleteRegistryWorktree(this.env, record.id);
+          await this.reapProvisioningRecord(record);
           continue;
         }
         // Manual worktrees remain until explicit removal; only run-owned worktrees expire.
@@ -935,10 +952,10 @@ export class ManagedWorktreeService {
     }
     // The row is visible as 'provisioning' (list()) while copy/setup run; that is what makes
     // in-flight creates unadoptable and observable. Failed creates still end with no row.
-    // Wall-clock lease heartbeat for the whole provisioning phase: any stall class (a single
-    // large include-file copy, a slow setup) keeps proving a live holder, so gc never reaps
-    // a lease whose process is still alive. Always cleared below; a leaked interval would
-    // keep bumping a dead lease forever.
+    // Wall-clock provisioning heartbeat for the whole phase: any stall class (a single large
+    // include-file copy, a slow setup) keeps proving a live holder, so gc never reaps a
+    // claim whose process is still alive. Always cleared below; a leaked interval would
+    // keep bumping a dead claim forever.
     const heartbeat = setInterval(() => {
       updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
     }, PROVISIONING_HEARTBEAT_MS);
@@ -965,7 +982,7 @@ export class ManagedWorktreeService {
     const readyAt = this.now();
     updateRegistryWorktree(this.env, record.id, { readiness: "ready", lastActiveAt: readyAt });
     // Backstop for the pathological suspended holder: heartbeats can stall long enough for
-    // gc to reap the lease mid-create; the flip above then updated zero rows. Never hand
+    // gc to reap the claim mid-create; the flip above then updated zero rows. Never hand
     // back a record whose path was already reclaimed.
     const flipped = getRegistryWorktree(this.env, record.id);
     if (!flipped || flipped.removedAt !== undefined) {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -363,6 +363,8 @@ export class ManagedWorktreeService {
     }
     if (existing?.name === name && existing.removedAt === undefined) {
       if (await pathExists(existing.path)) {
+        // May return a record whose provisioning is still in flight (rows are visible from
+        // claim-time onward); callers already face that window via restore() and re-creates.
         return existing;
       }
       updateRegistryWorktree(this.env, existing.id, { removedAt: this.now() });
@@ -390,57 +392,21 @@ export class ManagedWorktreeService {
         existing === undefined &&
         (await findAdoptableOrphan(repository.repoRoot, worktreePath, branch))
       ) {
-        const adoptedBase = await resolveBase(repository.repoRoot, params.baseRef);
-        // Claim BEFORE provisioning: only the claim holder may provision or destroy this
-        // path; losers must never touch it. Claiming first means a concurrent create()
-        // cannot register the path during the (long) setup re-run and then have its live
-        // worktree force-removed by this call's failure cleanup, and the repo setup script
-        // never runs twice concurrently in the same path.
-        const adopted = this.adoptOrphan({
-          repoFingerprint: repository.fingerprint,
-          repoRoot: repository.repoRoot,
-          path: worktreePath,
+        // The crash may have hit before provisioning finished; claimThenProvision re-runs
+        // copy + setup as the claim holder, or defers to a concurrent winner untouched.
+        const adoptedBase = await resolveWorktreeBase(repository.repoRoot, params.baseRef);
+        const adopted = await this.claimThenProvision({
+          repository,
+          params,
+          name,
+          worktreePath,
           branch,
-          baseRef: adoptedBase.base,
-          ...(params.ownerKind ? { ownerKind: params.ownerKind } : {}),
-          ...(params.ownerId ? { ownerId: params.ownerId } : {}),
+          baseRef: adoptedBase.recordRef,
         });
-        if (adopted === undefined) {
-          // Claim lost: a concurrent registration won the path; this call runs no setup,
-          // no copy, no cleanup. Mirror create()'s live-row-at-path shortcut for the winner.
-          const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
-          if (winner) {
-            if (!recordOwnerMatches(winner, params)) {
-              throw worktreeNameInUseError(winner, name);
-            }
-            return winner;
-          }
-          // Winner vanished between claim and lookup; fall through to the collision error.
-        } else {
-          // The crash may have hit before provisioning finished, so re-run copy + setup with
-          // the normal create() failure semantics. Unlike normal create() the row exists
-          // during this re-run — acceptable: the physical worktree already exists (orphan
-          // reclaim), and gc-side adoption also registers without provisioning.
-          try {
-            await copyIncludedFiles(repository.sourceRoot, worktreePath);
-            if (params.runSetupScript !== false) {
-              await runSetupScript(repository.sourceRoot, worktreePath);
-            }
-          } catch (error) {
-            // Claim-holder-only destruction: the row is held while the worktree is removed,
-            // then dropped so no registration outlives the path.
-            try {
-              await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
-            } catch (cleanupError) {
-              throw new Error(`${String(error)}\n${String(cleanupError)}`, {
-                cause: cleanupError,
-              });
-            }
-            deleteRegistryWorktree(this.env, adopted.id);
-            throw error;
-          }
+        if (adopted) {
           return adopted;
         }
+        // Winner vanished between claim and lookup; fall through to the collision error.
       }
       throw new Error(`branch already exists: ${branch}`);
     }
@@ -480,45 +446,19 @@ export class ManagedWorktreeService {
     if (added.code !== 0) {
       throw commandError("git worktree add", added);
     }
-    try {
-      await copyIncludedFiles(repository.sourceRoot, worktreePath);
-      if (params.runSetupScript !== false) {
-        await runSetupScript(repository.sourceRoot, worktreePath);
-      }
-    } catch (error) {
-      try {
-        await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
-      } catch (cleanupError) {
-        throw new Error(`${String(error)}\n${String(cleanupError)}`, { cause: cleanupError });
-      }
-      throw error;
-    }
-    const createdAt = this.now();
-    const record: ManagedWorktreeRecord = {
-      id: randomUUID(),
+    // Claim immediately after the add so the in-flight create is registered before any user
+    // code (copy/setup) runs; the only no-row window left is add -> claim, which runs no
+    // user code and is what the adoption path above recovers.
+    const record = await this.claimThenProvision({
+      repository,
+      params,
       name,
-      repoFingerprint: repository.fingerprint,
-      repoRoot: repository.repoRoot,
-      path: worktreePath,
+      worktreePath,
       branch,
       baseRef: recordBase,
-      ownerKind: params.ownerKind ?? "manual",
-      ...(params.ownerId ? { ownerId: params.ownerId } : {}),
-      createdAt,
-      lastActiveAt: createdAt,
-    };
-    // Every new live row goes through the atomic path claim. A lost claim means a concurrent
-    // create() registered this exact path during the setup window (same-name serialization);
-    // mirror the live-row-at-path shortcut for the row that won.
-    if (!insertRegistryWorktreeIfPathFree(this.env, record)) {
-      const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
-      if (!winner) {
-        throw new Error(`worktree registration raced and lost: ${worktreePath}`);
-      }
-      if (!recordOwnerMatches(winner, params)) {
-        throw worktreeNameInUseError(winner, name);
-      }
-      return winner;
+    });
+    if (!record) {
+      throw new Error(`worktree registration raced and lost: ${worktreePath}`);
     }
     return record;
   }
@@ -871,35 +811,67 @@ export class ManagedWorktreeService {
     return { removed, orphansDeleted, snapshotsPruned };
   }
 
-  private adoptOrphan(params: {
-    repoFingerprint: string;
-    repoRoot: string;
-    path: string;
+  /**
+   * Shared post-`git worktree add` sequence for normal create and orphan adoption: claim the
+   * path atomically FIRST, then only the claim holder provisions; on provisioning failure the
+   * holder removes worktree+branch and drops its own row, so failed creates leave no row.
+   * Invariant: an in-flight create holds a live row from claim-time onward, so a live worktree
+   * with NO row genuinely means a crashed create — an in-flight worktree can never be adopted,
+   * re-provisioned, or destroyed by a concurrent same-name call. A lost claim mirrors the
+   * live-row-at-path shortcut; undefined means the claim lost and no live winner row exists.
+   */
+  private async claimThenProvision(args: {
+    repository: { fingerprint: string; repoRoot: string; sourceRoot: string };
+    params: CreateManagedWorktreeParams;
+    name: string;
+    worktreePath: string;
     branch: string;
     baseRef: string;
-    ownerKind?: ManagedWorktreeOwnerKind;
-    ownerId?: string;
-  }): ManagedWorktreeRecord | undefined {
+  }): Promise<ManagedWorktreeRecord | undefined> {
+    const { repository, params, name, worktreePath, branch, baseRef } = args;
     const createdAt = this.now();
     const record: ManagedWorktreeRecord = {
       id: randomUUID(),
-      name: path.basename(params.path),
-      repoFingerprint: params.repoFingerprint,
-      repoRoot: params.repoRoot,
-      path: params.path,
-      branch: params.branch,
-      baseRef: params.baseRef,
-      // Mirrors create()'s owner defaulting so a retried create() keeps findLiveByOwner()
-      // lookups and idle-gc expiry working.
+      name,
+      repoFingerprint: repository.fingerprint,
+      repoRoot: repository.repoRoot,
+      path: worktreePath,
+      branch,
+      baseRef,
       ownerKind: params.ownerKind ?? "manual",
       ...(params.ownerId ? { ownerId: params.ownerId } : {}),
       createdAt,
       lastActiveAt: createdAt,
     };
-    // Atomic path claim: a concurrent create() may have registered this path after this
-    // call's registry lookup; the loser must never add a second row for the same path.
     if (!insertRegistryWorktreeIfPathFree(this.env, record)) {
-      return undefined;
+      // Claim lost: a concurrent create() owns the path; this call runs no setup, no copy,
+      // no cleanup.
+      const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
+      if (!winner) {
+        return undefined;
+      }
+      if (!recordOwnerMatches(winner, params)) {
+        throw worktreeNameInUseError(winner, name);
+      }
+      return winner;
+    }
+    // Trade-off: the row is visible (list()) while provisioning runs; that is the cost of
+    // making in-flight creates unadoptable. Failed creates still end with no row.
+    try {
+      await copyIncludedFiles(repository.sourceRoot, worktreePath);
+      if (params.runSetupScript !== false) {
+        await runSetupScript(repository.sourceRoot, worktreePath);
+      }
+    } catch (error) {
+      // Claim-holder-only destruction: the row is held while the worktree is removed, then
+      // dropped so no registration outlives the path.
+      try {
+        await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
+      } catch (cleanupError) {
+        throw new Error(`${String(error)}\n${String(cleanupError)}`, { cause: cleanupError });
+      }
+      deleteRegistryWorktree(this.env, record.id);
+      throw error;
     }
     return record;
   }

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -80,6 +80,13 @@ export class WorktreeProvisioningReapedError extends Error {
     super(`worktree provisioning exceeded its window and was reclaimed: ${name}`);
   }
 }
+
+/** Snapshot restore refused: a provisioning-origin snapshot has no usable checkout. */
+export class WorktreeUnprovisionedRestoreError extends Error {
+  constructor(name: string) {
+    super(`cannot restore a worktree that never finished provisioning: ${name}; create it again`);
+  }
+}
 const SNAPSHOT_REF_PREFIX = "refs/openclaw/snapshots";
 const log = createSubsystemLogger("agents/worktrees");
 
@@ -399,9 +406,17 @@ export class ManagedWorktreeService {
       if (!recordOwnerMatches(existing, params)) {
         throw worktreeNameInUseError(existing, name);
       }
-      // restore() re-activates this EXISTING row via updateRegistryWorktree — it operates on
-      // the row that already owns the path, so it cannot create a duplicate live row.
-      return await this.restore({ id: existing.id });
+      if (existing.readiness === "provisioning") {
+        // A provisioning-origin snapshot has no completed provisioning and no user work
+        // (same rationale as the missing-path heal); drop the row and its snapshot ref so
+        // the fresh create below provisions from scratch instead of restoring a stub.
+        await runGit(existing.repoRoot, ["update-ref", "-d", existing.snapshotRef]);
+        deleteRegistryWorktree(this.env, existing.id);
+      } else {
+        // restore() re-activates this EXISTING row via updateRegistryWorktree — it operates on
+        // the row that already owns the path, so it cannot create a duplicate live row.
+        return await this.restore({ id: existing.id });
+      }
     }
     const branch = `openclaw/${name}`;
     const branchExists = await runGit(repository.repoRoot, [
@@ -732,6 +747,11 @@ export class ManagedWorktreeService {
     const record = getRegistryWorktree(this.env, params.id);
     if (!record?.snapshotRef || record.removedAt === undefined) {
       throw new Error(`worktree ${params.id} is not restorable`);
+    }
+    // A provisioning-origin snapshot contains no completed provisioning and no user work;
+    // restoring it as ready would hand out an unusable checkout. Fresh create is the recovery.
+    if (record.readiness === "provisioning") {
+      throw new WorktreeUnprovisionedRestoreError(record.name);
     }
     if (!(await pathExists(record.repoRoot))) {
       throw new Error(`source repository no longer exists: ${record.repoRoot}`);

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -47,6 +47,11 @@ import type {
 export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain restorable after automatic cleanup.
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
+const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
+// Provisioning rows are transient by contract: copy + setup are bounded by
+// SETUP_SCRIPT_TIMEOUT_MS, so a row still 'provisioning' this long after its claim has a
+// dead holder and gc may reclaim the path and branch for the next create().
+export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
@@ -56,6 +61,13 @@ export class WorktreeSnapshotError extends Error {
   constructor(snapshotError: string, options?: ErrorOptions) {
     super(`worktree snapshot failed; removal aborted: ${snapshotError}`, options);
     this.snapshotError = snapshotError;
+  }
+}
+
+/** Name reuse hit a same-path row still provisioning; retry after it settles or gc reaps it. */
+export class WorktreeProvisioningError extends Error {
+  constructor(name: string) {
+    super(`worktree provisioning in progress: ${name}`);
   }
 }
 const SNAPSHOT_REF_PREFIX = "refs/openclaw/snapshots";
@@ -292,7 +304,7 @@ async function runSetupScript(repoRoot: string, worktreePath: string): Promise<v
     return;
   }
   const result = await runCommandWithTimeout([setupScript], {
-    timeoutMs: 120_000,
+    timeoutMs: SETUP_SCRIPT_TIMEOUT_MS,
     cwd: worktreePath,
     env: {
       OPENCLAW_SOURCE_TREE_PATH: repoRoot,
@@ -355,6 +367,12 @@ export class ManagedWorktreeService {
     const root = path.join(resolveStateDir(this.env), "worktrees", repository.fingerprint);
     const worktreePath = path.join(root, name);
     const existing = findRegistryWorktreeByPath(this.env, worktreePath);
+    // Usable records are 'ready' only: a live 'provisioning' row means another create()
+    // holds the claim (or crashed mid-setup, which gc reaps after PROVISIONING_STALE_MS).
+    // Returning it would hand out a checkout whose copy/setup never finished.
+    if (existing?.name === name && !existing.removedAt && existing.readiness === "provisioning") {
+      throw new WorktreeProvisioningError(name);
+    }
     // Name reuse only ever adopts the caller's own record. Without this guard a
     // caller-chosen name could bind a new owner to another session's or a
     // manual checkout and run inside it.
@@ -363,8 +381,6 @@ export class ManagedWorktreeService {
     }
     if (existing?.name === name && existing.removedAt === undefined) {
       if (await pathExists(existing.path)) {
-        // May return a record whose provisioning is still in flight (rows are visible from
-        // claim-time onward); callers already face that window via restore() and re-creates.
         return existing;
       }
       updateRegistryWorktree(this.env, existing.id, { removedAt: this.now() });
@@ -762,6 +778,20 @@ export class ManagedWorktreeService {
           updateRegistryWorktree(this.env, record.id, { removedAt: now });
           record.removedAt = now;
         }
+        // Stale 'provisioning' rows have a dead holder by contract (PROVISIONING_STALE_MS);
+        // reap worktree+branch+row so the next create() — including auto-named orphans no
+        // retry will ever reach — starts fresh. Fresh provisioning rows stay untouched.
+        if (
+          record.removedAt === undefined &&
+          record.readiness === "provisioning" &&
+          now - record.createdAt > PROVISIONING_STALE_MS
+        ) {
+          // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
+          // (unlisted dir, missing branch), unlike the happy-path cleanupFailedCreate.
+          await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
+          deleteRegistryWorktree(this.env, record.id);
+          continue;
+        }
         // Manual worktrees remain until explicit removal; only run-owned worktrees expire.
         const expiresWhenIdle = record.ownerKind === "workboard" || record.ownerKind === "session";
         if (
@@ -840,6 +870,7 @@ export class ManagedWorktreeService {
       baseRef,
       ownerKind: params.ownerKind ?? "manual",
       ...(params.ownerId ? { ownerId: params.ownerId } : {}),
+      readiness: "provisioning",
       createdAt,
       lastActiveAt: createdAt,
     };
@@ -850,13 +881,17 @@ export class ManagedWorktreeService {
       if (!winner) {
         return undefined;
       }
+      // Only 'ready' rows are usable records; the winner is still provisioning its checkout.
+      if (winner.readiness === "provisioning") {
+        throw new WorktreeProvisioningError(name);
+      }
       if (!recordOwnerMatches(winner, params)) {
         throw worktreeNameInUseError(winner, name);
       }
       return winner;
     }
-    // Trade-off: the row is visible (list()) while provisioning runs; that is the cost of
-    // making in-flight creates unadoptable. Failed creates still end with no row.
+    // The row is visible as 'provisioning' (list()) while copy/setup run; that is what makes
+    // in-flight creates unadoptable and observable. Failed creates still end with no row.
     try {
       await copyIncludedFiles(repository.sourceRoot, worktreePath);
       if (params.runSetupScript !== false) {
@@ -873,7 +908,10 @@ export class ManagedWorktreeService {
       deleteRegistryWorktree(this.env, record.id);
       throw error;
     }
-    return record;
+    // Readiness flips only after provisioning fully succeeded; every usable-record path
+    // (entry shortcut, findLiveByOwner) filters on it.
+    updateRegistryWorktree(this.env, record.id, { readiness: "ready" });
+    return { ...record, readiness: "ready" };
   }
 
   private requireLiveRecord(id: string): ManagedWorktreeRecord {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -392,6 +392,8 @@ export class ManagedWorktreeService {
           repoRoot: repository.repoRoot,
           path: worktreePath,
           branch,
+          ...(params.ownerKind ? { ownerKind: params.ownerKind } : {}),
+          ...(params.ownerId ? { ownerId: params.ownerId } : {}),
         });
       }
       throw new Error(`branch already exists: ${branch}`);
@@ -816,6 +818,8 @@ export class ManagedWorktreeService {
     repoRoot: string;
     path: string;
     branch: string;
+    ownerKind?: ManagedWorktreeOwnerKind;
+    ownerId?: string;
   }): ManagedWorktreeRecord {
     const createdAt = this.now();
     const record: ManagedWorktreeRecord = {
@@ -826,7 +830,10 @@ export class ManagedWorktreeService {
       path: params.path,
       branch: params.branch,
       baseRef: "HEAD",
-      ownerKind: "manual",
+      // Mirrors create()'s owner defaulting so a retried create() keeps findLiveByOwner()
+      // lookups and idle-gc expiry working; gc-side adoption cannot recover an owner.
+      ownerKind: params.ownerKind ?? "manual",
+      ...(params.ownerId ? { ownerId: params.ownerId } : {}),
       createdAt,
       lastActiveAt: createdAt,
     };

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -48,10 +48,11 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
-// Lease contract: provisioning rows carry a heartbeat (lastActiveAt bumps at claim, per
-// copied include-file, and at the ready flip), so the longest legitimate silent gap is the
-// SETUP_SCRIPT_TIMEOUT_MS-bounded setup script plus a single file copy. A lease silent for
-// 10x the setup bound has a dead holder and gc may reclaim the path and branch.
+// Lease contract: a provisioning holder bumps lastActiveAt on a wall-clock interval for the
+// whole provisioning phase, so no stall class (large include-file copy, slow setup, ...)
+// leaves a silence gap while the process lives. A lease silent for PROVISIONING_STALE_MS
+// has a dead holder and gc may reclaim the path and branch.
+export const PROVISIONING_HEARTBEAT_MS = 30_000; // 40x inside the stale threshold.
 export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -171,13 +172,7 @@ async function ensureNoSymlinkDirectory(root: string, relativePath: string): Pro
   return true;
 }
 
-async function copyIncludedFiles(
-  repoRoot: string,
-  worktreePath: string,
-  // Invoked once per copied file so provisioning callers can heartbeat their lease
-  // through arbitrarily long multi-file copies; stays clock/env-free itself.
-  heartbeat?: () => void,
-): Promise<void> {
+async function copyIncludedFiles(repoRoot: string, worktreePath: string): Promise<void> {
   const includePath = path.join(repoRoot, ".worktreeinclude");
   if (!(await pathExists(includePath))) {
     return;
@@ -224,7 +219,6 @@ async function copyIncludedFiles(
       }
     });
     await fs.chmod(destination, sourceStat.mode);
-    heartbeat?.();
   }
 }
 
@@ -496,14 +490,40 @@ export class ManagedWorktreeService {
 
   async list(): Promise<ManagedWorktreeRecord[]> {
     const records = listRegistryWorktrees(this.env);
+    const listed: ManagedWorktreeRecord[] = [];
     for (const record of records) {
       if (record.removedAt === undefined && !(await pathExists(record.path))) {
-        const removedAt = this.now();
-        updateRegistryWorktree(this.env, record.id, { removedAt });
-        record.removedAt = removedAt;
+        try {
+          if (await this.healMissingPathRecord(record)) {
+            continue;
+          }
+        } catch (error) {
+          log.warn(`missing-path cleanup failed for ${record.id}: ${String(error)}`);
+        }
       }
+      listed.push(record);
     }
-    return records.filter((record) => record.removedAt === undefined || record.snapshotRef);
+    return listed.filter((record) => record.removedAt === undefined || record.snapshotRef);
+  }
+
+  /**
+   * Missing-path self-heal shared by list() and gc(). Provisioning rows carry no snapshot
+   * and no user work — retiring one would hide the row while its branch survives and
+   * permanently block the name, so row AND branch are hard-deleted. Ready rows retire
+   * restorably. Returns true when the row was hard-deleted.
+   */
+  private async healMissingPathRecord(record: ManagedWorktreeRecord): Promise<boolean> {
+    if (record.readiness === "provisioning") {
+      // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
+      // (unlisted dir, missing branch).
+      await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
+      deleteRegistryWorktree(this.env, record.id);
+      return true;
+    }
+    const removedAt = this.now();
+    updateRegistryWorktree(this.env, record.id, { removedAt });
+    record.removedAt = removedAt;
+    return false;
   }
 
   findLiveByOwner(
@@ -797,16 +817,9 @@ export class ManagedWorktreeService {
     for (const record of records) {
       try {
         if (record.removedAt === undefined && !(await pathExists(record.path))) {
-          // Provisioning rows have no snapshot and represent no user work; retiring one
-          // whose directory vanished would hide the row while its branch survives and
-          // permanently block the name. Delete branch + row so the name stays retriable.
-          if (record.readiness === "provisioning") {
-            await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
-            deleteRegistryWorktree(this.env, record.id);
+          if (await this.healMissingPathRecord(record)) {
             continue;
           }
-          updateRegistryWorktree(this.env, record.id, { removedAt: now });
-          record.removedAt = now;
         }
         // A 'provisioning' lease silent past PROVISIONING_STALE_MS has a dead holder; reap
         // worktree+branch+row so the next create() — including auto-named orphans no retry
@@ -922,12 +935,15 @@ export class ManagedWorktreeService {
     }
     // The row is visible as 'provisioning' (list()) while copy/setup run; that is what makes
     // in-flight creates unadoptable and observable. Failed creates still end with no row.
+    // Wall-clock lease heartbeat for the whole provisioning phase: any stall class (a single
+    // large include-file copy, a slow setup) keeps proving a live holder, so gc never reaps
+    // a lease whose process is still alive. Always cleared below; a leaked interval would
+    // keep bumping a dead lease forever.
+    const heartbeat = setInterval(() => {
+      updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
+    }, PROVISIONING_HEARTBEAT_MS);
     try {
-      // Per-file lease heartbeats: a long multi-file copy must keep proving a live holder,
-      // or gc would reap the lease mid-copy after PROVISIONING_STALE_MS of silence.
-      await copyIncludedFiles(repository.sourceRoot, worktreePath, () => {
-        updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
-      });
+      await copyIncludedFiles(repository.sourceRoot, worktreePath);
       if (params.runSetupScript !== false) {
         await runSetupScript(repository.sourceRoot, worktreePath);
       }
@@ -941,6 +957,8 @@ export class ManagedWorktreeService {
       }
       deleteRegistryWorktree(this.env, record.id);
       throw error;
+    } finally {
+      clearInterval(heartbeat);
     }
     // Readiness flips only after provisioning fully succeeded; every usable-record path
     // (entry shortcut, findLiveByOwner) filters on it. The flip is also the final heartbeat.

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -48,9 +48,10 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
-// Provisioning rows are transient by contract: copy + setup are bounded by
-// SETUP_SCRIPT_TIMEOUT_MS, so a row still 'provisioning' this long after its claim has a
-// dead holder and gc may reclaim the path and branch for the next create().
+// Provisioning rows are transient by contract: setup is hard-bounded by
+// SETUP_SCRIPT_TIMEOUT_MS and the include-file copy is short in practice, so a row still
+// 'provisioning' this long after its claim has a dead holder and gc may reclaim the path
+// and branch for the next create().
 export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -68,6 +69,13 @@ export class WorktreeSnapshotError extends Error {
 export class WorktreeProvisioningError extends Error {
   constructor(name: string) {
     super(`worktree provisioning in progress: ${name}`);
+  }
+}
+
+/** Provisioning outlived PROVISIONING_STALE_MS and gc reclaimed the path mid-create. */
+export class WorktreeProvisioningReapedError extends Error {
+  constructor(name: string) {
+    super(`worktree provisioning exceeded its window and was reclaimed: ${name}`);
   }
 }
 const SNAPSHOT_REF_PREFIX = "refs/openclaw/snapshots";
@@ -712,11 +720,18 @@ export class ManagedWorktreeService {
       throw error;
     }
     const lastActiveAt = this.now();
-    updateRegistryWorktree(this.env, params.id, { removedAt: undefined, lastActiveAt });
+    // Restore fully rematerializes the checkout, so the row is ready regardless of the
+    // readiness it was removed with; reviving a stale 'provisioning' row would let the next
+    // gc reap the freshly restored worktree and strand its snapshot ref.
+    updateRegistryWorktree(this.env, params.id, {
+      removedAt: undefined,
+      lastActiveAt,
+      readiness: "ready",
+    });
     // Clear any lease rows or removal marker stranded by a crash between git removal
     // and finalize so the restored worktree admits runs again.
     finalizeWorktreeRemoval(this.env, params.id);
-    const restored = { ...record, lastActiveAt };
+    const restored: ManagedWorktreeRecord = { ...record, lastActiveAt, readiness: "ready" };
     delete restored.removedAt;
     return restored;
   }
@@ -911,6 +926,13 @@ export class ManagedWorktreeService {
     // Readiness flips only after provisioning fully succeeded; every usable-record path
     // (entry shortcut, findLiveByOwner) filters on it.
     updateRegistryWorktree(this.env, record.id, { readiness: "ready" });
+    // Provisioning can outlive PROVISIONING_STALE_MS (suspension; copy is unbounded) and be
+    // reaped by gc mid-create; the flip above then updated zero rows. Never hand back a
+    // record whose path was already reclaimed.
+    const flipped = getRegistryWorktree(this.env, record.id);
+    if (!flipped || flipped.removedAt !== undefined) {
+      throw new WorktreeProvisioningReapedError(name);
+    }
     return { ...record, readiness: "ready" };
   }
 

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -390,23 +390,12 @@ export class ManagedWorktreeService {
         existing === undefined &&
         (await findAdoptableOrphan(repository.repoRoot, worktreePath, branch))
       ) {
-        // The crash may have hit before provisioning finished, so re-run copy + setup with the
-        // normal create() failure semantics before the registry row exists. Safe because the
-        // crashed create() never returned this worktree to any caller.
         const adoptedBase = await resolveBase(repository.repoRoot, params.baseRef);
-        try {
-          await copyIncludedFiles(repository.sourceRoot, worktreePath);
-          if (params.runSetupScript !== false) {
-            await runSetupScript(repository.sourceRoot, worktreePath);
-          }
-        } catch (error) {
-          try {
-            await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
-          } catch (cleanupError) {
-            throw new Error(`${String(error)}\n${String(cleanupError)}`, { cause: cleanupError });
-          }
-          throw error;
-        }
+        // Claim BEFORE provisioning: only the claim holder may provision or destroy this
+        // path; losers must never touch it. Claiming first means a concurrent create()/gc()
+        // cannot register the path during the (long) setup re-run and then have its live
+        // worktree force-removed by this call's failure cleanup, and the repo setup script
+        // never runs twice concurrently in the same path.
         const adopted = this.adoptOrphan({
           repoFingerprint: repository.fingerprint,
           repoRoot: repository.repoRoot,
@@ -416,18 +405,41 @@ export class ManagedWorktreeService {
           ...(params.ownerKind ? { ownerKind: params.ownerKind } : {}),
           ...(params.ownerId ? { ownerId: params.ownerId } : {}),
         });
-        if (adopted) {
-          return adopted;
-        }
-        // Claim lost: a concurrent registration won the path while we re-provisioned; the
-        // winner owns the worktree (the re-run above is idempotent). Mirror create()'s
-        // live-row-at-path shortcut for the row we lost to.
-        const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
-        if (winner) {
-          if (!recordOwnerMatches(winner, params)) {
-            throw worktreeNameInUseError(winner, name);
+        if (adopted === undefined) {
+          // Claim lost: a concurrent registration won the path; this call runs no setup,
+          // no copy, no cleanup. Mirror create()'s live-row-at-path shortcut for the winner.
+          const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
+          if (winner) {
+            if (!recordOwnerMatches(winner, params)) {
+              throw worktreeNameInUseError(winner, name);
+            }
+            return winner;
           }
-          return winner;
+          // Winner vanished between claim and lookup; fall through to the collision error.
+        } else {
+          // The crash may have hit before provisioning finished, so re-run copy + setup with
+          // the normal create() failure semantics. Unlike normal create() the row exists
+          // during this re-run — acceptable: the physical worktree already exists (orphan
+          // reclaim), and gc-side adoption also registers without provisioning.
+          try {
+            await copyIncludedFiles(repository.sourceRoot, worktreePath);
+            if (params.runSetupScript !== false) {
+              await runSetupScript(repository.sourceRoot, worktreePath);
+            }
+          } catch (error) {
+            // Claim-holder-only destruction: the row is held while the worktree is removed,
+            // then dropped so no registration outlives the path.
+            try {
+              await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
+            } catch (cleanupError) {
+              throw new Error(`${String(error)}\n${String(cleanupError)}`, {
+                cause: cleanupError,
+              });
+            }
+            deleteRegistryWorktree(this.env, adopted.id);
+            throw error;
+          }
+          return adopted;
         }
       }
       throw new Error(`branch already exists: ${branch}`);

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -24,7 +24,6 @@ import {
   findLiveRegistryWorktreeByOwner,
   findLiveRegistryWorktreeByPath,
   getRegistryWorktree,
-  insertRegistryWorktree,
   insertRegistryWorktreeIfPathFree,
   listRegistryWorktrees,
   updateRegistryWorktree,
@@ -269,10 +268,9 @@ async function canResetFailedWorktreeAdd(
 }
 
 /**
- * A crash between `git worktree add` and `insertRegistryWorktree()` (or an orphan directory
- * found during gc) can leave a live git worktree + managed branch with no registry row.
- * Adoption requires an exact match on both path and branch so foreign or detached worktrees
- * are never silently claimed.
+ * A create() that crashed between `git worktree add` and its registry insert leaves a live
+ * git worktree + managed branch with no registry row. Adoption requires an exact match on
+ * both path and branch so foreign or detached worktrees are never silently claimed.
  */
 async function findAdoptableOrphan(
   repoRoot: string,
@@ -373,6 +371,8 @@ export class ManagedWorktreeService {
       if (!recordOwnerMatches(existing, params)) {
         throw worktreeNameInUseError(existing, name);
       }
+      // restore() re-activates this EXISTING row via updateRegistryWorktree — it operates on
+      // the row that already owns the path, so it cannot create a duplicate live row.
       return await this.restore({ id: existing.id });
     }
     const branch = `openclaw/${name}`;
@@ -392,7 +392,7 @@ export class ManagedWorktreeService {
       ) {
         const adoptedBase = await resolveBase(repository.repoRoot, params.baseRef);
         // Claim BEFORE provisioning: only the claim holder may provision or destroy this
-        // path; losers must never touch it. Claiming first means a concurrent create()/gc()
+        // path; losers must never touch it. Claiming first means a concurrent create()
         // cannot register the path during the (long) setup re-run and then have its live
         // worktree force-removed by this call's failure cleanup, and the repo setup script
         // never runs twice concurrently in the same path.
@@ -507,7 +507,19 @@ export class ManagedWorktreeService {
       createdAt,
       lastActiveAt: createdAt,
     };
-    insertRegistryWorktree(this.env, record);
+    // Every new live row goes through the atomic path claim. A lost claim means a concurrent
+    // create() registered this exact path during the setup window (same-name serialization);
+    // mirror the live-row-at-path shortcut for the row that won.
+    if (!insertRegistryWorktreeIfPathFree(this.env, record)) {
+      const winner = findLiveRegistryWorktreeByPath(this.env, worktreePath);
+      if (!winner) {
+        throw new Error(`worktree registration raced and lost: ${worktreePath}`);
+      }
+      if (!recordOwnerMatches(winner, params)) {
+        throw worktreeNameInUseError(winner, name);
+      }
+      return winner;
+    }
     return record;
   }
 
@@ -864,7 +876,7 @@ export class ManagedWorktreeService {
     repoRoot: string;
     path: string;
     branch: string;
-    baseRef?: string;
+    baseRef: string;
     ownerKind?: ManagedWorktreeOwnerKind;
     ownerId?: string;
   }): ManagedWorktreeRecord | undefined {
@@ -876,17 +888,16 @@ export class ManagedWorktreeService {
       repoRoot: params.repoRoot,
       path: params.path,
       branch: params.branch,
-      // gc-side adoption cannot recover the crashed create()'s base; "HEAD" is its placeholder.
-      baseRef: params.baseRef ?? "HEAD",
+      baseRef: params.baseRef,
       // Mirrors create()'s owner defaulting so a retried create() keeps findLiveByOwner()
-      // lookups and idle-gc expiry working; gc-side adoption cannot recover an owner.
+      // lookups and idle-gc expiry working.
       ownerKind: params.ownerKind ?? "manual",
       ...(params.ownerId ? { ownerId: params.ownerId } : {}),
       createdAt,
       lastActiveAt: createdAt,
     };
-    // Atomic path claim: a concurrent create()/gc() may have registered this path after the
-    // caller's registry snapshot; the loser must never add a second row for the same path.
+    // Atomic path claim: a concurrent create() may have registered this path after this
+    // call's registry lookup; the loser must never add a second row for the same path.
     if (!insertRegistryWorktreeIfPathFree(this.env, record)) {
       return undefined;
     }
@@ -922,23 +933,11 @@ export class ManagedWorktreeService {
         }
         const repository = await resolveRepository(candidate).catch(() => undefined);
         if (repository) {
-          const managedBranch = `openclaw/${name.name}`;
-          if (await findAdoptableOrphan(repository.repoRoot, candidate, managedBranch)) {
-            // Orphaned by a create() that crashed before insertRegistryWorktree(); reclaim it
-            // instead of deleting a live worktree or leaving it invisible to list()/gc() forever.
-            // Registration-only: background gc must not execute repo setup scripts, so a possibly
-            // half-provisioned worktree becomes visible/removable rather than silently trusted.
-            // A lost claim means a concurrent create() registered the path first; skip either way.
-            this.adoptOrphan({
-              repoFingerprint: repository.fingerprint,
-              repoRoot: repository.repoRoot,
-              path: candidate,
-              branch: managedBranch,
-            });
-            continue;
-          }
           const listed = await listGitWorktrees(repository.repoRoot).catch(() => []);
           if (listed.some((entry) => path.resolve(entry.path) === path.resolve(candidate))) {
+            // Live git worktrees are preserved, never adopted: background gc cannot tell a
+            // crash orphan from a legitimate manual worktree without an owner-safe recovery
+            // marker (schema-backed). Retried create() is the supported crash-recovery path.
             continue;
           }
         }

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -387,11 +387,29 @@ export class ManagedWorktreeService {
         existing === undefined &&
         (await findAdoptableOrphan(repository.repoRoot, worktreePath, branch))
       ) {
+        // The crash may have hit before provisioning finished, so re-run copy + setup with the
+        // normal create() failure semantics before the registry row exists. Safe because the
+        // crashed create() never returned this worktree to any caller.
+        const adoptedBase = await resolveBase(repository.repoRoot, params.baseRef);
+        try {
+          await copyIncludedFiles(repository.sourceRoot, worktreePath);
+          if (params.runSetupScript !== false) {
+            await runSetupScript(repository.sourceRoot, worktreePath);
+          }
+        } catch (error) {
+          try {
+            await cleanupFailedCreate(repository.repoRoot, worktreePath, branch);
+          } catch (cleanupError) {
+            throw new Error(`${String(error)}\n${String(cleanupError)}`, { cause: cleanupError });
+          }
+          throw error;
+        }
         return this.adoptOrphan({
           repoFingerprint: repository.fingerprint,
           repoRoot: repository.repoRoot,
           path: worktreePath,
           branch,
+          baseRef: adoptedBase.base,
           ...(params.ownerKind ? { ownerKind: params.ownerKind } : {}),
           ...(params.ownerId ? { ownerId: params.ownerId } : {}),
         });
@@ -818,6 +836,7 @@ export class ManagedWorktreeService {
     repoRoot: string;
     path: string;
     branch: string;
+    baseRef?: string;
     ownerKind?: ManagedWorktreeOwnerKind;
     ownerId?: string;
   }): ManagedWorktreeRecord {
@@ -829,7 +848,8 @@ export class ManagedWorktreeService {
       repoRoot: params.repoRoot,
       path: params.path,
       branch: params.branch,
-      baseRef: "HEAD",
+      // gc-side adoption cannot recover the crashed create()'s base; "HEAD" is its placeholder.
+      baseRef: params.baseRef ?? "HEAD",
       // Mirrors create()'s owner defaulting so a retried create() keeps findLiveByOwner()
       // lookups and idle-gc expiry working; gc-side adoption cannot recover an owner.
       ownerKind: params.ownerKind ?? "manual",
@@ -874,6 +894,8 @@ export class ManagedWorktreeService {
           if (await findAdoptableOrphan(repository.repoRoot, candidate, managedBranch)) {
             // Orphaned by a create() that crashed before insertRegistryWorktree(); reclaim it
             // instead of deleting a live worktree or leaving it invisible to list()/gc() forever.
+            // Registration-only: background gc must not execute repo setup scripts, so a possibly
+            // half-provisioned worktree becomes visible/removable rather than silently trusted.
             this.adoptOrphan({
               repoFingerprint: repository.fingerprint,
               repoRoot: repository.repoRoot,

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -48,10 +48,10 @@ export const IDLE_GC_MS = 7 * 24 * 60 * 60 * 1000; // Idle worktrees remain rest
 export const SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // Snapshot refs expire with their registry affordance.
 export const WORKTREE_GC_INTERVAL_MS = 60 * 60 * 1000;
 const SETUP_SCRIPT_TIMEOUT_MS = 120_000;
-// Provisioning rows are transient by contract: setup is hard-bounded by
-// SETUP_SCRIPT_TIMEOUT_MS and the include-file copy is short in practice, so a row still
-// 'provisioning' this long after its claim has a dead holder and gc may reclaim the path
-// and branch for the next create().
+// Lease contract: provisioning rows carry a heartbeat (lastActiveAt bumps at claim, after
+// the include-file copy, and at the ready flip), and setup is hard-bounded by
+// SETUP_SCRIPT_TIMEOUT_MS. A lease silent for 10x the setup bound has a dead holder and gc
+// may reclaim the path and branch for the next create().
 export const PROVISIONING_STALE_MS = 10 * SETUP_SCRIPT_TIMEOUT_MS;
 
 const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -790,16 +790,24 @@ export class ManagedWorktreeService {
     for (const record of records) {
       try {
         if (record.removedAt === undefined && !(await pathExists(record.path))) {
+          // Provisioning rows have no snapshot and represent no user work; retiring one
+          // whose directory vanished would hide the row while its branch survives and
+          // permanently block the name. Delete branch + row so the name stays retriable.
+          if (record.readiness === "provisioning") {
+            await resetFailedWorktreeAdd(record.repoRoot, record.path, record.branch);
+            deleteRegistryWorktree(this.env, record.id);
+            continue;
+          }
           updateRegistryWorktree(this.env, record.id, { removedAt: now });
           record.removedAt = now;
         }
-        // Stale 'provisioning' rows have a dead holder by contract (PROVISIONING_STALE_MS);
-        // reap worktree+branch+row so the next create() — including auto-named orphans no
-        // retry will ever reach — starts fresh. Fresh provisioning rows stay untouched.
+        // A 'provisioning' lease silent past PROVISIONING_STALE_MS has a dead holder; reap
+        // worktree+branch+row so the next create() — including auto-named orphans no retry
+        // will ever reach — starts fresh. Recently heartbeating leases stay untouched.
         if (
           record.removedAt === undefined &&
           record.readiness === "provisioning" &&
-          now - record.createdAt > PROVISIONING_STALE_MS
+          now - record.lastActiveAt > PROVISIONING_STALE_MS
         ) {
           // resetFailedWorktreeAdd tolerates the partial states a dead holder leaves
           // (unlisted dir, missing branch), unlike the happy-path cleanupFailedCreate.
@@ -909,6 +917,9 @@ export class ManagedWorktreeService {
     // in-flight creates unadoptable and observable. Failed creates still end with no row.
     try {
       await copyIncludedFiles(repository.sourceRoot, worktreePath);
+      // Lease heartbeat between phases: gc treats a lease silent past PROVISIONING_STALE_MS
+      // as dead, and setup alone is bounded well under that (SETUP_SCRIPT_TIMEOUT_MS).
+      updateRegistryWorktree(this.env, record.id, { lastActiveAt: this.now() });
       if (params.runSetupScript !== false) {
         await runSetupScript(repository.sourceRoot, worktreePath);
       }
@@ -924,16 +935,17 @@ export class ManagedWorktreeService {
       throw error;
     }
     // Readiness flips only after provisioning fully succeeded; every usable-record path
-    // (entry shortcut, findLiveByOwner) filters on it.
-    updateRegistryWorktree(this.env, record.id, { readiness: "ready" });
-    // Provisioning can outlive PROVISIONING_STALE_MS (suspension; copy is unbounded) and be
-    // reaped by gc mid-create; the flip above then updated zero rows. Never hand back a
-    // record whose path was already reclaimed.
+    // (entry shortcut, findLiveByOwner) filters on it. The flip is also the final heartbeat.
+    const readyAt = this.now();
+    updateRegistryWorktree(this.env, record.id, { readiness: "ready", lastActiveAt: readyAt });
+    // Backstop for the pathological suspended holder: heartbeats can stall long enough for
+    // gc to reap the lease mid-create; the flip above then updated zero rows. Never hand
+    // back a record whose path was already reclaimed.
     const flipped = getRegistryWorktree(this.env, record.id);
     if (!flipped || flipped.removedAt !== undefined) {
       throw new WorktreeProvisioningReapedError(name);
     }
-    return { ...record, readiness: "ready" };
+    return { ...record, readiness: "ready", lastActiveAt: readyAt };
   }
 
   private requireLiveRecord(id: string): ManagedWorktreeRecord {

--- a/src/agents/worktrees/types.ts
+++ b/src/agents/worktrees/types.ts
@@ -1,5 +1,8 @@
 export type ManagedWorktreeOwnerKind = "manual" | "workboard" | "session";
 
+// 'provisioning' = claimed but copy/setup not finished; only 'ready' rows are usable records.
+export type ManagedWorktreeReadiness = "provisioning" | "ready";
+
 export type ManagedWorktreeRecord = {
   id: string;
   name: string;
@@ -11,6 +14,7 @@ export type ManagedWorktreeRecord = {
   ownerKind: ManagedWorktreeOwnerKind;
   ownerId?: string;
   snapshotRef?: string;
+  readiness: ManagedWorktreeReadiness;
   createdAt: number;
   lastActiveAt: number;
   removedAt?: number;

--- a/src/cli/worktrees-cli.ts
+++ b/src/cli/worktrees-cli.ts
@@ -53,7 +53,12 @@ export function registerWorktreesCli(program: Command): void {
             ID: record.id,
             Repo: record.repoRoot,
             Branch: record.branch,
-            Status: record.removedAt ? "restorable" : "active",
+            // Surfaces claimed-but-not-ready rows so operators can spot crashed provisioning.
+            Status: record.removedAt
+              ? "restorable"
+              : record.readiness === "provisioning"
+                ? "provisioning"
+                : "active",
           })),
         }).trimEnd(),
       );

--- a/src/gateway/server-methods/worktrees.test.ts
+++ b/src/gateway/server-methods/worktrees.test.ts
@@ -13,6 +13,7 @@ const record: ManagedWorktreeRecord = {
   branch: "openclaw/task-one",
   baseRef: "HEAD",
   ownerKind: "manual",
+  readiness: "ready",
   createdAt: 1,
   lastActiveAt: 2,
 };

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1186,6 +1186,7 @@ export interface Worktrees {
   owner_id: string | null;
   owner_kind: string;
   path: string;
+  readiness: Generated<string>;
   removed_at: number | null;
   repo_fingerprint: string;
   repo_root: string;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1573,6 +1573,57 @@ describe("openclaw state database", () => {
     }
   }, 60_000);
 
+
+  it("backfills worktree readiness as ready for pre-column rows", () => {
+    const stateDir = createTempStateDir();
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacyDb = new DatabaseSync(databasePath);
+    legacyDb.exec("ALTER TABLE worktrees DROP COLUMN readiness");
+    // Shipped releases inserted worktree rows only after provisioning finished, so a
+    // pre-column row is by construction a fully provisioned checkout.
+    legacyDb
+      .prepare(
+        `INSERT INTO worktrees (
+          id,
+          repo_fingerprint,
+          repo_root,
+          path,
+          branch,
+          base_ref,
+          owner_kind,
+          created_at,
+          last_active_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "legacy-worktree",
+        "0123456789abcdef",
+        "/repo",
+        "/state/worktrees/0123456789abcdef/task",
+        "openclaw/task",
+        "HEAD",
+        "manual",
+        1,
+        1,
+      );
+    legacyDb.close();
+
+    const reopened = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const row = reopened.db
+      .prepare("SELECT readiness FROM worktrees WHERE id = ?")
+      .get("legacy-worktree") as { readiness?: unknown };
+
+    expect(row.readiness).toBe("ready");
+  });
+
   it("migrates requester and executor attribution for existing cross-agent tasks", () => {
     const stateDir = createTempStateDir();
     const database = openOpenClawStateDatabase({

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1585,8 +1585,8 @@ describe("openclaw state database", () => {
     const { DatabaseSync } = requireNodeSqlite();
     const legacyDb = new DatabaseSync(databasePath);
     legacyDb.exec("ALTER TABLE worktrees DROP COLUMN readiness");
-    // Shipped releases inserted worktree rows only after provisioning finished, so a
-    // pre-column row is by construction a fully provisioned checkout.
+    // No release tag contains the worktrees feature; pre-column rows come only from
+    // unreleased main builds whose create() was insert-last, so they are fully provisioned.
     legacyDb
       .prepare(
         `INSERT INTO worktrees (

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1573,7 +1573,6 @@ describe("openclaw state database", () => {
     }
   }, 60_000);
 
-
   it("backfills worktree readiness as ready for pre-column rows", () => {
     const stateDir = createTempStateDir();
     const database = openOpenClawStateDatabase({

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1541,8 +1541,9 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
     "teardown_terminal_state TEXT CHECK (teardown_terminal_state IN ('destroyed', 'failed'))",
   );
   ensureOperatorApprovalResolutionRefs(db);
-  // Backfill-as-ready is provably correct: every shipped release inserted worktree rows only
-  // after provisioning completed (insert-last), so no pre-column row can be mid-provisioning.
+  // Backfill-as-ready is provably correct: no release tag contains the worktrees feature,
+  // so pre-column rows come only from unreleased main builds whose create() inserted rows
+  // strictly after provisioning completed (insert-last).
   ensureColumn(db, "worktrees", "readiness TEXT NOT NULL DEFAULT 'ready'");
 }
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1541,6 +1541,9 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
     "teardown_terminal_state TEXT CHECK (teardown_terminal_state IN ('destroyed', 'failed'))",
   );
   ensureOperatorApprovalResolutionRefs(db);
+  // Backfill-as-ready is provably correct: every shipped release inserted worktree rows only
+  // after provisioning completed (insert-last), so no pre-column row can be mid-provisioning.
+  ensureColumn(db, "worktrees", "readiness TEXT NOT NULL DEFAULT 'ready'");
 }
 
 function ensureSchema(db: DatabaseSync, pathname: string): void {

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1521,7 +1521,8 @@ CREATE TABLE IF NOT EXISTS worktrees (
   snapshot_ref TEXT,
   created_at INTEGER NOT NULL,
   last_active_at INTEGER NOT NULL,
-  removed_at INTEGER
+  removed_at INTEGER,
+  readiness TEXT NOT NULL DEFAULT 'ready' CHECK (readiness IN ('provisioning', 'ready'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_worktrees_repo_fingerprint

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1516,7 +1516,8 @@ CREATE TABLE IF NOT EXISTS worktrees (
   snapshot_ref TEXT,
   created_at INTEGER NOT NULL,
   last_active_at INTEGER NOT NULL,
-  removed_at INTEGER
+  removed_at INTEGER,
+  readiness TEXT NOT NULL DEFAULT 'ready' CHECK (readiness IN ('provisioning', 'ready'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_worktrees_repo_fingerprint


### PR DESCRIPTION
## What Problem This Solves

A gateway crash (OOM kill, forced restart) landing between `git worktree add` and the registry insert inside `ManagedWorktreeService.create()` leaves an on-disk worktree and an `openclaw/<name>` branch that no managed API can ever see, repair, or remove: `list()`/`get()` never show it, every `gc()` pass skips it forever, and any later `create()` with the same name fails hard with `branch already exists`. The only way out today is manual operator surgery (`git worktree remove` + `git branch -D`) outside the managed API. Reported with source-level analysis in #103239; this PR makes the orphan self-heal (gc adopts it; a retried create adopts it and preserves the caller's owner) while leaving foreign/detached worktrees untouched.

## Summary

- Problem: A crash between `git worktree add` and `insertRegistryWorktree()` inside `ManagedWorktreeService.create()` leaves a live git worktree + `openclaw/<name>` branch with no registry row. `reconcileOrphans()` explicitly skips it forever (invisible to `list()`/`gc()`), and a retried `create()` with the same name dead-ends on `branch already exists`.
- Why it matters: In real deployments (OOM kill, forced restart) the orphan is permanently unrecoverable through the managed API — only manual `git worktree remove` + `git branch -D` unblocks the name.
- What changed: recovery happens through the retried `create()` path only. `create()`'s branch-exists guard self-heals the exact crashed-create signature (live worktree at the derived path on exactly `refs/heads/openclaw/<name>`, no registry row) instead of dead-ending: it atomically claims the path in the registry (`insertRegistryWorktreeIfPathFree()`, a single Kysely `INSERT ... SELECT ... WHERE NOT EXISTS (live row at path)` — no schema change), then re-provisions (`copyIncludedFiles()` + `runSetupScript()`), preserving the caller's `ownerKind`/`ownerId` and recording the real resolved base. Only the claim holder may provision or destroy the path: a losing adopter provably touches nothing, and a holder whose re-provisioning fails removes the worktree and deletes its own row. The registry carries a persisted readiness contract: `readiness ('provisioning'|'ready')` (closed union; additive `ensureColumn` migration per repo precedent — backfill-as-ready is provably safe because no release tag contains the worktrees feature, and unreleased-main builds inserted rows only post-provisioning). The claim inserts `provisioning`; a single UPDATE flips to `ready` only after copy+setup succeed. Every usable-record path is gated on ready (`findLiveByOwner` filters in SQL; the entry shortcut and claim-loser throw a closed `WorktreeProvisioningError`; `restore()` revives as ready; provisioning rows are leases with heartbeats (`lastActiveAt` bumped at claim, post-copy, and at the ready flip): gc reaps only leases SILENT past `PROVISIONING_STALE_MS` — a persisted holder-liveness signal, so claim age alone can never kill a live-but-slow holder — restoring background recovery for auto-named orphans, while a reaped-mid-flight create fails closed with `WorktreeProvisioningReapedError`; a provisioning row whose directory vanished is hard-deleted (branch + row; no snapshot, no user work) so the name stays genuinely retriable). The gateway protocol's `WorktreeRecordSchema` gains an additive optional `readiness` enum (no version bump). Normal (non-adopting) `create()` uses the identical claim-early ordering (claim immediately after `git worktree add`; both paths share one claim → provision-as-holder → holder-only-cleanup helper), establishing the invariant that an in-flight create always holds a live row — so the no-row+live-worktree signature genuinely means a crashed create, and an in-flight worktree can never be adopted, re-provisioned, or destroyed by a concurrent same-name call. Every new live registry row is uniqueness-enforced through the one claim. `reconcileOrphans()`/gc remains preserve-only (upstream behavior) — background adoption is deliberately not shipped (see Risks). `git.ts` additively parses the porcelain `branch` field for the adoption signature check.
- What did NOT change (scope boundary): gc keeps upstream's preserve-only behavior for foreign/detached and live git-listed worktrees (only dead debris and stale provisioning rows are cleaned); no protocol version bump; no changes to snapshot semantics; web UI status label deliberately unchanged (would pull in i18n regeneration disproportionate to this PR).

This is AI-assisted work (Claude conductor + Claude worker/verifier agents, human-operated); every change was gated on tests written first and independently reviewed by a fresh-context model before submission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #103239
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `create()` performs the irreversible git-side effects (`git worktree add`, branch creation) before the registry insert, with no crash-window reconciliation: `reconcileOrphans()` treated "git still lists this directory as a live worktree" purely as a preserve signal and never checked whether the worktree matches the managed naming scheme but lacks a registry row.
- Missing detection / guardrail: no adopt-or-repair path for the crashed-create signature; `create()`'s branch-exists guard had no way to distinguish "user's foreign branch" from "our own crashed create()".
- Contributing context (if known): the registry has no `name` column (name derives from the path's last segment), so adoption needs no extra bookkeeping — the orphan is fully re-derivable from path + branch.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/worktrees/service.test.ts`
- Scenario the test should lock in: a live worktree + managed branch with no registry row (the exact end-state of a crash between `git worktree add` and the registry insert) is adopted by a retried `create()` with the same name — preserving the caller's `ownerKind`/`ownerId`, re-running provisioning (include files + setup script restored, real `baseRef` recorded), and holding the loser-touches-nothing / holder-only-destruction invariants under deterministic interleavings; gc during an in-flight normal `create()` adopts nothing and exactly one live row remains; a parked in-flight create cannot be adopted, re-provisioned, or destroyed by a concurrent same-name retry (same-owner and foreign-owner both covered, setup executes exactly once); a failing setup leaves no worktree, branch, or registry row.
- Why this is the smallest reliable guardrail: the tests use the real `git` binary and real SQLite registry (the file's established pattern — no mocks), produce the crash end-state via production code (`create()` then deleting only the registry row), and assert through the public service API only.
- Existing test that already covers this (if any): "deletes unregistered orphan debris but preserves git-listed worktrees" covers the foreign/detached case and stays green, locking in that non-managed worktrees are never claimed.
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes

- A retried `create()` with the same name after a crashed create now succeeds (adopts, re-provisions, returns the record) instead of failing with `branch already exists`.
- gc behavior is unchanged from upstream (preserve-only for live worktrees); foreign or detached-HEAD worktrees are unaffected.
- Concurrent same-path registrations can no longer produce duplicate live registry rows (atomic claim; loser gets the existing "name already in use" semantics).
- `list()` now shows a worktree from claim-time (during provisioning) rather than after setup completes; failed creates still end with no registry row.

## Diagram (if applicable)

```text
Before:
create() crash after `git worktree add` -> live worktree + branch, no registry row
  -> create(same name): "branch already exists" (dead end; manual git surgery required)

After:
create() crash after `git worktree add` -> live worktree + branch, no registry row
  -> create(same name): exact orphan signature -> atomic path claim -> re-provision
     (owner + real base preserved) -> returns record
  -> claim loser (concurrent registration won): touches nothing; standard in-use semantics
  -> gc: preserve-only (unchanged upstream behavior)
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A. Adoption is gated on an exact `git worktree list --porcelain` path + `refs/heads/openclaw/<name>` branch match; fabricating that state requires local filesystem/git access equivalent to what `create()` already requires. `insertRegistryWorktree` is the same call path `create()` already uses.

## Repro + Verification

### Environment

- OS: macOS 26 (arm64); fix is platform-independent (pure git + SQLite service logic)
- Runtime/container: Node 22 / bun, source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default `OPENCLAW_STATE_DIR`-backed state

### Steps

1. `ManagedWorktreeService.create({ repoRoot, name: "task-1" })` and kill the process after `git worktree add` completes but before the registry insert (repro: create normally, then delete only the registry row — identical end state).
2. Run `service.create({ repoRoot, name: "task-1" })` again.

### Expected

- retried create succeeds (adopts, re-provisions, returns the record); gc preserves the orphan untouched.

### Actual

- Before this PR: gc skips it forever; retried create throws `branch already exists: openclaw/task-1`. After this PR: expected behavior (see tests).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before (tests added, fix stashed):

```
❯ |agents| src/agents/worktrees/service.test.ts (24 tests | 2 failed)
FAIL … adopts a worktree orphaned when create() crashed …, during gc()
  AssertionError: expected undefined to match object {…}
FAIL … adopts an orphaned worktree instead of throwing on a retried create() …
  Error: branch already exists: openclaw/orphan-retry
```

After:

```
pnpm test src/agents/worktrees/service.test.ts src/agents/worktrees/registry.test.ts
 Test Files  2 passed (2)
      Tests  41 passed (41) agents shard + 23 passed state shard
```

Real-behavior proof on the FROZEN FINAL head e5b7677497 (all four requested scenarios — active holder survives gc, SIGKILLed holder reaped after lease expiry and recreated fully provisioned, missing-path claim cleaned to a retriable name, pre-column DB backfills ready): https://github.com/openclaw/openclaw/pull/103390#issuecomment-4947439791. Earlier ordering-specific transcript: https://github.com/openclaw/openclaw/pull/103390#issuecomment-4944938951 — Window B is a genuine mid-provisioning SIGKILL (exit 137) showing the crash state is observable (claim-time row, missing setup marker), gc preserves it, and the operator recovery path works end-to-end (remove() cleans worktree+branch, fresh create fully provisions); Window A (add→claim, no user code) is a labeled constructed end-state recovered by retried-create adoption with full re-provisioning. Supersedes the earlier transcript (#issuecomment-4937129438), which demonstrated the pre-claim-early ordering.

Also green on the touched surface: `pnpm tsgo:core` (exit 0), `oxlint` (0 findings), `oxfmt --check` (formatted). Note: repo-wide `pnpm check` currently fails in its preflight `npm shrinkwrap guard` on an unmodified `origin/main` checkout in this environment (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` for the `defu` override) — pre-existing and unrelated; no lockfile/override files are touched by this PR.

The previously-acknowledged gc-vs-create double-insert race is now eliminated by the atomic path claim (deterministic interleaving tests cover both directions, with a pasted negative control showing the pre-claim code produces the duplicate row). Remaining narrow edge deliberately out of scope: a lingering *removed* registry row at the same path still blocks create()-side adoption for a fresh orphan (name-reuse-after-remove + crash sequence).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: full scoped test suite (25/25) against real git + real SQLite locally, including both new adoption tests and the pre-existing foreign-worktree preservation test; typecheck/lint/format on the touched files.
- Edge cases checked: detached-HEAD foreign worktree (preserved), bare branch collision without a live worktree (still throws), owner preservation (`workboard`/`ownerId`) on retried-create adoption including `findLiveByOwner()` lookup, crash-before-setup retry re-provisioning (include file + setup marker restored, real base recorded), and full cleanup on a failing setup script during adoption-retry.
- What you did **not** verify: a literal `kill -9` mid-`create()` on a production gateway (the crash end-state is reproduced through the service's own code paths instead); the two out-of-scope narrow edges above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: schema/migration surface (new `readiness` column).
  - Mitigation: additive `ensureColumn` per the repo's established migration pattern; backfill default provably correct (see body); legacy-DB backfill test included; fresh-vs-migrated CHECK divergence is unobservable to prod writes (closed TS union at every write site).
- Risk: adopting a worktree that a user intentionally created outside the managed API at the exact managed path on an `openclaw/<name>` branch.
  - Mitigation: that state is indistinguishable from (and equivalent to) a crashed managed create; adoption only registers it — it never deletes or modifies the worktree.
- Risk: concurrent adoption attempts (gc vs retried create) racing for one path.
  - Mitigation: eliminated — adoption is a single-statement atomic path claim with explicit loser handling; losers never provision, mutate, or destroy; covered by deterministic interleaving tests in both directions.

