### PR TITLE
fix(discord): inherit default_auto_archive_duration in createThreadDiscord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.
 - **Channel ingress recovery:** tombstone and scrub malformed durable ingress payloads without letting corrupt rows hide or starve later valid messages. (#98402) Thanks @Pick-cat.
+- **Discord thread archive defaults:** inherit each parent channel's configured auto-archive duration for binding-created threads instead of forcing 60 minutes, while preserving explicit overrides. (#103413) Thanks @wings1029.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -287,7 +287,6 @@ export async function createThreadForBinding(params: {
       params.channelId,
       {
         name: params.threadName,
-        autoArchiveMinutes: 60,
       },
       {
         cfg: params.cfg,

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -109,6 +109,12 @@ function expectFields(
   return record;
 }
 
+function expectThreadCreateOptionsWithoutArchiveOverride(value: unknown): void {
+  const options = requireRecord(value, "thread options");
+  expect(options.name).toBeTypeOf("string");
+  expect(options).not.toHaveProperty("autoArchiveMinutes");
+}
+
 function mockCallArg(mock: unknown, callIndex: number, argIndex: number, label: string) {
   const calls = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls;
   if (!Array.isArray(calls)) {
@@ -894,14 +900,9 @@ describe("thread binding lifecycle", () => {
     });
     expect(hoisted.createThreadDiscord).toHaveBeenCalledTimes(1);
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe("parent-1");
-    expect(
-      (
-        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
-          string,
-          unknown
-        >
-      )?.name,
-    ).toBeTypeOf("string");
+    expectThreadCreateOptionsWithoutArchiveOverride(
+      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
+    );
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -945,14 +946,9 @@ describe("thread binding lifecycle", () => {
     expectFields(childBinding, "child binding", { channelId: "parent-1" });
     expect(hoisted.restGet).toHaveBeenCalledTimes(1);
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe("parent-1");
-    expect(
-      (
-        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
-          string,
-          unknown
-        >
-      )?.name,
-    ).toBeTypeOf("string");
+    expectThreadCreateOptionsWithoutArchiveOverride(
+      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
+    );
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -1118,14 +1114,9 @@ describe("thread binding lifecycle", () => {
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe(
       "parent-runtime",
     );
-    expect(
-      (
-        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
-          string,
-          unknown
-        >
-      )?.name,
-    ).toBeTypeOf("string");
+    expectThreadCreateOptionsWithoutArchiveOverride(
+      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
+    );
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -1182,14 +1173,9 @@ describe("thread binding lifecycle", () => {
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe(
       "1491611525914558667",
     );
-    expect(
-      (
-        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
-          string,
-          unknown
-        >
-      )?.name,
-    ).toBeTypeOf("string");
+    expectThreadCreateOptionsWithoutArchiveOverride(
+      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
+    );
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -220,7 +220,6 @@ describe("thread binding lifecycle", () => {
           params.channelId,
           {
             name: params.threadName,
-            autoArchiveMinutes: 60,
           },
           {
             accountId: params.accountId,
@@ -895,13 +894,14 @@ describe("thread binding lifecycle", () => {
     });
     expect(hoisted.createThreadDiscord).toHaveBeenCalledTimes(1);
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe("parent-1");
-    expectFields(
-      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
-      "thread options",
-      {
-        autoArchiveMinutes: 60,
-      },
-    );
+    expect(
+      (
+        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
+          string,
+          unknown
+        >
+      )?.name,
+    ).toBeTypeOf("string");
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -945,13 +945,14 @@ describe("thread binding lifecycle", () => {
     expectFields(childBinding, "child binding", { channelId: "parent-1" });
     expect(hoisted.restGet).toHaveBeenCalledTimes(1);
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe("parent-1");
-    expectFields(
-      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
-      "thread options",
-      {
-        autoArchiveMinutes: 60,
-      },
-    );
+    expect(
+      (
+        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
+          string,
+          unknown
+        >
+      )?.name,
+    ).toBeTypeOf("string");
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -1117,13 +1118,14 @@ describe("thread binding lifecycle", () => {
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe(
       "parent-runtime",
     );
-    expectFields(
-      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
-      "thread options",
-      {
-        autoArchiveMinutes: 60,
-      },
-    );
+    expect(
+      (
+        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
+          string,
+          unknown
+        >
+      )?.name,
+    ).toBeTypeOf("string");
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",
@@ -1180,13 +1182,14 @@ describe("thread binding lifecycle", () => {
     expect(mockCallArg(hoisted.createThreadDiscord, 0, 0, "createThreadDiscord")).toBe(
       "1491611525914558667",
     );
-    expectFields(
-      mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord"),
-      "thread options",
-      {
-        autoArchiveMinutes: 60,
-      },
-    );
+    expect(
+      (
+        mockCallArg(hoisted.createThreadDiscord, 0, 1, "createThreadDiscord") as Record<
+          string,
+          unknown
+        >
+      )?.name,
+    ).toBeTypeOf("string");
     expectFields(
       mockCallArg(hoisted.createThreadDiscord, 0, 2, "createThreadDiscord"),
       "thread context",

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -156,6 +156,40 @@ describe("sendMessageDiscord", () => {
     });
   });
 
+  it("inherits default_auto_archive_duration for forum threads", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({
+      type: ChannelType.GuildForum,
+      default_auto_archive_duration: 1440,
+    });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
+    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+      name: "thread",
+      auto_archive_duration: 1440,
+      message: { content: "thread" },
+    });
+  });
+
+  it("prefers explicit autoArchiveMinutes over channel default", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({
+      type: ChannelType.GuildForum,
+      default_auto_archive_duration: 1440,
+    });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", autoArchiveMinutes: 4320 },
+      discordClientOpts(rest),
+    );
+    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+      name: "thread",
+      auto_archive_duration: 4320,
+      message: { content: "thread" },
+    });
+  });
+
   it("creates media threads with provided content", async () => {
     const { rest, getMock, postMock } = makeDiscordRest();
     getMock.mockResolvedValue({ type: ChannelType.GuildMedia });

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -171,6 +171,21 @@ describe("sendMessageDiscord", () => {
     });
   });
 
+  it("inherits default_auto_archive_duration for text-channel threads", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    getMock.mockResolvedValue({
+      type: ChannelType.GuildText,
+      default_auto_archive_duration: 10080,
+    });
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord("chan1", { name: "thread" }, discordClientOpts(rest));
+    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+      name: "thread",
+      auto_archive_duration: 10080,
+      type: ChannelType.PublicThread,
+    });
+  });
+
   it("prefers explicit autoArchiveMinutes over channel default", async () => {
     const { rest, getMock, postMock } = makeDiscordRest();
     getMock.mockResolvedValue({
@@ -187,6 +202,21 @@ describe("sendMessageDiscord", () => {
       name: "thread",
       auto_archive_duration: 4320,
       message: { content: "thread" },
+    });
+  });
+
+  it("preserves explicit autoArchiveMinutes for message-attached threads", async () => {
+    const { rest, getMock, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "t1" });
+    await createThreadDiscord(
+      "chan1",
+      { name: "thread", messageId: "m1", autoArchiveMinutes: 4320 },
+      discordClientOpts(rest),
+    );
+    expect(getMock).not.toHaveBeenCalled();
+    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+      name: "thread",
+      auto_archive_duration: 4320,
     });
   });
 

--- a/extensions/discord/src/send.messages.ts
+++ b/extensions/discord/src/send.messages.ts
@@ -158,22 +158,33 @@ export async function createThreadDiscord(
 ) {
   const rest = resolveDiscordRest(opts);
   const body: Record<string, unknown> = { name: payload.name };
-  if (payload.autoArchiveMinutes) {
-    body.auto_archive_duration = payload.autoArchiveMinutes;
-  }
   if (!payload.messageId && payload.type !== undefined) {
     body.type = payload.type;
   }
+  let channel: APIChannel | undefined;
   let channelType: ChannelType | undefined;
   if (!payload.messageId) {
     // Only detect channel kind for route-less thread creation.
     // If this lookup fails, keep prior behavior and let Discord validate.
     try {
-      const channel = await getChannel(rest, channelId);
+      channel = await getChannel(rest, channelId);
       channelType = channel?.type;
     } catch {
       channelType = undefined;
     }
+  }
+  // Inherit auto_archive_duration from the parent channel when the caller does
+  // not provide an explicit value. Forum and media channels expose
+  // default_auto_archive_duration; text channels omit it so the field is left
+  // unset, preserving Discord's server-side default.
+  // APIChannel is a union; default_auto_archive_duration only exists on guild
+  // channels (text, news, forum, media) so narrow via an intersection cast.
+  const archiveDuration =
+    payload.autoArchiveMinutes ??
+    (channel as { default_auto_archive_duration?: number } | undefined)
+      ?.default_auto_archive_duration;
+  if (archiveDuration !== undefined) {
+    body.auto_archive_duration = archiveDuration;
   }
   const isForumLike =
     channelType === ChannelType.GuildForum || channelType === ChannelType.GuildMedia;

--- a/extensions/discord/src/send.messages.ts
+++ b/extensions/discord/src/send.messages.ts
@@ -44,6 +44,13 @@ function assertDiscordResponseObject(value: unknown, label: string): Record<stri
   return value as Record<string, unknown>;
 }
 
+function resolveDefaultThreadAutoArchiveDuration(channel?: APIChannel): number | undefined {
+  if (!channel || !("default_auto_archive_duration" in channel)) {
+    return undefined;
+  }
+  return channel.default_auto_archive_duration;
+}
+
 export class DiscordThreadInitialMessageError extends Error {
   readonly initialMessageError: string;
   readonly thread: APIChannel;
@@ -162,32 +169,22 @@ export async function createThreadDiscord(
     body.type = payload.type;
   }
   let channel: APIChannel | undefined;
-  let channelType: ChannelType | undefined;
   if (!payload.messageId) {
-    // Only detect channel kind for route-less thread creation.
-    // If this lookup fails, keep prior behavior and let Discord validate.
     try {
       channel = await getChannel(rest, channelId);
-      channelType = channel?.type;
     } catch {
-      channelType = undefined;
+      // Channel metadata only enriches standalone creation; Discord still validates it.
     }
   }
-  // Inherit auto_archive_duration from the parent channel when the caller does
-  // not provide an explicit value. Forum and media channels expose
-  // default_auto_archive_duration; text channels omit it so the field is left
-  // unset, preserving Discord's server-side default.
-  // APIChannel is a union; default_auto_archive_duration only exists on guild
-  // channels (text, news, forum, media) so narrow via an intersection cast.
+  // Discord clients preselect the parent default, but REST thread creation needs
+  // it explicitly. Keep a caller override authoritative when one was supplied.
   const archiveDuration =
-    payload.autoArchiveMinutes ??
-    (channel as { default_auto_archive_duration?: number } | undefined)
-      ?.default_auto_archive_duration;
+    payload.autoArchiveMinutes ?? resolveDefaultThreadAutoArchiveDuration(channel);
   if (archiveDuration !== undefined) {
     body.auto_archive_duration = archiveDuration;
   }
   const isForumLike =
-    channelType === ChannelType.GuildForum || channelType === ChannelType.GuildMedia;
+    channel?.type === ChannelType.GuildForum || channel?.type === ChannelType.GuildMedia;
   if (isForumLike) {
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };


### PR DESCRIPTION
## What Problem This Solves

Discord session bindings forced every newly created child thread to auto-archive after 60 minutes. That override ignored the parent channel's `default_auto_archive_duration`, so operators who configured a longer lifetime saw binding-created threads disappear from the active channel list much sooner than expected.

## Why This Change Was Made

`createThreadDiscord` already fetches parent metadata for standalone thread creation. The shared helper is therefore the right owner for carrying Discord's parent default into the create request:

- `createThreadForBinding` no longer injects a binding-specific 60-minute policy.
- Standalone text, announcement, forum, and media thread creation inherits `default_auto_archive_duration` when Discord returns it.
- An explicit `autoArchiveMinutes` remains authoritative.
- Message-attached thread creation still skips the parent lookup and preserves explicit values.
- Parent lookup remains best-effort; a metadata failure still lets Discord validate the create request.

This matches Discord's documented model: channel defaults are copied into newly created threads by clients, while REST thread creation accepts `auto_archive_duration` explicitly. See [Discord Channels](https://docs.discord.com/developers/resources/channel) and [Discord Threads](https://docs.discord.com/developers/topics/threads).

## User Impact

Binding-created Discord threads now honor the parent channel's configured archive lifetime instead of silently forcing 60 minutes. Existing explicit thread-create overrides are unchanged.

## Evidence

- Focused Blacksmith Testbox: 70 Discord tests passed across shared thread creation and binding lifecycle coverage.
- Changed-surface gate passed: extension production/test tsgo, lint, format, dependency, SDK, database-first, and import-cycle checks.
- Live Discord exact-source proof on head `2f66935d12f`: parent default `10080`; created thread read back `10080`; test thread deleted.
- Fresh autoreview: no accepted or actionable findings.

Co-authored-by: 陈志强0668000989 <chen.zhiqiang1@xydigit.com>
