### PR TITLE
fix(test): make deleted-session admission proof deterministic

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1421,7 +1421,7 @@ describe("gateway server chat", () => {
 
   test("chat.send does not recreate a session deleted while admission waits", async () => {
     const sessionDir = autoCleanupTempDirs.make("openclaw-gw-");
-    const releaseMutation = createDeferred();
+    const performDeletion = createDeferred();
     try {
       testState.sessionStorePath = path.join(sessionDir, "sessions.json");
       await writeSessionStore({
@@ -1432,13 +1432,34 @@ describe("gateway server chat", () => {
           },
         },
       });
+      const [{ deleteSessionEntryLifecycle }, { loadSessionEntry }] = await Promise.all([
+        import("../config/sessions/session-accessor.js"),
+        import("./session-utils.js"),
+      ]);
+      const seededSession = loadSessionEntry("main");
+      expect(seededSession.entry?.sessionId).toBe("sess-main");
       const mutationStarted = createDeferred();
       const mutation = runExclusiveSessionLifecycleMutation({
-        scope: testState.sessionStorePath,
-        identities: ["agent:main:main", "sess-main"],
+        scope: seededSession.storePath,
+        identities: [seededSession.canonicalKey, seededSession.entry?.sessionId],
         run: async () => {
           mutationStarted.resolve();
-          await releaseMutation.promise;
+          await performDeletion.promise;
+          // Use the resolved store target: writeSessionStore also rewrites the
+          // suite config, adding an unrelated config-watcher race to this test.
+          const deletion = await deleteSessionEntryLifecycle({
+            agentId: "main",
+            archiveTranscript: false,
+            expectedEntry: seededSession.entry,
+            expectedSessionId: seededSession.entry?.sessionId,
+            requireWriteSuccess: true,
+            storePath: seededSession.storePath,
+            target: {
+              canonicalKey: seededSession.canonicalKey,
+              storeKeys: seededSession.storeKeys,
+            },
+          });
+          expect(deletion.deleted).toBe(true);
         },
       });
       await mutationStarted.promise;
@@ -1468,8 +1489,7 @@ describe("gateway server chat", () => {
         expect(context.dedupe.has(pendingChatSendDedupeKey(runId))).toBe(true);
       }, FAST_WAIT_OPTS);
 
-      await writeSessionStore({ entries: {} });
-      releaseMutation.resolve();
+      performDeletion.resolve();
       await mutation;
       await send;
 
@@ -1481,7 +1501,7 @@ describe("gateway server chat", () => {
       expect(context.chatAbortControllers.has(runId)).toBe(false);
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
     } finally {
-      releaseMutation.resolve();
+      performDeletion.resolve();
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI could intermittently report that `chat.send`
recreated a session deleted while lifecycle admission was waiting. The test
rewrote the suite's shared gateway config while the send was intentionally
blocked, adding an unrelated config-observer race to the session-deletion
assertion.

## Why This Change Was Made

The test now captures the production-resolved session store target after
seeding and performs a guarded, durable deletion through the production session
lifecycle accessor while the conflicting lifecycle mutation is still active.
Admission resumes only after that deletion completes. This is a test-only
change; runtime behavior is unchanged.

AI-assisted. I reviewed the complete admission, lifecycle-mutation, session
lookup, deletion, and test-helper paths and understand the change.

## User Impact

No user-visible runtime change. Main and release validation get deterministic
coverage for the deleted-session admission invariant instead of an occasional
false failure.

## Evidence

- Failure: [main CI 29073447090, job 86300026092](https://github.com/openclaw/openclaw/actions/runs/29073447090/job/86300026092) failed this assertion at exact SHA `514829f0e1457e5b8f1c64ae4ce7a55889361f36` with 300 other shard tests passing.
- Control: [the same shard in the next main CI run](https://github.com/openclaw/openclaw/actions/runs/29073647318/job/86300721117) passed at `20bc552590b2e1f31b8dd8534446011661d009d2`; the intervening commit changed only unrelated Control UI files.
- Blacksmith Testbox `tbx_01kx5brvcjjsq2ddhj24qbjbck`: 44/44 baseline executions passed under the exact `vitest.gateway-server.config.ts`, confirming a rare fixture race rather than a deterministic product regression.
- Same Testbox after the change: 50/50 exact-config stress executions passed.
- Final exact-config file proof: 52/52 tests passed.
- `pnpm check:changed -- src/gateway/server.chat.gateway-server-chat-b.test.ts` passed, including core-test types and lint.
- Fresh autoreview: no accepted or actionable findings.
- `git diff --check` passed.
