### PR TITLE
fix(ui): dismiss topbar menus when their anchors disappear

### DIFF
--- a/ui/src/components/app-topbar.ts
+++ b/ui/src/components/app-topbar.ts
@@ -134,8 +134,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
       x: Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8)),
       y: rect.bottom + 6,
     };
-    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
-    document.addEventListener("keydown", this.handleDocumentKeydown, true);
+    this.listenForDismissal();
     void this.updateComplete.then(() => {
       this.querySelector<HTMLElement>(".topbar-menu .topbar-menu__item")?.focus();
     });
@@ -145,7 +144,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
     const trigger = this.moreMenuTrigger;
     this.moreMenuTrigger = null;
     this.moreMenuPosition = null;
-    this.syncDocumentListeners();
+    this.syncDismissListeners();
     if (options.restoreFocus) {
       trigger?.focus();
     }
@@ -160,8 +159,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
     };
-    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
-    document.addEventListener("keydown", this.handleDocumentKeydown, true);
+    this.listenForDismissal();
     void this.updateComplete.then(() => {
       this.querySelector<HTMLElement>(".sidebar-customize-menu__item")?.focus();
     });
@@ -171,19 +169,33 @@ class AppTopbar extends OpenClawLightDomContentsElement {
     const trigger = this.customizeMenuTrigger;
     this.customizeMenuTrigger = null;
     this.customizeMenuPosition = null;
-    this.syncDocumentListeners();
+    this.syncDismissListeners();
     if (options.restoreFocus) {
       trigger?.focus();
     }
   }
 
-  private syncDocumentListeners() {
+  private listenForDismissal() {
+    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
+    document.addEventListener("keydown", this.handleDocumentKeydown, true);
+    window.addEventListener("resize", this.handleWindowResize);
+  }
+
+  private syncDismissListeners() {
     if (this.moreMenuPosition || this.customizeMenuPosition) {
       return;
     }
     document.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
     document.removeEventListener("keydown", this.handleDocumentKeydown, true);
+    window.removeEventListener("resize", this.handleWindowResize);
   }
+
+  private readonly handleWindowResize = () => {
+    // Fixed-position menus are anchored to desktop-only controls. Close them
+    // whenever that geometry changes so an overlay cannot outlive its anchor.
+    this.closeMoreMenu();
+    this.closeCustomizeMenu();
+  };
 
   private readonly handleDocumentPointerDown = (event: PointerEvent) => {
     const path = event.composedPath();
@@ -200,11 +212,50 @@ class AppTopbar extends OpenClawLightDomContentsElement {
 
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
+      event.preventDefault();
       event.stopPropagation();
       this.closeMoreMenu({ restoreFocus: true });
       this.closeCustomizeMenu({ restoreFocus: true });
+      return;
     }
+    if (event.key === "Tab") {
+      // Menu items stay outside the page tab order. Restore the durable trigger
+      // before the browser performs its normal forward/backward Tab movement.
+      this.closeMoreMenu({ restoreFocus: true });
+      this.closeCustomizeMenu({ restoreFocus: true });
+      return;
+    }
+    this.moveMenuFocus(event);
   };
+
+  private moveMenuFocus(event: KeyboardEvent) {
+    const menu = this.querySelector<HTMLElement>(".topbar-menu, .sidebar-customize-menu");
+    if (!menu) {
+      return;
+    }
+    const items = Array.from(
+      menu.querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemcheckbox"]'),
+    );
+    if (items.length === 0) {
+      return;
+    }
+    const activeIndex = items.indexOf(document.activeElement as HTMLElement);
+    let nextIndex: number;
+    if (event.key === "ArrowDown") {
+      nextIndex = (activeIndex + 1) % items.length;
+    } else if (event.key === "ArrowUp") {
+      nextIndex = activeIndex <= 0 ? items.length - 1 : activeIndex - 1;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = items.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    items[nextIndex]?.focus();
+  }
 
   private readonly openCustomizeMenuFromContext = (event: MouseEvent) => {
     event.preventDefault();
@@ -237,6 +288,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
         href=${href}
         class=${classes}
         role=${menuItem ? "menuitem" : nothing}
+        tabindex=${menuItem ? "-1" : nothing}
         aria-current=${active ? "page" : nothing}
         @focus=${(event: Event) => this.preloadRoute(routeId, event)}
         @blur=${this.cancelPreload}
@@ -273,6 +325,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
         href=${href}
         class="topbar-menu__item ${active ? "topbar-menu__item--active" : ""}"
         role="menuitem"
+        tabindex="-1"
         @click=${(event: MouseEvent) => {
           if (!shouldHandleNavigationClick(event)) {
             return;
@@ -306,6 +359,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
         <a
           class="topbar-menu__item"
           role="menuitem"
+          tabindex="-1"
           href="https://docs.openclaw.ai"
           target=${EXTERNAL_LINK_TARGET}
           rel=${buildExternalLinkRel()}
@@ -318,10 +372,11 @@ class AppTopbar extends OpenClawLightDomContentsElement {
           type="button"
           class="topbar-menu__item"
           role="menuitem"
+          tabindex="-1"
           @click=${(event: MouseEvent) => {
             const trigger = event.currentTarget as HTMLElement;
             const rect = trigger.getBoundingClientRect();
-            this.openCustomizeMenu(rect.left, rect.top);
+            this.openCustomizeMenu(rect.left, rect.top, this.moreMenuTrigger);
           }}
         >
           <span class="nav-item__icon" aria-hidden="true">${icons.penLine}</span>
@@ -351,6 +406,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
               type="button"
               class="sidebar-customize-menu__item"
               role="menuitemcheckbox"
+              tabindex="-1"
               aria-checked=${String(pinned)}
               @click=${() => this.togglePinnedRoute(routeId)}
             >
@@ -369,6 +425,7 @@ class AppTopbar extends OpenClawLightDomContentsElement {
           type="button"
           class="sidebar-customize-menu__item"
           role="menuitem"
+          tabindex="-1"
           @click=${() => {
             this.onUpdatePinnedRoutes?.([...DEFAULT_SIDEBAR_PINNED_ROUTES]);
             this.closeCustomizeMenu({ restoreFocus: true });

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -63,6 +63,18 @@ async function holdUiProof(page: Page, durationMs = 600) {
   }
 }
 
+async function openTopbarTestPage() {
+  const context = await browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1440 },
+  });
+  const page = await context.newPage();
+  await installMockGateway(page);
+  await page.goto(`${server.baseUrl}overview`);
+  return { context, page };
+}
+
 describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -442,6 +454,97 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await page.locator(".topbar-nav-toggle").click();
       const drawerPet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
       await expect.poll(() => outcome(drawerPet)).toBe("error");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("dismisses the desktop More menu when the viewport enters drawer layout", async () => {
+    const { context, page } = await openTopbarTestPage();
+
+    try {
+      const moreButton = page.locator(".topbar-nav").getByRole("button", { name: "More" });
+      await moreButton.click();
+      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(1);
+      await captureUiProof(page, "07-topbar-menu-open.png");
+
+      await page.setViewportSize({ height: 900, width: 900 });
+      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(0);
+      await captureUiProof(page, "08-drawer-with-menu-dismissed.png");
+
+      await page.setViewportSize({ height: 900, width: 1440 });
+      await expect.poll(() => moreButton.isVisible()).toBe(true);
+      await moreButton.click();
+      await page.getByRole("menuitem", { name: "Edit pinned items" }).click();
+      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(1);
+      await page.setViewportSize({ height: 900, width: 900 });
+      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("restores focus to More after closing the pin editor with Escape", async () => {
+    const { context, page } = await openTopbarTestPage();
+
+    try {
+      const moreButton = page.locator(".topbar-nav").getByRole("button", { name: "More" });
+      await moreButton.click();
+      await page.getByRole("menuitem", { name: "Edit pinned items" }).click();
+      const pinItems = page
+        .getByRole("menu", { name: "Edit pinned items" })
+        .locator('[role="menuitem"], [role="menuitemcheckbox"]');
+      await page.keyboard.press("End");
+      await expect
+        .poll(() => pinItems.last().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("Home");
+      await expect
+        .poll(() => pinItems.first().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("Escape");
+
+      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(0);
+      await expect
+        .poll(() => moreButton.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("moves focus through the More menu with arrow keys", async () => {
+    const { context, page } = await openTopbarTestPage();
+
+    try {
+      await page.locator(".topbar-nav").getByRole("button", { name: "More" }).click();
+      const menuItems = page.locator(".topbar-menu").getByRole("menuitem");
+      await expect
+        .poll(() => menuItems.evaluateAll((items) => items.every((item) => item.tabIndex === -1)))
+        .toBe(true);
+      await expect
+        .poll(() => menuItems.first().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await page.keyboard.press("ArrowDown");
+      await expect
+        .poll(() => menuItems.nth(1).evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("End");
+      await expect
+        .poll(() => menuItems.last().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("ArrowDown");
+      await expect
+        .poll(() => menuItems.first().evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await page.keyboard.press("Tab");
+      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(0);
+      await expect
+        .poll(() =>
+          page.locator(".topbar-search").evaluate((element) => element === document.activeElement),
+        )
+        .toBe(true);
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Closes #103500
Related: #103426

## What Problem This Solves

Fixes an issue where desktop Control UI users could leave the topbar More or pin-editor menu floating over the drawer layout after resizing below the 1100px breakpoint. Keyboard users also lost focus after More → Edit pinned items → Escape, and the elements exposed as ARIA menus did not support arrow/Home/End movement or a clean Tab exit.

## Why This Change Was Made

The topbar now owns the complete lifetime of its fixed-position menus: any viewport resize dismisses them before their anchor geometry can become stale, and all dismissal listeners are removed together. Opening the pin editor from More carries the durable More button forward as its focus-restoration target instead of retaining the disappearing Edit menu item.

Menu items are removed from the page tab order and the topbar implements the declared menu keyboard contract: ArrowUp/ArrowDown with wraparound, Home/End, Escape back to the durable trigger, and Tab dismissal followed by normal browser traversal.

Landing coordination: rebased again only because the repo-native merge wrapper detected an E2E overlap after #103501 landed; both independent test blocks were retained and the stable patch id is unchanged. Current head is 427b1af5a361. Keep this PR as the sole active UI merge until it lands.

## User Impact

Responsive layout changes no longer leave an orphaned menu over the narrow drawer UI. Keyboard users keep their place when leaving the pin editor and can move predictably through both topbar menus.

## Evidence

- **Exact current-main red proof:** real Chromium mocked-Gateway E2E on Blacksmith Testbox had 2 existing passes and 3 focused failures:
  - More menu count remained 1 after resizing from 1440px to 900px.
  - More did not regain document.activeElement after pin-editor Escape.
  - ArrowDown did not move focus to the next menu item.
- **Rebased exact-head real Chromium:** head 427b1af5a3612ebaf9f5951fb551984d10fb933a; Testbox-through-Crabbox passed 6/6, including the retained #103501 lobster case plus all three menu regressions.
- **Rebased exact-head hosted changed gate:** path-scoped check:changed passed core/coreTests typechecks, lint, guards, and import-cycle checks in 2m52s.
- **Formatting:** format:check passed for both changed files.
- **Independent review:** fresh branch Codex autoreview clean, confidence 0.91.
- **Exact-head CI:** 58 successful checks, 20 expected skips, no failures or pending checks.
- **Testbox:** tbx_01kx5epmyq4ja1s1mw5hpnt676; hosted run https://github.com/openclaw/openclaw/actions/runs/29076665424; stopped after proof.

| Desktop More menu open at 1440px | Drawer after resize to 900px |
| --- | --- |
| ![Desktop More menu open](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/topbar-transient-menus/07-topbar-menu-open.png) | ![Drawer with the transient menu dismissed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/topbar-transient-menus/08-drawer-with-menu-dismissed.png) |

Visual artifact manifest: https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/topbar-transient-menus/artifact-manifest.json


