### PR TITLE
fix(imessage): bound drop diagnostic dedupe

### DIFF
--- a/extensions/imessage/src/monitor/drop-diagnostic-cache.test.ts
+++ b/extensions/imessage/src/monitor/drop-diagnostic-cache.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { createIMessageThrottledDropDiagnosticCache } from "./drop-diagnostic-cache.js";
+
+describe("createIMessageThrottledDropDiagnosticCache", () => {
+  it("evicts the least recently used conversation after 512 entries", () => {
+    const cache = createIMessageThrottledDropDiagnosticCache();
+
+    for (let index = 0; index < 512; index += 1) {
+      expect(cache.check(`conversation-${index}`)).toBe(false);
+    }
+    expect(cache.check("conversation-0")).toBe(true);
+    expect(cache.check("conversation-512")).toBe(false);
+
+    expect(cache.size()).toBe(512);
+    expect(cache.check("conversation-0")).toBe(true);
+    expect(cache.check("conversation-1")).toBe(false);
+  });
+});

--- a/extensions/imessage/src/monitor/drop-diagnostic-cache.ts
+++ b/extensions/imessage/src/monitor/drop-diagnostic-cache.ts
@@ -1,0 +1,11 @@
+import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+
+const THROTTLED_DROP_DIAGNOSTIC_CACHE_MAX_SIZE = 512;
+
+export function createIMessageThrottledDropDiagnosticCache() {
+  // Bound monitor-lifetime warn-once state; evicted conversations may log again.
+  return createDedupeCache({
+    maxSize: THROTTLED_DROP_DIAGNOSTIC_CACHE_MAX_SIZE,
+    ttlMs: 0,
+  });
+}

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -79,6 +79,7 @@ import {
 import { repairIMessageConversationAnchor } from "./conversation-repair.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { resolveIMessageDmHistoryContext, resolveIMessageDmHistoryLimit } from "./dm-history.js";
+import { createIMessageThrottledDropDiagnosticCache } from "./drop-diagnostic-cache.js";
 import { createSentMessageCache } from "./echo-cache.js";
 import {
   warnGroupAllowlistDropPerChatOnce,
@@ -523,7 +524,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   // replay aggressively without the old catchup cursor/retry bookkeeping.
   const inboundReplayGuard = createIMessageInboundReplayGuard();
   let staleBacklogSuppressed = 0;
-  const loggedThrottledDropDiagnostics = new Set<string>();
+  const loggedThrottledDropDiagnostics = createIMessageThrottledDropDiagnosticCache();
 
   // Downtime recovery. We pass the persisted recovery cursor (the last
   // dispatched rowid) to watch.subscribe as since_rowid so imsg replays the rows
@@ -1048,10 +1049,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         const shouldThrottleDiagnostic = shouldThrottleIMessageInboundDropDiagnostic(
           decision.reason,
         );
-        if (!shouldThrottleDiagnostic || !loggedThrottledDropDiagnostics.has(throttleKey)) {
-          if (shouldThrottleDiagnostic) {
-            loggedThrottledDropDiagnostics.add(throttleKey);
-          }
+        if (!shouldThrottleDiagnostic || !loggedThrottledDropDiagnostics.check(throttleKey)) {
           runtime.log?.(warn(diagnostic));
         }
       }


### PR DESCRIPTION
## What Problem This Solves

- Fixes process-lifetime growth in iMessage inbound-drop diagnostics.
- The monitor retained one key per account, conversation, and throttled reason in an unbounded `Set`.
- Long-lived gateways that encounter many conversations could retain diagnostic-only state indefinitely.

## Why This Change Was Made

- Reuses the existing bounded dedupe cache at the monitor-owned state boundary.
- Retains at most 512 recently used keys with no time expiry; an evicted conversation may emit its diagnostic again.
- Keeps the existing iMessage RPC notification callback and concurrency behavior unchanged.
- Removes the earlier branch's stale merge orchestration and async-callback churn.
- Adds a direct regression test for capacity, LRU refresh, and eviction. Existing monitor coverage still proves repeated from-me diagnostics are suppressed and redacted.

## User Impact

- Long-lived iMessage monitors now bound this diagnostic state.
- Recent duplicate diagnostics remain suppressed.
- No configuration, API, channel behavior, or persistence changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/drop-diagnostic-cache.test.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts` — 2 files, 4 tests passed.
- `git diff --check` — passed.
- Maintainer autoreview — clean, 0.98 confidence.
- `node scripts/check-changed.mjs -- extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/monitor/drop-diagnostic-cache.ts extensions/imessage/src/monitor/drop-diagnostic-cache.test.ts` reached hosted checks and found only unrelated current-main max-lines baseline drift for `src/config/zod-schema.ts`; exact-head PR CI is the merge gate.
- No signed-in macOS Messages session was used. This change affects only process-local cache retention and is covered at the cache contract and production monitor path.

## Release Note

Fixed unbounded diagnostic dedupe state in long-running iMessage monitors.
