### PR TITLE
fix: preserve selected models through hot reloads and fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.
 - **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -3,6 +3,7 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveThreadBindingIdleTimeoutMsForChannel,
   resolveThreadBindingMaxAgeMsForChannel,
@@ -14,8 +15,7 @@ import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "openclaw/plugin-sdk/native-command-config-runtime";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
-import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -26,7 +26,10 @@ import { resolveTelegramAccount } from "./accounts.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import { registerTelegramHandlers } from "./bot-handlers.runtime.js";
-import { createTelegramMessageProcessor } from "./bot-message.js";
+import {
+  createTelegramMessageProcessor,
+  resolveTelegramMessageTurnSettings,
+} from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
   getTelegramSpooledReplayDeferredParticipant,
@@ -39,7 +42,7 @@ import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import { resolveDefaultAgentId } from "./bot.agent.runtime.js";
 import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
 import type { TelegramBotOptions } from "./bot.types.js";
-import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
+import { buildTelegramGroupPeerId } from "./bot/helpers.js";
 import { setTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
 import {
   asTelegramClientFetch,
@@ -54,10 +57,8 @@ import {
   buildTelegramGroupHistorySelfSender,
   recordTelegramGroupHistoryEntry,
 } from "./group-history-window.js";
-import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
 import { formatTelegramRawUpdateForLog } from "./raw-update-log.js";
-import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
@@ -253,12 +254,12 @@ export function createTelegramBotCore(
     await next();
   });
 
-  const historyLimit = Math.max(
-    0,
-    telegramCfg.historyLimit ??
-      cfg.messages?.groupChat?.historyLimit ??
-      DEFAULT_GROUP_HISTORY_LIMIT,
-  );
+  const { historyLimit } = resolveTelegramMessageTurnSettings({
+    accountId: account.accountId,
+    cfg,
+    telegramCfg,
+    opts,
+  });
   const groupHistories = new Map<string, HistoryEntry[]>();
   const botHistorySender = buildTelegramGroupHistorySelfSender(
     account.name ?? opts.botInfo?.first_name ?? opts.botInfo?.username ?? "OpenClaw",
@@ -282,19 +283,6 @@ export function createTelegramBotCore(
       });
     },
   });
-  const telegramTextLimit =
-    telegramCfg.richMessages === true ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
-  const textLimit = Math.min(
-    resolveTextChunkLimit(cfg, "telegram", account.accountId, {
-      fallbackLimit: telegramTextLimit,
-    }),
-    telegramTextLimit,
-  );
-  const dmPolicy = telegramCfg.dmPolicy ?? "pairing";
-  const allowFrom = opts.allowFrom ?? telegramCfg.allowFrom;
-  const groupAllowFrom =
-    opts.groupAllowFrom ?? telegramCfg.groupAllowFrom ?? telegramCfg.allowFrom ?? allowFrom;
-  const replyToMode = opts.replyToMode ?? telegramCfg.replyToMode ?? "off";
   const nativeEnabled = resolveNativeCommandsEnabled({
     providerId: "telegram",
     providerSetting: telegramCfg.commands?.native,
@@ -309,14 +297,11 @@ export function createTelegramBotCore(
     providerSetting: telegramCfg.commands?.native,
     globalSetting: cfg.commands?.native,
   });
-  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-  const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const mediaMaxBytes = (opts.mediaMaxMb ?? telegramCfg.mediaMaxMb ?? 100) * 1024 * 1024;
   const logger = getChildLogger({ module: "telegram-auto-reply" });
-  const streamMode = resolveTelegramStreamMode(telegramCfg);
-  const resolveGroupPolicy = (chatId: string | number) =>
+  const resolveGroupPolicy = (chatId: string | number, turnCfg: OpenClawConfig) =>
     resolveChannelGroupPolicy({
-      cfg,
+      cfg: turnCfg,
       channel: "telegram",
       accountId: account.accountId,
       groupId: String(chatId),
@@ -326,12 +311,13 @@ export function createTelegramBotCore(
     agentId?: string;
     messageThreadId?: number;
     sessionKey?: string;
+    cfg: OpenClawConfig;
   }) => {
-    const agentId = params.agentId ?? resolveDefaultAgentId(cfg);
+    const agentId = params.agentId ?? resolveDefaultAgentId(params.cfg);
     const sessionKey =
       params.sessionKey ??
       `agent:${agentId}:telegram:group:${buildTelegramGroupPeerId(params.chatId, params.messageThreadId)}`;
-    const storePath = telegramDeps.resolveStorePath(cfg.session?.store, { agentId });
+    const storePath = telegramDeps.resolveStorePath(params.cfg.session?.store, { agentId });
     try {
       const getSessionEntry = telegramDeps.getSessionEntry;
       if (!getSessionEntry) {
@@ -349,31 +335,25 @@ export function createTelegramBotCore(
     }
     return undefined;
   };
-  const resolveGroupRequireMention = (chatId: string | number) =>
+  const resolveGroupRequireMention = (chatId: string | number, turnCfg: OpenClawConfig) =>
     resolveChannelGroupRequireMention({
-      cfg,
+      cfg: turnCfg,
       channel: "telegram",
       accountId: account.accountId,
       groupId: String(chatId),
       requireMentionOverride: opts.requireMention,
       overrideOrder: "after-config",
     });
-  const loadFreshTelegramAccountConfig = () => {
-    try {
-      return resolveTelegramAccount({
-        cfg: telegramDeps.getRuntimeConfig(),
-        accountId: account.accountId,
-      }).config;
-    } catch (error) {
-      logVerbose(
-        `telegram: failed to load fresh config for account ${account.accountId}; using startup snapshot: ${String(error)}`,
-      );
-      return telegramCfg;
-    }
-  };
-  const resolveTelegramGroupConfig = (chatId: string | number, messageThreadId?: number) => {
-    const freshTelegramCfg = loadFreshTelegramAccountConfig();
-    return resolveTelegramScopedGroupConfig(freshTelegramCfg, chatId, messageThreadId);
+  const resolveTelegramGroupConfig = (
+    chatId: string | number,
+    messageThreadId: number | undefined,
+    turnCfg: OpenClawConfig,
+  ) => {
+    const turnTelegramCfg = resolveTelegramAccount({
+      cfg: turnCfg,
+      accountId: account.accountId,
+    }).config;
+    return resolveTelegramScopedGroupConfig(turnTelegramCfg, chatId, messageThreadId);
   };
 
   // Global sendChatAction handler with 401 backoff and transient cooldown.
@@ -389,25 +369,14 @@ export function createTelegramBotCore(
 
   const processMessage = createTelegramMessageProcessor({
     bot,
-    cfg,
     account,
-    telegramCfg,
-    historyLimit,
     groupHistories,
-    dmPolicy,
-    allowFrom,
-    groupAllowFrom,
-    ackReactionScope,
     logger,
     resolveGroupActivation,
     resolveGroupRequireMention,
     resolveTelegramGroupConfig,
-    loadFreshConfig: () => telegramDeps.getRuntimeConfig(),
     sendChatActionHandler,
     runtime,
-    replyToMode,
-    streamMode,
-    textLimit,
     opts,
     telegramDeps,
   });
@@ -418,12 +387,7 @@ export function createTelegramBotCore(
     runtime,
     accountId: account.accountId,
     telegramCfg,
-    allowFrom,
-    groupAllowFrom,
-    replyToMode,
-    textLimit,
     mediaMaxBytes,
-    useAccessGroups,
     nativeEnabled,
     nativeSkillsEnabled,
     nativeDisabledExplicit,
@@ -443,8 +407,6 @@ export function createTelegramBotCore(
     runtime,
     mediaMaxBytes,
     telegramCfg,
-    allowFrom,
-    groupAllowFrom,
     resolveGroupPolicy,
     resolveGroupActivation,
     resolveGroupRequireMention,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -18,7 +18,11 @@ import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-nat
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
-import type { DmPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  DmPolicy,
+  OpenClawConfig,
+  TelegramAccountConfig,
+} from "openclaw/plugin-sdk/config-contracts";
 import type {
   TelegramGroupConfig,
   TelegramTopicConfig,
@@ -83,6 +87,7 @@ import type {
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
+import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
 import { parseTelegramNativeCommandCallbackData } from "./bot-native-commands.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
@@ -111,7 +116,6 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
-  loadTelegramPairingStoreIfNeeded,
   resolveTelegramBotHasTopicsEnabled,
   resolveTelegramMediaPlaceholder,
   TelegramPairingStoreReadError,
@@ -210,8 +214,6 @@ export const registerTelegramHandlers = ({
   runtime,
   mediaMaxBytes,
   telegramCfg,
-  allowFrom,
-  groupAllowFrom,
   resolveGroupPolicy,
   resolveTelegramGroupConfig,
   shouldSkipUpdate,
@@ -251,6 +253,8 @@ export const registerTelegramHandlers = ({
         : MEDIA_GROUP_TIMEOUT_MS;
 
   type BufferedMediaGroupEntry = MediaGroupEntry & {
+    // Album mention preflight must use the same policy snapshot that admitted its first item.
+    authorizationCfg: OpenClawConfig;
     storeAllowFrom: string[];
     isGroup: boolean;
     isForum: boolean;
@@ -279,6 +283,7 @@ export const registerTelegramHandlers = ({
 
   type TextFragmentEntry = {
     key: string;
+    storeAllowFrom: string[];
     threadId?: number;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     promptContextMinTimestampMs?: number;
@@ -751,7 +756,7 @@ export const registerTelegramHandlers = ({
     resolvedThreadId?: number;
     botHasTopicsEnabled?: boolean;
     senderId?: string | number;
-    runtimeCfg?: OpenClawConfig;
+    runtimeCfg: OpenClawConfig;
   }): {
     agentId: string;
     sessionEntry: ReturnType<typeof getSessionEntry>;
@@ -759,7 +764,7 @@ export const registerTelegramHandlers = ({
     storePath: string;
     model?: string;
   } => {
-    const runtimeCfg = params.runtimeCfg ?? telegramDeps.getRuntimeConfig();
+    const runtimeCfg = params.runtimeCfg;
     const resolvedThreadId =
       params.resolvedThreadId ??
       resolveTelegramForumThreadId({
@@ -768,7 +773,7 @@ export const registerTelegramHandlers = ({
       });
     const dmThreadId = !params.isGroup ? params.messageThreadId : undefined;
     const topicThreadId = resolvedThreadId ?? dmThreadId;
-    const { topicConfig } = resolveTelegramGroupConfig(params.chatId, topicThreadId);
+    const { topicConfig } = resolveTelegramGroupConfig(params.chatId, topicThreadId, runtimeCfg);
     const { route } = resolveTelegramConversationRoute({
       cfg: runtimeCfg,
       accountId,
@@ -879,6 +884,7 @@ export const registerTelegramHandlers = ({
   };
 
   const shouldSkipMediaDownloadForUnaddressedMentionGroup = async (params: {
+    authorizationCfg: OpenClawConfig;
     ctx: TelegramContext;
     msg: Message;
     chatId: number;
@@ -893,6 +899,7 @@ export const registerTelegramHandlers = ({
     topicConfig?: TelegramTopicConfig;
   }): Promise<boolean> => {
     const {
+      authorizationCfg,
       ctx,
       msg,
       chatId,
@@ -910,7 +917,7 @@ export const registerTelegramHandlers = ({
       return false;
     }
 
-    const runtimeCfg = telegramDeps.getRuntimeConfig();
+    const runtimeCfg = authorizationCfg;
     const sessionState = resolveTelegramSessionState({
       chatId,
       isGroup,
@@ -925,12 +932,13 @@ export const registerTelegramHandlers = ({
       messageThreadId: resolvedThreadId,
       sessionKey: sessionState.sessionKey,
       agentId: sessionState.agentId,
+      cfg: runtimeCfg,
     });
     const requireMention = firstDefined(
       topicConfig?.requireMention,
       activationOverride,
       groupConfig?.requireMention,
-      resolveGroupRequireMention(chatId),
+      resolveGroupRequireMention(chatId, runtimeCfg),
     );
     if (!requireMention) {
       return false;
@@ -1016,6 +1024,7 @@ export const registerTelegramHandlers = ({
 
       if (
         await shouldSkipMediaDownloadForUnaddressedMentionGroup({
+          authorizationCfg: entry.authorizationCfg,
           ctx: primaryEntry.ctx,
           msg: primaryEntry.msg,
           chatId: primaryEntry.msg.chat.id,
@@ -1143,7 +1152,6 @@ export const registerTelegramHandlers = ({
         date: last.msg.date ?? first.msg.date,
       });
 
-      const storeAllowFrom = await loadStoreAllowFrom(first.msg);
       const baseCtx = first.ctx;
 
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
@@ -1151,7 +1159,7 @@ export const registerTelegramHandlers = ({
         ctx: syntheticCtx,
         msg: syntheticMessage,
         allMedia: [],
-        storeAllowFrom,
+        storeAllowFrom: entry.storeAllowFrom,
         options: {
           messageIdOverride: String(last.msg.message_id),
           ambientTranscriptBody: formatTelegramAmbientTranscriptBody(
@@ -1194,30 +1202,6 @@ export const registerTelegramHandlers = ({
     entry.timer = setTimeout(() => {
       void runTextFragmentFlush(entry);
     }, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS);
-  };
-
-  const loadStoreAllowFrom = async (msg: Message) => {
-    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
-    const { groupConfig, topicConfig } = resolveTelegramGroupConfig(
-      msg.chat.id,
-      msg.message_thread_id,
-    );
-    const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
-    const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({
-      isGroup,
-      groupConfig,
-      dmPolicy: telegramCfg.dmPolicy,
-    });
-    return loadTelegramPairingStoreIfNeeded({
-      cfg,
-      allowFrom,
-      groupAllowOverride,
-      accountId,
-      senderId: msg.from?.id != null ? String(msg.from.id) : undefined,
-      isGroup,
-      effectiveDmPolicy,
-      readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
-    });
   };
 
   const recordMessageForReplyChain = (msg: Message, threadId?: number) =>
@@ -1275,6 +1259,8 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext,
     msg: Message,
     replyChainNodes: TelegramCachedMessageNode[],
+    runtimeCfg: OpenClawConfig,
+    runtimeTelegramCfg: TelegramAccountConfig,
     options?: TelegramMessageContextOptions,
     mediaByMessageId?: ReadonlyMap<string, TelegramMediaRef>,
     selectedMessageIds?: PromptContextMessageSelection,
@@ -1282,8 +1268,8 @@ export const registerTelegramHandlers = ({
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
     const groupHistoryLimit = Math.max(
       0,
-      telegramCfg.historyLimit ??
-        cfg.messages?.groupChat?.historyLimit ??
+      runtimeTelegramCfg.historyLimit ??
+        runtimeCfg.messages?.groupChat?.historyLimit ??
         DEFAULT_GROUP_HISTORY_LIMIT,
     );
     const messageId = typeof msg.message_id === "number" ? String(msg.message_id) : undefined;
@@ -1309,6 +1295,7 @@ export const registerTelegramHandlers = ({
               messageThreadId: msg.message_thread_id,
               botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
               senderId: msg.from?.id,
+              runtimeCfg,
             }),
             limit: 10,
             ...(sessionBeforeTimestampMs !== undefined
@@ -1471,11 +1458,13 @@ export const registerTelegramHandlers = ({
       await forgetDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
     };
     try {
+      // One assembled turn owns one config identity. Reloading below this point
+      // can validate a model pin against a different allowlist than dispatch uses.
+      const runtimeCfg = telegramDeps.getRuntimeConfig();
+      const runtimeTelegramCfg = resolveTelegramAccount({ cfg: runtimeCfg, accountId }).config;
       const replyChainNodes = await buildReplyChainForMessage(params.msg);
       const isGroupConversation =
         params.msg.chat.type === "group" || params.msg.chat.type === "supergroup";
-      const runtimeCfg = telegramDeps.getRuntimeConfig();
-      const runtimeTelegramCfg = resolveTelegramAccount({ cfg: runtimeCfg, accountId }).config;
       const isForum =
         params.msg.chat.type === "supergroup" &&
         Boolean(params.msg.chat.is_forum || params.msg.is_topic_message);
@@ -1560,6 +1549,8 @@ export const registerTelegramHandlers = ({
         params.ctx,
         params.msg,
         replyChainNodes,
+        runtimeCfg,
+        runtimeTelegramCfg,
         params.options,
         promptContextMediaByMessageId,
         params.promptContextMessageSelection,
@@ -1568,16 +1559,18 @@ export const registerTelegramHandlers = ({
         params.ctx,
         params.allMedia,
         params.storeAllowFrom,
-        params.options,
-        replyMedia,
-        replyChain,
-        promptContext,
         {
+          cfg: runtimeCfg,
+          telegramCfg: runtimeTelegramCfg,
           onDispatchStart: async () => {
             await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
             dispatchDedupeCommitted = true;
           },
         },
+        params.options,
+        replyMedia,
+        replyChain,
+        promptContext,
       );
       if (result.kind === "completed" && !dispatchDedupeCommitted) {
         await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
@@ -1608,6 +1601,8 @@ export const registerTelegramHandlers = ({
     hasGroupAllowOverride: boolean;
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
+    cfg: OpenClawConfig;
+    telegramCfg: TelegramAccountConfig;
   }) => {
     const {
       isGroup,
@@ -1620,6 +1615,8 @@ export const registerTelegramHandlers = ({
       hasGroupAllowOverride,
       groupConfig,
       topicConfig,
+      cfg: authorizationCfg,
+      telegramCfg: authorizationTelegramCfg,
     } = params;
     const baseAccess = evaluateTelegramGroupBaseAccess({
       isGroup,
@@ -1654,8 +1651,8 @@ export const registerTelegramHandlers = ({
     const policyAccess = evaluateTelegramGroupPolicyAccess({
       isGroup,
       chatId,
-      cfg,
-      telegramCfg,
+      cfg: authorizationCfg,
+      telegramCfg: authorizationTelegramCfg,
       topicConfig,
       groupConfig,
       effectiveGroupAllow,
@@ -1696,7 +1693,12 @@ export const registerTelegramHandlers = ({
 
   type TelegramGroupAllowContext = Awaited<ReturnType<typeof resolveTelegramGroupAllowFromContext>>;
   type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
-  type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
+  type TelegramEventAuthorizationContext = TelegramGroupAllowContext & {
+    cfg: OpenClawConfig;
+    telegramCfg: TelegramAccountConfig;
+    allowFrom: ReturnType<typeof resolveTelegramMessageTurnSettings>["allowFrom"];
+    dmPolicy: DmPolicy;
+  };
   const getChat: TelegramGetChat = bot.api.getChat.bind(bot.api);
 
   const TELEGRAM_EVENT_AUTH_RULES: Record<
@@ -1812,36 +1814,53 @@ export const registerTelegramHandlers = ({
     }
   };
 
+  // Authorization owns one ingress snapshot. The agent turn intentionally
+  // captures again after batching so reloads during debounce apply to execution.
   const resolveTelegramEventAuthorizationContext = async (params: {
+    cfg: OpenClawConfig;
     chatId: number;
     isGroup: boolean;
     isForum: boolean;
     senderId?: string;
     messageThreadId?: number;
-    groupAllowContext?: TelegramGroupAllowContext;
   }): Promise<TelegramEventAuthorizationContext> => {
-    const groupAllowContext =
-      params.groupAllowContext ??
-      (await resolveTelegramGroupAllowFromContext({
-        cfg,
-        chatId: params.chatId,
-        accountId,
-        dmPolicy: telegramCfg.dmPolicy,
-        allowFrom,
-        senderId: params.senderId,
-        isGroup: params.isGroup,
-        isForum: params.isForum,
-        messageThreadId: params.messageThreadId,
-        groupAllowFrom,
-        readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
-        resolveTelegramGroupConfig,
-      }));
+    const authorizationCfg = params.cfg;
+    const authorizationTelegramCfg = resolveTelegramAccount({
+      cfg: authorizationCfg,
+      accountId,
+    }).config;
+    const authorizationSettings = resolveTelegramMessageTurnSettings({
+      accountId,
+      cfg: authorizationCfg,
+      telegramCfg: authorizationTelegramCfg,
+      opts,
+    });
+    const groupAllowContext = await resolveTelegramGroupAllowFromContext({
+      cfg: authorizationCfg,
+      chatId: params.chatId,
+      accountId,
+      dmPolicy: authorizationSettings.dmPolicy,
+      allowFrom: authorizationSettings.allowFrom,
+      senderId: params.senderId,
+      isGroup: params.isGroup,
+      isForum: params.isForum,
+      messageThreadId: params.messageThreadId,
+      groupAllowFrom: authorizationSettings.groupAllowFrom,
+      readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
+      resolveTelegramGroupConfig,
+    });
     const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({
       isGroup: params.isGroup,
       groupConfig: groupAllowContext.groupConfig,
-      dmPolicy: telegramCfg.dmPolicy,
+      dmPolicy: authorizationSettings.dmPolicy,
     });
-    return { dmPolicy: effectiveDmPolicy, ...groupAllowContext };
+    return {
+      cfg: authorizationCfg,
+      allowFrom: authorizationSettings.allowFrom,
+      telegramCfg: authorizationTelegramCfg,
+      dmPolicy: effectiveDmPolicy,
+      ...groupAllowContext,
+    };
   };
 
   const authorizeTelegramEventSender = async (params: {
@@ -1863,6 +1882,9 @@ export const registerTelegramHandlers = ({
       groupAllowOverride,
       effectiveGroupAllow,
       hasGroupAllowOverride,
+      cfg: authorizationCfg,
+      telegramCfg: authorizationTelegramCfg,
+      allowFrom: authorizationAllowFrom,
     } = context;
     const authRules = TELEGRAM_EVENT_AUTH_RULES[mode];
     const {
@@ -1883,6 +1905,8 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
         groupConfig,
         topicConfig,
+        cfg: authorizationCfg,
+        telegramCfg: authorizationTelegramCfg,
       })
     ) {
       return false;
@@ -1890,9 +1914,9 @@ export const registerTelegramHandlers = ({
 
     if (!isGroup && enforceDirectAuthorization) {
       // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom.
-      const dmAllowFrom = groupAllowOverride ?? allowFrom;
+      const dmAllowFrom = groupAllowOverride ?? authorizationAllowFrom;
       const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-        cfg,
+        cfg: authorizationCfg,
         allowFrom: dmAllowFrom,
         accountId,
         senderId,
@@ -1952,10 +1976,10 @@ export const registerTelegramHandlers = ({
     senderId: string;
     senderUsername: string;
     context: TelegramEventAuthorizationContext;
-    cfg: OpenClawConfig;
   }): Promise<boolean> => {
-    const { chatId, isGroup, senderId, senderUsername, context, cfg: cfgLocal } = params;
-    const dmAllowFrom = context.groupAllowOverride ?? allowFrom;
+    const { chatId, isGroup, senderId, senderUsername, context } = params;
+    const cfgLocal = context.cfg;
+    const dmAllowFrom = context.groupAllowOverride ?? context.allowFrom;
     if (isTelegramCommandsAllowFromConfigured(cfgLocal)) {
       return resolveTelegramCommandAuthorization({
         cfg: cfgLocal,
@@ -2014,22 +2038,31 @@ export const registerTelegramHandlers = ({
       const senderUsername = user?.username ?? "";
       const isGroup = reaction.chat.type === "group" || reaction.chat.type === "supergroup";
       const isForum = reaction.chat.is_forum === true;
+      const authorizationCfg = telegramDeps.getRuntimeConfig();
+      const authorizationTelegramCfg = resolveTelegramAccount({
+        cfg: authorizationCfg,
+        accountId,
+      }).config;
 
       // Resolve reaction notification mode (default: "own").
-      const reactionMode = telegramCfg.reactionNotifications ?? "own";
+      const reactionMode = authorizationTelegramCfg.reactionNotifications ?? "own";
       if (reactionMode === "off") {
         return;
       }
       if (user?.is_bot) {
         return;
       }
-      if (reactionMode === "own" && !telegramDeps.wasSentByBot(chatId, messageId, cfg)) {
+      if (
+        reactionMode === "own" &&
+        !telegramDeps.wasSentByBot(chatId, messageId, authorizationCfg)
+      ) {
         logVerbose(
           `telegram: skipped reaction on msg ${messageId} in chat ${chatId} (own mode, not sent by bot)`,
         );
         return;
       }
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        cfg: authorizationCfg,
         chatId,
         isGroup,
         isForum,
@@ -2103,7 +2136,7 @@ export const registerTelegramHandlers = ({
       const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
       // Fresh config for bindings lookup; other routing inputs are payload-derived.
       const route = resolveAgentRoute({
-        cfg: telegramDeps.getRuntimeConfig(),
+        cfg: eventAuthContext.cfg,
         channel: "telegram",
         accountId,
         peer: { kind: isGroup ? "group" : "direct", id: peerId },
@@ -2127,6 +2160,7 @@ export const registerTelegramHandlers = ({
     }
   });
   const processInboundMessage = async (params: {
+    authorizationCfg: OpenClawConfig;
     ctx: TelegramContext;
     msg: Message;
     chatId: number;
@@ -2148,6 +2182,7 @@ export const registerTelegramHandlers = ({
     dispatchDedupeKeys: string[];
   }) => {
     const {
+      authorizationCfg,
       ctx,
       msg,
       chatId,
@@ -2179,7 +2214,7 @@ export const registerTelegramHandlers = ({
       }
       abortControlAuthorized ??= resolveTelegramCommandIngressAuthorization({
         accountId,
-        cfg,
+        cfg: authorizationCfg,
         dmPolicy,
         isGroup,
         chatId,
@@ -2268,6 +2303,7 @@ export const registerTelegramHandlers = ({
         );
         const entry: TextFragmentEntry = {
           key,
+          storeAllowFrom,
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
           dispatchDedupeKeys,
           spooledReplayParticipants: spooledReplayParticipant ? [spooledReplayParticipant] : [],
@@ -2332,6 +2368,7 @@ export const registerTelegramHandlers = ({
           `media-group:${mediaGroupKey}:${msg.message_id}`,
         );
         const entry: BufferedMediaGroupEntry = {
+          authorizationCfg,
           messages: [{ msg, ctx }],
           storeAllowFrom,
           isGroup,
@@ -2363,6 +2400,7 @@ export const registerTelegramHandlers = ({
 
     if (
       await shouldSkipMediaDownloadForUnaddressedMentionGroup({
+        authorizationCfg,
         ctx,
         msg,
         chatId,
@@ -2607,14 +2645,15 @@ export const registerTelegramHandlers = ({
         nativeCallbackCommand ?? (opaqueCallbackData ? "" : data),
       );
       const isApprovalCallback = approvalCallback !== null;
+      const authorizationCfg = telegramDeps.getRuntimeConfig();
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
-        cfg,
+        cfg: authorizationCfg,
         accountId,
       });
       const execApprovalButtonsEnabled =
         isApprovalCallback &&
         shouldEnableTelegramExecApprovalButtons({
-          cfg,
+          cfg: authorizationCfg,
           accountId,
           to: String(chatId),
         });
@@ -2642,6 +2681,7 @@ export const registerTelegramHandlers = ({
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
+        cfg: authorizationCfg,
         chatId,
         isGroup,
         isForum,
@@ -2692,7 +2732,7 @@ export const registerTelegramHandlers = ({
         await replyToCallbackChat(buildPluginBindingResolvedText(resolved));
         return;
       }
-      const runtimeCfg = telegramDeps.getRuntimeConfig();
+      const runtimeCfg = eventAuthContext.cfg;
       const pluginCallback = await dispatchTelegramPluginInteractiveHandler({
         data: pluginCallbackData,
         callbackId: callback.id,
@@ -2713,7 +2753,6 @@ export const registerTelegramHandlers = ({
               senderId,
               senderUsername,
               context: eventAuthContext,
-              cfg: runtimeCfg,
             }),
           },
           callbackMessage: {
@@ -2982,7 +3021,6 @@ export const registerTelegramHandlers = ({
             senderId,
             senderUsername,
             context: eventAuthContext,
-            cfg: runtimeCfg,
           }))
         ) {
           logVerbose(
@@ -3002,6 +3040,7 @@ export const registerTelegramHandlers = ({
             resolvedThreadId,
             botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(ctx.me),
             senderId,
+            runtimeCfg,
           });
           modelData = await telegramDeps.buildModelsProviderData(runtimeCfg, sessionState.agentId);
         } catch (err) {
@@ -3103,8 +3142,8 @@ export const registerTelegramHandlers = ({
           const text = formatModelsAvailableHeader({
             provider,
             total: models.length,
-            cfg,
-            agentDir: resolveAgentDir(cfg, sessionState.agentId),
+            cfg: runtimeCfg,
+            agentDir: resolveAgentDir(runtimeCfg, sessionState.agentId),
             sessionEntry: sessionState.sessionEntry,
           });
           try {
@@ -3375,7 +3414,9 @@ export const registerTelegramHandlers = ({
     requireConfiguredGroup: boolean;
     dmAccess: "challenge" | "silent";
   }): Promise<TelegramInboundGate> => {
+    const authorizationCfg = telegramDeps.getRuntimeConfig();
     const context = await resolveTelegramEventAuthorizationContext({
+      cfg: authorizationCfg,
       chatId: params.chatId,
       isGroup: params.isGroup,
       isForum: params.isForum,
@@ -3392,11 +3433,13 @@ export const registerTelegramHandlers = ({
       groupAllowOverride,
       effectiveGroupAllow,
       hasGroupAllowOverride,
+      telegramCfg: authorizationTelegramCfg,
+      allowFrom: authorizationAllowFrom,
     } = context;
     // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
     const expandedDmAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-      cfg,
-      allowFrom: groupAllowOverride ?? allowFrom,
+      cfg: authorizationCfg,
+      allowFrom: groupAllowOverride ?? authorizationAllowFrom,
       accountId,
       senderId: params.senderId,
     });
@@ -3423,6 +3466,8 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
         groupConfig,
         topicConfig,
+        cfg: authorizationCfg,
+        telegramCfg: authorizationTelegramCfg,
       })
     ) {
       return { allowed: false };
@@ -3539,7 +3584,7 @@ export const registerTelegramHandlers = ({
         resolvedThreadId,
         botHasTopicsEnabled: resolveTelegramBotHasTopicsEnabled(event.ctx.me),
         senderId: event.senderId,
-        runtimeCfg: cfg,
+        runtimeCfg: gate.context.cfg,
       });
       const promptContextMinTimestampMs = normalizePromptContextMinTimestampMs(
         sessionState.sessionEntry?.sessionStartedAt,
@@ -3559,6 +3604,7 @@ export const registerTelegramHandlers = ({
       dispatchDedupeKeys = dispatchDedupe.keys;
       await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId);
       await processInboundMessage({
+        authorizationCfg: gate.context.cfg,
         ctx: event.ctx,
         msg: event.msg,
         chatId: event.chatId,

--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -1,26 +1,5 @@
 // Telegram tests cover bot message context.require mention plugin behavior.
-import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { defaultRouteConfig } = vi.hoisted(() => ({
-  defaultRouteConfig: {
-    agents: {
-      list: [{ id: "main", default: true }],
-    },
-    channels: { telegram: {} },
-    messages: { groupChat: { mentionPatterns: [] } },
-  },
-}));
-
-vi.mock("openclaw/plugin-sdk/runtime-config-snapshot", async () => {
-  const actual = await vi.importActual<
-    typeof import("openclaw/plugin-sdk/runtime-config-snapshot")
-  >("openclaw/plugin-sdk/runtime-config-snapshot");
-  return {
-    ...actual,
-    getRuntimeConfig: vi.fn(() => defaultRouteConfig),
-  };
-});
+import { describe, expect, it, vi } from "vitest";
 
 const { buildTelegramMessageContextForTest } =
   await import("./bot-message-context.test-harness.js");
@@ -42,10 +21,6 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
       from: { id: 42, first_name: "Alice" },
     };
   }
-
-  beforeEach(() => {
-    vi.mocked(getRuntimeConfig).mockReturnValue(defaultRouteConfig as never);
-  });
 
   it("lets explicit topic requireMention=false override group requireMention=true", async () => {
     const ctx = await buildTelegramMessageContextForTest({

--- a/extensions/telegram/src/bot-message-context.runtime.ts
+++ b/extensions/telegram/src/bot-message-context.runtime.ts
@@ -1,5 +1,4 @@
 // Telegram plugin module implements bot message context behavior.
 export { createStatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 export { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-export { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 export { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversation-runtime";

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -133,7 +133,6 @@ export async function buildTelegramMessageContextForTest(
       },
     } as never,
     cfg: (params.cfg ?? baseTelegramMessageContextConfig) as never,
-    loadFreshConfig: () => (params.cfg ?? baseTelegramMessageContextConfig) as never,
     runtime: {
       recordChannelActivity: () => undefined,
       ...params.runtime,

--- a/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
+++ b/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
@@ -1,26 +1,5 @@
 // Telegram tests cover bot message context.topic agentid plugin behavior.
-import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { defaultRouteConfig } = vi.hoisted(() => ({
-  defaultRouteConfig: {
-    agents: {
-      list: [{ id: "main", default: true }, { id: "zu" }, { id: "q" }, { id: "support" }],
-    },
-    channels: { telegram: {} },
-    messages: { groupChat: { mentionPatterns: [] } },
-  },
-}));
-
-vi.mock("openclaw/plugin-sdk/runtime-config-snapshot", async () => {
-  const actual = await vi.importActual<
-    typeof import("openclaw/plugin-sdk/runtime-config-snapshot")
-  >("openclaw/plugin-sdk/runtime-config-snapshot");
-  return {
-    ...actual,
-    getRuntimeConfig: vi.fn(() => defaultRouteConfig),
-  };
-});
+import { describe, expect, it, vi } from "vitest";
 
 const { buildTelegramMessageContextForTest } =
   await import("./bot-message-context.test-harness.js");
@@ -56,10 +35,6 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
       }),
     });
   }
-
-  beforeEach(() => {
-    vi.mocked(getRuntimeConfig).mockReturnValue(defaultRouteConfig as never);
-  });
 
   it("uses group-level agent when no topic agentId is set", async () => {
     const ctx = await buildForumContext({ topicConfig: { systemPrompt: "Be nice" } });
@@ -116,7 +91,7 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
       resolveTelegramGroupConfig,
     });
 
-    expect(resolveTelegramGroupConfig).toHaveBeenCalledWith(-1001234567890, 3);
+    expect(resolveTelegramGroupConfig).toHaveBeenCalledWith(-1001234567890, 3, expect.any(Object));
     expect(ctx?.ctxPayload?.SessionKey).toContain("agent:zu:");
     expect(ctx?.ctxPayload?.SessionKey).toContain("telegram:group:-1001234567890:topic:3");
   });
@@ -130,14 +105,6 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
   });
 
   it("preserves an unknown topic agentId in the session key", async () => {
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      agents: {
-        list: [{ id: "main", default: true }, { id: "zu" }],
-      },
-      channels: { telegram: {} },
-      messages: { groupChat: { mentionPatterns: [] } },
-    } as never);
-
     const ctx = await buildForumContext({ topicConfig: { agentId: "ghost" } });
 
     expect(ctx?.ctxPayload?.SessionKey).toContain("agent:ghost:");

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -83,6 +83,7 @@ type TelegramStatusReactionController = {
 };
 
 export type TelegramMessageContext = {
+  cfg: BuildTelegramMessageContextParams["cfg"];
   ctxPayload: TelegramMessageContextPayload["ctxPayload"];
   turn: TelegramMessageContextPayload["turn"];
   primaryCtx: BuildTelegramMessageContextParams["primaryCtx"];
@@ -136,7 +137,6 @@ export const buildTelegramMessageContext = async ({
   resolveGroupActivation,
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
-  loadFreshConfig,
   runtime,
   sessionRuntime,
   upsertPairingRequest,
@@ -226,7 +226,7 @@ export const buildTelegramMessageContext = async ({
   }
 
   const threadIdForConfig = resolvedThreadId ?? dmThreadId;
-  const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, threadIdForConfig);
+  const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, threadIdForConfig, cfg);
   const directConfig = !isGroup ? (groupConfig as TelegramDirectConfig | undefined) : undefined;
   const telegramGroupConfig = isGroup
     ? (groupConfig as TelegramGroupConfig | undefined)
@@ -236,11 +236,8 @@ export const buildTelegramMessageContext = async ({
     groupConfig,
     dmPolicy,
   });
-  const freshCfg =
-    loadFreshConfig?.() ??
-    (runtime?.getRuntimeConfig ?? (await loadTelegramMessageContextRuntime()).getRuntimeConfig)();
   const conversationRoute = resolveTelegramConversationRoute({
-    cfg: freshCfg,
+    cfg,
     accountId: account.accountId,
     chatId,
     isGroup,
@@ -255,8 +252,7 @@ export const buildTelegramMessageContext = async ({
     candidate: ReturnType<typeof resolveTelegramConversationRoute>["route"],
   ): boolean =>
     normalizeAccountId(candidate.accountId) !==
-      normalizeAccountId(resolveDefaultTelegramAccountId(freshCfg)) &&
-    candidate.matchedBy === "default";
+      normalizeAccountId(resolveDefaultTelegramAccountId(cfg)) && candidate.matchedBy === "default";
   const isNamedAccountFallback = requiresExplicitAccountBinding(route);
   const hasExplicitTopicRoute = isGroup && Boolean(topicConfig?.agentId?.trim());
   if (isNamedAccountFallback && isGroup && !hasExplicitTopicRoute) {
@@ -270,7 +266,7 @@ export const buildTelegramMessageContext = async ({
   }
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   const dmAllow = await resolveTelegramDmAllow({
-    cfg: freshCfg,
+    cfg,
     groupAllowOverride,
     allowFrom,
     accountId: account.accountId,
@@ -279,7 +275,7 @@ export const buildTelegramMessageContext = async ({
     dmPolicy: effectiveDmPolicy,
   });
   const expandedGroupAllowFrom = await expandTelegramAllowFromWithAccessGroups({
-    cfg: freshCfg,
+    cfg,
     allowFrom: groupAllowOverride ?? groupAllowFrom,
     accountId: account.accountId,
     senderId,
@@ -376,7 +372,7 @@ export const buildTelegramMessageContext = async ({
       runtime?.ensureConfiguredBindingRouteReady ??
       (await loadTelegramMessageContextRuntime()).ensureConfiguredBindingRouteReady;
     const ensured = await ensureConfiguredBindingRouteReady({
-      cfg: freshCfg,
+      cfg,
       bindingResolution: bindingMode.binding,
     });
     if (ensured.ok) {
@@ -398,7 +394,7 @@ export const buildTelegramMessageContext = async ({
   };
 
   const baseSessionKey = resolveTelegramConversationBaseSessionKey({
-    cfg: freshCfg,
+    cfg,
     route,
     chatId,
     isGroup,
@@ -426,8 +422,9 @@ export const buildTelegramMessageContext = async ({
     messageThreadId: resolvedThreadId,
     sessionKey,
     agentId: route.agentId,
+    cfg,
   });
-  const baseRequireMention = resolveGroupRequireMention(chatId);
+  const baseRequireMention = resolveGroupRequireMention(chatId, cfg);
   const groupRequireMention = firstDefined(
     topicConfig?.requireMention,
     activationOverride,
@@ -640,6 +637,7 @@ export const buildTelegramMessageContext = async ({
       : null;
 
   return {
+    cfg,
     ctxPayload,
     turn,
     primaryCtx,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -46,7 +46,8 @@ export type TelegramLogger = {
 
 type ResolveTelegramGroupConfig = (
   chatId: string | number,
-  messageThreadId?: number,
+  messageThreadId: number | undefined,
+  cfg: OpenClawConfig,
 ) => {
   groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
@@ -57,17 +58,15 @@ type ResolveGroupActivation = (params: {
   agentId?: string;
   messageThreadId?: number;
   sessionKey?: string;
+  cfg: OpenClawConfig;
 }) => boolean | undefined;
 
-type ResolveGroupRequireMention = (chatId: string | number) => boolean;
+type ResolveGroupRequireMention = (chatId: string | number, cfg: OpenClawConfig) => boolean;
 
 type TelegramMessageContextRuntimeOverrides = Partial<
   Pick<
     typeof import("./bot-message-context.runtime.js"),
-    | "createStatusReactionController"
-    | "ensureConfiguredBindingRouteReady"
-    | "getRuntimeConfig"
-    | "recordChannelActivity"
+    "createStatusReactionController" | "ensureConfiguredBindingRouteReady" | "recordChannelActivity"
   >
 >;
 
@@ -106,7 +105,6 @@ export type BuildTelegramMessageContextParams = {
   resolveGroupActivation: ResolveGroupActivation;
   resolveGroupRequireMention: ResolveGroupRequireMention;
   resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
-  loadFreshConfig?: () => OpenClawConfig;
   runtime?: TelegramMessageContextRuntimeOverrides;
   sessionRuntime?: TelegramMessageContextSessionRuntimeOverrides;
   upsertPairingRequest?: typeof import("openclaw/plugin-sdk/conversation-runtime").upsertChannelPairingRequest;

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -52,11 +52,14 @@ describe("telegram bot message processor", () => {
     upsertChannelPairingRequest,
   } as unknown as TelegramBotDeps;
 
+  const baseTurnContext = {
+    cfg: {},
+    telegramCfg: {},
+  } satisfies import("./bot-message.js").TelegramMessageProcessorTurnContext;
+
   const baseDeps = {
     bot: {},
-    cfg: {},
     account: {},
-    telegramCfg: {},
     historyLimit: 0,
     groupHistories: {},
     dmPolicy: {},
@@ -92,8 +95,8 @@ describe("telegram bot message processor", () => {
       [],
       [],
       {
-        cfg: turnContext?.cfg ?? baseDeps.cfg,
-        telegramCfg: turnContext?.telegramCfg ?? baseDeps.telegramCfg,
+        cfg: turnContext?.cfg ?? baseTurnContext.cfg,
+        telegramCfg: turnContext?.telegramCfg ?? baseTurnContext.telegramCfg,
         onDispatchStart: turnContext?.onDispatchStart,
       },
       options,

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -77,9 +77,9 @@ describe("telegram bot message processor", () => {
 
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
-    lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
+    turnContext?: Partial<import("./bot-message.js").TelegramMessageProcessorTurnContext>,
     primaryCtxOverrides: Record<string, unknown> = {},
-    options: Parameters<typeof processMessage>[3] = {},
+    options: Parameters<typeof processMessage>[4] = {},
   ) {
     return await processMessage(
       {
@@ -91,11 +91,15 @@ describe("telegram bot message processor", () => {
       } as unknown as Parameters<typeof processMessage>[0],
       [],
       [],
+      {
+        cfg: turnContext?.cfg ?? baseDeps.cfg,
+        telegramCfg: turnContext?.telegramCfg ?? baseDeps.telegramCfg,
+        onDispatchStart: turnContext?.onDispatchStart,
+      },
       options,
       undefined,
       undefined,
       undefined,
-      lifecycle,
     );
   }
 
@@ -117,6 +121,7 @@ describe("telegram bot message processor", () => {
 
   function createMessageContext(context: Record<string, unknown> = {}) {
     return {
+      cfg: {},
       chatId: 123,
       ctxPayload: {
         From: "telegram:123",
@@ -150,6 +155,43 @@ describe("telegram bot message processor", () => {
     expect(telegramInboundInfo).toHaveBeenCalledWith(
       "Inbound message telegram:123 -> @openclaw_bot (direct, 11 chars)",
     );
+  });
+
+  it("uses one supplied config snapshot for context and dispatch", async () => {
+    const turnCfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-luna" },
+          models: { "openai/gpt-5.6-luna": {} },
+        },
+      },
+    };
+    const turnTelegramCfg = {
+      dmPolicy: "open" as const,
+      streaming: { mode: "off" as const },
+    };
+    buildTelegramMessageContext.mockImplementationOnce(async (params) =>
+      createMessageContext({ cfg: params.cfg }),
+    );
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await expect(
+      processSampleMessage(processMessage, { cfg: turnCfg, telegramCfg: turnTelegramCfg }),
+    ).resolves.toEqual({ kind: "completed" });
+
+    expect(buildTelegramMessageContext).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: turnCfg, dmPolicy: "open" }),
+    );
+    expect(buildTelegramMessageContext.mock.calls[0]?.[0]?.cfg).toBe(turnCfg);
+    expect(dispatchTelegramMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: turnCfg,
+        telegramCfg: turnTelegramCfg,
+        streamMode: "off",
+      }),
+    );
+    expect(dispatchTelegramMessage.mock.calls[0]?.[0]?.cfg).toBe(turnCfg);
+    expect(dispatchTelegramMessage.mock.calls[0]?.[0]?.telegramCfg).toBe(turnTelegramCfg);
   });
 
   it("runs the dispatch-start lifecycle after context creation and before dispatch", async () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements bot message behavior.
-import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
-import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig, TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
+import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import {
   createSubsystemLogger,
   danger,
@@ -23,9 +24,11 @@ import {
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
 import type { TelegramBotOptions } from "./bot.types.js";
-import { buildTelegramThreadParams } from "./bot/helpers.js";
-import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import { buildTelegramThreadParams, resolveTelegramStreamMode } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import type { TelegramReplyChainEntry } from "./message-cache.js";
+import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
+import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 
 const telegramInboundLog = createSubsystemLogger("gateway/channels/telegram").child("inbound");
 
@@ -42,43 +45,74 @@ export function formatTelegramInboundLogLine(params: {
 
 type TelegramMessageProcessorDeps = Omit<
   BuildTelegramMessageContextParams,
-  "primaryCtx" | "allMedia" | "storeAllowFrom" | "options"
+  | "primaryCtx"
+  | "allMedia"
+  | "storeAllowFrom"
+  | "options"
+  | "cfg"
+  | "historyLimit"
+  | "dmPolicy"
+  | "allowFrom"
+  | "groupAllowFrom"
+  | "ackReactionScope"
 > & {
-  telegramCfg: TelegramAccountConfig;
   runtime: RuntimeEnv;
-  replyToMode: ReplyToMode;
-  streamMode: TelegramStreamMode;
-  textLimit: number;
   telegramDeps: TelegramBotDeps;
-  opts: Pick<TelegramBotOptions, "token">;
+  opts: Pick<TelegramBotOptions, "token" | "allowFrom" | "groupAllowFrom" | "replyToMode">;
 };
 
-export type TelegramMessageProcessorLifecycle = {
+export type TelegramMessageProcessorTurnContext = {
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
   onDispatchStart?: () => Promise<void> | void;
 };
+
+export function resolveTelegramMessageTurnSettings(params: {
+  accountId: string;
+  cfg: OpenClawConfig;
+  telegramCfg: TelegramAccountConfig;
+  opts: Pick<TelegramBotOptions, "allowFrom" | "groupAllowFrom" | "replyToMode">;
+}) {
+  const allowFrom = params.opts.allowFrom ?? params.telegramCfg.allowFrom;
+  const telegramTextLimit =
+    params.telegramCfg.richMessages === true ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
+  return {
+    ackReactionScope: params.cfg.messages?.ackReactionScope ?? "group-mentions",
+    allowFrom,
+    dmPolicy: params.telegramCfg.dmPolicy ?? "pairing",
+    groupAllowFrom:
+      params.opts.groupAllowFrom ??
+      params.telegramCfg.groupAllowFrom ??
+      params.telegramCfg.allowFrom ??
+      allowFrom,
+    historyLimit: Math.max(
+      0,
+      params.telegramCfg.historyLimit ??
+        params.cfg.messages?.groupChat?.historyLimit ??
+        DEFAULT_GROUP_HISTORY_LIMIT,
+    ),
+    replyToMode: params.opts.replyToMode ?? params.telegramCfg.replyToMode ?? "off",
+    streamMode: resolveTelegramStreamMode(params.telegramCfg),
+    textLimit: Math.min(
+      resolveTextChunkLimit(params.cfg, "telegram", params.accountId, {
+        fallbackLimit: telegramTextLimit,
+      }),
+      telegramTextLimit,
+    ),
+  };
+}
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
   const {
     bot,
-    cfg,
     account,
-    telegramCfg,
-    historyLimit,
     groupHistories,
-    dmPolicy,
-    allowFrom,
-    groupAllowFrom,
-    ackReactionScope,
     logger,
     resolveGroupActivation,
     resolveGroupRequireMention,
     resolveTelegramGroupConfig,
-    loadFreshConfig,
     sendChatActionHandler,
     runtime,
-    replyToMode,
-    streamMode,
-    textLimit,
     telegramDeps,
     opts,
   } = deps;
@@ -116,12 +150,20 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     primaryCtx: TelegramContext,
     allMedia: TelegramMediaRef[],
     storeAllowFrom: string[],
+    turnContext: TelegramMessageProcessorTurnContext,
     options?: TelegramMessageContextOptions,
     replyMedia?: TelegramMediaRef[],
     replyChain?: TelegramReplyChainEntry[],
     promptContext?: TelegramPromptContextEntry[],
-    lifecycle?: TelegramMessageProcessorLifecycle,
   ) => {
+    const turnCfg = turnContext.cfg;
+    const turnTelegramCfg = turnContext.telegramCfg;
+    const turnSettings = resolveTelegramMessageTurnSettings({
+      accountId: account.accountId,
+      cfg: turnCfg,
+      telegramCfg: turnTelegramCfg,
+      opts,
+    });
     const ingressReceivedAtMs =
       typeof options?.receivedAtMs === "number" && Number.isFinite(options.receivedAtMs)
         ? options.receivedAtMs
@@ -144,20 +186,19 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       storeAllowFrom,
       options,
       bot,
-      cfg,
+      cfg: turnCfg,
       account,
-      historyLimit,
+      historyLimit: turnSettings.historyLimit,
       groupHistories,
-      dmPolicy,
-      allowFrom,
-      groupAllowFrom,
-      ackReactionScope,
+      dmPolicy: turnSettings.dmPolicy,
+      allowFrom: turnSettings.allowFrom,
+      groupAllowFrom: turnSettings.groupAllowFrom,
+      ackReactionScope: turnSettings.ackReactionScope,
       logger,
       resolveGroupActivation,
       resolveGroupRequireMention,
       resolveTelegramGroupConfig,
       sendChatActionHandler,
-      loadFreshConfig,
       runtime: contextRuntime,
       sessionRuntime,
       upsertPairingRequest: telegramDeps.upsertChannelPairingRequest,
@@ -199,19 +240,19 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         mediaType: allMedia[0]?.contentType,
       }),
     );
-    await lifecycle?.onDispatchStart?.();
+    await turnContext.onDispatchStart?.();
     const spooledReplay =
       options?.spooledReplay === true || isTelegramSpooledReplayUpdate(primaryCtx.update);
     try {
       const dispatchResult = await dispatchTelegramMessage({
         context,
         bot,
-        cfg,
+        cfg: context.cfg,
         runtime,
-        replyToMode,
-        streamMode,
-        textLimit,
-        telegramCfg,
+        replyToMode: turnSettings.replyToMode,
+        streamMode: turnSettings.streamMode,
+        textLimit: turnSettings.textLimit,
+        telegramCfg: turnTelegramCfg,
         telegramDeps,
         opts,
         retryDispatchErrors: spooledReplay,

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -4,7 +4,11 @@ import { vi } from "vitest";
 import type { OpenClawConfig, TelegramAccountConfig } from "../runtime-api.js";
 import type { RegisterTelegramNativeCommandsParams } from "./bot-native-commands.js";
 
-export type NativeCommandTestParams = RegisterTelegramNativeCommandsParams;
+export type NativeCommandTestParams = RegisterTelegramNativeCommandsParams & {
+  allowFrom?: RegisterTelegramNativeCommandsParams["opts"]["allowFrom"];
+  groupAllowFrom?: RegisterTelegramNativeCommandsParams["opts"]["groupAllowFrom"];
+  replyToMode?: RegisterTelegramNativeCommandsParams["opts"]["replyToMode"];
+};
 
 export function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -16,7 +20,7 @@ export function createDeferred<T>() {
 
 export function createNativeCommandTestParams(
   params: Partial<NativeCommandTestParams> = {},
-): NativeCommandTestParams {
+): RegisterTelegramNativeCommandsParams {
   const log = vi.fn();
   return {
     bot:
@@ -38,11 +42,6 @@ export function createNativeCommandTestParams(
       } as unknown as RuntimeEnv),
     accountId: params.accountId ?? "default",
     telegramCfg: params.telegramCfg ?? ({} as TelegramAccountConfig),
-    allowFrom: params.allowFrom ?? [],
-    groupAllowFrom: params.groupAllowFrom ?? [],
-    replyToMode: params.replyToMode ?? "off",
-    textLimit: params.textLimit ?? 4000,
-    useAccessGroups: params.useAccessGroups ?? false,
     nativeEnabled: params.nativeEnabled ?? true,
     nativeSkillsEnabled: params.nativeSkillsEnabled ?? false,
     nativeDisabledExplicit: params.nativeDisabledExplicit ?? false,
@@ -58,7 +57,12 @@ export function createNativeCommandTestParams(
       ((_chatId, _messageThreadId) => ({ groupConfig: undefined, topicConfig: undefined })),
     shouldSkipUpdate: params.shouldSkipUpdate ?? (() => false),
     telegramDeps: params.telegramDeps,
-    opts: params.opts ?? { token: "token" },
+    opts: {
+      ...(params.opts ?? { token: "token" }),
+      allowFrom: params.allowFrom ?? params.opts?.allowFrom ?? [],
+      groupAllowFrom: params.groupAllowFrom ?? params.opts?.groupAllowFrom ?? [],
+      replyToMode: params.replyToMode ?? params.opts?.replyToMode ?? "off",
+    },
   };
 }
 

--- a/extensions/telegram/src/bot-native-commands.registry.test.ts
+++ b/extensions/telegram/src/bot-native-commands.registry.test.ts
@@ -264,7 +264,7 @@ describe("registerTelegramNativeCommands real plugin registry", () => {
         commands: { allowFrom: { telegram: ["999"] } } as OpenClawConfig["commands"],
       }),
       bot,
-      allowFrom: ["999"],
+      opts: { token: "token", allowFrom: ["999"] },
       nativeEnabled: false,
     });
 

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -275,6 +275,7 @@ type TelegramLoginFlow = NonNullable<TelegramNativeCommandDeps["runModelsAuthLog
 
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
+  runtimeCfg?: OpenClawConfig;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   storeAllowFrom?: string[];
@@ -286,6 +287,7 @@ function registerAndResolveStatusHandler(params: {
 } {
   const {
     cfg,
+    runtimeCfg,
     allowFrom,
     groupAllowFrom,
     storeAllowFrom,
@@ -295,6 +297,7 @@ function registerAndResolveStatusHandler(params: {
   return registerAndResolveCommandHandlerBase({
     commandName: "status",
     cfg,
+    runtimeCfg,
     allowFrom: allowFrom ?? ["*"],
     groupAllowFrom: groupAllowFrom ?? [],
     storeAllowFrom,
@@ -307,6 +310,7 @@ function registerAndResolveStatusHandler(params: {
 function registerAndResolveCommandHandlerBase(params: {
   commandName: string;
   cfg: OpenClawConfig;
+  runtimeCfg?: OpenClawConfig;
   allowFrom: string[];
   groupAllowFrom: string[];
   storeAllowFrom?: string[];
@@ -322,6 +326,7 @@ function registerAndResolveCommandHandlerBase(params: {
   const {
     commandName,
     cfg,
+    runtimeCfg,
     allowFrom,
     groupAllowFrom,
     storeAllowFrom,
@@ -333,8 +338,16 @@ function registerAndResolveCommandHandlerBase(params: {
   } = params;
   const commandHandlers = new Map<string, TelegramCommandHandler>();
   const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const baseRuntimeCfg = runtimeCfg ?? cfg;
+  const commandRuntimeCfg =
+    (baseRuntimeCfg.commands?.useAccessGroups !== false) === useAccessGroups
+      ? baseRuntimeCfg
+      : {
+          ...baseRuntimeCfg,
+          commands: { ...baseRuntimeCfg.commands, useAccessGroups },
+        };
   const telegramDeps: TelegramNativeCommandDeps = {
-    getRuntimeConfig: vi.fn(() => cfg),
+    getRuntimeConfig: vi.fn(() => commandRuntimeCfg),
     readChannelAllowFromStore: vi.fn(async () => storeAllowFrom ?? []),
     dispatchReplyWithBufferedBlockDispatcher: replyMocks.dispatchReplyWithBufferedBlockDispatcher,
     getPluginCommandSpecs: vi.fn(() => pluginCommandSpecs ?? []),
@@ -356,7 +369,6 @@ function registerAndResolveCommandHandlerBase(params: {
       cfg,
       allowFrom,
       groupAllowFrom,
-      useAccessGroups,
       telegramCfg,
       resolveTelegramGroupConfig,
       telegramDeps,
@@ -687,6 +699,20 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(call?.ctx?.OriginatingChannel).toBe("telegram");
     expect(call?.ctx?.Provider).toBe("telegram");
     expect(call?.sessionKey).toBe(dispatchCall?.ctx?.CommandTargetSessionKey);
+  });
+
+  it("keeps one live config snapshot through native command execution", async () => {
+    const startupCfg: OpenClawConfig = { session: { store: "/tmp/startup-sessions.json" } };
+    const runtimeCfg: OpenClawConfig = { session: { store: "/tmp/runtime-sessions.json" } };
+    const { handler } = registerAndResolveStatusHandler({ cfg: startupCfg, runtimeCfg });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    const dispatchCall = firstMockArg(
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher,
+      "dispatchReplyWithBufferedBlockDispatcher",
+    );
+    expect(dispatchCall.cfg).toBe(runtimeCfg);
   });
 
   it("uses the target session model when building native argument menus", async () => {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -708,9 +708,12 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
     await handler(createTelegramPrivateCommandContext());
 
-    const dispatchCall = firstMockArg(
-      replyMocks.dispatchReplyWithBufferedBlockDispatcher,
-      "dispatchReplyWithBufferedBlockDispatcher",
+    const dispatchCall = requireRecord(
+      firstMockArg(
+        replyMocks.dispatchReplyWithBufferedBlockDispatcher,
+        "dispatchReplyWithBufferedBlockDispatcher",
+      ),
+      "dispatch call",
     );
     expect(dispatchCall.cfg).toBe(runtimeCfg);
   });

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -148,10 +148,18 @@ export function createNativeCommandsHarness(params?: {
   const sendMessage: AnyAsyncMock = vi.fn(async () => undefined);
   const setMyCommands: AnyAsyncMock = vi.fn(async () => undefined);
   const log: AnyMock = vi.fn();
+  const baseCfg = params?.cfg ?? ({} as OpenClawConfig);
+  const cfg =
+    params?.useAccessGroups === undefined
+      ? baseCfg
+      : {
+          ...baseCfg,
+          commands: { ...baseCfg.commands, useAccessGroups: params.useAccessGroups },
+        };
   const readChannelAllowFromStore: AnyAsyncMock =
     params?.readChannelAllowFromStore ?? vi.fn(async () => params?.storeAllowFrom ?? []);
   const telegramDeps = {
-    getRuntimeConfig: vi.fn(() => params?.cfg ?? ({} as OpenClawConfig)),
+    getRuntimeConfig: vi.fn(() => cfg),
     readChannelAllowFromStore:
       readChannelAllowFromStore as TelegramNativeCommandDeps["readChannelAllowFromStore"],
     dispatchReplyWithBufferedBlockDispatcher:
@@ -172,15 +180,10 @@ export function createNativeCommandsHarness(params?: {
 
   registerTelegramNativeCommands({
     bot,
-    cfg: params?.cfg ?? ({} as OpenClawConfig),
+    cfg,
     runtime: params?.runtime ?? ({ log } as unknown as RuntimeEnv),
     accountId: "default",
     telegramCfg: params?.telegramCfg ?? ({} as TelegramAccountConfig),
-    allowFrom: params?.allowFrom ?? [],
-    groupAllowFrom: params?.groupAllowFrom ?? [],
-    replyToMode: "off",
-    textLimit: 4000,
-    useAccessGroups: params?.useAccessGroups ?? false,
     nativeEnabled: params?.nativeEnabled ?? true,
     nativeSkillsEnabled: false,
     nativeDisabledExplicit: false,
@@ -197,7 +200,12 @@ export function createNativeCommandsHarness(params?: {
       topicConfig: undefined,
     }),
     shouldSkipUpdate: () => false,
-    opts: { token: "token" },
+    opts: {
+      token: "token",
+      allowFrom: params?.allowFrom ?? [],
+      groupAllowFrom: params?.groupAllowFrom ?? [],
+      replyToMode: "off",
+    },
   });
 
   return { handlers, sendMessage, setMyCommands, log, bot, readChannelAllowFromStore };

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -36,7 +36,6 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-run
 import { codexChannelLoginRuntime } from "openclaw/plugin-sdk/provider-auth-login-flow-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
-import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -57,6 +56,7 @@ import { normalizeDmAllowFromWithStore, resolveTelegramEffectiveDmPolicy } from 
 import type { TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
+import { resolveTelegramMessageTurnSettings } from "./bot-message.js";
 import {
   defaultTelegramNativeCommandDeps,
   type TelegramNativeCommandDeps,
@@ -560,30 +560,30 @@ export type RegisterTelegramHandlerParams = {
   runtime: RuntimeEnv;
   telegramCfg: TelegramAccountConfig;
   telegramDeps: TelegramBotDeps;
-  allowFrom?: Array<string | number>;
-  groupAllowFrom?: Array<string | number>;
-  resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   resolveGroupActivation: (params: {
     chatId: string | number;
     agentId?: string;
     messageThreadId?: number;
     sessionKey?: string;
+    cfg: OpenClawConfig;
   }) => boolean | undefined;
-  resolveGroupRequireMention: (chatId: string | number) => boolean;
+  resolveGroupRequireMention: (chatId: string | number, cfg: OpenClawConfig) => boolean;
   resolveTelegramGroupConfig: (
     chatId: string | number,
-    messageThreadId?: number,
+    messageThreadId: number | undefined,
+    cfg: OpenClawConfig,
   ) => TelegramResolvedGroupConfig;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: TelegramContext,
     allMedia: TelegramMediaRef[],
     storeAllowFrom: string[],
+    turnContext: import("./bot-message.js").TelegramMessageProcessorTurnContext,
     options?: TelegramMessageContextOptions,
     replyMedia?: TelegramMediaRef[],
     replyChain?: import("./message-cache.js").TelegramReplyChainEntry[],
     promptContext?: import("./bot-message-context.types.js").TelegramPromptContextEntry[],
-    lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
   ) => Promise<TelegramMessageProcessingResult>;
   logger: ReturnType<typeof getChildLogger>;
 };
@@ -601,23 +601,19 @@ export type RegisterTelegramNativeCommandsParams = {
   runtime: RuntimeEnv;
   accountId: string;
   telegramCfg: TelegramAccountConfig;
-  allowFrom?: Array<string | number>;
-  groupAllowFrom?: Array<string | number>;
-  replyToMode: ReplyToMode;
-  textLimit: number;
   mediaMaxBytes?: number;
-  useAccessGroups: boolean;
   nativeEnabled: boolean;
   nativeSkillsEnabled: boolean;
   nativeDisabledExplicit: boolean;
-  resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
     chatId: string | number,
-    messageThreadId?: number,
+    messageThreadId: number | undefined,
+    cfg: OpenClawConfig,
   ) => TelegramResolvedGroupConfig;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   telegramDeps?: TelegramNativeCommandDeps;
-  opts: { token: string };
+  opts: Pick<TelegramBotOptions, "token" | "allowFrom" | "groupAllowFrom" | "replyToMode">;
 };
 
 async function resolveTelegramCommandAuth(params: {
@@ -629,11 +625,11 @@ async function resolveTelegramCommandAuth(params: {
   readChannelAllowFromStore: TelegramBotDeps["readChannelAllowFromStore"];
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
-  useAccessGroups: boolean;
-  resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   resolveTelegramGroupConfig: (
     chatId: string | number,
-    messageThreadId?: number,
+    messageThreadId: number | undefined,
+    cfg: OpenClawConfig,
   ) => TelegramResolvedGroupConfig;
   requireAuth: boolean;
 }): Promise<TelegramCommandAuthResult | null> {
@@ -646,7 +642,6 @@ async function resolveTelegramCommandAuth(params: {
     readChannelAllowFromStore,
     allowFrom,
     groupAllowFrom,
-    useAccessGroups,
     resolveGroupPolicy,
     resolveTelegramGroupConfig,
     requireAuth,
@@ -772,12 +767,12 @@ async function resolveTelegramCommandAuth(params: {
     senderId,
     senderUsername,
     resolveGroupPolicy,
-    enforcePolicy: useAccessGroups,
+    enforcePolicy: cfg.commands?.useAccessGroups !== false,
     useTopicAndGroupOverrides: false,
     enforceAllowlistAuthorization: requireAuth && !commandsAllowFromConfigured,
     allowEmptyAllowlistEntries: true,
     requireSenderForAllowlistAuthorization: true,
-    checkChatAllowlist: useAccessGroups,
+    checkChatAllowlist: cfg.commands?.useAccessGroups !== false,
   });
   if (!policyAccess.allowed) {
     if (policyAccess.reason === "group-policy-disabled") {
@@ -846,12 +841,7 @@ export const registerTelegramNativeCommands = ({
   runtime,
   accountId,
   telegramCfg,
-  allowFrom,
-  groupAllowFrom,
-  replyToMode,
-  textLimit,
   mediaMaxBytes,
-  useAccessGroups,
   nativeEnabled,
   nativeSkillsEnabled,
   nativeDisabledExplicit,
@@ -974,19 +964,8 @@ export const registerTelegramNativeCommands = ({
   }
   const { nativeCommands, pluginCatalog } = fullCommandCatalog;
   const loadFreshRuntimeConfig = (): OpenClawConfig => telegramDeps.getRuntimeConfig();
-  const resolveFreshTelegramConfig = (runtimeCfg: OpenClawConfig): TelegramAccountConfig => {
-    try {
-      return resolveTelegramAccount({
-        cfg: runtimeCfg,
-        accountId,
-      }).config;
-    } catch (error) {
-      logVerbose(
-        `telegram native command: failed to load fresh account config for ${accountId}; using startup snapshot: ${String(error)}`,
-      );
-      return telegramCfg;
-    }
-  };
+  const resolveFreshTelegramConfig = (runtimeCfg: OpenClawConfig): TelegramAccountConfig =>
+    resolveTelegramAccount({ cfg: runtimeCfg, accountId }).config;
   const {
     commandsToRegister,
     totalCommands,
@@ -1111,6 +1090,8 @@ export const registerTelegramNativeCommands = ({
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: TelegramChunkMode;
+    replyToMode: ReplyToMode;
+    textLimit: number;
     linkPreview?: boolean;
     richMessages?: boolean;
   }) => ({
@@ -1126,8 +1107,8 @@ export const registerTelegramNativeCommands = ({
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
     mediaMaxBytes,
-    replyToMode,
-    textLimit,
+    replyToMode: params.replyToMode,
+    textLimit: params.textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
     chunkMode: params.chunkMode,
@@ -1178,6 +1159,12 @@ export const registerTelegramNativeCommands = ({
         }
         const runtimeCfg = loadFreshRuntimeConfig();
         const runtimeTelegramCfg = resolveFreshTelegramConfig(runtimeCfg);
+        const turnSettings = resolveTelegramMessageTurnSettings({
+          accountId,
+          cfg: runtimeCfg,
+          telegramCfg: runtimeTelegramCfg,
+          opts,
+        });
         const auth = await resolveTelegramCommandAuth({
           msg,
           bot,
@@ -1185,9 +1172,8 @@ export const registerTelegramNativeCommands = ({
           accountId,
           telegramCfg: runtimeTelegramCfg,
           readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
-          allowFrom,
-          groupAllowFrom,
-          useAccessGroups,
+          allowFrom: turnSettings.allowFrom,
+          groupAllowFrom: turnSettings.groupAllowFrom,
           resolveGroupPolicy,
           resolveTelegramGroupConfig,
           requireAuth: true,
@@ -1222,8 +1208,6 @@ export const registerTelegramNativeCommands = ({
         const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
         const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
         const originatingTo = buildTelegramRoutingTarget(chatId, threadSpec);
-        const executionCfg = getRuntimeConfigSnapshot() ?? cfg;
-
         const commandDefinition = findCommandByNativeName(command.name, "telegram");
         const rawText = ctx.match?.trim() ?? "";
         const commandArgs = commandDefinition
@@ -1478,7 +1462,7 @@ export const registerTelegramNativeCommands = ({
             targetSessionKey: sessionKey,
           });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
-          cfg: executionCfg,
+          cfg: runtimeCfg,
           chatId,
           accountId: route.accountId,
           sessionKeyForInternalHooks: commandSessionKey,
@@ -1489,13 +1473,15 @@ export const registerTelegramNativeCommands = ({
           threadSpec,
           tableMode,
           chunkMode,
+          replyToMode: turnSettings.replyToMode,
+          textLimit: turnSettings.textLimit,
           linkPreview: runtimeTelegramCfg.linkPreview,
           richMessages: runtimeTelegramCfg.richMessages,
         });
         let topicName: string | undefined;
         if (isForum && resolvedThreadId != null) {
           try {
-            const storePath = resolveStorePath(executionCfg.session?.store, {
+            const storePath = resolveStorePath(runtimeCfg.session?.store, {
               agentId: route.accountId,
             });
             const scope = resolveTopicNameCacheScope(storePath);
@@ -1548,7 +1534,7 @@ export const registerTelegramNativeCommands = ({
           OriginatingTo: originatingTo,
         });
         await nativeCommandRuntime.recordInboundSessionMetaSafe({
-          cfg: executionCfg,
+          cfg: runtimeCfg,
           agentId: route.agentId,
           sessionKey: commandTargetSessionKey,
           ctx: ctxPayload,
@@ -1566,7 +1552,7 @@ export const registerTelegramNativeCommands = ({
         const { createChannelMessageReplyPipeline, deliverReplies } =
           await loadTelegramNativeCommandDeliveryRuntime();
         const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
-          cfg: executionCfg,
+          cfg: runtimeCfg,
           agentId: route.agentId,
           channel: "telegram",
           accountId: route.accountId,
@@ -1574,14 +1560,14 @@ export const registerTelegramNativeCommands = ({
 
         await telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
           ctx: ctxPayload,
-          cfg: executionCfg,
+          cfg: runtimeCfg,
           dispatcherOptions: {
             ...replyPipeline,
             beforeDeliver: async (payload) => payload,
             deliver: async (payload, _info) => {
               if (
                 shouldSuppressLocalTelegramExecApprovalPrompt({
-                  cfg: executionCfg,
+                  cfg: runtimeCfg,
                   accountId: route.accountId,
                   payload,
                 })
@@ -1641,6 +1627,12 @@ export const registerTelegramNativeCommands = ({
         const chatId = msg.chat.id;
         const runtimeCfg = loadFreshRuntimeConfig();
         const runtimeTelegramCfg = resolveFreshTelegramConfig(runtimeCfg);
+        const turnSettings = resolveTelegramMessageTurnSettings({
+          accountId,
+          cfg: runtimeCfg,
+          telegramCfg: runtimeTelegramCfg,
+          opts,
+        });
         const { threadParams } = await resolveTelegramNativeCommandThreadContext({ msg, bot });
         const rawText = ctx.match?.trim() ?? "";
         const commandBody = `/${pluginCommand.command}${rawText ? ` ${rawText}` : ""}`;
@@ -1661,9 +1653,8 @@ export const registerTelegramNativeCommands = ({
           accountId,
           telegramCfg: runtimeTelegramCfg,
           readChannelAllowFromStore: telegramDeps.readChannelAllowFromStore,
-          allowFrom,
-          groupAllowFrom,
-          useAccessGroups,
+          allowFrom: turnSettings.allowFrom,
+          groupAllowFrom: turnSettings.groupAllowFrom,
           resolveGroupPolicy,
           resolveTelegramGroupConfig,
           requireAuth: match.command.requireAuth !== false,
@@ -1712,6 +1703,8 @@ export const registerTelegramNativeCommands = ({
           threadSpec,
           tableMode,
           chunkMode,
+          replyToMode: turnSettings.replyToMode,
+          textLimit: turnSettings.textLimit,
           linkPreview: runtimeTelegramCfg.linkPreview,
           richMessages: runtimeTelegramCfg.richMessages,
         });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -29,6 +29,7 @@ const {
   answerCallbackQuerySpy,
   commandSpy,
   deleteMessageSpy,
+  dispatchReplyWithBufferedBlockDispatcher,
   editMessageReplyMarkupSpy,
   editMessageTextSpy,
   enqueueSystemEventSpy,
@@ -380,22 +381,34 @@ describe("createTelegramBot", () => {
     );
   });
 
-  it("blocks callback_query when inline buttons are allowlist-only and sender not authorized", async () => {
+  it("uses the live allowlist when authorizing callbacks", async () => {
     onSpy.mockClear();
     replySpy.mockClear();
     sendMessageSpy.mockClear();
+    loadConfig.mockClear();
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "pairing",
-            capabilities: { inlineButtons: "allowlist" },
-            allowFrom: [],
-          },
+    const startupConfig = {
+      channels: {
+        telegram: {
+          dmPolicy: "pairing" as const,
+          capabilities: { inlineButtons: "allowlist" as const },
+          allowFrom: ["9"],
         },
       },
+    };
+    const liveConfig = {
+      channels: {
+        telegram: {
+          dmPolicy: "pairing" as const,
+          capabilities: { inlineButtons: "allowlist" as const },
+          allowFrom: [],
+        },
+      },
+    };
+    loadConfig.mockReturnValue(liveConfig);
+    createTelegramBot({
+      token: "tok",
+      config: startupConfig,
     });
     const callbackHandler = getOnHandler("callback_query") as (
       ctx: Record<string, unknown>,
@@ -421,6 +434,7 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-2");
+    expect(loadConfig).toHaveBeenCalledTimes(1);
   });
 
   it("blocks DM model-selection callbacks for unpaired users when inline buttons are DM-scoped", async () => {
@@ -1396,17 +1410,19 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     editMessageTextSpy.mockClear();
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "pairing",
-            capabilities: { inlineButtons: "allowlist" },
-            allowFrom: [],
-          },
+    const config = {
+      channels: {
+        telegram: {
+          dmPolicy: "pairing" as const,
+          capabilities: { inlineButtons: "allowlist" as const },
+          allowFrom: [],
         },
       },
+    };
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({
+      token: "tok",
+      config,
     });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
       ctx: Record<string, unknown>,
@@ -1744,7 +1760,7 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("persists non-default model override using fresh config, not stale startup snapshot", async () => {
+  it("keeps hot-reloaded model pins on the next assembled turn", async () => {
     // Regression: the callback handler used the startup `cfg` snapshot for
     // store path and default-model resolution.  If the config was reloaded
     // (e.g. default model changed) the override could be written to the wrong
@@ -1754,6 +1770,7 @@ describe("createTelegramBot", () => {
     editMessageTextSpy.mockClear();
 
     const storePath = `/tmp/openclaw-telegram-model-fresh-cfg-${process.pid}-${Date.now()}.json`;
+    const debounceMs = 4321;
 
     await rm(storePath, { force: true });
     try {
@@ -1774,12 +1791,13 @@ describe("createTelegramBot", () => {
             allowFrom: ["*"],
           },
         },
+        messages: { inbound: { debounceMs } },
         session: {
           store: storePath,
         },
       } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
 
-      // Fresh config: default changed to anthropic/claude-opus-4-6
+      // Fresh config: default changed and GPT-5.6 Luna was added after startup.
       const freshConfig = {
         ...startupConfig,
         agents: {
@@ -1787,11 +1805,13 @@ describe("createTelegramBot", () => {
             model: "anthropic/claude-opus-4-6",
             models: {
               "openai/gpt-5.4": {},
+              "openai/gpt-5.6-luna": {},
               "anthropic/claude-opus-4-6": {},
             },
           },
         },
       };
+      const authorizationConfig = { ...freshConfig };
 
       // Bot created with startup config; loadConfig now returns fresh config
       loadConfig.mockReturnValue(freshConfig);
@@ -1806,8 +1826,8 @@ describe("createTelegramBot", () => {
         throw new Error("Expected Telegram callback_query handler");
       }
 
-      // User selects openai/gpt-5.4 — was default at startup but NOT default
-      // in fresh config.  The override must be persisted.
+      // The old startup default is no longer the live default, so selecting it
+      // must persist an override instead of being cleared as inherited.
       await callbackHandler({
         callbackQuery: {
           id: "cbq-model-fresh-cfg-1",
@@ -1823,11 +1843,91 @@ describe("createTelegramBot", () => {
         getFile: async () => ({ download: async () => new Uint8Array() }),
       });
 
-      // Override must be persisted (not cleared) because openai/gpt-5.4 is
-      // NOT the default in the fresh config.
       const entry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
       expect(entry?.providerOverride).toBe("openai");
       expect(entry?.modelOverride).toBe("gpt-5.4");
+      expect(entry?.modelOverrideSource).toBe("user");
+
+      // A model added after startup must also resolve and become the new user pin.
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-model-fresh-cfg-2",
+          data: "mdl_sel_openai/gpt-5.6-luna",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380801,
+            message_id: 21,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      const lunaEntry = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
+      expect(lunaEntry?.providerOverride).toBe("openai");
+      expect(lunaEntry?.modelOverride).toBe("gpt-5.6-luna");
+      expect(lunaEntry?.modelOverrideSource).toBe("user");
+
+      dispatchReplyWithBufferedBlockDispatcher.mockClear();
+      replySpy.mockClear();
+      loadConfig.mockClear();
+      loadConfig
+        .mockImplementationOnce(() => authorizationConfig)
+        .mockImplementationOnce(() => freshConfig)
+        .mockReturnValue(startupConfig);
+
+      const messageHandler = getOnHandler("message") as (
+        ctx: Record<string, unknown>,
+      ) => Promise<void>;
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      try {
+        const replyDelivered = waitForReplyCalls(1);
+        await messageHandler({
+          me: { id: 999, username: "openclaw_bot" },
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+          message: {
+            chat: { id: 1234, type: "private" },
+            text: "use the selected model",
+            date: 1_736_380_802,
+            message_id: 22,
+            from: { id: 9, is_bot: false, first_name: "Ada", username: "ada_bot" },
+          },
+        });
+
+        expect(loadConfig).toHaveBeenCalledTimes(1);
+        const flushTimerCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+          (call) => call[1] === debounceMs,
+        );
+        const flushTimer =
+          flushTimerCallIndex >= 0
+            ? (setTimeoutSpy.mock.calls[flushTimerCallIndex]?.[0] as (() => unknown) | undefined)
+            : undefined;
+        if (flushTimerCallIndex >= 0) {
+          clearTimeout(
+            setTimeoutSpy.mock.results[flushTimerCallIndex]?.value as ReturnType<typeof setTimeout>,
+          );
+        }
+        expect(flushTimer).toBeTypeOf("function");
+        await flushTimer?.();
+        await replyDelivered;
+      } finally {
+        setTimeoutSpy.mockRestore();
+      }
+
+      expect(loadConfig).toHaveBeenCalledTimes(2);
+      const dispatchParams = mockArg(
+        dispatchReplyWithBufferedBlockDispatcher as unknown as MockCallSource,
+        0,
+        0,
+        "buffered dispatch",
+      ) as { cfg?: OpenClawConfig };
+      expect(dispatchParams.cfg).toBe(freshConfig);
+
+      const afterTurn = Object.values(loadSessionStore(storePath, { skipCache: true }))[0];
+      expect(afterTurn?.providerOverride).toBe("openai");
+      expect(afterTurn?.modelOverride).toBe("gpt-5.6-luna");
+      expect(afterTurn?.modelOverrideSource).toBe("user");
     } finally {
       await rm(storePath, { force: true });
     }

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -207,7 +207,7 @@ export function withResolvedTelegramForumFlag<T extends { chat: object }>(
 }
 
 export async function resolveTelegramGroupAllowFromContext(params: {
-  cfg?: OpenClawConfig;
+  cfg: OpenClawConfig;
   chatId: string | number;
   accountId?: string;
   dmPolicy?: DmPolicy;
@@ -224,7 +224,8 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   readChannelAllowFromStore?: typeof readChannelAllowFromStore;
   resolveTelegramGroupConfig: (
     chatId: string | number,
-    messageThreadId?: number,
+    messageThreadId: number | undefined,
+    cfg: OpenClawConfig,
   ) => {
     groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
     topicConfig?: TelegramTopicConfig;
@@ -252,6 +253,7 @@ export async function resolveTelegramGroupAllowFromContext(params: {
   const { groupConfig, topicConfig } = params.resolveTelegramGroupConfig(
     params.chatId,
     threadIdForConfig,
+    params.cfg,
   );
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   const effectiveDmPolicy = resolveTelegramEffectiveDmPolicy({

--- a/extensions/telegram/src/group-access.ts
+++ b/extensions/telegram/src/group-access.ts
@@ -127,7 +127,7 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   effectiveGroupAllow: NormalizedAllowFrom;
   senderId?: string;
   senderUsername?: string;
-  resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
+  resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   enforcePolicy: boolean;
   useTopicAndGroupOverrides: boolean;
   enforceAllowlistAuthorization: boolean;
@@ -162,7 +162,7 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   // `groups` config are not blocked by the sender-level "empty allowlist" guard.
   let chatExplicitlyAllowed = false;
   if (params.checkChatAllowlist) {
-    const groupAllowlist = params.resolveGroupPolicy(params.chatId);
+    const groupAllowlist = params.resolveGroupPolicy(params.chatId, params.cfg);
     if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
       return { allowed: false, reason: "group-chat-not-allowed", groupPolicy };
     }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2204,31 +2204,12 @@ async function agentCommandInternal(
             sessionKey &&
             !suppressVisibleSessionEffects &&
             !preserveUserFacingSessionModelState &&
-            entryMatchesAutoFallbackPrimaryProbe(sessionEntry, autoFallbackPrimaryProbe)
+            entryMatchesAutoFallbackPrimaryProbe(sessionEntry, autoFallbackPrimaryProbe) &&
+            fallbackProvider === autoFallbackPrimaryProbe.provider &&
+            fallbackModel === autoFallbackPrimaryProbe.model
           ) {
             const nextSessionEntry = { ...sessionEntry };
-            if (
-              fallbackProvider === autoFallbackPrimaryProbe.provider &&
-              fallbackModel === autoFallbackPrimaryProbe.model
-            ) {
-              clearAutoFallbackPrimaryProbeSelection(nextSessionEntry);
-            } else {
-              nextSessionEntry.providerOverride = fallbackProvider;
-              nextSessionEntry.modelOverride = fallbackModel;
-              nextSessionEntry.modelOverrideSource = "auto";
-              nextSessionEntry.modelOverrideFallbackOriginProvider =
-                autoFallbackPrimaryProbe.provider;
-              nextSessionEntry.modelOverrideFallbackOriginModel = autoFallbackPrimaryProbe.model;
-              if (
-                nextSessionEntry.authProfileOverrideSource === "auto" &&
-                fallbackProvider !== autoFallbackPrimaryProbe.fallbackProvider
-              ) {
-                delete nextSessionEntry.authProfileOverride;
-                delete nextSessionEntry.authProfileOverrideSource;
-                delete nextSessionEntry.authProfileOverrideCompactionCount;
-              }
-              nextSessionEntry.updatedAt = Date.now();
-            }
+            clearAutoFallbackPrimaryProbeSelection(nextSessionEntry);
             const persistedEntry = await persistSessionEntry({
               sessionStore,
               sessionKey,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -315,10 +315,6 @@ async function getRunAgentTurnWithFallback() {
   return (await import("./agent-runner-execution.js")).runAgentTurnWithFallback;
 }
 
-async function getApplyFallbackCandidateSelectionToEntry() {
-  return (await import("./agent-runner-execution.js")).applyFallbackCandidateSelectionToEntry;
-}
-
 type FallbackRunnerParams = {
   provider: string;
   model: string;
@@ -2368,197 +2364,6 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("keeps fallback auth available for later same-provider fallback models", async () => {
-    const probe = {
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-5.4",
-      fallbackAuthProfileId: "openai:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "anthropic";
-    followupRun.run.model = "claude-sonnet-4-6";
-    followupRun.run.authProfileId = "anthropic:primary";
-    followupRun.run.authProfileIdSource = "auto";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "same-provider-fallback-auth";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openai",
-      modelOverride: "gpt-5.4",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
-      result: await params.run("openai", "gpt-5.5"),
-      provider: "openai",
-      model: "gpt-5.5",
-      attempts: [
-        { provider: "anthropic", model: "claude-sonnet-4-6", error: "rate limit" },
-        { provider: "openai", model: "gpt-5.4", error: "rate limit" },
-      ],
-    }));
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectMockCallArgFields(state.runEmbeddedAgentMock, 0, "embedded run", {
-      provider: "openai",
-      model: "gpt-5.5",
-      authProfileId: "openai:fallback",
-      authProfileIdSource: "auto",
-    });
-    expectRecordFields(sessionEntry as unknown as Record<string, unknown>, {
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
-  it("keeps the primary origin when an auto pin is cleared before fallback persists", async () => {
-    const probe = {
-      provider: "anthropic",
-      model: "claude-sonnet-4-6",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-5.4",
-      fallbackAuthProfileId: "openai:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "anthropic";
-    followupRun.run.model = "claude-sonnet-4-6";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "cleared-before-fallback-persists";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openai",
-      modelOverride: "gpt-5.4",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      activeSessionStore[sessionKey] = {
-        sessionId: "session",
-        updatedAt: 2,
-      };
-      return {
-        result: await params.run("openai", "gpt-5.5"),
-        provider: "openai",
-        model: "gpt-5.5",
-        attempts: [{ provider: "anthropic", model: "claude-sonnet-4-6", error: "rate limit" }],
-      };
-    });
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectRecordFields(activeSessionStore[sessionKey] as unknown as Record<string, unknown>, {
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      authProfileOverride: "openai:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
-  it("re-persists cross-provider same-model fallback pins after an in-flight clear", async () => {
-    const probe = {
-      provider: "openai",
-      model: "gpt-5.5",
-      fallbackProvider: "azure",
-      fallbackModel: "gpt-5.5",
-      fallbackAuthProfileId: "azure:fallback",
-      fallbackAuthProfileIdSource: "auto" as const,
-    };
-    const followupRun = createFollowupRun();
-    followupRun.run.provider = "openai";
-    followupRun.run.model = "gpt-5.5";
-    followupRun.run.autoFallbackPrimaryProbe = probe;
-    const sessionKey = "cleared-cross-provider-same-model";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "azure",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.5",
-      authProfileOverride: "azure:fallback",
-      authProfileOverrideSource: "auto",
-    };
-    const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      activeSessionStore[sessionKey] = {
-        sessionId: "session",
-        updatedAt: 2,
-      };
-      return {
-        result: await params.run("azure", "gpt-5.5"),
-        provider: "azure",
-        model: "gpt-5.5",
-        attempts: [{ provider: "openai", model: "gpt-5.5", error: "rate limit" }],
-      };
-    });
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "fallback" }],
-      meta: {},
-    });
-
-    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
-      sessionKey,
-      activeSessionStore,
-      getActiveSessionEntry: () => activeSessionStore[sessionKey],
-    });
-
-    expectRecordFields(activeSessionStore[sessionKey] as unknown as Record<string, unknown>, {
-      providerOverride: "azure",
-      modelOverride: "gpt-5.5",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.5",
-      authProfileOverride: "azure:fallback",
-      authProfileOverrideSource: "auto",
-    });
-  });
-
   it("keeps primary auth on same-provider primary probes", async () => {
     const probe = {
       provider: "openai",
@@ -4381,7 +4186,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
   });
 
-  it("rolls back persisted fallback selection when result classification rejects a candidate", async () => {
+  it("keeps fallback candidate selection turn-local during result classification", async () => {
     const followupRun = createFollowupRun();
     followupRun.run.provider = "anthropic";
     followupRun.run.model = "claude";
@@ -4395,8 +4200,8 @@ describe("runAgentTurnWithFallback", () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const failedResult = await params.run("openai", "gpt-5.4");
-      expect(sessionEntry.providerOverride).toBe("openai");
-      expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+      expect(sessionEntry.providerOverride).toBeUndefined();
+      expect(sessionEntry.modelOverride).toBeUndefined();
       const classification = await params.classifyResult?.({
         result: failedResult as { payloads?: [] },
         provider: "openai",
@@ -4407,8 +4212,6 @@ describe("runAgentTurnWithFallback", () => {
       expectRecordFields(requireRecord(classification, "fallback classification"), {
         code: "empty_result",
       });
-      expect(sessionEntry.providerOverride).toBeUndefined();
-      expect(sessionEntry.modelOverride).toBeUndefined();
       return {
         result: { payloads: [{ text: "fallback ok" }], meta: {} },
         provider: "anthropic",
@@ -8434,7 +8237,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionStore.main.modelOverride).toBe("glm-5");
   });
 
-  it("drops authProfileId when fallback switches providers", async () => {
+  it("keeps cross-provider fallback selection turn-local", async () => {
     state.runWithModelFallbackMock.mockImplementation(
       async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
         result: await params.run("openai", "gpt-5.4"),
@@ -8495,9 +8298,9 @@ describe("runAgentTurnWithFallback", () => {
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -8570,7 +8373,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionEntry.modelOverrideSource).toBeUndefined();
   });
 
-  it("persists fallback selection for recovered auto overrides without modelOverrideSource", async () => {
+  it("does not replace a recovered auto override during fallback", async () => {
     state.runWithModelFallbackMock.mockImplementation(
       async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
         result: await params.run("openai", "gpt-5.4"),
@@ -8627,9 +8430,9 @@ describe("runAgentTurnWithFallback", () => {
     });
 
     expect(result.kind).toBe("success");
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    expect(sessionEntry.providerOverride).toBe("bailian");
+    expect(sessionEntry.modelOverride).toBe("qwen3.6-plus");
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.modelOverrideFallbackOriginProvider).toBe("minimax");
     expect(sessionEntry.modelOverrideFallbackOriginModel).toBe("MiniMax-M2.7");
   });
@@ -8697,77 +8500,6 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionEntry.providerOverride).toBe("anthropic");
     expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
     expect(sessionEntry.modelOverrideSource).toBe("user");
-  });
-
-  it("keeps same-provider auth profile when fallback only changes model", async () => {
-    const applyFallbackCandidateSelectionToEntry =
-      await getApplyFallbackCandidateSelectionToEntry();
-    const entry = {
-      sessionId: "session",
-      updatedAt: 1,
-      authProfileOverride: "anthropic:openclaw",
-      authProfileOverrideSource: "user" as const,
-    } as SessionEntry;
-
-    const { updated } = applyFallbackCandidateSelectionToEntry({
-      entry,
-      run: {
-        provider: "anthropic",
-        model: "claude-opus",
-        authProfileId: "anthropic:openclaw",
-        authProfileIdSource: "user",
-      } as FollowupRun["run"],
-      provider: "anthropic",
-      model: "claude-sonnet",
-      now: 123,
-    });
-
-    expect(updated).toBe(true);
-    expectRecordFields(entry as unknown as Record<string, unknown>, {
-      updatedAt: 123,
-      providerOverride: "anthropic",
-      modelOverride: "claude-sonnet",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-      authProfileOverride: "anthropic:openclaw",
-      authProfileOverrideSource: "user",
-    });
-  });
-
-  it("preserves original auto-fallback origin across chained fallbacks", async () => {
-    const applyFallbackCandidateSelectionToEntry =
-      await getApplyFallbackCandidateSelectionToEntry();
-    const entry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "openrouter",
-      modelOverride: "fallback-b",
-      modelOverrideSource: "auto" as const,
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-    } as SessionEntry;
-
-    const { updated } = applyFallbackCandidateSelectionToEntry({
-      entry,
-      run: {
-        provider: "openrouter",
-        model: "fallback-b",
-      } as FollowupRun["run"],
-      provider: "openrouter",
-      model: "fallback-c",
-      now: 123,
-    });
-
-    expect(updated).toBe(true);
-    expectRecordFields(entry as unknown as Record<string, unknown>, {
-      updatedAt: 123,
-      providerOverride: "openrouter",
-      modelOverride: "fallback-c",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus",
-    });
   });
 
   it("latches assistant error stub suppression across main reply fallback candidates", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -435,240 +435,6 @@ export type AgentRunLoopResult =
 
 type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedAgent>>;
 
-type FallbackSelectionState = Pick<
-  SessionEntry,
-  | "providerOverride"
-  | "modelOverride"
-  | "modelOverrideSource"
-  | "modelOverrideFallbackOriginProvider"
-  | "modelOverrideFallbackOriginModel"
-  | "authProfileOverride"
-  | "authProfileOverrideSource"
-  | "authProfileOverrideCompactionCount"
->;
-
-const FALLBACK_SELECTION_STATE_KEYS = [
-  "providerOverride",
-  "modelOverride",
-  "modelOverrideSource",
-  "modelOverrideFallbackOriginProvider",
-  "modelOverrideFallbackOriginModel",
-  "authProfileOverride",
-  "authProfileOverrideSource",
-  "authProfileOverrideCompactionCount",
-] as const satisfies ReadonlyArray<keyof FallbackSelectionState>;
-
-function setFallbackSelectionStateField(
-  entry: SessionEntry,
-  key: keyof FallbackSelectionState,
-  value: FallbackSelectionState[keyof FallbackSelectionState],
-): boolean {
-  switch (key) {
-    case "providerOverride":
-      if (entry.providerOverride !== value) {
-        entry.providerOverride = value as SessionEntry["providerOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverride":
-      if (entry.modelOverride !== value) {
-        entry.modelOverride = value as SessionEntry["modelOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverrideSource":
-      if (entry.modelOverrideSource !== value) {
-        entry.modelOverrideSource = value as SessionEntry["modelOverrideSource"];
-        return true;
-      }
-      return false;
-    case "modelOverrideFallbackOriginProvider":
-      if (entry.modelOverrideFallbackOriginProvider !== value) {
-        entry.modelOverrideFallbackOriginProvider =
-          value as SessionEntry["modelOverrideFallbackOriginProvider"];
-        return true;
-      }
-      return false;
-    case "modelOverrideFallbackOriginModel":
-      if (entry.modelOverrideFallbackOriginModel !== value) {
-        entry.modelOverrideFallbackOriginModel =
-          value as SessionEntry["modelOverrideFallbackOriginModel"];
-        return true;
-      }
-      return false;
-    case "authProfileOverride":
-      if (entry.authProfileOverride !== value) {
-        entry.authProfileOverride = value as SessionEntry["authProfileOverride"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideSource":
-      if (entry.authProfileOverrideSource !== value) {
-        entry.authProfileOverrideSource = value as SessionEntry["authProfileOverrideSource"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideCompactionCount":
-      if (entry.authProfileOverrideCompactionCount !== value) {
-        entry.authProfileOverrideCompactionCount =
-          value as SessionEntry["authProfileOverrideCompactionCount"];
-        return true;
-      }
-      return false;
-  }
-  throw new Error("Unsupported fallback selection state key");
-}
-
-function snapshotFallbackSelectionState(entry: SessionEntry): FallbackSelectionState {
-  return {
-    providerOverride: entry.providerOverride,
-    modelOverride: entry.modelOverride,
-    modelOverrideSource: entry.modelOverrideSource,
-    modelOverrideFallbackOriginProvider: entry.modelOverrideFallbackOriginProvider,
-    modelOverrideFallbackOriginModel: entry.modelOverrideFallbackOriginModel,
-    authProfileOverride: entry.authProfileOverride,
-    authProfileOverrideSource: entry.authProfileOverrideSource,
-    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
-  };
-}
-
-function buildFallbackSelectionStatePatch(entry: SessionEntry): Partial<SessionEntry> {
-  return {
-    ...snapshotFallbackSelectionState(entry),
-    updatedAt: entry.updatedAt,
-  };
-}
-
-function buildFallbackSelectionState(params: {
-  provider: string;
-  model: string;
-  originProvider: string;
-  originModel: string;
-  authProfileId?: string;
-  authProfileIdSource?: "auto" | "user";
-}): FallbackSelectionState {
-  return {
-    providerOverride: params.provider,
-    modelOverride: params.model,
-    modelOverrideSource: "auto",
-    modelOverrideFallbackOriginProvider: params.originProvider,
-    modelOverrideFallbackOriginModel: params.originModel,
-    authProfileOverride: params.authProfileId,
-    authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,
-    authProfileOverrideCompactionCount: undefined,
-  };
-}
-
-function resolveFallbackSelectionOrigin(params: { entry: SessionEntry; run: FollowupRun["run"] }): {
-  provider: string;
-  model: string;
-} {
-  if (
-    params.entry.modelOverrideSource === "auto" ||
-    (params.entry.modelOverrideSource === undefined &&
-      hasSessionAutoModelFallbackProvenance(params.entry))
-  ) {
-    const persistedOriginProvider = normalizeOptionalString(
-      params.entry.modelOverrideFallbackOriginProvider,
-    );
-    const persistedOriginModel = normalizeOptionalString(
-      params.entry.modelOverrideFallbackOriginModel,
-    );
-    if (persistedOriginProvider && persistedOriginModel) {
-      return { provider: persistedOriginProvider, model: persistedOriginModel };
-    }
-  }
-  return { provider: params.run.provider, model: params.run.model };
-}
-
-/** Persists the fallback candidate selection onto a session entry. */
-export function applyFallbackCandidateSelectionToEntry(params: {
-  entry: SessionEntry;
-  run: FollowupRun["run"];
-  provider: string;
-  model: string;
-  origin?: { provider: string; model: string };
-  force?: boolean;
-  now?: number;
-}): { updated: boolean; nextState?: FallbackSelectionState } {
-  if (
-    !params.force &&
-    params.provider === params.run.provider &&
-    params.model === params.run.model
-  ) {
-    return { updated: false };
-  }
-  const scopedAuthProfile = resolveRunAuthProfile(params.run, params.provider);
-  const origin =
-    params.origin ?? resolveFallbackSelectionOrigin({ entry: params.entry, run: params.run });
-  const nextState = buildFallbackSelectionState({
-    provider: params.provider,
-    model: params.model,
-    originProvider: origin.provider,
-    originModel: origin.model,
-    authProfileId: scopedAuthProfile.authProfileId,
-    authProfileIdSource: scopedAuthProfile.authProfileIdSource,
-  });
-  return {
-    updated: applyFallbackSelectionState(params.entry, nextState, params.now),
-    nextState,
-  };
-}
-
-function applyFallbackSelectionState(
-  entry: SessionEntry,
-  nextState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    const nextValue = nextState[key];
-    if (nextValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== nextValue) {
-      updated = setFallbackSelectionStateField(entry, key, nextValue) || updated;
-    }
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
-}
-
-function rollbackFallbackSelectionStateIfUnchanged(
-  entry: SessionEntry,
-  expectedState: FallbackSelectionState,
-  previousState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    if (entry[key] !== expectedState[key]) {
-      continue;
-    }
-    const previousValue = previousState[key];
-    if (previousValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== previousValue) {
-      updated = setFallbackSelectionStateField(entry, key, previousValue) || updated;
-    }
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
-}
-
 /**
  * Build a human-friendly rate-limit message from a FallbackSummaryError.
  * Includes a countdown when the soonest cooldown expiry is known.
@@ -1936,147 +1702,6 @@ async function runAgentTurnWithFallbackInternal(
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
-  let pendingFallbackCandidateRollback:
-    | {
-        provider: string;
-        model: string;
-        rollback: () => Promise<void>;
-      }
-    | undefined;
-  const clearPendingFallbackRollback = (rollback?: () => Promise<void>) => {
-    if (!rollback || pendingFallbackCandidateRollback?.rollback === rollback) {
-      pendingFallbackCandidateRollback = undefined;
-    }
-  };
-  const rollbackClassifiedFallbackCandidateSelection = async (provider: string, model: string) => {
-    const pending = pendingFallbackCandidateRollback;
-    if (!pending || pending.provider !== provider || pending.model !== model) {
-      return;
-    }
-    pendingFallbackCandidateRollback = undefined;
-    try {
-      await pending.rollback();
-    } catch (rollbackError) {
-      logVerbose(
-        `failed to roll back classified fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-      );
-    }
-  };
-  const persistFallbackCandidateSelection = async (
-    provider: string,
-    model: string,
-    candidateRun: FollowupRun["run"],
-  ): Promise<(() => Promise<void>) | undefined> => {
-    if (
-      !params.sessionKey ||
-      !params.activeSessionStore ||
-      preserveUserFacingSessionState ||
-      (provider === effectiveRun.provider && model === effectiveRun.model)
-    ) {
-      return undefined;
-    }
-
-    const activeSessionEntry =
-      params.activeSessionStore[params.sessionKey] ?? params.getActiveSessionEntry();
-    if (!activeSessionEntry) {
-      return undefined;
-    }
-
-    // Don't overwrite a user-initiated model override (e.g. from /models or
-    // /model) with the fallback model.  The user's explicit selection should
-    // survive transient primary-model failures so subsequent messages still
-    // target the model the user chose.  Fallback persistence is only
-    // appropriate when the override was itself set by a previous fallback
-    // ("auto") or when there is no override yet.
-    //
-    // `modelOverrideSource` was added later, so older persisted sessions can
-    // carry a user-selected override without the source field.  Treat any
-    // entry with a `modelOverride` but missing `modelOverrideSource` as legacy
-    // user state, matching the backward-compat treatment in
-    // session-reset-service.
-    const isUserModelOverride =
-      activeSessionEntry.modelOverrideSource === "user" ||
-      (activeSessionEntry.modelOverrideSource === undefined &&
-        Boolean(normalizeOptionalString(activeSessionEntry.modelOverride)) &&
-        !hasSessionAutoModelFallbackProvenance(activeSessionEntry));
-    if (isUserModelOverride) {
-      return undefined;
-    }
-
-    const previousState = snapshotFallbackSelectionState(activeSessionEntry);
-    const selectionRun =
-      candidateRun !== effectiveRun && effectiveRun.autoFallbackPrimaryProbe
-        ? {
-            ...candidateRun,
-            provider: candidateRun.provider,
-            model: effectiveRun.model,
-          }
-        : candidateRun;
-    const persistedProvider = resolveOpenAIRuntimeProvider({
-      provider,
-      config: runtimeConfig,
-      workspaceDir: params.followupRun.run.workspaceDir,
-    });
-    const applied = applyFallbackCandidateSelectionToEntry({
-      entry: activeSessionEntry,
-      run: selectionRun,
-      provider: persistedProvider,
-      model,
-      force: candidateRun !== effectiveRun && Boolean(effectiveRun.autoFallbackPrimaryProbe),
-      ...(effectiveRun.autoFallbackPrimaryProbe
-        ? {
-            origin: {
-              provider: effectiveRun.autoFallbackPrimaryProbe.provider,
-              model: effectiveRun.autoFallbackPrimaryProbe.model,
-            },
-          }
-        : {}),
-    });
-    const nextState = applied.nextState;
-    if (!applied.updated || !nextState) {
-      return undefined;
-    }
-    params.activeSessionStore[params.sessionKey] = activeSessionEntry;
-
-    try {
-      if (params.storePath) {
-        await updateSessionEntry(
-          { storePath: params.storePath, sessionKey: params.sessionKey },
-          (persistedEntry) => {
-            applyFallbackSelectionState(persistedEntry, nextState);
-            return buildFallbackSelectionStatePatch(persistedEntry);
-          },
-        );
-      }
-    } catch (error) {
-      rollbackFallbackSelectionStateIfUnchanged(activeSessionEntry, nextState, previousState);
-      params.activeSessionStore[params.sessionKey] = activeSessionEntry;
-      throw error;
-    }
-
-    return async () => {
-      const rolledBackInMemory = rollbackFallbackSelectionStateIfUnchanged(
-        activeSessionEntry,
-        nextState,
-        previousState,
-      );
-      if (rolledBackInMemory) {
-        params.activeSessionStore![params.sessionKey!] = activeSessionEntry;
-      }
-      if (!params.storePath || !params.sessionKey) {
-        return;
-      }
-      await updateSessionEntry(
-        { storePath: params.storePath, sessionKey: params.sessionKey },
-        (persistedEntry) => {
-          if (rollbackFallbackSelectionStateIfUnchanged(persistedEntry, nextState, previousState)) {
-            return buildFallbackSelectionStatePatch(persistedEntry);
-          }
-          return null;
-        },
-      );
-    };
-  };
   const clearRecoveredAutoFallbackPrimaryProbe = async (paramsForClear: {
     provider: string;
     model: string;
@@ -2292,8 +1917,8 @@ async function runAgentTurnWithFallbackInternal(
               step,
             });
           },
-          classifyResult: async ({ result, provider, model }) => {
-            const classification = outcomePlan.classifyRunResult({
+          classifyResult: ({ result, provider, model }) =>
+            outcomePlan.classifyRunResult({
               result,
               provider,
               model,
@@ -2301,12 +1926,7 @@ async function runAgentTurnWithFallbackInternal(
               hasBlockReplyPipelineOutput: Boolean(
                 blockReplyPipeline?.hasBuffered() || blockReplyPipeline?.didStream(),
               ),
-            });
-            if (classification) {
-              await rollbackClassifiedFallbackCandidateSelection(provider, model);
-            }
-            return classification;
-          },
+            }),
           mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             attemptedRuntimeProvider = provider;
@@ -2338,25 +1958,6 @@ async function runAgentTurnWithFallbackInternal(
               model,
               thinkLevel: params.followupRun.run.thinkLevel,
             });
-            let rollbackFallbackCandidateSelection: (() => Promise<void>) | undefined;
-            try {
-              rollbackFallbackCandidateSelection = await agentTurnTiming.measure(
-                "fallback_persist_selection",
-                () => persistFallbackCandidateSelection(provider, model, candidateRun),
-              );
-              if (rollbackFallbackCandidateSelection) {
-                pendingFallbackCandidateRollback = {
-                  provider,
-                  model,
-                  rollback: rollbackFallbackCandidateSelection,
-                };
-              }
-            } catch (error) {
-              logVerbose(
-                `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
-              );
-            }
-
             const { sessionRuntimeOverride, cliExecutionProvider } = agentTurnTiming.measureSync(
               "fallback_resolve_runtime",
               () => {
@@ -2483,19 +2084,6 @@ async function runAgentTurnWithFallbackInternal(
                       : undefined,
                   onFastModeAutoProgress: async (payload) => {
                     await params.opts?.onToolResult?.(payload);
-                  },
-                  onErrorBeforeLifecycle: async () => {
-                    if (!rollbackFallbackCandidateSelection) {
-                      return;
-                    }
-                    try {
-                      await rollbackFallbackCandidateSelection();
-                      clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                    } catch (rollbackError) {
-                      logVerbose(
-                        `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                      );
-                    }
                   },
                   transformResult:
                     params.followupRun.currentInboundEventKind === "room_event"
@@ -3105,18 +2693,6 @@ async function runAgentTurnWithFallbackInternal(
                 );
                 attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
                 return result;
-              } catch (err) {
-                if (rollbackFallbackCandidateSelection) {
-                  try {
-                    await rollbackFallbackCandidateSelection();
-                    clearPendingFallbackRollback(rollbackFallbackCandidateSelection);
-                  } catch (rollbackError) {
-                    logVerbose(
-                      `failed to roll back fallback candidate selection (non-fatal): ${String(rollbackError)}`,
-                    );
-                  }
-                }
-                throw err;
               } finally {
                 autoCompactionCount += attemptCompactionCount;
               }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1286,8 +1286,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const sessionEntry: SessionEntry = {
         sessionId: "session",
         updatedAt: Date.now(),
-        providerOverride: "anthropic",
-        modelOverride: "claude",
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-luna",
         modelOverrideSource: "user",
       };
       await saveSessionStore(storePath, { main: sessionEntry }, { skipMaintenance: true });
@@ -1298,9 +1298,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
       });
       vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(async (args) => {
         const { run, onFallbackStep } = args;
+        expect(args.provider, testCase.name).toBe("openai");
+        expect(args.model, testCase.name).toBe("gpt-5.6-luna");
         await onFallbackStep?.({
           fallbackStepType: "fallback_step",
-          fallbackStepFromModel: "fireworks/fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+          fallbackStepFromModel: "openai/gpt-5.6-luna",
           fallbackStepToModel: "deepinfra/moonshotai/Kimi-K2.5",
           fallbackStepFromFailureReason: "rate_limit",
           fallbackStepFinalOutcome: "succeeded",
@@ -1312,9 +1314,9 @@ describe("runReplyAgent typing (heartbeat)", () => {
           model: "moonshotai/Kimi-K2.5",
           attempts: [
             {
-              provider: "fireworks",
-              model: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
-              error: "Provider fireworks is in cooldown (all profiles unavailable)",
+              provider: "openai",
+              model: "gpt-5.6-luna",
+              error: "Provider openai is in cooldown (all profiles unavailable)",
               reason: "rate_limit",
             },
           ],
@@ -1327,6 +1329,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         sessionStore,
         sessionKey: "main",
         storePath,
+        runOverrides: { provider: "openai", model: "gpt-5.6-luna" },
       });
       const phases: string[] = [];
       const off = onAgentEvent((evt) => {
@@ -1343,12 +1346,12 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const stored = requireStoredSessionEntry(storePath);
       expect(payload.text, testCase.name).toContain("Model Fallback:");
       expect(payload.text, testCase.name).toContain("deepinfra/moonshotai/Kimi-K2.5");
-      expect(stored.providerOverride, testCase.name).toBe("anthropic");
-      expect(stored.modelOverride, testCase.name).toBe("claude");
+      expect(stored.providerOverride, testCase.name).toBe("openai");
+      expect(stored.modelOverride, testCase.name).toBe("gpt-5.6-luna");
       expect(stored.modelOverrideSource, testCase.name).toBe("user");
       expect(stored.modelProvider, testCase.name).toBe("deepinfra");
       expect(stored.model, testCase.name).toBe("moonshotai/Kimi-K2.5");
-      expect(stored.fallbackNoticeSelectedModel, testCase.name).toBe("anthropic/claude");
+      expect(stored.fallbackNoticeSelectedModel, testCase.name).toBe("openai/gpt-5.6-luna");
       expect(stored.fallbackNoticeActiveModel, testCase.name).toBe(
         "deepinfra/moonshotai/Kimi-K2.5",
       );

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1276,6 +1276,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it("announces model fallback transitions across verbose levels", async () => {
+    const storeRoot = await mkdtemp(join(tmpdir(), "openclaw-fallback-pin-"));
+    const storePath = join(storeRoot, "sessions.json");
     const cases = [
       { name: "verbose on", verbose: "on" as const },
       { name: "verbose off", verbose: "off" as const },
@@ -1284,11 +1286,15 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const sessionEntry: SessionEntry = {
         sessionId: "session",
         updatedAt: Date.now(),
+        providerOverride: "anthropic",
+        modelOverride: "claude",
+        modelOverrideSource: "user",
       };
+      await saveSessionStore(storePath, { main: sessionEntry }, { skipMaintenance: true });
       const sessionStore = { main: sessionEntry };
       state.runEmbeddedAgentMock.mockResolvedValueOnce({
         payloads: [{ text: "final" }],
-        meta: {},
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
       });
       vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(async (args) => {
         const { run, onFallbackStep } = args;
@@ -1320,6 +1326,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         sessionEntry,
         sessionStore,
         sessionKey: "main",
+        storePath,
       });
       const phases: string[] = [];
       const off = onAgentEvent((evt) => {
@@ -1333,15 +1340,26 @@ describe("runReplyAgent typing (heartbeat)", () => {
       const payload = Array.isArray(res)
         ? (res[0] as { text?: string })
         : (res as { text?: string });
+      const stored = requireStoredSessionEntry(storePath);
       expect(payload.text, testCase.name).toContain("Model Fallback:");
       expect(payload.text, testCase.name).toContain("deepinfra/moonshotai/Kimi-K2.5");
-      expect(sessionEntry.fallbackNoticeReason, testCase.name).toBe("rate limit");
+      expect(stored.providerOverride, testCase.name).toBe("anthropic");
+      expect(stored.modelOverride, testCase.name).toBe("claude");
+      expect(stored.modelOverrideSource, testCase.name).toBe("user");
+      expect(stored.modelProvider, testCase.name).toBe("deepinfra");
+      expect(stored.model, testCase.name).toBe("moonshotai/Kimi-K2.5");
+      expect(stored.fallbackNoticeSelectedModel, testCase.name).toBe("anthropic/claude");
+      expect(stored.fallbackNoticeActiveModel, testCase.name).toBe(
+        "deepinfra/moonshotai/Kimi-K2.5",
+      );
+      expect(stored.fallbackNoticeReason, testCase.name).toBe("rate limit");
       expect(
         phases.filter((phase) => phase === "fallback"),
         testCase.name,
       ).toHaveLength(1);
       expect(phases, testCase.name).toContain("fallback_step");
     }
+    await rm(storeRoot, { recursive: true, force: true });
   });
 
   it("does not report an exhausted fallback candidate as a successful winner", async () => {

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -22,13 +22,9 @@ import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { createReplySessionEntryHandle } from "./session-entry-handle.js";
 import type { SessionInitResult } from "./session.js";
 
-const COMPLETE_REPLY_CONFIG_SYMBOL = Symbol.for("openclaw.reply.complete-config");
-const FULL_REPLY_RUNTIME_SYMBOL = Symbol.for("openclaw.reply.full-runtime");
-
-type ReplyConfigWithMarker = OpenClawConfig & {
-  [COMPLETE_REPLY_CONFIG_SYMBOL]?: true;
-  [FULL_REPLY_RUNTIME_SYMBOL]?: true;
-};
+// Reply completeness is process-local metadata. Keep it off config objects so
+// frozen runtime snapshots and identity-keyed caches remain valid.
+const replyConfigRuntimeModes = new WeakMap<OpenClawConfig, "fast" | "full">();
 
 function isSlowReplyTestAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
   return (
@@ -49,27 +45,11 @@ function resolveFastSessionKey(params: {
   return resolveSessionKey(params.sessionScope, ctx, params.mainKey);
 }
 
-function markReplyConfigRuntimeMode(
-  config: ReplyConfigWithMarker,
-  runtimeMode: "fast" | "full" = "fast",
-): void {
-  Object.defineProperty(config, FULL_REPLY_RUNTIME_SYMBOL, {
-    value: runtimeMode === "full" ? true : undefined,
-    configurable: true,
-    enumerable: false,
-  });
-}
-
 export function markCompleteReplyConfig<T extends OpenClawConfig>(
   config: T,
   options?: { runtimeMode?: "fast" | "full" },
 ): T {
-  Object.defineProperty(config as ReplyConfigWithMarker, COMPLETE_REPLY_CONFIG_SYMBOL, {
-    value: true,
-    configurable: true,
-    enumerable: false,
-  });
-  markReplyConfigRuntimeMode(config as ReplyConfigWithMarker, options?.runtimeMode ?? "fast");
+  replyConfigRuntimeModes.set(config, options?.runtimeMode ?? "fast");
   return config;
 }
 
@@ -83,9 +63,7 @@ export function withFullRuntimeReplyConfig<T extends OpenClawConfig>(config: T):
 
 function isCompleteReplyConfig(config: unknown): config is OpenClawConfig {
   return Boolean(
-    config &&
-    typeof config === "object" &&
-    (config as ReplyConfigWithMarker)[COMPLETE_REPLY_CONFIG_SYMBOL] === true,
+    config && typeof config === "object" && replyConfigRuntimeModes.has(config as OpenClawConfig),
   );
 }
 
@@ -93,7 +71,7 @@ function usesFullReplyRuntime(config: unknown): boolean {
   return Boolean(
     config &&
     typeof config === "object" &&
-    (config as ReplyConfigWithMarker)[FULL_REPLY_RUNTIME_SYMBOL] === true,
+    replyConfigRuntimeModes.get(config as OpenClawConfig) === "full",
   );
 }
 

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -92,4 +92,24 @@ describe("getReplyFromConfig configOverride", () => {
     expect(loadConfigMock).not.toHaveBeenCalled();
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
   });
+
+  it("marks a frozen complete config without changing its identity or own keys", async () => {
+    const { withFullRuntimeReplyConfig } = await import("./get-reply-fast-path.js");
+    const cfg = Object.freeze({
+      agents: { defaults: { userTimezone: "America/New_York" } },
+      channels: { telegram: { botToken: "resolved-telegram-token" } },
+    } satisfies OpenClawConfig);
+    const ownKeys = Reflect.ownKeys(cfg);
+    vi.mocked(loadConfigMock).mockImplementation(() => {
+      throw new Error("getRuntimeConfig should not be called for complete runtime config");
+    });
+
+    const marked = withFullRuntimeReplyConfig(cfg);
+    await getReplyFromConfig(buildGetReplyCtx(), undefined, marked);
+
+    expect(marked).toBe(cfg);
+    expect(Reflect.ownKeys(cfg)).toEqual(ownKeys);
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
+  });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -154,6 +154,9 @@ export function applyModelOverrideToSessionEntry(params: {
   // Clear stale fallback notice when the user explicitly switches models.
   if (updated) {
     if ((selectionUpdated || profileUpdated) && params.markLiveSwitchPending) {
+      // Pending without modelOverride is the deliberate encoding for "switch
+      // back to the agent default": the default branch above also clears the
+      // runtime model fields so live-switch resolution lands on the default.
       entry.liveModelSwitchPending = true;
     }
     delete entry.fallbackNoticeSelectedModel;


### PR DESCRIPTION
Closes #103324.

Supersedes #103417. This replacement retains Ayaan Zaidi's (@obviyus) turn-local fallback commit with original authorship and incorporates his root-cause investigation.

## What Problem This Solves

Fixes an issue where Telegram could confirm a `/model` selection from hot-reloaded config, but the next turn still used the Gateway's startup snapshot. The selected model was then rejected, and fallback could permanently overwrite the user's explicit session pin.

This was observed when selecting `openai/gpt-5.6-luna`: `/model` and `/status` showed Luna, while the next message ran another provider and persisted that fallback over the pin.

## Why This Change Was Made

Fallback candidates are now turn-local and never replace an explicit user model selection. Each Telegram authorization operation owns one live config snapshot; independently, each assembled agent turn captures once after debounce/media/text batching and carries that exact object through routing, context construction, model resolution, and dispatch. Native commands likewise use one live snapshot for auth, routing, delivery settings, and execution. Complete reply-config metadata is tracked out of band so frozen configs and identity-keyed caches remain valid.

This keeps the sound first commit from #103417 while replacing its later approaches:

- A late global config read inside reply dispatch would create two config authorities within one turn, override explicit caller/SDK configuration, and break object-identity caches. The live snapshot belongs at the channel turn boundary instead.
- Globally reordering expired OAuth profiles would change explicit account precedence and could silently switch identity or billing account. OAuth expiry is refreshable at use, and provider rotation can try sibling profiles without rewriting configured order.

## User Impact

Telegram model selections made after a config hot reload take effect on the next assembled turn without requiring a Gateway restart. If the selected model fails, OpenClaw may use a fallback for that turn and show the existing notice, but later turns retry the user's pinned model instead of silently replacing it. Hot-reloaded Telegram authorization policy is applied consistently, and auth-profile ordering remains unchanged.

## Evidence

- Regression coverage starts the bot without Luna, hot-adds `openai/gpt-5.6-luna`, selects it through the Telegram model callback, and proves the next debounced turn dispatches with the exact post-batching live config while preserving the user pin.
- Callback coverage proves a sender allowed by startup config is rejected after the live allowlist removes them.
- Native-command and grouped-media coverage prove auth, preflight, routing, settings, and execution retain their owning snapshot.
- Frozen-config coverage proves complete reply configs retain object identity and own keys without another global config read.
- Fallback E2E coverage proves a failed `openai/gpt-5.6-luna` turn can use another provider without changing the persisted user selection.
- Focused validation:
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/telegram/src/bot-native-commands.group-auth.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts` (178 passed)
  - `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.config-override.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
  - `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin <Codex 0.144.1>` (clean, no actionable findings)
  - `git diff --check`

Sanitized AWS Crabbox was unavailable because this environment had no usable AWS credentials or instance role; secretless PR CI is the authoritative remote proof.
