### PR TITLE
fix(macos): keep dashboard tab reuse and ordering accurate

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
@@ -74,14 +74,24 @@ final class DashboardLinkBrowserTabBar: NSView {
         let location = self.stackView.convert(event.locationInWindow, from: nil)
         let arrangedItems = self.stackView.arrangedSubviews.compactMap { $0 as? DashboardLinkBrowserTabItemView }
         guard let currentIndex = arrangedItems.firstIndex(of: item) else { return }
-
-        var targetIndex = arrangedItems.count - 1
-        for (index, candidate) in arrangedItems.enumerated() where location.x < candidate.frame.midX {
-            targetIndex = index
-            break
-        }
-        guard targetIndex != currentIndex else { return }
+        let midpoints = arrangedItems.map(\.frame.midX)
+        guard let targetIndex = Self.dropIndex(
+            currentIndex: currentIndex,
+            itemMidpoints: midpoints,
+            locationX: location.x)
+        else { return }
         self.delegate?.tabBar(self, didMoveTab: id, toIndex: targetIndex)
+    }
+
+    static func dropIndex(currentIndex: Int, itemMidpoints: [CGFloat], locationX: CGFloat) -> Int? {
+        guard itemMidpoints.indices.contains(currentIndex) else { return nil }
+        // Delegate indexes describe the array after removal. Excluding the dragged
+        // item keeps rightward drops from advancing one tab too far.
+        let remainingMidpoints = itemMidpoints.enumerated().compactMap { index, midpoint in
+            index == currentIndex ? nil : midpoint
+        }
+        let targetIndex = remainingMidpoints.firstIndex { locationX < $0 } ?? remainingMidpoints.count
+        return targetIndex == currentIndex ? nil : targetIndex
     }
 
     fileprivate func contextMenu(forTab id: UUID) -> NSMenu? {

--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
@@ -72,6 +72,12 @@ private final class DashboardLinkBrowserTab {
             break
         }
     }
+
+    func failNavigation() {
+        // A failed initial chain has no reusable page. Retire its alias so
+        // opening the original link again starts a fresh load.
+        self.requestAliasPhase = .retired
+    }
 }
 
 @MainActor
@@ -240,6 +246,12 @@ final class DashboardLinkBrowserView: NSView {
 
     func navigationDidFinish(_ navigation: WKNavigation?, for webView: WKWebView) {
         self.finishNavigation(navigation, at: webView.url, title: webView.title, in: webView)
+    }
+
+    func navigationDidFail(for webView: WKWebView) {
+        guard let tab = self.tab(owning: webView) else { return }
+        tab.failNavigation()
+        self.updateChrome()
     }
 
     func navigationURLDidChange(for webView: WKWebView) {

--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
@@ -4,15 +4,73 @@ import WebKit
 
 @MainActor
 private final class DashboardLinkBrowserTab {
+    /// WebKit preserves one WKNavigation identity across a redirect chain.
+    /// A different identity means the opened-link alias is no longer current.
+    private enum RequestAliasPhase {
+        case awaitingNavigation
+        case loading(AnyObject)
+        case retained
+        case retired
+    }
+
     let id = UUID()
     let webView: WKWebView
+    let requestedURL: URL
     var representedURL: URL?
     var title: String?
     var observations: [NSKeyValueObservation] = []
+    private var requestAliasPhase: RequestAliasPhase = .awaitingNavigation
 
-    init(webView: WKWebView, representedURL: URL?) {
+    init(webView: WKWebView, requestedURL: URL) {
         self.webView = webView
-        self.representedURL = representedURL
+        self.requestedURL = requestedURL
+        self.representedURL = requestedURL
+    }
+
+    var requestedURLAlias: URL? {
+        if case .retired = self.requestAliasPhase {
+            nil
+        } else {
+            self.requestedURL
+        }
+    }
+
+    func startNavigation(_ navigation: AnyObject) {
+        switch self.requestAliasPhase {
+        case .awaitingNavigation:
+            self.requestAliasPhase = .loading(navigation)
+        case let .loading(initial) where initial !== navigation:
+            self.requestAliasPhase = .retired
+        case .retained:
+            self.requestAliasPhase = .retired
+        case .loading, .retired:
+            break
+        }
+    }
+
+    func updateRepresentedURL(_ url: URL?) {
+        // Initial redirects keep the opened link reusable. Once that chain
+        // finishes, a distinct navigation retires the now-stale alias.
+        if case .retained = self.requestAliasPhase, let url, url != self.representedURL {
+            self.requestAliasPhase = .retired
+        }
+        self.representedURL = url
+    }
+
+    func finishNavigation(_ navigation: AnyObject?, at url: URL?, title: String?) {
+        self.updateRepresentedURL(url)
+        self.title = title
+        guard let navigation else { return }
+        switch self.requestAliasPhase {
+        case .awaitingNavigation:
+            self.requestAliasPhase = .retained
+        case let .loading(initial) where initial === navigation:
+            self.requestAliasPhase = .retained
+        case .loading:
+            self.requestAliasPhase = .retired
+        case .retained, .retired:
+            break
+        }
     }
 }
 
@@ -83,9 +141,11 @@ final class DashboardLinkBrowserView: NSView {
     }
 
     func open(_ url: URL) {
-        // Repeat clicks on the exact same chat link reuse its tab so inline
-        // browsing does not pile up duplicates.
-        if let tab = self.tabs.first(where: { $0.representedURL == url }) {
+        // Keep the original request as a stable dedupe key across redirects while
+        // also reusing a tab that has since navigated to the requested target.
+        let tab = self.tabs.first(where: { $0.representedURL == url }) ??
+            self.tabs.first(where: { $0.requestedURLAlias == url })
+        if let tab {
             self.activateTab(id: tab.id)
             return
         }
@@ -93,7 +153,7 @@ final class DashboardLinkBrowserView: NSView {
     }
 
     func openInNewTab(_ url: URL) {
-        let tab = self.makeTab(representedURL: url)
+        let tab = self.makeTab(requestedURL: url)
         self.tabs.append(tab)
         self.tabBar.appendTab(id: tab.id, title: self.displayTitle(for: tab), toolTip: url.absoluteString)
         self.activateTab(id: tab.id)
@@ -169,14 +229,33 @@ final class DashboardLinkBrowserView: NSView {
 
     func navigationWillStart(_ url: URL, in webView: WKWebView) {
         guard let tab = self.tab(owning: webView) else { return }
-        tab.representedURL = url
+        tab.updateRepresentedURL(url)
         self.refreshTab(tab)
     }
 
-    func navigationDidFinish(for webView: WKWebView) {
+    func navigationDidStart(_ navigation: WKNavigation?, in webView: WKWebView) {
+        guard let navigation, let tab = self.tab(owning: webView) else { return }
+        tab.startNavigation(navigation)
+    }
+
+    func navigationDidFinish(_ navigation: WKNavigation?, for webView: WKWebView) {
+        self.finishNavigation(navigation, at: webView.url, title: webView.title, in: webView)
+    }
+
+    func navigationURLDidChange(for webView: WKWebView) {
         guard let tab = self.tab(owning: webView) else { return }
-        tab.representedURL = webView.url
-        tab.title = webView.title
+        tab.updateRepresentedURL(webView.url)
+        self.refreshTab(tab)
+    }
+
+    private func finishNavigation(
+        _ navigation: AnyObject?,
+        at url: URL?,
+        title: String?,
+        in webView: WKWebView)
+    {
+        guard let tab = self.tab(owning: webView) else { return }
+        tab.finishNavigation(navigation, at: url, title: title)
         self.refreshTab(tab)
     }
 
@@ -197,11 +276,11 @@ final class DashboardLinkBrowserView: NSView {
         return webView
     }
 
-    private func makeTab(representedURL: URL?) -> DashboardLinkBrowserTab {
+    private func makeTab(requestedURL: URL) -> DashboardLinkBrowserTab {
         let webView = Self.makeWebView(websiteDataStore: self.websiteDataStore)
         webView.navigationDelegate = self.webViewNavigationDelegate
         webView.uiDelegate = self.webViewUIDelegate
-        let tab = DashboardLinkBrowserTab(webView: webView, representedURL: representedURL)
+        let tab = DashboardLinkBrowserTab(webView: webView, requestedURL: requestedURL)
         self.installWebView(webView)
         self.observeNavigationState(for: tab)
         return tab
@@ -284,7 +363,7 @@ final class DashboardLinkBrowserView: NSView {
             webView.observe(\.url, options: [.new]) { [weak self, weak webView] _, _ in
                 Task { @MainActor in
                     guard let self, let webView else { return }
-                    self.navigationDidFinish(for: webView)
+                    self.navigationURLDidChange(for: webView)
                 }
             },
             webView.observe(\.title, options: [.new]) { [weak self, weak tab, weak webView] _, _ in
@@ -560,6 +639,15 @@ extension DashboardLinkBrowserView {
 
     func _testOpenInNewTab(_ url: URL) {
         self.openInNewTab(url)
+    }
+
+    func _testStartNavigation(_ navigation: AnyObject, in webView: WKWebView) {
+        guard let tab = self.tab(owning: webView) else { return }
+        tab.startNavigation(navigation)
+    }
+
+    func _testFinishNavigation(_ navigation: AnyObject, at url: URL?, in webView: WKWebView) {
+        self.finishNavigation(navigation, at: url, title: webView.title, in: webView)
     }
 
     func _testContextMenu(forTabAt index: Int) -> NSMenu? {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -672,15 +672,16 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         decisionHandler(.cancel)
     }
 
-    func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         if self.linkBrowser.owns(webView) {
+            self.linkBrowser.navigationDidStart(navigation, in: webView)
             self.linkBrowser.updateChrome()
         }
     }
 
-    func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if self.linkBrowser.owns(webView) {
-            self.linkBrowser.navigationDidFinish(for: webView)
+            self.linkBrowser.navigationDidFinish(navigation, for: webView)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -687,7 +687,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
     func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError error: Error) {
         if self.linkBrowser.owns(webView) {
-            self.linkBrowser.updateChrome()
+            self.linkBrowser.navigationDidFail(for: webView)
             return
         }
         guard webView === self.webView else { return }
@@ -700,7 +700,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         withError error: Error)
     {
         if self.linkBrowser.owns(webView) {
-            self.linkBrowser.updateChrome()
+            self.linkBrowser.navigationDidFail(for: webView)
             return
         }
         guard webView === self.webView else { return }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -210,19 +210,28 @@ struct DashboardWindowSmokeTests {
 
     @Test func `dashboard link browser calculates final drag insertion indexes`() {
         let midpoints: [CGFloat] = [50, 150, 250]
-        let cases: [(currentIndex: Int, locationX: CGFloat, expected: Int?)] = [
-            (0, 100, nil),
-            (0, 200, 1),
-            (0, 300, 2),
-            (2, 100, 1),
-            (2, 0, 0),
-            (1, 150, nil),
+        let cases: [(currentIndex: Int, locationX: CGFloat, targetIndex: Int?, order: [Int])] = [
+            (0, 100, nil, [0, 1, 2]),
+            (0, 150, 1, [1, 0, 2]),
+            (0, 200, 1, [1, 0, 2]),
+            (0, 300, 2, [1, 2, 0]),
+            (2, 100, 1, [0, 2, 1]),
+            (2, 0, 0, [2, 0, 1]),
+            (1, 150, nil, [0, 1, 2]),
         ]
         for testCase in cases {
-            #expect(DashboardLinkBrowserTabBar.dropIndex(
+            let targetIndex = DashboardLinkBrowserTabBar.dropIndex(
                 currentIndex: testCase.currentIndex,
                 itemMidpoints: midpoints,
-                locationX: testCase.locationX) == testCase.expected)
+                locationX: testCase.locationX)
+            #expect(targetIndex == testCase.targetIndex)
+
+            var order = Array(midpoints.indices)
+            if let targetIndex {
+                let moved = order.remove(at: testCase.currentIndex)
+                order.insert(moved, at: targetIndex)
+            }
+            #expect(order == testCase.order)
         }
     }
 
@@ -246,6 +255,10 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView === webView)
 
         view._testFinishNavigation(initialNavigation, at: currentURL, in: webView)
+        view.open(requestedURL)
+        #expect(view._testTabCount == 1)
+        #expect(view._testActiveWebView === webView)
+
         view._testStartNavigation(NSObject(), in: webView)
         view.navigationWillStart(currentURL, in: webView)
         view.open(requestedURL)

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -285,6 +285,23 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView !== webView)
     }
 
+    @Test func `dashboard link browser retires initial URL when redirected navigation fails`() throws {
+        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+        defer { view.closeBrowser() }
+        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
+        let redirectURL = try #require(URL(string: "http://127.0.0.1:1/redirect"))
+        view.open(requestedURL)
+        let webView = try #require(view._testActiveWebView)
+        view._testStartNavigation(NSObject(), in: webView)
+        view.navigationWillStart(redirectURL, in: webView)
+        view.navigationDidFail(for: webView)
+
+        view.open(requestedURL)
+
+        #expect(view._testTabCount == 2)
+        #expect(view._testActiveWebView !== webView)
+    }
+
     @Test func `dashboard link browser prefers current URL over initial alias`() throws {
         let view = DashboardLinkBrowserView(websiteDataStore: .default())
         defer { view.closeBrowser() }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -208,13 +208,95 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testLinkBrowserActiveTabIndex == 0)
     }
 
+    @Test func `dashboard link browser calculates final drag insertion indexes`() {
+        let midpoints: [CGFloat] = [50, 150, 250]
+        let cases: [(currentIndex: Int, locationX: CGFloat, expected: Int?)] = [
+            (0, 100, nil),
+            (0, 200, 1),
+            (0, 300, 2),
+            (2, 100, 1),
+            (2, 0, 0),
+            (1, 150, nil),
+        ]
+        for testCase in cases {
+            #expect(DashboardLinkBrowserTabBar.dropIndex(
+                currentIndex: testCase.currentIndex,
+                itemMidpoints: midpoints,
+                locationX: testCase.locationX) == testCase.expected)
+        }
+    }
+
+    @Test func `dashboard link browser retires initial URL after later navigation`() throws {
+        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+        defer { view.closeBrowser() }
+        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
+        let currentURL = try #require(URL(string: "http://127.0.0.1:1/final"))
+        view.open(requestedURL)
+        let webView = try #require(view._testActiveWebView)
+        let initialNavigation = NSObject()
+        view._testStartNavigation(initialNavigation, in: webView)
+        view.navigationWillStart(currentURL, in: webView)
+
+        view.open(requestedURL)
+        #expect(view._testTabCount == 1)
+        #expect(view._testActiveWebView === webView)
+
+        view.open(currentURL)
+        #expect(view._testTabCount == 1)
+        #expect(view._testActiveWebView === webView)
+
+        view._testFinishNavigation(initialNavigation, at: currentURL, in: webView)
+        view._testStartNavigation(NSObject(), in: webView)
+        view.navigationWillStart(currentURL, in: webView)
+        view.open(requestedURL)
+        #expect(view._testTabCount == 2)
+        #expect(view._testActiveWebView !== webView)
+    }
+
+    @Test func `dashboard link browser retires initial URL when navigation is replaced`() throws {
+        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+        defer { view.closeBrowser() }
+        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
+        let redirectURL = try #require(URL(string: "http://127.0.0.1:1/redirect"))
+        let replacementURL = try #require(URL(string: "http://127.0.0.1:1/replacement"))
+        view.open(requestedURL)
+        let webView = try #require(view._testActiveWebView)
+        view._testStartNavigation(NSObject(), in: webView)
+        view.navigationWillStart(redirectURL, in: webView)
+        view._testStartNavigation(NSObject(), in: webView)
+        view.navigationWillStart(replacementURL, in: webView)
+
+        view.open(requestedURL)
+
+        #expect(view._testTabCount == 2)
+        #expect(view._testActiveWebView !== webView)
+    }
+
+    @Test func `dashboard link browser prefers current URL over initial alias`() throws {
+        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+        defer { view.closeBrowser() }
+        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
+        let currentURL = try #require(URL(string: "http://127.0.0.1:1/final"))
+        view.open(requestedURL)
+        let redirectedWebView = try #require(view._testActiveWebView)
+        view.navigationWillStart(currentURL, in: redirectedWebView)
+        view._testOpenInNewTab(requestedURL)
+        let currentWebView = try #require(view._testActiveWebView)
+        view._testSelectTab(at: 0)
+
+        view.open(requestedURL)
+
+        #expect(view._testTabCount == 2)
+        #expect(view._testActiveWebView === currentWebView)
+    }
+
     @Test func `dashboard link browser menu disables URL actions for blank tab`() throws {
         let view = DashboardLinkBrowserView(websiteDataStore: .default())
         let url = try #require(URL(string: "http://127.0.0.1:1/blank"))
         view.open(url)
         let webView = try #require(view._testActiveWebView)
         #expect(webView.url == nil)
-        view.navigationDidFinish(for: webView)
+        view.navigationURLDidChange(for: webView)
         let menu = try #require(view._testContextMenu(forTabAt: 0))
         #expect(!menu.items[0].isEnabled)
         #expect(!menu.items[1].isEnabled)


### PR DESCRIPTION
Closes #103460
Closes #103459
Related: #103438
Related: #103469

## What Problem This Solves

Fixes two issues where users browsing links in the macOS dashboard sidebar could get duplicate tabs after an initial redirect, and could have a tab land one position too far right when reordering it.

## Why This Change Was Made

Each browser tab keeps its initially requested URL as a temporary alias across the first WebKit navigation and its redirect chain. A replacement, failure, or later navigation retires that alias, and an exact current-URL match always wins, so an old link cannot reactivate unrelated page state. Drag targeting derives the final insertion index after excluding the dragged item, matching the delegate's remove-then-insert contract.

## User Impact

Opening a dashboard link again reuses its tab through initial redirects or canonicalization, while later or failed navigation does not leave a stale alias behind. Sidebar tab drops now match the pointer position in both directions instead of skipping a slot on rightward moves.

## Evidence

- Before-fix deterministic Swift models reproduced both original failures: A-to-B navigation made repeat-open A miss the existing tab, and dragging A between B and C produced B,C,A instead of B,A,C.
- Exact final head `faef51079d7399e2fe4aa119bf58017c998d696c` and tree `bbdec7bce5c21774826cd81813f1c8c194fa9ba0` were verified locally and on the PR branch.
- Exact-head CI [run 29087362959](https://github.com/openclaw/openclaw/actions/runs/29087362959) completed successfully with no pending or failing relevant checks.
- macos-swift [job 86344228184](https://github.com/openclaw/openclaw/actions/runs/29087362959/job/86344228184) passed Swift lint, release build, Talk-trait opt-out, and 786 tests across 123 suites on the first attempt.
- Focused regressions passed for final drag insertion indexes, alias retirement after later navigation, replacement navigation, redirected navigation failure, and current-URL precedence.
- Blacksmith Testbox lease `tbx_01kx5ra35hs5snbsv64709ybz0` ran the exact final tree's apps lane: 171 passed, 37 skipped, exit 0.
- `swiftc -frontend -parse`, `swiftformat --lint --config config/swiftformat`, and `git diff --check` passed for the touched Swift files/diff.
- Fresh whole-branch mandatory autoreview is clean with no accepted/actionable findings after adding failure-path alias retirement.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 103464` passed the repository-native exact-head prepare gate.

The local macOS broad-check fallback reached an unrelated `npm shrinkwrap --check` host failure that reproduced identically on clean `main` with no package or lockfile diff. Clean-main Blacksmith Testbox guard [run 29086844831](https://github.com/openclaw/openclaw/actions/runs/29086844831) and full check [run 29087123944](https://github.com/openclaw/openclaw/actions/runs/29087123944) were green; exact-head hosted macOS CI is the authoritative platform proof.

AI-assisted: diagnosis, implementation, regression tests, and validation were prepared with Codex; maintainer-authored issues and exact hosted evidence are linked above.
