### PR TITLE
fix(feishu): bound sender name cache

### DIFF
--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -65,4 +65,37 @@ describe("resolveFeishuSenderName", () => {
 
     expect(get).toHaveBeenCalledTimes(2);
   });
+
+  it("evicts the oldest sender while retaining recent sender names", async () => {
+    const get = vi.fn(async (params: { path: { user_id: string } }) => ({
+      data: { user: { name: `name-${params.path.user_id}` } },
+    }));
+    createFeishuClientMock.mockReturnValue({ contact: { user: { get } } });
+
+    for (let index = 0; index < 501; index += 1) {
+      await resolveFeishuSenderName({
+        account,
+        senderId: `ou_sender_cap_${index}`,
+        log: vi.fn(),
+      });
+    }
+    await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender_cap_0",
+      log: vi.fn(),
+    });
+    await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender_cap_500",
+      log: vi.fn(),
+    });
+
+    expect(get).toHaveBeenCalledTimes(502);
+    expect(
+      get.mock.calls.filter(([params]) => params.path.user_id === "ou_sender_cap_0"),
+    ).toHaveLength(2);
+    expect(
+      get.mock.calls.filter(([params]) => params.path.user_id === "ou_sender_cap_500"),
+    ).toHaveLength(1);
+  });
 });

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements bot sender name behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -29,6 +30,7 @@ const FEISHU_SCOPE_CORRECTIONS: Record<string, string> = {
   "contact:contact.base:readonly": "contact:user.base:readonly",
 };
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
+const SENDER_NAME_CACHE_MAX_SIZE = 500;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 
 function correctFeishuScopeInUrl(url: string): string {
@@ -117,6 +119,7 @@ export async function resolveFeishuSenderName(params: {
       const expireAt = resolveExpiresAtMsFromDurationMs(SENDER_NAME_TTL_MS);
       if (expireAt !== undefined) {
         senderNameCache.set(normalizedSenderId, { name, expireAt });
+        pruneMapToMaxSize(senderNameCache, SENDER_NAME_CACHE_MAX_SIZE);
       }
       return { name };
     }


### PR DESCRIPTION
## What Problem This Solves

- **Fixes an issue where high-volume Feishu bots could retain an unbounded number of sender-name cache entries inside the ten-minute TTL window.**
- **Affected surface / workflow:** sender attribution for inbound Feishu bot events.
- **Root cause, in product terms:** `senderNameCache` had per-entry expiry but no maximum size, so a burst of unique sender IDs could grow the map without a hard bound.
- **Why it matters / User impact:** large groups and high-traffic bots can encounter many unique senders before entries expire, increasing process memory with no upper limit.

## Why This Change Was Made

- **Fix classification:** Root cause fix
- **Complete shipped solution:** cap the sender-name cache at 500 entries and prune the oldest entry after successful insertions.
- **Why this is root-cause fix:** the cache owner now enforces a hard retention bound in addition to the existing TTL.
- **Key design boundary / source of truth:** the 500-entry limit matches Feishu's existing group-name cache policy and uses the shared `pruneMapToMaxSize` helper.
- **Non-goals / what did not change:** sender ID type selection, permission handling, name precedence, and the ten-minute TTL are unchanged.
- **Compatibility, merge-risk, or maintainer-decision notes:** no public API or configuration changes; an evicted sender simply performs the existing contact lookup again.

## User Impact

- **Users/operators/developers can now:** run high-cardinality Feishu bot workloads with a bounded sender-name cache.
- **Existing behavior preserved:** recently inserted sender names remain cached and reuse the existing TTL.
- **What was not tested or remains unavailable:** no external Feishu tenant credentials were used; the live proof exercised the production resolver and client-construction path against a local HTTP-backed client boundary.

## Evidence

- **Environment:** Windows Git Bash, Node.js 22.17.0, local HTTP server returning Feishu contact-user response shapes.
- **Commands run after this patch:** focused Vitest for `extensions/feishu/src/bot-sender-name.test.ts`; `node --import tsx` live HTTP proof through `resolveFeishuSenderName`; `oxfmt --check`; `git diff --check`.
- **Key results / observations:** focused suite passed `3/3`; the live proof resolved 501 distinct senders, then observed two HTTP requests for the evicted oldest sender and one request for the retained recent sender.
- **Review findings addressed, if any:** none; a final open-PR search found no exact sender-name cache overlap.
- **Regression guardrail:** the test overflows the 500-entry cap and verifies both oldest-entry eviction and recent-entry reuse.
- **Patch quality notes:** two focused files; no dependency, schema, configuration, or lockfile changes.
- **Maintainer-ready confidence:** high; latest `origin/main` was refreshed before push and still had TTL-only retention at commit `0ac5394192f026b90bab0ba2f8ec18c5f7797ac1`.
