### PR TITLE
fix(mcp): redact secrets from /mcp show in group chats

### DIFF
--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withTempHome } from "../../config/home-env.test-harness.js";
+import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 import { createCommandWorkspaceHarness } from "./commands-filesystem.test-support.js";
 import { handleMcpCommand } from "./commands-mcp.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
@@ -160,6 +161,66 @@ describe("handleCommands /mcp", () => {
 
       const result = expectMcpResult(await handleMcpCommand(params, true));
       expect(result.reply?.text).toContain('MCP server "remote" saved');
+    });
+  });
+
+  it("redacts credential-bearing headers and env from /mcp show in groups", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      const headerSecret = "Bearer sk-test-secret-value";
+      const envSecret = "stdio-process-token-value";
+      mcpServers.set("billing-server", {
+        command: "uvx",
+        args: ["billing-mcp"],
+        transport: "streamable-http",
+        url: "https://billing.example.com/mcp",
+        headers: {
+          Authorization: headerSecret,
+        },
+        env: {
+          BILLING_TOKEN: envSecret,
+        },
+      });
+      mcpServers.set("local-tools", {
+        command: "uvx",
+        args: ["local-mcp"],
+        env: {
+          TOOL_API_KEY: "local-env-secret-value",
+        },
+      });
+
+      const namedParams = buildCommandTestParams(
+        "/mcp show billing-server",
+        buildCfg(),
+        undefined,
+        {
+          workspaceDir,
+        },
+      );
+      namedParams.command.senderIsOwner = true;
+      namedParams.isGroup = true;
+      const namedResult = expectMcpResult(await handleMcpCommand(namedParams, true));
+      const namedText = namedResult.reply?.text ?? "";
+      expect(namedText).toContain('MCP server "billing-server"');
+      expect(namedText).toContain('"command": "uvx"');
+      expect(namedText).toContain(REDACTED_SENTINEL);
+      expect(namedText).not.toContain(headerSecret);
+      expect(namedText).not.toContain(envSecret);
+      expect(namedText).not.toContain("sk-test-secret-value");
+
+      const allParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      allParams.command.senderIsOwner = true;
+      allParams.isGroup = true;
+      const allResult = expectMcpResult(await handleMcpCommand(allParams, true));
+      const allText = allResult.reply?.text ?? "";
+      expect(allText).toContain('"billing-server"');
+      expect(allText).toContain('"local-tools"');
+      expect(allText).toContain(REDACTED_SENTINEL);
+      expect(allText).not.toContain(headerSecret);
+      expect(allText).not.toContain(envSecret);
+      expect(allText).not.toContain("local-env-secret-value");
     });
   });
 });

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -4,6 +4,8 @@ import {
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
 } from "../../config/mcp-config.js";
+import { redactConfigObject } from "../../config/redact-snapshot.js";
+import { buildConfigSchema } from "../../config/schema.js";
 import {
   rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
@@ -15,6 +17,14 @@ import { parseMcpCommand } from "./mcp-commands.js";
 
 function renderJsonBlock(label: string, value: unknown): string {
   return `${label}\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+/** Redact MCP server secrets (headers/env/url material) before chat display. */
+function redactMcpServersForDisplay(servers: Record<string, unknown>): Record<string, unknown> {
+  const redactedRoot = redactConfigObject({ mcp: { servers } }, buildConfigSchema().uiHints) as {
+    mcp?: { servers?: Record<string, unknown> };
+  };
+  return redactedRoot.mcp?.servers ?? {};
 }
 
 /** Command handler for /mcp show/set/unset operations. */
@@ -64,10 +74,16 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
           reply: { text: `🔌 No MCP server named "${mcpCommand.name}" in ${loaded.path}.` },
         };
       }
+      const redactedServer = redactMcpServersForDisplay({
+        [mcpCommand.name]: server,
+      })[mcpCommand.name];
       return {
         shouldContinue: false,
         reply: {
-          text: renderJsonBlock(`🔌 MCP server "${mcpCommand.name}" (${loaded.path})`, server),
+          text: renderJsonBlock(
+            `🔌 MCP server "${mcpCommand.name}" (${loaded.path})`,
+            redactedServer,
+          ),
         },
       };
     }
@@ -80,7 +96,10 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
     return {
       shouldContinue: false,
       reply: {
-        text: renderJsonBlock(`🔌 MCP servers (${loaded.path})`, loaded.mcpServers),
+        text: renderJsonBlock(
+          `🔌 MCP servers (${loaded.path})`,
+          redactMcpServersForDisplay(loaded.mcpServers),
+        ),
       },
     };
   }

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -8,6 +8,7 @@ import {
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
 } from "./mcp-config.js";
+import { REDACTED_SENTINEL } from "./redact-snapshot.js";
 
 function validationOk(raw: unknown) {
   return { ok: true as const, config: raw, warnings: [] };
@@ -153,6 +154,80 @@ describe("config mcp config", () => {
           "X-Debug": true,
         },
       });
+    });
+  });
+
+  it("restores redacted MCP secrets on set instead of writing the sentinel", async () => {
+    await withMcpConfigHome(
+      {
+        mcp: {
+          servers: {
+            billing: {
+              command: "uvx",
+              args: ["billing-mcp"],
+              headers: {
+                Authorization: "Bearer real-token",
+              },
+              env: {
+                BILLING_TOKEN: "real-env-secret",
+              },
+            },
+          },
+        },
+      },
+      async () => {
+        const setResult = await setConfiguredMcpServer({
+          name: "billing",
+          server: {
+            command: "uvx",
+            args: ["billing-mcp", "--verbose"],
+            headers: {
+              Authorization: REDACTED_SENTINEL,
+            },
+            env: {
+              BILLING_TOKEN: REDACTED_SENTINEL,
+            },
+          },
+        });
+
+        expect(setResult.ok).toBe(true);
+        const loaded = await listConfiguredMcpServers();
+        expect(loaded.ok).toBe(true);
+        if (!loaded.ok) {
+          throw new Error("expected MCP config to load");
+        }
+        expect(loaded.mcpServers.billing).toEqual({
+          command: "uvx",
+          args: ["billing-mcp", "--verbose"],
+          headers: {
+            Authorization: "Bearer real-token",
+          },
+          env: {
+            BILLING_TOKEN: "real-env-secret",
+          },
+        });
+      },
+    );
+  });
+
+  it("rejects unrestorable redacted MCP secrets on set for a new server", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "new-server",
+        server: {
+          command: "uvx",
+          args: ["new-mcp"],
+          headers: {
+            Authorization: REDACTED_SENTINEL,
+          },
+        },
+      });
+
+      expect(setResult.ok).toBe(false);
+      if (setResult.ok) {
+        throw new Error("expected redacted set to fail");
+      }
+      expect(setResult.error).toContain(REDACTED_SENTINEL);
     });
   });
 

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -6,6 +6,8 @@ import {
   normalizeConfiguredMcpServers,
 } from "./mcp-config-normalize.js";
 import { replaceConfigFile } from "./mutate.js";
+import { restoreRedactedValues } from "./redact-snapshot.js";
+import { buildConfigSchema } from "./schema.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 
@@ -176,9 +178,31 @@ export async function setConfiguredMcpServer(params: {
     return loaded;
   }
 
+  // Restore redaction sentinels from the existing server entry so a show→set
+  // round-trip cannot replace real credentials with the display placeholder.
+  const restored = restoreRedactedValues(
+    { mcp: { servers: { [name]: params.server } } },
+    { mcp: { servers: loaded.mcpServers } },
+    buildConfigSchema().uiHints,
+  );
+  if (!restored.ok) {
+    return {
+      ok: false,
+      path: loaded.path,
+      error:
+        restored.humanReadableMessage ??
+        "MCP server config contains an unrestorable redacted value.",
+    };
+  }
+  const restoredServer = (restored.result as { mcp?: { servers?: Record<string, unknown> } }).mcp
+    ?.servers?.[name];
+  if (!isRecord(restoredServer)) {
+    return { ok: false, path: loaded.path, error: "MCP server config must be a JSON object." };
+  }
+
   const next = structuredClone(loaded.config);
   const servers = normalizeConfiguredMcpServers(next.mcp?.servers);
-  servers[name] = canonicalizeConfiguredMcpServer(params.server);
+  servers[name] = canonicalizeConfiguredMcpServer(restoredServer);
   next.mcp = {
     ...next.mcp,
     servers,

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -120,6 +120,7 @@ describe("config schema", () => {
     expect(groupPolicyLabel).toBeTypeOf("string");
     expect(groupPolicyLabel?.trim().length).toBeGreaterThan(0);
     expect(res.uiHints["mcp.servers.*.headers.*"]?.sensitive).toBe(true);
+    expect(res.uiHints["mcp.servers.*.env.*"]?.sensitive).toBe(true);
     expect(res.uiHints["mcp.servers.*.url"]?.tags).toContain(SENSITIVE_URL_HINT_TAG);
     expect(res.uiHints["models.providers.*.baseUrl"]?.tags).toContain(SENSITIVE_URL_HINT_TAG);
     expect(res.uiHints["proxy.tls.caFile"]?.tags).toEqual(

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -389,7 +389,12 @@ const McpServerSchema = z
     enabled: z.boolean().optional(),
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
-    env: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+    env: z
+      .record(
+        z.string(),
+        z.union([z.string().register(sensitive), z.number(), z.boolean()]).register(sensitive),
+      )
+      .optional(),
     cwd: z.string().optional(),
     workingDirectory: z.string().optional(),
     url: HttpUrlSchema.optional(),

--- a/test/mcp-show-redact.e2e.test.ts
+++ b/test/mcp-show-redact.e2e.test.ts
@@ -1,0 +1,244 @@
+// E2E: ephemeral gateway must not leak MCP secrets via /mcp show replies.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { afterAll, describe, expect, it } from "vitest";
+import { REDACTED_SENTINEL } from "../src/config/redact-snapshot.js";
+import { connectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { extractFirstTextBlock } from "../src/shared/chat-message-content.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const E2E_TIMEOUT_MS = 180_000;
+const CHAT_FINAL_TIMEOUT_MS = 45_000;
+
+const HEADER_SECRET = "Bearer e2e-live-mcp-header-secret-value";
+const ENV_SECRET = "e2e-live-mcp-env-secret-value";
+const SERVER_NAME = "billing-server";
+
+type ChatEventPayload = {
+  runId?: string;
+  state?: string;
+  message?: unknown;
+  errorMessage?: string;
+};
+
+function collectFinalText(payload: ChatEventPayload | undefined): string {
+  if (!payload) {
+    return "";
+  }
+  const fromMessage = extractFirstTextBlock(payload.message);
+  if (fromMessage) {
+    return fromMessage;
+  }
+  if (typeof payload.errorMessage === "string") {
+    return payload.errorMessage;
+  }
+  return JSON.stringify(payload);
+}
+
+async function waitForChatFinal(
+  events: Array<{ event?: string; payload?: unknown }>,
+  runId: string,
+  timeoutMs = CHAT_FINAL_TIMEOUT_MS,
+): Promise<ChatEventPayload> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const event of events) {
+      if (event.event !== "chat" || !event.payload || typeof event.payload !== "object") {
+        continue;
+      }
+      const payload = event.payload as ChatEventPayload;
+      if (payload.runId === runId && payload.state === "final") {
+        return payload;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `timed out waiting for chat final runId=${runId}; events=${JSON.stringify(
+      events.slice(-12),
+      null,
+      2,
+    )}`,
+  );
+}
+
+describe("mcp show redaction e2e", () => {
+  const instances: OpenClawTestInstance[] = [];
+
+  afterAll(async () => {
+    for (const instance of instances) {
+      await instance.cleanup();
+    }
+  });
+
+  it(
+    "starts an ephemeral gateway and redacts MCP secrets from /mcp show chat replies",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      const instance = await createOpenClawTestInstance({
+        name: "mcp-show-redact",
+        env: {
+          OPENCLAW_TEST_FAST: "1",
+        },
+        config: {
+          commands: {
+            text: true,
+            mcp: true,
+          },
+          mcp: {
+            servers: {
+              [SERVER_NAME]: {
+                command: "uvx",
+                args: ["billing-mcp"],
+                transport: "streamable-http",
+                url: "https://billing.example.com/mcp",
+                headers: {
+                  Authorization: HEADER_SECRET,
+                },
+                env: {
+                  BILLING_TOKEN: ENV_SECRET,
+                },
+              },
+              "local-tools": {
+                command: "uvx",
+                args: ["local-mcp"],
+                env: {
+                  TOOL_API_KEY: "second-env-secret-value",
+                },
+              },
+            },
+          },
+        },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+
+      const onDiskBefore = JSON.parse(await fs.readFile(instance.configPath, "utf8")) as {
+        mcp?: { servers?: Record<string, { headers?: Record<string, string> }> };
+      };
+      expect(onDiskBefore.mcp?.servers?.[SERVER_NAME]?.headers?.Authorization).toBe(HEADER_SECRET);
+
+      const events: Array<{ event?: string; payload?: unknown }> = [];
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        onEvent: (event) => {
+          events.push(event);
+        },
+      });
+
+      try {
+        const namedRunId = randomUUID();
+        await client.request("chat.send", {
+          sessionKey: "agent:main:main",
+          message: `/mcp show ${SERVER_NAME}`,
+          deliver: false,
+          idempotencyKey: namedRunId,
+        });
+        const namedFinal = await waitForChatFinal(events, namedRunId);
+        const namedText = collectFinalText(namedFinal);
+
+        expect(namedText).toContain(`MCP server "${SERVER_NAME}"`);
+        expect(namedText).toContain('"command": "uvx"');
+        expect(namedText).toContain(REDACTED_SENTINEL);
+        expect(namedText).not.toContain(HEADER_SECRET);
+        expect(namedText).not.toContain(ENV_SECRET);
+        expect(namedText).not.toContain("e2e-live-mcp-header-secret-value");
+        expect(namedText).not.toContain("e2e-live-mcp-env-secret-value");
+
+        const listRunId = randomUUID();
+        await client.request("chat.send", {
+          sessionKey: "agent:main:main",
+          message: "/mcp show",
+          deliver: false,
+          idempotencyKey: listRunId,
+        });
+        const listFinal = await waitForChatFinal(events, listRunId);
+        const listText = collectFinalText(listFinal);
+
+        expect(listText).toContain(`"${SERVER_NAME}"`);
+        expect(listText).toContain('"local-tools"');
+        expect(listText).toContain(REDACTED_SENTINEL);
+        expect(listText).not.toContain(HEADER_SECRET);
+        expect(listText).not.toContain(ENV_SECRET);
+        expect(listText).not.toContain("second-env-secret-value");
+
+        // show → set with redacted secrets must restore live values, not write the sentinel.
+        // Keep the JSON free of array brackets so chat body normalization cannot mangle it.
+        const setPayload = {
+          command: "uvx",
+          transport: "streamable-http",
+          url: "https://billing.example.com/mcp",
+          headers: {
+            Authorization: REDACTED_SENTINEL,
+          },
+          env: {
+            BILLING_TOKEN: REDACTED_SENTINEL,
+          },
+        };
+        const setRunId = randomUUID();
+        await client.request("chat.send", {
+          sessionKey: "agent:main:main",
+          message: `/mcp set ${SERVER_NAME}=${JSON.stringify(setPayload)}`,
+          deliver: false,
+          idempotencyKey: setRunId,
+        });
+        const setFinal = await waitForChatFinal(events, setRunId);
+        const setText = collectFinalText(setFinal);
+        expect(setText).toContain(`MCP server "${SERVER_NAME}" saved`);
+
+        const onDiskAfter = JSON.parse(await fs.readFile(instance.configPath, "utf8")) as {
+          mcp?: {
+            servers?: Record<
+              string,
+              {
+                command?: string;
+                headers?: Record<string, string>;
+                env?: Record<string, string>;
+              }
+            >;
+          };
+        };
+        const saved = onDiskAfter.mcp?.servers?.[SERVER_NAME];
+        expect(saved?.command).toBe("uvx");
+        expect(saved?.headers?.Authorization).toBe(HEADER_SECRET);
+        expect(saved?.env?.BILLING_TOKEN).toBe(ENV_SECRET);
+        expect(JSON.stringify(saved)).not.toContain(REDACTED_SENTINEL);
+
+        // Same process, same config: CLI set with sentinel also restores (write path e2e).
+        const cliSet = await instance.cli([
+          "mcp",
+          "set",
+          SERVER_NAME,
+          JSON.stringify({
+            command: "uvx",
+            headers: { Authorization: REDACTED_SENTINEL },
+            env: { BILLING_TOKEN: REDACTED_SENTINEL },
+          }),
+        ]);
+        expect(cliSet.code).toBe(0);
+        expect(cliSet.stdout + cliSet.stderr).toContain(`Saved MCP server "${SERVER_NAME}"`);
+        const onDiskCli = JSON.parse(await fs.readFile(instance.configPath, "utf8")) as {
+          mcp?: {
+            servers?: Record<
+              string,
+              { headers?: Record<string, string>; env?: Record<string, string> }
+            >;
+          };
+        };
+        expect(onDiskCli.mcp?.servers?.[SERVER_NAME]?.headers?.Authorization).toBe(HEADER_SECRET);
+        expect(onDiskCli.mcp?.servers?.[SERVER_NAME]?.env?.BILLING_TOKEN).toBe(ENV_SECRET);
+      } finally {
+        client.stop();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #103053

## What Problem This Solves

Fixes an issue where an owner running `/mcp show` (or `/mcp show <name>`) from a group or channel would post the full MCP server config—including credential-bearing `headers` and `env` values—into that shared chat for every member to read.

## Why This Change Was Made

`/mcp show` was owner-gated but still rendered raw server JSON with no secret redaction. This change reuses the existing config redaction contract (`redactConfigObject` + schema uiHints) so show output never contains live secrets, and marks MCP `env` values sensitive the same way `headers` already were.

Write-side safety is included: `/mcp set` restores redaction sentinels from the existing server entry (and rejects unrestorable sentinels), so a show → edit → set round-trip cannot overwrite real credentials with the display placeholder.

## User Impact

- Owners can run `/mcp show` in groups without leaking MCP Authorization headers, env tokens, or other sensitive server fields.
- Non-secret fields (`command`, `args`, server names, etc.) still appear for inspection.
- Operators who copy redacted show output into `/mcp set` keep existing secrets instead of silently writing `__OPENCLAW_REDACTED__`.

## Evidence

Focused tests:

```text
pnpm test src/auto-reply/reply/commands-mcp.test.ts src/config/schema.test.ts src/config/mcp-config.test.ts
→ 69 tests passed
```

Coverage added:

- Group `/mcp show` named + list forms with secret `headers`/`env` must emit the redaction sentinel and never the secret values.
- `setConfiguredMcpServer` restores secrets when the payload contains the redaction sentinel.
- Unrestorable sentinels for a new server fail closed.
- Schema assert: `mcp.servers.*.env.*` is sensitive.

fable-5 closeout review: accepted show→set restore gap and fixed it; remaining P3 note about short env values affecting raw snapshot text view is intentional/shared with other all-sensitive env maps and is fail-safe (no leak).