### PR TITLE
fix(sdk): retry after synchronous connection errors

### DIFF
--- a/packages/sdk/src/transport.test.ts
+++ b/packages/sdk/src/transport.test.ts
@@ -14,13 +14,16 @@ type MockGatewayClientInstance = {
 
 const gatewayClientMocks = vi.hoisted(() => ({
   instances: [] as MockGatewayClientInstance[],
+  onStart: undefined as ((client: MockGatewayClientInstance) => void) | undefined,
 }));
 
 vi.mock("@openclaw/gateway-client", () => ({
   GatewayClient: class {
     readonly opts: MockGatewayClientInstance["opts"];
     readonly request = vi.fn();
-    readonly start = vi.fn();
+    readonly start = vi.fn(() => {
+      gatewayClientMocks.onStart?.(this);
+    });
     readonly stopAndWait = vi.fn(async () => {});
 
     constructor(opts: MockGatewayClientInstance["opts"]) {
@@ -33,6 +36,7 @@ vi.mock("@openclaw/gateway-client", () => ({
 describe("GatewayClientTransport", () => {
   beforeEach(() => {
     gatewayClientMocks.instances.length = 0;
+    gatewayClientMocks.onStart = undefined;
   });
 
   it("rejects a pending connect when the transport closes before hello-ok", async () => {
@@ -94,5 +98,21 @@ describe("GatewayClientTransport", () => {
     await connectExpectation;
     expect(onConnectError).toHaveBeenCalledOnce();
     expect(client?.stopAndWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries after a synchronous connection error", async () => {
+    gatewayClientMocks.onStart = (client) => {
+      client.opts.onConnectError?.(new Error("synchronous connection failure"));
+    };
+    const transport = new GatewayClientTransport();
+
+    await expect(transport.connect()).rejects.toThrow("synchronous connection failure");
+
+    gatewayClientMocks.onStart = (client) => {
+      client.opts.onHelloOk?.({ sessionId: "session-1" });
+    };
+
+    await expect(transport.connect()).resolves.toBeUndefined();
+    expect(gatewayClientMocks.instances).toHaveLength(2);
   });
 });

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -93,47 +93,55 @@ export class GatewayClientTransport implements ConnectableOpenClawTransport {
     if (this.connectPromise) {
       return this.connectPromise;
     }
-    this.connectPromise = new Promise<void>((resolve, reject) => {
-      this.rejectPendingConnect = reject;
-      const client = new GatewayClient({
-        ...this.options,
-        onEvent: (event: unknown) => {
-          const normalized = toGatewayEvent(event);
-          this.eventsHub.publish(normalized);
-          this.options.onEvent?.(normalized);
-        },
-        onHelloOk: (_hello: unknown) => {
-          try {
-            this.options.onHelloOk?.(_hello);
-          } finally {
-            this.rejectPendingConnect = null;
-            resolve();
-          }
-        },
-        onConnectError: (error: Error) => {
-          try {
-            this.options.onConnectError?.(error);
-          } finally {
-            if (this.client === client) {
-              this.client = null;
-            }
-            if (this.connectPromise) {
-              this.connectPromise = null;
-            }
-            void client.stopAndWait().catch(() => {});
-            this.rejectPendingConnect = null;
-            reject(error);
-          }
-        },
-        onReconnectPaused: this.options.onReconnectPaused,
-        onClose: this.options.onClose,
-        onGap: this.options.onGap,
-      } as never);
-
-      this.client = client;
-      client.start();
+    let resolveConnect!: () => void;
+    let rejectConnect!: (error: Error) => void;
+    const connectPromise = new Promise<void>((resolve, reject) => {
+      resolveConnect = resolve;
+      rejectConnect = reject;
     });
-    return this.connectPromise;
+    this.connectPromise = connectPromise;
+    this.rejectPendingConnect = rejectConnect;
+
+    const client = new GatewayClient({
+      ...this.options,
+      onEvent: (event: unknown) => {
+        const normalized = toGatewayEvent(event);
+        this.eventsHub.publish(normalized);
+        this.options.onEvent?.(normalized);
+      },
+      onHelloOk: (_hello: unknown) => {
+        try {
+          this.options.onHelloOk?.(_hello);
+        } finally {
+          if (this.connectPromise === connectPromise) {
+            this.rejectPendingConnect = null;
+          }
+          resolveConnect();
+        }
+      },
+      onConnectError: (error: Error) => {
+        try {
+          this.options.onConnectError?.(error);
+        } finally {
+          if (this.client === client) {
+            this.client = null;
+          }
+          if (this.connectPromise === connectPromise) {
+            this.connectPromise = null;
+            this.rejectPendingConnect = null;
+          }
+          void client.stopAndWait().catch(() => {});
+          rejectConnect(error);
+        }
+      },
+      onReconnectPaused: this.options.onReconnectPaused,
+      onClose: this.options.onClose,
+      onGap: this.options.onGap,
+    } as never);
+
+    this.client = client;
+    client.start();
+    return connectPromise;
   }
 
   async request<T = unknown>(


### PR DESCRIPTION
## What Problem This Solves

`GatewayClientTransport.connect()` cached its connection promise only after calling `GatewayClient.start()`. The gateway client can synchronously report a startup failure (for example, when it rejects an insecure remote `ws://` URL), so its error callback could reject the attempt before the transport stored that promise. The subsequent assignment then cached the already-rejected promise permanently, making every later `connect()` call fail without retrying.

## Why This Change Was Made

The transport now creates and stores the pending promise before constructing and starting the gateway client. Both success and error callbacks clear only the promise that owns their attempt, which preserves retry behavior while preventing an older callback from clearing a newer attempt.

## User Impact

SDK consumers can retry a connection after a synchronous startup failure instead of having to recreate the transport instance.

## Evidence

- Added a regression test that makes `start()` synchronously invoke `onConnectError`, then verifies a second `connect()` creates a new client and succeeds.
- `node_modules/.bin/vitest run --config test/vitest/vitest.unit-support.config.ts packages/sdk/src/transport.test.ts` (5 passed)
- `node scripts/run-oxlint.mjs packages/sdk/src/transport.ts packages/sdk/src/transport.test.ts`
- `node_modules/.bin/oxfmt --write packages/sdk/src/transport.ts packages/sdk/src/transport.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --output /tmp/openclaw-autoreview/sdk-connect-failure.json` (clean; no accepted/actionable findings)

Remote Testbox validation is unavailable in this environment because the current account is not authenticated to the `openclaw` organization. The focused test is therefore a narrow local fallback; GitHub CI remains the remote validation path.
