### PR TITLE
fix(qqbot): route channel API by account

### DIFF
--- a/extensions/qqbot/src/bridge/tools/channel.test.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.test.ts
@@ -25,7 +25,7 @@ function resolveChannelTool(params: {
   agentAccountId?: string;
 }): ChannelTool {
   const registerTool = vi.fn();
-  registerChannelTool({ config: params.config, registerTool } as OpenClawPluginApi);
+  registerChannelTool({ config: params.config, registerTool });
   const registration = registerTool.mock.calls[0]?.[0] as (ctx: {
     agentAccountId?: string;
   }) => ChannelTool;

--- a/extensions/qqbot/src/bridge/tools/channel.test.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.test.ts
@@ -1,0 +1,95 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+// QQBot tests cover channel API account selection behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPlatformAdapter, type PlatformAdapter } from "../../engine/adapter/index.js";
+import { registerChannelTool } from "./channel.js";
+
+const executeChannelApiMock = vi.hoisted(() => vi.fn(async () => ({ details: {} })));
+const getAccessTokenMock = vi.hoisted(() => vi.fn(async () => "access-token"));
+
+vi.mock("../../engine/tools/channel-api.js", () => ({
+  ChannelApiSchema: {},
+  executeChannelApi: executeChannelApiMock,
+}));
+
+vi.mock("../../engine/messaging/sender.js", () => ({
+  getAccessToken: getAccessTokenMock,
+}));
+
+type ChannelTool = {
+  execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{ details: unknown }>;
+};
+
+function resolveChannelTool(params: {
+  config: OpenClawPluginApi["config"];
+  agentAccountId?: string;
+}): ChannelTool {
+  const registerTool = vi.fn();
+  registerChannelTool({ config: params.config, registerTool } as OpenClawPluginApi);
+  const registration = registerTool.mock.calls[0]?.[0] as (ctx: {
+    agentAccountId?: string;
+  }) => ChannelTool;
+  return registration({ agentAccountId: params.agentAccountId });
+}
+
+function createConfig(params: { enabledA?: boolean; enabledB?: boolean; hasSecretA?: boolean }) {
+  return {
+    channels: {
+      qqbot: {
+        accounts: {
+          a: {
+            appId: "app-a",
+            ...(params.hasSecretA === false ? {} : { clientSecret: "secret-a" }), // pragma: allowlist secret
+            enabled: params.enabledA,
+          },
+          b: {
+            appId: "app-b",
+            clientSecret: "secret-b", // pragma: allowlist secret
+            enabled: params.enabledB,
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+describe("registerChannelTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerPlatformAdapter({
+      hasConfiguredSecret: (value) => typeof value === "string" && value.length > 0,
+      normalizeSecretInputString: (value) => (typeof value === "string" ? value : undefined),
+      resolveSecretInputString: ({ value }) => (typeof value === "string" ? value : undefined),
+    } as PlatformAdapter);
+  });
+
+  it("uses a credentialed account when no contextual account is available", async () => {
+    const tool = resolveChannelTool({ config: createConfig({ hasSecretA: false }) });
+
+    await tool.execute("call", { method: "GET", path: "/users/@me/guilds" });
+
+    expect(getAccessTokenMock).toHaveBeenCalledWith("app-b", "secret-b");
+  });
+
+  it("routes the channel API token request to the contextual account", async () => {
+    const tool = resolveChannelTool({ config: createConfig({}), agentAccountId: "b" });
+
+    await tool.execute("call", { method: "GET", path: "/users/@me/guilds" });
+
+    expect(getAccessTokenMock).toHaveBeenCalledWith("app-b", "secret-b");
+  });
+
+  it("does not fall back to another account when the contextual account is disabled", async () => {
+    const tool = resolveChannelTool({
+      config: createConfig({ enabledA: true, enabledB: false }),
+      agentAccountId: "b",
+    });
+
+    const result = await tool.execute("call", { method: "GET", path: "/users/@me/guilds" });
+
+    expect(result.details).toEqual({
+      error: 'QQBot Channel API is not configured for account "b"',
+    });
+    expect(getAccessTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qqbot/src/bridge/tools/channel.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.ts
@@ -1,8 +1,13 @@
 // Qqbot plugin module implements channel behavior.
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
 import { ChannelApiSchema, executeChannelApi } from "../../engine/tools/channel-api.js";
 import type { ChannelApiParams } from "../../engine/tools/channel-api.js";
 import { listQQBotAccountIds, resolveQQBotAccount } from "../config.js";
+
+function hasChannelApiCredentials(account: ReturnType<typeof resolveQQBotAccount>): boolean {
+  return account.enabled && Boolean(account.appId && account.clientSecret);
+}
 
 /**
  * Register the QQ channel API proxy tool.
@@ -22,38 +27,51 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
     return;
   }
 
-  const firstAccountId = accountIds[0];
-  const account = resolveQQBotAccount(cfg, firstAccountId);
-
-  if (!account.appId || !account.clientSecret) {
+  if (
+    !accountIds.some((accountId) => hasChannelApiCredentials(resolveQQBotAccount(cfg, accountId)))
+  ) {
     return;
   }
 
   api.registerTool(
-    {
-      name: "qqbot_channel_api",
-      label: "QQBot Channel API",
-      description:
-        "Authenticated HTTP proxy for QQ Open Platform channel APIs. " +
-        "Use write and delete endpoints only after explicit user intent; DELETE requires confirmed=true, and bulk deletes require bulkConfirmed=true after confirming the exact target. " +
-        "Common endpoints: " +
-        "list guilds GET /users/@me/guilds | " +
-        "list channels GET /guilds/{guild_id}/channels | " +
-        "get channel GET /channels/{channel_id} | " +
-        "create channel POST /guilds/{guild_id}/channels | " +
-        "list members GET /guilds/{guild_id}/members?after=0&limit=100 | " +
-        "get member GET /guilds/{guild_id}/members/{user_id} | " +
-        "list threads GET /channels/{channel_id}/threads | " +
-        "create thread PUT /channels/{channel_id}/threads | " +
-        "create announce POST /guilds/{guild_id}/announces | " +
-        "create schedule POST /channels/{channel_id}/schedules. " +
-        "See the qqbot-channel skill for full endpoint details.",
-      parameters: ChannelApiSchema,
-      async execute(_toolCallId, params) {
-        const { getAccessToken } = await import("../../engine/messaging/sender.js");
-        const accessToken = await getAccessToken(account.appId, account.clientSecret);
-        return executeChannelApi(params as ChannelApiParams, { accessToken });
-      },
+    (ctx) => {
+      const accountId =
+        ctx.agentAccountId && accountIds.includes(ctx.agentAccountId)
+          ? ctx.agentAccountId
+          : accountIds.find((candidateAccountId) =>
+              hasChannelApiCredentials(resolveQQBotAccount(cfg, candidateAccountId)),
+            );
+      return {
+        name: "qqbot_channel_api",
+        label: "QQBot Channel API",
+        description:
+          "Authenticated HTTP proxy for QQ Open Platform channel APIs. " +
+          "Use write and delete endpoints only after explicit user intent; DELETE requires confirmed=true, and bulk deletes require bulkConfirmed=true after confirming the exact target. " +
+          "Common endpoints: " +
+          "list guilds GET /users/@me/guilds | " +
+          "list channels GET /guilds/{guild_id}/channels | " +
+          "get channel GET /channels/{channel_id} | " +
+          "create channel POST /guilds/{guild_id}/channels | " +
+          "list members GET /guilds/{guild_id}/members?after=0&limit=100 | " +
+          "get member GET /guilds/{guild_id}/members/{user_id} | " +
+          "list threads GET /channels/{channel_id}/threads | " +
+          "create thread PUT /channels/{channel_id}/threads | " +
+          "create announce POST /guilds/{guild_id}/announces | " +
+          "create schedule POST /channels/{channel_id}/schedules. " +
+          "See the qqbot-channel skill for full endpoint details.",
+        parameters: ChannelApiSchema,
+        async execute(_toolCallId, params) {
+          const account = resolveQQBotAccount(cfg, accountId);
+          if (!hasChannelApiCredentials(account)) {
+            return json({
+              error: `QQBot Channel API is not configured for account "${account.accountId}"`,
+            });
+          }
+          const { getAccessToken } = await import("../../engine/messaging/sender.js");
+          const accessToken = await getAccessToken(account.appId, account.clientSecret);
+          return executeChannelApi(params as ChannelApiParams, { accessToken });
+        },
+      };
     },
     { name: "qqbot_channel_api" },
   );

--- a/extensions/qqbot/src/bridge/tools/channel.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.ts
@@ -16,7 +16,7 @@ function hasChannelApiCredentials(account: ReturnType<typeof resolveQQBotAccount
  * channel APIs. Agents learn endpoint details from the skill docs and
  * send requests through this proxy.
  */
-export function registerChannelTool(api: OpenClawPluginApi): void {
+export function registerChannelTool(api: Pick<OpenClawPluginApi, "config" | "registerTool">): void {
   const cfg = api.config;
   if (!cfg) {
     return;


### PR DESCRIPTION
## What Problem This Solves

`qqbot_channel_api` captured the first configured QQBot account at registration time. In a multi-account installation, an agent bound to another QQBot account therefore obtained an access token for the wrong bot. The tool was also hidden when the first account lacked a secret even if another account was fully configured.

## Why This Change Was Made

The tool now resolves credentials per tool context. A valid contextual account is always used and an unusable contextual account fails explicitly rather than silently crossing accounts. When no contextual account exists, the tool selects an account that actually has usable credentials so the broader registration check remains executable.

## User Impact

QQBot channel API calls use the credentials for the active account. Multi-account configurations no longer accidentally expose one bot's channel API to another bot's agent context.

## Evidence

- Added coverage for contextual account token selection, disabled contextual accounts not falling back, and no-context selection of the available credentialed account.
- `node_modules/.bin/vitest run --config test/vitest/vitest.extension-messaging.config.ts extensions/qqbot/src/bridge/tools/channel.test.ts extensions/qqbot/src/engine/tools/channel-api.test.ts` (12 passed)
- `node scripts/run-oxlint.mjs extensions/qqbot/src/bridge/tools/channel.ts extensions/qqbot/src/bridge/tools/channel.test.ts`
- `node_modules/.bin/oxfmt --write extensions/qqbot/src/bridge/tools/channel.ts extensions/qqbot/src/bridge/tools/channel.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --output /tmp/openclaw-autoreview/qqbot-channel-account-final.json` (clean; no accepted/actionable findings after one in-scope correction)

Remote Testbox validation is unavailable in this environment because the current account is not authenticated to the `openclaw` organization. The focused test is therefore a narrow local fallback; GitHub CI remains the remote validation path.
