### PR TITLE
feat(ios): render native Markdown heading hierarchy

### DIFF
--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -165,6 +165,32 @@ struct SwiftUIRenderSmokeTests {
         }
     }
 
+    @Test @MainActor func `markdown heading hierarchy builds with inline formatting and table`() {
+        let markdown = """
+        # First **strong** heading
+        ## Second [linked](https://example.com) heading
+        ### Third `code` heading
+        #### Fourth heading
+        ##### Fifth heading
+        ###### Sixth heading
+
+        | Surface | State |
+        | --- | --- |
+        | iOS | Native |
+        """
+        for typeSize in [DynamicTypeSize.large, .accessibility2] {
+            let root = ChatMarkdownRenderer(
+                text: markdown,
+                context: .assistant,
+                variant: .standard,
+                font: OpenClawChatTypography.body,
+                textColor: OpenClawChatTheme.assistantText)
+                .environment(\.dynamicTypeSize, typeSize)
+
+            _ = Self.host(root, size: CGSize(width: 393, height: 700))
+        }
+    }
+
     @Test @MainActor func `streaming assistant bubble builds mixed prose and code`() {
         let text = """
         Earlier prose stays visible.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -2,12 +2,20 @@ import Foundation
 import Markdown
 
 /// One renderable block of a chat message. Prose stays on the
-/// AttributedString pipeline; fenced code, display math, and GFM tables get dedicated views.
+/// AttributedString pipeline; headings, fenced code, display math, and GFM tables get dedicated views.
 enum ChatMarkdownBlock: Equatable {
     case prose(String)
+    case heading(ChatMarkdownHeading)
     case code(ChatCodeBlock)
     case math(ChatMathBlock)
     case table(ChatMarkdownTable)
+}
+
+struct ChatMarkdownHeading: Equatable {
+    let level: Int
+    /// Keep the complete source so Swift's Markdown parser continues to own
+    /// inline formatting and both ATX and Setext heading syntax.
+    let markdown: String
 }
 
 struct ChatCodeBlock: Equatable {
@@ -63,7 +71,7 @@ enum ChatMarkdownBlockSegmenter {
     static let maxTableColumns = 12
     static let maxTableCells = 600
 
-    /// Extracts only top-level fenced code, display math, and GFM tables. The parser owns
+    /// Extracts only top-level headings, fenced code, display math, and GFM tables. The parser owns
     /// CommonMark container and reference semantics; nested blocks stay in the
     /// surrounding prose range unchanged.
     static func segments(markdown: String, isComplete: Bool) -> [ChatMarkdownBlock] {
@@ -78,6 +86,15 @@ enum ChatMarkdownBlockSegmenter {
         for child in document.children {
             guard let lineRange = source.lineRange(for: child.range) else { continue }
             if mathResult.protectedRanges.contains(where: { $0.contains(lineRange.lowerBound) }) {
+                continue
+            }
+
+            if let heading = child as? Markdown.Heading {
+                extractions.append(Extraction(
+                    lineRange: lineRange,
+                    block: .heading(ChatMarkdownHeading(
+                        level: heading.level,
+                        markdown: source.text(in: lineRange)))))
                 continue
             }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -93,6 +93,15 @@ struct ChatMarkdownRenderer: View {
                 .textSelection(.enabled)
                 .lineSpacing(self.variant == .compact ? 2 : 4)
                 .modifier(ChatInlineMathAccessibilityModifier(label: prose.inlineAccessibilityText))
+        case let .heading(level, prose):
+            self.proseText(prose, index: index)
+                .font(OpenClawChatTypography.heading(level: level))
+                .foregroundStyle(self.textColor)
+                .tint(self.linkColor)
+                .textSelection(.enabled)
+                .lineSpacing(self.variant == .compact ? 2 : 4)
+                .modifier(ChatInlineMathAccessibilityModifier(label: prose.inlineAccessibilityText))
+                .accessibilityAddTraits(.isHeader)
         case let .code(code):
             ChatCodeBlockView(block: code)
         case let .math(math):
@@ -141,6 +150,13 @@ struct ChatMarkdownRenderSnapshot {
                     markdown: markdown,
                     isComplete: isComplete,
                     preparesReveal: preparesReveal))
+            case let .heading(heading):
+                .heading(
+                    level: heading.level,
+                    prose: ChatMarkdownProse(
+                        markdown: heading.markdown,
+                        isComplete: isComplete,
+                        preparesReveal: false))
             case let .code(code):
                 .code(code)
             case let .math(math):
@@ -164,6 +180,7 @@ struct ChatMarkdownRenderSnapshot {
 
 enum ChatMarkdownRenderedBlock {
     case prose(ChatMarkdownProse)
+    case heading(level: Int, prose: ChatMarkdownProse)
     case code(ChatCodeBlock)
     case math(ChatMathBlock)
     case table(ChatMarkdownTable)
@@ -445,7 +462,7 @@ private struct ChatInlineMathAccessibilityModifier: ViewModifier {
     }
 }
 
-/// Fenced code, display math, and GFM tables are split out by `ChatMarkdownBlockSegmenter`
+/// Headings, fenced code, display math, and GFM tables are split out by `ChatMarkdownBlockSegmenter`
 /// before this runs, so prose only needs chat-style soft-break preservation.
 enum ChatMarkdownDisplayPreprocessor {
     static func preserveChatSoftBreaks(in markdown: String) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTypography.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTypography.swift
@@ -19,6 +19,23 @@ enum OpenClawChatTypography {
         display(size: 17, weight: .semibold, relativeTo: .headline)
     }
 
+    static func heading(level: Int) -> Font {
+        switch level {
+        case 1:
+            self.display(size: 24, weight: .bold, relativeTo: .title2)
+        case 2:
+            self.display(size: 21, weight: .bold, relativeTo: .title3)
+        case 3:
+            self.display(size: 19, weight: .semibold, relativeTo: .headline)
+        case 4:
+            self.body(size: 17, weight: .semibold, relativeTo: .body)
+        case 5:
+            self.body(size: 16, weight: .semibold, relativeTo: .callout)
+        default:
+            self.body(size: 15, weight: .semibold, relativeTo: .subheadline)
+        }
+    }
+
     static var callout: Font {
         body(size: 16, weight: .regular, relativeTo: .callout)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -26,6 +26,81 @@ struct ChatMarkdownBlockSegmenterTests {
         ])
     }
 
+    // MARK: - Headings
+
+    @Test func `all ATX heading levels become native blocks`() {
+        for level in 1...6 {
+            let markdown = "\(String(repeating: "#", count: level)) Heading \(level)"
+            #expect(self.segments(markdown) == [
+                .heading(ChatMarkdownHeading(level: level, markdown: markdown)),
+            ])
+        }
+    }
+
+    @Test func `Setext headings preserve their complete source`() {
+        #expect(self.segments("Primary\n=======") == [
+            .heading(ChatMarkdownHeading(level: 1, markdown: "Primary\n=======")),
+        ])
+        #expect(self.segments("Secondary\n---------") == [
+            .heading(ChatMarkdownHeading(level: 2, markdown: "Secondary\n---------")),
+        ])
+    }
+
+    @Test func `streaming ATX heading keeps the current source`() {
+        let markdown = "### Streamed heading"
+        #expect(self.segments(markdown, isComplete: false) == [
+            .heading(ChatMarkdownHeading(level: 3, markdown: markdown)),
+        ])
+    }
+
+    @Test func `heading keeps inline markdown source and surrounding prose`() {
+        let heading = "## **Status** with `code` and [docs](https://example.com) ##"
+        #expect(self.segments("before\n\n\(heading)\n\nafter") == [
+            .prose("before"),
+            .heading(ChatMarkdownHeading(level: 2, markdown: heading)),
+            .prose("after"),
+        ])
+    }
+
+    @Test func `headings nested in containers stay on the prose path`() {
+        for markdown in ["> # Quoted", "- # Listed"] {
+            #expect(self.segments(markdown) == [.prose(markdown)])
+        }
+    }
+
+    @Test func `reference heading keeps document scoped definition`() {
+        let markdown = "# [Docs][docs]\n\n[docs]: https://example.com"
+        #expect(self.segments(markdown) == [.prose(markdown)])
+    }
+
+    @Test func `heading composes with an unchanged native table`() {
+        let blocks = self.segments("# Results\n\n| Name | Count |\n| --- | ---: |\n| Claw | 2 |")
+        #expect(blocks == [
+            .heading(ChatMarkdownHeading(level: 1, markdown: "# Results")),
+            .table(ChatMarkdownTable(
+                header: ["Name", "Count"],
+                alignments: [.leading, .trailing],
+                rows: [["Claw", "2"]])),
+        ])
+    }
+
+    @Test @MainActor func `render snapshot preserves heading inline attributes`() throws {
+        let snapshot = ChatMarkdownRenderSnapshot(
+            text: "## **Status** and [docs](https://example.com)",
+            isComplete: true)
+        guard case let .heading(level, prose) = try #require(snapshot.blocks.first) else {
+            Issue.record("expected heading block")
+            return
+        }
+
+        #expect(level == 2)
+        #expect(String(prose.attributed.characters) == "Status and docs")
+        #expect(prose.attributed.runs.contains { $0.link != nil })
+        #expect(prose.attributed.runs.contains {
+            $0.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+        })
+    }
+
     // MARK: - Fenced code
 
     @Test func `fence with language and surrounding prose`() {


### PR DESCRIPTION
Fixes #98290

## What Problem This Solves

Fixes an issue where Markdown headings in native Apple chat rendered at the same visual weight as ordinary paragraph text, so structured responses lost their heading hierarchy. Native table rendering from the same issue already landed in #100207.

## Why This Change Was Made

The shared Apple Markdown segmenter now extracts only top-level CommonMark headings as dedicated blocks while preserving their complete ATX or Setext source for the existing Markdown parser. The renderer applies branded H1–H6 Dynamic Type styles and the accessibility header trait, while nested headings remain on the prose path and document-scoped reference links retain the existing whole-document fallback.

This avoids regex-based heading inference, preserves inline emphasis, links, code, and math behavior, and leaves the existing native table path unchanged.

## User Impact

iOS and macOS chat responses now show a clear, accessible heading hierarchy that scales with Dynamic Type and remains compatible with inline formatting, streaming updates, containers, reference links, and adjacent tables.

## Evidence

- Exact head: `6e8eef750b9e2dd2f0dbda0e0e723c8fabd86fed`.
- Added focused coverage for ATX H1–H6, Setext H1/H2, inline attributes, surrounding prose, nested containers, reference fallback, streaming source, and unchanged table composition.
- Added SwiftUI render smoke coverage at normal and accessibility Dynamic Type sizes with inline formatting and an adjacent native table.
- `swiftformat --lint --config config/swiftformat`, native i18n, and `git diff --check` passed after rebasing onto current main.
- Blacksmith Testbox-through-Crabbox `tbx_01kx56fkq9h9pbyk99x9sncw69`: remote `pnpm check:changed` passed.
- Fresh full-branch Codex autoreview reported no accepted or actionable findings.

