### PR TITLE
fix(ui): controls across the Control UI show a link cursor instead of the default arrow

### DIFF
--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -177,7 +177,6 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       border: none;
       background: transparent;
       color: var(--text);
-      cursor: pointer;
       font: inherit;
       outline: none;
       text-align: left;
@@ -296,7 +295,6 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       border-radius: var(--radius-md);
       background: var(--bg-elevated);
       color: var(--muted);
-      cursor: pointer;
     }
 
     .chat-copy-btn:hover {
@@ -452,7 +450,6 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       background: var(--bg-elevated);
       color: var(--text);
       font-weight: 600;
-      cursor: pointer;
     }
 
     .button:hover {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -1060,7 +1060,6 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       gap: 7px;
       padding: 0 10px;
       height: 36px;
-      cursor: pointer;
       color: var(--muted, #8a919e);
       white-space: nowrap;
       font-size: 12.5px;
@@ -1105,7 +1104,6 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       border: none;
       background: transparent;
       color: inherit;
-      cursor: pointer;
       border-radius: 4px;
       padding: 0;
     }
@@ -1123,7 +1121,6 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       border: none;
       background: transparent;
       color: var(--muted, #8a919e);
-      cursor: pointer;
       border-radius: 6px;
       padding: 0;
     }

--- a/ui/src/pages/overview/cards.ts
+++ b/ui/src/pages/overview/cards.ts
@@ -64,7 +64,7 @@ function renderStatCard(card: StatCard, props: OverviewCardsProps) {
       >
         ${content}
       </button>`
-    : html`<div class="ov-card" data-kind=${card.kind} style="cursor:default">${content}</div>`;
+    : html`<div class="ov-card" data-kind=${card.kind}>${content}</div>`;
 }
 
 function renderProviderQuotaCard(windows: QuotaWindowSummary[]): StatCard | null {
@@ -110,7 +110,7 @@ function renderSkeletonCards() {
     <section class="ov-cards">
       ${[0, 1, 2, 3].map(
         (i) => html`
-          <div class="ov-card" style="cursor:default;animation-delay:${i * 50}ms">
+          <div class="ov-card" style="animation-delay:${i * 50}ms">
             <span class="skeleton skeleton-line" style="width:60px;height:10px"></span>
             <span class="skeleton skeleton-stat"></span>
             <span class="skeleton skeleton-line skeleton-line--medium" style="height:12px"></span>

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -125,7 +125,6 @@
   gap: 10px;
   align-items: center;
   padding: 12px 14px;
-  cursor: pointer;
   list-style: none;
 }
 

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -594,6 +594,10 @@ openclaw-app {
   }
 }
 
+/* Cursor convention: app chrome (buttons, menus, tabs, rails, controls) uses
+   the default arrow cursor; the pointer hand is reserved for real hyperlinks
+   (UA default on a[href]). Do not add `cursor: pointer` to controls; anchors
+   that act as chrome override to `cursor: default` instead. */
 a {
   color: var(--accent);
   text-decoration: underline;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -97,7 +97,6 @@
 .chat-message-actions-row button {
   background: none;
   border: none;
-  cursor: pointer;
   padding: 4px;
   min-width: 24px;
   min-height: 24px;
@@ -442,7 +441,6 @@ img.chat-avatar {
   border-radius: var(--radius-sm, 4px);
   background: transparent;
   color: inherit;
-  cursor: pointer;
   user-select: none;
 }
 
@@ -571,7 +569,6 @@ details.msg-meta:not([open]) .msg-meta__details {
   font-size: 12px; /* was 11px */
   color: var(--muted, #888);
   margin-bottom: 10px;
-  cursor: pointer;
   user-select: none;
 }
 
@@ -579,7 +576,6 @@ details.msg-meta:not([open]) .msg-meta__details {
   width: 14px;
   height: 14px;
   accent-color: var(--accent);
-  cursor: pointer;
 }
 
 .chat-delete-confirm__actions {
@@ -595,7 +591,6 @@ details.msg-meta:not([open]) .msg-meta__details {
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 500;
-  cursor: pointer;
   transition: background 120ms ease-out;
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -101,7 +101,6 @@ openclaw-chat-page {
   background: var(--panel-strong);
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  cursor: pointer;
   white-space: nowrap;
   z-index: 10;
   transition:
@@ -150,7 +149,6 @@ openclaw-chat-page {
   font-size: 11px;
   line-height: 1;
   list-style: none;
-  cursor: pointer;
   user-select: none;
   animation: fade-in 0.2s var(--ease-out);
   transition:
@@ -420,7 +418,6 @@ openclaw-chat-page {
   font: inherit;
   font-size: 11px;
   line-height: 1;
-  cursor: pointer;
   transition:
     background 150ms ease-out,
     border-color 150ms ease-out,
@@ -532,7 +529,6 @@ openclaw-chat-page {
   background: none;
   border: none;
   border-radius: var(--radius-sm);
-  cursor: pointer;
 }
 
 .agent-chat__goal-action:hover {
@@ -632,7 +628,6 @@ openclaw-chat-page {
   color: #fff;
   font-size: 12px;
   line-height: 1;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -684,7 +679,6 @@ openclaw-chat-page {
   max-height: 200px;
   border-radius: var(--radius-md);
   object-fit: contain;
-  cursor: pointer;
   transition: transform 150ms ease-out;
 }
 
@@ -857,7 +851,6 @@ openclaw-chat-page {
   border: none;
   background: none;
   color: var(--muted);
-  cursor: pointer;
   border-radius: 4px;
   flex-shrink: 0;
 }
@@ -896,7 +889,6 @@ openclaw-chat-page {
   border: none;
   background: none;
   color: var(--fg);
-  cursor: pointer;
   border-radius: 6px;
   text-align: left;
 }
@@ -1284,7 +1276,6 @@ openclaw-chat-page {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease,
@@ -1482,7 +1473,6 @@ openclaw-chat-page {
   border: none;
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   flex-shrink: 0;
   padding: 0 10px;
   transition: all var(--duration-fast) ease;
@@ -1569,7 +1559,6 @@ openclaw-chat-page {
   font: inherit;
   font-size: 12px;
   text-align: left;
-  cursor: pointer;
 }
 
 .agent-chat__attach-menu-option:hover,
@@ -1855,7 +1844,6 @@ openclaw-chat-page {
   color: var(--muted);
   font: inherit;
   font-size: 0.75rem;
-  cursor: pointer;
 }
 
 .agent-chat__talk-settings-link:hover,
@@ -1901,7 +1889,6 @@ openclaw-chat-page {
   color: var(--text);
   font-size: 0.78rem;
   line-height: 1.35;
-  cursor: pointer;
   overflow: hidden;
   user-select: none;
 }
@@ -1982,7 +1969,6 @@ openclaw-chat-page {
   font-size: 0.78rem;
   line-height: 1;
   text-align: left;
-  cursor: pointer;
 }
 
 .agent-chat__talk-select-option:hover,
@@ -2021,7 +2007,6 @@ openclaw-chat-page {
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
   color: var(--muted);
-  cursor: pointer;
 }
 
 .agent-chat__talk-input-refresh:hover:not(:disabled),
@@ -2206,7 +2191,6 @@ openclaw-chat-page {
   border: 1px solid var(--accent);
   background: transparent;
   color: var(--accent);
-  cursor: pointer;
   flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
@@ -2671,7 +2655,6 @@ openclaw-chat-page {
   gap: 8px;
   padding: 7px 10px;
   border-radius: var(--radius-sm);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -2766,7 +2749,6 @@ openclaw-chat-page {
   background: none;
   border: none;
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -2840,7 +2822,6 @@ openclaw-chat-page {
   color: #fff;
   font-size: 12px;
   line-height: 1;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2941,7 +2922,6 @@ openclaw-chat-page {
   font: inherit;
   font-size: 14px;
   line-height: 1.2;
-  cursor: pointer;
   min-width: 0;
   transition:
     background var(--duration-fast) ease-out,
@@ -3061,7 +3041,6 @@ openclaw-chat-page {
   color: var(--text);
   font-size: 13px;
   line-height: 1.35;
-  cursor: pointer;
   overflow: hidden;
   user-select: none;
 }
@@ -3144,7 +3123,6 @@ openclaw-chat-page {
   font: inherit;
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
 }
 
 .chat-controls__inline-select-option:hover,
@@ -3208,7 +3186,6 @@ openclaw-chat-page {
   font-size: 12px;
   font-weight: 550;
   text-align: left;
-  cursor: pointer;
 }
 
 .chat-controls__provider-icon {
@@ -3397,7 +3374,6 @@ openclaw-chat-page {
   border-radius: var(--radius-full);
   background: none;
   color: var(--muted);
-  cursor: pointer;
 }
 
 .chat-controls__reasoning-reset:hover:not(:disabled),
@@ -3462,7 +3438,6 @@ openclaw-chat-page {
   margin: 0;
   padding: 0;
   background: transparent;
-  cursor: pointer;
 }
 
 .chat-controls__reasoning-range:disabled {
@@ -3560,7 +3535,6 @@ openclaw-chat-page {
   font-size: 12px;
   font-weight: 550;
   line-height: 1;
-  cursor: pointer;
 }
 
 .chat-controls__speed-toggle:hover:not(:disabled),
@@ -3618,7 +3592,6 @@ openclaw-chat-page {
   font: inherit;
   font-size: 12px;
   line-height: 1;
-  cursor: pointer;
 }
 
 .chat-controls__reasoning-option:hover:not(:disabled),
@@ -3987,7 +3960,6 @@ openclaw-chat-page {
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--foreground);
-  cursor: pointer;
   transition:
     background 0.15s,
     border-color 0.15s;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -130,7 +130,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
 }
 
 .chat-workspace-rail__terminal:hover,
@@ -299,7 +298,6 @@
   border: 0;
   background: transparent;
   color: inherit;
-  cursor: pointer;
   font: inherit;
   text-align: left;
 }
@@ -370,7 +368,6 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
 }
 
 .chat-workspace-rail__row-action:hover,
@@ -599,7 +596,6 @@
   font: inherit;
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
 }
 
 .sidebar-file-view__editor-item:hover,
@@ -1187,7 +1183,6 @@
 }
 
 .sidebar-markdown :where(summary) {
-  cursor: pointer;
   padding: 8px 12px;
   font-weight: 500;
   font-size: 13px;

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -89,6 +89,8 @@
 
 .chat-text :where(a.markdown-file-link) {
   color: var(--accent);
+  /* File links are href-less anchors (driven by data-file-path), so the UA
+     link pointer does not apply; they are content links and keep the hand. */
   cursor: pointer;
   text-decoration: none;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -23,7 +23,6 @@
   width: 100%;
   box-sizing: border-box;
   padding: 4px 8px;
-  cursor: pointer;
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
@@ -175,7 +174,6 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   font: inherit;
   transition:
     color 150ms ease-out,
@@ -347,7 +345,6 @@
   color: var(--muted);
   font: inherit;
   font-size: 12px;
-  cursor: pointer;
   transition: color 150ms ease-out;
 }
 
@@ -394,7 +391,6 @@
   align-items: center;
   gap: 6px;
   padding: 6px 10px;
-  cursor: pointer;
   font-size: 12px;
   color: var(--muted);
   user-select: none;
@@ -492,7 +488,6 @@
   color: var(--text);
   font: inherit;
   text-align: left;
-  cursor: pointer;
   user-select: text;
   transition: background 150ms ease;
 }

--- a/ui/src/styles/codex-sessions.css
+++ b/ui/src/styles/codex-sessions.css
@@ -184,7 +184,6 @@
   color: var(--muted);
   font: inherit;
   font-size: var(--control-ui-text-sm);
-  cursor: pointer;
 }
 
 .codex-sessions__scope button:hover:not(:disabled) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -162,7 +162,6 @@
 }
 
 .login-gate__failure-detail summary {
-  cursor: pointer;
   color: var(--muted);
 }
 
@@ -188,7 +187,6 @@
   font-weight: 600;
   font-size: 12px;
   color: var(--fg);
-  cursor: pointer;
 }
 
 .login-gate__steps {
@@ -333,7 +331,6 @@
   min-height: 24px;
   background: none;
   border: none;
-  cursor: pointer;
   color: currentColor;
   opacity: 0.7;
   transition: opacity 0.15s;
@@ -461,7 +458,6 @@
   font-size: 12.5px;
   font-weight: 500;
   white-space: nowrap;
-  cursor: pointer;
   transition: background var(--duration-fast) var(--ease-out);
 }
 
@@ -716,7 +712,6 @@
 .skill-toggle-wrap {
   display: inline-flex;
   align-items: center;
-  cursor: pointer;
 }
 
 .skill-toggle {
@@ -726,7 +721,6 @@
   border-radius: var(--radius-full);
   background: var(--border);
   position: relative;
-  cursor: pointer;
   border: none;
   outline: none;
   transition:
@@ -781,7 +775,6 @@
   font-size: 13px;
   font-weight: 500;
   letter-spacing: -0.01em;
-  cursor: pointer;
   transition:
     border-color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out),
@@ -1246,7 +1239,6 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
-  cursor: pointer;
 }
 
 .field textarea {
@@ -1556,7 +1548,6 @@
   border: 0;
   background: transparent;
   color: var(--text);
-  cursor: pointer;
   font-size: 12px;
   line-height: 1.4;
   padding: 0;
@@ -1612,7 +1603,6 @@
 }
 
 .cron-advanced__summary {
-  cursor: pointer;
   color: var(--muted);
   font-size: 13px;
   font-weight: 500;
@@ -1662,7 +1652,6 @@
   gap: 12px;
   padding: 10px 12px;
   color: var(--muted);
-  cursor: pointer;
   font-size: 13px;
   font-weight: 600;
   list-style: none;
@@ -2059,7 +2048,6 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: currentColor;
-  cursor: pointer;
 }
 
 .callout__dismiss:hover {
@@ -2546,7 +2534,6 @@
   color: var(--muted);
   font-size: 12px; /* was 11px */
   font-family: var(--font-body);
-  cursor: pointer;
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   transition:
@@ -2581,7 +2568,6 @@
 }
 
 .json-collapse summary {
-  cursor: pointer;
   font-size: 12px;
   color: var(--muted);
   padding: 4px 8px;
@@ -2612,10 +2598,6 @@
   padding: 12px;
   background: var(--card);
   transition: border-color var(--duration-fast) ease;
-}
-
-.list-item-clickable {
-  cursor: pointer;
 }
 
 .list-item-clickable:hover {
@@ -2743,7 +2725,6 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
-  cursor: pointer;
   list-style: none;
   min-width: 0;
 }
@@ -2894,7 +2875,6 @@
   font-size: 13px;
   padding: 7px 10px;
   border-radius: var(--radius-sm);
-  cursor: pointer;
 }
 
 .cron-job-menu__item:hover {
@@ -3117,7 +3097,6 @@
 }
 
 .data-table th[data-sortable] {
-  cursor: pointer;
   transition: color var(--duration-fast) ease;
 }
 
@@ -3221,7 +3200,6 @@ td.data-table-checkbox-col {
   height: 16px;
   margin: 0;
   accent-color: var(--accent);
-  cursor: pointer;
   vertical-align: middle;
 }
 
@@ -3291,7 +3269,6 @@ td.data-table-key-col {
   border-radius: var(--radius-sm);
   background: var(--card);
   color: var(--text);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease;
@@ -3341,7 +3318,6 @@ td.data-table-key-col {
 
 .field-inline.checkbox {
   gap: 4px;
-  cursor: pointer;
 }
 
 .field-inline.checkbox input[type="checkbox"] {
@@ -3844,7 +3820,6 @@ td.data-table-key-col {
   font: inherit;
   font-size: 13px;
   font-weight: 500;
-  cursor: pointer;
   outline: none;
   text-align: left;
   transition:
@@ -3949,7 +3924,6 @@ td.data-table-key-col {
   font: inherit;
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
 }
 
 .agent-select__option:hover,
@@ -4026,7 +4000,6 @@ td.data-table-key-col {
   border-radius: var(--radius-md);
   background: var(--card);
   padding: 8px 12px;
-  cursor: pointer;
   transition: border-color var(--duration-fast) ease;
 }
 
@@ -4122,7 +4095,6 @@ td.data-table-key-col {
   font-weight: 600;
   color: var(--muted);
   background: transparent;
-  cursor: pointer;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -4202,7 +4174,6 @@ td.data-table-key-col {
   font-family: var(--mono);
   font-size: 12px;
   padding: 2px 0;
-  cursor: pointer;
   word-break: break-all;
   text-align: left;
   transition: opacity var(--duration-fast) ease;
@@ -4271,7 +4242,6 @@ td.data-table-key-col {
   background: transparent;
   color: var(--muted);
   line-height: 1;
-  cursor: pointer;
   transition:
     background var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out),
@@ -4943,7 +4913,6 @@ td.data-table-key-col {
   gap: 12px;
   justify-content: space-between;
   padding: 12px 14px;
-  cursor: pointer;
   list-style: none;
   transition:
     background-color var(--duration-fast) var(--ease-in-out),
@@ -5061,7 +5030,6 @@ td.data-table-key-col {
   align-items: center;
   min-width: 0;
   padding: 12px 92px 12px 12px;
-  cursor: pointer;
   list-style: none;
   transition:
     background-color var(--duration-fast) var(--ease-in-out),
@@ -5305,7 +5273,6 @@ td.data-table-key-col {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--muted);
-  cursor: pointer;
   gap: 8px;
 }
 
@@ -5472,7 +5439,6 @@ td.data-table-key-col {
   gap: 10px;
   padding: 8px 18px;
   font-size: 14px;
-  cursor: pointer;
   transition: background var(--duration-fast) ease;
 }
 
@@ -5547,7 +5513,6 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--card);
-  cursor: pointer;
   text-align: left;
   transition:
     border-color var(--duration-normal) var(--ease-out),
@@ -5809,7 +5774,6 @@ td.data-table-key-col {
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  cursor: pointer;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-strong);
@@ -5939,7 +5903,6 @@ details[open] > .ov-expandable-toggle::after {
   height: 24px;
   border-radius: var(--radius-sm);
   color: var(--muted);
-  cursor: pointer;
   transition:
     color var(--duration-fast) var(--ease-out),
     background var(--duration-fast) var(--ease-out);
@@ -6230,7 +6193,6 @@ details[open] > .ov-expandable-toggle::after {
 .device-pair-setup__fallback summary {
   width: fit-content;
   margin: 0 auto;
-  cursor: pointer;
 }
 
 .device-pair-setup__fallback code {

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -238,7 +238,6 @@ openclaw-logs-page {
 }
 
 .qs-row__value--action {
-  cursor: pointer;
   background: none;
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   padding: 4px 8px;
@@ -539,7 +538,6 @@ openclaw-logs-page {
   border-radius: calc(var(--radius-md) - 3px);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     color var(--duration-normal) var(--ease-out),
     background var(--duration-normal) var(--ease-out),
@@ -576,7 +574,6 @@ openclaw-logs-page {
   display: flex;
   align-items: center;
   gap: 10px;
-  cursor: pointer;
 }
 
 .qs-toggle input {
@@ -683,7 +680,6 @@ openclaw-logs-page {
   color: var(--accent);
   background: none;
   border: none;
-  cursor: pointer;
   padding: 2px 4px;
   border-radius: var(--radius-sm);
   transition:
@@ -877,7 +873,6 @@ openclaw-logs-page {
   color: var(--text-strong);
   background: color-mix(in srgb, var(--bg-elevated) 50%, var(--card) 50%);
   border: none;
-  cursor: pointer;
   transition: background var(--duration-fast) var(--ease-out);
 }
 
@@ -928,7 +923,6 @@ openclaw-logs-page {
   color: var(--muted);
   background: none;
   border: none;
-  cursor: pointer;
   transition:
     background var(--duration-fast) var(--ease-out),
     color var(--duration-fast) var(--ease-out);

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -108,7 +108,6 @@
   color: var(--muted);
   font-size: 14px;
   line-height: 1;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -145,7 +144,6 @@
   color: var(--muted);
   font-size: 12px; /* was 11px */
   font-weight: 600;
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease,
@@ -335,7 +333,6 @@
   font-size: 11.5px;
   font-weight: 600;
   white-space: nowrap;
-  cursor: pointer;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -374,7 +371,6 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  cursor: pointer;
   font-size: 12px;
   font-weight: 600;
   color: var(--accent);
@@ -563,7 +559,6 @@
   background: var(--bg);
   color: var(--text);
   text-align: left;
-  cursor: pointer;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -767,7 +762,6 @@
   border-radius: var(--radius-md);
   background: var(--card);
   color: var(--text);
-  cursor: pointer;
   text-align: left;
   transition:
     border-color var(--duration-fast) ease,
@@ -1374,7 +1368,6 @@
   background: var(--bg-elevated);
   color: var(--muted);
   font-size: 13px;
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1429,7 +1422,6 @@
 /* Redacted (click-to-reveal) */
 .cfg-input--redacted,
 .cfg-textarea--redacted {
-  cursor: pointer;
   opacity: 0.7;
 }
 
@@ -1458,7 +1450,6 @@
   color: var(--text);
   font-size: 16px;
   font-weight: 300;
-  cursor: pointer;
   transition: background var(--duration-fast) ease;
 }
 
@@ -1509,7 +1500,6 @@
   background-repeat: no-repeat;
   background-position: right 10px center;
   font-size: 13px;
-  cursor: pointer;
   outline: none;
   appearance: none;
   transition:
@@ -1568,7 +1558,6 @@
   color: var(--muted);
   font-size: 12px;
   font-weight: 500;
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease,
@@ -1601,7 +1590,6 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-accent);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease;
@@ -1727,7 +1715,6 @@
   justify-content: space-between;
   gap: 12px;
   padding: 10px 12px;
-  cursor: pointer;
   list-style: none;
   transition: background var(--duration-fast) ease;
   border-radius: calc(var(--radius-md) - 1px);
@@ -1843,7 +1830,6 @@
   color: var(--text);
   font-size: 12px;
   font-weight: 500;
-  cursor: pointer;
   transition: background var(--duration-fast) ease;
 }
 
@@ -1921,7 +1907,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1984,7 +1969,6 @@
   color: var(--text);
   font-size: 12px;
   font-weight: 500;
-  cursor: pointer;
   transition: background var(--duration-fast) ease;
 }
 
@@ -2057,7 +2041,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;

--- a/ui/src/styles/cron-quick-create.css
+++ b/ui/src/styles/cron-quick-create.css
@@ -61,7 +61,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) var(--ease-out),
     border-color var(--duration-fast) var(--ease-out),
@@ -269,7 +268,6 @@
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-md);
   background: var(--card);
-  cursor: pointer;
   transition:
     border-color var(--duration-normal) var(--ease-out),
     background var(--duration-normal) var(--ease-out),
@@ -329,7 +327,6 @@
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: var(--radius-md);
   background: var(--card);
-  cursor: pointer;
   transition:
     border-color var(--duration-normal) var(--ease-out),
     background var(--duration-normal) var(--ease-out);

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -31,7 +31,6 @@
   font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  cursor: pointer;
   transition:
     color 140ms ease,
     background 140ms ease;
@@ -347,7 +346,6 @@
   font-family: inherit;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  cursor: pointer;
   transition:
     border-color 200ms ease,
     color 200ms ease;
@@ -602,7 +600,6 @@
   border-radius: 999px;
   font-size: 12px; /* was 11px */
   line-height: 1;
-  cursor: pointer;
   transition:
     background 0.2s ease,
     color 0.2s ease;
@@ -738,7 +735,6 @@
   border-radius: 999px;
   padding: 5px 10px;
   font-size: 12px; /* was 11px */
-  cursor: pointer;
 }
 
 .dreams-diary__subtab--active {
@@ -846,7 +842,6 @@
   color: var(--muted);
   font-size: 12px; /* was 11px */
   font-variant-numeric: tabular-nums;
-  cursor: pointer;
   text-align: center;
   white-space: nowrap;
   transition:
@@ -887,7 +882,6 @@
 }
 
 .dreams-diary__insight-card--clickable {
-  cursor: pointer;
   transition:
     border-color 140ms ease,
     background 140ms ease,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -132,7 +132,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   font: inherit;
   font-size: 12.5px;
   font-weight: 550;
@@ -273,7 +272,6 @@
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
 }
 
 .settings-sidebar__search-clear:hover {
@@ -321,6 +319,8 @@
   color: color-mix(in srgb, var(--muted) 76%, transparent);
 }
 
+/* Settings rail entries are anchors but read as app chrome: default arrow,
+   not the UA link pointer. */
 .settings-sidebar__item {
   position: relative;
   display: flex;
@@ -332,6 +332,7 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
+  cursor: default;
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -528,7 +529,6 @@
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
   color: var(--muted);
   font-size: 13px;
-  cursor: pointer;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -568,7 +568,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -712,7 +711,6 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1206,7 +1204,6 @@
   background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
   border-radius: var(--radius-md);
-  cursor: pointer;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease,
@@ -1274,7 +1271,6 @@
   border: none;
   border-radius: var(--radius-md);
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
-  cursor: pointer;
   text-align: left;
   transition:
     color var(--duration-fast) ease,
@@ -1366,7 +1362,6 @@
   font: inherit;
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
 }
 
 .sidebar-customize-menu__item:hover {
@@ -1462,7 +1457,6 @@ openclaw-native-link-menu[popover] {
   font: inherit;
   font-size: 13px;
   text-align: left;
-  cursor: pointer;
 }
 
 .session-menu__item:hover:not(:disabled),
@@ -1550,6 +1544,8 @@ openclaw-native-link-menu[popover] {
   left: auto;
 }
 
+/* Nav rail entries are anchors (for middle-click/new-tab) but read as app
+   chrome: override the UA link pointer back to the default arrow. */
 .nav-item {
   position: relative;
   display: flex;
@@ -1562,7 +1558,7 @@ openclaw-native-link-menu[popover] {
   border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: default;
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -1719,6 +1715,9 @@ openclaw-native-link-menu[popover] {
   flex: 1 1 auto;
 }
 
+/* Footer icons mix in-app anchors, buttons, and one external docs link: the
+   chrome gets the default arrow; only the external (target=_blank) anchor is
+   a real hyperlink and keeps the pointer. */
 .sidebar-footer-icon {
   display: inline-flex;
   align-items: center;
@@ -1730,11 +1729,15 @@ openclaw-native-link-menu[popover] {
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
+  cursor: default;
   text-decoration: none;
   transition:
     color var(--duration-fast) ease,
     background var(--duration-fast) ease;
+}
+
+.sidebar-footer-icon[target] {
+  cursor: pointer;
 }
 
 .sidebar-footer-icon:hover:not(:disabled),
@@ -1827,7 +1830,6 @@ openclaw-native-link-menu[popover] {
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: pointer;
   transition:
     color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -2048,7 +2050,6 @@ openclaw-native-link-menu[popover] {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 600;
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 0;

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -59,7 +59,6 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   height: calc(14px * var(--lob-scale, 2) * var(--lob-h, 1));
   transform: translateX(-50%);
   pointer-events: auto;
-  cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;

--- a/ui/src/styles/logbook.css
+++ b/ui/src/styles/logbook.css
@@ -142,7 +142,6 @@
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
 }
 
 .logbook-card__header:hover {

--- a/ui/src/styles/nodes.css
+++ b/ui/src/styles/nodes.css
@@ -16,7 +16,6 @@
 }
 
 .nodes-entry__details > summary {
-  cursor: pointer;
   font-size: 12px;
   color: var(--muted);
   user-select: none;
@@ -38,7 +37,6 @@
 }
 
 .nodes-group__dups > summary {
-  cursor: pointer;
   font-size: 12px;
   color: var(--muted);
   padding: 4px 0;

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -236,7 +236,6 @@
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  cursor: pointer;
   user-select: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -340,10 +339,6 @@
 
 .sessions-table tbody tr.session-data-row > td {
   white-space: nowrap;
-}
-
-.session-data-row--expandable {
-  cursor: pointer;
 }
 
 .session-data-row--expandable:focus-visible {
@@ -812,7 +807,6 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  cursor: pointer;
   opacity: 0.65;
   transition:
     color var(--duration-fast) ease,
@@ -862,7 +856,6 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  cursor: pointer;
   transition:
     color var(--duration-fast) ease,
     background-color var(--duration-fast) ease,

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -70,7 +70,6 @@
   border: none;
   padding: 9px 14px;
   color: var(--muted);
-  cursor: pointer;
   font: inherit;
   font-size: 13px;
   display: flex;
@@ -206,7 +205,6 @@
 .sw-row {
   padding: 10px 14px;
   border-left: 3px solid transparent;
-  cursor: pointer;
   display: grid;
   grid-template-columns: 14px 1fr auto;
   gap: 8px;
@@ -470,7 +468,6 @@
   border: 1px solid var(--border);
   background: var(--bg);
   color: var(--text);
-  cursor: pointer;
   font-size: 14px;
 }
 
@@ -577,7 +574,6 @@
   font-size: 12px;
   color: var(--text);
   text-align: left;
-  cursor: pointer;
   transition:
     background 100ms,
     border-color 100ms;
@@ -690,7 +686,6 @@
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--muted);
-  cursor: pointer;
   font: inherit;
   font-size: 20px;
   line-height: 1;
@@ -766,7 +761,6 @@
 .sw-btn {
   padding: 7px 14px;
   border-radius: var(--radius-md);
-  cursor: pointer;
   font: inherit;
   font-size: 13px;
   font-weight: 600;
@@ -855,7 +849,6 @@
   font: inherit;
   font-size: 12px;
   color: var(--muted);
-  cursor: pointer;
   text-decoration: underline dotted;
   text-underline-offset: 3px;
   text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
@@ -892,7 +885,6 @@
   color: var(--muted);
   font-size: 12.5px;
   font-weight: 500;
-  cursor: pointer;
   white-space: nowrap;
 }
 
@@ -967,7 +959,6 @@
   font-size: 12.5px;
   font-weight: 500;
   color: var(--muted);
-  cursor: pointer;
   transition: color 160ms ease;
   white-space: nowrap;
 }
@@ -1272,7 +1263,6 @@
   font: inherit;
   color: var(--text-strong);
   font-weight: 600;
-  cursor: pointer;
   border-bottom: 1px dotted var(--border-strong);
 }
 
@@ -1293,7 +1283,6 @@
   border-radius: 12px;
   font-size: 12.5px;
   font-weight: 600;
-  cursor: pointer;
   font-family: inherit;
   border: 1px solid;
   transition:
@@ -1382,7 +1371,6 @@
   font: inherit;
   font-size: 12.5px;
   color: var(--accent);
-  cursor: pointer;
   font-weight: 500;
 }
 
@@ -1405,7 +1393,6 @@
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 14px 16px;
-  cursor: pointer;
   font-family: inherit;
   text-align: left;
   color: var(--text);
@@ -1456,7 +1443,6 @@
   gap: 14px;
   padding: 12px 16px;
   border-radius: 12px;
-  cursor: pointer;
   background: transparent;
   border: none;
   font: inherit;

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -606,7 +606,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--text);
-  cursor: pointer;
   font-size: 12px;
   font-weight: 500;
   transition:
@@ -696,7 +695,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   text-align: left;
   font: inherit;
   font-size: 12px;
-  cursor: pointer;
   transition:
     border-color 0.18s var(--ease-out),
     background 0.18s var(--ease-out),
@@ -739,13 +737,11 @@ details.usage-filter-select summary::-webkit-details-marker,
   border: 0;
   background: transparent;
   color: inherit;
-  cursor: pointer;
   font-size: 14px;
   line-height: 1;
 }
 
 .usage-query-suggestion {
-  cursor: pointer;
   transition:
     border-color 0.18s var(--ease-out),
     background 0.18s var(--ease-out),
@@ -1147,7 +1143,6 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-hour-cell {
   min-height: 46px;
-  cursor: pointer;
   transition:
     transform 0.18s var(--ease-out),
     border-color 0.18s var(--ease-out),
@@ -1356,7 +1351,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   align-items: end;
   justify-items: center;
   min-width: 18px;
-  cursor: pointer;
 }
 
 .daily-bar-wrapper.selected .daily-bar {
@@ -1555,7 +1549,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--card) 86%, var(--bg-muted));
-  cursor: pointer;
   transition:
     transform 0.18s var(--ease-out),
     border-color 0.18s var(--ease-out),
@@ -1854,7 +1847,6 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .session-log-tools summary {
-  cursor: pointer;
   font-size: 12px;
   font-weight: 600;
   color: var(--muted);

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -116,7 +116,6 @@
   padding: 3px 8px;
   background: color-mix(in srgb, var(--panel-strong) 44%, transparent);
   color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
-  cursor: pointer;
   font-size: 0.76rem;
   font-family: inherit;
   line-height: 1;
@@ -416,7 +415,6 @@
   min-height: var(--workboard-control-height);
   width: 100%;
   padding: 0 9px 0 10px;
-  cursor: pointer;
   user-select: none;
 }
 
@@ -494,7 +492,6 @@
   color: var(--text);
   font: inherit;
   text-align: left;
-  cursor: pointer;
 }
 
 .workboard-select__option:hover,
@@ -741,10 +738,6 @@
   width: 3px;
   background: color-mix(in srgb, var(--muted) 44%, transparent);
   content: "";
-}
-
-.workboard-card--openable {
-  cursor: pointer;
 }
 
 .workboard-card--openable:hover {
@@ -1057,7 +1050,6 @@
     5px 5px;
   background-repeat: no-repeat;
   color: var(--muted);
-  cursor: pointer;
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0;


### PR DESCRIPTION
Related: #103357

## What Problem This Solves

Follow-up to #103357 extending the cursor convention app-wide. After the sessions sidebar switched to the default arrow cursor, the rest of the Control UI still advertised the hyperlink hand on virtually every control: all buttons (`.btn`), menus, tabs, rails, selects, checkboxes, chart cells, accordion summaries, and terminal/file-preview chrome — around 160 `cursor: pointer` declarations across 20 stylesheets plus two Lit components.

## Why This Change Was Made

The product convention is now: app chrome uses the platform default cursor; the pointer hand is reserved for real hyperlinks. All `cursor: pointer` declarations on controls were deleted (buttons and other controls revert to the browser's default arrow, so no replacement rule is needed), while real links keep the hand via the browser's own anchor styling. Two intentional pointer rules remain, each with a contract comment: `.chat-text a.markdown-file-link` (href-less content anchors driven by `data-file-path`, which browsers do not style as links) and `.sidebar-footer-icon[target]` (the external docs link in the sidebar footer). Anchors that render as app chrome (`.nav-item`, `.settings-sidebar__item`, the in-app footer config icon) get explicit `cursor: default` overrides. Non-link affordances are untouched: `grab`/`grabbing` drag handles, `not-allowed` disabled states, `col-resize`/`ns-resize`/`ew-resize` dividers, and text-input I-beams. The convention is documented next to the anchor base styles in `base.css`.

## User Impact

Hovering buttons, menus, tabs, navigation rails, and other controls anywhere in the Control UI now shows the regular arrow cursor, matching desktop app behavior. The pointer hand still appears exactly where something is a genuine link: markdown/content links in chat, file links, external docs links, and attachment links.

## Evidence

Computed-style verification in a real browser (Chromium) loading the changed stylesheets with representative markup from each surface:

| Element | Before | After |
| --- | --- | --- |
| `.btn`, send button, menu items, tabs (agent/config), slash menu, selects, checkboxes | `pointer` | `default` |
| Nav rail / settings rail anchors, in-app footer icon anchor | `pointer` | `default` |
| External docs footer anchor (`[target]`) | `pointer` | `pointer` (kept — real link) |
| Markdown content link (`a[href]`) and href-less `a.markdown-file-link` | `pointer` | `pointer` (kept — real links) |
| Disabled controls | `not-allowed` | `not-allowed` (unchanged) |
| Drag handles / resizable dividers | `grab` / `*-resize` | unchanged |
| Redacted config input | `pointer` | `text` (standard input I-beam) |

Post-sweep grep: the only remaining `cursor: pointer` declarations in `ui/src` are the two documented link rules. Three rules left empty by the sweep were removed (their classes remain live via hover/focus variants). `oxfmt --check`: none of the 24 changed files flagged. Codex autoreview (gpt-5.5, high): clean, no accepted/actionable findings. Net: +22/−177 lines.
