### PR TITLE
fix(gateway): detect C1 control characters in config lookup path sanitizer

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -355,7 +355,7 @@ function parseRawConfigOrRespond(
 function sanitizeLookupPathForLog(path: string): string {
   const sanitized = Array.from(path, (char) => {
     const code = char.charCodeAt(0);
-    return code < 0x20 || code === 0x7f ? "?" : char;
+    return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f) ? "?" : char;
   }).join("");
   return sanitized.length > 120 ? `${truncateUtf16Safe(sanitized, 117)}...` : sanitized;
 }


### PR DESCRIPTION
Same C1 gap pattern as #103274. 1 file, +1/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)