### PR TITLE
fix(ci): select trusted release harness for Docker lanes

### DIFF
--- a/scripts/lib/docker-e2e-scenarios.mjs
+++ b/scripts/lib/docker-e2e-scenarios.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 export const DEFAULT_LIVE_RETRIES = 1;
 const LIVE_DOCKER_DEFAULT_HARNESS_DIR =
-  /[\\/]\\.release-harness[\\/]/u.test(fileURLToPath(import.meta.url)) &&
+  /[\\/]\.release-harness[\\/]/u.test(fileURLToPath(import.meta.url)) &&
   process.env.OPENCLAW_DOCKER_E2E_REPO_ROOT
     ? ".release-harness"
     : ".";

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1,5 +1,8 @@
 // Docker E2E Plan tests cover docker e2e plan script behavior.
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_LIVE_RETRIES,
@@ -7,7 +10,10 @@ import {
   parseLaneSelection,
   resolveDockerE2ePlan,
 } from "../../scripts/lib/docker-e2e-plan.mjs";
-import { BUNDLED_PLUGIN_INSTALL_UNINSTALL_SHARDS } from "../../scripts/lib/docker-e2e-scenarios.mjs";
+import {
+  allReleasePathLanes,
+  BUNDLED_PLUGIN_INSTALL_UNINSTALL_SHARDS,
+} from "../../scripts/lib/docker-e2e-scenarios.mjs";
 
 const orderLanes = <T>(lanes: T[]) => lanes;
 const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
@@ -97,6 +103,61 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 }
 
 describe("scripts/lib/docker-e2e-plan", () => {
+  it("routes live Docker scripts through the nested trusted release harness", () => {
+    const sourceLane = allReleasePathLanes({ releaseProfile: "beta" }).find(
+      (candidate) => candidate.name === "live-codex-npm-plugin",
+    );
+    const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-release-harness-"));
+    const nestedModule = join(
+      tempRoot,
+      ".release-harness",
+      "scripts",
+      "lib",
+      "docker-e2e-scenarios.mjs",
+    );
+
+    try {
+      expect(sourceLane?.command).toContain(
+        'harness="${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-.}"',
+      );
+
+      mkdirSync(dirname(nestedModule), { recursive: true });
+      copyFileSync("scripts/lib/docker-e2e-scenarios.mjs", nestedModule);
+
+      const laneJson = execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `
+            import { pathToFileURL } from "node:url";
+            const scenarios = await import(pathToFileURL(process.argv[1]).href);
+            const lane = scenarios
+              .allReleasePathLanes({ releaseProfile: "beta" })
+              .find((candidate) => candidate.name === "live-codex-npm-plugin");
+            process.stdout.write(JSON.stringify(lane));
+          `,
+          nestedModule,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            OPENCLAW_DOCKER_E2E_REPO_ROOT: tempRoot,
+          },
+        },
+      );
+      const lane = JSON.parse(laneJson) as { command: string };
+
+      expect(lane.command).toContain(
+        'harness="${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-.release-harness}"',
+      );
+      expect(lane.command).toContain('bash "$harness/scripts/e2e/codex-npm-plugin-live-docker.sh"');
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("plans package-backed Compose and package artifact proofs", () => {
     const plan = planFor({
       selectedLaneNames: ["compose-setup", "docker-package-install"],


### PR DESCRIPTION
Fixes #103451

## What Problem This Solves

Fixes an issue where targeted Docker release lanes loaded from the trusted `.release-harness` checkout would still execute the release candidate's stale harness scripts. This produced a false-negative Codex npm plugin gate after the provider preflight and all three live turns had passed.

## Why This Change Was Made

Correct the escaped path-component detector so a scenario catalog imported from `.release-harness/scripts/lib` defaults `OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR` to `.release-harness`. Keep ordinary source-checkout planning on the existing `.` default.

The regression test imports the real scenario catalog from a temporary nested `.release-harness` path and inspects the exact generated `live-codex-npm-plugin` command.

## User Impact

Release operators can apply harness-only fixes on trusted `main` without changing a frozen release candidate. Targeted Docker release lanes now execute those trusted scripts instead of silently falling back to candidate-side copies.

## Evidence

- Failure isolated in https://github.com/openclaw/openclaw/actions/runs/29074133207, job `86302246029`: Codex preflight and 3/3 live turns passed, then the candidate's stale assertion ran.
- Blacksmith Testbox `tbx_01kx5cjs637xpcy29svc7b486r`: `pnpm test:serial test/scripts/docker-e2e-plan.test.ts` - 33/33 passed.
- Same Testbox: `pnpm check:changed` - tooling lane, Docker E2E catalog guard, lint, and repository guards passed.
- Direct command-generation proof from a nested `.release-harness` module defaults to `.release-harness` and invokes `scripts/e2e/codex-npm-plugin-live-docker.sh`.
- `git diff --check` passed.
