### PR TITLE
test(terminal): cover C1 control filtering

### DIFF
--- a/src/gateway/terminal/buffer-text.test.ts
+++ b/src/gateway/terminal/buffer-text.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import { renderTerminalBufferText } from "./buffer-text.js";
 
 describe("renderTerminalBufferText", () => {
-  it("strips ANSI color and erase sequences", () => {
+  it("strips ANSI color and erase sequences in ESC and C1 forms", () => {
     expect(renderTerminalBufferText("\u001b[32mok\u001b[0m done\u001b[2K")).toBe("ok done");
+    expect(renderTerminalBufferText("\u009b31mred\u009b0m")).toBe("red");
   });
 
   it("collapses carriage-return overwrites to the last write per line", () => {
@@ -16,6 +17,13 @@ describe("renderTerminalBufferText", () => {
 
   it("drops residual control bytes but keeps tabs", () => {
     expect(renderTerminalBufferText("a\u0007b\tc")).toBe("ab\tc");
+  });
+
+  it("drops the full residual C1 range without clipping adjacent Unicode text", () => {
+    const c1 = Array.from({ length: 0x20 }, (_, offset) =>
+      String.fromCharCode(0x80 + offset),
+    ).join("");
+    expect(renderTerminalBufferText(`a\u007f${c1}\u00a0b\tc`)).toBe("a\u00a0b\tc");
   });
 
   it("strips OSC title sequences", () => {


### PR DESCRIPTION
Closes #103435

## What Problem This Solves

Fixes a release-proof gap where the C1-control filtering landed in #103274 had no focused regression coverage, so an off-by-one or removal regression could pass the existing terminal buffer tests.

## Why This Change Was Made

The test now covers a valid C1 CSI sequence, every residual C1 character from U+0080 through U+009F, and both adjacent boundaries: DEL remains filtered while U+00A0 and tabs remain visible. Production code is unchanged.

## User Impact

No runtime behavior changes. Release and future refactor validation now protect the intended `terminal.text` plain-text contract.

## Evidence

- Rebased exact head: `b1c3b899910cf58aaa0d1b0bf29d6bc2b1cb4f6c` on current `main` base `7b03a2ae201ab9c27dc3bc39569e97c9f9582360`; original patch-id preserved.
- Blacksmith Testbox `tbx_01kx5tbg2gqvkkkgxrv15bjban`: final-head focused gateway proof passed in all four routed projects (4 files, 24 tests).
- Same Testbox: `corepack pnpm check:changed` passed (`coreTests` typecheck, lint, and guards).
- Mutation proof: temporarily reverting the production C1 filter made the new full-range assertion fail in all four gateway projects (20 existing tests passed, 4 new regression instances failed); restoring the filter returned the suite to green. The mutation branch was never pushed.
- Broad Testbox run included the touched test successfully. Four unrelated shards failed: an aggregate-only UI custom-element registration collision (focused cron test: 3/3 passed), a stale QA scenario count, stale OpenAI default-model expectations, and Signal monitor mock-delivery failures.
- `git diff --check`: passed.
- Fresh Codex autoreview on the final rebased head: no accepted or actionable findings; patch correct (0.94).
- Scope: one test file, +9/-1; no production or changelog changes.

The previous exact-head CI failure was unrelated: `test/scripts/tsdown-build.test.ts` observed an already-dead process-group child. Fresh exact-head hosted checks are rerunning after the rebase.
