### PR TITLE
fix(github-copilot): keep device login polling within GitHub limits

### DIFF
--- a/extensions/github-copilot/login.test.ts
+++ b/extensions/github-copilot/login.test.ts
@@ -370,7 +370,7 @@ describe("runGitHubCopilotDeviceFlow — polling intervals", () => {
     const pollTimes: number[] = [];
     const pollResponses = [
       { error: "authorization_pending" },
-      { error: "slow_down" },
+      { error: "slow_down", interval: 7 },
       { error: "slow_down" },
       { access_token: "test-access-token", token_type: "bearer" },
     ];

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -222,9 +222,11 @@ async function pollForAccessToken(params: {
       continue;
     }
     if (err === "slow_down") {
-      intervalMs =
-        positiveSecondsToSafeMilliseconds(json.interval) ??
-        Math.min(Number.MAX_SAFE_INTEGER, intervalMs + GITHUB_DEVICE_FLOW_SLOW_DOWN_INCREMENT_MS);
+      // slow_down is cumulative; a returned interval may raise but never lower the required floor.
+      intervalMs = Math.max(
+        Math.min(Number.MAX_SAFE_INTEGER, intervalMs + GITHUB_DEVICE_FLOW_SLOW_DOWN_INCREMENT_MS),
+        positiveSecondsToSafeMilliseconds(json.interval) ?? 0,
+      );
       continue;
     }
     if (err === "expired_token") {


### PR DESCRIPTION
Closes #64319

## What Problem This Solves

GitHub Copilot device login could undo required OAuth device-flow backoff when a `slow_down` response returned an interval below the already accumulated minimum. That could make later token polls arrive too early and prolong rate limiting.

## Why This Change Was Made

The provider-owned poller now enforces the RFC 8628 cumulative floor and treats GitHub's returned interval as a possible increase, never a decrease: `max(current interval + 5 seconds, returned interval)`. Both interactive GitHub Copilot login entry points already share this poller, so no new helper or public surface is needed.

The stale branch implementation was replaced rather than rebased mechanically. The current wait-before-first-poll, expiry bound, and abort-aware sleep path remain intact.

## User Impact

GitHub Copilot device login stays within the required polling cadence after repeated `slow_down` responses, including a stale or smaller returned interval.

## Evidence

- RFC 8628 section 3.5 requires `slow_down` to increase the interval by five seconds for this and all subsequent requests: https://www.rfc-editor.org/rfc/rfc8628.html#section-3.5
- GitHub documents that `slow_down` adds five seconds to the last interval: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#rate-limits-for-the-device-flow
- Before the production change: `node scripts/run-vitest.mjs extensions/github-copilot/login.test.ts` failed 1/14. The regression expected the third poll at +20 seconds and observed +17 seconds.
- After the production change: the same command passed 14/14.
- `git diff --check` passed.
- Fresh Codex-backed autoreview passed with no accepted or actionable findings.
- Production delta: +5/-3. Test delta: +1/-1.

### ClawSweeper rank-up moves

- Applied: ported only the cumulative interval floor and regression onto the current abort-aware polling loop.
- Skipped: a live redacted transcript cannot deterministically exercise a GitHub response that violates its documented cumulative interval. No credentialed login was performed. The fake-timer regression drives the production poller through the exact lower-returned-interval sequence and proves both failing and passing directions.
