### PR TITLE
fix(agents): detect full C1 range in subagent spawn control character check

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -652,7 +652,13 @@ function sanitizeMountPathHint(value?: string): string | undefined {
 function hasPromptUnsafeControlCharacter(value: string): boolean {
   for (const char of value) {
     const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f || code === 0x85 || code === 0x2028 || code === 0x2029) {
+    if (
+      code <= 0x1f ||
+      code === 0x7f ||
+      (code >= 0x80 && code <= 0x9f) ||
+      code === 0x2028 ||
+      code === 0x2029
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

`hasPromptUnsafeControlCharacter()` only checked for 0x85 (NEL) in the C1 range, missing 0x80-0x84 and 0x86-0x9f including the CSI ANSI escape introducer (0x9b).

## Why This Change Was Made

Replace the single-byte 0x85 check with the full C1 range (0x80-0x9f). Same pattern as #103274 (being merged).

## Files Changed (1 file, +1/-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)