### PR TITLE
fix(update): prevent build workers surviving timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Managed update timeouts:** terminate the full package-manager and build process tree when an update command times out, preventing orphaned preflight workers from continuing after the updater exits. (#103403)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Managed update timeouts:** terminate the full package-manager and build process tree when an update command times out, preventing orphaned preflight workers from continuing after the updater exits. (#103403)
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **Doctor state isolation:** prevent automated update and Gateway watch repair from importing and archiving default-home exec or plugin-binding approvals when `OPENCLAW_STATE_DIR` points elsewhere, keep implicit CLI preflight notice-only, and reserve cross-state imports for direct operator doctor runs. (#103247, #103317)
 - **Doctor clean-state guidance:** stop suggesting `openclaw doctor --fix` after a clean run with no config changes while preserving targeted repair hints. (#103233)

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -11,7 +11,11 @@ import { pathExists } from "../utils.js";
 import { writePackageDistInventory } from "./package-dist-inventory.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
-import { resolveUpdateDoctorExecutionPolicy, runGatewayUpdate } from "./update-runner.js";
+import {
+  resolveUpdateDoctorExecutionPolicy,
+  resolveUpdateInstallSurface,
+  runGatewayUpdate,
+} from "./update-runner.js";
 
 const execFileSyncMock = vi.hoisted(() => vi.fn(() => "/tmp/openclaw-test-global-npmrc\n"));
 
@@ -44,6 +48,28 @@ function createRunner(responses: Record<string, CommandResponse>) {
     return toCommandResult(responses[key]);
   };
   return { runner, calls };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+  return !isProcessAlive(pid);
 }
 
 describe("resolveUpdateDoctorExecutionPolicy", () => {
@@ -167,6 +193,52 @@ describe("runGatewayUpdate", () => {
     }
     await fs.writeFile(path.join(tempDir, "package.json"), JSON.stringify(pkg), "utf-8");
   }
+
+  it.runIf(process.platform !== "win32")(
+    "kills nested updater subprocesses when a default command times out",
+    { timeout: 10_000 },
+    async () => {
+      await setupGitCheckout();
+      const fakeBinDir = path.join(tempDir, "fake-bin");
+      const fakeGitPath = path.join(fakeBinDir, "git");
+      const childPidPath = path.join(tempDir, "nested-child.pid");
+      await fs.mkdir(fakeBinDir, { recursive: true });
+      await fs.writeFile(
+        fakeGitPath,
+        `#!${process.execPath}\n` +
+          `const { spawn } = require("node:child_process");\n` +
+          `const fs = require("node:fs");\n` +
+          `const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });\n` +
+          `fs.writeFileSync(process.env.OPENCLAW_UPDATE_TEST_CHILD_PID_PATH, String(child.pid));\n` +
+          `setInterval(() => {}, 1000);\n`,
+        "utf-8",
+      );
+      await fs.chmod(fakeGitPath, 0o755);
+
+      let childPid: number | null = null;
+      let childExited = false;
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_UPDATE_TEST_CHILD_PID_PATH: childPidPath,
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          },
+          async () => {
+            await resolveUpdateInstallSurface({ cwd: tempDir, timeoutMs: 500 });
+          },
+        );
+        childPid = Number.parseInt(await fs.readFile(childPidPath, "utf-8"), 10);
+        expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
+        childExited = await waitForProcessExit(childPid);
+      } finally {
+        if (childPid && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+        }
+      }
+
+      expect(childExited).toBe(true);
+    },
+  );
 
   async function setupUiIndex() {
     const uiIndexPath = path.join(tempDir, "dist", "control-ui", "index.html");

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -746,6 +746,9 @@ async function buildUpdateCommandRunner(
       const res = await runCommandWithTimeout(argv, {
         ...options,
         env: mergeCommandEnvironments(defaultCommandEnv, options.env),
+        // Update steps invoke package-manager trees; timeout must retire the
+        // whole tree or detached build workers can outlive the updater.
+        killProcessTree: true,
       });
       return res;
     },

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -514,6 +514,42 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("gracefully then force-kills the Windows process tree when requested", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild({ autoClose: false });
+    child.exitCode = null;
+    const gracefulTaskkillChild = createMockChild();
+    const forcedTaskkillChild = createMockChild();
+
+    spawnMock
+      .mockImplementationOnce(() => child)
+      .mockImplementationOnce(() => gracefulTaskkillChild)
+      .mockImplementationOnce(() => forcedTaskkillChild);
+
+    try {
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "idle.js"], {
+          killProcessTree: true,
+          timeoutMs: 80,
+        });
+
+        await vi.advanceTimersByTimeAsync(81);
+        expect(requireSpawnCall(1)[1]).toEqual(["/PID", "1234", "/T"]);
+
+        await vi.advanceTimersByTimeAsync(300);
+        expect(requireSpawnCall(2)[1]).toEqual(["/PID", "1234", "/T", "/F"]);
+        expect(child.kill).not.toHaveBeenCalled();
+
+        child.emit("close", null, "SIGKILL");
+        const result = await resultPromise;
+        expect(result.termination).toBe("timeout");
+        expect(result.code).toBe(124);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back to direct child kill when forced Windows taskkill emits a spawn error", async () => {
     vi.useFakeTimers();
     const child = createMockChild({ autoClose: false });


### PR DESCRIPTION
Closes #103403

## What Problem This Solves

Fixes an issue where operators running a managed source/dev update could have package-manager or build workers continue consuming CPU after an update step timed out.

## Why This Change Was Made

The updater's default command runner now opts into the executor's existing process-tree termination contract. POSIX commands run in a detached process group and receive group SIGTERM followed by SIGKILL after the existing 300 ms grace; Windows uses `taskkill /PID <pid> /T` followed by `/T /F`. Injected runners and timeout values are unchanged.

## User Impact

Timed-out managed updates now retire their full command tree before returning, so orphaned preflight build workers cannot survive the updater and interfere with cleanup or later update attempts.

## Evidence

Base: `0e4c7cd15542da327dcde5edc937f1fcb275b45a`
Head: `b3759e5e1223fbc582e91d29768c4d396852064a`
Testbox: `tbx_01kx568q6s8p1dap30r4920krf`

Before fix, the deterministic nested-child regression produced 60 passing tests and 1 failure: the nested worker remained alive after a 2-second wait and was force-cleaned by the test.

After fix:

- Exact Testbox HEAD confirmed as `b3759e5e1223fbc582e91d29768c4d396852064a`.
- `pnpm test src/infra/update-runner.test.ts src/process/exec.windows.test.ts`: 61/61 updater tests and 22/22 Windows executor tests passed.
- The POSIX regression launches a fake updater command with a nested Node worker, times out the parent at 500 ms, and requires the recorded descendant PID to be gone.
- The Windows regression verifies graceful `taskkill /T` followed by forced `taskkill /T /F`.
- `pnpm check:changed`: core/coreTests changed-scope gates passed, including tsgo, lint, and guards.
- Targeted oxfmt check passed.
- Structured Codex autoreview: no accepted/actionable findings.

Release-note context remains here by policy; `CHANGELOG.md` is release-generation owned.