### PR TITLE
fix(ui): preserve lobster vigil reactions

### DIFF
--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -100,6 +100,21 @@ async function arrive(element: LobsterPetElement): Promise<void> {
   await advanceUntil(element, () => spritePresent(element), 200_000);
 }
 
+async function startVigilOnlyRun(outcome: LobsterPet["runOutcome"]): Promise<LobsterPetElement> {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+  // Seed 0 opts out of scheduled visits and passers, so vigil is the only
+  // presence owner when the run finishes.
+  const element = createPet(0, "busy");
+  element.runOutcome = outcome;
+  await element.updateComplete;
+  expect(spritePresent(element)).toBe(false);
+  await vi.advanceTimersByTimeAsync(600_500);
+  await element.updateComplete;
+  expect(spriteClasses(element)).toContain("lobster-pet--vigil");
+  return element;
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -630,6 +645,22 @@ describe("lobster pet element", () => {
     expect(spriteClasses(element)).not.toContain("lobster-pet--act-startle");
   });
 
+  it("cancels a pending pet when the pointer interaction is cancelled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42, "offline");
+    await element.updateComplete;
+
+    const sprite = element.querySelector(".lobster-pet");
+    sprite?.dispatchEvent(new Event("pointerdown"));
+    await vi.advanceTimersByTimeAsync(300);
+    sprite?.dispatchEvent(new Event("pointercancel"));
+    await vi.advanceTimersByTimeAsync(400);
+    await element.updateComplete;
+
+    expect(spriteClasses(element)).not.toContain("lobster-pet--act-pet");
+  });
+
   it("droops instead of cheering when the finished run failed", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-09T12:00:00"));
@@ -661,6 +692,58 @@ describe("lobster pet element", () => {
     await element.updateComplete;
     expect(spriteClasses(element)).not.toContain("lobster-pet--vigil");
   });
+
+  it.each([
+    ["ok", "cheer"],
+    ["error", "droop"],
+    ["aborted", "startle"],
+  ] as const)(
+    "finishes a vigil-only %s run with a visible %s before leaving",
+    async (outcome, act) => {
+      const element = await startVigilOnlyRun(outcome);
+      element.mode = "idle";
+      await element.updateComplete;
+      expect(spriteClasses(element)).toContain(`lobster-pet--act-${act}`);
+      expect(spriteClasses(element)).not.toContain("lobster-pet--away");
+
+      await vi.advanceTimersByTimeAsync(LOBSTER_PET_ACT_DURATION_MS[act]);
+      await element.updateComplete;
+      if (outcome === "error") {
+        expect(spriteClasses(element)).toContain("lobster-pet--act-sweep");
+        expect(spriteClasses(element)).not.toContain("lobster-pet--away");
+        await vi.advanceTimersByTimeAsync(LOBSTER_PET_ACT_DURATION_MS.sweep);
+        await element.updateComplete;
+      }
+      expect(spriteClasses(element)).toContain("lobster-pet--away");
+
+      await vi.advanceTimersByTimeAsync(400);
+      await element.updateComplete;
+      expect(spritePresent(element)).toBe(false);
+    },
+  );
+
+  it.each(["seed reset", "page hide"] as const)(
+    "releases vigil outcome presence on %s",
+    async (cleanup) => {
+      const element = await startVigilOnlyRun("ok");
+      element.mode = "idle";
+      await element.updateComplete;
+
+      if (cleanup === "seed reset") {
+        element.seed = 7;
+      } else {
+        const hidden = vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+        document.dispatchEvent(new Event("visibilitychange"));
+        hidden.mockRestore();
+      }
+      await element.updateComplete;
+      expect(spriteClasses(element)).not.toContain("lobster-pet--act-cheer");
+
+      await vi.advanceTimersByTimeAsync(400);
+      await element.updateComplete;
+      expect(spritePresent(element)).toBe(false);
+    },
+  );
 
   it("watches the pointer between acts", async () => {
     vi.useFakeTimers();

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -904,6 +904,7 @@ export class LobsterPet extends LitElement {
   @state() private dismissed = false;
   @state() private grumpy = false;
   @state() private vigil = false;
+  @state() private outcomePresenceOwner: "vigil" | null = null;
   @state() private passer: LobsterPasserPlan | null = null;
   @state() private movingDay = false;
   private movingDayChecked = false;
@@ -985,7 +986,10 @@ export class LobsterPet extends LitElement {
     return (
       this.visitsEnabled &&
       !this.dismissed &&
-      (this.mode === "offline" || this.vigil || this.scheduledVisiting)
+      (this.mode === "offline" ||
+        this.vigil ||
+        this.outcomePresenceOwner !== null ||
+        this.scheduledVisiting)
     );
   }
 
@@ -1020,16 +1024,18 @@ export class LobsterPet extends LitElement {
       // The first update takes this branch, so the mode-change branch below
       // never sees the initial mode: arm the vigil tracker here as well.
       this.vigil = false;
+      this.outcomePresenceOwner = null;
       this.trackVigil();
     } else if (changed.has("mode")) {
+      const previousMode = changed.get("mode") as LobsterPetMode | undefined;
+      const finished = previousMode === "busy" && this.mode === "idle";
+      const presenceOwner = finished && this.vigil ? "vigil" : null;
       this.trackVigil();
       if (this.presence === "in" && !prefersReducedMotion()) {
         // Status flips get an immediate reaction. A finished run (busy ->
         // idle) earns a cheer when it succeeded and a sympathetic droop when
         // it failed; everything else startles. The act-end timer then
         // reschedules from the new mode's pool.
-        const previousMode = changed.get("mode") as LobsterPetMode | undefined;
-        const finished = previousMode === "busy" && this.mode === "idle";
         // Success cheers, failure droops, a user abort is nothing to
         // celebrate or mourn - just acknowledge the change.
         const finishAct =
@@ -1038,7 +1044,7 @@ export class LobsterPet extends LitElement {
             : this.runOutcome === "aborted"
               ? "startle"
               : "cheer";
-        this.performAct(finished ? finishAct : "startle");
+        this.performAct(finished ? finishAct : "startle", presenceOwner);
       }
     }
     // Moving day latches once per load, as soon as the gateway version is
@@ -1083,6 +1089,7 @@ export class LobsterPet extends LitElement {
       return;
     }
     if (!visible && this.presence === "in") {
+      this.outcomePresenceOwner = null;
       this.clearActTimers();
       this.act = null;
       this.entering = false;
@@ -1118,6 +1125,7 @@ export class LobsterPet extends LitElement {
 
   private readonly handleVisibilityChange = () => {
     if (document.hidden) {
+      this.outcomePresenceOwner = null;
       this.clearActTimers();
       this.act = null;
     } else {
@@ -1461,8 +1469,11 @@ export class LobsterPet extends LitElement {
     }, delay);
   }
 
-  private performAct(act: LobsterPetAct) {
+  private performAct(act: LobsterPetAct, presenceOwner: "vigil" | null = null) {
     this.clearActTimers();
+    // The active outcome chain carries its sole presence owner across linked
+    // acts; overrides, forced departures, and the terminal act release it.
+    this.outcomePresenceOwner = presenceOwner;
     this.entering = false;
     if (act === "scuttle") {
       this.startScuttle();
@@ -1476,10 +1487,13 @@ export class LobsterPet extends LitElement {
       }
       if (act === "droop") {
         // Bad news gets processed lobster-style: tidy the ledge, then move on.
-        this.performAct("sweep");
+        this.performAct("sweep", presenceOwner);
         return;
       }
-      this.scheduleNextAct();
+      this.outcomePresenceOwner = null;
+      if (this.wantsVisible()) {
+        this.scheduleNextAct();
+      }
     }, LOBSTER_PET_ACT_DURATION_MS[act]);
   }
 
@@ -1594,6 +1608,7 @@ export class LobsterPet extends LitElement {
         title=${title}
         @pointerdown=${this.handleHoldStart}
         @pointerup=${this.handleHoldEnd}
+        @pointercancel=${this.handleHoldCancel}
         @pointerleave=${this.handleHoldCancel}
         @contextmenu=${this.handleShoo}
       >

--- a/ui/src/e2e/lobster-pet.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet.e2e.test.ts
@@ -1,0 +1,126 @@
+// Control UI E2E tests cover real-browser lobster pet timing and pointer cancellation.
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+type BrowserLobsterPet = HTMLElement & {
+  mode: "idle" | "busy" | "offline";
+  runOutcome: "ok" | "error" | "aborted";
+  seed: number;
+  updateComplete: Promise<unknown>;
+};
+
+let browser: Browser;
+let context: BrowserContext;
+let page: Page;
+let server: ControlUiE2eServer;
+
+async function mountPet(params: {
+  mode: BrowserLobsterPet["mode"];
+  outcome: BrowserLobsterPet["runOutcome"];
+  seed: number;
+}) {
+  await page.evaluate(async (fixture) => {
+    const pet = document.createElement("openclaw-lobster-pet") as BrowserLobsterPet;
+    pet.seed = fixture.seed;
+    pet.mode = fixture.mode;
+    pet.runOutcome = fixture.outcome;
+    document.body.replaceChildren(pet);
+    await pet.updateComplete;
+  }, params);
+}
+
+async function settlePet() {
+  await page.evaluate(
+    () => (document.querySelector("openclaw-lobster-pet") as BrowserLobsterPet).updateComplete,
+  );
+}
+
+describeControlUiE2e("Control UI lobster pet", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium cannot start at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  beforeEach(async () => {
+    context = await browser.newContext({ hasTouch: true });
+    page = await context.newPage();
+    await page.clock.install({ time: new Date("2026-07-09T12:00:00") });
+    await installMockGateway(page);
+    await page.goto(server.baseUrl);
+    await page.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
+    const loadedAt = await page.evaluate(() => Date.now());
+    await page.clock.pauseAt(loadedAt + 1_000);
+  });
+
+  afterEach(async () => {
+    await context.close();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps a vigil-only failure present through droop and sweep before leaving", async () => {
+    await mountPet({ mode: "busy", outcome: "error", seed: 0 });
+    const sprite = page.locator(".lobster-pet");
+    await expect.poll(() => sprite.count()).toBe(0);
+
+    await page.clock.runFor(600_500);
+    await settlePet();
+    expect(await page.locator(".lobster-pet--vigil").count()).toBe(1);
+    await page.evaluate(async () => {
+      const pet = document.querySelector("openclaw-lobster-pet") as BrowserLobsterPet;
+      pet.mode = "idle";
+      await pet.updateComplete;
+    });
+
+    const droop = page.locator(".lobster-pet--act-droop");
+    expect(await droop.count()).toBe(1);
+    await page.clock.runFor(1_599);
+    await settlePet();
+    expect(await droop.count()).toBe(1);
+    await page.clock.runFor(1);
+    await settlePet();
+
+    const sweep = page.locator(".lobster-pet--act-sweep");
+    expect(await sweep.count()).toBe(1);
+    await page.clock.runFor(1_799);
+    await settlePet();
+    expect(await sweep.count()).toBe(1);
+    await page.clock.runFor(1);
+    await settlePet();
+
+    expect(await page.locator(".lobster-pet--away").count()).toBe(1);
+    await page.clock.runFor(350);
+    await expect.poll(() => sprite.count()).toBe(0);
+  });
+
+  it("does not pet after Chromium cancels a sub-threshold touch hold", async () => {
+    await mountPet({ mode: "offline", outcome: "ok", seed: 42 });
+    const sprite = page.locator(".lobster-pet");
+    await sprite.waitFor();
+
+    await sprite.dispatchEvent("pointerdown", { pointerId: 1, pointerType: "touch" });
+    await page.clock.runFor(300);
+    await sprite.dispatchEvent("pointercancel", { pointerId: 1, pointerType: "touch" });
+    await page.clock.runFor(400);
+
+    await expect.poll(() => page.locator(".lobster-pet--act-pet").count()).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

A shy lobster can be present solely because a busy run crossed the ten-minute vigil threshold. On busy-to-idle, the component consumed that sole presence owner before reconciliation, which immediately erased the success cheer, failure droop, or abort acknowledgement and sent the lobster away. Browser-cancelled pointer gestures also left the press-and-hold timer alive, allowing a delayed pet after the interaction had ended.

Closes #103475. Follow-up to #103344 and #103573.

## Why This Change Was Made

The active terminal outcome chain now carries a closed `"vigil" | null` presence owner. It survives the current failure sequence from droop through sweep, then releases after the terminal act. Seed resets, page hiding, overrides, and forced departures release it immediately. Existing scheduled-visit and offline presence owners remain unchanged. The existing hold-cancel handler is also wired to `pointercancel`.

## User Impact

Long-running shy pets visibly finish their success, failure, or abort reaction before performing the normal leave transition. Failed runs retain the complete droop-and-sweep sequence added on current `main`. Cancelled touch or stylus interactions cannot trigger a delayed pet.

## Evidence

- Exact-current-main red proof at `dff4c634f1a56d974a1e4faaa9520527ab026774`, Testbox-through-Crabbox lease `tbx_01kx5v4kjc25srfwkq9p6j3b62`: `pnpm test ui/src/components/lobster-pet.test.ts` failed exactly four new regressions (pointer cancel plus vigil-only success, failure, and abort), while 48 existing tests passed.
- Focused component proof: `pnpm test ui/src/components/lobster-pet.test.ts`, 54/54 passed, including full droop-to-sweep release and seed-reset/page-hide cleanup.
- Real Chromium proof: `ui/src/e2e/lobster-pet.e2e.test.ts`, 2/2 passed with a paused Playwright clock, covering terminal outcome timing and native `pointercancel` wiring.
- Broad Control UI proof: `pnpm test:ui:e2e`, 34 files and 108 tests passed.
- `pnpm format:check -- ui/src/components/lobster-pet.ts ui/src/components/lobster-pet.test.ts ui/src/e2e/lobster-pet.e2e.test.ts`: passed.
- Hosted path-scoped `check:changed`: passed core/core-test typechecks, lint, and repository guards.
- Fresh autoreview: clean, no actionable findings, confidence 0.90.
