### PR TITLE
improve(ui): mark the default model inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI model picker:** mark the actual default model with a compact inline indicator and clear session overrides by selecting that model, removing the duplicate pinned Default row.
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Control UI model picker:** mark the actual default model with a compact inline indicator and clear session overrides by selecting that model, removing the duplicate pinned Default row.
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -627,8 +627,11 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(() => composer.locator('[data-chat-model-provider-group="codex"]').count())
         .toBe(0);
-      // The default model is advertised as unavailable, so the pinned default
-      // option must not be offered.
+      // The advertised default is unavailable, so no usable catalog row is
+      // marked as the default and no synthetic empty row is introduced.
+      await expect
+        .poll(() => composer.locator('[data-chat-model-default="true"]').count())
+        .toBe(0);
       await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
     } finally {
       await context.close();

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2133,9 +2133,16 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       });
       expect(await modelSelect.textContent()).toContain("GPT-5.5");
 
-      // The picker stays open after an immediate apply; the pinned default
-      // option clears the override without a save step.
-      await main.locator('[data-chat-model-option=""]').click();
+      // The picker stays open after an immediate apply. Return to the default
+      // model's provider and select its real catalog row to clear the override.
+      await main.locator('[data-chat-model-provider="anthropic"]').click();
+      const defaultModel = main.locator(
+        '[data-chat-model-option="anthropic/claude-opus-4-5"][data-chat-model-default="true"]',
+      );
+      await defaultModel.waitFor({ state: "visible", timeout: 10_000 });
+      expect(await defaultModel.textContent()).toContain("Default");
+      expect(await main.locator('[data-chat-model-option=""]').count()).toBe(0);
+      await defaultModel.click();
       const patches = await waitForRequests(gateway, "sessions.patch", 2);
       expect(requireRecord(patches[1]?.params)).toMatchObject({
         key: "agent:ops:session-a",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3429,7 +3429,7 @@ describe("chat model controls", () => {
     ).toContain("GPT-5.5");
   });
 
-  it("shows the canonical OpenAI name when the default option is selected", () => {
+  it("marks the actual default model row and selects it when inherited", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -3463,15 +3463,19 @@ describe("chat model controls", () => {
     expect(
       container.querySelector(".chat-controls__inline-select-label")?.textContent?.trim(),
     ).toBe("GPT-5.5 · High");
-    const defaultOption = container.querySelector<HTMLButtonElement>('[data-chat-model-option=""]');
+    const defaultOptions = container.querySelectorAll<HTMLButtonElement>(
+      '[data-chat-model-default="true"]',
+    );
+    expect(defaultOptions).toHaveLength(1);
+    const defaultOption = defaultOptions[0];
+    expect(defaultOption?.dataset.chatModelOption).toBe("openai/gpt-5.5");
     expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
-    expect(defaultOption?.textContent).toContain("Default (GPT-5.5)");
-    expect(
-      container.querySelector('[data-chat-model-option="openai/gpt-5.5"]')?.textContent,
-    ).toContain("GPT-5.5");
+    expect(defaultOption?.textContent).toContain("GPT-5.5");
+    expect(defaultOption?.textContent).toContain("Default");
+    expect(container.querySelector('[data-chat-model-option=""]')).toBeNull();
   });
 
-  it("clears the model override from the pinned default option", async () => {
+  it("clears a different model override from the actual default model row", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.4",
       modelProvider: "openai",
@@ -3499,9 +3503,48 @@ describe("chat model controls", () => {
       container,
     );
 
-    const defaultOption = container.querySelector<HTMLButtonElement>('[data-chat-model-option=""]');
+    const defaultOption = container.querySelector<HTMLButtonElement>(
+      '[data-chat-model-option="openai/gpt-5.5"][data-chat-model-default="true"]',
+    );
     expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
     expect(defaultOption?.getAttribute("aria-selected")).toBe("false");
+    defaultOption?.click();
+
+    await vi.waitFor(() => {
+      expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
+    });
+  });
+
+  it("clears an explicit override that matches the default model", async () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+    });
+    state.sessionsResult = createSessionsListResult({
+      defaultsModel: "gpt-5.5",
+      defaultsProvider: "openai",
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    });
+    const onModelSelect = vi.fn(async () => true);
+    const container = document.createElement("div");
+    const sessionKey = "explicit-default";
+    render(
+      renderChatModelControls({
+        ...createChatModelControlsProps(state),
+        sessionKey,
+        modelOverrides: { [sessionKey]: "openai/gpt-5.5" },
+        onModelSelect,
+      }),
+      container,
+    );
+
+    const defaultOption = container.querySelector<HTMLButtonElement>(
+      '[data-chat-model-option="openai/gpt-5.5"][data-chat-model-default="true"]',
+    );
+    expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
+    expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
     defaultOption?.click();
 
     await vi.waitFor(() => {

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -1,5 +1,5 @@
 // Chat-owned model, reasoning, and speed picker.
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type { ModelCatalogEntry, SessionsListResult } from "../../../api/types.ts";
 import { inferControlUiPublicAssetPath } from "../../../app/public-assets.ts";
@@ -40,6 +40,8 @@ export type ChatModelControlsProps = {
 };
 
 type ChatModelProviderOption = ChatModelSelectOption & {
+  commitValue: string;
+  isDefault: boolean;
   provider: string;
 };
 
@@ -307,32 +309,27 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     defaultModel && canonicalDefaultLabel !== defaultLabel
       ? `Default (${canonicalDefaultLabel})`
       : defaultLabel;
-  const modelOptions: ChatModelProviderOption[] = [
-    ...(defaultSelectable
-      ? [
-          {
-            value: "",
-            label: pickerDefaultLabel,
-            provider: resolveChatModelProvider(
-              "",
-              props.modelCatalog,
-              defaultModel,
-              defaultProviderHint,
-            ),
-          },
-        ]
-      : []),
-    ...selectOptions.map((option) => ({
+  const normalizedDefaultModel = defaultModel.trim().toLowerCase();
+  const modelOptions: ChatModelProviderOption[] = selectOptions.map((option) => {
+    const isDefault =
+      defaultSelectable && option.value.trim().toLowerCase() === normalizedDefaultModel;
+    return {
+      commitValue: isDefault ? "" : option.value,
+      isDefault,
       value: option.value,
       label: resolveChatModelPickerLabel(option.value, option.label, props.modelCatalog),
       provider: resolveChatModelProvider(
         option.value,
         props.modelCatalog,
         "",
-        option.value === currentOverride ? currentProviderHint : "",
+        isDefault
+          ? defaultProviderHint
+          : option.value === currentOverride
+            ? currentProviderHint
+            : "",
       ),
-    })),
-  ];
+    };
+  });
   const committedModelLabel =
     modelOptions.find((entry) => entry.value === currentOverride)?.label ??
     resolveChatModelPickerLabel(
@@ -385,12 +382,8 @@ function formatCombinedPickerModelLabel(label: string): string {
   return match?.[1] ?? label;
 }
 
-function formatCombinedPickerModelOptionLabel(
-  option: ChatModelProviderOption,
-  selected: boolean,
-): string {
-  const label =
-    option.value === "" && selected ? formatCombinedPickerModelLabel(option.label) : option.label;
+function formatCombinedPickerModelOptionLabel(option: ChatModelProviderOption): string {
+  const label = option.label;
   const providerPrefixes = [
     formatRawChatModelProviderLabel(option.provider),
     formatChatModelProviderLabel(option.provider),
@@ -534,9 +527,6 @@ function renderChatModelReasoningSelect(params: {
   const showReasoningPanel = true;
   const providerGroups = new Map<string, ChatModelProviderOption[]>();
   for (const option of modelOptions) {
-    if (option.value === "") {
-      continue;
-    }
     const existing = providerGroups.get(option.provider);
     if (existing) {
       existing.push(option);
@@ -544,7 +534,7 @@ function renderChatModelReasoningSelect(params: {
       providerGroups.set(option.provider, [option]);
     }
   }
-  const defaultModelOption = modelOptions.find((option) => option.value === "");
+  const defaultModelOption = modelOptions.find((option) => option.isDefault);
   const orderedProviderGroups = [...providerGroups];
   const defaultProviderIndex = orderedProviderGroups.findIndex(
     ([provider]) => provider === defaultModelOption?.provider,
@@ -555,46 +545,43 @@ function renderChatModelReasoningSelect(params: {
       orderedProviderGroups.unshift(defaultProviderGroup);
     }
   }
-  const selectedModelProvider =
-    modelOptions.find((option) => option.value === selectedModelValue)?.provider ??
-    modelOptions[0]?.provider ??
-    "other";
-  const selectedProvider =
-    selectedModelValue === ""
-      ? (orderedProviderGroups[0]?.[0] ?? selectedModelProvider)
-      : selectedModelProvider;
+  const selectedModelOption =
+    (selectedModelValue === ""
+      ? defaultModelOption
+      : modelOptions.find((option) => option.value === selectedModelValue)) ?? modelOptions[0];
+  const selectedProvider = selectedModelOption?.provider ?? orderedProviderGroups[0]?.[0] ?? "other";
   const renderModelOption = (entry: ChatModelProviderOption) => {
-    const selected = entry.value === selectedModelValue;
-    const isDefaultOption = entry.value === "";
-    const modelLabel = formatCombinedPickerModelOptionLabel(entry, selected);
+    const selected =
+      entry.value === selectedModelValue || (entry.isDefault && selectedModelValue === "");
+    const modelLabel = formatCombinedPickerModelOptionLabel(entry);
     return html`
-      <div
-        class="chat-controls__combined-model ${isDefaultOption
-          ? "chat-controls__combined-model--default"
-          : ""}"
-      >
+      <div class="chat-controls__combined-model">
         <openclaw-tooltip .content=${entry.label}>
           <button
             class="chat-controls__inline-select-option chat-controls__combined-model-option ${selected
               ? "chat-controls__inline-select-option--selected"
               : ""}"
             data-chat-model-option=${entry.value}
+            data-chat-model-default=${entry.isDefault ? "true" : nothing}
             role="option"
             aria-selected=${selected ? "true" : "false"}
             type="button"
             ?disabled=${disabled}
             @click=${(event: MouseEvent) => {
               event.stopPropagation();
-              if (disabled || selected) {
+              if (disabled || entry.commitValue === selectedModelValue) {
                 event.preventDefault();
                 return;
               }
-              commitModel(entry.value);
+              commitModel(entry.commitValue);
             }}
           >
             <span class="chat-controls__model-option-copy">
               <span class="chat-controls__model-option-title">
-                ${isDefaultOption ? entry.label : modelLabel}
+                <span class="chat-controls__model-option-name">${modelLabel}</span>
+                ${entry.isDefault
+                  ? html`<span class="chat-controls__model-default-label">Default</span>`
+                  : ""}
               </span>
               <span class="chat-controls__model-option-provider">
                 ${formatChatModelProviderLabel(entry.provider)}
@@ -665,8 +652,11 @@ function renderChatModelReasoningSelect(params: {
               },
             )}
           </div>
-          <div class="chat-controls__provider-models">
-            ${defaultModelOption ? renderModelOption(defaultModelOption) : ""}
+          <div
+            class="chat-controls__provider-models"
+            role="listbox"
+            aria-label=${t("chat.selectors.model")}
+          >
             ${repeat(
               orderedProviderGroups,
               ([provider]) => provider,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3277,14 +3277,6 @@ openclaw-chat-page {
   display: block;
 }
 
-/* Pinned "Default (...)" row stays above the per-provider groups so clearing
-   the session override is one click; selections apply immediately. */
-.chat-controls__combined-model--default {
-  margin-bottom: 6px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-}
-
 .chat-controls__combined-model-option {
   justify-content: flex-start;
   gap: 8px;
@@ -3307,9 +3299,39 @@ openclaw-chat-page {
 }
 
 .chat-controls__model-option-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   color: var(--text);
   font-size: 12px;
   font-weight: 600;
+}
+
+.chat-controls__model-option-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-controls__model-default-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--accent) 76%, var(--text));
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.chat-controls__model-default-label::before {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  content: "";
 }
 
 .chat-controls__model-option-provider {


### PR DESCRIPTION
Related: #102871

## What Problem This Solves

The Control UI model picker showed a separate pinned `Default (<model>)` row above the real model catalog entry. That duplicated the same model, visually separated the default from its provider, and made a simple picker feel heavier than necessary.

## Why This Change Was Made

The actual canonical default-model row now carries a compact inline `Default` indicator and clears the session override when selected. The default provider remains first, unavailable defaults remain unmarked, and the synthetic empty-value row and divider are removed.

## User Impact

Users see each model exactly once. The default remains obvious through a small dot-and-label annotation, and selecting that real model resets the session to inherit its configured default without a separate action row.

## Evidence

- Deterministic mocked Control UI render in Chromium: the marker has a transparent background, zero border/radius, and no shadow; the duplicate row is absent. Local screenshot/video artifacts were captured under `.artifacts/control-ui-e2e/default-model-badge/` and are not committed.
- AWS Crabbox `run_2f1c97ab241a` on the rebased commit: `pnpm test ui/src/pages/chat/chat-view.test.ts ui/src/e2e/chat-flow.e2e.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 137 unit tests and 44 Chromium E2E tests passed.
- AWS Crabbox `run_7fa9fbff013d`: `pnpm check:changed` — passed before the conflict-free rebase; the patch is unchanged.
- Autoreview (Codex gpt-5.5): clean, no accepted/actionable findings.

AI-assisted: yes.
