### PR TITLE
fix(agents): make model pins survive fallback, hot reloads, and stale auth profiles

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2204,31 +2204,12 @@ async function agentCommandInternal(
             sessionKey &&
             !suppressVisibleSessionEffects &&
             !preserveUserFacingSessionModelState &&
-            entryMatchesAutoFallbackPrimaryProbe(sessionEntry, autoFallbackPrimaryProbe)
+            entryMatchesAutoFallbackPrimaryProbe(sessionEntry, autoFallbackPrimaryProbe) &&
+            fallbackProvider === autoFallbackPrimaryProbe.provider &&
+            fallbackModel === autoFallbackPrimaryProbe.model
           ) {
             const nextSessionEntry = { ...sessionEntry };
-            if (
-              fallbackProvider === autoFallbackPrimaryProbe.provider &&
-              fallbackModel === autoFallbackPrimaryProbe.model
-            ) {
-              clearAutoFallbackPrimaryProbeSelection(nextSessionEntry);
-            } else {
-              nextSessionEntry.providerOverride = fallbackProvider;
-              nextSessionEntry.modelOverride = fallbackModel;
-              nextSessionEntry.modelOverrideSource = "auto";
-              nextSessionEntry.modelOverrideFallbackOriginProvider =
-                autoFallbackPrimaryProbe.provider;
-              nextSessionEntry.modelOverrideFallbackOriginModel = autoFallbackPrimaryProbe.model;
-              if (
-                nextSessionEntry.authProfileOverrideSource === "auto" &&
-                fallbackProvider !== autoFallbackPrimaryProbe.fallbackProvider
-              ) {
-                delete nextSessionEntry.authProfileOverride;
-                delete nextSessionEntry.authProfileOverrideSource;
-                delete nextSessionEntry.authProfileOverrideCompactionCount;
-              }
-              nextSessionEntry.updatedAt = Date.now();
-            }
+            clearAutoFallbackPrimaryProbeSelection(nextSessionEntry);
             const persistedEntry = await persistSessionEntry({
               sessionStore,
               sessionKey,

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -746,6 +746,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       provider: "openai",
       profileId,
     });
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledOnce();
   });
 
   it("does not refresh managed OAuth for direct OpenAI API-key models", async () => {
@@ -1082,6 +1083,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       source: `profile:${healthyProfileId}`,
       mode: "oauth",
     });
+    expect(getOAuthApiKeyMock).not.toHaveBeenCalled();
+    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
 
     await markAuthProfileSuccess({
       store: ensureAuthProfileStore(agentDir),

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -349,6 +349,100 @@ describe("resolveAuthProfileOrder", () => {
     expect(order).toEqual(["openai:personal", "openai:oauth", "openai:backup"]);
   });
 
+  it("demotes expired OAuth profiles behind a healthy sibling", () => {
+    const now = Date.now();
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:expired": {
+          type: "oauth",
+          provider: "openai",
+          access: "expired-access",
+          refresh: "expired-refresh",
+          expires: now - 60_000,
+        },
+        "openai:healthy": {
+          type: "oauth",
+          provider: "openai",
+          access: "healthy-access",
+          refresh: "healthy-refresh",
+          expires: now + 60_000,
+        },
+      },
+      order: {
+        openai: ["openai:expired", "openai:healthy"],
+      },
+    };
+
+    expect(resolveAuthProfileOrder({ store, provider: "openai" })).toEqual([
+      "openai:healthy",
+      "openai:expired",
+    ]);
+  });
+
+  it("keeps an explicitly preferred profile first even when its OAuth token is expired", () => {
+    // preferredProfile targets a specific account; refresh runs at use, so
+    // expiry must not silently swap the credential identity.
+    const now = Date.now();
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:expired": {
+          type: "oauth",
+          provider: "openai",
+          access: "expired-access",
+          refresh: "expired-refresh",
+          expires: now - 60_000,
+        },
+        "openai:healthy": {
+          type: "oauth",
+          provider: "openai",
+          access: "healthy-access",
+          refresh: "healthy-refresh",
+          expires: now + 60_000,
+        },
+      },
+      order: {
+        openai: ["openai:expired", "openai:healthy"],
+      },
+    };
+
+    expect(
+      resolveAuthProfileOrder({ store, provider: "openai", preferredProfile: "openai:expired" }),
+    ).toEqual(["openai:expired", "openai:healthy"]);
+  });
+
+  it("attempts normal auth resolution when every OAuth profile is expired", () => {
+    const now = Date.now();
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:first": {
+          type: "oauth",
+          provider: "openai",
+          access: "first-access",
+          refresh: "first-refresh",
+          expires: now - 60_000,
+        },
+        "openai:second": {
+          type: "oauth",
+          provider: "openai",
+          access: "second-access",
+          refresh: "second-refresh",
+          expires: now - 30_000,
+        },
+      },
+      order: {
+        openai: ["openai:first", "openai:second"],
+      },
+    };
+
+    expect(resolveAuthProfileOrder({ store, provider: "openai" })).toEqual([
+      "openai:first",
+      "openai:second",
+    ]);
+  });
+
   it("does not discover OAuth profiles without inline credential material", async () => {
     const store: AuthProfileStore = {
       version: 1,

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -7,6 +7,7 @@ import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
+import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   type ProviderAuthAliasLookupParams,
@@ -346,6 +347,20 @@ export function resolveAuthProfileOrder(params: {
   }
 
   const deduped = dedupeProfileIds(filtered);
+  // Demote OAuth profiles whose access token is locally expired behind healthy
+  // siblings: one stale credential must not lead availability probes/rotation.
+  // Expired profiles stay selectable (refresh still runs at use), and explicit
+  // preferredProfile promotion below wins over expiry.
+  const isLocallyExpiredOAuthProfile = (profileId: string): boolean => {
+    const credential = store.profiles[profileId];
+    return (
+      credential?.type === "oauth" && !isFutureDateTimestampMs(credential.expires, { nowMs: now })
+    );
+  };
+  const demoteExpiredOAuth = (profileIds: string[]): string[] => [
+    ...profileIds.filter((profileId) => !isLocallyExpiredOAuthProfile(profileId)),
+    ...profileIds.filter(isLocallyExpiredOAuthProfile),
+  ];
 
   // Explicit order remains a hard user/config preference, but cooldown tracking
   // moves temporarily bad profiles behind available ones.
@@ -367,7 +382,7 @@ export function resolveAuthProfileOrder(params: {
       .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
       .map((entry) => entry.profileId);
 
-    const ordered = [...available, ...cooldownSorted];
+    const ordered = [...demoteExpiredOAuth(available), ...cooldownSorted];
 
     // Explicit user choice still wins when it is part of the filtered order.
     if (preferredProfile && ordered.includes(preferredProfile)) {
@@ -378,7 +393,7 @@ export function resolveAuthProfileOrder(params: {
 
   // Otherwise, use round-robin by lastUsed. lastGood is intentionally ignored
   // because prioritizing it would starve other healthy profiles.
-  const sorted = orderProfilesByMode(deduped, store);
+  const sorted = demoteExpiredOAuth(orderProfilesByMode(deduped, store));
 
   if (preferredProfile && sorted.includes(preferredProfile)) {
     return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -315,10 +315,6 @@ async function getRunAgentTurnWithFallback() {
   return (await import("./agent-runner-execution.js")).runAgentTurnWithFallback;
 }
 
-async function getApplyFallbackCandidateSelectionToEntry() {
-  return (await import("./agent-runner-execution.js")).applyFallbackCandidateSelectionToEntry;
-}
-
 type FallbackRunnerParams = {
   provider: string;
   model: string;
@@ -2368,197 +2364,6 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("keeps fallback auth available for later same-provider fallback models", async () => {
-    const probe = {
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-5.4",
-      fallbackAuthProfileId: "openai:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "anthropic";
-    followupRun.run.model = "claude-sonnet-4-6";
-    followupRun.run.authProfileId = "anthropic:primary";
-    followupRun.run.authProfileIdSource = "auto";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "same-provider-fallback-auth";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openai",
-      modelOverride: "gpt-5.4",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
-      result: await params.run("openai", "gpt-5.5"),
-      provider: "openai",
-      model: "gpt-5.5",
-      attempts: [
-        { provider: "anthropic", model: "claude-sonnet-4-6", error: "rate limit" },
-        { provider: "openai", model: "gpt-5.4", error: "rate limit" },
-      ],
-    }));
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectMockCallArgFields(state.runEmbeddedAgentMock, 0, "embedded run", {
-      provider: "openai",
-      model: "gpt-5.5",
-      authProfileId: "openai:fallback",
-      authProfileIdSource: "auto",
-    });
-    expectRecordFields(sessionEntry as unknown as Record<string, unknown>, {
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
-  it("keeps the primary origin when an auto pin is cleared before fallback persists", async () => {
-    const probe = {
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-5.4",
-      fallbackAuthProfileId: "openai:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "anthropic";
-    followupRun.run.model = "claude-sonnet-4-6";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "cleared-before-fallback-persists";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openai",
-      modelOverride: "gpt-5.4",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      activeSessionStore[sessionKey] = {
-        sessionId: "session",
-        updatedAt: 2,
-      };
-      return {
-        result: await params.run("openai", "gpt-5.5"),
-        provider: "openai",
-        model: "gpt-5.5",
-        attempts: [{ provider: "anthropic", model: "claude-sonnet-4-6", error: "rate limit" }],
-      };
-    });
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectRecordFields(activeSessionStore[sessionKey] as unknown as Record<string, unknown>, {
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
-  it("re-persists cross-provider same-model fallback pins after an in-flight clear", async () => {
-    const probe = {
-      provider: "openai",
-      model: "gpt-5.5",
-      fallbackProvider: "azure",
-      fallbackModel: "gpt-5.5",
-      fallbackAuthProfileId: "azure:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "openai";
-    followupRun.run.model = "gpt-5.5";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "cleared-cross-provider-same-model";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "azure",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.5",
-      authProfileOverride: "azure:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      activeSessionStore[sessionKey] = {
-        sessionId: "session",
-        updatedAt: 2,
-      };
-      return {
-        result: await params.run("azure", "gpt-5.5"),
-        provider: "azure",
-        model: "gpt-5.5",
-        attempts: [{ provider: "openai", model: "gpt-5.5", error: "rate limit" }],
-      };
-    });
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectRecordFields(activeSessionStore[sessionKey] as unknown as Record<string, unknown>, {
-      providerOverride: "azure",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.5",
-      authProfileOverride: "azure:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
   it("keeps primary auth on same-provider primary probes", async () => {
     const probe = {
       provider: "openai",
@@ -4381,7 +4186,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
   });
 
-  it("rolls back persisted fallback selection when result classification rejects a candidate", async () => {
+  it("keeps fallback candidate selection turn-local during result classification", async () => {
     const followupRun = createFollowupRun();
     followupRun.run.provider = "anthropic";
     followupRun.run.model = "claude";
@@ -4395,8 +4200,8 @@ describe("runAgentTurnWithFallback", () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const failedResult = await params.run("openai", "gpt-5.4");
-      expect(sessionEntry.providerOverride).toBe("openai");
-      expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+      expect(sessionEntry.providerOverride).toBeUndefined();
+      expect(sessionEntry.modelOverride).toBeUndefined();
       const classification = await params.classifyResult?.({
         result: failedResult as { payloads?: [] },
         provider: "openai",
@@ -4407,8 +4212,6 @@ describe("runAgentTurnWithFallback", () => {
       expectRecordFields(requireRecord(classification, "fallback classification"), {
         code: "empty_result",
       });
-      expect(sessionEntry.providerOverride).toBeUndefined();
-      expect(sessionEntry.modelOverride).toBeUndefined();
       return {
         result: { payloads: [{ text: "fallback ok" }], meta: {} },
         provider: "anthropic",
@@ -8434,7 +8237,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionStore.main.modelOverride).toBe("glm-5");
   });
 
-  it("drops authProfileId when fallback switches providers", async () => {
+  it("keeps cross-provider fallback selection turn-local", async () => {
     state.runWithModelFallbackMock.mockImplementation(
       async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
         result: await params.run("openai", "gpt-5.4"),
@@ -8495,9 +8298,9 @@ describe("runAgentTurnWithFallback", () => {
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -8570,7 +8373,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionEntry.modelOverrideSource).toBeUndefined();
   });
 
-  it("persists fallback selection for recovered auto overrides without modelOverrideSource", async () => {
+  it("does not replace a recovered auto override during fallback", async () => {
     state.runWithModelFallbackMock.mockImplementation(
       async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
         result: await params.run("openai", "gpt-5.4"),
@@ -8627,9 +8430,9 @@ describe("runAgentTurnWithFallback", () => {
     });
 
     expect(result.kind).toBe("success");
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    expect(sessionEntry.providerOverride).toBe("bailian");
+    expect(sessionEntry.modelOverride).toBe("qwen3.6-plus");
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.modelOverrideFallbackOriginProvider).toBe("minimax");
     expect(sessionEntry.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
   });
@@ -8697,77 +8500,6 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionEntry.providerOverride).toBe("anthropic");
     expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
     expect(sessionEntry.modelOverrideSource).toBe("user");
-  });
-
-  it("keeps same-provider auth profile when fallback only changes model", async () => {
-    const applyFallbackCandidateSelectionToEntry =
-      await getApplyFallbackCandidateSelectionToEntry();
-    const entry = {
-      sessionId: "session",
-      updatedAt: 1,
-      authProfileOverride: "anthropic:openclaw",
-      authProfileOverrideSource: "user" as const,
-    } as SessionEntry;
-
-    const { updated } = applyFallbackCandidateSelectionToEntry({
-      entry,
-      run: {
-        provider: "anthropic",
-        model: "claude-opus",
-        authProfileId: "anthropic:openclaw",
-        authProfileIdSource: "user",
-      } as FollowupRun["run"],
-      provider: "anthropic",
-      model: "claude-sonnet",
-      now: 123,
-    });
-
-    expect(updated).toBe(true);
-    expectRecordFields(entry as unknown as Record<string, unknown>, {
-      updatedAt: 123,
-      providerOverride: "anthropic",
-      modelOverride: "claude-sonnet",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-      authProfileOverride: "anthropic:openclaw",
-      authProfileOverrideSource: "user",
-    });
-  });
-
-  it("preserves original auto-fallback origin across chained fallbacks", async () => {
-    const applyFallbackCandidateSelectionToEntry =
-      await getApplyFallbackCandidateSelectionToEntry();
-    const entry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openrouter",
-      modelOverride: "fallback-b",
-      modelOverrideSource: "auto" as const,
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-    } as SessionEntry;
-
-    const { updated } = applyFallbackCandidateSelectionToEntry({
-      entry,
-      run: {
-        provider: "openrouter",
-        model: "fallback-b",
-      } as FollowupRun["run"],
-      provider: "openrouter",
-      model: "fallback-c",
-      now: 123,
-    });
-
-    expect(updated).toBe(true);
-    expectRecordFields(entry as unknown as Record<string, unknown>, {
-      updatedAt: 123,
-      providerOverride: "openrouter",
-      modelOverride: "fallback-c",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-    });
   });
 
   it("latches assistant error stub suppression across main reply fallback candidates", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -435,240 +435,6 @@ export type AgentRunLoopResult =
 
 type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedAgent>>;
 
-type FallbackSelectionState = Pick<
-  SessionEntry,
-  | "providerOverride"
-  | "modelOverride"
-  | "modelOverrideSource"
-  | "modelOverrideFallbackOriginProvider"
-  | "modelOverrideFallbackOriginModel"
-  | "authProfileOverride"
-  | "authProfileOverrideSource"
-  | "authProfileOverrideCompactionCount"
->;
-
-const FALLBACK_SELECTION_STATE_KEYS = [
-  "providerOverride",
-  "modelOverride",
-  "modelOverrideSource",
-  "modelOverrideFallbackOriginProvider",
-  "modelOverrideFallbackOriginModel",
-  "authProfileOverride",
-  "authProfileOverrideSource",
-  "authProfileOverrideCompactionCount",
-] as const satisfies ReadonlyArray<keyof FallbackSelectionState>;
-
-function setFallbackSelectionStateField(
-  entry: SessionEntry,
-  key: keyof FallbackSelectionState,
-  value: FallbackSelectionState[keyof FallbackSelectionState],
-): boolean {
-  switch (key) {
-    case "providerOverride":
-      if (entry.providerOverride !== value) {
-        entry.providerOverride = value as SessionEntry["providerOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverride":
-      if (entry.modelOverride !== value) {
-        entry.modelOverride = value as SessionEntry["modelOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverrideSource":
-      if (entry.modelOverrideSource !== value) {
-        entry.modelOverrideSource = value as SessionEntry["modelOverrideSource"];
-        return true;
-      }
-      return false;
-    case "modelOverrideFallbackOriginProvider":
-      if (entry.modelOverrideFallbackOriginProvider !== value) {
-        entry.modelOverrideFallbackOriginProvider =
-          value as SessionEntry["modelOverrideFallbackOriginProvider"];
-        return true;
-      }
-      return false;
-    case "modelOverrideFallbackOriginModel":
-      if (entry.modelOverrideFallbackOriginModel !== value) {
-        entry.modelOverrideFallbackOriginModel =
-          value as SessionEntry["modelOverrideFallbackOriginModel"];
-        return true;
-      }
-      return false;
-    case "authProfileOverride":
-      if (entry.authProfileOverride !== value) {
-        entry.authProfileOverride = value as SessionEntry["authProfileOverride"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideSource":
-      if (entry.authProfileOverrideSource !== value) {
-        entry.authProfileOverrideSource = value as SessionEntry["authProfileOverrideSource"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideCompactionCount":
-      if (entry.authProfileOverrideCompactionCount !== value) {
-        entry.authProfileOverrideCompactionCount =
-          value as SessionEntry["authProfileOverrideCompactionCount"];
-        return true;
-      }
-      return false;
-  }
-  throw new Error("Unsupported fallback selection state key");
-}
-
-function snapshotFallbackSelectionState(entry: SessionEntry): FallbackSelectionState {
-  return {
-    providerOverride: entry.providerOverride,
-    modelOverride: entry.modelOverride,
-    modelOverrideSource: entry.modelOverrideSource,
-    modelOverrideFallbackOriginProvider: entry.modelOverrideFallbackOriginProvider,
-    modelOverrideFallbackOriginModel: entry.modelOverrideFallbackOriginModel,
-    authProfileOverride: entry.authProfileOverride,
-    authProfileOverrideSource: entry.authProfileOverrideSource,
-    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
-  };
-}
-
-function buildFallbackSelectionStatePatch(entry: SessionEntry): Partial<SessionEntry> {
-  return {
-    ...snapshotFallbackSelectionState(entry),
-    updatedAt: entry.updatedAt,
-  };
-}
-
-function buildFallbackSelectionState(params: {
-  provider: string;
-  model: string;
-  originProvider: string;
-  originModel: string;
-  authProfileId?: string;
-  authProfileIdSource?: "auto" | "user";
-}): FallbackSelectionState {
-  return {
-    providerOverride: params.provider,
-    modelOverride: params.model,
-    modelOverrideSource: "auto",
-    modelOverrideFallbackOriginProvider: params.originProvider,
-    modelOverrideFallbackOriginModel: params.originModel,
-    authProfileOverride: params.authProfileId,
-    authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,
-    authProfileOverrideCompactionCount: undefined,
-  };
-}
-
-function resolveFallbackSelectionOrigin(params: { entry: SessionEntry; run: FollowupRun["run"] }): {
-  provider: string;
-  model: string;
-} {
-  if (
-    params.entry.modelOverrideSource === "auto" ||
-    (params.entry.modelOverrideSource === undefined &&
-      hasSessionAutoModelFallbackProvenance(params.entry))
-  ) {
-    const persistedOriginProvider = normalizeOptionalString(
-      params.entry.modelOverrideFallbackOriginProvider,
-    );
-    const persistedOriginModel = normalizeOptionalString(
-      params.entry.modelOverrideFallbackOriginModel,
-    );
-    if (persistedOriginProvider && persistedOriginModel) {
-      return { provider: persistedOriginProvider, model: persistedOriginModel };
-    }
-  }
-  return { provider: params.run.provider, model: params.run.model };
-}
-
-/** Persists the fallback candidate selection onto a session entry. */
-export function applyFallbackCandidateSelectionToEntry(params: {
-  entry: SessionEntry;
-  run: FollowupRun["run"];
-  provider: string;
-  model: string;
-  origin?: { provider: string; model: string };
-  force?: boolean;
-  now?: number;
-}): { updated: boolean; nextState?: FallbackSelectionState } {
-  if (
-    !params.force &&
-    params.provider === params.run.provider &&
-    params.model === params.run.model
-  ) {
-    return { updated: false };
-  }
-  const scopedAuthProfile = resolveRunAuthProfile(params.run, params.provider);
-  const origin =
-    params.origin ?? resolveFallbackSelectionOrigin({ entry: params.entry, run: params.run });
-  const nextState = buildFallbackSelectionState({
-    provider: params.provider,
-    model: params.model,
-    originProvider: origin.provider,
-    originModel: origin.model,
-    authProfileId: scopedAuthProfile.authProfileId,
-    authProfileIdSource: scopedAuthProfile.authProfileIdSource,
-  });
-  return {
-    updated: applyFallbackSelectionState(params.entry, nextState, params.now),
-    nextState,
-  };
-}
-
-function applyFallbackSelectionState(
-  entry: SessionEntry,
-  nextState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    const nextValue = nextState[key];
-    if (nextValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== nextValue) {
-      updated = setFallbackSelectionStateField(entry, key, nextValue) || updated;
-    }
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
-}
-
-function rollbackFallbackSelectionStateIfUnchanged(
-  entry: SessionEntry,
-  expectedState: FallbackSelectionState,
-  previousState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    if (entry[key] !== expectedState[key]) {
-      continue;
-    }
-    const previousValue = previousState[key];
-    if (previousValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== previousValue) {
-      updated = setFallbackSelectionStateField(entry, key, previousValue) || updated;
-    }
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
-}
-
 /**
  * Build a human-friendly rate-limit message from a FallbackSummaryError.
  * Includes a countdown when the soonest cooldown expiry is known.
@@ -1936,147 +1702,6 @@ async function runAgentTurnWithFallbackInternal(
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
-  let pendingFallbackCandidateRollback:
-    | {
-        provider: string;
-        model: string;
-        rollback: () => Promise<void>;
-      }
-    | undefined;
-  const clearPendingFallbackRollback = (rollback?: () => Promise<void>) => {
-    if (!rollback || pendingFallbackCandidateRollback?.rollback === rollback) {
-      pendingFallbackCandidateRollback = undefined;
-    }
-  };
-  const rollbackClassifiedFallbackCandidateSelection = async (provider: string, model: string) => {
-    const pending = pendingFallbackCandidateRollback;
-    if (!pending || pending.provider !== provider || pending.model !== model) {
-      return;
-    }
-    pendingFallbackCandidateRollback = undefined;
-    try {
-      await pending.rollback();
-    } catch (rollbackError) {
-      logVerbose(
-        `failed to roll back classified fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-      );
-    }
-  };
-  const persistFallbackCandidateSelection = async (
-    provider: string,
-    model: string,
-    candidateRun: FollowupRun["run"],
-  ): Promise<(() => Promise<void>) | undefined> => {
-    if (
-      !params.sessionKey ||
-      !params.activeSessionStore ||
-      preserveUserFacingSessionState ||
-      (provider === effectiveRun.provider && model === effectiveRun.model)
-    ) {
-      return undefined;
-    }
-
-    const activeSessionEntry =
-      params.activeSessionStore[params.sessionKey] ?? params.getActiveSessionEntry();
-    if (!activeSessionEntry) {
-      return undefined;
-    }
-
-    // Don't overwrite a user-initiated model override (e.g. from /models or
-    // /model) with the fallback model.  The user's explicit selection should
-    // survive transient primary-model failures so subsequent messages still
-    // target the model the user chose.  Fallback persistence is only
-    // appropriate when the override was itself set by a previous fallback
-    // ("auto") or when there is no override yet.
-    //
-    // `modelOverrideSource` was added later, so older persisted sessions can
-    // carry a user-selected override without the source field.  Treat any
-    // entry with a `modelOverride` but missing `modelOverrideSource` as legacy
-    // user state, matching the backward-compat treatment in
-    // session-reset-service.
-    const isUserModelOverride =
-      activeSessionEntry.modelOverrideSource === "user" ||
-      (activeSessionEntry.modelOverrideSource === undefined &&
-        Boolean(normalizeOptionalString(activeSessionEntry.modelOverride)) &&
-        !hasSessionAutoModelFallbackProvenance(activeSessionEntry));
-    if (isUserModelOverride) {
-      return undefined;
-    }
-
-    const previousState = snapshotFallbackSelectionState(activeSessionEntry);
-    const selectionRun =
-      candidateRun !== effectiveRun && effectiveRun.autoFallbackPrimaryProbe
-        ? {
-            ...candidateRun,
-            provider: candidateRun.provider,
-            model: effectiveRun.model,
-          }
-        : candidateRun;
-    const persistedProvider = resolveOpenAIRuntimeProvider({
-      provider,
-      config: runtimeConfig,
-      workspaceDir: params.followupRun.run.workspaceDir,
-    });
-    const applied = applyFallbackCandidateSelectionToEntry({
-      entry: activeSessionEntry,
-      run: selectionRun,
-      provider: persistedProvider,
-      model,
-      force: candidateRun !== effectiveRun && Boolean(effectiveRun.autoFallbackPrimaryProbe),
-      ...(effectiveRun.autoFallbackPrimaryProbe
-        ? {
-            origin: {
-              provider: effectiveRun.autoFallbackPrimaryProbe.provider,
-              model: effectiveRun.autoFallbackPrimaryProbe.model,
-            },
-          }
-        : {}),
-    });
-    const nextState = applied.nextState;
-    if (!applied.updated || !nextState) {
-      return undefined;
-    }
-    params.activeSessionStore[params.sessionKey] = activeSessionEntry;
-
-    try {
-      if (params.storePath) {
-        await updateSessionEntry(
-          { storePath: params.storePath, sessionKey: params.sessionKey },
-          (persistedEntry) => {
-            applyFallbackSelectionState(persistedEntry, nextState);
-            return buildFallbackSelectionStatePatch(persistedEntry);
-          },
-        );
-      }
-    } catch (error) {
-      rollbackFallbackSelectionStateIfUnchanged(activeSessionEntry, nextState, previousState);
-      params.activeSessionStore[params.sessionKey] = activeSessionEntry;
-      throw error;
-    }
-
-    return async () => {
-      const rolledBackInMemory = rollbackFallbackSelectionStateIfUnchanged(
-        activeSessionEntry,
-        nextState,
-        previousState,
-      );
-      if (rolledBackInMemory) {
-        params.activeSessionStore![params.sessionKey!] = activeSessionEntry;
-      }
-      if (!params.storePath || !params.sessionKey) {
-        return;
-      }
-      await updateSessionEntry(
-        { storePath: params.storePath, sessionKey: params.sessionKey },
-        (persistedEntry) => {
-          if (rollbackFallbackSelectionStateIfUnchanged(persistedEntry, nextState, previousState)) {
-            return buildFallbackSelectionStatePatch(persistedEntry);
-          }
-          return null;
-        },
-      );
-    };
-  };
   const clearRecoveredAutoFallbackPrimaryProbe = async (paramsForClear: {
     provider: string;
     model: string;
@@ -2292,8 +1917,8 @@ async function runAgentTurnWithFallbackInternal(
               step,
             });
           },
-          classifyResult: async ({ result, provider, model }) => {
-            const classification = outcomePlan.classifyRunResult({
+          classifyResult: ({ result, provider, model }) =>
+            outcomePlan.classifyRunResult({
               result,
               provider,
               model,
@@ -2301,12 +1926,7 @@ async function runAgentTurnWithFallbackInternal(
               hasBlockReplyPipelineOutput: Boolean(
                 blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
               ),
-            });
-            if (classification) {
-              await rollbackClassifiedFallbackCandidateSelection(provider, model);
-            }
-            return classification;
-          },
+            }),
           mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             attemptedRuntimeProvider = provider;
@@ -2338,25 +1958,6 @@ async function runAgentTurnWithFallbackInternal(
               model,
               thinkLevel: params.followupRun.run.thinkLevel,
             });
-            let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
-            try {
-              rollbackFallbackCandidateSelection = await agentTurnTiming.measure(
-                "fallback_persist_selection",
-                () => persistFallbackCandidateSelection(provider, model, candidateRun),
-              );
-              if (rollbackFallbackCandidateSelection) {
-                pendingFallbackCandidateRollback = {
-                  provider,
-                  model,
-                  rollback: rollbackFallbackCandidateSelection,
-                };
-              }
-            } catch (error) {
-              logVerbose(
-                `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
-              );
-            }
-
             const { sessionRuntimeOverride, cliExecutionProvider } = agentTurnTiming.measureSync(
               "fallback_resolve_runtime",
               () => {
@@ -2483,19 +2084,6 @@ async function runAgentTurnWithFallbackInternal(
                       : undefined,
                   onFastModeAutoProgress: async (payload) => {
                     await params.opts?.onToolResult?.(payload);
-                  },
-                  onErrorBeforeLifecycle: async () => {
-                    if (!rollbackFallbackCandidateSelection) {
-                      return;
-                    }
-                    try {
-                      await rollbackFallbackCandidateSelection();
-                      clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                    } catch (rollbackError) {
-                      logVerbose(
-                        `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                      );
-                    }
                   },
                   transformResult:
                     params.followupRun.currentInboundEventKind === "room_event"
@@ -3105,18 +2693,6 @@ async function runAgentTurnWithFallbackInternal(
                 );
                 attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
                 return result;
-              } catch (err) {
-                if (rollbackFallbackCandidateSelection) {
-                  try {
-                    await rollbackFallbackCandidateSelection();
-                    clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                  } catch (rollbackError) {
-                    logVerbose(
-                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                    );
-                  }
-                }
-                throw err;
               } finally {
                 autoCompactionCount += attemptCompactionCount;
               }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1276,6 +1276,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("announces model fallback transitions across verbose levels", async () => {
+    const storeRoot = await mkdtemp(join(tmpdir(), "openclaw-fallback-pin-"));
+    const storePath = join(storeRoot, "sessions.json");
     const cases = [
       { name: "verbose on", verbose: "on" as const },
       { name: "verbose off", verbose: "off" as const },
@@ -1284,11 +1286,15 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const sessionEntry: SessionEntry = {
         sessionId: "session",
         updatedAt: Date.now(),
+        providerOverride: "anthropic",
+        modelOverride: "claude",
+        modelOverrideSource: "user",
       };
+      await saveSessionStore(storePath, { main: sessionEntry }, { skipMaintenance: true });
       const sessionStore = { main: sessionEntry };
       state.runEmbeddedAgentMock.mockResolvedValueOnce({
         payloads: [{ text: "final" }],
-        meta: {},
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
       });
       vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(async (args) => {
         const { run, onFallbackStep } = args;
@@ -1320,6 +1326,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         sessionEntry,
         sessionStore,
         sessionKey: "main",
+        storePath,
       });
       const phases: string[] = [];
       const off = onAgentEvent((evt) => {
@@ -1333,15 +1340,26 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const payload = Array.isArray(res)
         ? (res[0] as { text?: string })
         : (res as { text?: string });
+      const stored = requireStoredSessionEntry(storePath);
       expect(payload.text, testCase.name).toContain("Model Fallback:");
       expect(payload.text, testCase.name).toContain("deepinfra/moonshotai/Kimi-K2.5");
-      expect(sessionEntry.fallbackNoticeReason, testCase.name).toBe("rate limit");
+      expect(stored.providerOverride, testCase.name).toBe("anthropic");
+      expect(stored.modelOverride, testCase.name).toBe("claude");
+      expect(stored.modelOverrideSource, testCase.name).toBe("user");
+      expect(stored.modelProvider, testCase.name).toBe("deepinfra");
+      expect(stored.model, testCase.name).toBe("moonshotai/Kimi-K2.5");
+      expect(stored.fallbackNoticeSelectedModel, testCase.name).toBe("anthropic/claude");
+      expect(stored.fallbackNoticeActiveModel, testCase.name).toBe(
+        "deepinfra/moonshotai/Kimi-K2.5",
+      );
+      expect(stored.fallbackNoticeReason, testCase.name).toBe("rate limit");
       expect(
         phases.filter((phase) => phase === "fallback"),
         testCase.name,
       ).toHaveLength(1);
       expect(phases, testCase.name).toContain("fallback_step");
     }
+    await rm(storeRoot, { recursive: true, force: true });
   });
 
   it("does not report an exhausted fallback candidate as a successful winner", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -399,6 +399,12 @@ function parseGenericThreadSessionInfo(sessionKey: string | undefined) {
   return { baseSessionKey, threadId };
 }
 
+const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return { ...actual, getRuntimeConfig: getRuntimeConfigMock };
+});
+
 vi.mock("./route-reply.runtime.js", () => ({
   isRoutableChannel: (channel: string | undefined) =>
     Boolean(
@@ -5040,14 +5046,15 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "handled" } satisfies ReplyPayload;
     };
 
+    getRuntimeConfigMock.mockReturnValueOnce({
+      agents: { defaults: { verboseDefault: "on" } },
+      messages: {
+        suppressToolErrors: true,
+      },
+    } as OpenClawConfig);
     await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: { defaults: { verboseDefault: "on" } },
-        messages: {
-          suppressToolErrors: true,
-        },
-      } as OpenClawConfig,
+      cfg: { agents: { defaults: { verboseDefault: "on" } } } as OpenClawConfig,
       dispatcher,
       replyResolver,
       replyOptions: { onToolResult },
@@ -9265,7 +9272,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
-  it("passes the loaded config plus configOverride patch to replyResolver when provided", async () => {
+  it("applies configOverride as a patch over the runtime config for replyResolver", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -9293,12 +9300,12 @@ describe("dispatchReplyFromConfig", () => {
       configOverride: overrideCfg,
     });
 
-    expect(receivedCfg).not.toBe(cfg);
+    expect(receivedCfg?.agents?.defaults?.userTimezone).toBe("America/New_York");
     expect(receivedCfg).not.toBe(overrideCfg);
-    expect(receivedCfg).toEqual(overrideCfg);
+    expect(receivedCfg).not.toBe(cfg);
   });
 
-  it("passes the already loaded config to replyResolver when configOverride is not provided", async () => {
+  it("resolves the runtime config instead of the channel startup config for replyResolver", async () => {
     setNoAbort();
     const cfg = { agents: { defaults: { userTimezone: "UTC" } } } as OpenClawConfig;
     const dispatcher = createDispatcher();
@@ -9314,9 +9321,16 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "hi" } satisfies ReplyPayload;
     };
 
+    getRuntimeConfigMock.mockReturnValueOnce({
+      agents: { defaults: { userTimezone: "Asia/Tokyo" } },
+    } as OpenClawConfig);
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(receivedCfg).toBe(cfg);
+    // The startup capture must not reach reply resolution; the dispatch layer
+    // re-resolves the live runtime snapshot so hot-reloaded config applies.
+    expect(receivedCfg).toBeDefined();
+    expect(receivedCfg).not.toBe(cfg);
+    expect(receivedCfg?.agents?.defaults?.userTimezone).toBe("Asia/Tokyo");
   });
 
   it("suppresses isReasoning payloads from final replies (WhatsApp channel)", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -44,6 +44,7 @@ import {
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
+import { getRuntimeConfig } from "../../config/config.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -3288,8 +3289,14 @@ export async function dispatchReplyFromConfig(
       params.replyResolver ??
       (await traceReplyPhase("reply.load_reply_resolver", () => loadGetReplyFromConfigRuntime()))
         .getReplyFromConfig;
+    // Resolve reply config from the live runtime snapshot: the cfg captured at
+    // channel startup goes stale across config hot reloads, and a single turn
+    // must not split config authority between reply resolution and dispatch
+    // callbacks (#103324).
     const replyConfig = withFullRuntimeReplyConfig(
-      params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
+      params.configOverride
+        ? (applyMergePatch(getRuntimeConfig(), params.configOverride) as OpenClawConfig)
+        : { ...getRuntimeConfig() },
     );
     recordAgentDispatchStarted();
     const replyResult = await runWithDispatchLifecycleAdmission(

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -28,7 +28,7 @@ export type DispatchFromConfigParams = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
   fastAbortResolver?: TryFastAbortFromMessage;
   formatAbortReplyTextResolver?: FormatAbortReplyText;
-  /** Optional patch applied to the already loaded config before reply resolution. */
+  /** Optional patch applied to the current runtime config before reply resolution. */
   configOverride?: OpenClawConfig;
 };
 

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -66,6 +66,43 @@ describe("getReplyFromConfig configOverride", () => {
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
   });
 
+  it("resolves models added to the runtime config after channel startup", async () => {
+    const addedModel = "openai/gpt-5.6-luna";
+    vi.mocked(loadConfigMock).mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {
+            "openai/gpt-5.4": {},
+            [addedModel]: {},
+          },
+        },
+      },
+    } satisfies OpenClawConfig);
+    mocks.resolveReplyDirectives.mockImplementationOnce(
+      async ({ cfg }: { cfg: OpenClawConfig }) => {
+        const { resolveAllowedModelRef } = await import("../../agents/model-selection.js");
+        expect(
+          resolveAllowedModelRef({
+            cfg,
+            catalog: [],
+            raw: addedModel,
+            defaultProvider: "openai",
+            defaultModel: "gpt-5.4",
+          }),
+        ).toMatchObject({
+          ref: { provider: "openai", model: "gpt-5.6-luna" },
+          key: addedModel,
+        });
+        return { kind: "reply", reply: { text: "ok" } };
+      },
+    );
+
+    await getReplyFromConfig(buildGetReplyCtx());
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses complete configOverride without reloading config", async () => {
     const { withFullRuntimeReplyConfig } = await import("./get-reply-fast-path.js");
     vi.mocked(loadConfigMock).mockImplementation(() => {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -154,6 +154,9 @@ export function applyModelOverrideToSessionEntry(params: {
   // Clear stale fallback notice when the user explicitly switches models.
   if (updated) {
     if ((selectionUpdated || profileUpdated) && params.markLiveSwitchPending) {
+      // Pending without modelOverride is the deliberate encoding for "switch
+      // back to the agent default": the default branch above also clears the
+      // runtime model fields so live-switch resolution lands on the default.
       entry.liveModelSwitchPending = true;
     }
     delete entry.fallbackNoticeSelectedModel;


### PR DESCRIPTION
## What Problem This Solves

A production incident (#103324) showed three compounding failures that make `/model` unreliable: a user pinned `openai/gpt-5.6-luna` for a Telegram session, the command confirmed and `/status` showed the pin — then the next turn silently ran a different provider and **persisted the fallback over the user's pin**. Root causes, each fixed here at its own boundary:

1. **Fallback rotation persisted over user pins.** The rotation machinery wrote `modelOverride`/`providerOverride` (source `"auto"`), so a transient availability failure permanently replaced the user's explicit selection.
2. **Reply resolution judged models against a config snapshot captured at channel startup.** `dispatchReplyFromConfig` marked the channel-boot config as a complete runtime config, so hot-reloaded config (`config hot reload applied` in logs) never reached model allowlisting — models added after gateway start were "not in agents.defaults.models" to the run layer while the command layer accepted them.
3. **One expired OAuth profile could poison provider availability.** With several profiles for a provider, an expired one participating in ordering could front availability probes and veto a model the account actually serves.

Closes #103324.

## Why This Change Was Made

- **Fallback is now turn-local** (`fix(agents): keep model fallback turn-local…`): the entire fallback-selection persistence machinery (patch builders, rollback state, `"auto"` override provenance writers) is deleted — fallback can only record runtime facts (`model`, `modelProvider`, `fallbackNotice*`). The user's pin survives; the next turn retries it. The auto-fallback primary probe in `agent-command.ts` likewise no longer converts a successful fallback candidate into a persisted auto pin. Net **−700 lines** of prod+test code.
- **Reply config is resolved from the live runtime snapshot once per turn** (`fix(agents): resolve reply config from the live runtime snapshot…`): dispatch builds `replyConfig` from `getRuntimeConfig()` (plus the explicit `configOverride` patch when provided) and passes that same object to both reply resolution and dispatch callbacks — restoring single-config-authority per turn while making hot reload effective. A regression test replays the incident: a model added to config after channel startup resolves in the next turn, with config loaded exactly once.
- **Expired OAuth profiles are demoted, not removed** (`fix(agents): demote locally-expired OAuth profiles…`): `resolveAuthProfileOrder` sorts locally-expired OAuth profiles behind healthy siblings so probes and rotation lead with refreshable-and-live credentials. Expired profiles stay selectable (OAuth refresh runs at use) and an explicit `preferredProfile` still wins over expiry, so targeted account selection never silently switches identity.

**Deliberately not done:** issue #103324's suggestion 3 ("never persist `liveModelSwitchPending` without an override") turned out to be a misdiagnosis — flag-without-override is main's intentional, test-covered encoding for "pending switch back to the agent default" (`applyModelOverrideToSessionEntry` clears runtime model fields so live-switch resolution lands on the default). The orphaned-state harm in the incident came from the destroyed override, which fix 1 eliminates at the source. A contract comment now documents the encoding at the writer.

## User Impact

`/model` selections stick. If the pinned model fails, the turn falls back with the existing visible fallback notice and the pin is retried next turn instead of being silently replaced. Models added to config at runtime are usable immediately after the hot reload instead of requiring a gateway restart. Multi-profile OpenAI/OAuth setups no longer lose model availability to one stale credential. `/model default` mid-run keeps its live-restart-to-default behavior.

## Evidence

- Behavior tests per fix: pin preservation through failed turns (e2e + unit, replacing seven deleted tests that asserted the old persist-over-pin behavior), hot-added model resolution with single config load, `suppressToolErrors` callback policy following the runtime config (proving dispatch callbacks and reply resolution share one config), expired-profile demotion / all-expired attempt / expired-preferred-still-first.
- `pnpm tsgo`, `pnpm check:test-types`: exit 0. All touched test files green locally (`node scripts/run-vitest.mjs`, 5 shards).
- Structured review (repo autoreview helper, three cycles): first two cycles surfaced real findings — `/model default` live-switch regression and expired-preferred-profile bypass — both fixed as above; final cycle clean ("no accepted/actionable findings").
- Blacksmith Testbox `tbx_01kx56z3p5hvsjmph9te4e9szd` (`pnpm test:changed`, 40 shards): all touched surfaces green remotely (`dispatch-from-config` 256 tests, `agent-runner-execution` 237, `auth-profiles/order` 21, `model-overrides` suites across 4 shards). Three failures are unrelated to this diff and pass locally on this branch: `ui/cron-page`, `ui/agent-select` (locale assertion; no UI files touched), and `clawrouter-managed-gateway.e2e` (passes locally in 50s); the agents shard additionally hit `Worker exited unexpectedly` crashes (box memory pressure).
- Production repro validation of the incident chain is documented in #103324 (session-state forensics + live `/model` retest after a gateway restart confirmed the stale-snapshot trigger).
