### PR TITLE
fix(macos): stop config tests counting unrelated notifications

### DIFF
--- a/apps/macos/Sources/OpenClaw/ConfigStore.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigStore.swift
@@ -9,6 +9,10 @@ enum ConfigStore {
         var loadRemote: (@MainActor @Sendable () async -> [String: Any])?
         var saveRemote: (@MainActor @Sendable ([String: Any]) async throws -> Void)?
         var saveGateway: (@MainActor @Sendable ([String: Any]) async throws -> Void)?
+        #if DEBUG
+        /// Isolates focused notification assertions without changing the production sender contract.
+        var notificationCenter: NotificationCenter?
+        #endif
     }
 
     private actor OverrideStore {
@@ -83,7 +87,12 @@ enum ConfigStore {
                 }
             }
         }
-        NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+        #if DEBUG
+        let notificationCenter = overrides.notificationCenter ?? .default
+        #else
+        let notificationCenter = NotificationCenter.default
+        #endif
+        notificationCenter.post(name: .openclawConfigDidChange, object: nil)
     }
 
     @MainActor

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
@@ -40,24 +40,34 @@ struct ConfigStoreTests {
     @Test func `save routes to remote in remote mode`() async throws {
         var localHit = false
         var remoteHit = false
+        let notificationCenter = NotificationCenter()
         let changeCount = NotificationCount()
-        let observer = NotificationCenter.default.addObserver(
+        let observer = notificationCenter.addObserver(
             forName: .openclawConfigDidChange,
             object: nil,
             queue: nil)
-        { _ in changeCount.increment() }
-        defer { NotificationCenter.default.removeObserver(observer) }
-        await ConfigStore._testSetOverrides(.init(
+        { note in changeCount.record(note) }
+        defer { notificationCenter.removeObserver(observer) }
+
+        try await self.withOverrides(.init(
             isRemoteMode: { true },
             saveLocal: { _ in localHit = true },
-            saveRemote: { _ in remoteHit = true }))
+            saveRemote: { _ in
+                remoteHit = true
+                // Reproduce a concurrent AppState-style publisher overlapping this save.
+                await Task.detached {
+                    NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+                }.value
+            },
+            notificationCenter: notificationCenter))
+        {
+            try await ConfigStore.save(["remote": true])
+        }
 
-        try await ConfigStore.save(["remote": true])
-
-        await ConfigStore._testClearOverrides()
         #expect(remoteHit)
         #expect(!localHit)
         #expect(changeCount.value == 1)
+        #expect(changeCount.allSendersWereNil)
     }
 
     @Test func `save routes to local in local mode`() async throws {
@@ -76,25 +86,32 @@ struct ConfigStoreTests {
     }
 
     @Test func `failed save does not announce config change`() async {
+        let notificationCenter = NotificationCenter()
         let changeCount = NotificationCount()
-        let observer = NotificationCenter.default.addObserver(
+        let observer = notificationCenter.addObserver(
             forName: .openclawConfigDidChange,
             object: nil,
             queue: nil)
-        { _ in changeCount.increment() }
-        defer { NotificationCenter.default.removeObserver(observer) }
-        await ConfigStore._testSetOverrides(.init(
+        { note in changeCount.record(note) }
+        defer { notificationCenter.removeObserver(observer) }
+
+        await self.withOverrides(.init(
             isRemoteMode: { true },
             saveRemote: { _ in
+                // Concurrent same-name traffic must not look like a ConfigStore announcement.
+                await Task.detached {
+                    NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+                }.value
                 throw NSError(domain: "ConfigStoreTests", code: 1)
-            }))
+            },
+            notificationCenter: notificationCenter))
+        {
+            do {
+                try await ConfigStore.save(["remote": true])
+                Issue.record("Expected save to fail")
+            } catch {}
+        }
 
-        do {
-            try await ConfigStore.save(["remote": true])
-            Issue.record("Expected save to fail")
-        } catch {}
-
-        await ConfigStore._testClearOverrides()
         #expect(changeCount.value == 0)
     }
 
@@ -169,17 +186,40 @@ struct ConfigStoreTests {
             #expect((root?["meta"] as? [String: Any]) != nil)
         }
     }
+
+    private func withOverrides<T>(
+        _ overrides: ConfigStore.Overrides,
+        _ body: () async throws -> T) async rethrows -> T
+    {
+        await ConfigStore._testSetOverrides(overrides)
+        do {
+            let result = try await body()
+            await ConfigStore._testClearOverrides()
+            return result
+        } catch {
+            await ConfigStore._testClearOverrides()
+            throw error
+        }
+    }
 }
 
 private final class NotificationCount: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0
+    private var sawNonNilSender = false
 
     var value: Int {
         self.lock.withLock { self.count }
     }
 
-    func increment() {
-        self.lock.withLock { self.count += 1 }
+    var allSendersWereNil: Bool {
+        self.lock.withLock { !self.sawNonNilSender }
+    }
+
+    func record(_ notification: Notification) {
+        self.lock.withLock {
+            self.count += 1
+            self.sawNonNilSender = self.sawNonNilSender || notification.object != nil
+        }
     }
 }


### PR DESCRIPTION
Closes #103477
Related: #102637

## What Problem This Solves

The macOS Swift suite could fail `ConfigStoreTests` when another publisher emitted the same config-change notification during the focused save assertion. The failure was timing-dependent: the original exact-head macOS run observed two notifications on its first attempt, then passed on retry.

## Why This Change Was Made

Production keeps its existing sender contract: `ConfigStore` still posts `.openclawConfigDidChange` with a nil object on `NotificationCenter.default`. The focused tests now inject a private notification center through the existing DEBUG-only test overrides and deliberately race a competing nil-sender notification on the default center. This proves the save success path announces exactly once, the failure path does not announce, and the production nil-sender contract remains unchanged. A shared override helper also guarantees cleanup on both successful and throwing test paths.

## User Impact

There is no user-visible behavior change. This is a test-robustness change that removes cross-test notification contamination without weakening the assertions.

## Evidence

- Before fix: exact-head macOS CI [run 29073655164, job 86300486692](https://github.com/openclaw/openclaw/actions/runs/29073655164/job/86300486692) failed attempt 1 at `ConfigStoreTests.swift:60` because `changeCount` was 2 instead of 1; the automatic retry passed.
- Contract audit: `ConfigStore` and `AppState` both publish `.openclawConfigDidChange` with a nil sender, while `SettingsRootView` intentionally subscribes without a sender filter. Foundation documents that a nil observer object accepts notifications from any sender.
- Blacksmith Testbox `pnpm check:changed` passed on lease `tbx_01kx5sc6mejkzymc4qvxaq7j3g`: all five selected lanes passed (171 tests passed, 37 skipped).
- `swiftc -frontend -parse` passed for both touched Swift files.
- `swiftformat --lint --config config/swiftformat` passed for both touched Swift files.
- `git diff --check origin/main...HEAD` passed.
- Fresh branch autoreview against base `29d018f0af5e92ff1c131f08dd9308e6c9e38e59` was clean with no accepted/actionable findings.
- Exact-head [CI run 29086898086](https://github.com/openclaw/openclaw/actions/runs/29086898086) passed on `da2009f015437c759cd5bba3ab97fcce822d4fb6`, including [macos-swift job 86342723880](https://github.com/openclaw/openclaw/actions/runs/29086898086/job/86342723880): lint, release build, dependency trait check, and the first full Swift test attempt passed with 781 tests in 123 suites. macos-node, native-i18n, security-fast, and preflight also passed.

Exact-head PR macOS CI is the authoritative full Swift build/test proof.

AI-assisted: diagnosis, implementation, and validation were prepared with Codex; the linked issue and hosted failure provide the original evidence.
