### PR TITLE
fix(ui): preserve desktop lobster run outcomes

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -37,6 +37,11 @@ type SidebarLifecycleState = HTMLElement & {
   sessionsAgentId: string | null;
   sessionsResult: SessionsListResult | null;
   updateComplete: Promise<boolean>;
+  variant: "panel" | "drawer";
+};
+
+type LobsterPetElement = HTMLElement & {
+  runOutcome: "ok" | "error" | "aborted";
 };
 
 function createGatewayHarness(client: GatewayBrowserClient) {
@@ -157,11 +162,16 @@ function createContext(
   } as unknown as ApplicationContext<RouteId>;
 }
 
-async function mountSidebar(gateway: ApplicationGateway, sessions: SessionCapability) {
+async function mountSidebar(
+  gateway: ApplicationGateway,
+  sessions: SessionCapability,
+  variant: SidebarLifecycleState["variant"] = "panel",
+) {
   const provider = document.createElement(PROVIDER_ELEMENT_NAME) as AppSidebarContextProvider;
   const sidebar = document.createElement(
     "openclaw-app-sidebar",
   ) as unknown as SidebarLifecycleState;
+  sidebar.variant = variant;
   provider.setContext(createContext(gateway, sessions));
   provider.append(sidebar);
   document.body.append(provider);
@@ -171,6 +181,50 @@ async function mountSidebar(gateway: ApplicationGateway, sessions: SessionCapabi
 
 afterEach(() => {
   document.body.replaceChildren();
+});
+
+describe("AppSidebar lobster outcome wiring", () => {
+  it.each([
+    ["panel", "failed", "error"],
+    ["panel", "killed", "aborted"],
+    ["drawer", "failed", "error"],
+    ["drawer", "killed", "aborted"],
+  ] as const)(
+    "passes the %s variant's latest %s session outcome",
+    async (variant, status, expectedOutcome) => {
+      const client = {} as GatewayBrowserClient;
+      const gateway = createGateway(client);
+      const sessions = createSessionsHarness("main", ["agent:main:main"]);
+      const { sidebar } = await mountSidebar(gateway, sessions.sessions, variant);
+      const terminalState = createSessionState("main", ["agent:main:main"]);
+      const result = terminalState.result;
+      if (!result) {
+        throw new Error("expected terminal session result");
+      }
+      const row = result.sessions[0];
+      if (!row) {
+        throw new Error("expected terminal session row");
+      }
+
+      sessions.publishList({
+        result: {
+          ...result,
+          sessions: [
+            {
+              ...row,
+              status,
+              endedAt: 100,
+            },
+          ],
+        },
+        agentId: terminalState.agentId,
+      });
+      await sidebar.updateComplete;
+
+      const pet = sidebar.querySelector<LobsterPetElement>("openclaw-lobster-pet");
+      expect(pet?.runOutcome).toBe(expectedOutcome);
+    },
+  );
 });
 
 describe("AppSidebar session source lifecycle", () => {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1645,6 +1645,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               <openclaw-lobster-pet
                 .seed=${lobsterPetSeed(this.sessionKey)}
                 .mode=${resolveLobsterPetMode(this.connected, this.sessionsResult?.sessions)}
+                .runOutcome=${resolveLobsterRunOutcome(this.sessionsResult?.sessions)}
                 .visitsEnabled=${this.lobsterPetVisits}
               ></openclaw-lobster-pet>
             </div>

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -397,4 +397,53 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await context.close();
     }
   });
+
+  it("passes failed run outcomes to both desktop and drawer lobsters", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": {
+          count: 1,
+          defaults: {
+            contextTokens: null,
+            model: "gpt-5.5",
+            modelProvider: "openai",
+          },
+          path: "",
+          sessions: [
+            {
+              endedAt: 100,
+              key: "main",
+              kind: "direct",
+              status: "failed",
+              updatedAt: 100,
+            },
+          ],
+          ts: 100,
+        },
+      },
+    });
+
+    const outcome = (locator: Locator) =>
+      locator.evaluate((element) => (element as HTMLElement & { runOutcome: string }).runOutcome);
+
+    try {
+      await page.goto(`${server.baseUrl}overview`);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const desktopPet = sidebar.locator(".sidebar-panel openclaw-lobster-pet");
+      await expect.poll(() => outcome(desktopPet)).toBe("error");
+
+      await page.setViewportSize({ height: 900, width: 900 });
+      await page.locator(".topbar-nav-toggle").click();
+      const drawerPet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
+      await expect.poll(() => outcome(drawerPet)).toBe("error");
+    } finally {
+      await context.close();
+    }
+  });
 });


### PR DESCRIPTION
Closes #103489

Related: #103426

## What Problem This Solves

Fixes an issue where desktop Control UI users could see the sidebar lobster celebrate a failed or aborted run because the new sessions-only panel dropped the terminal run outcome. The narrow drawer kept the correct behavior, so the same session produced different reactions across responsive layouts.

## Why This Change Was Made

The desktop panel now passes the existing `resolveLobsterRunOutcome` result through the same component property already used by the drawer and by the pre-#103426 shared render. The change adds symmetric panel/drawer regression coverage without changing the resolver, pet lifecycle, session contract, or visual layout.

## User Impact

The desktop lobster can once again react honestly to terminal run state: failed and timed-out runs receive the error reaction, killed runs receive the aborted reaction, and successful runs remain unchanged.

## Evidence

- Pre-fix Blacksmith Testbox through Crabbox (`tbx_01kx5c7d77sgck8mhyewtnpbrg`): `pnpm test ui/src/components/app-sidebar.test.ts` failed only the two new desktop-panel cases (`failed`: expected `error`, got `ok`; `killed`: expected `aborted`, got `ok`) while both drawer controls and four existing tests passed.
- Post-fix focused unit: the same command passed 8/8 tests.
- Real Chromium mocked-Gateway E2E: `sidebar-customization.e2e.test.ts` passed 3/3, including the new desktop-to-drawer failed-outcome assertion (572 ms).
- Hosted changed gate: `pnpm check:changed -- ui/src/components/app-sidebar.ts ui/src/components/app-sidebar.test.ts ui/src/e2e/sidebar-customization.e2e.test.ts` passed typecheck, lint, guards, and import-cycle checks (56.4 s).
- Hosted `pnpm format:check` passed all three files; `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; overall patch confidence 0.9.
- Merge-tree check with the separate vigil/pointer-cancel fix at `b4c2a3c9c808` was clean (`a49cf7960a13341e8c16f0a68361048fa6c95093`).
- Rebased exactly once onto pinned `main` `a97633a9ad89`; exact head is `c7aa2eeae8d2`, and the stable patch-id remained `4430301841e9da869d94495f59b3a4882d5152b4`.
- No screenshot is attached because this patch changes a runtime property rather than static pixels; the real-browser assertion proves the responsive component contract, while the lobster component's existing tests prove outcome-to-reaction rendering.

Landing is intentionally held behind security PR #103502 while exact-head CI runs.

AI-assisted: implemented and independently reviewed with Codex; the maintainer understands the one-line runtime change and the test matrix.
