### PR TITLE
fix(xai): route provider alias to native endpoint

### DIFF
--- a/extensions/xai/api.test.ts
+++ b/extensions/xai/api.test.ts
@@ -1,6 +1,11 @@
 // Xai tests cover api plugin behavior.
 import { describe, expect, it } from "vitest";
-import { isXaiModelHint, resolveXaiTransport } from "./api.js";
+import {
+  isXaiModelHint,
+  resolveXaiForwardCompatModel,
+  resolveXaiTransport,
+  XAI_BASE_URL,
+} from "./api.js";
 
 describe("xai api helpers", () => {
   it("uses shared endpoint classification for native xAI transports", () => {
@@ -16,17 +21,53 @@ describe("xai api helpers", () => {
     });
   });
 
-  it("keeps default-route xAI transport for the declared provider", () => {
+  it.each([
+    ["xai", "openai-completions"],
+    ["x-ai", "openai-completions"],
+    ["xai", "openai-responses"],
+    ["x-ai", "openai-responses"],
+  ])("keeps default-route xAI transport for %s with %s", (provider, api) => {
     expect(
       resolveXaiTransport({
-        provider: "xai",
-        api: "openai-completions",
+        provider,
+        api,
       }),
     ).toEqual({
       api: "openai-responses",
-      baseUrl: undefined,
+      baseUrl: XAI_BASE_URL,
     });
   });
+
+  it.each(["openai-completions", "openai-responses"])(
+    "preserves explicit foreign proxy routing for %s",
+    (api) => {
+      expect(
+        resolveXaiTransport({
+          provider: "x-ai",
+          api,
+          baseUrl: "https://proxy.example.test/v1",
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it.each(["xai", "x-ai"])(
+    "restores the native endpoint for materialized %s overlays",
+    (provider) => {
+      const model = resolveXaiForwardCompatModel({
+        providerId: "xai",
+        ctx: {
+          provider,
+          modelId: "grok-4.5",
+          modelRegistry: { find: () => null } as never,
+          providerConfig: { baseUrl: "", models: [] },
+        },
+      });
+
+      expect(model?.baseUrl).toBe(XAI_BASE_URL);
+      expect(model?.reasoning).toBe(true);
+    },
+  );
 
   it("detects xAI model hints", () => {
     expect(isXaiModelHint("x-ai/grok-4")).toBe(true);

--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -1,8 +1,7 @@
 // Xai API module exposes the plugin public contract.
-import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   normalizeOptionalLowercaseString,
-  readStringValue,
+  normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   applyXaiModelCompat,
@@ -10,6 +9,8 @@ import {
   normalizeNativeXaiModelId,
   XAI_TOOL_SCHEMA_PROFILE,
 } from "./model-compat.js";
+import { XAI_BASE_URL } from "./model-definitions.js";
+import { isXaiProviderId } from "./provider-id.js";
 
 export { buildXaiProvider } from "./provider-catalog.js";
 export { applyXaiConfig, applyXaiProviderConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -68,13 +69,12 @@ function shouldUseXaiResponsesTransport(params: {
   api?: unknown;
   baseUrl?: unknown;
 }): boolean {
-  if (params.api !== "openai-completions") {
-    return false;
-  }
-  if (isXaiNativeEndpoint(params.baseUrl)) {
-    return true;
-  }
-  return normalizeProviderId(params.provider) === "xai" && !params.baseUrl;
+  const hasDefaultXaiRoute =
+    isXaiProviderId(params.provider) && !normalizeOptionalString(params.baseUrl);
+  return params.api === "openai-responses"
+    ? hasDefaultXaiRoute
+    : params.api === "openai-completions" &&
+        (isXaiNativeEndpoint(params.baseUrl) || hasDefaultXaiRoute);
 }
 
 export function resolveXaiTransport(params: {
@@ -87,6 +87,8 @@ export function resolveXaiTransport(params: {
   }
   return {
     api: "openai-responses",
-    baseUrl: readStringValue(params.baseUrl),
+    baseUrl:
+      normalizeOptionalString(params.baseUrl) ??
+      (isXaiProviderId(params.provider) ? XAI_BASE_URL : undefined),
   };
 }

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -4,7 +4,10 @@ import type {
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
-import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveXaiCatalogEntry, XAI_BASE_URL } from "./model-definitions.js";
 import { normalizeXaiModelId } from "./model-id.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
@@ -35,7 +38,7 @@ export function resolveXaiForwardCompatModel(params: {
       name: definition.name,
       api: params.ctx.providerConfig?.api ?? "openai-responses",
       provider: params.providerId,
-      baseUrl: params.ctx.providerConfig?.baseUrl ?? XAI_BASE_URL,
+      baseUrl: normalizeOptionalString(params.ctx.providerConfig?.baseUrl) ?? XAI_BASE_URL,
       reasoning: definition.reasoning,
       input: definition.input,
       cost: definition.cost,

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -92,6 +92,7 @@ describe("model provider localService config", () => {
   });
 
   it.each([
+    { provider: "x-ai", name: "xAI alias" },
     { provider: "xiaomi-token-plan", name: "Xiaomi Token Plan" },
     { provider: "tencent-tokenplan", name: "Tencent TokenPlan" },
   ] as const)("accepts standalone timeout overlays for $name", ({ provider }) => {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -508,6 +508,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "volcengine",
   "volcengine-plan",
   "vydra",
+  "x-ai",
   "xai",
   "xiaomi",
   "xiaomi-token-plan",

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -20,6 +20,7 @@ describe("ModelsConfigSchema", () => {
     "qwen-oauth",
     "qwen-portal",
     "qwen-token-plan",
+    "x-ai",
     "z.ai",
     "z-ai",
   ])("accepts bundled provider overlay for %s without baseUrl or models", (providerId) => {


### PR DESCRIPTION
Closes #103454

_AI-assisted._

## What Problem This Solves

Fixes an issue where users selecting the shipped `x-ai` alias could authenticate successfully but the Gateway rejected the generated provider overlay before starting `grok-4.5`. Once accepted, the materialized blank endpoint could also fall through to the OpenAI SDK default and send the xAI key to `api.openai.com`.

## Why This Change Was Made

Treat `x-ai` like the other explicit bundled provider aliases during config validation/materialization. At the plugin boundary, recognize both xAI provider IDs, turn blank materialized endpoints into xAI's native endpoint for Responses and legacy Completions rows, and preserve explicit foreign proxy URLs. This stays narrow: generic auth aliases are not promoted to model-provider aliases, alias-keyed overlays retain their identity, and custom provider validation is unchanged.

## User Impact

`x-ai/<model>` now follows the same Gateway startup, credential, native endpoint, thinking-policy, and Responses transport path as canonical `xai/<model>`.

## Evidence

- Before: a source-backed real-key `x-ai/grok-4.5` Gateway run resolved credentials, then failed with `models.providers.x-ai.baseUrl: custom model providers must declare baseUrl`.
- Before endpoint repair: the accepted materialized overlay resolved `baseUrl: ""`; an actual agent turn targeted `https://api.openai.com/v1/responses` and failed with HTTP 401.
- Testbox [run 29073409023](https://github.com/openclaw/openclaw/actions/runs/29073409023): 129 focused config and xAI transport tests passed.
- Source-current `node scripts/build-all.mjs`: passed in 70.4 seconds.
- Fresh structured autoreview: clean, no accepted/actionable findings (0.87 confidence).
- Real-key raw-config Gateway proof: startup passed; `x-ai/grok-4.5` targeted `https://api.x.ai/v1/responses`, sent `reasoningEffort=high`, returned HTTP 200, and produced the exact expected response.
