### PR TITLE
fix(media-core): detect MIME from encoded URL extensions

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -6,6 +6,7 @@ import {
   detectMime,
   extensionForMime,
   FILE_TYPE_SNIFF_MAX_BYTES,
+  getFileExtension,
   imageMimeFromFormat,
   isAudioFileName,
   isGifMedia,
@@ -154,6 +155,14 @@ describe("mime detection", () => {
     expect(mime).toBe("text/css");
   });
 
+  it("detects MIME types from encoded URL extensions", async () => {
+    const mime = await detectMime({
+      filePath: "https://cdn.example.com/render%2Emp4?download=1#preview",
+    });
+
+    expect(mime).toBe("video/mp4");
+  });
+
   it("detects AAC from a bare filename when buffer sniffing is inconclusive", async () => {
     const mime = await detectMime({ buffer: Buffer.alloc(16), filePath: "voice.aac" });
     expect(mime).toBe("audio/aac");
@@ -185,6 +194,26 @@ describe("mime detection", () => {
   });
 });
 
+describe("getFileExtension", () => {
+  it.each([
+    { filePath: "https://cdn.example.com/render.mp4", expected: ".mp4" },
+    { filePath: "https://cdn.example.com/render.mp4/", expected: undefined },
+    {
+      filePath: "https://cdn.example.com/render.mp4%2Fpreview",
+      expected: ".mp4%2fpreview",
+    },
+    {
+      filePath: "https://cdn.example.com/render.mp4%5Cpreview",
+      expected: ".mp4%5cpreview",
+    },
+    { filePath: "https://cdn.example.com/bad%ZZ%2Emp4", expected: undefined },
+    { filePath: "https://cdn.example.com/render%2Emp4/", expected: undefined },
+    { filePath: String.raw`C:\media\clip.MP4`, expected: ".mp4" },
+  ] as const)("extracts $expected from $filePath", ({ filePath, expected }) => {
+    expect(getFileExtension(filePath)).toBe(expected);
+  });
+});
+
 describe("mimeTypeFromFilePath", () => {
   it.each([
     { filePath: "image.bmp", expected: "image/bmp" },
@@ -197,8 +226,22 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "clip.avi", expected: "video/x-msvideo" },
     { filePath: "clip.mkv", expected: "video/x-matroska" },
     { filePath: "clip.webm", expected: "video/webm" },
+    {
+      filePath: "https://cdn.example.com/render%2Emp4?download=1#preview",
+      expected: "video/mp4",
+    },
+    { filePath: "https://cdn.example.com/render%2Em%70%34", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/render%2EMP4", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/clip%2Ewebm", expected: "video/webm" },
+    { filePath: "https://cdn.example.com/bad%ZZ/render%2Emp4", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/archive%2Fclip.mp4", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/archive%2Fclip%2Emp4", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/archive%5Cclip%2Emp4", expected: "video/mp4" },
+    { filePath: "https://cdn.example.com/render.mp4%2Fpreview", expected: undefined },
+    { filePath: "https://cdn.example.com/render.mp4%5Cpreview", expected: undefined },
     { filePath: "clip.flv", expected: "video/x-flv" },
     { filePath: "clip.wmv", expected: "video/x-ms-wmv" },
+    { filePath: "https://cdn.example.com/bad%E0%A4%A%2Emp4", expected: undefined },
     { filePath: "debug.log", expected: "text/plain" },
     { filePath: "config.yml", expected: "application/yaml" },
     { filePath: "config.yaml", expected: "application/yaml" },

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -144,7 +144,15 @@ export function getFileExtension(filePath?: string | null): string | undefined {
   try {
     if (/^https?:\/\//i.test(filePath)) {
       const url = new URL(filePath);
-      return path.extname(url.pathname).toLowerCase() || undefined;
+      let filename = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
+      try {
+        // Decode only the URL filename while keeping encoded separators literal.
+        const decodable = filename.replace(/%2f/gi, "%252F").replace(/%5c/gi, "%255C");
+        filename = decodeURIComponent(decodable);
+      } catch {
+        // Preserve the raw filename when its own percent encoding is malformed.
+      }
+      return path.posix.extname(filename).toLowerCase() || undefined;
     }
   } catch {
     // fall back to plain path parsing

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1273,24 +1273,18 @@ describe("capability cli", () => {
     expect(outputs[0]?.kind).toBe("image.description");
   });
 
-  it("keeps image describe HTTP URLs as URLs", async () => {
+  it("keeps encoded image describe HTTP URLs intact", async () => {
+    const mediaUrl = "https://cdn.example.com/clip%2Emp4?download=1#preview";
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
-      argv: [
-        "capability",
-        "image",
-        "describe",
-        "--file",
-        "https://httpbin.org/image/png",
-        "--json",
-      ],
+      argv: ["capability", "image", "describe", "--file", mediaUrl, "--json"],
     });
 
     const describeCall = imageDescribeCall();
-    expect(describeCall?.filePath).toBe("https://httpbin.org/image/png");
+    expect(describeCall).toMatchObject({ filePath: mediaUrl, mediaUrl });
     const output = firstJsonOutput();
     const outputs = output?.outputs as Array<Record<string, unknown>>;
-    expect(outputs[0]?.path).toBe("https://httpbin.org/image/png");
+    expect(outputs[0]?.path).toBe(mediaUrl);
   });
 
   it("passes image describe prompts through media understanding", async () => {

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -242,8 +242,9 @@ describe("media-understanding runtime", () => {
     });
   });
 
-  it("does not force typed remote URLs into the requested capability", async () => {
-    const media = [{ index: 0, url: "https://example.com/clip.mp4", mime: "video/mp4" }];
+  it("does not force encoded video URLs into the requested image capability", async () => {
+    const mediaUrl = "https://example.com/clip%2Emp4?download=1#preview";
+    const media = [{ index: 0, url: mediaUrl, mime: "video/mp4" }];
     mocks.normalizeMediaAttachments.mockReturnValue(media);
     mocks.runCapability.mockResolvedValue({
       outputs: [],
@@ -252,7 +253,7 @@ describe("media-understanding runtime", () => {
 
     await expect(
       describeImageFile({
-        filePath: "https://example.com/clip.mp4",
+        filePath: mediaUrl,
         cfg: {} as OpenClawConfig,
         agentDir: "/tmp/agent",
       }),
@@ -262,12 +263,12 @@ describe("media-understanding runtime", () => {
     });
 
     expect(mocks.normalizeMediaAttachments).toHaveBeenCalledWith({
-      MediaUrl: "https://example.com/clip.mp4",
+      MediaUrl: mediaUrl,
       MediaType: "video/mp4",
     });
     expect(requireRunCapabilityRequest()).toMatchObject({
       capability: "image",
-      ctx: { MediaUrl: "https://example.com/clip.mp4", MediaType: "video/mp4" },
+      ctx: { MediaUrl: mediaUrl, MediaType: "video/mp4" },
       media,
     });
   });


### PR DESCRIPTION
## What Problem This Solves

HTTP(S) media URLs can percent-encode filename characters. Node's WHATWG `URL.pathname` preserves those escapes, so the shared MIME fallback on `main` passes names such as `render%2Emp4` to `path.extname()` and fails to recognize `video/mp4`.

This is active outside Discord. The capability CLI preserves a remote media reference into `describeImageFile()`, whose file runtime uses `mimeTypeFromFilePath()` to build the attachment type. On `main`, an encoded video requested through the image command falls back to `image/*` and enters image selection; this change keeps it `video/mp4`, so the image capability correctly skips it.

This is a maintainer replacement for #102649 because GitHub rejected the rebased fork update at its 45 MB `createCommitOnBranch` limit. The patch and evidence come from @VectorPeak's contribution, preserved with a `Co-authored-by` trailer. The original PR should be closed only after this replacement lands.

## Why This Change Was Made

`getFileExtension()` now:

- extracts only the final HTTP(S) pathname component, including an empty component after a trailing slash;
- preserves encoded `/` and `\` bytes (`%2F` and `%5C`) as literal filename data while decoding the rest of the component;
- uses `path.posix.extname()` for host-independent URL semantics;
- retains the raw final component when its percent encoding is malformed.

Plain local paths keep the existing native `path.extname()` behavior. There is no new helper, dependency, config, fallback stack, or caller-specific MIME policy.

## User Impact

Encoded URL filenames now follow the same MIME fallback as decoded equivalents, while encoded path separators cannot become path boundaries:

```text
https://cdn.example/render%2Emp4?download=1 -> video/mp4
https://cdn.example/clip%2Ewebm             -> video/webm
https://cdn.example/bad%ZZ/render%2Emp4     -> video/mp4
https://cdn.example/render.mp4%2Fpreview    -> unknown
https://cdn.example/render%2Emp4/           -> unknown
```

## Evidence

- Whole-path review covered media-core, every core/plugin caller, the capability CLI and media-understanding runtime, sibling filename decoders, the shipped behavior, and Node URL/path contracts.
- Node 26.5 contract probe: `URL.pathname` leaves `%2E` encoded; final-component decoding returns `.mp4`, isolates malformed earlier segments, preserves encoded separators, and retains an empty trailing component.
- Focused branch coverage includes helper/MIME edge cases, registered CLI URL propagation, and media-understanding capability routing.
- The source PR's exact head `e63681767545314c09b2311fa8ad60cd02ed716d` passed CI run 29065371141, including build, lint, types, contract shards, and Real behavior proof.
- Replacement-head formatter and `git diff --check`: passed.
- Fresh replacement-head autoreview, sanitized AWS focused/live proof, changed gate, and exact hosted CI will be posted before merge.

## Contributor Credit

Thanks @VectorPeak for the original diagnosis, implementation, edge-case follow-through, and runtime evidence in #102649.
