### PR TITLE
fix(ci): read Codex bindings from SQLite in live harness

### DIFF
--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -1,6 +1,8 @@
 // Assertions for Codex npm plugin live E2E scenarios.
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { extractAgentReplyTexts } from "../agent-turn-output.mjs";
 import {
   assertPathInside,
@@ -41,6 +43,7 @@ const AGENT_TURN_TIMEOUT_SECONDS = readPositiveIntEnv(
   "OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS",
   420,
 );
+const CODEX_BINDING_NAMESPACE = "app-server-thread-bindings";
 
 function readPositiveIntEnv(name, fallback) {
   const text = String(process.env[name] ?? fallback).trim();
@@ -77,6 +80,43 @@ function readTextFileTail(filePath, label, maxBytes = MAX_ERROR_TAIL_BYTES) {
     return `[${label} truncated to last ${maxBytes} bytes]\n${buffer.toString("utf8")}`;
   } finally {
     fs.closeSync(fd);
+  }
+}
+
+function readCodexBinding(sessionId, sessionKey) {
+  const dbPath = path.join(stateDir(), "state", "openclaw.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`missing OpenClaw state database: ${dbPath}`);
+  }
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    const stableSessionKey = String(sessionKey ?? "").trim();
+    const key = stableSessionKey
+      ? `session-key:main:${createHash("sha256").update(stableSessionKey).digest("base64url")}`
+      : `session:main:${sessionId}`;
+    const row = db
+      .prepare(
+        `SELECT value_json
+           FROM plugin_state_entries
+          WHERE plugin_id = ? AND namespace = ? AND entry_key = ?
+            AND (expires_at IS NULL OR expires_at > ?)`,
+      )
+      .get("codex", CODEX_BINDING_NAMESPACE, key, Date.now());
+    if (!row || typeof row.value_json !== "string") {
+      throw new Error(`missing Codex app-server binding row: ${key}`);
+    }
+    const stored = JSON.parse(row.value_json);
+    if (stored?.version !== 1 || stored.state !== "active" || !stored.binding) {
+      throw new Error(`invalid Codex app-server binding row ${key}: ${row.value_json}`);
+    }
+    if (stored.sessionId && stored.sessionId !== sessionId) {
+      throw new Error(
+        `Codex app-server binding row ${key} belongs to session ${stored.sessionId}, expected ${sessionId}`,
+      );
+    }
+    return stored.binding;
+  } finally {
+    db.close();
   }
 }
 
@@ -405,10 +445,13 @@ function assertAgentTurn() {
   const sessionsDir = path.join(stateDir(), "agents", "main", "sessions");
   const storePath = path.join(sessionsDir, "sessions.json");
   const store = readJson(storePath);
-  const entry = Object.values(store).find((candidate) => candidate?.sessionId === sessionId);
-  if (!entry) {
+  const sessionMatch = Object.entries(store).find(
+    ([, candidate]) => candidate?.sessionId === sessionId,
+  );
+  if (!sessionMatch) {
     throw new Error(`missing session store entry for ${sessionId}: ${JSON.stringify(store)}`);
   }
+  const [sessionKey, entry] = sessionMatch;
   if (entry.agentHarnessId !== "codex") {
     throw new Error(`expected codex harness in session entry, got ${entry.agentHarnessId}`);
   }
@@ -419,9 +462,8 @@ function assertAgentTurn() {
     throw new Error(`missing OpenClaw session file: ${entry.sessionFile}`);
   }
 
-  const bindingPath = `${entry.sessionFile}.codex-app-server.json`;
-  const binding = readJson(bindingPath);
-  if (![1, 2].includes(binding.schemaVersion) || typeof binding.threadId !== "string") {
+  const binding = readCodexBinding(sessionId, sessionKey);
+  if (typeof binding.threadId !== "string") {
     throw new Error(`invalid Codex app-server binding: ${JSON.stringify(binding)}`);
   }
   if (binding.model !== modelRef.split("/").slice(1).join("/")) {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1663,7 +1663,7 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ],
   [
     "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs",
-    ["test/scripts/docker-build-helper.test.ts"],
+    ["test/scripts/codex-install-assertions.test.ts", "test/scripts/docker-build-helper.test.ts"],
   ],
   ["scripts/e2e/lib/codex-install-utils.mjs", ["test/scripts/codex-install-assertions.test.ts"]],
   [

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -1,5 +1,6 @@
 // Codex Install Assertions tests cover Codex plugin install E2E helpers.
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -12,10 +13,17 @@ import {
 } from "../../scripts/e2e/lib/codex-install-utils.mjs";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
-const ASSERTIONS_SCRIPT = "scripts/e2e/lib/codex-on-demand/assertions.mjs";
+const CODEX_ON_DEMAND_ASSERTIONS_SCRIPT = "scripts/e2e/lib/codex-on-demand/assertions.mjs";
+const CODEX_NPM_PLUGIN_LIVE_ASSERTIONS_SCRIPT =
+  "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs";
 const DISABLE_EXPERIMENTAL_WARNING = "--disable-warning=ExperimentalWarning";
 const tempDirs: string[] = [];
-const tmpFixtureFiles = ["/tmp/openclaw-codex-inspect.json", "/tmp/openclaw-plugins-list.json"];
+const tmpFixtureFiles = [
+  "/tmp/openclaw-codex-agent.err",
+  "/tmp/openclaw-codex-agent.json",
+  "/tmp/openclaw-codex-inspect.json",
+  "/tmp/openclaw-plugins-list.json",
+];
 
 afterEach(() => {
   for (const file of tmpFixtureFiles) {
@@ -72,7 +80,7 @@ function writeAuthProfileStoreSqlite(agentDir: string) {
 }
 
 function runCodexOnDemandAssertions(root: string) {
-  return spawnSync(process.execPath, [ASSERTIONS_SCRIPT], {
+  return spawnSync(process.execPath, [CODEX_ON_DEMAND_ASSERTIONS_SCRIPT], {
     encoding: "utf8",
     env: {
       ...process.env,
@@ -82,6 +90,120 @@ function runCodexOnDemandAssertions(root: string) {
       OPENCLAW_STATE_DIR: path.join(root, "state"),
     },
   });
+}
+
+function runCodexNpmPluginLiveAssertions(params: {
+  root: string;
+  marker: string;
+  sessionId: string;
+  modelRef: string;
+}) {
+  return spawnSync(
+    process.execPath,
+    [
+      CODEX_NPM_PLUGIN_LIVE_ASSERTIONS_SCRIPT,
+      "assert-agent-turn",
+      params.marker,
+      params.sessionId,
+      params.modelRef,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: path.join(params.root, "home"),
+        NODE_OPTIONS: nodeOptionsWithoutExperimentalWarnings(),
+        OPENCLAW_STATE_DIR: path.join(params.root, "state"),
+      },
+    },
+  );
+}
+
+function writeCodexBindingStateSqlite(params: {
+  stateDir: string;
+  sessionKey: string;
+  sessionId: string;
+  storedSessionId?: string;
+  threadId: string;
+}) {
+  const dbPath = path.join(params.stateDir, "state", "openclaw.sqlite");
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE plugin_state_entries (
+        plugin_id TEXT NOT NULL,
+        namespace TEXT NOT NULL,
+        entry_key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        PRIMARY KEY (plugin_id, namespace, entry_key)
+      );
+    `);
+    const entryKey = `session-key:main:${createHash("sha256")
+      .update(params.sessionKey)
+      .digest("base64url")}`;
+    db.prepare(
+      `INSERT INTO plugin_state_entries (
+         plugin_id, namespace, entry_key, value_json, created_at, expires_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "codex",
+      "app-server-thread-bindings",
+      entryKey,
+      JSON.stringify({
+        version: 1,
+        state: "active",
+        sessionId: params.storedSessionId ?? params.sessionId,
+        binding: {
+          threadId: params.threadId,
+          cwd: params.stateDir,
+          model: "gpt-5.4",
+          modelProvider: "codex",
+        },
+      }),
+      Date.now(),
+      null,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function createCodexNpmPluginLiveFixture(root: string, storedSessionId?: string) {
+  const stateDir = path.join(root, "state");
+  const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+  const sessionKey = "agent:main:codex-npm-plugin-live";
+  const sessionId = "codex-npm-plugin-live";
+  const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+  const marker = "OPENCLAW-CODEX-NPM-PLUGIN-LIVE-OK";
+  const threadId = "thread-codex-npm-live";
+  const modelRef = "codex/gpt-5.4";
+  writeJson("/tmp/openclaw-codex-agent.json", {
+    payloads: [{ text: marker }],
+    meta: { executionTrace: { winnerProvider: "codex" } },
+  });
+  writeJson(path.join(sessionsDir, "sessions.json"), {
+    [sessionKey]: {
+      sessionId,
+      sessionFile,
+      agentHarnessId: "codex",
+    },
+  });
+  writeFileSync(sessionFile, '{"type":"session"}\n', "utf8");
+  writeJson(path.join(stateDir, "agents", "main", "codex-home", "sessions", "native.jsonl"), {
+    threadId,
+    marker,
+  });
+  writeCodexBindingStateSqlite({
+    stateDir,
+    sessionKey,
+    sessionId,
+    storedSessionId,
+    threadId,
+  });
+  return { root, marker, sessionId, modelRef };
 }
 
 function createCodexInstallFixture(root: string) {
@@ -162,6 +284,28 @@ describe("Codex install helpers", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+  });
+
+  it("accepts the SQLite-backed Codex binding in the npm live assertion", () => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-npm-live-");
+    const fixture = createCodexNpmPluginLiveFixture(root);
+
+    const result = runCodexNpmPluginLiveAssertions(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("rejects a Codex binding owned by a stale physical session generation", () => {
+    const root = makeTempDir(tempDirs, "openclaw-codex-npm-live-stale-");
+    const fixture = createCodexNpmPluginLiveFixture(root, "previous-session");
+
+    const result = runCodexNpmPluginLiveAssertions(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "belongs to session previous-session, expected codex-npm-plugin-live",
+    );
   });
 
   it("rejects on-demand fixtures missing the managed @openai/codex dependency", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -504,7 +504,10 @@ describe("scripts/test-projects changed-target routing", () => {
       ],
       [
         "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs",
-        ["test/scripts/docker-build-helper.test.ts"],
+        [
+          "test/scripts/codex-install-assertions.test.ts",
+          "test/scripts/docker-build-helper.test.ts",
+        ],
       ],
       [
         "scripts/e2e/lib/codex-install-utils.mjs",


### PR DESCRIPTION
## What Problem This Solves

The Codex npm plugin live release harness still reads the retired JSONL sidecar for thread bindings. After the binding store migrated to SQLite, genuine live turns pass but the harness reports `ENOENT` and fails the release lane.

Fixes #103451

## Why This Change Was Made

Read the canonical `plugin_state_entries` row from `state/openclaw.sqlite`, using the same session-key digest and active/expiry rules as the Codex binding store. Reject bindings owned by a different physical session generation so the assertion cannot accept stale state.

Targeted-test routing now includes this harness file.

## User Impact

No runtime or product behavior changes. Release validation can correctly verify successful Codex npm plugin live turns after the SQLite migration.

## Evidence

- Reproduced in release validation job 86296271087: Codex CLI preflight and all 3 live turns passed before the stale sidecar assertion failed.
- Blacksmith Testbox `tbx_01kx5a4wcdhakjn1fdrc5pnses`: 190/190 focused tests passed on exact head `37cb842d02a7a44ab7a6d35cd1278aa42d3ea4b4`.
- Path-scoped `pnpm check:changed` passed in the same Testbox.
- Fresh exact-head structured autoreview: no accepted/actionable findings, confidence 0.90.
- `node --check` and `git diff --check` passed.
