### PR TITLE
fix(gateway): detect C1 control characters in config lookup path sanitizer

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -145,6 +145,27 @@ describe("config.openFile", () => {
     });
   });
 
+  it("replaces C1 control characters in the logged failed config path", async () => {
+    // U+009B is the C1 CSI introducer, an alternative ANSI escape prefix (ESC [).
+    // Assert only on the sanitized filename portion so the check is independent
+    // of the OS-specific path prefix (e.g. /tmp vs D:\tmp).
+    const CSI = String.fromCharCode(0x9b);
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: `/tmp/cfg${CSI}.json` }, async () => {
+      mockExecFileError(new Error("open failed"));
+
+      const { logGateway } = await invokeConfigOpenFile();
+
+      const logged = String(
+        (logGateway.warn as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)?.[0] ??
+          "",
+      );
+      expect(logged.startsWith("config.openFile failed path=")).toBe(true);
+      // The raw C1 byte is replaced with "?" before it reaches the warning log.
+      expect(logged).toContain("cfg?.json");
+      expect(logged).not.toContain(CSI);
+    });
+  });
+
   it("returns actionable headless environment error when xdg-open reports no method available", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config.json" }, async () => {
       mockExecFileError(new Error("xdg-open: no method available for opening '/tmp/config.json'"));

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -355,7 +355,7 @@ function parseRawConfigOrRespond(
 function sanitizeLookupPathForLog(path: string): string {
   const sanitized = Array.from(path, (char) => {
     const code = char.charCodeAt(0);
-    return code < 0x20 || code === 0x7f ? "?" : char;
+    return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f) ? "?" : char;
   }).join("");
   return sanitized.length > 120 ? `${truncateUtf16Safe(sanitized, 117)}...` : sanitized;
 }


### PR DESCRIPTION
## What Problem This Solves

`sanitizeLookupPathForLog()` in `src/gateway/server-methods/config.ts` replaces control characters in a config path with `?` before the path is embedded in the gateway warning logs (`config.schema.lookup produced invalid payload for ...` and `config.openFile failed path=...`). It only replaced the C0 range (0x00-0x1f) and DEL (0x7f), not the C1 control range (0x80-0x9f), which includes the CSI introducer U+009B — an alternative ANSI escape prefix equivalent to `ESC [`. A C1 byte in the path therefore passed unchanged into both warning-log callers.

## Change

Extend the replacement predicate to also cover 0x80-0x9f:

```ts
return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f) ? "?" : char;
```

## Testing / Proof

Added a regression to the existing `config.openFile` suite in `src/gateway/server-methods/config.test.ts`. It drives the real `config.openFile` handler with a config path containing U+009B, forces an open failure, and asserts the emitted `logGateway.warn` message replaces the C1 byte with `?` (`cfg?.json`) and contains no raw C1 byte. The assertion is scoped to the sanitized filename so it is independent of the OS-specific path prefix.

```
$ node scripts/run-vitest.mjs run src/gateway/server-methods/config.test.ts
...
      Tests  8 failed | 14 passed (22)
```

The new `replaces C1 control characters in the logged failed config path` test passes (passed count rises from 12 → 14, i.e. +1 in each of the two gateway vitest projects).

> Note on the 8 "failed": these are 4 pre-existing sibling `config.openFile` tests (× 2 projects) that hard-code POSIX `/tmp/...` paths and assert the full path string. On my local **Windows** checkout the handler resolves those to `D:\tmp\...`, so they fail identically on `main` — they are unrelated to this change and pass on Linux CI. This PR's new test deliberately avoids the path prefix and asserts only the sanitized `cfg?.json` fragment, so it is green on both platforms.
