### PR TITLE
fix(agents): detect full C1 range in image-generate inline directive check

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -538,7 +538,13 @@ function sanitizeInlineDirectiveText(value: string): string {
 
 function isInlineDirectiveControlCharacter(char: string): boolean {
   const code = char.charCodeAt(0);
-  return code <= 0x1f || code === 0x7f || code === 0x2028 || code === 0x2029;
+  return (
+    code <= 0x1f ||
+    code === 0x7f ||
+    (code >= 0x80 && code <= 0x9f) ||
+    code === 0x2028 ||
+    code === 0x2029
+  );
 }
 
 function validateImageGenerationCapabilities(params: {


### PR DESCRIPTION
Same C1 gap pattern as #103274. Add full C1 range (0x80-0x9f). 1 file, +1/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)