### PR TITLE
fix(skill-workshop): reject invalid proposal list limits

### DIFF
--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -83,6 +83,19 @@ describe("skill_workshop tool", () => {
     expect(tools.some((tool) => tool.name === "skill_workshop")).toBe(false);
   });
 
+  it.each([0, 1.5, "1.5", "many"])("rejects invalid list limit %s", async (limit) => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+    });
+
+    await expect(tool.execute("call-list-limit", { action: "list", limit })).rejects.toThrow(
+      "limit must be a positive integer",
+    );
+  });
+
   it("creates pending skill proposals without applying them", async () => {
     // Creation writes reviewable proposal artifacts under state, not live skill
     // files in the workspace.

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -83,17 +83,48 @@ describe("skill_workshop tool", () => {
     expect(tools.some((tool) => tool.name === "skill_workshop")).toBe(false);
   });
 
-  it.each([0, 1.5, "1.5", "many"])("rejects invalid list limit %s", async (limit) => {
+  it.each([0, 1.5, "1.5", "25items", "many"])(
+    "rejects invalid list limit %s before touching proposal state",
+    async (limit) => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
+      const tool = createSkillWorkshopTool({
+        workspaceDir,
+        config: {},
+        agentId: "main",
+      });
+
+      await expect(tool.execute("call-list-limit", { action: "list", limit })).rejects.toThrow(
+        "limit must be a positive integer",
+      );
+      await expect(fs.access(path.join(stateDir, "skill-workshop"))).rejects.toThrow();
+    },
+  );
+
+  it("preserves list limits through 50 and clamps larger requests", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tool = createSkillWorkshopTool({
       workspaceDir,
-      config: {},
+      config: { skills: { workshop: { maxPending: 200 } } },
       agentId: "main",
     });
 
-    await expect(tool.execute("call-list-limit", { action: "list", limit })).rejects.toThrow(
-      "limit must be a positive integer",
-    );
+    for (let index = 0; index < 51; index += 1) {
+      await tool.execute(`call-create-${index}`, {
+        action: "create",
+        name: `Limit Proposal ${index}`,
+        description: `Proposal ${index}`,
+        proposal_content: `# Limit Proposal ${index}\n`,
+      });
+    }
+
+    for (const [limit, expectedCount] of [
+      [49, 49],
+      [50, 50],
+      [51, 50],
+    ] as const) {
+      const result = await tool.execute(`call-list-${limit}`, { action: "list", limit });
+      expect((result.details as { proposals: unknown[] }).proposals).toHaveLength(expectedCount);
+    }
   });
 
   it("creates pending skill proposals without applying them", async () => {

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -145,11 +145,14 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       const action = readStringParam(params, "action", { required: true });
 
       if (action === "list") {
+        const status = readProposalStatusParam(params);
+        const query = readStringParam(params, "query");
+        const limit = readListLimitParam(params);
         const proposals = listProposalEntries({
           proposals: (await listSkillProposals({ workspaceDir: options.workspaceDir })).proposals,
-          status: readProposalStatusParam(params),
-          query: readStringParam(params, "query"),
-          limit: readListLimitParam(params),
+          status,
+          query,
+          limit,
         });
         return {
           content: [{ type: "text", text: formatProposalList(proposals) }],

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -27,7 +27,7 @@ import type {
 import { stringEnum } from "../schema/typebox.js";
 import {
   asToolParamsRecord,
-  readNumberParam,
+  readPositiveIntegerParam,
   readStringParam,
   ToolInputError,
   type AnyAgentTool,
@@ -366,13 +366,7 @@ function readProposalStatusParam(params: Record<string, unknown>): SkillProposal
 }
 
 function readListLimitParam(params: Record<string, unknown>): number {
-  return (
-    readNumberParam(params, "limit", {
-      integer: true,
-      positiveInteger: true,
-      label: "limit",
-    }) ?? 20
-  );
+  return readPositiveIntegerParam(params, "limit") ?? 20;
 }
 
 function listProposalEntries(params: {


### PR DESCRIPTION
## What Problem This Solves

`skill_workshop` proposal listing accepted partial numeric strings such as `25items` as valid limits. Invalid list parameters were also parsed only after proposal storage had already been read, so a rejected request could initialize workshop state.

## Why This Change Was Made

The list action now uses the shared strict positive-integer reader and parses `status`, `query`, and `limit` before proposal storage access. The existing downstream clamp remains canonical: valid values above 50 still clamp instead of becoming validation errors.

## User Impact

Malformed list limits fail fast with `limit must be a positive integer` and do not create workshop state. Omitted limits remain unchanged; valid limits return the requested count through 50 and clamp above 50.

## Evidence

- Exact refreshed head: `63968e16c9dbfadc11204f09389a7ecd726660d5`.
- Sanitized AWS Crabbox run `run_0a8db2bc4369`, Linux Node 24: `pnpm test src/agents/tools/skill-workshop-tool.test.ts src/agents/tools/common.params.test.ts`; 2 files, 35 tests passed.
- Facade regressions: `25items`, decimals, zero, and nonnumeric values reject; the workshop state directory remains absent; 49/50/51 limits return 49/50/50 proposals.
- `git diff --check` passed.
- Fresh branch autoreview reported no accepted/actionable findings.
- Exact-head [GitHub CI run 29134388157](https://github.com/openclaw/openclaw/actions/runs/29134388157) passed.
