### PR TITLE
fix(xai): discover TTS voices dynamically

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -315,8 +315,12 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     The bundled `xai` plugin registers text-to-speech through the shared `tts`
     provider surface.
 
-    - Voices: `eve`, `ara`, `rex`, `sal`, `leo`, `una`
+    - Voices: authenticated live catalog from xAI; list it with
+      `openclaw infer tts voices --provider xai`
+    - Offline fallback voices: `ara`, `eve`, `leo`, `rex`, `sal`
     - Default voice: `eve`
+    - Account custom voice IDs are forwarded even when they are absent from the
+      built-in catalog response
     - Formats: `mp3`, `wav`, `pcm`, `mulaw`, `alaw`
     - Language: BCP-47 code or `auto`
     - Speed: provider-native speed override
@@ -340,9 +344,9 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     ```
 
     <Note>
-    OpenClaw uses xAI's batch `/v1/tts` endpoint. xAI also offers streaming
-    TTS over WebSocket, but the bundled xAI provider does not implement that
-    streaming hook yet.
+    OpenClaw uses xAI's batch `/v1/tts` endpoint and authenticated
+    `/v1/tts/voices` catalog. xAI also offers streaming TTS over WebSocket, but
+    the bundled xAI provider does not implement that streaming hook yet.
     </Note>
 
   </Accordion>

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -929,7 +929,7 @@ Reply -> TTS enabled?
   <Accordion title="xAI">
     <ParamField path="apiKey" type="string">Env: `XAI_API_KEY`.</ParamField>
     <ParamField path="baseUrl" type="string">Default `https://api.x.ai/v1`. Env: `XAI_BASE_URL`.</ParamField>
-    <ParamField path="speakerVoiceId" type="string">Default `eve`. Live voices: `ara`, `eve`, `leo`, `rex`, `sal`, `una`. Legacy alias: `voiceId`.</ParamField>
+    <ParamField path="speakerVoiceId" type="string">Default `eve`. With auth, `openclaw infer tts voices --provider xai` fetches the current built-in catalog; without auth it lists offline fallbacks `ara`, `eve`, `leo`, `rex`, and `sal`. Account custom voice IDs are forwarded even when absent from the built-in list. Legacy alias: `voiceId`.</ParamField>
     <ParamField path="language" type="string">BCP-47 language code or `auto`. Default `en`.</ParamField>
     <ParamField path="responseFormat" type='"mp3" | "wav" | "pcm" | "mulaw" | "alaw"'>Default `mp3`.</ParamField>
     <ParamField path="speed" type="number">Provider-native speed override, `0.7..1.5`.</ParamField>

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -2,19 +2,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildXaiSpeechProvider } from "./speech-provider.js";
 
-const { xaiTTSMock, isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } =
-  vi.hoisted(() => ({
-    xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
-    isProviderAuthProfileConfiguredMock: vi.fn(() => false),
-    resolveApiKeyForProviderMock: vi.fn(
-      async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
-    ),
-  }));
+const {
+  xaiTTSMock,
+  listXaiTtsVoicesMock,
+  isProviderAuthProfileConfiguredMock,
+  resolveApiKeyForProviderMock,
+} = vi.hoisted(() => ({
+  xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
+  listXaiTtsVoicesMock: vi.fn(async () => [{ id: "altair", name: "Altair" }]),
+  isProviderAuthProfileConfiguredMock: vi.fn(() => false),
+  resolveApiKeyForProviderMock: vi.fn(
+    async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
+  ),
+}));
 
 vi.mock("./tts.js", () => ({
   XAI_BASE_URL: "https://api.x.ai/v1",
-  XAI_TTS_VOICES: ["eve", "ara", "rex", "sal", "leo", "una"],
-  isValidXaiTtsVoice: (voice: string) => ["eve", "ara", "rex", "sal", "leo", "una"].includes(voice),
+  XAI_TTS_FALLBACK_VOICES: ["ara", "eve", "leo", "rex", "sal"],
+  isValidXaiTtsVoice: (voice: string) => voice.trim().length > 0,
+  listXaiTtsVoices: listXaiTtsVoicesMock,
   normalizeXaiLanguageCode: (value: unknown) =>
     typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined,
   normalizeXaiTtsBaseUrl: (baseUrl?: string) =>
@@ -64,7 +70,10 @@ describe("xai speech provider", () => {
     isProviderAuthProfileConfiguredMock.mockReturnValue(false);
     resolveApiKeyForProviderMock.mockReset();
     resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+    listXaiTtsVoicesMock.mockReset();
+    listXaiTtsVoicesMock.mockResolvedValue([{ id: "altair", name: "Altair" }]);
     delete process.env.XAI_API_KEY;
+    delete process.env.XAI_BASE_URL;
   });
 
   it("synthesizes mp3 audio and does not claim native voice-note compatibility", async () => {
@@ -194,6 +203,112 @@ describe("xai speech provider", () => {
         timeoutMs: 5_000,
       }),
     ).toBe(false);
+  });
+
+  it("uses direct voice-list auth and URL overrides before configured sources", async () => {
+    process.env.XAI_API_KEY = "env-key";
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });
+    const provider = buildXaiSpeechProvider();
+
+    await provider.listVoices?.({
+      apiKey: "request-key",
+      baseUrl: "https://api.x.ai/v1/",
+      providerConfig: {
+        apiKey: "config-key",
+        baseUrl: "https://config.example/v1",
+      },
+      cfg: {},
+    });
+
+    expect(listXaiTtsVoicesMock).toHaveBeenCalledWith({
+      apiKey: "request-key",
+      baseUrl: "https://api.x.ai/v1",
+    });
+    expect(resolveApiKeyForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("uses provider config auth before environment and profiles", async () => {
+    process.env.XAI_API_KEY = "env-key";
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });
+    const provider = buildXaiSpeechProvider();
+
+    await provider.listVoices?.({
+      providerConfig: {
+        apiKey: "config-key",
+        baseUrl: "https://config.example/v1/",
+      },
+      cfg: {},
+    });
+
+    expect(listXaiTtsVoicesMock).toHaveBeenCalledWith({
+      apiKey: "config-key",
+      baseUrl: "https://config.example/v1",
+    });
+    expect(resolveApiKeyForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("uses environment auth before profiles for voice discovery", async () => {
+    process.env.XAI_API_KEY = "env-key";
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });
+    const provider = buildXaiSpeechProvider();
+
+    await provider.listVoices?.({ providerConfig: {}, cfg: {} });
+
+    expect(listXaiTtsVoicesMock).toHaveBeenCalledWith({
+      apiKey: "env-key",
+      baseUrl: "https://api.x.ai/v1",
+    });
+    expect(resolveApiKeyForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the environment-only base URL for voice discovery", async () => {
+    process.env.XAI_API_KEY = "env-key";
+    process.env.XAI_BASE_URL = "https://env.example/v1/";
+    const provider = buildXaiSpeechProvider();
+
+    await provider.listVoices?.({ providerConfig: {}, cfg: {} });
+
+    expect(listXaiTtsVoicesMock).toHaveBeenCalledWith({
+      apiKey: "env-key",
+      baseUrl: "https://env.example/v1",
+    });
+  });
+
+  it("uses cfg-scoped profile auth for voice discovery", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });
+    const provider = buildXaiSpeechProvider();
+    const cfg = { agents: { defaults: {} } };
+
+    await provider.listVoices?.({ providerConfig: {}, cfg });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith({ provider: "xai", cfg });
+    expect(listXaiTtsVoicesMock).toHaveBeenCalledWith({
+      apiKey: "oauth-bearer",
+      baseUrl: "https://api.x.ai/v1",
+    });
+  });
+
+  it("returns the five offline fallback voices only when auth is absent", async () => {
+    const provider = buildXaiSpeechProvider();
+
+    await expect(provider.listVoices?.({ providerConfig: {} })).resolves.toEqual([
+      { id: "ara", name: "ara" },
+      { id: "eve", name: "eve" },
+      { id: "leo", name: "leo" },
+      { id: "rex", name: "rex" },
+      { id: "sal", name: "sal" },
+    ]);
+    expect(listXaiTtsVoicesMock).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mask authenticated catalog failures with offline voices", async () => {
+    listXaiTtsVoicesMock.mockRejectedValueOnce(new Error("catalog unavailable"));
+    const provider = buildXaiSpeechProvider();
+
+    await expect(
+      provider.listVoices?.({ providerConfig: { apiKey: "bad-key" }, cfg: {} }),
+    ).rejects.toThrow("catalog unavailable");
   });
 
   it("threads cfg into the OAuth fallback resolver when no direct apiKey is available", async () => {

--- a/extensions/xai/speech-provider.ts
+++ b/extensions/xai/speech-provider.ts
@@ -19,10 +19,11 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   isValidXaiTtsVoice,
+  listXaiTtsVoices,
   normalizeXaiLanguageCode,
   normalizeXaiTtsBaseUrl,
   XAI_BASE_URL,
-  XAI_TTS_VOICES,
+  XAI_TTS_FALLBACK_VOICES,
   xaiTTS,
 } from "./tts.js";
 
@@ -147,8 +148,6 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   overrides?: SpeechProviderOverrides;
   warnings?: string[];
 } {
-  const providerConfig = ctx.providerConfig as Record<string, unknown> | undefined;
-  const baseUrl = trimToUndefined(providerConfig?.baseUrl);
   switch (ctx.key) {
     case "voice":
     case "voice_id":
@@ -158,7 +157,7 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
       if (!ctx.policy.allowVoice) {
         return { handled: true };
       }
-      if (!isValidXaiTtsVoice(ctx.value, baseUrl)) {
+      if (!isValidXaiTtsVoice(ctx.value)) {
         return { handled: true, warnings: [`invalid xAI voice "${ctx.value}"`] };
       }
       return { handled: true, overrides: { voiceId: ctx.value } };
@@ -173,7 +172,7 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
     label: "xAI",
     autoSelectOrder: 25,
     models: [],
-    voices: XAI_TTS_VOICES,
+    voices: XAI_TTS_FALLBACK_VOICES,
     resolveConfig: ({ rawConfig }) => normalizeXaiProviderConfig(rawConfig),
     parseDirectiveToken,
     resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
@@ -225,7 +224,18 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
         ? {}
         : { speed: normalizeXaiSpeechSpeed(params.speed) }),
     }),
-    listVoices: async () => XAI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
+    listVoices: async (req) => {
+      const config = readXaiProviderConfig(req.providerConfig ?? {});
+      const directApiKey = trimToUndefined(req.apiKey) ?? config.apiKey;
+      const apiKey = await resolveOptionalXaiAudioApiKey(directApiKey, req.cfg);
+      if (!apiKey) {
+        return XAI_TTS_FALLBACK_VOICES.map((voice) => ({ id: voice, name: voice }));
+      }
+      return await listXaiTtsVoices({
+        apiKey,
+        baseUrl: normalizeXaiTtsBaseUrl(trimToUndefined(req.baseUrl) ?? config.baseUrl),
+      });
+    },
     isConfigured: ({ providerConfig, cfg }) =>
       Boolean(readXaiProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY) ||
       isProviderAuthProfileConfigured({ provider: "xai", cfg }),
@@ -278,18 +288,28 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
 // 1. Configured `messages.tts.providers.xai.apiKey` (or talk equivalent)
 // 2. `XAI_API_KEY` env var
 // 3. xAI OAuth auth profile (cfg-scoped)
-async function resolveXaiAudioApiKey(
+async function resolveOptionalXaiAudioApiKey(
   configApiKey: string | undefined,
-  cfg: OpenClawConfig,
-): Promise<string> {
+  cfg?: OpenClawConfig,
+): Promise<string | undefined> {
   const direct = trimToUndefined(configApiKey) ?? trimToUndefined(process.env.XAI_API_KEY);
   if (direct) {
     return direct;
   }
+  if (!cfg) {
+    return undefined;
+  }
   const auth = await resolveApiKeyForProvider({ provider: "xai", cfg });
-  const oauthKey = trimToUndefined(auth?.apiKey);
-  if (oauthKey) {
-    return oauthKey;
+  return trimToUndefined(auth?.apiKey);
+}
+
+async function resolveXaiAudioApiKey(
+  configApiKey: string | undefined,
+  cfg: OpenClawConfig,
+): Promise<string> {
+  const apiKey = await resolveOptionalXaiAudioApiKey(configApiKey, cfg);
+  if (apiKey) {
+    return apiKey;
   }
   throw new Error(
     "xAI credentials missing for TTS. Sign in with `openclaw onboard --auth-choice xai-oauth`, or run `openclaw onboard --auth-choice xai-api-key`, or set XAI_API_KEY.",

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -1,7 +1,13 @@
 // Xai tests cover tts plugin behavior.
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { isValidXaiTtsVoice, XAI_BASE_URL, XAI_TTS_VOICES, xaiTTS } from "./tts.js";
+import {
+  isValidXaiTtsVoice,
+  listXaiTtsVoices,
+  XAI_BASE_URL,
+  XAI_TTS_FALLBACK_VOICES,
+  xaiTTS,
+} from "./tts.js";
 
 function createStreamingAudioResponse(params: {
   chunkCount: number;
@@ -44,22 +50,123 @@ describe("xai tts", () => {
   });
 
   describe("isValidXaiTtsVoice", () => {
-    it("accepts all valid voices", () => {
-      for (const voice of XAI_TTS_VOICES) {
+    it("accepts fallback, current, legacy, and custom voice ids", () => {
+      for (const voice of XAI_TTS_FALLBACK_VOICES) {
+        expect(isValidXaiTtsVoice(voice)).toBe(true);
+      }
+      for (const voice of ["altair", "ALTAIR", "una", "nlbqfwie"]) {
         expect(isValidXaiTtsVoice(voice)).toBe(true);
       }
     });
 
-    it("rejects invalid voice names", () => {
-      expect(isValidXaiTtsVoice("invalid")).toBe(false);
-      expect(isValidXaiTtsVoice("")).toBe(false);
-      expect(isValidXaiTtsVoice("ALLOY")).toBe(false);
-      expect(isValidXaiTtsVoice("alloy ")).toBe(false);
-      expect(isValidXaiTtsVoice(" alloy")).toBe(false);
+    it("rejects blank voice ids", () => {
+      for (const voice of ["", "   ", "\n"]) {
+        expect(isValidXaiTtsVoice(voice)).toBe(false);
+      }
+    });
+  });
+
+  describe("listXaiTtsVoices", () => {
+    it("maps the authenticated catalog and sends the expected request", async () => {
+      vi.stubEnv("OPENCLAW_VERSION", "2026.7.9");
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(
+            JSON.stringify({
+              voices: [
+                {
+                  voice_id: "altair",
+                  name: "Altair",
+                  language: "en",
+                  gender: "male",
+                },
+                { voice_id: "  celeste  ", name: " Celeste " },
+                { voice_id: " " },
+                { name: "missing id" },
+                null,
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const voices = await listXaiTtsVoices({
+        apiKey: "xai-key",
+        baseUrl: "https://api.x.ai/v1/",
+      });
+
+      expect(voices).toEqual([
+        { id: "altair", name: "Altair", locale: "en", gender: "male" },
+        { id: "celeste", name: "Celeste", locale: undefined, gender: undefined },
+      ]);
+      const call = fetchMock.mock.calls[0];
+      if (!call) {
+        throw new Error("expected voice catalog request");
+      }
+      const [input, init] = call;
+      const requestUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      expect(requestUrl).toBe("https://api.x.ai/v1/tts/voices");
+      expect(init?.method).toBe("GET");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer xai-key");
+      expect(headers.get("user-agent")).toBe("openclaw/2026.7.9");
+      vi.unstubAllEnvs();
     });
 
-    it("treats custom endpoints as permissive", () => {
-      expect(isValidXaiTtsVoice("grok-voice-custom", "https://custom.api.x.ai/v1")).toBe(true);
+    it("includes provider detail and request id for catalog errors", async () => {
+      globalThis.fetch = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                message: "Invalid API key",
+                type: "invalid_request_error",
+                code: "invalid_api_key",
+              },
+            }),
+            {
+              status: 401,
+              headers: {
+                "Content-Type": "application/json",
+                "x-request-id": "req_voices",
+              },
+            },
+          ),
+      ) as unknown as typeof fetch;
+
+      await expect(listXaiTtsVoices({ apiKey: "bad-key" })).rejects.toThrow(
+        "xAI TTS voices API error (401): Invalid API key [type=invalid_request_error, code=invalid_api_key] [request_id=req_voices]",
+      );
+    });
+
+    it("rejects malformed catalog payloads", async () => {
+      globalThis.fetch = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ items: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ) as unknown as typeof fetch;
+
+      await expect(listXaiTtsVoices({ apiKey: "xai-key" })).rejects.toThrow(
+        "xAI TTS voices: malformed JSON response",
+      );
+    });
+
+    it("caps catalog responses before parsing JSON", async () => {
+      globalThis.fetch = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ voices: [], padding: "x".repeat(1024 * 1024) }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ) as unknown as typeof fetch;
+
+      await expect(listXaiTtsVoices({ apiKey: "xai-key" })).rejects.toThrow(
+        "xAI TTS voices: JSON response exceeds 1048576 bytes",
+      );
     });
   });
 

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -1,15 +1,23 @@
 // Xai plugin module implements tts behavior.
-import { assertOkOrThrowProviderError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
+import {
+  assertOkOrThrowProviderError,
+  postJsonRequest,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { trimToUndefined } from "openclaw/plugin-sdk/speech";
+import { asObject, trimToUndefined, type SpeechVoiceOption } from "openclaw/plugin-sdk/speech";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { XAI_BASE_URL } from "./api.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 export { XAI_BASE_URL };
 
 const DEFAULT_TTS_MAX_BYTES = 16 * 1024 * 1024;
-export const XAI_TTS_VOICES = ["eve", "ara", "rex", "sal", "leo", "una"] as const;
-
-type XaiTtsVoice = (typeof XAI_TTS_VOICES)[number];
+const XAI_TTS_VOICE_LIST_TIMEOUT_MS = 30_000;
+const XAI_TTS_VOICE_LIST_MAX_BYTES = 1024 * 1024;
+export const XAI_TTS_FALLBACK_VOICES = ["ara", "eve", "leo", "rex", "sal"] as const;
 
 export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
   const trimmed = baseUrl?.trim();
@@ -19,14 +27,55 @@ export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
   return trimmed.replace(/\/+$/, "");
 }
 
-export function isValidXaiTtsVoice(voice: string, baseUrl?: string): voice is XaiTtsVoice {
-  const normalizedBase = normalizeXaiTtsBaseUrl(baseUrl ?? process.env.XAI_BASE_URL);
-  const host = normalizedBase.includes("://") ? new URL(normalizedBase).hostname : normalizedBase;
-  const isNative = host === "api.x.ai";
-  if (!isNative) {
-    return true;
+export function isValidXaiTtsVoice(voice: string): boolean {
+  return trimToUndefined(voice) !== undefined;
+}
+
+export async function listXaiTtsVoices(params: {
+  apiKey: string;
+  baseUrl?: string;
+}): Promise<SpeechVoiceOption[]> {
+  const baseUrl = normalizeXaiTtsBaseUrl(params.baseUrl);
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${baseUrl}/tts/voices`,
+    init: {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        ...xaiUserAgentHeaderFor(baseUrl),
+      },
+    },
+    timeoutMs: XAI_TTS_VOICE_LIST_TIMEOUT_MS,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(baseUrl),
+    auditContext: "xai tts voices",
+  });
+  try {
+    await assertOkOrThrowProviderError(response, "xAI TTS voices API error");
+    const payload = await readProviderJsonResponse<unknown>(response, "xAI TTS voices", {
+      maxBytes: XAI_TTS_VOICE_LIST_MAX_BYTES,
+    });
+    const voices = asObject(payload)?.voices;
+    if (!Array.isArray(voices)) {
+      throw new Error("xAI TTS voices: malformed JSON response");
+    }
+    return voices.flatMap((value) => {
+      const voice = asObject(value);
+      const id = trimToUndefined(voice?.voice_id);
+      if (!id) {
+        return [];
+      }
+      return [
+        {
+          id,
+          name: trimToUndefined(voice?.name),
+          locale: trimToUndefined(voice?.language),
+          gender: trimToUndefined(voice?.gender),
+        },
+      ];
+    });
+  } finally {
+    await release();
   }
-  return XAI_TTS_VOICES.includes(voice as XaiTtsVoice);
 }
 
 export function normalizeXaiLanguageCode(value: unknown): string | undefined {
@@ -67,7 +116,7 @@ export async function xaiTTS(params: {
   } = params;
   const language = normalizeXaiLanguageCode(rawLanguage) ?? "en";
 
-  if (!isValidXaiTtsVoice(voiceId, baseUrl)) {
+  if (!isValidXaiTtsVoice(voiceId)) {
     throw new Error(`Invalid voice: ${voiceId}`);
   }
 

--- a/extensions/xai/xai.live.test.ts
+++ b/extensions/xai/xai.live.test.ts
@@ -240,8 +240,15 @@ describeLive("xai plugin live", () => {
       const speechProvider = requireRegisteredProvider(speechProviders, "xai");
       const cfg = createLiveConfig();
 
-      const voices = await speechProvider.listVoices?.({});
+      const voices = await speechProvider.listVoices?.({
+        cfg,
+        providerConfig: {
+          apiKey: XAI_API_KEY,
+          baseUrl: "https://api.x.ai/v1",
+        },
+      });
       expect(voices?.some((voice) => voice.id === "eve")).toBe(true);
+      expect(voices?.some((voice) => voice.id === "altair")).toBe(true);
 
       const audioFile = await speechProvider.synthesize({
         text: "OpenClaw xAI text to speech integration test OK.",
@@ -249,7 +256,7 @@ describeLive("xai plugin live", () => {
         providerConfig: {
           apiKey: XAI_API_KEY,
           baseUrl: "https://api.x.ai/v1",
-          voiceId: "eve",
+          voiceId: "altair",
         },
         target: "audio-file",
         timeoutMs: 90_000,


### PR DESCRIPTION
Closes #103389

## What Problem This Solves

The xAI speech provider hardcodes six voice IDs and rejects every other ID before making a request. xAI's authenticated `/v1/tts/voices` catalog currently returns 26 built-in voices, and account custom voice IDs are valid even though they are not part of that built-in list. This makes current voices such as `altair` unusable through OpenClaw and lets the hardcoded list drift again.

## Why This Change Was Made

- Fetch the authenticated xAI built-in voice catalog through an SSRF-guarded, 30-second, 1 MiB-bounded request.
- Keep five documented offline fallback voices only when no xAI credential is available.
- Accept any nonblank voice ID and let xAI validate current, legacy, uppercase, and account custom IDs.
- Preserve auth precedence: direct request, provider config, environment, then cfg-scoped auth profile.
- Surface configured-key, API, timeout, malformed-response, and SSRF errors instead of masking them with offline fallbacks.
- Update xAI provider/tool docs and live coverage.

## User Impact

`openclaw infer tts voices --provider xai` can return the current authenticated catalog, and synthesis accepts current or account-owned voice IDs without an OpenClaw release. Offline/no-auth listing remains useful with `ara`, `eve`, `leo`, `rex`, and `sal`; `eve` remains the default. Existing legacy IDs such as `una` continue to be forwarded to xAI.

Release-note context: fixes stale xAI TTS voice validation and discovery while preserving offline behavior and legacy/custom voice compatibility.

## Evidence

- Live xAI catalog: 26 voices, including `altair` and `eve`.
- Live exact-branch registered provider: authenticated listing plus `altair` synthesis passed.
- Live exact-source transport: `altair` synthesized 61,440 bytes; legacy `una` synthesized 54,912 bytes.
- Blacksmith Testbox `tbx_01kx56sct3vfvdx54getfgbct0`: focused xAI TTS/provider suites passed 24/24; extension test types and xAI extension lint passed.
- Fresh Codex autoreview rerun: clean, no accepted or actionable findings.
- Exact-head hosted CI: pending PR creation.
