### PR TITLE
docs(slack): fix channel config examples — use 'enabled' instead of 'allow' to match strict schema

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1203,7 +1203,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
         slack: {
           groupPolicy: "allowlist",
           channels: {
-            C12345678: { allow: true, requireMention: true },
+            C12345678: { enabled: true, requireMention: true },
           },
         },
       },
@@ -1218,7 +1218,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
         slack: {
           groupPolicy: "allowlist",
           channels: {
-            "#eng-my-channel": { allow: true, requireMention: true },
+            "#eng-my-channel": { enabled: true, requireMention: true },
           },
         },
       },

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -443,9 +443,9 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       allowFrom: ["U123", "U456", "*"],
       dm: { enabled: true, groupEnabled: false, groupChannels: ["G123"] },
       channels: {
-        C123: { allow: true, requireMention: true, allowBots: false },
+        C123: { enabled: true, requireMention: true, allowBots: false },
         "#general": {
-          allow: true,
+          enabled: true,
           requireMention: true,
           allowBots: false,
           users: ["U123"],


### PR DESCRIPTION
## What Problem This Solves

Same pattern as [#102129](https://github.com/openclaw/openclaw/pull/102129) (discord doc fix). Two config examples in `docs/channels/slack.md` use `"allow": true`, but the channel config schema only accepts `"enabled"`.

## Why This Change Was Made

`docs/channels/slack.md:1206` and `:1221` show config examples with `"allow"` — a key that triggers a validation error when someone copy-pastes it into their config because the schema is `.strict()`.

## User Impact

Operators who copy-paste these examples no longer hit a silent validation error.

## Evidence

**Doc (wrong)** — `docs/channels/slack.md:1206`:
```json5
C12345678: { allow: true, requireMention: true },
```

**Doc (wrong)** — `docs/channels/slack.md:1221`:
```json5
"#eng-my-channel": { allow: true, requireMention: true },
```

**Schema** — `SlackChannelConfig` via `buildChannelConfigSchema(SlackConfigSchema)`:
- Only `"enabled"` is accepted, not `"allow"`
- `.strict()` rejects unknown keys

**Cmd:**
```bash
sed -n "1206p;1221p" docs/channels/slack.md
```

**Diff:**
```diff
-            C12345678: { allow: true, requireMention: true },
+            C12345678: { enabled: true, requireMention: true },
-            "#eng-my-channel": { allow: true, requireMention: true },
+            "#eng-my-channel": { enabled: true, requireMention: true },
```

## Review

- Manually reviewed and verified
- AI-assisted: Yes
