### PR TITLE
fix(scripts): preserve empty Windows cmd args

### DIFF
--- a/scripts/windows-cmd-helpers.mjs
+++ b/scripts/windows-cmd-helpers.mjs
@@ -79,6 +79,9 @@ function escapeForCmdExe(arg) {
   if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
     throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
   }
+  if (arg === "") {
+    return '""';
+  }
   const escaped = arg.replace(/\^/g, "^^");
   if (!escaped.includes(" ") && !escaped.includes('"')) {
     return escaped;

--- a/test/scripts/windows-cmd-helpers.test.ts
+++ b/test/scripts/windows-cmd-helpers.test.ts
@@ -1,0 +1,17 @@
+// Windows cmd helper tests cover argv quoting used by script runners.
+import { describe, expect, it } from "vitest";
+import { buildCmdExeCommandLine } from "../../scripts/windows-cmd-helpers.mjs";
+
+describe("windows-cmd-helpers", () => {
+  it("preserves empty Windows cmd.exe arguments", () => {
+    expect(buildCmdExeCommandLine("pnpm.cmd", ["exec", "", "vitest"])).toBe(
+      'pnpm.cmd exec "" vitest',
+    );
+  });
+
+  it("preserves empty arguments when the command also needs outer quotes", () => {
+    expect(buildCmdExeCommandLine("C:\\Program Files\\pnpm\\pnpm.cmd", ["exec", ""])).toBe(
+      '""C:\\Program Files\\pnpm\\pnpm.cmd" exec """',
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows script runners that wrap `.cmd` shims through `cmd.exe` would drop an empty string argument when building the command line.

AI-assisted: yes.

## Why This Change Was Made

The shared Windows cmd helper now quotes empty arguments as `""`, matching the way it already quotes arguments with spaces. A focused regression test covers empty arguments for both simple commands and quoted command paths.

## User Impact

Windows contributors and release/tooling scripts can pass intentional empty argv values through `.cmd` wrappers without silently losing that argument position.

## Evidence

- `node scripts\\run-vitest.mjs run test\\scripts\\windows-cmd-helpers.test.ts` passed: 1 file, 2 tests.
- `node scripts\\run-vitest.mjs run test\\scripts\\windows-cmd-helpers.test.ts test\\scripts\\pnpm-runner.test.ts test\\scripts\\npm-runner.test.ts test\\scripts\\managed-child-process.test.ts` passed: 4 files across 2 shards, 33 tests passed, 6 skipped.
- `git diff --check` passed.
- `codex review --base origin/main` could not complete locally because the Codex CLI returned API 401 Unauthorized.
