### PR TITLE
fix(config): recognize x-ai as built-in provider overlay

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -508,6 +508,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "volcengine",
   "volcengine-plan",
   "vydra",
+  "x-ai",
   "xai",
   "xiaomi",
   "xiaomi-token-plan",

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -20,6 +20,7 @@ describe("ModelsConfigSchema", () => {
     "qwen-oauth",
     "qwen-portal",
     "qwen-token-plan",
+    "x-ai",
     "z.ai",
     "z-ai",
   ])("accepts bundled provider overlay for %s without baseUrl or models", (providerId) => {


### PR DESCRIPTION
Closes #103454

## What Problem This Solves

Gateway startup rejects the shipped `x-ai` provider alias overlay with:

```
models.providers.x-ai.baseUrl: custom model providers must declare baseUrl; provider overlays without baseUrl are only supported for bundled providers
```

`extensions/xai` declares `x-ai` as a bundled alias for the `xai` provider (`aliases: ["x-ai"]` in `extensions/xai/index.ts` and `extensions/xai/provider-contract-api.ts`, `providerAuthAliases: { "x-ai": "xai" }`), but the core config schema's `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS` allowlist in `src/config/zod-schema.core.ts` only listed `xai`, not `x-ai`. Any `models.providers.x-ai` overlay was therefore treated as an unrecognized custom provider and rejected for missing `baseUrl`/`models`, blocking Gateway startup for any config using the alias.

## Why This Change Was Made

Added `"x-ai"` to `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS`, matching the existing pattern already used for other provider alias variants in the same set (`z.ai`/`z-ai`/`zai`, `moonshot`/`moonshot-ai`/`moonshotai`, `gmi`/`gmi-cloud`/`gmicloud`, `novita`/`novita-ai`/`novitaai`). No other behavior changes.

## User Impact

Users who configure `models.providers.x-ai` (the alias xAI itself declares) no longer hit a Gateway startup validation error; the overlay is accepted the same way `models.providers.xai` already is.

## Evidence

- [x] `pnpm test -- src/config/zod-schema.models.test.ts` (22 passed, including new `x-ai` case in the bundled-overlay-without-baseUrl parametrized test)
- [x] `pnpm tsgo`
- [x] Manual: confirmed `BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS` used by both `ModelProvidersSchema.superRefine` (validation.ts) and `materializeBundledModelProviderOverlays` (validation.ts) share the same allowlist, so both call sites are fixed together.

Test level: fully tested.

Made with Copilot.
