### PR TITLE
feat(macos): tabs for the dashboard link browser sidebar

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
@@ -1,0 +1,291 @@
+import AppKit
+import Foundation
+
+@MainActor
+protocol DashboardLinkBrowserTabBarDelegate: AnyObject {
+    func tabBar(_ tabBar: DashboardLinkBrowserTabBar, didSelectTab id: UUID)
+    func tabBar(_ tabBar: DashboardLinkBrowserTabBar, didCloseTab id: UUID)
+    func tabBar(_ tabBar: DashboardLinkBrowserTabBar, didMoveTab id: UUID, toIndex: Int)
+    func tabBar(_ tabBar: DashboardLinkBrowserTabBar, contextMenuForTab id: UUID) -> NSMenu?
+}
+
+@MainActor
+final class DashboardLinkBrowserTabBar: NSView {
+    weak var delegate: DashboardLinkBrowserTabBarDelegate?
+
+    private let scrollView = NSScrollView()
+    fileprivate let stackView = NSStackView()
+    private var itemViews: [UUID: DashboardLinkBrowserTabItemView] = [:]
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.buildView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    func appendTab(id: UUID, title: String, toolTip: String?) {
+        let item = DashboardLinkBrowserTabItemView(id: id, title: title, owner: self)
+        item.toolTip = toolTip
+        self.itemViews[id] = item
+        self.stackView.addArrangedSubview(item)
+    }
+
+    func removeTab(id: UUID) {
+        guard let item = self.itemViews.removeValue(forKey: id) else { return }
+        self.stackView.removeArrangedSubview(item)
+        item.removeFromSuperview()
+    }
+
+    func updateTab(id: UUID, title: String, toolTip: String?) {
+        guard let item = self.itemViews[id] else { return }
+        item.title = title
+        item.toolTip = toolTip
+    }
+
+    func setActiveTab(id: UUID?) {
+        for (itemID, item) in self.itemViews {
+            item.isActive = itemID == id
+        }
+        guard let id, let item = self.itemViews[id] else { return }
+        item.scrollToVisible(item.bounds)
+    }
+
+    func moveTab(id: UUID, toIndex: Int) {
+        guard let item = self.itemViews[id], self.stackView.arrangedSubviews.contains(item) else { return }
+        self.stackView.removeArrangedSubview(item)
+        item.removeFromSuperview()
+        self.stackView.insertArrangedSubview(item, at: min(max(0, toIndex), self.stackView.arrangedSubviews.count))
+    }
+
+    fileprivate func selectTab(id: UUID) {
+        self.delegate?.tabBar(self, didSelectTab: id)
+    }
+
+    fileprivate func closeTab(id: UUID) {
+        self.delegate?.tabBar(self, didCloseTab: id)
+    }
+
+    fileprivate func moveTab(id: UUID, event: NSEvent) {
+        guard let item = self.itemViews[id] else { return }
+        let location = self.stackView.convert(event.locationInWindow, from: nil)
+        let arrangedItems = self.stackView.arrangedSubviews.compactMap { $0 as? DashboardLinkBrowserTabItemView }
+        guard let currentIndex = arrangedItems.firstIndex(of: item) else { return }
+
+        var targetIndex = arrangedItems.count - 1
+        for (index, candidate) in arrangedItems.enumerated() where location.x < candidate.frame.midX {
+            targetIndex = index
+            break
+        }
+        guard targetIndex != currentIndex else { return }
+        self.delegate?.tabBar(self, didMoveTab: id, toIndex: targetIndex)
+    }
+
+    fileprivate func contextMenu(forTab id: UUID) -> NSMenu? {
+        self.delegate?.tabBar(self, contextMenuForTab: id)
+    }
+
+    private func buildView() {
+        self.scrollView.hasHorizontalScroller = false
+        self.scrollView.hasVerticalScroller = false
+        self.scrollView.horizontalScrollElasticity = .none
+        self.scrollView.verticalScrollElasticity = .none
+        self.scrollView.drawsBackground = false
+        self.scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(self.scrollView)
+
+        self.stackView.orientation = .horizontal
+        self.stackView.alignment = .centerY
+        self.stackView.distribution = .fill
+        self.stackView.spacing = 2
+        self.stackView.edgeInsets = NSEdgeInsets(top: 3, left: 4, bottom: 3, right: 4)
+        self.stackView.translatesAutoresizingMaskIntoConstraints = false
+        self.scrollView.documentView = self.stackView
+
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separator)
+
+        NSLayoutConstraint.activate([
+            self.scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            self.scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            self.scrollView.topAnchor.constraint(equalTo: topAnchor),
+            self.scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            self.stackView.leadingAnchor.constraint(equalTo: self.scrollView.contentView.leadingAnchor),
+            self.stackView.topAnchor.constraint(equalTo: self.scrollView.contentView.topAnchor),
+            self.stackView.bottomAnchor.constraint(equalTo: self.scrollView.contentView.bottomAnchor),
+            self.stackView.heightAnchor.constraint(equalTo: self.scrollView.contentView.heightAnchor),
+            self.stackView.trailingAnchor.constraint(greaterThanOrEqualTo: self.scrollView.contentView.trailingAnchor),
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+}
+
+@MainActor
+private final class DashboardLinkBrowserTabItemView: NSView {
+    let id: UUID
+    var title: String {
+        didSet {
+            self.titleLabel.stringValue = self.title
+            self.setAccessibilityLabel(self.title)
+        }
+    }
+
+    var isActive = false {
+        didSet {
+            self.titleLabel.textColor = self.isActive ? .labelColor : .secondaryLabelColor
+            self.needsDisplay = true
+        }
+    }
+
+    private weak var owner: DashboardLinkBrowserTabBar?
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let closeButton: NSButton
+    private var trackingArea: NSTrackingArea?
+    private var mouseDownLocation: NSPoint?
+    private var didDrag = false
+    private var isHovered = false {
+        didSet { self.needsDisplay = true }
+    }
+
+    init(id: UUID, title: String, owner: DashboardLinkBrowserTabBar) {
+        self.id = id
+        self.title = title
+        self.owner = owner
+        self.closeButton = Self.makeCloseButton()
+        super.init(frame: .zero)
+
+        self.setAccessibilityLabel(title)
+        self.buildView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let color: NSColor? = if self.isActive {
+            .quaternaryLabelColor
+        } else if self.isHovered {
+            // macOS 14+ spells this without the "Color" suffix; quinaryLabelColor does not exist.
+            .quinaryLabel
+        } else {
+            nil
+        }
+        guard let color else { return }
+        color.setFill()
+        NSBezierPath(roundedRect: bounds.insetBy(dx: 1, dy: 1), xRadius: 6, yRadius: 6).fill()
+    }
+
+    override func updateTrackingAreas() {
+        if let trackingArea {
+            self.removeTrackingArea(trackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil)
+        self.addTrackingArea(trackingArea)
+        self.trackingArea = trackingArea
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with _: NSEvent) {
+        self.isHovered = true
+    }
+
+    override func mouseExited(with _: NSEvent) {
+        self.isHovered = false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        self.mouseDownLocation = self.convert(event.locationInWindow, from: nil)
+        self.didDrag = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let mouseDownLocation else { return }
+        let location = self.convert(event.locationInWindow, from: nil)
+        if !self.didDrag, hypot(location.x - mouseDownLocation.x, location.y - mouseDownLocation.y) >= 4 {
+            self.didDrag = true
+        }
+        guard self.didDrag else { return }
+        self.owner?.moveTab(id: self.id, event: event)
+    }
+
+    override func mouseUp(with _: NSEvent) {
+        defer {
+            self.mouseDownLocation = nil
+            self.didDrag = false
+        }
+        guard !self.didDrag else { return }
+        self.owner?.selectTab(id: self.id)
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        guard event.buttonNumber == 2 else {
+            super.otherMouseUp(with: event)
+            return
+        }
+        self.owner?.closeTab(id: self.id)
+    }
+
+    override func menu(for _: NSEvent) -> NSMenu? {
+        self.owner?.contextMenu(forTab: self.id)
+    }
+
+    private func buildView() {
+        self.titleLabel.stringValue = self.title
+        self.titleLabel.font = .systemFont(ofSize: 11, weight: .medium)
+        self.titleLabel.textColor = .secondaryLabelColor
+        self.titleLabel.lineBreakMode = .byTruncatingTail
+        self.titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        self.titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(self.titleLabel)
+
+        self.closeButton.target = self
+        self.closeButton.action = #selector(self.closeTab)
+        self.closeButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(self.closeButton)
+
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            widthAnchor.constraint(lessThanOrEqualToConstant: 180),
+            heightAnchor.constraint(equalToConstant: 24),
+            self.titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            self.titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            self.closeButton.leadingAnchor.constraint(equalTo: self.titleLabel.trailingAnchor, constant: 4),
+            self.closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
+            self.closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            self.closeButton.widthAnchor.constraint(equalToConstant: 16),
+            self.closeButton.heightAnchor.constraint(equalToConstant: 16),
+        ])
+    }
+
+    private static func makeCloseButton() -> NSButton {
+        let configuration = NSImage.SymbolConfiguration(pointSize: 9, weight: .medium)
+        let image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close Tab")?
+            .withSymbolConfiguration(configuration) ?? NSImage(size: NSSize(width: 12, height: 12))
+        let button = NSButton(image: image, target: nil, action: nil)
+        button.isBordered = false
+        button.bezelStyle = .regularSquare
+        button.imageScaling = .scaleProportionallyDown
+        button.toolTip = "Close Tab"
+        button.setAccessibilityLabel("Close Tab")
+        return button
+    }
+
+    @objc private func closeTab() {
+        self.owner?.closeTab(id: self.id)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
@@ -3,13 +3,45 @@ import Foundation
 import WebKit
 
 @MainActor
+private final class DashboardLinkBrowserTab {
+    let id = UUID()
+    let webView: WKWebView
+    var representedURL: URL?
+    var title: String?
+    var observations: [NSKeyValueObservation] = []
+
+    init(webView: WKWebView, representedURL: URL?) {
+        self.webView = webView
+        self.representedURL = representedURL
+    }
+}
+
+@MainActor
 final class DashboardLinkBrowserView: NSView {
-    private(set) var webView: WKWebView
+    var activeWebView: WKWebView? {
+        self.activeTab?.webView
+    }
+
+    weak var webViewNavigationDelegate: WKNavigationDelegate? {
+        didSet {
+            self.tabs.forEach { $0.webView.navigationDelegate = self.webViewNavigationDelegate }
+        }
+    }
+
+    weak var webViewUIDelegate: WKUIDelegate? {
+        didSet {
+            self.tabs.forEach { $0.webView.uiDelegate = self.webViewUIDelegate }
+        }
+    }
+
     var onClose: (() -> Void)?
     var onOpenExternal: ((URL) -> Void)?
 
     private let websiteDataStore: WKWebsiteDataStore
+    private var tabs: [DashboardLinkBrowserTab] = []
+    private var activeTabID: UUID?
     private let toolbar = NSVisualEffectView()
+    private let tabBar = DashboardLinkBrowserTabBar()
     private let backButton = DashboardLinkBrowserView.makeButton(symbol: "chevron.left", label: "Back")
     private let forwardButton = DashboardLinkBrowserView.makeButton(symbol: "chevron.right", label: "Forward")
     private let reloadButton = DashboardLinkBrowserView.makeButton(symbol: "arrow.clockwise", label: "Reload")
@@ -17,9 +49,6 @@ final class DashboardLinkBrowserView: NSView {
         symbol: "arrow.up.right.square",
         label: "Open in Default Browser")
     private let closeButton = DashboardLinkBrowserView.makeButton(symbol: "xmark", label: "Close Sidebar")
-    private var navigationObservations: [NSKeyValueObservation] = []
-    private var webViewConstraints: [NSLayoutConstraint] = []
-    private var representedURL: URL?
     private let addressLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
         label.font = .systemFont(ofSize: 12, weight: .medium)
@@ -30,14 +59,17 @@ final class DashboardLinkBrowserView: NSView {
         return label
     }()
 
+    private var activeTab: DashboardLinkBrowserTab? {
+        guard let activeTabID else { return nil }
+        return self.tabs.first { $0.id == activeTabID }
+    }
+
     init(websiteDataStore: WKWebsiteDataStore) {
         self.websiteDataStore = websiteDataStore
-        self.webView = Self.makeWebView(websiteDataStore: websiteDataStore)
         super.init(frame: .zero)
 
         self.configureActions()
         self.buildView()
-        self.observeNavigationState()
         self.updateChrome()
     }
 
@@ -46,40 +78,116 @@ final class DashboardLinkBrowserView: NSView {
         fatalError("init(coder:) is not supported")
     }
 
+    func owns(_ webView: WKWebView) -> Bool {
+        self.tabs.contains { $0.webView === webView }
+    }
+
     func open(_ url: URL) {
-        self.navigationWillStart(url)
-        self.webView.load(URLRequest(url: url))
+        // Repeat clicks on the exact same chat link reuse its tab so inline
+        // browsing does not pile up duplicates.
+        if let tab = self.tabs.first(where: { $0.representedURL == url }) {
+            self.activateTab(id: tab.id)
+            return
+        }
+        self.openInNewTab(url)
+    }
+
+    func openInNewTab(_ url: URL) {
+        let tab = self.makeTab(representedURL: url)
+        self.tabs.append(tab)
+        self.tabBar.appendTab(id: tab.id, title: self.displayTitle(for: tab), toolTip: url.absoluteString)
+        self.activateTab(id: tab.id)
+        let webView = tab.webView
+        // Let the installed tab become observable before navigation starts.
+        // An immediate close then cancels the pending load without retaining it.
+        Task { @MainActor [weak self, weak webView] in
+            guard let self, let webView, self.owns(webView) else { return }
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    func closeTab(id: UUID) {
+        guard let index = self.tabs.firstIndex(where: { $0.id == id }) else { return }
+        let wasActive = self.activeTabID == id
+        let tab = self.tabs.remove(at: index)
+        self.dispose(tab)
+        self.tabBar.removeTab(id: id)
+
+        guard !self.tabs.isEmpty else {
+            self.activeTabID = nil
+            self.tabBar.setActiveTab(id: nil)
+            self.updateChrome()
+            self.onClose?()
+            return
+        }
+        if wasActive {
+            let nextIndex = min(index, self.tabs.count - 1)
+            self.activateTab(id: self.tabs[nextIndex].id)
+        }
+    }
+
+    func closeOtherTabs(keeping id: UUID) {
+        guard let keptTab = self.tabs.first(where: { $0.id == id }) else { return }
+        let removedTabs = self.tabs.filter { $0.id != id }
+        for tab in removedTabs {
+            self.dispose(tab)
+            self.tabBar.removeTab(id: tab.id)
+        }
+        self.tabs = [keptTab]
+        self.activateTab(id: id)
+    }
+
+    func moveTab(fromIndex: Int, toIndex: Int) {
+        guard self.tabs.indices.contains(fromIndex), toIndex >= 0, toIndex < self.tabs.count else { return }
+        let tab = self.tabs.remove(at: fromIndex)
+        self.tabs.insert(tab, at: toIndex)
+        self.tabBar.moveTab(id: tab.id, toIndex: toIndex)
     }
 
     func closeBrowser() {
-        self.representedURL = nil
-        self.replaceWebView()
+        let tabs = self.tabs
+        self.tabs.removeAll()
+        self.activeTabID = nil
+        for tab in tabs {
+            self.dispose(tab)
+            self.tabBar.removeTab(id: tab.id)
+        }
+        self.tabBar.setActiveTab(id: nil)
         self.updateChrome()
     }
 
     func updateChrome() {
-        let url = self.representedURL
+        let tab = self.activeTab
+        let url = tab?.representedURL
         self.addressLabel.stringValue = url?.host(percentEncoded: false) ?? url?.absoluteString ?? ""
         self.addressLabel.toolTip = url?.absoluteString
-        self.backButton.isEnabled = self.webView.canGoBack
-        self.forwardButton.isEnabled = self.webView.canGoForward
+        self.backButton.isEnabled = tab?.webView.canGoBack == true
+        self.forwardButton.isEnabled = tab?.webView.canGoForward == true
         self.reloadButton.isEnabled = url != nil
         self.externalButton.isEnabled = url.flatMap(Self.httpURL) != nil
     }
 
-    func navigationWillStart(_ url: URL) {
-        self.representedURL = url
-        self.updateChrome()
+    func navigationWillStart(_ url: URL, in webView: WKWebView) {
+        guard let tab = self.tab(owning: webView) else { return }
+        tab.representedURL = url
+        self.refreshTab(tab)
     }
 
-    func navigationDidFinish() {
-        self.representedURL = self.webView.url
-        self.updateChrome()
+    func navigationDidFinish(for webView: WKWebView) {
+        guard let tab = self.tab(owning: webView) else { return }
+        tab.representedURL = webView.url
+        tab.title = webView.title
+        self.refreshTab(tab)
+    }
+
+    func contextMenu(forTabAt index: Int) -> NSMenu? {
+        guard self.tabs.indices.contains(index) else { return nil }
+        return self.contextMenu(for: self.tabs[index])
     }
 
     private static func makeWebView(websiteDataStore: WKWebsiteDataStore) -> WKWebView {
-        // External pages share persisted browser sessions, but never inherit the
-        // dashboard's auth scripts or privileged message handler.
+        // Every tab shares persisted browser sessions, but never inherits the
+        // dashboard's auth scripts, user scripts, or privileged message handler.
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = websiteDataStore
         configuration.preferences.isElementFullscreenEnabled = true
@@ -89,25 +197,57 @@ final class DashboardLinkBrowserView: NSView {
         return webView
     }
 
-    private func replaceWebView() {
-        let previousWebView = self.webView
-        let navigationDelegate = previousWebView.navigationDelegate
-        let uiDelegate = previousWebView.uiDelegate
-        let replacement = Self.makeWebView(websiteDataStore: self.websiteDataStore)
+    private func makeTab(representedURL: URL?) -> DashboardLinkBrowserTab {
+        let webView = Self.makeWebView(websiteDataStore: self.websiteDataStore)
+        webView.navigationDelegate = self.webViewNavigationDelegate
+        webView.uiDelegate = self.webViewUIDelegate
+        let tab = DashboardLinkBrowserTab(webView: webView, representedURL: representedURL)
+        self.installWebView(webView)
+        self.observeNavigationState(for: tab)
+        return tab
+    }
 
-        self.navigationObservations.forEach { $0.invalidate() }
-        self.navigationObservations.removeAll()
-        NSLayoutConstraint.deactivate(self.webViewConstraints)
-        previousWebView.navigationDelegate = nil
-        previousWebView.uiDelegate = nil
-        previousWebView.stopLoading()
-        previousWebView.removeFromSuperview()
+    private func dispose(_ tab: DashboardLinkBrowserTab) {
+        tab.observations.forEach { $0.invalidate() }
+        tab.observations.removeAll()
+        tab.webView.navigationDelegate = nil
+        tab.webView.uiDelegate = nil
+        tab.webView.stopLoading()
+        tab.webView.removeFromSuperview()
+    }
 
-        self.webView = replacement
-        self.installWebView()
-        replacement.navigationDelegate = navigationDelegate
-        replacement.uiDelegate = uiDelegate
-        self.observeNavigationState()
+    private func tab(owning webView: WKWebView) -> DashboardLinkBrowserTab? {
+        self.tabs.first { $0.webView === webView }
+    }
+
+    private func activateTab(id: UUID) {
+        guard self.tabs.contains(where: { $0.id == id }) else { return }
+        self.activeTabID = id
+        for tab in self.tabs {
+            tab.webView.isHidden = tab.id != id
+        }
+        self.tabBar.setActiveTab(id: id)
+        self.updateChrome()
+        if self.window != nil {
+            self.window?.makeFirstResponder(self.activeWebView)
+        }
+    }
+
+    private func refreshTab(_ tab: DashboardLinkBrowserTab) {
+        self.tabBar.updateTab(
+            id: tab.id,
+            title: self.displayTitle(for: tab),
+            toolTip: tab.representedURL?.absoluteString)
+        if tab.id == self.activeTabID {
+            self.updateChrome()
+        }
+    }
+
+    private func displayTitle(for tab: DashboardLinkBrowserTab) -> String {
+        if let title = tab.title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+            return title
+        }
+        return tab.representedURL?.host(percentEncoded: false) ?? "New Tab"
     }
 
     private func configureActions() {
@@ -121,25 +261,37 @@ final class DashboardLinkBrowserView: NSView {
         self.externalButton.action = #selector(self.openExternal)
         self.closeButton.target = self
         self.closeButton.action = #selector(self.close)
+        self.tabBar.delegate = self
     }
 
-    private func observeNavigationState() {
+    private func observeNavigationState(for tab: DashboardLinkBrowserTab) {
+        let webView = tab.webView
         // WebKit updates these properties after some navigation delegate callbacks.
         // KVO also catches same-document SPA URL changes that skip didFinish.
-        self.navigationObservations = [
-            self.webView.observe(\.canGoBack, options: [.new]) { [weak self] _, _ in
+        tab.observations = [
+            webView.observe(\.canGoBack, options: [.new]) { [weak self, weak tab] _, _ in
                 Task { @MainActor in
-                    self?.updateChrome()
+                    guard let self, let tab else { return }
+                    self.refreshTab(tab)
                 }
             },
-            self.webView.observe(\.canGoForward, options: [.new]) { [weak self] _, _ in
+            webView.observe(\.canGoForward, options: [.new]) { [weak self, weak tab] _, _ in
                 Task { @MainActor in
-                    self?.updateChrome()
+                    guard let self, let tab else { return }
+                    self.refreshTab(tab)
                 }
             },
-            self.webView.observe(\.url, options: [.new]) { [weak self] _, _ in
+            webView.observe(\.url, options: [.new]) { [weak self, weak webView] _, _ in
                 Task { @MainActor in
-                    self?.navigationDidFinish()
+                    guard let self, let webView else { return }
+                    self.navigationDidFinish(for: webView)
+                }
+            },
+            webView.observe(\.title, options: [.new]) { [weak self, weak tab, weak webView] _, _ in
+                Task { @MainActor in
+                    guard let self, let tab, let webView else { return }
+                    tab.title = webView.title
+                    self.refreshTab(tab)
                 }
             },
         ]
@@ -169,40 +321,96 @@ final class DashboardLinkBrowserView: NSView {
         controls.translatesAutoresizingMaskIntoConstraints = false
         self.toolbar.addSubview(controls)
 
+        self.tabBar.translatesAutoresizingMaskIntoConstraints = false
+        self.toolbar.addSubview(self.tabBar)
+
         let separator = NSBox()
         separator.boxType = .separator
         separator.translatesAutoresizingMaskIntoConstraints = false
         self.toolbar.addSubview(separator)
-        self.installWebView()
 
         NSLayoutConstraint.activate([
             self.toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             self.toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
             self.toolbar.topAnchor.constraint(equalTo: topAnchor),
+            self.toolbar.heightAnchor.constraint(equalToConstant: 98),
+            // Browser-style header: tabs on top, navigation controls below.
             // The top 32 points stay clear of the dashboard window's drag overlay.
-            self.toolbar.heightAnchor.constraint(equalToConstant: 68),
-
+            self.tabBar.leadingAnchor.constraint(equalTo: self.toolbar.leadingAnchor),
+            self.tabBar.trailingAnchor.constraint(equalTo: self.toolbar.trailingAnchor),
+            self.tabBar.topAnchor.constraint(equalTo: self.toolbar.topAnchor, constant: 32),
+            self.tabBar.heightAnchor.constraint(equalToConstant: DashboardWindowLayout.linkBrowserTabBarHeight),
             controls.leadingAnchor.constraint(equalTo: self.toolbar.leadingAnchor, constant: 10),
             controls.trailingAnchor.constraint(equalTo: self.toolbar.trailingAnchor, constant: -10),
-            controls.bottomAnchor.constraint(equalTo: self.toolbar.bottomAnchor, constant: -8),
+            controls.bottomAnchor.constraint(equalTo: self.toolbar.bottomAnchor, constant: -4),
             controls.heightAnchor.constraint(equalToConstant: 28),
-
             separator.leadingAnchor.constraint(equalTo: self.toolbar.leadingAnchor),
             separator.trailingAnchor.constraint(equalTo: self.toolbar.trailingAnchor),
             separator.bottomAnchor.constraint(equalTo: self.toolbar.bottomAnchor),
         ])
     }
 
-    private func installWebView() {
-        self.webView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(self.webView)
-        self.webViewConstraints = [
-            self.webView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            self.webView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            self.webView.topAnchor.constraint(equalTo: self.toolbar.bottomAnchor),
-            self.webView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ]
-        NSLayoutConstraint.activate(self.webViewConstraints)
+    private func installWebView(_ webView: WKWebView) {
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.isHidden = true
+        addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            webView.topAnchor.constraint(equalTo: self.toolbar.bottomAnchor),
+            webView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    private func contextMenu(for tab: DashboardLinkBrowserTab) -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let externalURL = tab.representedURL.flatMap(Self.httpURL)
+        menu.addItem(self.menuItem(
+            title: "Open in Default Browser",
+            action: #selector(self.openTabExternal(_:)),
+            tabID: tab.id,
+            isEnabled: externalURL != nil))
+        menu.addItem(self.menuItem(
+            title: "Copy Link",
+            action: #selector(self.copyTabLink(_:)),
+            tabID: tab.id,
+            isEnabled: tab.representedURL != nil))
+        menu.addItem(self.menuItem(
+            title: "Reload",
+            action: #selector(self.reloadTab(_:)),
+            tabID: tab.id,
+            isEnabled: tab.representedURL != nil))
+        menu.addItem(.separator())
+        menu.addItem(self.menuItem(
+            title: "Close Tab",
+            action: #selector(self.closeTabFromMenu(_:)),
+            tabID: tab.id,
+            isEnabled: true))
+        menu.addItem(self.menuItem(
+            title: "Close Other Tabs",
+            action: #selector(self.closeOtherTabsFromMenu(_:)),
+            tabID: tab.id,
+            isEnabled: self.tabs.count > 1))
+        return menu
+    }
+
+    private func menuItem(
+        title: String,
+        action: Selector,
+        tabID: UUID,
+        isEnabled: Bool) -> NSMenuItem
+    {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        item.representedObject = tabID as NSUUID
+        item.isEnabled = isEnabled
+        return item
+    }
+
+    private func tab(for menuItem: NSMenuItem) -> DashboardLinkBrowserTab? {
+        guard let id = menuItem.representedObject as? UUID else { return nil }
+        return self.tabs.first { $0.id == id }
     }
 
     private static func makeButton(symbol: String, label: String) -> NSButton {
@@ -228,35 +436,133 @@ final class DashboardLinkBrowserView: NSView {
     }
 
     @objc private func goBack() {
-        self.webView.goBack()
+        self.activeWebView?.goBack()
     }
 
     @objc private func goForward() {
-        self.webView.goForward()
+        self.activeWebView?.goForward()
     }
 
     @objc private func reload() {
-        self.webView.reload()
+        self.activeWebView?.reload()
     }
 
     @objc private func openExternal() {
-        guard let url = representedURL.flatMap(Self.httpURL) else { return }
+        guard let url = self.activeTab?.representedURL.flatMap(Self.httpURL) else { return }
         self.onOpenExternal?(url)
     }
 
     @objc private func close() {
         self.onClose?()
     }
+
+    @objc private func openTabExternal(_ sender: NSMenuItem) {
+        guard let url = self.tab(for: sender)?.representedURL.flatMap(Self.httpURL) else { return }
+        self.onOpenExternal?(url)
+    }
+
+    @objc private func copyTabLink(_ sender: NSMenuItem) {
+        guard let url = self.tab(for: sender)?.representedURL else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([url as NSURL])
+        pasteboard.setString(url.absoluteString, forType: .string)
+    }
+
+    @objc private func reloadTab(_ sender: NSMenuItem) {
+        self.tab(for: sender)?.webView.reload()
+    }
+
+    @objc private func closeTabFromMenu(_ sender: NSMenuItem) {
+        guard let id = (sender.representedObject as? UUID) else { return }
+        self.closeTab(id: id)
+    }
+
+    @objc private func closeOtherTabsFromMenu(_ sender: NSMenuItem) {
+        guard let id = (sender.representedObject as? UUID) else { return }
+        self.closeOtherTabs(keeping: id)
+    }
+}
+
+extension DashboardLinkBrowserView: DashboardLinkBrowserTabBarDelegate {
+    func tabBar(_: DashboardLinkBrowserTabBar, didSelectTab id: UUID) {
+        self.activateTab(id: id)
+    }
+
+    func tabBar(_: DashboardLinkBrowserTabBar, didCloseTab id: UUID) {
+        self.closeTab(id: id)
+    }
+
+    func tabBar(_: DashboardLinkBrowserTabBar, didMoveTab id: UUID, toIndex: Int) {
+        guard let fromIndex = self.tabs.firstIndex(where: { $0.id == id }) else { return }
+        self.moveTab(fromIndex: fromIndex, toIndex: toIndex)
+    }
+
+    func tabBar(_: DashboardLinkBrowserTabBar, contextMenuForTab id: UUID) -> NSMenu? {
+        guard let tab = self.tabs.first(where: { $0.id == id }) else { return nil }
+        return self.contextMenu(for: tab)
+    }
 }
 
 #if DEBUG
 extension DashboardLinkBrowserView {
+    var _testTabCount: Int {
+        self.tabs.count
+    }
+
+    var _testTabURLs: [URL?] {
+        self.tabs.map(\.representedURL)
+    }
+
+    var _testTabTitles: [String] {
+        self.tabs.map { self.displayTitle(for: $0) }
+    }
+
+    var _testActiveTabIndex: Int? {
+        guard let activeTabID else { return nil }
+        return self.tabs.firstIndex { $0.id == activeTabID }
+    }
+
+    var _testActiveWebView: WKWebView? {
+        self.activeWebView
+    }
+
     var _testRepresentedURL: URL? {
-        self.representedURL
+        self.activeTab?.representedURL
     }
 
     var _testNavigationObservationCount: Int {
-        self.navigationObservations.count
+        self.activeTab?.observations.count ?? 0
+    }
+
+    var _testWebsiteDataStore: WKWebsiteDataStore {
+        self.websiteDataStore
+    }
+
+    var _testAllWebViews: [WKWebView] {
+        self.tabs.map(\.webView)
+    }
+
+    func _testSelectTab(at index: Int) {
+        guard self.tabs.indices.contains(index) else { return }
+        self.activateTab(id: self.tabs[index].id)
+    }
+
+    func _testCloseTab(at index: Int) {
+        guard self.tabs.indices.contains(index) else { return }
+        self.closeTab(id: self.tabs[index].id)
+    }
+
+    func _testMoveTab(from fromIndex: Int, to toIndex: Int) {
+        self.moveTab(fromIndex: fromIndex, toIndex: toIndex)
+    }
+
+    func _testOpenInNewTab(_ url: URL) {
+        self.openInNewTab(url)
+    }
+
+    func _testContextMenu(forTabAt index: Int) -> NSMenu? {
+        self.contextMenu(forTabAt: index)
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/DashboardWindow.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindow.swift
@@ -11,6 +11,7 @@ enum DashboardWindowLayout {
     static let linkBrowserMinWidth: CGFloat = 320
     static let linkBrowserMaxWidth: CGFloat = 760
     static let linkBrowserPreferredFraction: CGFloat = 0.4
+    static let linkBrowserTabBarHeight: CGFloat = 30
     static let linkBrowserSplitAutosaveName = "OpenClawDashboardLinkBrowserSplit"
 }
 
@@ -23,6 +24,12 @@ enum DashboardTargetlessNavigationAction: Equatable {
     case allow
     case openExternal
     case cancel
+}
+
+enum DashboardNewWindowAction: Equatable {
+    case openTab(URL)
+    case openExternal(URL)
+    case ignore
 }
 
 struct DashboardLinkRequest: Equatable {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -106,8 +106,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         linkMessageHandler.owner = self
         self.webView.navigationDelegate = self
         self.webView.uiDelegate = self
-        self.linkBrowser.webView.navigationDelegate = self
-        self.linkBrowser.webView.uiDelegate = self
+        self.linkBrowser.webViewNavigationDelegate = self
+        self.linkBrowser.webViewUIDelegate = self
         self.linkBrowser.onClose = { [weak self] in self?.closeLinkBrowser() }
         self.linkBrowser.onOpenExternal = { [weak self] url in self?.openExternal(url) }
         self.window?.delegate = self
@@ -125,7 +125,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         initiatedByFrame _: WKFrameInfo,
         completionHandler: @escaping @MainActor @Sendable ([URL]?) -> Void)
     {
-        guard webView === self.webView || webView === self.linkBrowser.webView else {
+        guard webView === self.webView || self.linkBrowser.owns(webView) else {
             completionHandler(nil)
             return
         }
@@ -152,15 +152,25 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         windowFeatures _: WKWindowFeatures) -> WKWebView?
     {
         // WebKit reaches this callback only for user-allowed new-window requests;
-        // both configurations disable automatic JavaScript windows.
-        guard webView === self.webView || webView === self.linkBrowser.webView,
-              navigationAction.targetFrame == nil,
-              let url = navigationAction.request.url,
-              Self.isHTTPURL(url)
+        // every configuration disables automatic JavaScript windows.
+        guard navigationAction.targetFrame == nil,
+              webView === self.webView || self.linkBrowser.owns(webView)
         else {
             return nil
         }
-        self.openExternal(url)
+        // Sidebar target=_blank links become tabs; dashboard requests preserve
+        // the existing handoff to the default browser.
+        switch Self.newWindowAction(
+            for: navigationAction.request.url,
+            sourceIsLinkBrowser: self.linkBrowser.owns(webView))
+        {
+        case let .openTab(url):
+            self.linkBrowser.openInNewTab(url)
+        case let .openExternal(url):
+            self.openExternal(url)
+        case .ignore:
+            break
+        }
         return nil
     }
 
@@ -232,7 +242,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private func openLinkBrowser(_ url: URL) {
         self.linkBrowserItem.isCollapsed = false
         self.linkBrowser.open(url)
-        window?.makeFirstResponder(self.linkBrowser.webView)
+        window?.makeFirstResponder(self.linkBrowser.activeWebView)
     }
 
     private func closeLinkBrowser(focusDashboard: Bool = true) {
@@ -590,7 +600,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void)
     {
         let isDashboardWebView = webView === self.webView
-        let isLinkBrowserWebView = webView === self.linkBrowser.webView
+        let isLinkBrowserWebView = self.linkBrowser.owns(webView)
         guard isDashboardWebView || isLinkBrowserWebView else {
             decisionHandler(.cancel)
             return
@@ -625,7 +635,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             let isMainFrame = navigationAction.targetFrame?.isMainFrame == true
             if Self.shouldAllowBrowserNavigation(to: url, isMainFrame: isMainFrame) {
                 if isMainFrame {
-                    self.linkBrowser.navigationWillStart(url)
+                    self.linkBrowser.navigationWillStart(url, in: webView)
                 }
                 decisionHandler(.allow)
                 return
@@ -670,19 +680,19 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
-        if webView === self.linkBrowser.webView {
+        if self.linkBrowser.owns(webView) {
             self.linkBrowser.updateChrome()
         }
     }
 
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-        if webView === self.linkBrowser.webView {
-            self.linkBrowser.navigationDidFinish()
+        if self.linkBrowser.owns(webView) {
+            self.linkBrowser.navigationDidFinish(for: webView)
         }
     }
 
     func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError error: Error) {
-        if webView === self.linkBrowser.webView {
+        if self.linkBrowser.owns(webView) {
             self.linkBrowser.updateChrome()
             return
         }
@@ -695,7 +705,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         didFailProvisionalNavigation _: WKNavigation!,
         withError error: Error)
     {
-        if webView === self.linkBrowser.webView {
+        if self.linkBrowser.owns(webView) {
             self.linkBrowser.updateChrome()
             return
         }
@@ -754,6 +764,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             return .openExternal
         }
         return .cancel
+    }
+
+    static func newWindowAction(for url: URL?, sourceIsLinkBrowser: Bool) -> DashboardNewWindowAction {
+        guard let url, self.isHTTPURL(url) else { return .ignore }
+        return sourceIsLinkBrowser ? .openTab(url) : .openExternal(url)
     }
 
     private func decideTargetlessNavigation(
@@ -919,7 +934,10 @@ extension DashboardWindowController {
     }
 
     var _testLinkBrowserDataStore: WKWebsiteDataStore {
-        self.linkBrowser.webView.configuration.websiteDataStore
+        // Prefer the active tab's configured store so tests catch a tab that
+        // was built with the wrong (non-shared) data store.
+        self.linkBrowser.activeWebView?.configuration.websiteDataStore
+            ?? self.linkBrowser._testWebsiteDataStore
     }
 
     var _testLinkBrowserRepresentedURL: URL? {
@@ -930,25 +948,26 @@ extension DashboardWindowController {
         self.linkBrowser._testNavigationObservationCount
     }
 
-    var _testLinkBrowserWebViewIdentity: ObjectIdentifier {
-        ObjectIdentifier(self.linkBrowser.webView)
+    var _testLinkBrowserWebViewIdentity: ObjectIdentifier? {
+        self.linkBrowser.activeWebView.map(ObjectIdentifier.init)
     }
 
     var _testLinkBrowserWebViewURL: URL? {
-        self.linkBrowser.webView.url
+        self.linkBrowser.activeWebView?.url
     }
 
     var _testLinkBrowserHistoryIsEmpty: Bool {
-        let history = self.linkBrowser.webView.backForwardList
+        guard let history = self.linkBrowser.activeWebView?.backForwardList else { return true }
         return history.currentItem == nil && history.backItem == nil && history.forwardItem == nil
     }
 
     var _testLinkBrowserDelegatesAreInstalled: Bool {
-        self.linkBrowser.webView.navigationDelegate === self && self.linkBrowser.webView.uiDelegate === self
+        guard let webView = self.linkBrowser.activeWebView else { return false }
+        return webView.navigationDelegate === self && webView.uiDelegate === self
     }
 
     var _testLinkBrowserWebViewIsInstalled: Bool {
-        self.linkBrowser.webView.superview === self.linkBrowser
+        self.linkBrowser.activeWebView?.superview === self.linkBrowser
     }
 
     var _testDashboardDataStore: WKWebsiteDataStore {
@@ -957,7 +976,9 @@ extension DashboardWindowController {
 
     var _testCanOpenWindowsAutomatically: Bool {
         self.webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically ||
-            self.linkBrowser.webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically
+            self.linkBrowser._testAllWebViews.contains {
+                $0.configuration.preferences.javaScriptCanOpenWindowsAutomatically
+            }
     }
 
     var _testSplitAutosaveName: String? {
@@ -970,6 +991,38 @@ extension DashboardWindowController {
 
     func _testCloseLinkBrowser() {
         self.closeLinkBrowser()
+    }
+
+    var _testLinkBrowserTabCount: Int {
+        self.linkBrowser._testTabCount
+    }
+
+    var _testLinkBrowserTabURLs: [URL?] {
+        self.linkBrowser._testTabURLs
+    }
+
+    var _testLinkBrowserActiveTabIndex: Int? {
+        self.linkBrowser._testActiveTabIndex
+    }
+
+    func _testLinkBrowserOpenInNewTab(_ url: URL) {
+        self.linkBrowser.openInNewTab(url)
+    }
+
+    func _testLinkBrowserCloseTab(at index: Int) {
+        self.linkBrowser._testCloseTab(at: index)
+    }
+
+    func _testLinkBrowserMoveTab(from fromIndex: Int, to toIndex: Int) {
+        self.linkBrowser._testMoveTab(from: fromIndex, to: toIndex)
+    }
+
+    func _testLinkBrowserSelectTab(at index: Int) {
+        self.linkBrowser._testSelectTab(at: index)
+    }
+
+    func _testLinkBrowserContextMenu(forTabAt index: Int) -> NSMenu? {
+        self.linkBrowser._testContextMenu(forTabAt: index)
     }
 
     var _testAllowsBackForwardGestures: Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Foundation
-@testable import OpenClaw
 import Testing
+@testable import OpenClaw
 
 @Suite(.serialized)
 @MainActor
@@ -13,9 +13,7 @@ struct DashboardWindowSmokeTests {
             auth: DashboardWindowAuth(
                 gatewayUrl: "ws://127.0.0.1:18789/control/",
                 token: "device-token",
-                password: nil
-            )
-        )
+                password: nil))
         controller.show()
         #expect(controller.window?.styleMask.contains(.titled) == true)
         #expect(controller.window?.styleMask.contains(.closable) == true)
@@ -31,21 +29,17 @@ struct DashboardWindowSmokeTests {
         let staleEndpoint = try #require(URL(string: "http://127.0.0.1:18790/control/chat"))
         #expect(try DashboardWindowController.shouldAllowNavigation(
             to: #require(URL(string: "http://127.0.0.1:18789/control/chat")),
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
         #expect(try !DashboardWindowController.shouldAllowNavigation(
             to: #require(URL(string: "https://docs.openclaw.ai/")),
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: staleEndpoint,
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
         #expect(!DashboardWindowController.shouldOpenExternalDashboardNavigation(
             staleEndpoint,
             navigationType: .backForward,
-            buttonNumber: 1
-        ))
+            buttonNumber: 1))
     }
 
     @Test func `dashboard parses only bounded native link requests`() throws {
@@ -56,8 +50,7 @@ struct DashboardWindowSmokeTests {
         ])
         #expect(try request == DashboardLinkRequest(
             url: #require(URL(string: "https://docs.openclaw.ai/platforms/macos")),
-            target: .inline
-        ))
+            target: .inline))
 
         #expect(DashboardWindowController.linkRequest(from: [
             "type": "open-link",
@@ -80,8 +73,7 @@ struct DashboardWindowSmokeTests {
             "target": "external",
         ]) == DashboardLinkRequest(
             url: #require(URL(string: "mailto:hello@example.com")),
-            target: .external
-        ))
+            target: .external))
         #expect(DashboardWindowController.linkRequest(from: [
             "type": "open-link",
             "url": "mailto:hello@example.com",
@@ -106,47 +98,147 @@ struct DashboardWindowSmokeTests {
         #expect(DashboardWindowController.shouldAllowEditorURLLaunch(
             from: trusted,
             isMainFrame: true,
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
         #expect(!DashboardWindowController.shouldAllowEditorURLLaunch(
             from: wrongPath,
             isMainFrame: true,
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
         #expect(!DashboardWindowController.shouldAllowEditorURLLaunch(
             from: trusted,
             isMainFrame: false,
-            dashboardURL: dashboard
-        ))
+            dashboardURL: dashboard))
     }
 
-    @Test func `dashboard link browser is isolated collapsed and width persistent`() throws {
+    @Test func `dashboard link browser tabs preserve isolation and lifecycle`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(
             url: dashboard,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
-        )
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         #expect(controller._testLinkBrowserIsCollapsed)
+        #expect(controller._testLinkBrowserTabCount == 0)
+        #expect(controller._testLinkBrowserActiveTabIndex == nil)
+        #expect(controller._testLinkBrowserWebViewIdentity == nil)
         #expect(controller._testLinkBrowserDataStore === controller._testDashboardDataStore)
         #expect(!controller._testCanOpenWindowsAutomatically)
-        #expect(controller._testLinkBrowserNavigationObservationCount == 3)
+        #expect(controller._testLinkBrowserNavigationObservationCount == 0)
         #expect(controller._testSplitAutosaveName == DashboardWindowLayout.linkBrowserSplitAutosaveName)
-        let initialBrowserIdentity = controller._testLinkBrowserWebViewIdentity
 
-        let report = try #require(URL(string: "http://127.0.0.1:1/report"))
-        controller._testOpenLinkBrowser(report)
+        let urlA = try #require(URL(string: "http://127.0.0.1:1/a"))
+        let urlB = try #require(URL(string: "http://127.0.0.1:1/b"))
+        controller._testOpenLinkBrowser(urlA)
+        #expect(controller._testLinkBrowserTabCount == 1)
+        #expect(controller._testLinkBrowserTabURLs == [urlA])
+        #expect(controller._testLinkBrowserActiveTabIndex == 0)
         #expect(!controller._testLinkBrowserIsCollapsed)
-        #expect(controller._testLinkBrowserRepresentedURL == report)
-        controller._testCloseLinkBrowser()
+        #expect(controller._testLinkBrowserRepresentedURL == urlA)
+        #expect(!controller._testCanOpenWindowsAutomatically)
+
+        controller._testOpenLinkBrowser(urlB)
+        #expect(controller._testLinkBrowserTabURLs == [urlA, urlB])
+        #expect(controller._testLinkBrowserActiveTabIndex == 1)
+        controller._testOpenLinkBrowser(urlA)
+        #expect(controller._testLinkBrowserTabURLs == [urlA, urlB])
+        #expect(controller._testLinkBrowserActiveTabIndex == 0)
+
+        controller._testLinkBrowserOpenInNewTab(urlA)
+        #expect(controller._testLinkBrowserTabURLs == [urlA, urlB, urlA])
+        #expect(controller._testLinkBrowserActiveTabIndex == 2)
+        controller._testLinkBrowserSelectTab(at: 1)
+        controller._testLinkBrowserCloseTab(at: 1)
+        #expect(controller._testLinkBrowserTabURLs == [urlA, urlA])
+        #expect(controller._testLinkBrowserActiveTabIndex == 1)
+        controller._testLinkBrowserCloseTab(at: 0)
+        controller._testLinkBrowserCloseTab(at: 0)
         #expect(controller._testLinkBrowserIsCollapsed)
+        #expect(controller._testLinkBrowserTabCount == 0)
         #expect(controller._testLinkBrowserRepresentedURL == nil)
-        #expect(controller._testLinkBrowserWebViewIdentity != initialBrowserIdentity)
-        #expect(controller._testLinkBrowserNavigationObservationCount == 3)
+
+        controller._testOpenLinkBrowser(urlB)
+        #expect(!controller._testLinkBrowserIsCollapsed)
+        #expect(controller._testLinkBrowserTabCount == 1)
         #expect(controller._testLinkBrowserWebViewURL == nil)
         #expect(controller._testLinkBrowserHistoryIsEmpty)
         #expect(controller._testLinkBrowserDelegatesAreInstalled)
         #expect(controller._testLinkBrowserWebViewIsInstalled)
+        #expect(controller._testLinkBrowserNavigationObservationCount == 4)
         #expect(controller._testLinkBrowserDataStore === controller._testDashboardDataStore)
+        controller._testLinkBrowserOpenInNewTab(urlA)
+        #expect(controller._testLinkBrowserTabCount == 2)
+        controller._testCloseLinkBrowser()
+        #expect(controller._testLinkBrowserIsCollapsed)
+        #expect(controller._testLinkBrowserTabCount == 0)
+        #expect(controller._testLinkBrowserRepresentedURL == nil)
+    }
+
+    @Test func `dashboard link browser reorders and closes other tabs`() throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        let urlA = try #require(URL(string: "https://127.0.0.1:1/a"))
+        let urlB = try #require(URL(string: "https://127.0.0.1:1/b"))
+        let urlC = try #require(URL(string: "https://127.0.0.1:1/c"))
+        controller._testOpenLinkBrowser(urlA)
+        controller._testOpenLinkBrowser(urlB)
+        controller._testOpenLinkBrowser(urlC)
+        controller._testLinkBrowserSelectTab(at: 1)
+        let activeIdentity = controller._testLinkBrowserWebViewIdentity
+
+        controller._testLinkBrowserMoveTab(from: 0, to: 2)
+        #expect(controller._testLinkBrowserTabURLs == [urlB, urlC, urlA])
+        #expect(controller._testLinkBrowserActiveTabIndex == 0)
+        #expect(controller._testLinkBrowserWebViewIdentity == activeIdentity)
+
+        let menu = try #require(controller._testLinkBrowserContextMenu(forTabAt: 2))
+        #expect(menu.items.map(\.title) == [
+            "Open in Default Browser",
+            "Copy Link",
+            "Reload",
+            "",
+            "Close Tab",
+            "Close Other Tabs",
+        ])
+        #expect(menu.items[0].isEnabled)
+        #expect(menu.items[1].isEnabled)
+        #expect(menu.items[2].isEnabled)
+        #expect(menu.items[4].isEnabled)
+        #expect(menu.items[5].isEnabled)
+        menu.performActionForItem(at: 5)
+        #expect(controller._testLinkBrowserTabURLs == [urlA])
+        #expect(controller._testLinkBrowserActiveTabIndex == 0)
+    }
+
+    @Test func `dashboard link browser menu disables URL actions for blank tab`() throws {
+        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+        let url = try #require(URL(string: "http://127.0.0.1:1/blank"))
+        view.open(url)
+        let webView = try #require(view._testActiveWebView)
+        #expect(webView.url == nil)
+        view.navigationDidFinish(for: webView)
+        let menu = try #require(view._testContextMenu(forTabAt: 0))
+        #expect(!menu.items[0].isEnabled)
+        #expect(!menu.items[1].isEnabled)
+        #expect(!menu.items[2].isEnabled)
+        #expect(menu.items[4].isEnabled)
+        #expect(!menu.items[5].isEnabled)
+        view.closeBrowser()
+    }
+
+    @Test func `dashboard new windows route by source browser`() throws {
+        let url = try #require(URL(string: "https://127.0.0.1:1/new"))
+        let fileURL = try #require(URL(string: "file:///tmp/private"))
+        #expect(DashboardWindowController.newWindowAction(
+            for: url,
+            sourceIsLinkBrowser: true) == .openTab(url))
+        #expect(DashboardWindowController.newWindowAction(
+            for: url,
+            sourceIsLinkBrowser: false) == .openExternal(url))
+        #expect(DashboardWindowController.newWindowAction(
+            for: fileURL,
+            sourceIsLinkBrowser: true) == .ignore)
+        #expect(DashboardWindowController.newWindowAction(
+            for: nil,
+            sourceIsLinkBrowser: false) == .ignore)
     }
 
     @Test func `sidebar browser reserves auxiliary schemes for subframes`() throws {
@@ -168,56 +260,47 @@ struct DashboardWindowSmokeTests {
         #expect(DashboardWindowController.shouldOpenExternalDashboardNavigation(
             webURL,
             navigationType: .linkActivated,
-            buttonNumber: 1
-        ))
+            buttonNumber: 1))
         #expect(DashboardWindowController.shouldOpenExternalDashboardNavigation(
             mailURL,
             navigationType: .linkActivated,
-            buttonNumber: 1
-        ))
+            buttonNumber: 1))
         #expect(!DashboardWindowController.shouldOpenExternalDashboardNavigation(
             webURL,
             navigationType: .linkActivated,
-            buttonNumber: 0
-        ))
+            buttonNumber: 0))
         #expect(!DashboardWindowController.shouldOpenExternalDashboardNavigation(
             mailURL,
             navigationType: .other,
-            buttonNumber: 1
-        ))
+            buttonNumber: 1))
 
         #expect(DashboardWindowController.targetlessNavigationAction(
             for: webURL,
             navigationType: .linkActivated,
             buttonNumber: 1,
-            allowEditorURLs: false
-        ) == .allow)
+            allowEditorURLs: false) == .allow)
         #expect(DashboardWindowController.targetlessNavigationAction(
             for: mailURL,
             navigationType: .linkActivated,
             buttonNumber: 1,
-            allowEditorURLs: false
-        ) == .openExternal)
+            allowEditorURLs: false) == .openExternal)
         #expect(DashboardWindowController.targetlessNavigationAction(
             for: mailURL,
             navigationType: .linkActivated,
             buttonNumber: 0,
-            allowEditorURLs: false
-        ) == .cancel)
+            allowEditorURLs: false) == .cancel)
 
         let editorURL = try #require(URL(string: "vscode://file/workspace/src/foo.ts"))
         #expect(DashboardWindowController.targetlessNavigationAction(
             for: editorURL,
             navigationType: .other,
             buttonNumber: 0,
-            allowEditorURLs: true
-        ) == .openExternal)
+            allowEditorURLs: true) == .openExternal)
         #expect(DashboardWindowController.targetlessNavigationAction(
             for: editorURL,
             navigationType: .other,
             buttonNumber: 0,
-            allowEditorURLs: false
-        ) == .cancel)
+            allowEditorURLs: false) == .cancel)
     }
 
     @Test func `dashboard origin brackets ipv6 literals`() throws {
@@ -234,8 +317,7 @@ struct DashboardWindowSmokeTests {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
-        )
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         let chromeScript = try #require(controller._testUserScripts.first {
             $0.source.contains("openclaw-native-macos-chrome")
         })
@@ -269,13 +351,11 @@ struct DashboardWindowSmokeTests {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
-        )
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         controller.showFailure(
             title: "Dashboard unavailable",
             message: "Remote control tunnel failed",
-            detail: "Reset the remote tunnel and try again."
-        )
+            detail: "Reset the remote tunnel and try again.")
         #expect(controller.window?.isVisible == true)
         #expect(controller.window?.styleMask.contains(.closable) == true)
         controller.closeDashboard()
@@ -288,9 +368,7 @@ struct DashboardWindowSmokeTests {
             auth: DashboardWindowAuth(
                 gatewayUrl: "ws://127.0.0.1:60001/",
                 token: "device-token",
-                password: nil
-            )
-        )
+                password: nil))
         controller.show()
         return controller
     }
@@ -305,8 +383,7 @@ struct DashboardWindowSmokeTests {
             mode: .remote,
             url: #require(URL(string: "ws://127.0.0.1:60002")),
             token: "device-token",
-            password: nil
-        ))
+            password: nil))
 
         #expect(controller.currentURL.absoluteString == "http://127.0.0.1:60002/#token=device-token")
         let authScripts = controller._testUserScripts
@@ -328,8 +405,7 @@ struct DashboardWindowSmokeTests {
             mode: .remote,
             url: #require(URL(string: "ws://127.0.0.1:60001")),
             token: "device-token",
-            password: nil
-        ))
+            password: nil))
         await manager.handleEndpointState(.connecting(mode: .remote, detail: "Connecting…"))
         await manager.handleEndpointState(.unavailable(mode: .remote, reason: "tunnel down"))
 
@@ -345,9 +421,7 @@ struct DashboardWindowSmokeTests {
             auth: DashboardWindowAuth(
                 gatewayUrl: "ws://127.0.0.1:60001/",
                 token: "device-token",
-                password: nil
-            )
-        )
+                password: nil))
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
 
@@ -355,8 +429,7 @@ struct DashboardWindowSmokeTests {
             mode: .remote,
             url: #require(URL(string: "ws://127.0.0.1:60002")),
             token: "device-token",
-            password: nil
-        ))
+            password: nil))
 
         #expect(controller.currentURL == url)
     }

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -43,9 +43,9 @@ For permission recovery, use [macOS permissions](/platforms/mac/permissions).
 
 ## Open dashboard links
 
-In the macOS app's embedded dashboard, clicking an external web link opens it in a resizable browser sidebar. The window's titlebar back/forward controls and trackpad swipes navigate dashboard history; the sidebar's own back/forward controls navigate external page history. The sidebar also has reload, open-in-default-browser, and close controls, and it remembers its width.
+In the macOS app's embedded dashboard, clicking an external web link opens it in a resizable browser sidebar. Each link opens in its own tab; clicking the same link again reuses its existing tab. Drag tabs to reorder them, close them with the tab close button or a middle-click, and right-click a tab for **Open in Default Browser**, **Copy Link**, **Reload**, **Close Tab**, and **Close Other Tabs**. The window's titlebar back/forward controls and trackpad swipes navigate dashboard history; the sidebar's own back/forward controls navigate the active tab's history. The sidebar also has reload, open-in-default-browser, and close controls, and it remembers its width.
 
-Right-click an external link to choose **Open in Sidebar**, **Open in Default Browser**, or **Copy Link**. Modified clicks and user-activated new-window links continue to open in the default browser. Regular browser-hosted Control UI pages keep the browser's normal link and context-menu behavior.
+Right-click an external link to choose **Open in Sidebar**, **Open in Default Browser**, or **Copy Link**. Modified clicks and user-activated new-window links from the dashboard continue to open in the default browser; new-window links inside the sidebar open as new sidebar tabs. Regular browser-hosted Control UI pages keep the browser's normal link and context-menu behavior.
 
 ## Choose a Gateway mode
 


### PR DESCRIPTION
Closes #103334

## What Problem This Solves

In the macOS app's embedded dashboard, every external link opened in a single-page browser sidebar: opening a second link replaced the first page, and there was no way to keep several pages open, reorder them, or act on one page (open externally, copy its link) without losing another. The sidebar felt inconsistent with the rest of the product, where the terminal panel already has a tab strip.

## Why This Change Was Made

The link browser sidebar now has real tabs, each owning its own WKWebView. The header is browser-style per maintainer feedback: tab strip on top (below the window drag clearance), back/forward/reload/address/open-external/close controls underneath. Inline links from the Control UI reuse an existing tab when the URL matches exactly and open a new tab otherwise; user-activated target="_blank" links inside the sidebar open a new sidebar tab (dashboard-originated new-window links still go to the default browser). Tabs support click-to-activate, per-tab close buttons, middle-click close, pointer-drag reorder, and a per-tab context menu (Open in Default Browser, Copy Link, Reload, Close Tab, Close Other Tabs). Closing the last tab collapses the sidebar and disposes all webviews, preserving the existing no-lingering-history invariant. Every tab webview is built by the same hardened factory as before (shared persisted data store, no auth scripts, no privileged message handlers, JavaScript cannot open windows automatically), and the openclawLink trust checks are unchanged.

Non-goals: favicons, a "+" new-tab button (the sidebar has no URL entry), tab persistence across app restarts, and web-UI (ui/) changes.

## User Impact

macOS app users can keep multiple external pages open side-by-side in the dashboard sidebar, switch between them, drag tabs to reorder, close them individually (button or middle-click), and right-click a tab to open it in the default browser, copy its link, reload it, or close other tabs. Repeat clicks on the same chat link no longer pile up duplicate pages.

## Evidence

- swift build --package-path apps/macos --product OpenClaw — passes (re-verified after rebase on latest main).
- swift test --package-path apps/macos --filter OpenClawIPCTests — 711 tests / 118 suites; the only failure across runs was the pre-existing flake MacNodeCodexThreadCatalogTests ("drains App Server frames…", .timedOut) under parallel load; it passes in isolation together with the dashboard suite (27/27). Unrelated to this change; CI retries this lane 3x.
- swift test --filter DashboardWindowSmokeTests — 18/18, including new coverage: tab dedupe/open-in-new-tab, close-activates-neighbor, last-tab-close collapses + fresh history on reopen, reorder preserves active identity, context-menu items/enablement, newWindowAction routing (sidebar to tab, dashboard to external), and isolation invariants (shared data store, no automatic JS windows) across all tabs.
- swiftformat --lint (repo config) on all touched Swift files — clean.
- Autoreview (Codex gpt-5.5, thinking high): one finding rejected with compile proof (NSColor.quinaryLabel is real macOS 14+ AppKit API; the package builds), rerun clean: "no accepted/actionable findings".
- Live interaction proof (signed debug build, window driven via DEBUG test hooks and screenshotted):

| State | Screenshot |
| --- | --- |
| Three tabs, tabs-on-top header | ![initial](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-browser-tabs/tabs-initial-three.png) |
| Tab switch: github.com active, address follows | ![switch](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-browser-tabs/tabs-switch-github-active.png) |
| Reorder (moveTab 2 to 0), active tab identity preserved | ![reorder](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-browser-tabs/tabs-reordered.png) |
| After closing a tab, remaining tabs relayout | ![close](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-browser-tabs/tabs-after-close.png) |

- Known proof gaps: real-pointer drag/middle-click/context-menu were not synthetically driven end-to-end (the screenshot harness window cannot become the active app, and the shared clawmac gateway was flapping during verification); those pointer handlers route through the same delegate paths the unit tests and the scripted drive exercised, and menu construction/enablement is unit-tested.
- Docs updated: docs/platforms/macos.md (Open dashboard links section).
