### PR TITLE
fix(macos): stabilize Codex pipe-drain test under load

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -285,14 +285,16 @@ struct MacNodeCodexThreadCatalogTests {
         IFS= read -r initialized || exit 3
         IFS= read -r list || exit 4
         printf '%s\n' '\(response)'
-        sleep 1
+        # Keep stdout open until the client closes stdin; completion must come
+        # from draining the full JSONL frame, never from observing process EOF.
+        IFS= read -r keep_open || exit 0
         """)
         defer { try? FileManager.default.removeItem(at: fake.directory) }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":50}"#,
             executable: fake.executable.path,
-            timeoutSeconds: 1)
+            timeoutSeconds: 10)
         let decoded = try #require(
             JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any])
         #expect((decoded["sessions"] as? [Any])?.count == 50)


### PR DESCRIPTION
Follow-up to #102586.

AI-assisted: Codex implemented and reviewed this change; the maintainer requested the fix and landing.

## What Problem This Solves

Fixes an intermittent timeout in the macOS Codex thread-catalog pipe-drain regression test when the full `OpenClawIPCTests` target runs in parallel under CPU contention. The fake server stayed open for one second while the client used the same one-second deadline, allowing the timeout timer to beat queued stdout consumption on a loaded runner.

## Why This Change Was Made

After emitting the oversized JSONL response, the fake App Server now blocks on another stdin read. Successful response parsing closes stdin, so the test can pass only by draining and parsing the full frame before process EOF. A 10-second deadline gives parallel CI enough scheduling headroom while still making any EOF-dependent implementation fail.

No production behavior changes.

## User Impact

Developers and CI get reliable macOS IPC coverage under parallel load without weakening the regression assertion for App Server frames larger than one pipe read.

## Evidence

- Focused Swift test passed.
- `MacNodeCodexThreadCatalogTests`: 9/9 passed.
- Three 12-worker, coverage-enabled `OpenClawIPCTests` attempts showed no recurrence in this test. The aggregate target remained red only on unrelated existing timing failures in `GatewayChannelDisconnectTests` and `TalkBufferedAudioPlayerTests`.
- Blacksmith Testbox through Crabbox `tbx_01kx5bfryyexftegvkx8fj6cva`: `pnpm check:changed` passed (SwiftLint correctly deferred to macOS CI).
- Structured Codex autoreview: no findings; patch correct at 0.99 confidence.
- `git diff --check` passed.
