### PR TITLE
fix(ui): detect encoded media URL extensions

### DIFF
--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -377,6 +377,36 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("classifies encoded assistant MEDIA extensions", () => {
+      const imageUrl = "https://cdn.example/render%2Epng?download=1";
+      const videoUrl = "https://cdn.example/clip%2Emp4";
+      const result = normalizeMessage({
+        role: "assistant",
+        content: `MEDIA:${imageUrl}\nMEDIA:${videoUrl}`,
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: imageUrl,
+            kind: "image",
+            label: "render%2Epng",
+            mimeType: "image/png",
+          },
+        },
+        {
+          type: "attachment",
+          attachment: {
+            url: videoUrl,
+            kind: "video",
+            label: "clip%2Emp4",
+            mimeType: "video/mp4",
+          },
+        },
+      ]);
+    });
+
     it("keeps valid local MEDIA paths as assistant attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../src/chat/tool-content.js";
 import { splitMediaFromOutput } from "../../../../src/media/parse.js";
 import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
+import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
 
 export function normalizeRoleForGrouping(role: string): string {
@@ -158,26 +159,8 @@ const MIME_BY_EXT: Record<string, string> = {
   zip: "application/zip",
 };
 
-function getFileExtension(url: string): string | undefined {
-  const trimmed = url.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const source = (() => {
-    try {
-      if (/^https?:\/\//i.test(trimmed)) {
-        return new URL(trimmed).pathname;
-      }
-    } catch {}
-    return trimmed;
-  })();
-  const fileName = source.split(/[\\/]/).pop() ?? source;
-  const match = /\.([a-zA-Z0-9]+)$/.exec(fileName);
-  return match?.[1]?.toLowerCase();
-}
-
 function mimeTypeFromUrl(url: string): string | undefined {
-  const ext = getFileExtension(url);
+  const ext = getMediaFileExtension(url);
   return ext ? MIME_BY_EXT[ext] : undefined;
 }
 

--- a/ui/src/lib/media-file-extension.test.ts
+++ b/ui/src/lib/media-file-extension.test.ts
@@ -1,0 +1,20 @@
+// Control UI tests cover browser-safe media extension parsing.
+import { describe, expect, it } from "vitest";
+import { getMediaFileExtension } from "./media-file-extension.ts";
+
+describe("getMediaFileExtension", () => {
+  it.each([
+    { value: "https://cdn.example/render%2Emp4?download=1#preview", expected: "mp4" },
+    { value: "https://cdn.example/render%2Em%70%34", expected: "mp4" },
+    { value: "https://cdn.example/bad%ZZ/render%2Emp4", expected: "mp4" },
+    { value: "https://cdn.example/archive%2Fclip%2Emp4", expected: "mp4" },
+    { value: "https://cdn.example/archive%5Cclip%2Emp4", expected: "mp4" },
+    { value: "https://cdn.example/render.mp4%2Fpreview", expected: undefined },
+    { value: "https://cdn.example/render.mp4%5Cpreview", expected: undefined },
+    { value: "https://cdn.example/bad%ZZ%2Emp4", expected: undefined },
+    { value: "https://cdn.example/render%2Emp4/", expected: undefined },
+    { value: String.raw`C:\media\clip.MP4`, expected: "mp4" },
+  ] as const)("extracts $expected from $value", ({ value, expected }) => {
+    expect(getMediaFileExtension(value)).toBe(expected);
+  });
+});

--- a/ui/src/lib/media-file-extension.ts
+++ b/ui/src/lib/media-file-extension.ts
@@ -1,0 +1,29 @@
+// Browser-safe media filename extension parsing shared by Control UI renderers.
+
+/** Returns a lowercase extension without the leading dot. */
+export function getMediaFileExtension(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  let filename: string;
+  try {
+    if (/^https?:\/\//i.test(trimmed)) {
+      const pathname = new URL(trimmed).pathname;
+      filename = pathname.slice(pathname.lastIndexOf("/") + 1);
+      try {
+        // Match media-core: decode only the filename and keep encoded path
+        // separators as filename data instead of turning them into boundaries.
+        const decodable = filename.replace(/%2f/gi, "%252F").replace(/%5c/gi, "%255C");
+        filename = decodeURIComponent(decodable);
+      } catch {
+        // Preserve the raw filename when its own percent encoding is malformed.
+      }
+    } else {
+      filename = trimmed.split(/[\\/]/).pop() ?? trimmed;
+    }
+  } catch {
+    filename = trimmed.split(/[\\/]/).pop() ?? trimmed;
+  }
+  return /\.([a-zA-Z0-9]+)$/.exec(filename)?.[1]?.toLowerCase();
+}

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -644,6 +644,43 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("renders encoded media extensions from assistant output and transcript fields", async () => {
+    if (!realChatServer) {
+      throw new Error("Expected the Control UI server to be ready");
+    }
+    const imageUrl = "https://cdn.example/render%2Epng?download=1";
+    const videoUrl = "https://cdn.example/clip%2Emp4?download=1";
+    const page = await openBrowserPage(1366, 900);
+    try {
+      await page.route("https://cdn.example/**", (route) => route.abort());
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            content: `MEDIA:${imageUrl}`,
+            role: "assistant",
+            timestamp: Date.UTC(2026, 6, 9, 10, 0),
+          },
+          {
+            content: "Encoded transcript video",
+            MediaPath: videoUrl,
+            role: "user",
+            timestamp: Date.UTC(2026, 6, 9, 10, 1),
+          },
+        ],
+      });
+      await page.goto(`${realChatServer.baseUrl}chat`);
+
+      const image = page.locator("img.chat-message-image");
+      const video = page.locator("video");
+      await image.waitFor({ timeout: 10_000 });
+      await video.waitFor({ timeout: 10_000 });
+      expect(await image.getAttribute("src")).toBe(imageUrl);
+      expect(await video.getAttribute("src")).toBe(videoUrl);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it.each([
     [393, 852],
     [1366, 900],

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1868,6 +1868,26 @@ describe("grouped chat rendering", () => {
     expect(onAssistantAttachmentLoaded).toHaveBeenCalledTimes(2);
   });
 
+  it("renders transcript video URLs with encoded extensions", () => {
+    const container = document.createElement("div");
+    const mediaUrl = "https://cdn.example/clip%2Emp4?download=1";
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-encoded-video",
+        role: "user",
+        content: "",
+        MediaPath: mediaUrl,
+        timestamp: Date.now(),
+      },
+      "user",
+      { showToolCalls: false },
+    );
+
+    expect(expectElement(container, "video", HTMLVideoElement).src).toBe(mediaUrl);
+  });
+
   it("renders allowed transcript and content image variants", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -40,6 +40,7 @@ import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
 import { resolveUiHourCycleOptions } from "../../../lib/format.ts";
 import { formatCompactTokenCount } from "../../../lib/format.ts";
 import "../../../components/tooltip.ts";
+import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
 import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
 import { stripThinkingTags } from "../../../lib/strip-thinking-tags.ts";
 import { detectTextDirection } from "../../../lib/text-direction.ts";
@@ -250,23 +251,6 @@ function buildBase64ImageUrl(params: { data: string; mediaType?: string }): stri
     : `data:${params.mediaType ?? "image/png"};base64,${params.data}`;
 }
 
-function getFileExtension(url: string): string | undefined {
-  const source = (() => {
-    try {
-      const trimmed = url.trim();
-      if (/^https?:\/\//i.test(trimmed)) {
-        return new URL(trimmed).pathname;
-      }
-    } catch {
-      // Fall back to the raw path when URL parsing fails.
-    }
-    return url;
-  })();
-  const fileName = source.split(/[\\/]/).pop() ?? source;
-  const match = /\.([a-zA-Z0-9]+)$/.exec(fileName);
-  return match?.[1]?.toLowerCase();
-}
-
 function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   if (typeof mediaType === "string" && mediaType.trim()) {
     const normalized = mediaType.trim().toLowerCase();
@@ -277,7 +261,7 @@ function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
       return false;
     }
   }
-  const ext = getFileExtension(path);
+  const ext = getMediaFileExtension(path);
   return (
     ext !== undefined &&
     ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "heic", "heif", "avif"].includes(ext)
@@ -288,7 +272,7 @@ function isAudioTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   if (typeof mediaType === "string" && mediaType.trim().toLowerCase().startsWith("audio/")) {
     return true;
   }
-  const ext = getFileExtension(path);
+  const ext = getMediaFileExtension(path);
   return (
     ext !== undefined &&
     ["aac", "flac", "m2a", "m4a", "mp3", "oga", "ogg", "opus", "wav"].includes(ext)
@@ -299,7 +283,7 @@ function isVideoTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   if (typeof mediaType === "string" && mediaType.trim().toLowerCase().startsWith("video/")) {
     return true;
   }
-  const ext = getFileExtension(path);
+  const ext = getMediaFileExtension(path);
   return ext !== undefined && ["m4v", "mov", "mp4", "webm"].includes(ext);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI had two independent filename-extension parsers that treated percent-encoded filename dots as unknown media. URLs such as `render%2Epng` and `clip%2Emp4` therefore lost their image/video classification in assistant `MEDIA:` output and transcript media fields even though the shared media-core path already handled them.

Closes #103452. Related to #103410 and #102649.

## Why This Change Was Made

This replaces the duplicated UI parsers with one browser-safe helper. For HTTP(S) URLs it decodes only the final pathname component, protects encoded slash and backslash bytes from becoming path boundaries, and falls back safely for malformed filename encoding. Existing MIME/extension allowlists remain unchanged.

The helper stays UI-local because `@openclaw/media-core/mime` imports `node:path` and is a Node-targeted package surface; importing it into the browser bundle would widen the change beyond filename classification.

## User Impact

Encoded image and video URLs now render through the same attachment and transcript paths as literal-extension URLs. Plain local paths and malformed or suffix-bearing URLs retain their previous classification behavior.

## Evidence

- Current-main negative control: `new URL("https://cdn.example/render%2Epng?download=1").pathname` remains `/render%2Epng`, and the previous UI parser returns no extension.
- Final rebase head `129f6519ba0996c5b4042d15e9b0aa1b4d5fc414` preserves stable patch-id `dcd960825e4ea18a1133598f9795e0574cbdf9a7` on current-main base `bacc75a35854900bda78d1a8ea7705e62593df2d`.
- Blacksmith Testbox `tbx_01kx5r7r6nkfdr3wxeze12apq2` (`amber-crab`): 131/131 focused helper, message-normalizer, and DOM renderer tests passed.
- Real Chromium: `ui/src/pages/chat/chat-responsive.browser.test.ts`, 56/56 passed, including encoded assistant-image and transcript-video rendering.
- Targeted `check:changed` passed core/core-test typechecks, lint, import-cycle checking, and applicable repository guards.
- Production `pnpm ui:build` and `git diff --check` passed.
- Fresh final-head autoreview: clean, no actionable findings, confidence 0.86.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/29086144221 completed successfully with no blocking failures or pending jobs.

AI-assisted: yes. No agent transcript attached.
