### PR TITLE
fix: stabilize gateway deletion admission CI fixture

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1422,6 +1422,7 @@ describe("gateway server chat", () => {
   test("chat.send does not recreate a session deleted while admission waits", async () => {
     const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
     const releaseMutation = createDeferred();
+    let mutation: Promise<void> | undefined;
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -1432,10 +1433,14 @@ describe("gateway server chat", () => {
           },
         },
       });
+      const { loadSessionEntry } = await import("./session-utils.js");
+      const seededSession = loadSessionEntry("main");
+      const seededSessionId = seededSession.entry?.sessionId;
+      expect(seededSessionId).toBe("sess-main");
       const mutationStarted = createDeferred();
-      const mutation = runExclusiveSessionLifecycleMutation({
-        scope: testState.sessionStorePath,
-        identities: ["agent:main:main", "sess-main"],
+      mutation = runExclusiveSessionLifecycleMutation({
+        scope: seededSession.storePath,
+        identities: [seededSession.canonicalKey, seededSessionId],
         run: async () => {
           mutationStarted.resolve();
           await releaseMutation.promise;
@@ -1443,7 +1448,12 @@ describe("gateway server chat", () => {
       });
       await mutationStarted.promise;
 
-      const sendResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const sendResponses: Array<{
+        ok: boolean;
+        payload?: unknown;
+        error?: unknown;
+        meta?: unknown;
+      }> = [];
       const context = createDirectChatContext();
       const runId = "idem-deleted-during-admission";
       const params = {
@@ -1458,8 +1468,8 @@ describe("gateway server chat", () => {
           params,
           client: null,
           isWebchatConnect: () => false,
-          respond: ((ok, payload, error) => {
-            sendResponses.push({ ok, payload, error });
+          respond: ((ok, payload, error, meta) => {
+            sendResponses.push({ ok, payload, error, meta });
           }) as RespondFn,
           context,
         }),
@@ -1468,20 +1478,26 @@ describe("gateway server chat", () => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
-      await writeSessionStore({ entries: {} });
+      await writeSessionStore({ entries: {}, storePath: seededSession.storePath });
       releaseMutation.resolve();
       await mutation;
       await send;
 
-      expect(sendResponses).toHaveLength(1);
-      expect(sendResponses[0]?.ok).toBe(false);
-      expect(sendResponses[0]?.error).toMatchObject({
-        message: expect.stringMatching(/deleted while starting work/i),
-      });
+      expect(sendResponses).toEqual([
+        {
+          ok: false,
+          payload: undefined,
+          error: expect.objectContaining({
+            message: expect.stringMatching(/deleted while starting work/i),
+          }),
+          meta: undefined,
+        },
+      ]);
       expect(context.chatAbortControllers.has(runId)).toBe(false);
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
     } finally {
       releaseMutation.resolve();
+      await Promise.allSettled(mutation ? [mutation] : []);
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1421,7 +1421,7 @@ describe("gateway server chat", () => {
 
   test("chat.send does not recreate a session deleted while admission waits", async () => {
     const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
-    const releaseMutation = createDeferred();
+    const performDeletion = createDeferred();
     let mutation: Promise<void> | undefined;
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
@@ -1433,7 +1433,10 @@ describe("gateway server chat", () => {
           },
         },
       });
-      const { loadSessionEntry } = await import("./session-utils.js");
+      const [{ deleteSessionEntryLifecycle }, { loadSessionEntry }] = await Promise.all([
+        import("../config/sessions/session-accessor.js"),
+        import("./session-utils.js"),
+      ]);
       const seededSession = loadSessionEntry("main");
       const seededSessionId = seededSession.entry?.sessionId;
       expect(seededSessionId).toBe("sess-main");
@@ -1443,7 +1446,22 @@ describe("gateway server chat", () => {
         identities: [seededSession.canonicalKey, seededSessionId],
         run: async () => {
           mutationStarted.resolve();
-          await releaseMutation.promise;
+          await performDeletion.promise;
+          // Use the resolved store target: writeSessionStore also rewrites the
+          // suite config, adding an unrelated config-watcher race to this test.
+          const deletion = await deleteSessionEntryLifecycle({
+            agentId: "main",
+            archiveTranscript: false,
+            expectedEntry: seededSession.entry,
+            expectedSessionId: seededSessionId,
+            requireWriteSuccess: true,
+            storePath: seededSession.storePath,
+            target: {
+              canonicalKey: seededSession.canonicalKey,
+              storeKeys: seededSession.storeKeys,
+            },
+          });
+          expect(deletion.deleted).toBe(true);
         },
       });
       await mutationStarted.promise;
@@ -1478,8 +1496,7 @@ describe("gateway server chat", () => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
-      await writeSessionStore({ entries: {}, storePath: seededSession.storePath });
-      releaseMutation.resolve();
+      performDeletion.resolve();
       await mutation;
       await send;
 
@@ -1496,7 +1513,7 @@ describe("gateway server chat", () => {
       expect(context.chatAbortControllers.has(runId)).toBe(false);
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
     } finally {
-      releaseMutation.resolve();
+      performDeletion.resolve();
       await Promise.allSettled(mutation ? [mutation] : []);
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;


### PR DESCRIPTION
Closes #103480

AI-assisted maintainer fix.

## What Problem This Solves

Fixes an intermittent failure in the non-isolated gateway-server shard. The deleted-session admission fixture used hard-coded lifecycle identities and then called a broad store helper that also rewrote shared suite configuration, coupling the assertion to an unrelated config-watcher race.

## Why This Change Was Made

The fixture now resolves the seeded session through the same gateway seam as `chat.send`, builds the lifecycle blocker from that store path, canonical key, and session ID, and performs a guarded durable deletion through the production session lifecycle owner. It also captures the complete response and settles the mutation during cleanup, preserving useful provenance and preventing leaked work after assertion failures.

Production admission behavior is unchanged; repeated exact-head reproduction found no product regression.

## User Impact

No user-visible behavior change. Maintainers get a deterministic release gate and a more diagnostic failure if the response path regresses.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/29073447090/job/86300026092
- Immediate unchanged-gateway successor passed 301/301: https://github.com/openclaw/openclaw/actions/runs/29073647318/job/86300721117
- Baseline focused stress passed 10/10 loops (20 project executions): https://github.com/openclaw/openclaw/actions/runs/29073794649
- Baseline exact 18-file shard passed 3/3 loops (903 tests): https://github.com/openclaw/openclaw/actions/runs/29074132691
- Patched focused test passed in both projects; exact non-isolated shard passed 301/301; oxfmt clean: https://github.com/openclaw/openclaw/actions/runs/29074514316
- Final combined head `31072e29cb`: exact gateway-server config/full file passed 52/52 on Testbox
- Fresh final-head autoreview: clean, no accepted/actionable findings, 0.90 confidence
