### PR TITLE
fix(codex): require human approval for app-server commands

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -206,6 +206,8 @@ Examples that strict mode catches: `python -c`, `node -e`/`--eval`/`-p`,
 In strict mode these commands need reviewer or explicit approval. With
 `tools.exec.mode: "auto"`, the reviewer may grant one low-risk execution when
 the command has an enforceable plan; otherwise OpenClaw asks a human.
+`Codex app-server` command approvals always ask a human because their approval
+requests do not expose an enforceable resolved executable.
 `allow-always` does not persist new allowlist entries for inline-eval commands.
 
 ### `tools.exec.commandHighlighting`

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -206,8 +206,9 @@ Examples that strict mode catches: `python -c`, `node -e`/`--eval`/`-p`,
 In strict mode these commands need reviewer or explicit approval. With
 `tools.exec.mode: "auto"`, the reviewer may grant one low-risk execution when
 the command has an enforceable plan; otherwise OpenClaw asks a human.
-`Codex app-server` command approvals always ask a human because their approval
-requests do not expose an enforceable resolved executable.
+`Codex app-server` command approvals that reach the reviewer fallback ask a
+human because their approval requests do not expose an enforceable resolved
+executable.
 `allow-always` does not persist new allowlist entries for inline-eval commands.
 
 ### `tools.exec.commandHighlighting`

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -132,6 +132,8 @@ Example:
 
 Auto-review approval is single-use. On the gateway, OpenClaw supplies the resolved executable path to the reviewer and pins execution to that same path. Commands that cannot be reduced to one enforceable execution plan—such as heredocs, shell expansions, or unsupported wrapper quoting—fall back to human approval even if the model would otherwise allow them.
 
+Codex app-server command approvals always use the human approval route. Codex does not expose an enforceable resolved executable in its approval request, so OpenClaw cannot safely bind an automatic review decision to the command that Codex runs.
+
 ### Inline eval (`strictInlineEval`)
 
 When `tools.exec.strictInlineEval` is `true`, inline interpreter-eval forms require reviewer or explicit approval: `python -c`, `node -e`, `ruby -e`, `perl -e`, `php -r`, `lua -e`, `osascript -e`, and similar forms across other supported interpreters and command carriers (`awk`, `find -exec`, `make`, `sed`, `xargs`, and more). In `mode=auto`, the normal exec approval path may let the native auto reviewer allow a clearly low-risk one-off command; direct node-host `system.run` calls still require an explicit approval because they cannot hand the command to a human approval route. If the reviewer asks, the request goes to a human. `allow-always` can still persist benign interpreter/script invocations, but inline-eval forms do not become durable allow rules.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -132,7 +132,7 @@ Example:
 
 Auto-review approval is single-use. On the gateway, OpenClaw supplies the resolved executable path to the reviewer and pins execution to that same path. Commands that cannot be reduced to one enforceable execution plan—such as heredocs, shell expansions, or unsupported wrapper quoting—fall back to human approval even if the model would otherwise allow them.
 
-Codex app-server command approvals always use the human approval route. Codex does not expose an enforceable resolved executable in its approval request, so OpenClaw cannot safely bind an automatic review decision to the command that Codex runs.
+Codex app-server command approvals that are not already decided by explicit runtime or native policy use the human approval route. OpenClaw does not run its configured exec reviewer for these requests because Codex does not expose an enforceable resolved executable that can bind the review decision to the command Codex runs.
 
 ### Inline eval (`strictInlineEval`)
 

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -251,9 +251,8 @@ describe("Codex app-server approval bridge", () => {
     findApprovalEvent(params, { status: "approved", approvalId: "plugin:approval-1" });
   });
 
-  it("uses the configured OpenClaw exec auto-review model before plugin approvals", async () => {
+  it("keeps configured exec auto-review on the human approval route", async () => {
     const params = createParams();
-    params.workspaceDir = "/workspace";
     params.config = {
       tools: {
         exec: {
@@ -270,6 +269,9 @@ describe("Codex app-server approval bridge", () => {
       rationale: "read-only version check",
       risk: "low",
     });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-auto-review", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-auto-review", decision: "deny" });
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -282,43 +284,15 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      execReviewerAgentId: "main",
-      internalExecAutoReview: true,
     });
 
-    expect(result).toEqual({ decision: "accept" });
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
-    expect(mockReviewExecRequestWithConfiguredModel).toHaveBeenCalledWith({
-      cfg: params.config,
-      agentId: "main",
-      reviewer: {
-        model: "openai/gpt-5.5-mini",
-        timeoutMs: 12_000,
-      },
-      input: {
-        command: "node --version",
-        argv: ["node", "--version"],
-        cwd: "/workspace",
-        envKeys: undefined,
-        host: "codex-app-server",
-        reason: "approval-required",
-        analysis: {
-          parsed: true,
-          allowlistMatched: false,
-          inlineEval: false,
-        },
-        agent: {
-          id: "main",
-          sessionKey: "agent:main:session-1",
-        },
-      },
-    });
-    findApprovalEvent(params, {
-      status: "approved",
-      message:
-        "Codex app-server command approval granted by OpenClaw exec auto-reviewer: read-only version check",
-    });
+    expect(result).toEqual({ decision: "decline" });
+    expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
+    findApprovalEvent(params, { status: "denied", approvalId: "plugin:approval-auto-review" });
   });
 
   it("falls back to plugin approval when no exec auto-review model is configured", async () => {
@@ -345,8 +319,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -394,8 +366,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -440,8 +410,6 @@ describe("Codex app-server approval bridge", () => {
         paramsForRun: params,
         threadId: "thread-1",
         turnId: "turn-1",
-        execPolicy: { mode: "auto" },
-        internalExecAutoReview: true,
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -549,8 +517,6 @@ describe("Codex app-server approval bridge", () => {
         paramsForRun: params,
         threadId: "thread-1",
         turnId: "turn-1",
-        execPolicy: { mode: "auto" },
-        internalExecAutoReview: true,
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -603,8 +569,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -615,7 +579,7 @@ describe("Codex app-server approval bridge", () => {
     ]);
   });
 
-  it("keeps exec auto-review when only an agent-specific alias matches the OpenAI reviewer", async () => {
+  it("keeps agent-scoped exec reviewer configuration on the human approval route", async () => {
     const params = createParams();
     params.config = {
       agents: {
@@ -644,6 +608,9 @@ describe("Codex app-server approval bridge", () => {
       rationale: "real OpenAI reviewer",
       risk: "low",
     });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-agent-reviewer", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-agent-reviewer", decision: "allow-once" });
 
     const result = await handleCodexAppServerApprovalRequest({
       method: "item/commandExecution/requestApproval",
@@ -656,22 +623,14 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      execReviewerAgentId: "main",
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
-    expect(mockReviewExecRequestWithConfiguredModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cfg: params.config,
-        agentId: "main",
-        reviewer: {
-          model: "openai/gpt-5.5-mini@work",
-        },
-      }),
-    );
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
+    expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
+      "plugin.approval.request",
+      "plugin.approval.waitDecision",
+    ]);
   });
 
   it("falls back to plugin approval when OpenAI reviewer uses a custom environment base URL", async () => {
@@ -707,8 +666,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -759,8 +716,6 @@ describe("Codex app-server approval bridge", () => {
         paramsForRun: params,
         threadId: "thread-1",
         turnId: "turn-1",
-        execPolicy: { mode: "auto" },
-        internalExecAutoReview: true,
       });
 
       expect(result).toEqual({ decision: "accept" });
@@ -811,8 +766,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -859,8 +812,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "acceptForSession" });
@@ -903,8 +854,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -952,8 +901,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -999,8 +946,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
@@ -1050,8 +995,6 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({
@@ -1068,7 +1011,7 @@ describe("Codex app-server approval bridge", () => {
     ]);
   });
 
-  it("falls back to plugin approval when the exec auto-review model asks", async () => {
+  it("does not invoke the exec auto-review model before plugin approval", async () => {
     const params = createParams();
     params.config = {
       tools: {
@@ -1100,69 +1043,14 @@ describe("Codex app-server approval bridge", () => {
       paramsForRun: params,
       threadId: "thread-1",
       turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
     });
 
     expect(result).toEqual({ decision: "accept" });
-    expect(mockReviewExecRequestWithConfiguredModel).toHaveBeenCalledTimes(1);
+    expect(mockReviewExecRequestWithConfiguredModel).not.toHaveBeenCalled();
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
       "plugin.approval.waitDecision",
     ]);
-  });
-
-  it("cancels command approvals when the run aborts during exec auto-review", async () => {
-    const params = createParams();
-    params.config = {
-      tools: {
-        exec: {
-          mode: "auto",
-          reviewer: {
-            model: "openai/gpt-5.5-mini",
-          },
-        },
-      },
-    } as EmbeddedRunAttemptParams["config"];
-    const abortController = new AbortController();
-    mockReviewExecRequestWithConfiguredModel.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(
-            () =>
-              resolve({
-                decision: "allow-once",
-                rationale: "late allow",
-                risk: "low",
-              }),
-            50,
-          );
-        }),
-    );
-
-    const resultPromise = handleCodexAppServerApprovalRequest({
-      method: "item/commandExecution/requestApproval",
-      requestParams: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "cmd-auto-review-abort",
-        command: "node --version",
-      },
-      paramsForRun: params,
-      threadId: "thread-1",
-      turnId: "turn-1",
-      execPolicy: { mode: "auto" },
-      internalExecAutoReview: true,
-      signal: abortController.signal,
-    });
-    abortController.abort(new Error("run stopped"));
-
-    await expect(resultPromise).resolves.toEqual({ decision: "cancel" });
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
-    findApprovalEvent(params, {
-      status: "failed",
-      message: "Codex app-server approval cancelled because the run stopped.",
-    });
   });
 
   it("normalizes prefixed channel targets for OpenClaw tool policy context", async () => {

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -1,7 +1,3 @@
-import {
-  buildExecAutoReviewInputForShellCommand,
-  reviewExecRequestWithConfiguredModel,
-} from "openclaw/plugin-sdk/agent-harness-exec-review-runtime";
 /**
  * Bridges Codex app-server approval requests into OpenClaw policy hooks and
  * plugin approval UX.
@@ -19,14 +15,9 @@ import {
   type NativeHookRelayRegistrationHandle,
   runBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
-import {
-  isTrustedCodexModelBackedOpenAIProvider,
-  type OpenClawExecPolicyForCodexAppServer,
-} from "./config.js";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import {
   approvalRequestExplicitlyUnavailable,
@@ -84,9 +75,6 @@ export async function handleCodexAppServerApprovalRequest(params: {
     NativeHookRelayRegistrationHandle,
     "allowedEvents" | "generation" | "relayId"
   >;
-  execPolicy?: Pick<OpenClawExecPolicyForCodexAppServer, "mode">;
-  execReviewerAgentId?: string;
-  internalExecAutoReview?: boolean;
   autoApprove?: boolean;
   signal?: AbortSignal;
   onNativeToolFailureDisposition?: (
@@ -157,29 +145,8 @@ export async function handleCodexAppServerApprovalRequest(params: {
       });
       return buildApprovalResponse(params.method, context.requestParams, "approved-session");
     }
-    const autoReviewOutcome = await runInternalExecAutoReviewForApprovalRequest({
-      enabled: params.internalExecAutoReview === true && params.execPolicy?.mode === "auto",
-      method: params.method,
-      requestParams,
-      paramsForRun: params.paramsForRun,
-      context,
-      agentId: params.execReviewerAgentId,
-      signal: params.signal,
-    });
-    if (autoReviewOutcome?.outcome === "approved-once") {
-      emitApprovalEvent(params.paramsForRun, {
-        phase: "resolved",
-        kind: context.kind,
-        status: "approved",
-        title: context.title,
-        ...context.eventDetails,
-        ...approvalEventScope(params.method, autoReviewOutcome.outcome),
-        message: autoReviewOutcome.reason,
-      });
-      return buildApprovalResponse(params.method, context.requestParams, autoReviewOutcome.outcome);
-    }
-    // Native hook/model policy did not decide; fall back to the OpenClaw
-    // approval route so user-facing runs still get an approval prompt.
+    // Codex app-server approval requests do not expose an enforceable resolved
+    // executable, so unresolved requests must stay on the human approval route.
     const requestResult = await requestPluginApproval({
       paramsForRun: params.paramsForRun,
       title: context.title,
@@ -429,244 +396,6 @@ type ApprovalPolicyOutcome =
     }
   | { outcome: "approved-once" | "approved-session" }
   | { outcome: "no-decision" };
-
-async function runInternalExecAutoReviewForApprovalRequest(params: {
-  enabled: boolean;
-  method: string;
-  requestParams: JsonObject | undefined;
-  paramsForRun: EmbeddedRunAttemptParams;
-  context: ApprovalContext;
-  agentId?: string;
-  signal?: AbortSignal;
-}): Promise<{ outcome: "approved-once"; reason: string } | undefined> {
-  if (!params.enabled || params.method !== "item/commandExecution/requestApproval") {
-    return undefined;
-  }
-  if (hasCommandApprovalCapabilityAmendments(params.requestParams)) {
-    return undefined;
-  }
-  const input = await buildAppServerExecAutoReviewInput({
-    requestParams: params.requestParams,
-    paramsForRun: params.paramsForRun,
-  });
-  if (!input) {
-    return undefined;
-  }
-  const reviewerConfig = resolveExecReviewerConfig(params.paramsForRun, params.agentId);
-  if (
-    !canUseInternalExecAutoReviewReviewer(
-      reviewerConfig,
-      params.paramsForRun.config,
-      process.env,
-      params.paramsForRun.agentDir,
-    )
-  ) {
-    return undefined;
-  }
-  const decision = await waitForInternalExecAutoReviewDecision({
-    signal: params.signal,
-    promise: reviewExecRequestWithConfiguredModel({
-      cfg: params.paramsForRun.config,
-      agentId: params.agentId ?? params.paramsForRun.agentId,
-      reviewer: reviewerConfig,
-      input,
-    }),
-  });
-  if (decision.decision !== "allow-once" || decision.risk !== "low") {
-    return undefined;
-  }
-  return {
-    outcome: "approved-once",
-    reason: `Codex app-server command approval granted by OpenClaw exec auto-reviewer: ${formatCodexDisplayText(
-      decision.rationale,
-    )}`,
-  };
-}
-
-async function waitForInternalExecAutoReviewDecision(params: {
-  signal?: AbortSignal;
-  promise: Promise<Awaited<ReturnType<typeof reviewExecRequestWithConfiguredModel>>>;
-}): Promise<Awaited<ReturnType<typeof reviewExecRequestWithConfiguredModel>>> {
-  if (!params.signal) {
-    return params.promise;
-  }
-  if (params.signal.aborted) {
-    throw toCodexAppServerApprovalCancellationError(params.signal.reason);
-  }
-  let onAbort: (() => void) | undefined;
-  const abortPromise = new Promise<never>((_, reject) => {
-    onAbort = () => reject(toCodexAppServerApprovalCancellationError(params.signal?.reason));
-    params.signal?.addEventListener("abort", onAbort, { once: true });
-  });
-  try {
-    return await Promise.race([params.promise, abortPromise]);
-  } finally {
-    if (onAbort) {
-      params.signal.removeEventListener("abort", onAbort);
-    }
-  }
-}
-
-function toCodexAppServerApprovalCancellationError(reason: unknown): Error {
-  if (reason instanceof Error) {
-    return reason;
-  }
-  return new Error(
-    typeof reason === "string" && reason.trim() ? reason : "Codex app-server approval cancelled.",
-  );
-}
-
-async function buildAppServerExecAutoReviewInput(params: {
-  requestParams: JsonObject | undefined;
-  paramsForRun: EmbeddedRunAttemptParams;
-}) {
-  const command = readString(params.requestParams, "command");
-  if (!command) {
-    return undefined;
-  }
-  return buildExecAutoReviewInputForShellCommand({
-    command,
-    cwd: readString(params.requestParams, "cwd") ?? params.paramsForRun.workspaceDir ?? null,
-    host: "codex-app-server",
-    agent: {
-      id: params.paramsForRun.agentId ?? null,
-      sessionKey: params.paramsForRun.sessionKey ?? null,
-    },
-  });
-}
-
-function hasCommandApprovalCapabilityAmendments(requestParams: JsonObject | undefined): boolean {
-  return (
-    hasNonEmptyJsonObject(requestParams?.additionalPermissions) ||
-    hasNonEmptyJsonObject(requestParams?.networkApprovalContext) ||
-    hasNonEmptyJsonObject(requestParams?.proposedExecpolicyAmendment) ||
-    hasNonEmptyArray(requestParams?.proposedExecpolicyAmendment) ||
-    hasNonEmptyArray(requestParams?.proposedNetworkPolicyAmendments) ||
-    findAvailableCommandAmendmentDecision(requestParams) !== undefined ||
-    commandAcceptDecisionUnavailable(requestParams)
-  );
-}
-
-function commandAcceptDecisionUnavailable(requestParams: JsonObject | undefined): boolean {
-  const available = requestParams?.availableDecisions;
-  return Array.isArray(available) && !available.includes("accept");
-}
-
-function hasNonEmptyJsonObject(value: unknown): boolean {
-  return isJsonObject(value) && Object.keys(value).length > 0;
-}
-
-function hasNonEmptyArray(value: unknown): boolean {
-  return Array.isArray(value) && value.length > 0;
-}
-
-function resolveExecReviewerConfig(
-  params: EmbeddedRunAttemptParams,
-  agentId?: string,
-): Record<string, unknown> | undefined {
-  const configRoot = readUnknownRecord(params.config);
-  const globalExec = readUnknownRecord(readUnknownRecord(configRoot?.tools)?.exec);
-  const agentExec = resolveAgentExecConfig(configRoot, agentId ?? params.agentId);
-  return readUnknownRecord(agentExec?.reviewer) ?? readUnknownRecord(globalExec?.reviewer);
-}
-
-function canUseInternalExecAutoReviewReviewer(
-  reviewerConfig: Record<string, unknown> | undefined,
-  config: EmbeddedRunAttemptParams["config"] | undefined,
-  env: NodeJS.ProcessEnv | undefined,
-  agentDir: string | undefined,
-): boolean {
-  const model = readExecReviewerModelRef(reviewerConfig);
-  const slashIndex = model?.indexOf("/") ?? -1;
-  if (!model || slashIndex <= 0) {
-    return false;
-  }
-  if (configuredAgentModelAliasMatches(config, model)) {
-    return false;
-  }
-  const provider = model.slice(0, slashIndex).trim().toLowerCase();
-  if (provider !== "openai") {
-    return false;
-  }
-  return isTrustedCodexModelBackedOpenAIProvider({
-    config,
-    env,
-    agentDir,
-    model: model.slice(slashIndex + 1).trim(),
-  });
-}
-
-function readExecReviewerModelRef(
-  reviewerConfig: Record<string, unknown> | undefined,
-): string | undefined {
-  const model = reviewerConfig?.model;
-  if (typeof model === "string") {
-    return model.trim() || undefined;
-  }
-  const primary = readUnknownRecord(model)?.primary;
-  return typeof primary === "string" && primary.trim() ? primary.trim() : undefined;
-}
-
-function configuredAgentModelAliasMatches(
-  config: EmbeddedRunAttemptParams["config"] | undefined,
-  modelRef: string,
-): boolean {
-  const normalizedModelRef = normalizeExecReviewerAliasRef(modelRef);
-  const agents = readUnknownRecord(readUnknownRecord(config)?.agents);
-  return agentModelAliasMatches(readUnknownRecord(agents?.defaults), normalizedModelRef);
-}
-
-function agentModelAliasMatches(
-  agentConfig: Record<string, unknown> | undefined,
-  normalizedModelRef: string,
-): boolean {
-  const models = readUnknownRecord(agentConfig?.models);
-  if (!models) {
-    return false;
-  }
-  for (const entry of Object.values(models)) {
-    const alias = readUnknownRecord(entry)?.alias;
-    if (typeof alias === "string" && normalizeExecReviewerAliasRef(alias) === normalizedModelRef) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function normalizeExecReviewerAliasRef(modelRef: string): string {
-  const trimmed = modelRef.trim().toLowerCase();
-  const slashIndex = trimmed.indexOf("/");
-  const authProfileIndex = trimmed.indexOf("@", slashIndex + 1);
-  return authProfileIndex > 0 ? trimmed.slice(0, authProfileIndex) : trimmed;
-}
-
-function resolveAgentExecConfig(
-  configRoot: Record<string, unknown> | undefined,
-  agentId: string | undefined,
-): Record<string, unknown> | undefined {
-  const normalizedAgentId = agentId ? normalizeAgentId(agentId) : undefined;
-  if (!normalizedAgentId) {
-    return undefined;
-  }
-  const agentList = readUnknownRecord(configRoot?.agents)?.list;
-  if (!Array.isArray(agentList)) {
-    return undefined;
-  }
-  for (const entry of agentList) {
-    const record = readUnknownRecord(entry);
-    if (typeof record?.id !== "string" || normalizeAgentId(record.id) !== normalizedAgentId) {
-      continue;
-    }
-    return readUnknownRecord(readUnknownRecord(record.tools)?.exec);
-  }
-  return undefined;
-}
-
-function readUnknownRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
 
 async function runOpenClawToolPolicyForApprovalRequest(params: {
   method: string;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -136,7 +136,6 @@ import {
   resolveOpenClawExecPolicyForCodexAppServer,
   shouldAutoApproveCodexAppServerApprovals,
   type CodexAppServerRuntimeOptions,
-  type OpenClawExecPolicyForCodexAppServer,
 } from "./config.js";
 import {
   type CodexProjectedContextRange,
@@ -2422,9 +2421,6 @@ export async function runCodexAppServerAttempt(
             threadId: thread.threadId,
             turnId,
             nativeHookRelay,
-            execPolicy,
-            execReviewerAgentId: sessionAgentId,
-            internalExecAutoReview: appServer.approvalsReviewer === "user",
             autoApprove: shouldAutoApproveCodexAppServerApprovals(appServer),
             signal: runAbortController.signal,
             onNativeToolFailureDisposition: (itemId, disposition) =>
@@ -3909,9 +3905,6 @@ function handleApprovalRequest(params: {
   threadId: string;
   turnId: string;
   nativeHookRelay?: NativeHookRelayRegistrationHandle;
-  execPolicy?: Pick<OpenClawExecPolicyForCodexAppServer, "mode">;
-  execReviewerAgentId?: string;
-  internalExecAutoReview?: boolean;
   autoApprove?: boolean;
   signal?: AbortSignal;
   onNativeToolFailureDisposition?: Parameters<
@@ -3925,9 +3918,6 @@ function handleApprovalRequest(params: {
     threadId: params.threadId,
     turnId: params.turnId,
     nativeHookRelay: params.nativeHookRelay,
-    execPolicy: params.execPolicy,
-    execReviewerAgentId: params.execReviewerAgentId,
-    internalExecAutoReview: params.internalExecAutoReview,
     autoApprove: params.autoApprove,
     signal: params.signal,
     onNativeToolFailureDisposition: params.onNativeToolFailureDisposition,

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -394,9 +394,6 @@ export async function runCodexAppServerSideQuestion(
           threadId: childThreadId,
           turnId,
           nativeHookRelay,
-          execPolicy,
-          execReviewerAgentId: sessionAgentId,
-          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
           autoApprove: shouldAutoApproveCodexAppServerApprovals({
             approvalPolicy,
             networkProxy: modelScopedAppServer.networkProxy,


### PR DESCRIPTION
Closes #103427

## What Problem This Solves

Fixes an issue where Codex app-server command approvals could be accepted by the configured exec reviewer even though Codex does not expose an enforceable resolved executable. A low-risk review decision therefore was not bound to the executable that Codex would run.

## Why This Change Was Made

Removes the Codex app-server-only internal exec reviewer and its caller plumbing. Explicit runtime/native policy decisions remain intact; otherwise the existing plugin approval route asks a human. The gateway and node exec reviewers remain unchanged because those paths enforce resolved execution plans.

## User Impact

Codex app-server commands that previously could receive a low-risk automatic review now wait for human approval unless explicit runtime or native policy already decided the request. This trades a small amount of convenience for an enforceable approval boundary.

## Evidence

- Direct upstream contract inspection: Codex command approval requests carry command/cwd/actions but no enforceable resolved executable, and acceptance executes the original command.
- Blacksmith Testbox `crimson-hermit`: `pnpm test extensions/codex/src/app-server/approval-bridge.test.ts` — 78/78 passed on final rebased head.
- Blacksmith Testbox `crimson-hermit`: `pnpm check:changed` — extension production/tests, docs, typechecks, lint, guards, and import-cycle checks passed on the same functional patch before the final documentation-only clarification/rebase.
- Regression proves a configured low-risk reviewer is not invoked and cannot override a human denial.
- Fresh branch autoreview: no accepted/actionable findings.
