### PR TITLE
fix(http): accept repeated content-length values

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -574,6 +574,49 @@ describe("model-pricing-cache", () => {
     expect(health.sources[0]?.detail).toContain("invalid content-length header: 1e3");
   });
 
+  it("accepts matching repeated pricing content-length headers", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "custom/gpt-remote" },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-completions",
+            models: [{ id: "gpt-remote" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const body = JSON.stringify({ data: [] });
+    const size = new TextEncoder().encode(body).byteLength;
+    const fetchImpl = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("openrouter.ai")) {
+        return new Response(body, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": `${size}, ${size}`,
+          },
+        });
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    const health = getGatewayModelPricingHealth();
+    expect(health.state).toBe("ok");
+    expect(health.sources).toHaveLength(0);
+  });
+
   it("records and clears scheduled refresh rejections for health surfaces", async () => {
     vi.useFakeTimers();
     try {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -1,5 +1,6 @@
 // Gateway model-pricing refresh and normalization.
 // Fetches, normalizes, and schedules cached pricing for model usage estimates.
+import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
 import {
   normalizeOptionalString,
@@ -153,18 +154,7 @@ function parseNumberString(value: unknown): number | null {
 }
 
 function parsePricingContentLength(value: string | null): number | null {
-  if (value === null) {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    throw new Error(`invalid content-length header: ${value}`);
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isSafeInteger(parsed)) {
-    throw new Error(`invalid content-length header: ${value}`);
-  }
-  return parsed;
+  return parseMediaContentLength(value);
 }
 
 function formatTimeoutSeconds(timeoutMs: number): string {

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -899,6 +899,46 @@ describe("marketplace plugins", () => {
     });
   });
 
+  it("accepts matching repeated archive content-length headers", async () => {
+    await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
+      const body = Buffer.from("tgz-bytes");
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: new Response(new Blob([body]), {
+          status: 200,
+          headers: { "content-length": `${body.byteLength}, ${body.byteLength}` },
+        }),
+        finalUrl: "https://cdn.example.com/releases/frontend-design.tgz",
+        release: vi.fn(async () => undefined),
+      });
+      installPluginFromPathMock.mockResolvedValue({
+        ok: true,
+        pluginId: "frontend-design",
+        targetDir: "/tmp/frontend-design",
+        version: "0.1.0",
+        extensions: ["index.ts"],
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [
+          {
+            name: "frontend-design",
+            source: "https://example.com/frontend-design.tgz",
+          },
+        ],
+      });
+
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "frontend-design",
+      });
+
+      expectMarketplaceInstallSuccess(result, {
+        marketplacePlugin: "frontend-design",
+        marketplaceSource: manifestPath,
+      });
+      expect(installPluginFromPathMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("rejects non-streaming archive responses before buffering them", async () => {
     await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
       const arrayBuffer = vi.fn(async () => new Uint8Array([1, 2, 3]).buffer);

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -747,15 +748,7 @@ async function cancelUnreadMarketplaceResponseBody(response: Response): Promise<
 }
 
 function parseMarketplaceContentLength(raw: string): number {
-  const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    throw new Error(`invalid content-length header: ${raw}`);
-  }
-  const size = Number(trimmed);
-  if (!Number.isSafeInteger(size)) {
-    throw new Error(`invalid content-length header: ${raw}`);
-  }
-  return size;
+  return parseMediaContentLength(raw) ?? 0;
 }
 
 async function readMarketplaceChunkWithTimeout(

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -460,6 +460,34 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("accepts matching repeated hosted feed content-length headers", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 2,
+      entries: [],
+    });
+    const size = new TextEncoder().encode(body).byteLength;
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: {
+              "content-length": `${size}, ${size}`,
+            },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("hosted");
+    if (result.source === "hosted") {
+      expect(result.feed.sequence).toBe(2);
+    }
+  });
+
   it("uses the default local feed profile for hosted catalog loading", async () => {
     const body = JSON.stringify({
       schemaVersion: 1,

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1,5 +1,6 @@
 /** Reads official external plugin/channel/provider catalogs into manifest-like metadata. */
 import { createHash } from "node:crypto";
+import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
@@ -546,11 +547,13 @@ function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): 
   if (!normalized) {
     return;
   }
-  if (!/^\d+$/.test(normalized)) {
+  let size: number | null;
+  try {
+    size = parseMediaContentLength(normalized);
+  } catch {
     throw new Error("hosted catalog feed has invalid content-length");
   }
-  const size = Number(normalized);
-  if (!Number.isSafeInteger(size) || size > maxBytes) {
+  if (size !== null && size > maxBytes) {
     throw new Error(`hosted catalog feed exceeds ${maxBytes} bytes`);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Some external HTTP response readers still rejected comma-joined duplicate `Content-Length` headers such as `"10, 10"`. That shape can be produced by HTTP stacks/proxies when duplicate identical headers are merged, and `packages/media-core` already treats matching repeated values as valid while still rejecting conflicting or malformed values.

This caused unnecessary failures for otherwise valid responses in three bounded download/feed paths:

- Marketplace plugin archive downloads
- Hosted official external plugin catalog feeds
- Gateway model pricing catalog refreshes

## Why This Change Was Made

The fix reuses the existing `parseMediaContentLength()` helper instead of keeping three slightly different local parsers. This preserves the existing byte limits and malformed-header failures, while accepting only repeated values whose trimmed decimal bytes match exactly.

## User Impact

Users avoid false failures when a CDN/proxy returns an equivalent repeated `Content-Length` value. Oversized, unsafe, malformed, or conflicting lengths are still rejected before streaming or parsing the body.

## Evidence

No public issue/PR already occupied this exact hidden bug class:

```text
$ gh search prs --repo openclaw/openclaw "content-length marketplace pricing hosted catalog" --limit 20 --json number,title,state,url,author,createdAt,updatedAt
[]

$ gh search issues --repo openclaw/openclaw "content-length marketplace pricing hosted catalog" --limit 20 --json number,title,state,url,author,createdAt,updatedAt
[]
```

Focused regression tests with real local console output:

```text
$ node scripts/run-vitest.mjs src/plugins/marketplace.test.ts src/plugins/official-external-plugin-catalog.test.ts src/gateway/model-pricing-cache.test.ts
[test] starting test/vitest/vitest.gateway.config.ts
The `envFile` option is deprecated, please use `envDir: false` instead.
The `envFile` option is deprecated, please use `envDir: false` instead.
The `envFile` option is deprecated, please use `envDir: false` instead.
The `envFile` option is deprecated, please use `envDir: false` instead.
The `envFile` option is deprecated, please use `envDir: false` instead.

 RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw

[vitest] still running with no output for 30000ms (test/vitest/vitest.gateway.config.ts).

 Test Files  4 passed (4)
      Tests  104 passed (104)
   Start at  15:01:40
   Duration  39.74s (transform 11.04s, setup 1.73s, import 18.09s, tests 18.94s, environment 1ms)

[test] starting test/vitest/vitest.plugins.config.ts
The `envFile` option is deprecated, please use `envDir: false` instead.

 RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw


 Test Files  2 passed (2)
      Tests  90 passed (90)
   Start at  15:02:26
   Duration  3.07s (transform 1.09s, setup 680ms, import 508ms, tests 1.56s, environment 0ms)

[test] passed 2 Vitest shards in 74.98s
```

Patch sanity:

```text
$ git diff --check && git status -sb && git diff --numstat
## main...origin/main
 M src/gateway/model-pricing-cache.test.ts
 M src/gateway/model-pricing-cache.ts
 M src/plugins/marketplace.test.ts
 M src/plugins/marketplace.ts
 M src/plugins/official-external-plugin-catalog.test.ts
 M src/plugins/official-external-plugin-catalog.ts
43	0	src/gateway/model-pricing-cache.test.ts
2	12	src/gateway/model-pricing-cache.ts
40	0	src/plugins/marketplace.test.ts
2	9	src/plugins/marketplace.ts
28	0	src/plugins/official-external-plugin-catalog.test.ts
6	3	src/plugins/official-external-plugin-catalog.ts
```

Autoreview was attempted but blocked by local tool/auth environment, not by a code finding:

- `autoreview --mode local` using Codex failed with OpenAI API `401 Unauthorized`.
- `autoreview --mode local --engine opencode` failed because the installed `opencode` CLI does not support the helper's expected option set.
- `autoreview --mode local --engine claude` and `--engine copilot` failed because those executables are not installed.

Remote validation note: Crabbox/Testbox prewarm was unavailable in this environment because `scripts/crabbox-wrapper.mjs warmup --provider blacksmith-testbox --keep --timing-json` could not find a sane Crabbox binary.
