### PR TITLE
fix(acp): abort controller in clearActiveRun to match cancelActiveRun contract

### DIFF
--- a/packages/acp-core/src/session.test.ts
+++ b/packages/acp-core/src/session.test.ts
@@ -19,6 +19,20 @@ describe("acp session manager", () => {
     store.clearAllSessionsForTest();
   });
 
+  it("aborts the controller when clearing an active run", () => {
+    const session = store.createSession({
+      sessionKey: "acp:clear",
+      cwd: "/tmp",
+    });
+    const controller = new AbortController();
+    store.setActiveRun(session.sessionId, "run-1", controller);
+
+    store.clearActiveRun(session.sessionId);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(store.getSessionByRunId("run-1")).toBeUndefined();
+  });
+
   it("tracks active runs and clears on cancel", () => {
     const session = store.createSession({
       sessionKey: "acp:test",

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -167,6 +167,7 @@ export function createInMemorySessionStore(options: AcpSessionStoreOptions = {})
     if (session.activeRunId) {
       runIdToSessionId.delete(session.activeRunId);
     }
+    session.abortController?.abort();
     session.activeRunId = null;
     session.abortController = null;
     touchSession(session, now());


### PR DESCRIPTION
## What Problem This Solves

`clearActiveRun` discards the AbortController without calling `.abort()`. Any asynchronous operation holding a reference to the controller's signal will not receive a cancellation notification and will continue running to completion, wasting resources.

In the same file `cancelActiveRun` correctly calls `.abort()` before setting the controller to null. `removeSession` also does the right thing. The omission in `clearActiveRun` is a one-line gap.

## Why This Change Was Made

Add `session.abortController?.abort()` so `clearActiveRun` matches the behaviour of `cancelActiveRun` and `removeSession`.

## User Impact

No visible impact for normal workflows. When `clearActiveRun` is called to release an active run without explicit cancellation, downstream async work that checks `signal.aborted` will now correctly observe the termination instead of silently continuing.

## Evidence

```
$ pnpm test packages/acp-core/src/session.test.ts -- --run
 ✓ 11 passed  (10 existing + 1 new)

$ pnpm exec tsgo --project tsconfig.json --noEmit
 (no type errors)

$ node scripts/run-oxlint.mjs packages/acp-core/src/session.ts packages/acp-core/src/session.test.ts
 exit 0
```

- 1 production line + 1 test case. No existing lines altered.
- Bounded to `packages/acp-core/`; no config, SDK, CLI, docs, or changelog surface was added.
