### PR TITLE
fix(ios): trim model names in model picker

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -301,7 +301,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             let name = model.name.trimmingCharacters(in: .whitespacesAndNewlines)
             return OpenClawChatModelChoice(
                 modelID: model.id,
-                name: name.isEmpty ? model.id : model.name,
+                name: name.isEmpty ? model.id : name,
                 provider: model.provider,
                 contextWindow: model.contextWindow,
                 reasoning: model.reasoning)

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -152,12 +152,13 @@ struct IOSGatewayChatTransportTests {
             #"""
             {"models":[
               {"id":"claude-opus-4","name":"Claude Opus 4","provider":"anthropic","contextWindow":200000,"reasoning":true},
-              {"id":"gpt-5","name":"  ","provider":"openai","extra":"ignored"}
+              {"id":"gpt-5","name":"  ","provider":"openai","extra":"ignored"},
+              {"id":"claude-opus-4-padded","name":"  Claude Opus 4  ","provider":"anthropic"}
             ]}
             """#.utf8)
         let choices = try IOSGatewayChatTransport.decodeModelChoices(data)
 
-        #expect(choices.count == 2)
+        #expect(choices.count == 3)
         #expect(choices[0].modelID == "claude-opus-4")
         #expect(choices[0].name == "Claude Opus 4")
         #expect(choices[0].provider == "anthropic")
@@ -168,6 +169,9 @@ struct IOSGatewayChatTransportTests {
         #expect(choices[1].provider == "openai")
         #expect(choices[1].contextWindow == nil)
         #expect(choices[1].reasoning == nil)
+        // Regression: the trimmed name must be used, not the padded raw value.
+        #expect(choices[2].modelID == "claude-opus-4-padded")
+        #expect(choices[2].name == "Claude Opus 4")
     }
 
     @Test func `commands list params request text scope with args`() throws {


### PR DESCRIPTION
Closes #103365

## What Problem This Solves

The iOS model picker shows model names with untrimmed leading/trailing whitespace when the gateway's model catalog returns a padded `name` (e.g. `"  Claude Opus 4  "`). This can misalign or truncate the label in the SwiftUI picker row. Model selection itself is unaffected since `modelID` is separate.

## Why This Change Was Made

`IOSGatewayChatTransport.decodeModelChoices` (`apps/ios/Sources/Chat/IOSGatewayChatTransport.swift:298`) already computes a trimmed `name` and uses it for the is-it-blank check, but the non-empty branch returned the untrimmed `model.name` instead of the already-trimmed local `name`. Fixed to return the trimmed value, which was already in hand.

## User Impact

iOS users see the model name rendered without stray padding in the model picker, matching what the app already computes and displays for the blank-name fallback case.

## Evidence

- [x] Extended `apps/ios/Tests/IOSGatewayChatTransportTests.swift` with a `"  Claude Opus 4  "` case that only fails on the untrimmed path (the existing suite only covered a fully-blank name, where both expressions happened to agree).
- [x] `pnpm test -- apps/ios` is not applicable (Swift package tests build via Xcode/SwiftPM, not Vitest); relying on the `ios-build` / `macos-swift` CI checks on this PR for compiled test proof.
- [x] Manual code review: confirmed `modelID` is untouched, so routing/selection behavior is unchanged; only the display `name` field changes.

Test level: lightly tested (relies on CI for compiled Swift test execution; verified logic and diff by source review).

Made with Copilot.
