### PR TITLE
fix(ui): Chat detail panels keep their own spacing

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1639,9 +1639,9 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (this.variant === "panel") {
       return html`
         <aside class="sidebar sidebar--panel">
-          <div class="sidebar-panel">
+          <div class="app-sidebar-panel">
             ${this.renderSessions()}
-            <div class="sidebar-panel__footer">
+            <div class="app-sidebar-panel__footer">
               <openclaw-lobster-pet
                 .seed=${lobsterPetSeed(this.sessionKey)}
                 .mode=${resolveLobsterPetMode(this.connected, this.sessionsResult?.sessions)}

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -107,7 +107,31 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => page.locator(".topbar").isVisible()).toBe(true);
       await expect.poll(() => trimmedTextContents(navItems)).toEqual(["Chat", "Overview", "More"]);
       await expect.poll(() => sidebar.locator(".sidebar-brand").count()).toBe(0);
-      await expect.poll(() => sidebar.locator(".sidebar-panel").count()).toBe(1);
+      const appSidebarPanel = sidebar.locator(".app-sidebar-panel");
+      await expect.poll(() => appSidebarPanel.count()).toBe(1);
+      await expect
+        .poll(() =>
+          appSidebarPanel.evaluate((panel) => {
+            const bounds = panel.getBoundingClientRect();
+            const sidebarBounds = panel.closest(".sidebar")?.getBoundingClientRect();
+            const style = getComputedStyle(panel);
+            return {
+              background: style.backgroundColor,
+              fillsSidebar: Math.abs(bounds.height - (sidebarBounds?.height ?? 0)) <= 1,
+              padding: [
+                style.paddingTop,
+                style.paddingRight,
+                style.paddingBottom,
+                style.paddingLeft,
+              ],
+            };
+          }),
+        )
+        .toEqual({
+          background: "rgba(0, 0, 0, 0)",
+          fillsSidebar: true,
+          padding: ["12px", "10px", "10px", "10px"],
+        });
       const shellNav = page.locator(".shell-nav");
       const sidebarResizer = page.getByRole("separator", { name: "Resize sidebar" });
       await expect.poll(() => roundedWidth(shellNav)).toBe(258);
@@ -369,6 +393,68 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       if (video) {
         await video.saveAs(path.join(uiProofArtifactDir, "settings-search-flow.webm"));
       }
+    }
+  });
+
+  it("keeps Chat detail panel geometry independent from the app sessions panel", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ type: "text", text: "Panel ownership proof." }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Panel ownership proof.").waitFor({ timeout: 10_000 });
+      const openInCanvas = page.getByRole("button", { name: "Open in canvas" }).first();
+      await openInCanvas.focus();
+      await page.keyboard.press("Enter");
+
+      const detailHost = page.locator("openclaw-chat-detail-panel");
+      const detailPanel = detailHost.locator(":scope > .sidebar-panel");
+      await expect.poll(() => detailPanel.count()).toBe(1);
+      await expect
+        .poll(() =>
+          detailPanel.evaluate((panel) => {
+            const bounds = panel.getBoundingClientRect();
+            const hostBounds = panel.parentElement?.getBoundingClientRect();
+            const headerBounds = panel.querySelector(".sidebar-header")?.getBoundingClientRect();
+            const style = getComputedStyle(panel);
+            return {
+              backgroundOpaque: style.backgroundColor !== "rgba(0, 0, 0, 0)",
+              fillsHost: Math.abs(bounds.height - (hostBounds?.height ?? 0)) <= 1,
+              headerOffset: {
+                x: (headerBounds?.left ?? 0) - bounds.left,
+                y: (headerBounds?.top ?? 0) - bounds.top,
+              },
+              padding: [
+                style.paddingTop,
+                style.paddingRight,
+                style.paddingBottom,
+                style.paddingLeft,
+              ],
+            };
+          }),
+        )
+        .toEqual({
+          backgroundOpaque: true,
+          fillsHost: true,
+          headerOffset: { x: 0, y: 0 },
+          padding: ["0px", "0px", "0px", "0px"],
+        });
+      await captureUiProof(page, "07-chat-detail-panel.png");
+    } finally {
+      await context.close();
     }
   });
 

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -445,6 +445,7 @@ type MarkdownSidebarProps = {
   content: SidebarContent | null;
   error: string | null;
   fileView?: FileViewControls;
+  onClick?: (event: Event) => void;
   onClose: () => void;
   onViewRawText: () => void;
   canvasPluginSurfaceUrl?: string | null;
@@ -481,7 +482,7 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
             ? "Markdown Preview"
             : "Tool Details";
   return html`
-    <div class="sidebar-panel">
+    <div class="sidebar-panel" @click=${props.onClick}>
       <div class="sidebar-header">
         <div class="sidebar-title">${title}</div>
         <openclaw-tooltip content="Close sidebar">
@@ -859,38 +860,35 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     const currentMatchIndex = matches.length
       ? Math.min(this.fileSearchMatchIndex, matches.length - 1)
       : 0;
-    return html`
-      <div @click=${this.handlePanelClick}>
-        ${renderMarkdownSidebar({
-          content: this.visibleContent,
-          error: this.error,
-          fileView: {
-            copied: this.fileContentsCopied,
-            currentMatchIndex,
-            editorMenuOpen: this.fileEditorMenuOpen,
-            matches,
-            query: this.fileSearchQuery,
-            searchOpen: this.fileSearchOpen,
-            onCopyContents: this.copyFileContents,
-            onNextMatch: () => this.moveFileSearch(1),
-            onOpenEditor: this.openInEditor,
-            onPreviousMatch: () => this.moveFileSearch(-1),
-            onReveal: this.onRevealInWorkspace ?? undefined,
-            onSearchInput: this.updateFileSearch,
-            onSearchKeydown: this.handleFileSearchKeydown,
-            onToggleEditorMenu: () => {
-              this.fileEditorMenuOpen = !this.fileEditorMenuOpen;
-            },
-            onToggleSearch: this.toggleFileSearch,
-          },
-          canvasPluginSurfaceUrl: this.canvasPluginSurfaceUrl,
-          embedSandboxMode: this.embedSandboxMode,
-          allowExternalEmbedUrls: this.allowExternalEmbedUrls,
-          onClose: this.close,
-          onViewRawText: this.showRawText,
-        })}
-      </div>
-    `;
+    return renderMarkdownSidebar({
+      content: this.visibleContent,
+      error: this.error,
+      fileView: {
+        copied: this.fileContentsCopied,
+        currentMatchIndex,
+        editorMenuOpen: this.fileEditorMenuOpen,
+        matches,
+        query: this.fileSearchQuery,
+        searchOpen: this.fileSearchOpen,
+        onCopyContents: this.copyFileContents,
+        onNextMatch: () => this.moveFileSearch(1),
+        onOpenEditor: this.openInEditor,
+        onPreviousMatch: () => this.moveFileSearch(-1),
+        onReveal: this.onRevealInWorkspace ?? undefined,
+        onSearchInput: this.updateFileSearch,
+        onSearchKeydown: this.handleFileSearchKeydown,
+        onToggleEditorMenu: () => {
+          this.fileEditorMenuOpen = !this.fileEditorMenuOpen;
+        },
+        onToggleSearch: this.toggleFileSearch,
+      },
+      canvasPluginSurfaceUrl: this.canvasPluginSurfaceUrl,
+      embedSandboxMode: this.embedSandboxMode,
+      allowExternalEmbedUrls: this.allowExternalEmbedUrls,
+      onClick: this.handlePanelClick,
+      onClose: this.close,
+      onViewRawText: this.showRawText,
+    });
   }
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -902,7 +902,7 @@
 /* Desktop sessions panel: sessions list + resident pet, nothing else. Kept
    apart from .sidebar-shell so the Mac app's drawer titlebar padding does not
    apply here (the topbar already clears the window controls). */
-.sidebar-panel {
+.app-sidebar-panel {
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -910,13 +910,13 @@
   padding: 12px 10px 10px;
 }
 
-.sidebar-panel .sidebar-sessions {
+.app-sidebar-panel .sidebar-sessions {
   margin-top: 0;
 }
 
 /* Slim ledge for the lobster pet: both its perch modes (ledge above the
    divider, bar inside the strip) need a footer bar to anchor to. */
-.sidebar-panel__footer {
+.app-sidebar-panel__footer {
   flex-shrink: 0;
   min-height: 26px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -5,7 +5,7 @@
 
 /* The footer bar is the pet's ledge. */
 .sidebar-shell__footer,
-.sidebar-panel__footer {
+.app-sidebar-panel__footer {
   position: relative;
 }
 


### PR DESCRIPTION
Closes #103495

AI-assisted: yes. I reviewed and understand the change.

## What Problem This Solves

Fixes an issue where users opening a file, tool, Markdown, image, or Canvas detail panel in Chat would see the app sessions panel's outer padding applied to the detail surface after the desktop topbar redesign.

## Why This Change Was Made

The new desktop sessions wrapper and footer now use app-owned class names, while the established Chat detail `.sidebar-panel` contract remains unchanged. The resident lobster-pet anchor and affected selectors follow the app-owned footer name, and real-browser coverage locks both panels' independent geometry.

## User Impact

Chat detail headers and content again align with their own panel edge. The desktop sessions panel keeps its intended full-height layout, transparent background, and 12px/10px/10px padding.

## Evidence

- Before on `main`: Chromium reported `padding: 12px 10px 10px` and header offset `x=10px, y=12px` on the Chat detail wrapper (`tbx_01kx5ckg6nkh69r9s8t7xqwzy0`).
- After on this branch: `corepack pnpm test ui/src/pages/chat/components/chat-sidebar.test.ts ui/src/e2e/sidebar-customization.e2e.test.ts` passed 14 component tests and 3 mocked-Gateway Chromium E2E tests (`tbx_01kx5cscfp5nvf5sxpv2hhrkeq`). The E2E opens the actual Chat detail component through its accessible `Open in canvas` action and verifies both owners' computed geometry.
- Source-blind post-build browser validation at 1440x900 passed in light, dark, and after refresh/reopen: the Chat panel exactly matched its `450.203125 x 852` host content box, with `0` padding, `0/0` header offset, and an opaque owner background. The app sessions panel separately matched its `257 x 852` host with `12px 10px 10px 10px` padding and a transparent background.
- `corepack pnpm format:check -- <five changed files>` passed on the same Testbox.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- <five changed files>` passed the `core` and `coreTests` lanes on the same Testbox in 8m51s.
- Fresh full-bundle structured autoreview: clean, with no accepted/actionable findings.
- Exact-head GitHub CI: [run 29077559783](https://github.com/openclaw/openclaw/actions/runs/29077559783) passed at `28ae39aa1479` (43 CI jobs successful, 12 intentionally skipped, no failures).

Merge sequencing: intentionally held behind #103447 for maintainer landing review.
