### PR TITLE
fix(agents): detect full C1 range in subagent spawn control character check

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -652,7 +652,13 @@ function sanitizeMountPathHint(value?: string): string | undefined {
 function hasPromptUnsafeControlCharacter(value: string): boolean {
   for (const char of value) {
     const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f || code === 0x85 || code === 0x2028 || code === 0x2029) {
+    if (
+      code <= 0x1f ||
+      code === 0x7f ||
+      (code >= 0x80 && code <= 0x9f) ||
+      code === 0x2028 ||
+      code === 0x2029
+    ) {
       return true;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

This function checks for control characters but only covers the C0 range (0x00-0x1f) and DEL (0x7f), missing the C1 control character range (0x80-0x9f). The C1 range includes the CSI introducer (0x9b), an alternative ANSI escape prefix equivalent to ESC [.

## Why This Change Was Made

Add `(code >= 0x80 \&\& code <= 0x9f)` to extend the control character check to cover the full C1 range. Same pattern as the merged fix in #103274.

## Evidence

### Same proven pattern as #103274

Peter merged the identical C1 range extension in `renderTerminalBufferText` (#103274):
> "Extended the existing terminal-text residual filter through DEL/C1 while preserving tabs."

This fix applies the same C1 completion to `agents): detect full C1 range in subagent spawn control character check`.

### Behavior

```
Before: C0 checked, C1 (0x80-0x9f) silently passes through
After:  Both C0 and C1 ranges are detected/filtered
```

## Files Changed (1 file, +1/-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)