### PR TITLE
fix: preserve native trace heading typography

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3299,6 +3299,7 @@ jobs:
             -only-testing:OpenClawTests/NodeAppModelInvokeTests \
             -only-testing:OpenClawTests/NotificationServingPreferenceTests \
             -only-testing:OpenClawTests/RootTabsSourceGuardTests \
+            -only-testing:OpenClawTests/TraceHeadingVisualProofTests \
             test
 
       - name: Upload iOS lifecycle simulator evidence

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -39939,7 +39939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 52,
+      "line": 51,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "Full message unavailable",
       "surface": "apple",
@@ -39947,7 +39947,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 58,
+      "line": 57,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "Full Message",
       "surface": "apple",
@@ -39955,7 +39955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 61,
+      "line": 60,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "Close",
       "surface": "apple",
@@ -39963,7 +39963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 77,
+      "line": 76,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "The full message is no longer available.",
       "surface": "apple",
@@ -39971,7 +39971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 82,
+      "line": 81,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "The full message has no readable text.",
       "surface": "apple",
@@ -39979,7 +39979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 89,
+      "line": 88,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift",
       "source": "The full message could not be loaded.",
       "surface": "apple",
@@ -40067,7 +40067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 292,
+      "line": 289,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift",
       "source": "List item",
       "surface": "apple",
@@ -40075,7 +40075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 295,
+      "line": 292,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift",
       "source": "Item",
       "surface": "apple",
@@ -40083,7 +40083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 577,
+      "line": 603,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
       "source": "Image",
       "surface": "apple",
@@ -40139,7 +40139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 448,
+      "line": 447,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -40147,7 +40147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 628,
+      "line": 627,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -40155,7 +40155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 685,
+      "line": 684,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -40163,7 +40163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 719,
+      "line": 718,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -40171,7 +40171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 722,
+      "line": 721,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -40179,7 +40179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 730,
+      "line": 729,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -40187,7 +40187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 731,
+      "line": 730,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -376,17 +376,17 @@ struct OpenClawTypographyTests {
             #expect(source.contains(".font(OpenClawType.body)"))
         }
 
-        #expect(chatMessageViews.contains("font: OpenClawChatTypography.body"))
+        #expect(chatMessageViews.contains("typography: segment.kind.markdownTypography"))
         #expect(chatMessageViews.contains(".font(OpenClawChatTypography.caption)"))
         #expect(chatMessageViews.contains("chat-user-message-disclosure-toggle"))
-        #expect(chatMessageViews.contains("OpenClawChatTypography.callout.italic()"))
+        #expect(chatMarkdownRenderer.contains("OpenClawChatTypography.callout.italic()"))
         #expect(!chatMessageViews.contains("font: .body"))
         #expect(!chatMessageViews.contains("Font.body"))
         #expect(!chatMessageViews.contains("Font.callout"))
         #expect(chatWorkingClawView.contains(".font(OpenClawChatTypography.caption)"))
         #expect(chatWorkingClawView.contains(".font(OpenClawChatTypography.captionSemiBold)"))
         #expect(!chatWorkingClawView.contains(".font(."))
-        #expect(chatMarkdownRenderer.contains(".font(self.font)"))
+        #expect(chatMarkdownRenderer.contains(".font(self.typography.proseFont)"))
         #expect(chatTypography
             .contains("Font.custom(self.macSystemFontName(size: size), size: size, relativeTo: textStyle)"))
         #expect(chatTypography.contains(

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -162,7 +162,6 @@ struct SwiftUIRenderSmokeTests {
                     text: #"Inline math \(E = mc^2\) stays inside prose."#,
                     context: .assistant,
                     variant: .standard,
-                    font: OpenClawChatTypography.body,
                     textColor: OpenClawChatTheme.assistantText)
                 ChatMathBlockView(block: ChatMathBlock(
                     latex: #"\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}"#,
@@ -207,7 +206,6 @@ struct SwiftUIRenderSmokeTests {
                 text: markdown,
                 context: .assistant,
                 variant: .standard,
-                font: OpenClawChatTypography.body,
                 textColor: OpenClawChatTheme.assistantText)
                 .environment(\.dynamicTypeSize, typeSize)
 
@@ -234,7 +232,6 @@ struct SwiftUIRenderSmokeTests {
                     text: markdown,
                     context: .assistant,
                     variant: .standard,
-                    font: OpenClawChatTypography.body,
                     textColor: OpenClawChatTheme.assistantText)
                     .environment(\.dynamicTypeSize, typeSize)
                     .preferredColorScheme(scheme)
@@ -301,6 +298,59 @@ struct SwiftUIRenderSmokeTests {
             isClean: false)
 
         _ = Self.host(root, size: CGSize(width: 393, height: 400))
+    }
+
+    @Test @MainActor func `completed and streaming assistant trace headings build across type sizes`() {
+        let text = """
+        <think>
+        # Internal plan
+        </think>
+        <final>
+        # Final answer
+        </final>
+        """
+        let message = OpenClawChatMessage(
+            role: "assistant",
+            content: [OpenClawChatMessageContent(
+                type: "text",
+                text: text,
+                mimeType: nil,
+                fileName: nil,
+                content: nil)],
+            timestamp: 1)
+
+        for typeSize in [DynamicTypeSize.large, .accessibility2] {
+            let root = VStack {
+                ChatMessageBubble(
+                    message: message,
+                    style: .standard,
+                    markdownVariant: .standard,
+                    userAccent: nil,
+                    displayOptions: [.reasoning],
+                    assistantName: "OpenClaw",
+                    assistantAvatarText: "OC",
+                    assistantAvatarTint: nil,
+                    showsAssistantAvatar: true,
+                    isClean: false,
+                    contextWindowTokens: nil,
+                    userMessageExpanded: false,
+                    onToggleUserMessageExpanded: {},
+                    inlineWidgetResolverReady: true,
+                    inlineWidgetResourceResolver: { _, _ in nil })
+                ChatStreamingAssistantBubble(
+                    text: text,
+                    markdownVariant: .standard,
+                    showsReasoning: true,
+                    assistantName: "OpenClaw",
+                    assistantAvatarText: "OC",
+                    assistantAvatarTint: nil,
+                    showsAssistantAvatar: true,
+                    isClean: false)
+            }
+            .environment(\.dynamicTypeSize, typeSize)
+
+            _ = Self.host(root, size: CGSize(width: 393, height: 700))
+        }
     }
 
     @Test @MainActor func `assistant usage footer builds across dynamic type sizes`() throws {

--- a/apps/ios/Tests/TraceHeadingVisualProofTests.swift
+++ b/apps/ios/Tests/TraceHeadingVisualProofTests.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import OpenClaw
+
+@MainActor
+final class TraceHeadingVisualProofTests: XCTestCase {
+    func testThinkingHeadingStaysSubordinateToFinalHeading() {
+        let responseHeading = ChatMarkdownRenderer(
+            text: "# Internal plan",
+            context: .assistant,
+            variant: .standard,
+            typography: .response,
+            textColor: OpenClawChatTheme.assistantText)
+            .environment(\.dynamicTypeSize, .accessibility2)
+        let thinkingHeading = ChatMarkdownRenderer(
+            text: "# Internal plan",
+            context: .assistant,
+            variant: .standard,
+            typography: .thinking,
+            textColor: OpenClawChatTheme.assistantText)
+            .environment(\.dynamicTypeSize, .accessibility2)
+        let responseHeight = UIHostingController(rootView: responseHeading)
+            .sizeThatFits(in: CGSize(width: 393, height: 1000)).height
+        let thinkingHeight = UIHostingController(rootView: thinkingHeading)
+            .sizeThatFits(in: CGSize(width: 393, height: 1000)).height
+
+        XCTAssertGreaterThan(responseHeight, thinkingHeight)
+
+        let root = VStack(alignment: .leading, spacing: 18) {
+            Text(verbatim: "Before: thinking rendered as response")
+                .font(OpenClawType.captionSemiBold)
+            ChatMarkdownRenderer(
+                text: "# Internal plan",
+                context: .assistant,
+                variant: .standard,
+                typography: .response,
+                textColor: OpenClawChatTheme.assistantText)
+
+            Divider()
+
+            Text(verbatim: "After: thinking profile")
+                .font(OpenClawType.captionSemiBold)
+            ChatMarkdownRenderer(
+                text: "# Internal plan",
+                context: .assistant,
+                variant: .standard,
+                typography: .thinking,
+                textColor: OpenClawChatTheme.assistantText)
+
+            Text(verbatim: "Final response")
+                .font(OpenClawType.captionSemiBold)
+            ChatMarkdownRenderer(
+                text: "# Final answer",
+                context: .assistant,
+                variant: .standard,
+                typography: .response,
+                textColor: OpenClawChatTheme.assistantText)
+        }
+        .padding(24)
+        .frame(width: 393, alignment: .leading)
+        .environment(\.dynamicTypeSize, .accessibility2)
+        .background(Color(uiColor: .systemBackground))
+
+        let controller = UIHostingController(rootView: root)
+        let size = controller.sizeThatFits(in: CGSize(width: 393, height: 1000))
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+
+        let image = UIGraphicsImageRenderer(size: size).image { _ in
+            controller.view.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
+        }
+        let attachment = XCTAttachment(image: image)
+        attachment.name = "trace-heading-before-after-accessibility"
+        attachment.lifetime = .keepAlways
+        self.add(attachment)
+
+        XCTAssertGreaterThan(image.size.height, 0)
+    }
+}

--- a/apps/ios/Tests/TraceHeadingVisualProofTests.swift
+++ b/apps/ios/Tests/TraceHeadingVisualProofTests.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import XCTest
 @testable import OpenClaw
+@testable import OpenClawChatUI
 
 @MainActor
 final class TraceHeadingVisualProofTests: XCTestCase {

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -1,8 +1,8 @@
 import AppKit
 import Foundation
-import OpenClawChatUI
 import Testing
 @testable import OpenClaw
+@testable import OpenClawChatUI
 
 @Suite(.serialized)
 @MainActor
@@ -39,6 +39,18 @@ struct WebChatSwiftUISmokeTests {
         }
 
         func setActiveSessionKey(_: String) async throws {}
+    }
+
+    @Test func `response and thinking headings keep their semantic typography`() {
+        #expect(ChatMarkdownRenderer.Typography.response.headingStyle == .hierarchy)
+        #expect(ChatMarkdownRenderer.Typography.thinking.headingStyle == .prose)
+    }
+
+    @Test func `assistant segments select one complete markdown typography profile`() {
+        let segments = AssistantTextParser.segments(
+            from: "<think># Internal plan</think><final># Final answer</final>")
+
+        #expect(segments.map(\.kind.markdownTypography) == [.thinking, .response])
     }
 
     @Test func `session observer remains visible until the last shared gateway window closes`() {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatFullMessageReader.swift
@@ -41,7 +41,6 @@ struct ChatFullMessageReader: View {
                             text: markdown,
                             context: .assistant,
                             variant: self.markdownVariant,
-                            font: OpenClawChatTypography.body,
                             textColor: OpenClawChatTheme.assistantText)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
@@ -194,9 +194,8 @@ struct ChatMarkdownListView: View {
     let list: ChatMarkdownList
     let context: ChatMarkdownRenderer.Context
     let variant: ChatMarkdownVariant
-    let font: Font
+    let typography: ChatMarkdownRenderer.Typography
     let textColor: Color
-    let inlineMathTypography: ChatMarkdownRenderer.InlineMathTypography
 
     var body: some View {
         Grid(alignment: .topLeading, horizontalSpacing: 8, verticalSpacing: 7) {
@@ -208,7 +207,7 @@ struct ChatMarkdownListView: View {
 
                     VStack(alignment: .leading, spacing: 7) {
                         if self.list.items[index].content.isEmpty {
-                            ChatMarkdownRenderer.styledText(" ", font: self.font)
+                            ChatMarkdownRenderer.styledText(" ", font: self.typography.proseFont)
                         } else {
                             ForEach(self.list.items[index].content.indices, id: \.self) { contentIndex in
                                 self.content(self.list.items[index].content[contentIndex])
@@ -230,14 +229,14 @@ struct ChatMarkdownListView: View {
         let marker = self.list.marker(for: item, at: index)
         HStack(spacing: 4) {
             if let text = marker.text {
-                ChatMarkdownRenderer.styledText(text, font: self.font)
+                ChatMarkdownRenderer.styledText(text, font: self.typography.proseFont)
                     .foregroundStyle(self.textColor)
                     .monospacedDigit()
                     .accessibilityLabel(self.markerAccessibilityLabel(at: index))
             }
             if let checkbox = marker.checkbox {
                 Image(systemName: checkbox == .checked ? "checkmark.square.fill" : "square")
-                    .font(self.font)
+                    .font(self.typography.proseFont)
                     .foregroundStyle(self.textColor)
                     .accessibilityLabel(Text(self.checkboxAccessibilityLabel(checkbox)))
             }
@@ -271,9 +270,8 @@ struct ChatMarkdownListView: View {
             text: markdown,
             context: self.context,
             variant: self.variant,
-            font: self.font,
-            textColor: self.textColor,
-            inlineMathTypography: self.inlineMathTypography)
+            typography: self.typography,
+            textColor: self.textColor)
     }
 
     func nestedListView(_ list: ChatMarkdownList) -> ChatMarkdownListView {
@@ -281,9 +279,8 @@ struct ChatMarkdownListView: View {
             list: list,
             context: self.context,
             variant: self.variant,
-            font: self.font,
-            textColor: self.textColor,
-            inlineMathTypography: self.inlineMathTypography)
+            typography: self.typography,
+            textColor: self.textColor)
     }
 
     private func markerAccessibilityLabel(at index: Int) -> Text {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -14,6 +14,37 @@ struct ChatMarkdownRenderer: View {
         case assistant
     }
 
+    enum Typography: Equatable {
+        enum HeadingStyle: Equatable {
+            case hierarchy
+            case prose
+        }
+
+        case response
+        case thinking
+
+        var headingStyle: HeadingStyle {
+            self == .response ? .hierarchy : .prose
+        }
+
+        var proseFont: Font {
+            self == .response
+                ? OpenClawChatTypography.body
+                : OpenClawChatTypography.callout.italic()
+        }
+
+        var inlineMath: InlineMathTypography {
+            self == .response ? .body : .callout
+        }
+
+        func headingFont(level: Int) -> Font {
+            switch self.headingStyle {
+            case .hierarchy: OpenClawChatTypography.heading(level: level)
+            case .prose: self.proseFont
+            }
+        }
+    }
+
     struct InlineMathTypography: Equatable {
         static let body = Self(size: OpenClawChatTypography.bodySize, relativeTo: .body)
         static let callout = Self(size: 16, relativeTo: .callout)
@@ -25,9 +56,8 @@ struct ChatMarkdownRenderer: View {
     let snapshot: ChatMarkdownRenderSnapshot
     let context: Context
     let variant: ChatMarkdownVariant
-    let font: Font
+    let typography: Typography
     let textColor: Color
-    let inlineMathTypography: InlineMathTypography
 
     static func styledText(_ content: String, font: Font) -> SwiftUI.Text {
         SwiftUI.Text(content)
@@ -43,39 +73,36 @@ struct ChatMarkdownRenderer: View {
         text: String,
         context: Context,
         variant: ChatMarkdownVariant,
-        font: Font,
+        typography: Typography = .response,
         textColor: Color,
-        inlineMathTypography: InlineMathTypography = .body,
         isComplete: Bool = true)
     {
         self.init(
             snapshot: ChatMarkdownRenderSnapshot(text: text, isComplete: isComplete),
             context: context,
             variant: variant,
-            font: font,
-            textColor: textColor,
-            inlineMathTypography: inlineMathTypography)
+            typography: typography,
+            textColor: textColor)
     }
 
     init(
         snapshot: ChatMarkdownRenderSnapshot,
         context: Context,
         variant: ChatMarkdownVariant,
-        font: Font,
+        typography: Typography = .response,
         textColor: Color,
-        inlineMathTypography: InlineMathTypography = .body,
         reveal: ChatMarkdownProseReveal? = nil)
     {
         self.snapshot = snapshot
         self.context = context
         self.variant = variant
-        self.font = font
+        self.typography = typography
         self.textColor = textColor
-        self.inlineMathTypography = inlineMathTypography
         self.reveal = reveal
+        let inlineMath = typography.inlineMath
         self._inlineMathFontSize = ScaledMetric(
-            wrappedValue: inlineMathTypography.size,
-            relativeTo: inlineMathTypography.relativeTo)
+            wrappedValue: inlineMath.size,
+            relativeTo: inlineMath.relativeTo)
     }
 
     var body: some View {
@@ -95,7 +122,7 @@ struct ChatMarkdownRenderer: View {
         switch block {
         case let .prose(prose):
             self.proseText(prose, index: index)
-                .font(self.font)
+                .font(self.typography.proseFont)
                 .foregroundStyle(self.textColor)
                 .tint(self.linkColor)
                 .textSelection(.enabled)
@@ -103,7 +130,7 @@ struct ChatMarkdownRenderer: View {
                 .modifier(ChatInlineMathAccessibilityModifier(label: prose.inlineAccessibilityText))
         case let .heading(level, prose):
             self.proseText(prose, index: index)
-                .font(OpenClawChatTypography.heading(level: level))
+                .font(self.typography.headingFont(level: level))
                 .foregroundStyle(self.textColor)
                 .tint(self.linkColor)
                 .textSelection(.enabled)
@@ -129,9 +156,8 @@ struct ChatMarkdownRenderer: View {
             list: list,
             context: self.context,
             variant: self.variant,
-            font: self.font,
-            textColor: self.textColor,
-            inlineMathTypography: self.inlineMathTypography)
+            typography: self.typography,
+            textColor: self.textColor)
     }
 
     private func proseText(_ prose: ChatMarkdownProse, index: Int) -> SwiftUI.Text {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -434,7 +434,6 @@ private struct ChatMessageBody: View {
             text: text,
             context: .user,
             variant: self.markdownVariant,
-            font: OpenClawChatTypography.body,
             textColor: textColor)
     }
 
@@ -920,6 +919,15 @@ extension ChatPendingToolsBubble: @MainActor Equatable {
     }
 }
 
+extension AssistantTextSegment.Kind {
+    var markdownTypography: ChatMarkdownRenderer.Typography {
+        switch self {
+        case .response: .response
+        case .thinking: .thinking
+        }
+    }
+}
+
 private struct ChatAssistantTextBody: View {
     let text: String
     let markdownVariant: ChatMarkdownVariant
@@ -941,19 +949,12 @@ private struct ChatAssistantTextBody: View {
         let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
         return VStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
-                let font = segment.kind == .thinking
-                    ? OpenClawChatTypography.callout.italic()
-                    : OpenClawChatTypography.body
-                let inlineMathTypography: ChatMarkdownRenderer.InlineMathTypography = segment.kind == .thinking
-                    ? .callout
-                    : .body
                 ChatMarkdownRenderer(
                     text: segment.text,
                     context: .assistant,
                     variant: self.markdownVariant,
-                    font: font,
+                    typography: segment.kind.markdownTypography,
                     textColor: OpenClawChatTheme.assistantText,
-                    inlineMathTypography: inlineMathTypography,
                     isComplete: self.isComplete)
             }
         }
@@ -1028,12 +1029,6 @@ private struct ChatStreamingAssistantTextBody: View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(Array(self.snapshot.segments.enumerated()), id: \.offset) { entry in
                 let segment = entry.element
-                let font = segment.kind == .thinking
-                    ? OpenClawChatTypography.callout.italic()
-                    : OpenClawChatTypography.body
-                let inlineMathTypography: ChatMarkdownRenderer.InlineMathTypography = segment.kind == .thinking
-                    ? .callout
-                    : .body
                 let reveal = self.reveal(
                     segmentIndex: entry.offset,
                     now: now)
@@ -1041,9 +1036,8 @@ private struct ChatStreamingAssistantTextBody: View {
                     snapshot: segment.markdown,
                     context: .assistant,
                     variant: self.markdownVariant,
-                    font: font,
+                    typography: segment.kind.markdownTypography,
                     textColor: OpenClawChatTheme.assistantText,
-                    inlineMathTypography: inlineMathTypography,
                     reveal: reveal)
             }
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -515,24 +515,23 @@ struct ChatMarkdownBlockSegmenterTests {
             snapshot: snapshot,
             context: .assistant,
             variant: .standard,
-            font: OpenClawChatTypography.callout.italic(),
-            textColor: OpenClawChatTheme.assistantText,
-            inlineMathTypography: .callout)
+            typography: .thinking,
+            textColor: OpenClawChatTheme.assistantText)
         let listView = renderer.listView(list)
         let nestedListView = listView.nestedListView(nestedList)
 
-        #expect(renderer.inlineMathTypography == .callout)
-        #expect(listView.inlineMathTypography == .callout)
-        #expect(listView.markdownRenderer("Parent \\(x\\)").inlineMathTypography == .callout)
-        #expect(nestedListView.inlineMathTypography == .callout)
-        #expect(nestedListView.markdownRenderer("Child \\(y\\)").inlineMathTypography == .callout)
+        #expect(renderer.typography == .thinking)
+        #expect(listView.typography == .thinking)
+        #expect(listView.markdownRenderer("Parent \\(x\\)").typography == .thinking)
+        #expect(nestedListView.typography == .thinking)
+        #expect(nestedListView.markdownRenderer("Child \\(y\\)").typography == .thinking)
     }
 
     #if canImport(UIKit)
     @MainActor private func fittedHeight(
         _ view: some View,
         width: CGFloat,
-        maximumHeight: CGFloat = 10_000) -> CGFloat
+        maximumHeight: CGFloat = 10000) -> CGFloat
     {
         let controller = UIHostingController(rootView: view)
         return controller.sizeThatFits(in: CGSize(width: width, height: maximumHeight)).height
@@ -555,7 +554,6 @@ struct ChatMarkdownBlockSegmenterTests {
                 text: markdown,
                 context: .assistant,
                 variant: .standard,
-                font: OpenClawChatTypography.body,
                 textColor: OpenClawChatTheme.assistantText)
                 .environment(\.dynamicTypeSize, .accessibility2)
                 .preferredColorScheme(scheme)
@@ -580,14 +578,12 @@ struct ChatMarkdownBlockSegmenterTests {
                         text: sample,
                         context: .assistant,
                         variant: .standard,
-                        font: OpenClawChatTypography.body,
                         textColor: OpenClawChatTheme.assistantText)
                         .environment(\.dynamicTypeSize, typeSize)
                     let list = ChatMarkdownRenderer(
                         text: "- \(sample)",
                         context: .assistant,
                         variant: .standard,
-                        font: OpenClawChatTypography.body,
                         textColor: OpenClawChatTheme.assistantText)
                         .environment(\.dynamicTypeSize, typeSize)
 


### PR DESCRIPTION
Closes #103428

Related: #103404

## What Problem This Solves

Fixes an issue where Markdown headings inside visible assistant reasoning used the prominent response H1-H6 hierarchy instead of the subdued thinking typography. Reasoning headings visually competed with the final answer even though thinking prose and inline math were already styled as a callout.

## Why This Change Was Made

The current-main rewrite gives the shared Apple Markdown renderer one closed semantic typography profile for response versus thinking content. Each profile owns prose, inline math, list markers, nested lists, and heading typography together. Response headings retain the branded hierarchy; thinking headings use callout italics while preserving the accessibility header trait.

The rewrite retains the newer list, thematic-break, inline-image, and streaming-reveal paths that made the old branch conflict with `main`.

## User Impact

When assistant reasoning is visible, headings inside it remain visually subordinate to the final response on iOS and macOS. Ordinary user/assistant Markdown headings and heading accessibility semantics are unchanged.

## Evidence

Exact head: `b66049160d5ae56f43af2865ba522740d3e3f2fe`

- direct dependency review confirmed swift-markdown 0.8.0 models heading level semantically and does not prescribe visual font hierarchy;
- focused tests cover response/thinking profile selection, completed and streaming rendering, Dynamic Type, and nested-list profile propagation;
- the selected iOS visual-proof test renders the before/after/final headings at accessibility Dynamic Type, asserts the response H1 is taller than the thinking H1, and retains the rendered image in the Xcode result bundle;
- current list, thematic-break, inline-image, inline-math, full-message, and streaming call sites were migrated in the same rewrite;
- native i18n verification passes with 5,317 entries;
- repository-pinned SwiftFormat, Swift syntax parsing, and `git diff --check` pass;
- the first selected iOS proof run correctly rejected a missing `OpenClawChatUI` test-target import; that boundary bug is fixed on the current head;
- final Codex autoreview reports no accepted/actionable findings and 0.96 confidence;
- the branch is conflict-free on current `main`; the resolved head passed the selected iPhone visual test and retained its before/after accessibility-size image in [Xcode result artifact 8675952697](https://github.com/openclaw/openclaw/actions/runs/30326487990/artifacts/8675952697);
- resolved-head CI completed successfully, including the selected iPhone visual proof, release screenshots, macOS Swift, native i18n, and the full integration graph.

AI-assisted: yes. Codex performed the current-main reconstruction, direct dependency review, focused proof design, and structured autoreview. The maintainer reviewed the final diff.
