### PR TITLE
fix(macos): tighten the link-browser tab header

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserView.swift
@@ -333,12 +333,13 @@ final class DashboardLinkBrowserView: NSView {
             self.toolbar.leadingAnchor.constraint(equalTo: leadingAnchor),
             self.toolbar.trailingAnchor.constraint(equalTo: trailingAnchor),
             self.toolbar.topAnchor.constraint(equalTo: topAnchor),
-            self.toolbar.heightAnchor.constraint(equalToConstant: 98),
+            self.toolbar.heightAnchor.constraint(equalToConstant: 78),
             // Browser-style header: tabs on top, navigation controls below.
-            // The top 32 points stay clear of the dashboard window's drag overlay.
+            // 12pt top inset clears the window's 12pt drag overlay (it reaches
+            // into wide sidebars), keeping every tab pixel clickable.
             self.tabBar.leadingAnchor.constraint(equalTo: self.toolbar.leadingAnchor),
             self.tabBar.trailingAnchor.constraint(equalTo: self.toolbar.trailingAnchor),
-            self.tabBar.topAnchor.constraint(equalTo: self.toolbar.topAnchor, constant: 32),
+            self.tabBar.topAnchor.constraint(equalTo: self.toolbar.topAnchor, constant: 12),
             self.tabBar.heightAnchor.constraint(equalToConstant: DashboardWindowLayout.linkBrowserTabBarHeight),
             controls.leadingAnchor.constraint(equalTo: self.toolbar.leadingAnchor, constant: 10),
             controls.trailingAnchor.constraint(equalTo: self.toolbar.trailingAnchor, constant: -10),


### PR DESCRIPTION
Related: #103334, follow-up to #103438

## What Problem This Solves

After #103438 the link-browser sidebar's tab strip sat 32pt below the window top — a visible dead gap between the tabs and the title area, left over from the old drag-overlay clearance. Maintainer feedback: put the tabs higher; the sidebar does not need a large window-drag band.

## Why This Change Was Made

The tab strip's top inset drops from 32pt to 12pt and the header shrinks from 98pt to 78pt. 12pt (not less) because the dashboard window's 12pt drag overlay extends into sidebars wider than 380pt; a smaller inset would let the overlay swallow clicks on the top sliver of the tabs. At 12pt every tab pixel stays clickable and the window's edge drag strip keeps working.

## User Impact

The sidebar browser header is 20pt shorter with the tabs sitting right under the window edge — no more dead gap above the tab strip.

## Evidence

- swift build --package-path apps/macos --product OpenClaw — pass.
- swift test --filter DashboardWindowSmokeTests — 18/18.
- swiftformat --lint on the touched file — clean.
- Autoreview (codex gpt-5.5, high): first iteration used an 8pt inset; review correctly flagged that the top 4pt of tabs would fall under the window's 12pt drag overlay on wide sidebars (verified against the overlay constraints in DashboardWindowController.makeWindow). Fixed to 12pt; rerun clean ("no accepted/actionable findings").
- Screenshot (captured during iteration at the 8pt inset; the landed 12pt differs by 4pt): ![tight header](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-browser-tabs/tabs-tight-header.png)
