### PR TITLE
fix(media): normalizeMediaSource should handle uppercase FILE:// URI schemes

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -66,6 +66,8 @@ describe("splitMediaFromOutput", () => {
       String.raw`MEDIA:/path/to/image.png\"}],\"details\":{\"provider\":\"openai\"}`,
     ],
     ["/tmp/render,final.png", "MEDIA:/tmp/render,final.png"],
+    ["/tmp/generated.png", "MEDIA:FILE:///tmp/generated.png"],
+    ["/tmp/generated.png", "MEDIA:file:///tmp/generated.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -68,6 +68,8 @@ describe("splitMediaFromOutput", () => {
     ["/tmp/render,final.png", "MEDIA:/tmp/render,final.png"],
     ["/tmp/generated.png", "MEDIA:FILE:///tmp/generated.png"],
     ["/tmp/generated.png", "MEDIA:file:///tmp/generated.png"],
+    ["/Users/pete/My File.png", "MEDIA:FILE:///Users/pete/My File.png"],
+    ["/Users/pete/My File.png", "MEDIA:file:///Users/pete/My File.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -35,7 +35,7 @@ export type SplitMediaFromOutputOptions = {
 
 /** Converts file URLs into plain local paths before downstream media validation. */
 export function normalizeMediaSource(src: string): string {
-  return src.startsWith("file://") ? src.replace("file://", "") : src;
+  return src.replace(/^file:\/\//i, "");
 }
 
 const TRAILING_SERIALIZED_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})\\?"(?=[\]},:]|$).*/s;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -33,9 +33,11 @@ export type SplitMediaFromOutputOptions = {
   extractMediaDirectives?: boolean;
 };
 
+const FILE_URL_PREFIX_RE = /^file:\/\//i;
+
 /** Converts file URLs into plain local paths before downstream media validation. */
 export function normalizeMediaSource(src: string): string {
-  return src.replace(/^file:\/\//i, "");
+  return src.replace(FILE_URL_PREFIX_RE, "");
 }
 
 const TRAILING_SERIALIZED_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})\\?"(?=[\]},:]|$).*/s;
@@ -603,7 +605,7 @@ export function splitMediaFromOutput(
 
       const trimmedPayload = payloadValue.trim();
       const looksLikeLocalPath =
-        looksLikeLocalFilePath(trimmedPayload) || trimmedPayload.startsWith("file://");
+        looksLikeLocalFilePath(trimmedPayload) || FILE_URL_PREFIX_RE.test(trimmedPayload);
       if (
         !unwrapped &&
         validCount === 1 &&


### PR DESCRIPTION
## What Problem This Solves

`MEDIA:` directives using an uppercase `FILE://` URI scheme are left in assistant text instead of being extracted as local media attachments. Uppercase unquoted file URIs containing spaces can also be split and truncated instead of being reassembled as one attachment path. Per RFC 3986, URI schemes are case-insensitive, so `MEDIA:FILE:///tmp/generated.png` should behave like `MEDIA:file:///tmp/generated.png`.

Issue: #103473

## Why This Change Was Made

The outbound parser used separate case-sensitive checks for prefix removal and spaced-path recovery. It now uses one anchored, case-insensitive file-URL predicate for both decisions, keeping the behavior local to the canonical parser and leaving downstream media access policy unchanged.

## User Impact

Assistant or tool output using non-lowercase file URI schemes now delivers the intended local attachment without exposing the raw directive or truncating paths containing spaces. Lowercase behavior and existing safety rejection remain unchanged.

## Evidence

- Exact head `73f5b3a2319fbc47dd1e756dace7acd55c945789`; patch-identical rebase of the validated head onto current `main`.
- Sanitized AWS run `run_621c85721cd0` on the patch-identical pre-rebase head: `pnpm test src/media/parse.test.ts`, 61/61 passed.
- Same run: fresh uppercase/lowercase, plain/spaced PNG fixtures all parsed to the complete path and staged byte-for-byte through the production outbound media path; unsupported-scheme and traversal controls stayed unattached.
- Matched base run `run_e6e856990bca` at `2d54be31ba68edb070732dc3d0511afb7c5ad32d`: both uppercase cases reproduced red while lowercase and safety controls passed.
- Fresh autoreview found the original spaced-uppercase gap; after the maintainer follow-up, a second fresh review reported no findings (0.98 correctness confidence).
- Targeted `oxfmt --check` and `git diff --check` passed.
