### PR TITLE
fix(feishu): route chat tools by account

### DIFF
--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -14,6 +14,25 @@ vi.mock("./client.js", () => ({
 
 let registerFeishuChatTools: typeof import("./chat.js").registerFeishuChatTools;
 
+type RegisteredChatTool = {
+  name: string;
+  parameters: { properties: { page_size?: unknown } };
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ details: Record<string, unknown> }>;
+};
+
+function resolveRegisteredChatTool(
+  registerTool: ReturnType<typeof vi.fn>,
+  agentAccountId?: string,
+) {
+  const registration = registerTool.mock.calls[0]?.[0] as
+    | RegisteredChatTool
+    | ((ctx: { agentAccountId?: string }) => RegisteredChatTool);
+  return typeof registration === "function" ? registration({ agentAccountId }) : registration;
+}
+
 function createFeishuToolRuntime(): PluginRuntime {
   return {} as PluginRuntime;
 }
@@ -75,8 +94,8 @@ describe("registerFeishuChatTools", () => {
     );
 
     expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.name).toBe("feishu_chat");
+    const tool = resolveRegisteredChatTool(registerTool);
+    expect(tool.name).toBe("feishu_chat");
 
     chatGetMock.mockResolvedValueOnce({
       code: 0,
@@ -186,8 +205,8 @@ describe("registerFeishuChatTools", () => {
       }),
     );
 
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.parameters.properties.page_size).toMatchObject({
+    const tool = resolveRegisteredChatTool(registerTool);
+    expect(tool.parameters.properties.page_size).toMatchObject({
       type: "integer",
       minimum: 1,
       maximum: 100,
@@ -260,7 +279,7 @@ describe("registerFeishuChatTools", () => {
       }),
     );
 
-    const tool = registerTool.mock.calls[0]?.[0];
+    const tool = resolveRegisteredChatTool(registerTool);
     contactUserGetMock.mockRejectedValueOnce(
       Object.assign(new Error("Request failed with status code 400"), {
         response: {
@@ -290,6 +309,43 @@ describe("registerFeishuChatTools", () => {
     expect(result.details.error).toContain('"feishu_log_id":"20260429124800CHAT"');
     expect(result.details.error).toContain(
       '"feishu_troubleshooter":"https://open.feishu.cn/search?log_id=20260429124800CHAT"',
+    );
+  });
+
+  it("registers for an enabled non-default account and uses the contextual account", async () => {
+    const registerTool = vi.fn();
+    registerFeishuChatTools(
+      createChatToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              accounts: {
+                a: {
+                  appId: "app-a",
+                  appSecret: "secret-a", // pragma: allowlist secret
+                  tools: { chat: false },
+                },
+                b: {
+                  appId: "app-b",
+                  appSecret: "secret-b", // pragma: allowlist secret
+                  tools: { chat: true },
+                },
+              },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const tool = resolveRegisteredChatTool(registerTool, "b");
+    chatGetMock.mockResolvedValueOnce({ code: 0, data: {} });
+
+    await tool.execute("tc_account", { action: "info", chat_id: "oc_1" });
+
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "b", appId: "app-b" }),
     );
   });
 });

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -5,9 +5,8 @@ import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
-import { createFeishuClient } from "./client.js";
 import { formatFeishuApiError } from "./comment-shared.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 function readChatPageSize(params: Record<string, unknown>): number | undefined {
   return readPositiveIntegerParam(params, "page_size", {
@@ -134,58 +133,65 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.chat) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuChatExecuteParams = FeishuChatParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_chat",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info, member_info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const rawParams = params as Record<string, unknown>;
-        const p = params as FeishuChatParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "members":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action members" });
-              }
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  readChatPageSize(rawParams),
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action info" });
-              }
-              return json(await getChatInfo(client, p.chat_id));
-            case "member_info":
-              if (!p.member_id) {
-                return json({ error: "member_id is required for action member_info" });
-              }
-              return json(
-                await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
-              );
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_chat",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info, member_info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const rawParams = params as Record<string, unknown>;
+          const p = params as FeishuChatExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+              requiredTool: { family: "chat", label: "Chat" },
+            });
+            switch (p.action) {
+              case "members":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action members" });
+                }
+                return json(
+                  await getChatMembers(
+                    client,
+                    p.chat_id,
+                    readChatPageSize(rawParams),
+                    p.page_token,
+                    p.member_id_type,
+                  ),
+                );
+              case "info":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action info" });
+                }
+                return json(await getChatInfo(client, p.chat_id));
+              case "member_info":
+                if (!p.member_id) {
+                  return json({ error: "member_id is required for action member_info" });
+                }
+                return json(
+                  await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
+                );
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: formatFeishuApiError(err, { includeNestedErrorLogId: true }) });
           }
-        } catch (err) {
-          return json({ error: formatFeishuApiError(err, { includeNestedErrorLogId: true }) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_chat" },
   );


### PR DESCRIPTION
## What Problem This Solves

`feishu_chat` registered and created its client from the first enabled Feishu account. In multi-account setups, this hid the tool when only another account enabled chat and sent chat lookups with the wrong tenant credentials when an agent was bound to a different account.

## Why This Change Was Made

The chat tool now follows the account-aware resolver already used by the other Feishu tool families. Registration is based on any enabled account with chat tools, and execution resolves the contextual `agentAccountId` (or an explicit account selection) while enforcing that the selected account enables chat tools.

## User Impact

Multi-account Feishu agents query chats and members in their own tenant instead of accidentally using the first configured account. A disabled contextual account produces a clear error rather than silently crossing tenants.

## Evidence

- Added a regression test where only the second account enables chat and the contextual account is that second account; it verifies the client receives that account's credentials.
- `node_modules/.bin/vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/chat.test.ts extensions/feishu/src/tool-account-routing.test.ts` (29 passed)
- `node scripts/run-oxlint.mjs extensions/feishu/src/chat.ts extensions/feishu/src/chat.test.ts`
- `node_modules/.bin/oxfmt --write extensions/feishu/src/chat.ts extensions/feishu/src/chat.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --output /tmp/openclaw-autoreview/feishu-chat-account.json` (clean; no accepted/actionable findings)

Remote Testbox validation is unavailable in this environment because the current account is not authenticated to the `openclaw` organization. The focused test is therefore a narrow local fallback; GitHub CI remains the remote validation path.
