### PR TITLE
fix(ui): use default cursor for mount fallback

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -158,7 +158,6 @@
         background: transparent;
         font: inherit;
         font-weight: 700;
-        cursor: pointer;
       }
 
       .mount-fallback__button--primary {

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -12,7 +12,7 @@ const describeBrowserLayout = canRunPlaywrightChromium(chromiumExecutablePath)
   ? describe
   : describe.skip;
 
-type MobileFixture = {
+type BrowserFixture = {
   browser: Browser;
   page: Page;
 };
@@ -25,8 +25,18 @@ function readUiCss(): string {
     "ui/src/styles/layout.css",
     "ui/src/styles/usage.css",
     "ui/src/styles/chat/layout.css",
+    "ui/src/styles/chat/text.css",
   ];
   return files.map((file) => readStyleSheet(file)).join("\n");
+}
+
+function readMountFallbackCss(): string {
+  const html = readStyleSheet("ui/index.html");
+  const css = html.match(/<style>([\s\S]*?)<\/style>/)?.[1];
+  if (!css) {
+    throw new Error("Missing inline mount fallback styles in ui/index.html");
+  }
+  return css;
 }
 
 function controlsHtml() {
@@ -59,17 +69,17 @@ function controlsHtml() {
   `;
 }
 
-async function openMobileFixture(): Promise<MobileFixture> {
+async function openBrowserFixture(
+  body: string,
+  css: string,
+  options?: Parameters<Browser["newPage"]>[0],
+): Promise<BrowserFixture> {
   const browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
   let page: Page | undefined;
   try {
-    page = await browser.newPage({
-      hasTouch: true,
-      isMobile: true,
-      viewport: { width: 390, height: 844 },
-    });
+    page = await browser.newPage(options);
     await page.setContent(
-      `<!doctype html><html data-theme-mode="light"><head><style>${readUiCss()}</style></head><body>${controlsHtml()}</body></html>`,
+      `<!doctype html><html data-theme-mode="light"><head><style>${css}</style></head><body>${body}</body></html>`,
     );
     return { browser, page };
   } catch (error) {
@@ -79,7 +89,15 @@ async function openMobileFixture(): Promise<MobileFixture> {
   }
 }
 
-async function closeMobileFixture(fixture: MobileFixture): Promise<void> {
+function openMobileFixture(): Promise<BrowserFixture> {
+  return openBrowserFixture(controlsHtml(), readUiCss(), {
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 390, height: 844 },
+  });
+}
+
+async function closeBrowserFixture(fixture: BrowserFixture): Promise<void> {
   await fixture.page.close().catch(() => {});
   await fixture.browser.close().catch(() => {});
 }
@@ -131,7 +149,7 @@ describeBrowserLayout("touch-primary form controls", () => {
         expect(size.fontSize, size.selector).toBeGreaterThanOrEqual(16);
       }
     } finally {
-      await closeMobileFixture(fixture);
+      await closeBrowserFixture(fixture);
     }
   });
 
@@ -157,7 +175,7 @@ describeBrowserLayout("touch-primary form controls", () => {
         expect(select.repeat).toContain("no-repeat");
       }
     } finally {
-      await closeMobileFixture(fixture);
+      await closeBrowserFixture(fixture);
     }
   });
 
@@ -186,7 +204,63 @@ describeBrowserLayout("touch-primary form controls", () => {
       expect(dimensions.checkbox).toBeLessThan(38);
       expect(dimensions.radio).toBeLessThan(38);
     } finally {
-      await closeMobileFixture(fixture);
+      await closeBrowserFixture(fixture);
+    }
+  });
+});
+
+describeBrowserLayout("cursor semantics", () => {
+  it("reserves the pointer for genuine content and external links", async () => {
+    const fixture = await openBrowserFixture(
+      `
+        <button class="btn">Control</button>
+        <a class="nav-item" href="/overview">Navigation</a>
+        <a class="sidebar-footer-icon" href="/settings">Settings</a>
+        <a class="sidebar-footer-icon" href="https://docs.openclaw.ai" target="_blank">Docs</a>
+        <section class="mount-fallback">
+          <button class="mount-fallback__button">Try again</button>
+        </section>
+        <p class="chat-text">
+          <a href="https://example.com">Content link</a>
+          <a class="markdown-file-link" data-file-path="report.txt">File link</a>
+        </p>
+      `,
+      `${readUiCss()}\n${readMountFallbackCss()}`,
+    );
+    const { page } = fixture;
+    try {
+      const cursors = await page.evaluate(() => {
+        const selectors = {
+          button: ".btn",
+          contentLink: '.chat-text a[href="https://example.com"]',
+          externalChromeLink: '.sidebar-footer-icon[target="_blank"]',
+          fileLink: ".markdown-file-link",
+          internalChromeLink: '.sidebar-footer-icon[href="/settings"]',
+          mountFallbackButton: ".mount-fallback__button",
+          navigation: ".nav-item",
+        };
+        return Object.fromEntries(
+          Object.entries(selectors).map(([name, selector]) => {
+            const node = document.querySelector(selector);
+            if (!(node instanceof HTMLElement)) {
+              throw new Error(`Missing cursor fixture ${selector}`);
+            }
+            return [name, getComputedStyle(node).cursor];
+          }),
+        );
+      });
+
+      expect(cursors).toEqual({
+        button: "default",
+        contentLink: "pointer",
+        externalChromeLink: "pointer",
+        fileLink: "pointer",
+        internalChromeLink: "default",
+        mountFallbackButton: "default",
+        navigation: "default",
+      });
+    } finally {
+      await closeBrowserFixture(fixture);
     }
   });
 });

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -12,7 +12,7 @@ const describeBrowserLayout = canRunPlaywrightChromium(chromiumExecutablePath)
   ? describe
   : describe.skip;
 
-type BrowserFixture = {
+type MobileFixture = {
   browser: Browser;
   page: Page;
 };
@@ -25,18 +25,8 @@ function readUiCss(): string {
     "ui/src/styles/layout.css",
     "ui/src/styles/usage.css",
     "ui/src/styles/chat/layout.css",
-    "ui/src/styles/chat/text.css",
   ];
   return files.map((file) => readStyleSheet(file)).join("\n");
-}
-
-function readMountFallbackCss(): string {
-  const html = readStyleSheet("ui/index.html");
-  const css = html.match(/<style>([\s\S]*?)<\/style>/)?.[1];
-  if (!css) {
-    throw new Error("Missing inline mount fallback styles in ui/index.html");
-  }
-  return css;
 }
 
 function controlsHtml() {
@@ -69,17 +59,17 @@ function controlsHtml() {
   `;
 }
 
-async function openBrowserFixture(
-  body: string,
-  css: string,
-  options?: Parameters<Browser["newPage"]>[0],
-): Promise<BrowserFixture> {
+async function openMobileFixture(): Promise<MobileFixture> {
   const browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
   let page: Page | undefined;
   try {
-    page = await browser.newPage(options);
+    page = await browser.newPage({
+      hasTouch: true,
+      isMobile: true,
+      viewport: { width: 390, height: 844 },
+    });
     await page.setContent(
-      `<!doctype html><html data-theme-mode="light"><head><style>${css}</style></head><body>${body}</body></html>`,
+      `<!doctype html><html data-theme-mode="light"><head><style>${readUiCss()}</style></head><body>${controlsHtml()}</body></html>`,
     );
     return { browser, page };
   } catch (error) {
@@ -89,15 +79,7 @@ async function openBrowserFixture(
   }
 }
 
-function openMobileFixture(): Promise<BrowserFixture> {
-  return openBrowserFixture(controlsHtml(), readUiCss(), {
-    hasTouch: true,
-    isMobile: true,
-    viewport: { width: 390, height: 844 },
-  });
-}
-
-async function closeBrowserFixture(fixture: BrowserFixture): Promise<void> {
+async function closeMobileFixture(fixture: MobileFixture): Promise<void> {
   await fixture.page.close().catch(() => {});
   await fixture.browser.close().catch(() => {});
 }
@@ -149,7 +131,7 @@ describeBrowserLayout("touch-primary form controls", () => {
         expect(size.fontSize, size.selector).toBeGreaterThanOrEqual(16);
       }
     } finally {
-      await closeBrowserFixture(fixture);
+      await closeMobileFixture(fixture);
     }
   });
 
@@ -175,7 +157,7 @@ describeBrowserLayout("touch-primary form controls", () => {
         expect(select.repeat).toContain("no-repeat");
       }
     } finally {
-      await closeBrowserFixture(fixture);
+      await closeMobileFixture(fixture);
     }
   });
 
@@ -204,63 +186,42 @@ describeBrowserLayout("touch-primary form controls", () => {
       expect(dimensions.checkbox).toBeLessThan(38);
       expect(dimensions.radio).toBeLessThan(38);
     } finally {
-      await closeBrowserFixture(fixture);
+      await closeMobileFixture(fixture);
     }
   });
 });
 
-describeBrowserLayout("cursor semantics", () => {
-  it("reserves the pointer for genuine content and external links", async () => {
-    const fixture = await openBrowserFixture(
-      `
-        <button class="btn">Control</button>
-        <a class="nav-item" href="/overview">Navigation</a>
-        <a class="sidebar-footer-icon" href="/settings">Settings</a>
-        <a class="sidebar-footer-icon" href="https://docs.openclaw.ai" target="_blank">Docs</a>
-        <section class="mount-fallback">
-          <button class="mount-fallback__button">Try again</button>
-        </section>
-        <p class="chat-text">
-          <a href="https://example.com">Content link</a>
-          <a class="markdown-file-link" data-file-path="report.txt">File link</a>
-        </p>
-      `,
-      `${readUiCss()}\n${readMountFallbackCss()}`,
-    );
-    const { page } = fixture;
+describeBrowserLayout("mount fallback cursor", () => {
+  it("uses the default cursor for its controls and the pointer for its real link", async () => {
+    const browser = await chromium.launch({
+      executablePath: chromiumExecutablePath,
+      headless: true,
+    });
     try {
+      const page = await browser.newPage();
+      await page.setContent(readStyleSheet("ui/index.html"));
       const cursors = await page.evaluate(() => {
-        const selectors = {
-          button: ".btn",
-          contentLink: '.chat-text a[href="https://example.com"]',
-          externalChromeLink: '.sidebar-footer-icon[target="_blank"]',
-          fileLink: ".markdown-file-link",
-          internalChromeLink: '.sidebar-footer-icon[href="/settings"]',
-          mountFallbackButton: ".mount-fallback__button",
-          navigation: ".nav-item",
+        const cursor = (selector: string) => {
+          const node = document.querySelector(selector);
+          if (!(node instanceof HTMLElement)) {
+            throw new Error(`Missing cursor fixture ${selector}`);
+          }
+          return getComputedStyle(node).cursor;
         };
-        return Object.fromEntries(
-          Object.entries(selectors).map(([name, selector]) => {
-            const node = document.querySelector(selector);
-            if (!(node instanceof HTMLElement)) {
-              throw new Error(`Missing cursor fixture ${selector}`);
-            }
-            return [name, getComputedStyle(node).cursor];
-          }),
-        );
+        return {
+          retry: cursor("#openclaw-mount-retry"),
+          wait: cursor("#openclaw-mount-wait"),
+          docs: cursor('.mount-fallback__panel a[href^="https://"]'),
+        };
       });
 
       expect(cursors).toEqual({
-        button: "default",
-        contentLink: "pointer",
-        externalChromeLink: "pointer",
-        fileLink: "pointer",
-        internalChromeLink: "default",
-        mountFallbackButton: "default",
-        navigation: "default",
+        retry: "default",
+        wait: "default",
+        docs: "pointer",
       });
     } finally {
-      await closeBrowserFixture(fixture);
+      await browser.close().catch(() => {});
     }
   });
 });


### PR DESCRIPTION
Closes #103444

Related: #103357, #103411

## What Problem This Solves

Users who reach the Control UI mount-failure fallback still see the pointer hand over `Try again` and `Keep waiting`, although these are internal controls and the Control UI reserves the pointer for real links.

## Why This Change Was Made

The stale inline `cursor: pointer` declaration is removed at the fallback style owner. The browser regression loads the real production `ui/index.html` shell in Chromium and checks both fallback controls plus the genuine troubleshooting link, without duplicating unrelated application cursor selectors.

## User Impact

The fallback controls now use the default arrow like other Control UI controls. The troubleshooting hyperlink keeps the pointer hand.

## Evidence

- Exact-current-main baseline: `bcf27989206d31bf4780c7857fc30f579357fa92` retains the stale declaration. On Blacksmith Testbox through Crabbox `tbx_01kx5rr94tpbdvqt71cwdv7ewf`, the focused Chromium test failed only because both fallback controls computed to `pointer`; the real link still computed to `pointer` (3 passed, 1 failed).
- Fixed branch: the same focused Chromium file passed 4/4 on the same Testbox lease.
- `corepack pnpm check:changed` on the same Testbox lease passed in 9m03s, including typechecks, full core/UI/package lint fanout, database-first and import-cycle guards.
- `corepack pnpm ui:build` on the same Testbox lease passed.
- Fresh whole-branch autoreview: clean; no accepted or actionable findings (0.96 confidence).
- Exact-head hosted CI run [29086670826](https://github.com/openclaw/openclaw/actions/runs/29086670826) passed at `dd03e75497d1beb69cc602ebe8dbf4fb5d1098d5` (43 successful jobs, 12 intentionally skipped, zero failed).
- Repo-native hosted prepare gate passed for the same head with `OPENCLAW_TESTBOX=1`.

Provenance: the stale declaration was introduced in #80644 (`42fc84f4b4c63a1075d98be91855bee7267c0e57`) by @BunsDev and became inconsistent when the Control UI cursor convention changed in #103357 and #103411.

AI-assisted change. I reviewed the production fallback actions, inline styles, current-main behavior, adjacent mount-fallback tests, sibling cursor contracts, history, and validation results.
