### PR TITLE
feat(ios): show per-message usage metadata

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22146,8 +22146,80 @@
       "id": "native.apple.898849eb2bcb0b53"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 122,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Input tokens: \\(input)",
+      "surface": "apple",
+      "id": "native.apple.c622ecbe64757e20"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 126,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Output tokens: \\(output)",
+      "surface": "apple",
+      "id": "native.apple.9a2df48646af1dde"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 130,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Cache read tokens: \\(cacheRead)",
+      "surface": "apple",
+      "id": "native.apple.0c6c7b65489adafa"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 134,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Cache write tokens: \\(cacheWrite)",
+      "surface": "apple",
+      "id": "native.apple.c71fa1cad2deba7e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 139,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Cost: \\(formattedCost)",
+      "surface": "apple",
+      "id": "native.apple.62bcf67218a0ecd0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 154,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "ctx",
+      "surface": "apple",
+      "id": "native.apple.118ab29788bb00fd"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 157,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "\\(contextPercent) percent of context used",
+      "surface": "apple",
+      "id": "native.apple.1b6b0d02dc774cc3"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 159,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Warning: \\(contextPercent) percent of context used",
+      "surface": "apple",
+      "id": "native.apple.4e7cd5b3f4e0ddc0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 161,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Critical: \\(contextPercent) percent of context used",
+      "surface": "apple",
+      "id": "native.apple.107321cf0b74cb7f"
+    },
+    {
       "kind": "ui-call",
-      "line": 115,
+      "line": 223,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(percent)%",
       "surface": "apple",
@@ -22155,7 +22227,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 122,
+      "line": 230,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Context usage",
       "surface": "apple",
@@ -22163,15 +22235,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 334,
+      "line": 337,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.title)",
       "surface": "apple",
       "id": "native.apple.8509385953c19619"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 351,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Message usage",
+      "surface": "apple",
+      "id": "native.apple.6426e369511b043c"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 569,
+      "line": 600,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
@@ -22179,7 +22259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 569,
+      "line": 600,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -22187,7 +22267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 628,
+      "line": 659,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -22195,7 +22275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -22203,7 +22283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 657,
+      "line": 688,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -22211,7 +22291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 665,
+      "line": 696,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -22219,7 +22299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 666,
+      "line": 697,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -22227,7 +22307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 689,
+      "line": 720,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued",
       "surface": "apple",
@@ -22235,7 +22315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 691,
+      "line": 722,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending…",
       "surface": "apple",
@@ -22243,7 +22323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 693,
+      "line": 724,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Confirming…",
       "surface": "apple",
@@ -22251,7 +22331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 695,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unknown",
       "surface": "apple",
@@ -22259,7 +22339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 697,
+      "line": 728,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent",
       "surface": "apple",
@@ -22267,7 +22347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 719,
+      "line": 750,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued, sends when reconnected",
       "surface": "apple",
@@ -22275,7 +22355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 721,
+      "line": 752,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending",
       "surface": "apple",
@@ -22283,7 +22363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 723,
+      "line": 754,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sent, waiting for chat history confirmation",
       "surface": "apple",
@@ -22291,7 +22371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 725,
+      "line": 756,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unconfirmed, touch and hold to retry or delete",
       "surface": "apple",
@@ -22299,7 +22379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 727,
+      "line": 758,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent, touch and hold to retry or delete",
       "surface": "apple",
@@ -22307,7 +22387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 822,
+      "line": 853,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
@@ -22315,7 +22395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 861,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.label)",
       "surface": "apple",
@@ -22459,7 +22539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 438,
+      "line": 444,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -22467,7 +22547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 452,
+      "line": 458,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -22475,7 +22555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 483,
+      "line": 489,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -22483,7 +22563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 492,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -22491,7 +22571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 533,
+      "line": 539,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -22499,7 +22579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 592,
+      "line": 598,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -22507,7 +22587,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 603,
+      "line": 609,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -22515,7 +22595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 623,
+      "line": 629,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -22523,7 +22603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1049,
+      "line": 1055,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -22531,7 +22611,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1129,
+      "line": 1135,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22187,7 +22187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 154,
+      "line": 155,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "ctx",
       "surface": "apple",
@@ -22195,7 +22195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 157,
+      "line": 158,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(contextPercent) percent of context used",
       "surface": "apple",
@@ -22203,7 +22203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 159,
+      "line": 160,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Warning: \\(contextPercent) percent of context used",
       "surface": "apple",
@@ -22211,7 +22211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 161,
+      "line": 162,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Critical: \\(contextPercent) percent of context used",
       "surface": "apple",
@@ -22219,7 +22219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 223,
+      "line": 224,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(percent)%",
       "surface": "apple",
@@ -22227,7 +22227,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 230,
+      "line": 231,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Context usage",
       "surface": "apple",

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -215,6 +215,46 @@ struct SwiftUIRenderSmokeTests {
         _ = Self.host(root, size: CGSize(width: 393, height: 400))
     }
 
+    @Test @MainActor func `assistant usage footer builds across dynamic type sizes`() throws {
+        let usage = try JSONDecoder().decode(
+            OpenClawChatUsage.self,
+            from: Data(#"{"input":12000,"output":300,"cacheRead":438400,"cacheWrite":307000,"cost":{"total":0.0123}}"#
+                .utf8))
+        let message = OpenClawChatMessage(
+            role: "assistant",
+            content: [OpenClawChatMessageContent(
+                type: "text",
+                text: "A completed assistant response with per-run usage.",
+                thinking: nil,
+                thinkingSignature: nil,
+                mimeType: nil,
+                fileName: nil,
+                content: nil,
+                id: nil,
+                name: nil,
+                arguments: nil)],
+            timestamp: nil,
+            usage: usage)
+
+        for typeSize in [DynamicTypeSize.large, .accessibility2] {
+            let root = ChatMessageBubble(
+                message: message,
+                style: .standard,
+                markdownVariant: .standard,
+                userAccent: nil,
+                showsAssistantTrace: false,
+                assistantName: "OpenClaw",
+                assistantAvatarText: "OC",
+                assistantAvatarTint: nil,
+                showsAssistantAvatar: true,
+                isClean: false,
+                contextWindowTokens: 1_000_000)
+                .environment(\.dynamicTypeSize, typeSize)
+
+            _ = Self.host(root, size: CGSize(width: 320, height: 280))
+        }
+    }
+
     @Test @MainActor func `root tabs builds device orientation shell matrix`() {
         for scenario in Self.rootTabsShellScenarios() {
             let appModel = NodeAppModel()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -142,11 +142,12 @@ struct ChatMessageUsagePresentation: Equatable {
         // Context pressure mirrors the Control UI prompt size. Output is response data;
         // input plus cache reads/writes is the context the model received for this run.
         let promptTokens = Double(input ?? 0) + Double(cacheRead ?? 0) + Double(cacheWrite ?? 0)
-        let contextPercent: Int? = if let contextWindowTokens, contextWindowTokens > 0, promptTokens > 0 {
+        let contextPercent: Int?
+        if let contextWindowTokens, contextWindowTokens > 0, promptTokens > 0 {
             let roundedPercent = (promptTokens / Double(contextWindowTokens) * 100).rounded()
-            Int(min(100, roundedPercent))
+            contextPercent = Int(min(100, roundedPercent))
         } else {
-            nil
+            contextPercent = nil
         }
         let pressure = self.pressure(for: contextPercent)
         if let contextPercent {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -93,6 +93,114 @@ extension OpenClawChatViewModel {
     }
 }
 
+struct ChatMessageUsagePresentation: Equatable {
+    enum Pressure: Equatable {
+        case normal
+        case warning
+        case danger
+    }
+
+    let text: String
+    let accessibilityValue: String
+    let pressure: Pressure
+
+    static func make(
+        message: OpenClawChatMessage,
+        contextWindowTokens: Int?) -> ChatMessageUsagePresentation?
+    {
+        guard message.role.lowercased() == "assistant", let usage = message.usage else { return nil }
+
+        var visualParts: [String] = []
+        var accessibilityParts: [String] = []
+        let input = self.positive(usage.input)
+        let output = self.positive(usage.output)
+        let cacheRead = self.positive(usage.cacheRead)
+        let cacheWrite = self.positive(usage.cacheWrite)
+
+        if let input {
+            visualParts.append("↑\(self.tokens(input))")
+            accessibilityParts.append(String(localized: "Input tokens: \(input)"))
+        }
+        if let output {
+            visualParts.append("↓\(self.tokens(output))")
+            accessibilityParts.append(String(localized: "Output tokens: \(output)"))
+        }
+        if let cacheRead {
+            visualParts.append("R\(self.tokens(cacheRead))")
+            accessibilityParts.append(String(localized: "Cache read tokens: \(cacheRead)"))
+        }
+        if let cacheWrite {
+            visualParts.append("W\(self.tokens(cacheWrite))")
+            accessibilityParts.append(String(localized: "Cache write tokens: \(cacheWrite)"))
+        }
+        if let cost = usage.cost?.total, cost > 0 {
+            let formattedCost = String(format: "$%.4f", locale: Locale(identifier: "en_US_POSIX"), cost)
+            visualParts.append(formattedCost)
+            accessibilityParts.append(String(localized: "Cost: \(formattedCost)"))
+        }
+
+        // Context pressure mirrors the Control UI prompt size. Output is response data;
+        // input plus cache reads/writes is the context the model received for this run.
+        let promptTokens = Double(input ?? 0) + Double(cacheRead ?? 0) + Double(cacheWrite ?? 0)
+        let contextPercent: Int? = if let contextWindowTokens, contextWindowTokens > 0, promptTokens > 0 {
+            let roundedPercent = (promptTokens / Double(contextWindowTokens) * 100).rounded()
+            Int(min(100, roundedPercent))
+        } else {
+            nil
+        }
+        let pressure = self.pressure(for: contextPercent)
+        if let contextPercent {
+            let warningPrefix = pressure == .normal ? "" : "⚠︎ "
+            visualParts.append("\(warningPrefix)\(contextPercent)% \(String(localized: "ctx"))")
+            switch pressure {
+            case .normal:
+                accessibilityParts.append(String(localized: "\(contextPercent) percent of context used"))
+            case .warning:
+                accessibilityParts.append(String(localized: "Warning: \(contextPercent) percent of context used"))
+            case .danger:
+                accessibilityParts.append(String(localized: "Critical: \(contextPercent) percent of context used"))
+            }
+        }
+
+        guard !visualParts.isEmpty else { return nil }
+        return ChatMessageUsagePresentation(
+            text: visualParts.joined(separator: " "),
+            accessibilityValue: accessibilityParts.joined(separator: ", "),
+            pressure: pressure)
+    }
+
+    private static func pressure(for percent: Int?) -> Pressure {
+        guard let percent else { return .normal }
+        if percent >= 90 { return .danger }
+        if percent >= 75 { return .warning }
+        return .normal
+    }
+
+    private static func positive(_ value: Int?) -> Int? {
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+
+    private static func tokens(_ value: Int) -> String {
+        if value >= 1_000_000 {
+            return "\(self.trimmedDecimal(Double(value) / 1_000_000))M"
+        }
+        if value >= 1000 {
+            let thousands = Double(value) / 1000
+            if thousands >= 999.95 {
+                return "\(self.trimmedDecimal(Double(value) / 1_000_000))M"
+            }
+            return "\(self.trimmedDecimal(thousands))k"
+        }
+        return "\(value)"
+    }
+
+    private static func trimmedDecimal(_ value: Double) -> String {
+        String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"), value)
+            .replacingOccurrences(of: ".0", with: "")
+    }
+}
+
 #if os(macOS)
 /// Compact token ring for the window toolbar, mirroring the web UI's context
 /// gauge: ring fill and tint track pressure, the menu carries the details.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -208,6 +208,7 @@ struct ChatMessageBubble: View {
     let assistantAvatarTint: Color?
     let showsAssistantAvatar: Bool
     let isClean: Bool
+    let contextWindowTokens: Int?
 
     var body: some View {
         if self.isUser {
@@ -245,7 +246,8 @@ struct ChatMessageBubble: View {
             markdownVariant: self.markdownVariant,
             userAccent: self.userAccent,
             showsAssistantTrace: self.showsAssistantTrace,
-            isClean: self.isClean)
+            isClean: self.isClean,
+            contextWindowTokens: self.contextWindowTokens)
     }
 }
 
@@ -259,6 +261,7 @@ private struct ChatMessageBody: View {
     let userAccent: Color?
     let showsAssistantTrace: Bool
     let isClean: Bool
+    let contextWindowTokens: Int?
 
     var body: some View {
         let text = self.primaryText
@@ -337,6 +340,17 @@ private struct ChatMessageBody: View {
                         toolName: toolResult.name)
                 }
             }
+
+            if let usagePresentation = self.usagePresentation {
+                Text(usagePresentation.text)
+                    .font(OpenClawChatTypography.caption2)
+                    .monospacedDigit()
+                    .foregroundStyle(self.usageTint(usagePresentation.pressure))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(String(localized: "Message usage"))
+                    .accessibilityValue(usagePresentation.accessibilityValue)
+            }
         }
         .textSelection(.enabled)
         .foregroundStyle(textColor)
@@ -397,6 +411,23 @@ private struct ChatMessageBody: View {
     private var isToolResultMessage: Bool {
         let role = self.message.role.lowercased()
         return role == "toolresult" || role == "tool_result"
+    }
+
+    private var usagePresentation: ChatMessageUsagePresentation? {
+        ChatMessageUsagePresentation.make(
+            message: self.message,
+            contextWindowTokens: self.contextWindowTokens)
+    }
+
+    private func usageTint(_ pressure: ChatMessageUsagePresentation.Pressure) -> Color {
+        switch pressure {
+        case .normal:
+            OpenClawChatTheme.muted
+        case .warning:
+            OpenClawChatTheme.warning
+        case .danger:
+            OpenClawChatTheme.danger
+        }
     }
 
     private var toolResultTitle: String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -350,6 +350,8 @@ public struct OpenClawChatView: View {
 
     @ViewBuilder
     private var messageListRows: some View {
+        let contextWindowTokens = self.viewModel.contextUsage?.contextWindowTokens
+
         if let introText = visibleEmptyAssistantIntro {
             ChatAssistantIntroCard(
                 text: introText,
@@ -367,7 +369,7 @@ public struct OpenClawChatView: View {
         }
 
         ForEach(self.visibleMessages) { msg in
-            self.messageRow(for: msg)
+            self.messageRow(for: msg, contextWindowTokens: contextWindowTokens)
         }
 
         if self.viewModel.hasBlockingRunActivity, !self.hasVisibleStreamingAssistantText {
@@ -404,7 +406,10 @@ public struct OpenClawChatView: View {
     }
 
     @ViewBuilder
-    private func messageRow(for msg: OpenClawChatMessage) -> some View {
+    private func messageRow(
+        for msg: OpenClawChatMessage,
+        contextWindowTokens: Int?) -> some View
+    {
         let bubble = ChatMessageBubble(
             message: msg,
             style: self.style,
@@ -415,7 +420,8 @@ public struct OpenClawChatView: View {
             assistantAvatarText: self.assistantAvatarText,
             assistantAvatarTint: self.assistantAvatarTint,
             showsAssistantAvatar: self.showsAssistantAvatars,
-            isClean: self.composerChrome == .clean)
+            isClean: self.composerChrome == .clean,
+            contextWindowTokens: contextWindowTokens)
             .frame(
                 maxWidth: .infinity,
                 alignment: msg.role.lowercased() == "user" ? .trailing : .leading)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
@@ -55,6 +55,7 @@ struct ChatContextUsageTests {
         input: Int? = nil,
         output: Int? = nil,
         cacheRead: Int? = nil,
+        cacheWrite: Int? = nil,
         total: Int? = nil,
         costTotal: Double? = nil) throws -> OpenClawChatUsage
     {
@@ -62,6 +63,7 @@ struct ChatContextUsageTests {
         payload["input"] = input
         payload["output"] = output
         payload["cacheRead"] = cacheRead
+        payload["cacheWrite"] = cacheWrite
         payload["total"] = total
         if let costTotal {
             payload["cost"] = ["total": costTotal]
@@ -215,5 +217,64 @@ struct ChatContextUsageTests {
 
         #expect(vm.contextUsage?.usedTokens == 5000)
         #expect(vm.contextUsage?.contextWindowTokens == 10000)
+    }
+
+    @Test func `assistant message usage mirrors the compact control UI footer`() throws {
+        let message = try self.message(usage: self.usage(
+            input: 59,
+            output: 13400,
+            cacheRead: 2_200_000,
+            cacheWrite: 43900,
+            costTotal: 0.01234))
+
+        let presentation = try #require(ChatMessageUsagePresentation.make(
+            message: message,
+            contextWindowTokens: 3_000_000))
+
+        #expect(presentation.text == "↑59 ↓13.4k R2.2M W43.9k $0.0123 ⚠︎ 75% ctx")
+        #expect(presentation.pressure == .warning)
+        #expect(presentation.accessibilityValue.contains("Warning"))
+    }
+
+    @Test func `context pressure excludes output tokens and clamps at one hundred percent`() throws {
+        let warning = try self.message(usage: self.usage(
+            input: 700,
+            output: 900_000,
+            cacheRead: 50,
+            cacheWrite: 50))
+        let danger = try self.message(usage: self.usage(input: 1200, output: 900_000))
+
+        let warningPresentation = try #require(ChatMessageUsagePresentation.make(
+            message: warning,
+            contextWindowTokens: 1000))
+        let dangerPresentation = try #require(ChatMessageUsagePresentation.make(
+            message: danger,
+            contextWindowTokens: 1000))
+
+        #expect(warningPresentation.text.hasSuffix("⚠︎ 80% ctx"))
+        #expect(warningPresentation.pressure == .warning)
+        #expect(dangerPresentation.text.hasSuffix("⚠︎ 100% ctx"))
+        #expect(dangerPresentation.pressure == .danger)
+        #expect(dangerPresentation.accessibilityValue.contains("Critical"))
+    }
+
+    @Test func `extreme decoded usage clamps without integer overflow`() throws {
+        let message = try self.message(usage: self.usage(input: Int.max, cacheRead: 1))
+
+        let presentation = try #require(ChatMessageUsagePresentation.make(
+            message: message,
+            contextWindowTokens: 1))
+
+        #expect(presentation.text.hasSuffix("⚠︎ 100% ctx"))
+        #expect(presentation.pressure == .danger)
+    }
+
+    @Test func `usage footer is assistant-only and omits unsupported totals`() throws {
+        let usage = try self.usage(total: 1200)
+        let user = self.message(role: "user", usage: usage)
+        let assistant = self.message(usage: usage)
+
+        #expect(ChatMessageUsagePresentation.make(message: user, contextWindowTokens: 4000) == nil)
+        #expect(ChatMessageUsagePresentation.make(message: assistant, contextWindowTokens: 4000) == nil)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The shared Apple chat UI decoded per-message usage but did not surface it beneath completed assistant replies. iOS users therefore had no per-run visibility into input/output tokens, cache activity, cost, or context pressure while chatting.

Refs #72133. This PR completes only the iOS/shared-Apple portion; the issue stays open for Android and optional channel footers.

## Why This Change Was Made

The footer lives in the existing shared `OpenClawChatUI` message owner and consumes the already-decoded `OpenClawChatUsage` plus the existing session/model context window. It mirrors the Control UI contract: compact input/output/cache/cost fields, prompt context calculated from input plus cache read/write (excluding output), and warning/danger states at 75%/90%.

No config, persistence, protocol, model label, or public API was added. The formatter is deterministic and per-message; the message list resolves the context window once per render.

## User Impact

Completed assistant replies on iOS now show a subtle footer such as `↑12k ↓300 R438.4k W307k $0.0123 ⚠︎ 76% ctx`. The footer wraps at large Dynamic Type sizes, uses branded typography, includes a non-color warning cue, and exposes expanded VoiceOver labels. User messages, streamed partial replies, and messages without supported usage remain unchanged.

## Evidence

- Unit coverage for compact formatting, assistant-only visibility, output-excluded context pressure, 75%/90% severity, 100% clamping, cost precision, and extreme decoded token counts.
- SwiftUI render smoke at standard and accessibility Dynamic Type sizes.
- Blacksmith Testbox-through-Crabbox `tbx_01kx59nbcmg7tj388b2sea2m3g`: remote `pnpm check:changed` passed after the final overflow fix.
- SwiftFormat, Swift parser, native i18n sync/check, `git diff --check`, and fresh full-branch Codex autoreview passed.
- Exact-head GitHub [CI 29074507532](https://github.com/openclaw/openclaw/actions/runs/29074507532) passed, including `ios-build`, `macos-swift`, and `native-i18n`.
- Exact-head [iOS Periphery 29074507534](https://github.com/openclaw/openclaw/actions/runs/29074507534) passed.
