### PR TITLE
fix(memory-wiki): prevent partial failures during concurrent agent writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Memory Wiki concurrent agent writes:** serialize each vault's `wiki_apply` mutation and compile transaction while allowing separate agent vaults to proceed in parallel, preventing partial-success tool errors and lost metadata during simultaneous agent turns. (#103400)
 - **QQBot token requests:** bound token acquisition with the shared 30-second guarded-fetch deadline so stalled singleflight callers fail together, clean up, and can retry. (#102897) Thanks @maweibin.
 - **Canvas A2UI validation:** reject malformed or unsupported JSONL at CLI, agent-tool, and final node-invoke boundaries while preserving native v0.8 dispatch. (#103713) Thanks @qingminglong.
 - **Twilio RCS inbound routing:** normalize RCS consumer addresses only after signed webhook validation so sender matching and sessions work without changing outbound RCS semantics. (#102373) Thanks @clawSean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Memory Wiki concurrent agent writes:** serialize each vault's `wiki_apply` mutation and compile transaction while allowing separate agent vaults to proceed in parallel, preventing partial-success tool errors and lost metadata during simultaneous agent turns. (#103400)
 - **QQBot token requests:** bound token acquisition with the shared 30-second guarded-fetch deadline so stalled singleflight callers fail together, clean up, and can retry. (#102897) Thanks @maweibin.
 - **Canvas A2UI validation:** reject malformed or unsupported JSONL at CLI, agent-tool, and final node-invoke boundaries while preserving native v0.8 dispatch. (#103713) Thanks @qingminglong.
 - **Twilio RCS inbound routing:** normalize RCS consumer addresses only after signed webhook validation so sender matching and sessions work without changing outbound RCS semantics. (#102373) Thanks @clawSean.

--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -314,4 +314,67 @@ keep this note
       fs.readFile(path.join(rootDir, "entities", "index.md"), "utf8"),
     ).resolves.toContain("[Alpha](alpha.md)");
   });
+
+  it("preserves disjoint metadata updates from concurrent agent turns", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-apply-concurrent-",
+    });
+    const targetPath = path.join(rootDir, "entities", "shared.md");
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(
+      targetPath,
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.shared",
+          title: "Shared",
+        },
+        body: "# Shared\n",
+      }),
+      "utf8",
+    );
+
+    await Promise.all([
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "update_metadata",
+          lookup: "entity.shared",
+          sourceIds: ["source.concurrent"],
+        },
+      }),
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "update_metadata",
+          lookup: "entity.shared",
+          questions: ["Which agent owns the next action?"],
+        },
+      }),
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "update_metadata",
+          lookup: "entity.shared",
+          confidence: 0.9,
+        },
+      }),
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "update_metadata",
+          lookup: "entity.shared",
+          status: "review",
+        },
+      }),
+    ]);
+
+    const parsed = parseWikiMarkdown(await fs.readFile(targetPath, "utf8"));
+    expect(parsed.frontmatter).toMatchObject({
+      sourceIds: ["source.concurrent"],
+      questions: ["Which agent owns the next action?"],
+      confidence: 0.9,
+      status: "review",
+    });
+  });
 });

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -18,6 +18,7 @@ import {
   normalizeWikiClaims,
   type WikiClaim,
 } from "./markdown.js";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import {
   readQueryableWikiPages,
   resolveQueryableWikiPageByLookup,
@@ -359,7 +360,7 @@ async function applyUpdateMetadataMutation(params: {
   };
 }
 
-export async function applyMemoryWikiMutation(params: {
+async function applyMemoryWikiMutationUnlocked(params: {
   config: ResolvedMemoryWikiConfig;
   mutation: ApplyMemoryWikiMutation;
 }): Promise<ApplyMemoryWikiMutationResult> {
@@ -382,4 +383,13 @@ export async function applyMemoryWikiMutation(params: {
     ...(result.pageId ? { pageId: result.pageId } : {}),
     compile,
   };
+}
+
+export async function applyMemoryWikiMutation(params: {
+  config: ResolvedMemoryWikiConfig;
+  mutation: ApplyMemoryWikiMutation;
+}): Promise<ApplyMemoryWikiMutationResult> {
+  return await withMemoryWikiVaultMutation(params.config.vault.path, () =>
+    applyMemoryWikiMutationUnlocked(params),
+  );
 }

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -44,6 +44,7 @@ import {
   WIKI_RELATED_END_MARKER,
   WIKI_RELATED_START_MARKER,
 } from "./markdown.js";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
@@ -1384,7 +1385,7 @@ async function writeAgentDigestArtifacts(params: {
   return updatedFiles;
 }
 
-export async function compileMemoryWikiVault(
+async function compileMemoryWikiVaultUnlocked(
   config: ResolvedMemoryWikiConfig,
 ): Promise<CompileMemoryWikiResult> {
   await initializeMemoryWikiVault(config);
@@ -1469,6 +1470,14 @@ export async function compileMemoryWikiVault(
     claimCount: pages.reduce((total, page) => total + page.claims.length, 0),
     updatedFiles,
   };
+}
+
+export async function compileMemoryWikiVault(
+  config: ResolvedMemoryWikiConfig,
+): Promise<CompileMemoryWikiResult> {
+  return await withMemoryWikiVaultMutation(config.vault.path, () =>
+    compileMemoryWikiVaultUnlocked(config),
+  );
 }
 
 async function hasMissingWikiIndexes(rootDir: string): Promise<boolean> {

--- a/extensions/memory-wiki/src/mutation-coordinator.test.ts
+++ b/extensions/memory-wiki/src/mutation-coordinator.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("withMemoryWikiVaultMutation", () => {
+  it("serializes mutations for one vault and permits nested work", async () => {
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const order: string[] = [];
+
+    const first = withMemoryWikiVaultMutation("/tmp/wiki-a", async () => {
+      order.push("first:start");
+      firstEntered.resolve();
+      await withMemoryWikiVaultMutation("/tmp/wiki-a", async () => {
+        order.push("first:nested");
+      });
+      await releaseFirst.promise;
+      order.push("first:end");
+    });
+    await firstEntered.promise;
+
+    const second = withMemoryWikiVaultMutation("/tmp/wiki-a", async () => {
+      order.push("second");
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(["first:start", "first:nested"]);
+
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:nested", "first:end", "second"]);
+  });
+
+  it("allows distinct agent vaults to mutate in parallel", async () => {
+    const firstEntered = deferred();
+    const secondEntered = deferred();
+    const releaseFirst = deferred();
+
+    const first = withMemoryWikiVaultMutation("/tmp/wiki/support", async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+    });
+    await firstEntered.promise;
+    const second = withMemoryWikiVaultMutation("/tmp/wiki/marketing", async () => {
+      secondEntered.resolve();
+    });
+
+    await secondEntered.promise;
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+  });
+
+  it("queues detached work after its inherited transaction has ended", async () => {
+    const releaseDetached = deferred();
+    const holderEntered = deferred();
+    const releaseHolder = deferred();
+    let detachedEntered = false;
+    let detached!: Promise<void>;
+
+    await withMemoryWikiVaultMutation("/tmp/wiki-detached", async () => {
+      detached = (async () => {
+        await releaseDetached.promise;
+        await withMemoryWikiVaultMutation("/tmp/wiki-detached", async () => {
+          detachedEntered = true;
+        });
+      })();
+    });
+
+    const holder = withMemoryWikiVaultMutation("/tmp/wiki-detached", async () => {
+      holderEntered.resolve();
+      await releaseHolder.promise;
+    });
+    await holderEntered.promise;
+    releaseDetached.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(detachedEntered).toBe(false);
+
+    releaseHolder.resolve();
+    await Promise.all([holder, detached]);
+    expect(detachedEntered).toBe(true);
+  });
+});

--- a/extensions/memory-wiki/src/mutation-coordinator.ts
+++ b/extensions/memory-wiki/src/mutation-coordinator.ts
@@ -1,0 +1,37 @@
+// Memory Wiki plugin module serializes vault mutation transactions.
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+
+type ActiveVaultMutation = { active: boolean };
+
+const activeVaultMutations = new AsyncLocalStorage<ReadonlyMap<string, ActiveVaultMutation>>();
+const vaultMutationQueue = new KeyedAsyncQueue();
+
+/**
+ * Keep coordinated vault read-modify-write transactions isolated from concurrent work in this process.
+ * Nested compile calls re-enter; different agent vaults remain parallel.
+ */
+export async function withMemoryWikiVaultMutation<T>(
+  vaultPath: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  const key = path.resolve(vaultPath);
+  const active = activeVaultMutations.getStore();
+  if (active?.get(key)?.active) {
+    return await mutation();
+  }
+
+  const lease = { active: true };
+  const nextActive = new Map(active ?? []);
+  nextActive.set(key, lease);
+  return await vaultMutationQueue.enqueue(key, async () => {
+    try {
+      return await activeVaultMutations.run(nextActive, mutation);
+    } finally {
+      // Detached children inherit this object. Mark it inactive when the
+      // owner exits so later work queues instead of bypassing serialization.
+      lease.active = false;
+    }
+  });
+}


### PR DESCRIPTION
Closes #103400

Related: #91828, #94443, #98787, #103349

## What Problem This Solves

Fixes an issue where simultaneous agent turns writing one Memory Wiki vault could report `wiki_apply` failure after the primary page had already been committed. Under a local 8+8 support/marketing email burst, six of 16 tool calls failed during compile even though all 16 synthesis pages existed afterward.

## Why This Change Was Made

The complete `wiki_apply` mutation-plus-compile sequence now runs through a reentrant queue keyed by the resolved vault path. Writes to one agent vault are serialized, while different agent vaults remain parallel; standalone compiles use the same coordinator. Bridge/source-sync coalescing and cross-process CLI/Gateway coordination remain separate work.

## User Impact

Bursty email ingestion and other concurrent agent turns can update the same Memory Wiki vault without partial-success tool errors or lost disjoint metadata. Support and marketing agents with separate vaults still write concurrently and remain isolated.

AI-assisted: yes. The implementation was source-reviewed, behavior-tested through a real local Gateway/tool loop, and passed the repository's structured autoreview.

## Evidence

Before-fix local product path:

- Isolated loopback Gateway, deterministic local Responses model, real Gmail hook routing, real agent sessions, and real `wiki_apply` calls.
- Eight support plus eight marketing emails submitted concurrently.
- 16 synthesis pages committed, but 6 `wiki_apply` calls failed during compile (`path changed during read` / `unable to resolve opened file path`).

After-fix replay of the same workload:

- 16/16 tool calls completed.
- 16/16 synthesis pages present.
- Support and marketing compiled digests each contained all eight new pages.
- Zero cross-vault markers and zero `wiki_apply` failures.

Focused local proof:

```text
node scripts/run-vitest.mjs \
  extensions/memory-wiki/src/mutation-coordinator.test.ts \
  extensions/memory-wiki/src/apply.test.ts \
  extensions/memory-wiki/src/compile.test.ts

Test Files  3 passed (3)
Tests       32 passed (32)
```

Blacksmith Testbox through Crabbox (`tbx_01kx56fg3xhjypxg7k9megebb2`):

```text
corepack pnpm test:extension memory-wiki
Test Files  36 passed (36)
Tests       290 passed (290)

corepack pnpm check:changed
passed: extension typecheck, extension test typecheck, lint, database-first guard,
runtime sidecar guard, and runtime import-cycle check
```

Autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.88)
```
