### PR TITLE
fix: sandbox containers exhaust process limits after long runs

### DIFF
--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -1,6 +1,7 @@
 // Verifies Docker create arguments for sandbox hardening and configured passthrough.
 import { describe, expect, it } from "vitest";
 import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
+import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./sandbox/constants.js";
 import { buildSandboxCreateArgs } from "./sandbox/docker.js";
 import type { SandboxDockerConfig } from "./sandbox/types.js";
 
@@ -101,6 +102,7 @@ describe("buildSandboxCreateArgs", () => {
       "openclaw.sandbox=1",
       "openclaw.sessionKey=main",
       "openclaw.createdAtMs=1700000000000",
+      `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`,
       "openclaw.sandboxBrowser=1",
     ]);
     expect(args).toContain("--read-only");
@@ -374,5 +376,20 @@ describe("buildSandboxCreateArgs", () => {
       createdAtMs: 1700000000000,
     });
     expectFlagValues(args, "--network", ["container:peer"]);
+  });
+
+  it("passes one --init flag so Docker reaps orphaned processes", () => {
+    const cfg = createSandboxConfig();
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-init",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+    expect(args.filter((arg) => arg === "--init")).toHaveLength(1);
+    // Docker create options must follow the subcommand and precede the image.
+    const createIdx = args.indexOf("create");
+    const initIdx = args.indexOf("--init");
+    expect(initIdx).toBeGreaterThan(createIdx);
   });
 });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -12,6 +12,7 @@ import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
 import {
   SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH,
   SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
+  SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
 } from "./constants.js";
 import { collectDockerFlagValues, findDockerArgsCall } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
@@ -37,6 +38,10 @@ const registryMocks = vi.hoisted(() => ({
 const bridgeMocks = vi.hoisted(() => ({
   startBrowserBridgeServer: vi.fn(),
   stopBrowserBridgeServer: vi.fn(),
+}));
+
+const runtimeMocks = vi.hoisted(() => ({
+  log: vi.fn(),
 }));
 
 const tmpDirs: string[] = [];
@@ -67,6 +72,10 @@ vi.mock("./registry.js", () => ({
 vi.mock("../../plugin-sdk/browser-bridge.js", () => ({
   startBrowserBridgeServer: bridgeMocks.startBrowserBridgeServer,
   stopBrowserBridgeServer: bridgeMocks.stopBrowserBridgeServer,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: runtimeMocks,
 }));
 
 vi.mock("../../plugin-sdk/browser-profiles.js", () => ({
@@ -154,6 +163,41 @@ function buildConfig(enableNoVnc: boolean): SandboxConfig {
   };
 }
 
+function computeTestBrowserHash(params: {
+  cfg: SandboxConfig;
+  createArgsEpoch: string;
+  workspaceDir?: string;
+  agentWorkspaceDir?: string;
+  dockerEnvPolicyEpoch?: string;
+}): string {
+  const workspaceDir = params.workspaceDir ?? "/tmp/workspace";
+  const agentWorkspaceDir = params.agentWorkspaceDir ?? workspaceDir;
+  const browserDockerCfg = resolveSandboxBrowserDockerCreateConfig({
+    docker: params.cfg.docker,
+    browser: params.cfg.browser,
+  });
+  return computeSandboxBrowserConfigHash({
+    docker: browserDockerCfg,
+    dockerEnvPolicyEpoch: params.dockerEnvPolicyEpoch,
+    browser: {
+      cdpPort: params.cfg.browser.cdpPort,
+      cdpSourceRange: params.cfg.browser.cdpSourceRange,
+      vncPort: params.cfg.browser.vncPort,
+      noVncPort: params.cfg.browser.noVncPort,
+      headless: params.cfg.browser.headless,
+      enableNoVnc: params.cfg.browser.enableNoVnc,
+      autoStartTimeoutMs: params.cfg.browser.autoStartTimeoutMs,
+    },
+    securityEpoch: SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
+    workspaceAccess: params.cfg.workspaceAccess,
+    workspaceDir,
+    agentWorkspaceDir,
+    mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    createArgsEpoch: params.createArgsEpoch,
+    readOnlyWorkspaceSkillMounts: [],
+  });
+}
+
 type EnsureSandboxBrowserParams = Parameters<typeof import("./browser.js").ensureSandboxBrowser>[0];
 
 async function ensureTestSandboxBrowser(params: Omit<EnsureSandboxBrowserParams, "bridgeAuth">) {
@@ -214,6 +258,7 @@ describe("ensureSandboxBrowser create args", () => {
     registryMocks.updateBrowserRegistry.mockClear();
     bridgeMocks.startBrowserBridgeServer.mockClear();
     bridgeMocks.stopBrowserBridgeServer.mockClear();
+    runtimeMocks.log.mockClear();
 
     dockerMocks.dockerContainerState.mockResolvedValue({ exists: false, running: false });
     dockerMocks.execDocker.mockImplementation(async (args: string[]) => {
@@ -306,6 +351,96 @@ describe("ensureSandboxBrowser create args", () => {
     expect(result?.noVncUrl).not.toContain("password=");
   });
 
+  it("creates browser containers with Docker init and the shared args epoch", async () => {
+    await ensureTestSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg: buildConfig(false),
+    });
+
+    const createArgs = requireDockerCreateArgs();
+    expect(createArgs.filter((arg) => arg === "--init")).toHaveLength(1);
+    expect(createArgs).toContain(`openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`);
+  });
+
+  it("recreates a cold browser container when the shared args epoch changes", async () => {
+    const cfg = buildConfig(false);
+    const oldHash = computeTestBrowserHash({
+      cfg,
+      createArgsEpoch: "pre-init",
+    });
+    dockerMocks.dockerContainerState.mockResolvedValue({ exists: true, running: true });
+    dockerMocks.readDockerContainerEnvVar.mockResolvedValue("existing-cdp-token");
+    dockerMocks.readDockerContainerLabel.mockResolvedValue(oldHash);
+    registryMocks.readBrowserRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-browser-session-test-0661d10a",
+          sessionKey: "session:test",
+          createdAtMs: 1,
+          lastUsedAtMs: 0,
+          image: cfg.browser.image,
+          configHash: oldHash,
+          cdpPort: 49100,
+        },
+      ],
+    });
+
+    await ensureTestSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    expect(dockerMocks.execDocker).toHaveBeenCalledWith(
+      ["rm", "-f", "openclaw-sbx-browser-session-test-0661d10a"],
+      { allowFailure: true },
+    );
+    expect(requireDockerCreateArgs()).toContain("--init");
+  });
+
+  it("keeps a hot pre-init browser running and emits the recreate hint", async () => {
+    const cfg = buildConfig(false);
+    const oldHash = computeTestBrowserHash({
+      cfg,
+      createArgsEpoch: "pre-init",
+    });
+    dockerMocks.dockerContainerState.mockResolvedValue({ exists: true, running: true });
+    dockerMocks.readDockerContainerEnvVar.mockResolvedValue("existing-cdp-token");
+    dockerMocks.readDockerContainerLabel.mockResolvedValue(oldHash);
+    registryMocks.readBrowserRegistry.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-browser-session-test-0661d10a",
+          sessionKey: "session:test",
+          createdAtMs: 1,
+          lastUsedAtMs: Date.now(),
+          image: cfg.browser.image,
+          configHash: oldHash,
+          cdpPort: 49100,
+        },
+      ],
+    });
+
+    await ensureTestSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    expect(findDockerArgsCall(dockerMocks.execDocker.mock.calls, "rm")).toBeUndefined();
+    expect(findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create")).toBeUndefined();
+    expect(runtimeMocks.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Recreate to apply: openclaw sandbox recreate --browser --session session:test",
+      ),
+    );
+    expect(registryMocks.updateBrowserRegistry.mock.calls.at(-1)?.[0]?.configHash).toBe(oldHash);
+  });
+
   it("does not inject noVNC password env when noVNC is disabled", async () => {
     const result = await ensureTestSandboxBrowser({
       scopeKey: "session:test",
@@ -362,28 +497,12 @@ describe("ensureSandboxBrowser create args", () => {
     const scopeKey = "session-1";
     const workspaceDir = "/tmp/workspace";
     const agentWorkspaceDir = "/tmp/workspace";
-    const browserDockerCfg = resolveSandboxBrowserDockerCreateConfig({
-      docker: cfg.docker,
-      browser: cfg.browser,
-    });
-    const expectedHash = computeSandboxBrowserConfigHash({
-      docker: browserDockerCfg,
+    const expectedHash = computeTestBrowserHash({
+      cfg,
       dockerEnvPolicyEpoch: SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
-      browser: {
-        cdpPort: cfg.browser.cdpPort,
-        vncPort: cfg.browser.vncPort,
-        noVncPort: cfg.browser.noVncPort,
-        headless: cfg.browser.headless,
-        enableNoVnc: cfg.browser.enableNoVnc,
-        autoStartTimeoutMs: cfg.browser.autoStartTimeoutMs,
-        cdpSourceRange: undefined,
-      },
-      securityEpoch: SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
-      workspaceAccess: cfg.workspaceAccess,
       workspaceDir,
       agentWorkspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     });
 
     await ensureTestSandboxBrowser({

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_SANDBOX_BROWSER_IMAGE,
   SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH,
   SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
+  SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
 } from "./constants.js";
 import {
   buildSandboxCreateArgs,
@@ -265,6 +266,7 @@ export async function ensureSandboxBrowser(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     readOnlyWorkspaceSkillMounts: formatReadOnlyWorkspaceSkillMountHashState(
       readOnlyWorkspaceSkillMounts,
     ),

--- a/src/agents/sandbox/config-hash.test.ts
+++ b/src/agents/sandbox/config-hash.test.ts
@@ -2,6 +2,7 @@
 // recreation versus reuse.
 import { describe, expect, it } from "vitest";
 import { computeSandboxBrowserConfigHash, computeSandboxConfigHash } from "./config-hash.js";
+import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import type { SandboxDockerConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
@@ -63,6 +64,7 @@ describe("computeSandboxConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxConfigHash({
       ...shared,
@@ -95,6 +97,7 @@ describe("computeSandboxConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxConfigHash({
       ...shared,
@@ -110,6 +113,20 @@ describe("computeSandboxConfigHash", () => {
     });
     expect(left).not.toBe(right);
   });
+
+  it("changes when the shared Docker create-args epoch changes", () => {
+    const shared = {
+      docker: createDockerConfig(),
+      workspaceAccess: "rw" as const,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    };
+    const left = computeSandboxConfigHash({ ...shared, createArgsEpoch: "epoch-v1" });
+    const right = computeSandboxConfigHash({ ...shared, createArgsEpoch: "epoch-v2" });
+    expect(left).not.toBe(right);
+  });
+
   it("changes when read-only workspace skill mount state changes", () => {
     // Skill overlays affect what the sandbox can read, so they are part of the
     // reuse identity even though they are read-only.
@@ -120,6 +137,7 @@ describe("computeSandboxConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
 
     const withoutSkills = computeSandboxConfigHash({
@@ -153,6 +171,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -166,6 +185,29 @@ describe("computeSandboxBrowserConfigHash", () => {
         binds: ["/tmp/cache:/cache:ro", "/tmp/workspace:/workspace:rw"],
       }),
     });
+    expect(left).not.toBe(right);
+  });
+
+  it("changes when the shared Docker create-args epoch changes", () => {
+    const shared = {
+      docker: createDockerConfig(),
+      browser: {
+        cdpPort: 9222,
+        cdpSourceRange: undefined,
+        vncPort: 5900,
+        noVncPort: 6080,
+        headless: false,
+        enableNoVnc: true,
+        autoStartTimeoutMs: 12000,
+      },
+      securityEpoch: "browser-security-v1",
+      workspaceAccess: "rw" as const,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    };
+    const left = computeSandboxBrowserConfigHash({ ...shared, createArgsEpoch: "epoch-v1" });
+    const right = computeSandboxBrowserConfigHash({ ...shared, createArgsEpoch: "epoch-v2" });
     expect(left).not.toBe(right);
   });
 
@@ -185,6 +227,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -213,6 +256,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,
@@ -241,6 +285,7 @@ describe("computeSandboxBrowserConfigHash", () => {
       workspaceAccess: "rw" as const,
       workspaceDir: "/tmp/workspace",
       agentWorkspaceDir: "/tmp/workspace",
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     };
     const left = computeSandboxBrowserConfigHash({
       ...shared,

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -21,6 +21,7 @@ type SandboxHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  createArgsEpoch: string;
   readOnlyWorkspaceSkillMounts?: readonly string[];
 };
 
@@ -42,6 +43,7 @@ type SandboxBrowserHashInput = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   mountFormatVersion: number;
+  createArgsEpoch: string;
   readOnlyWorkspaceSkillMounts?: readonly string[];
 };
 

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -48,6 +48,10 @@ export const DEFAULT_SANDBOX_COMMON_IMAGE = "openclaw-sandbox-common:bookworm-sl
 export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-05-12-cdp-relay-auth";
 export const SANDBOX_BROWSER_IMAGE_CONTRACT_EPOCH = "2026-05-12-cdp-relay-auth";
 
+// Bump with shared Docker create-flag changes so existing ordinary and browser
+// sandboxes roll through the hash/recreate path instead of keeping stale flags.
+export const SANDBOX_DOCKER_CREATE_ARGS_EPOCH = "2026-07-10-init";
+
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_NETWORK = "openclaw-sandbox-browser";
 export const DEFAULT_SANDBOX_BROWSER_CDP_PORT = 9222;

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -10,6 +10,7 @@ import {
   computeSandboxConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
 } from "./config-hash.js";
+import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import { collectDockerFlagValues } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
@@ -37,6 +38,10 @@ const registryMocks = vi.hoisted(() => ({
   updateRegistry: vi.fn(),
 }));
 
+const runtimeMocks = vi.hoisted(() => ({
+  log: vi.fn(),
+}));
+
 const tmpDirs: string[] = [];
 
 function makeTempDir(): string {
@@ -48,6 +53,10 @@ function makeTempDir(): string {
 vi.mock("./registry.js", () => ({
   readRegistryEntry: registryMocks.readRegistryEntry,
   updateRegistry: registryMocks.updateRegistry,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: runtimeMocks,
 }));
 
 function createMockDockerChild(): MockDockerChild {
@@ -114,6 +123,7 @@ async function createChildProcessMock() {
 vi.mock("node:child_process", async () => createChildProcessMock());
 
 let ensureSandboxContainer: typeof import("./docker.js").ensureSandboxContainer;
+let resolveDockerEnvPolicyEpoch: typeof import("./docker.js").resolveDockerEnvPolicyEpoch;
 
 async function loadFreshDockerModuleForTest() {
   vi.resetModules();
@@ -122,7 +132,7 @@ async function loadFreshDockerModuleForTest() {
     updateRegistry: registryMocks.updateRegistry,
   }));
   vi.doMock("node:child_process", async () => createChildProcessMock());
-  ({ ensureSandboxContainer } = await import("./docker.js"));
+  ({ ensureSandboxContainer, resolveDockerEnvPolicyEpoch } = await import("./docker.js"));
 }
 
 function createSandboxConfig(
@@ -212,6 +222,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     registryMocks.readRegistryEntry.mockClear();
     registryMocks.updateRegistry.mockClear();
     registryMocks.updateRegistry.mockResolvedValue(undefined);
+    runtimeMocks.log.mockClear();
     await loadFreshDockerModuleForTest();
   });
 
@@ -228,6 +239,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
       readOnlyWorkspaceSkillMounts: [],
     });
     const newHash = computeSandboxConfigHash({
@@ -236,6 +248,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
       readOnlyWorkspaceSkillMounts: [],
     });
     expect(newHash).not.toBe(oldHash);
@@ -275,6 +288,85 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(registryUpdate?.configHash).toBe(newHash);
   });
 
+  it("recreates a cold container when the shared Docker create-args epoch changes", async () => {
+    const workspaceDir = makeTempDir();
+    // Keep the create-args epoch as the only hash delta in this scenario.
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`], "rw", {});
+    const hashInput = {
+      docker: cfg.docker,
+      dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(cfg.docker.env),
+      workspaceAccess: cfg.workspaceAccess,
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      readOnlyWorkspaceSkillMounts: [],
+    };
+    const oldHash = computeSandboxConfigHash({
+      ...hashInput,
+      createArgsEpoch: "pre-init",
+    });
+    const newHash = computeSandboxConfigHash({
+      ...hashInput,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+    });
+
+    spawnState.labelHash = oldHash;
+    registryMocks.readRegistryEntry.mockResolvedValue({
+      containerName: "oc-test-shared",
+      sessionKey: "shared",
+      createdAtMs: 1,
+      lastUsedAtMs: 0,
+      image: cfg.docker.image,
+      configHash: oldHash,
+    });
+
+    const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
+    expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(true);
+    expect(createCall.args.filter((arg) => arg === "--init")).toHaveLength(1);
+    expect(createCall.args).toContain(
+      `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`,
+    );
+    expect(createCall.args).toContain(`openclaw.configHash=${newHash}`);
+  });
+
+  it("keeps a hot pre-init container running and emits the recreate hint", async () => {
+    const workspaceDir = makeTempDir();
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`], "rw", {});
+    const oldHash = computeSandboxConfigHash({
+      docker: cfg.docker,
+      dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(cfg.docker.env),
+      workspaceAccess: cfg.workspaceAccess,
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: "pre-init",
+      readOnlyWorkspaceSkillMounts: [],
+    });
+    spawnState.labelHash = oldHash;
+    registryMocks.readRegistryEntry.mockResolvedValue({
+      containerName: "oc-test-shared",
+      sessionKey: "shared",
+      createdAtMs: 1,
+      lastUsedAtMs: Date.now(),
+      image: cfg.docker.image,
+      configHash: oldHash,
+    });
+
+    await ensureSandboxContainer({
+      sessionKey: "agent:main:session-1",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg,
+    });
+
+    expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(false);
+    expect(spawnState.calls.some((call) => call.args[0] === "create")).toBe(false);
+    expect(runtimeMocks.log).toHaveBeenCalledWith(
+      expect.stringContaining("Recreate to apply: openclaw sandbox recreate --all"),
+    );
+    expect(registryMocks.updateRegistry.mock.calls.at(-1)?.[0]?.configHash).toBe(oldHash);
+  });
+
   it("recreates shared container when previously filtered explicit env becomes allowed", async () => {
     const workspaceDir = makeTempDir();
     const cfg = createSandboxConfig(["1.1.1.1"], undefined, "rw", {
@@ -289,6 +381,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
       readOnlyWorkspaceSkillMounts: [],
     });
     const newHash = computeSandboxConfigHash({
@@ -298,6 +391,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
       readOnlyWorkspaceSkillMounts: [],
     });
     expect(newHash).not.toBe(oldHash);
@@ -334,6 +428,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
       mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
       readOnlyWorkspaceSkillMounts: [],
     });
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -189,7 +189,7 @@ import {
   computeSandboxConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
 } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
+import { DEFAULT_SANDBOX_IMAGE, SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -438,10 +438,14 @@ export function buildSandboxCreateArgs(params: {
 
   const createdAtMs = params.createdAtMs ?? Date.now();
   const args = ["create", "--name", params.name];
+  // Docker's init owns PID 1 so orphaned children from long-running tool and
+  // browser workloads are reaped instead of accumulating against pidsLimit.
+  args.push("--init");
   args.push("--label", "openclaw.sandbox=1");
   args.push("--label", `openclaw.sessionKey=${params.scopeKey}`);
   args.push("--label", `openclaw.createdAtMs=${createdAtMs}`);
   args.push("--label", `openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`);
+  args.push("--label", `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`);
   if (params.configHash) {
     args.push("--label", `openclaw.configHash=${params.configHash}`);
   }
@@ -627,6 +631,7 @@ export async function ensureSandboxContainer(params: {
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
     readOnlyWorkspaceSkillMounts: formatReadOnlyWorkspaceSkillMountHashState(
       readOnlyWorkspaceSkillMounts,
     ),


### PR DESCRIPTION
Closes #68691

Supersedes #74083 and incorporates the rollout design from #76590.

## What Problem This Solves

Fixes an issue where long-running sandbox containers could accumulate orphaned zombie processes until their process limit was exhausted, causing otherwise valid commands to fail.

## Why This Change Was Made

Docker now starts every ordinary and browser sandbox with its built-in init process. One shared create-arguments epoch participates in both sandbox configuration hashes, so an idle container created under the old arguments is recreated automatically while a recently active container remains running and receives the existing explicit recreate hint. Existing environment, mount, network, capability, and security-policy inputs are unchanged.

Thanks @luckylhb90 for the original fix and @aaajiao for identifying the rollout requirement.

## User Impact

New or safely recreated sandbox containers reap orphaned descendants and no longer leak zombie processes toward the configured PID limit. Active containers are not interrupted automatically.

## Evidence

- Real Docker 29.4 negative control without init: one PID-1 zombie after an orphaned grandchild exited.
- Real Docker 29.4 with this branch: `HostConfig.Init=true`, PID 1 was `docker-init`, and the same orphaned-grandchild scenario left zero zombies.
- Real OpenClaw sandbox flow: an idle old-hash container was recreated; a recently active old-hash container was preserved and emitted the exact `openclaw sandbox recreate --all` hint.
- Focused Vitest proof: 63/63 tests passed across sandbox create arguments, ordinary/browser hashes, recreation, and hot-container deferral.
- Targeted `oxfmt` and `git diff --check` passed.
- Fresh configured Codex autoreview completed with no findings (0.91 confidence).
- Exact-head hosted CI passed on `0aacb507926e4416dc0c4d5337668de265b15bdb`: [run 29072559013](https://github.com/openclaw/openclaw/actions/runs/29072559013).
