### PR TITLE
fix(ui): stop session shortcuts after panel collapse

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -49,6 +49,10 @@ type ShellRouteState = {
   location?: RouteLocation;
 };
 
+type AppSidebarElement = HTMLElement & {
+  dismissTransientMenus: () => void;
+};
+
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
 const ROUTE_IDS_WITHOUT_WORKBOARD = APP_ROUTE_IDS.filter((routeId) => routeId !== "workboard");
@@ -530,23 +534,32 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
     if (isMobileNavLayout()) {
       if (this.navDrawerOpen) {
-        this.closeNavDrawer({ restoreFocus: Boolean(trigger) });
+        this.closeNavDrawer({ restoreFocus: true });
         return;
       }
-      this.navDrawerTrigger = trigger ?? null;
+      this.navDrawerTrigger = trigger ?? this.querySelector<HTMLElement>(".topbar-nav-toggle");
       this.navDrawerOpen = true;
       return;
     }
     // A drawer that survived a breakpoint change is visually expanded even
     // when the persisted desktop preference says collapsed.
     const nextNavCollapsed = this.navDrawerOpen || !context.navigation.snapshot.navCollapsed;
+    if (nextNavCollapsed) {
+      this.dismissSidebarTransientMenus();
+    }
     this.closeNavDrawer();
     context.navigation.update({
       navCollapsed: nextNavCollapsed,
     });
+    if (nextNavCollapsed) {
+      this.querySelector<HTMLElement>(".topbar-panel-toggle")?.focus();
+    }
   }
 
   private closeNavDrawer(options: { restoreFocus?: boolean } = {}) {
+    if (this.navDrawerOpen) {
+      this.dismissSidebarTransientMenus();
+    }
     const focusTarget = options.restoreFocus ? this.navDrawerTrigger : null;
     this.navDrawerOpen = false;
     this.navDrawerTrigger = null;
@@ -573,8 +586,15 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private readonly handleWindowResize = () => {
+    if (isMobileNavLayout() && !this.navDrawerOpen) {
+      this.dismissSidebarTransientMenus();
+    }
     this.requestUpdate();
   };
+
+  private dismissSidebarTransientMenus() {
+    this.querySelector<AppSidebarElement>("openclaw-app-sidebar")?.dismissTransientMenus();
+  }
 
   private readonly handleShellKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented || event.key !== "Escape" || !this.navDrawerOpen) {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -50,7 +50,7 @@ type ShellRouteState = {
 };
 
 type AppSidebarElement = HTMLElement & {
-  dismissTransientMenus: () => void;
+  dismissTransientMenus: () => boolean;
 };
 
 // Stable references so the sidebar's enabledRouteIds property does not churn
@@ -552,7 +552,9 @@ class OpenClawShell extends OpenClawLightDomElement {
       navCollapsed: nextNavCollapsed,
     });
     if (nextNavCollapsed) {
-      this.querySelector<HTMLElement>(".topbar-panel-toggle")?.focus();
+      void this.updateComplete.then(() => {
+        this.querySelector<HTMLElement>(".shell-nav-expand")?.focus();
+      });
     }
   }
 
@@ -586,14 +588,21 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private readonly handleWindowResize = () => {
-    if (isMobileNavLayout() && !this.navDrawerOpen) {
-      this.dismissSidebarTransientMenus();
-    }
+    const dismissedHiddenMenus =
+      isMobileNavLayout() && !this.navDrawerOpen && this.dismissSidebarTransientMenus();
     this.requestUpdate();
+    if (dismissedHiddenMenus) {
+      void this.updateComplete.then(() => {
+        this.querySelector<HTMLElement>(".topbar-nav-toggle")?.focus();
+      });
+    }
   };
 
-  private dismissSidebarTransientMenus() {
-    this.querySelector<AppSidebarElement>("openclaw-app-sidebar")?.dismissTransientMenus();
+  private dismissSidebarTransientMenus(): boolean {
+    return (
+      this.querySelector<AppSidebarElement>("openclaw-app-sidebar")?.dismissTransientMenus() ??
+      false
+    );
   }
 
   private readonly handleShellKeydown = (event: KeyboardEvent) => {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -250,10 +250,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   }
 
   override disconnectedCallback() {
-    this.closeCustomizeMenu();
-    this.closeSessionMenu();
-    this.closeSessionGroupMenu();
-    this.closeSessionSortMenu();
+    this.dismissTransientMenus();
     this.gatewaySource = null;
     this.gatewayClient = null;
     for (const timer of this.routePreloadTimers.values()) {
@@ -261,6 +258,15 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     }
     this.routePreloadTimers.clear();
     super.disconnectedCallback();
+  }
+
+  // The shell calls this before CSS hides the panel or drawer. Mounted menus
+  // keep their document-level shortcuts alive even when an ancestor is hidden.
+  dismissTransientMenus() {
+    this.closeCustomizeMenu();
+    this.closeSessionMenu();
+    this.closeSessionGroupMenu();
+    this.closeSessionSortMenu();
   }
 
   private readonly updateSessions = (sessions: SessionCapability) => {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -262,11 +262,18 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   // The shell calls this before CSS hides the panel or drawer. Mounted menus
   // keep their document-level shortcuts alive even when an ancestor is hidden.
-  dismissTransientMenus() {
+  dismissTransientMenus(): boolean {
+    const hadTransientMenu = Boolean(
+      this.customizeMenuPosition ||
+      this.sessionMenu ||
+      this.sessionGroupMenu ||
+      this.sessionSortMenuPosition,
+    );
     this.closeCustomizeMenu();
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
+    return hadTransientMenu;
   }
 
   private readonly updateSessions = (sessions: SessionCapability) => {

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -364,6 +364,184 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("dismisses session menus before keyboard, pointer, or narrow transitions hide them", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(
+            "agent:main:research",
+            "Research notes",
+            Date.parse("2026-07-01T15:00:00.000Z"),
+          ),
+        ]),
+        "sessions.patch": {},
+      },
+      sessionKey: "agent:main:main",
+    });
+    const dialogs: string[] = [];
+    page.on("dialog", (dialog) => {
+      dialogs.push(dialog.message());
+      void dialog.dismiss();
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const row = sidebar.locator(
+        '.sidebar-recent-session[data-session-key="agent:main:research"]',
+      );
+      const shell = page.locator(".shell");
+      const shellNav = page.locator(".shell-nav");
+      const panelToggle = page.locator(".topbar-panel-toggle");
+      const sessionMenu = sidebar.locator("openclaw-session-menu");
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+
+      const openSessionMenu = async () => {
+        await row.hover();
+        await row.getByRole("button", { name: "Open session menu" }).click();
+        await page
+          .getByRole("menu", { name: "Actions for Research notes" })
+          .waitFor({ state: "visible" });
+      };
+      const expectPanelCollapsed = async () => {
+        await expect.poll(() => sidebar.isVisible()).toBe(false);
+      };
+      const expectDrawerClosed = async () => {
+        await expect
+          .poll(() => shell.getAttribute("class"))
+          .not.toContain("shell--nav-drawer-open");
+        await expect
+          .poll(() => shellNav.evaluate((element) => element.getBoundingClientRect().right))
+          .toBeLessThanOrEqual(0);
+      };
+      const expectDismissedWithToggleFocus = async () => {
+        await expect.poll(() => sessionMenu.count()).toBe(0);
+        await expect
+          .poll(() => panelToggle.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+      };
+      const observeHiddenMenuAction = async (
+        shortcut: "p" | "a" | "d",
+        before: { deletes: number; dialogs: number; patches: number },
+      ) => {
+        const menuMounted = (await sessionMenu.count()) > 0;
+        const toggleFocused = await panelToggle.evaluate(
+          (element) => element === document.activeElement,
+        );
+        await page.keyboard.press(shortcut);
+        await page.waitForTimeout(150);
+        return {
+          deleteDelta: (await gateway.getRequests("sessions.delete")).length - before.deletes,
+          dialogDelta: dialogs.length - before.dialogs,
+          menuMounted,
+          patchDelta: (await gateway.getRequests("sessions.patch")).length - before.patches,
+          shortcut,
+          toggleFocused,
+        };
+      };
+
+      const keyboardObservations = [];
+      for (const shortcut of ["p", "a", "d"] as const) {
+        await openSessionMenu();
+        const before = {
+          deletes: (await gateway.getRequests("sessions.delete")).length,
+          dialogs: dialogs.length,
+          patches: (await gateway.getRequests("sessions.patch")).length,
+        };
+        await page.keyboard.press("Meta+B");
+        await expectPanelCollapsed();
+        keyboardObservations.push(await observeHiddenMenuAction(shortcut, before));
+        await panelToggle.click();
+        await expect.poll(() => sidebar.isVisible()).toBe(true);
+      }
+      expect(keyboardObservations).toEqual(
+        ["p", "a", "d"].map((shortcut) => ({
+          deleteDelta: 0,
+          dialogDelta: 0,
+          menuMounted: false,
+          patchDelta: 0,
+          shortcut,
+          toggleFocused: true,
+        })),
+      );
+
+      await openSessionMenu();
+      const beforePointerCollapse = {
+        deletes: (await gateway.getRequests("sessions.delete")).length,
+        dialogs: dialogs.length,
+        patches: (await gateway.getRequests("sessions.patch")).length,
+      };
+      await panelToggle.click();
+      await expectPanelCollapsed();
+      await expectDismissedWithToggleFocus();
+      for (const shortcut of ["p", "a", "d"] as const) {
+        expect(await observeHiddenMenuAction(shortcut, beforePointerCollapse)).toMatchObject({
+          deleteDelta: 0,
+          dialogDelta: 0,
+          patchDelta: 0,
+          shortcut,
+        });
+      }
+
+      await panelToggle.click();
+      await expect.poll(() => sidebar.isVisible()).toBe(true);
+      await openSessionMenu();
+      const beforeNarrowTransition = {
+        deletes: (await gateway.getRequests("sessions.delete")).length,
+        dialogs: dialogs.length,
+        patches: (await gateway.getRequests("sessions.patch")).length,
+      };
+      await page.setViewportSize({ height: 900, width: 900 });
+      await expectDrawerClosed();
+      await expect.poll(() => sessionMenu.count()).toBe(0);
+      for (const shortcut of ["p", "a", "d"] as const) {
+        expect(await observeHiddenMenuAction(shortcut, beforeNarrowTransition)).toMatchObject({
+          deleteDelta: 0,
+          dialogDelta: 0,
+          patchDelta: 0,
+          shortcut,
+        });
+      }
+
+      const drawerToggle = page.locator(".topbar-nav-toggle");
+      await drawerToggle.click();
+      await expect.poll(() => shell.getAttribute("class")).toContain("shell--nav-drawer-open");
+      await expect
+        .poll(() => shellNav.evaluate((element) => element.getBoundingClientRect().left))
+        .toBe(0);
+      await openSessionMenu();
+      const beforeDrawerCollapse = {
+        deletes: (await gateway.getRequests("sessions.delete")).length,
+        dialogs: dialogs.length,
+        patches: (await gateway.getRequests("sessions.patch")).length,
+      };
+      await page.keyboard.press("Meta+B");
+      await expectDrawerClosed();
+      await expect.poll(() => sessionMenu.count()).toBe(0);
+      await expect
+        .poll(() => drawerToggle.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      for (const shortcut of ["p", "a", "d"] as const) {
+        expect(await observeHiddenMenuAction(shortcut, beforeDrawerCollapse)).toMatchObject({
+          deleteDelta: 0,
+          dialogDelta: 0,
+          patchDelta: 0,
+          shortcut,
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
   it("archives a session from the Sessions page context menu and kebab", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -365,7 +365,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
-  it("dismisses session menus before keyboard, pointer, or narrow transitions hide them", async () => {
+  it("dismisses fixed session menus before the sidebar or drawer hides", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -400,8 +400,12 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       );
       const shell = page.locator(".shell");
       const shellNav = page.locator(".shell-nav");
-      const panelToggle = page.locator(".topbar-panel-toggle");
-      const sessionMenu = sidebar.locator("openclaw-session-menu");
+      const collapseButton = sidebar
+        .locator(".sidebar-brand")
+        .getByRole("button", { name: "Collapse sidebar" });
+      const expandButton = page.locator(".shell-nav-expand");
+      const drawerToggle = page.locator(".topbar-nav-toggle");
+      const sessionMenu = page.getByRole("menu", { name: "Actions for Research notes" });
       await row.waitFor({ state: "visible", timeout: 10_000 });
 
       const openSessionMenu = async () => {
@@ -411,8 +415,12 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
           .getByRole("menu", { name: "Actions for Research notes" })
           .waitFor({ state: "visible" });
       };
-      const expectPanelCollapsed = async () => {
+      const expectDesktopCollapsed = async () => {
         await expect.poll(() => sidebar.isVisible()).toBe(false);
+        await expect.poll(() => expandButton.isVisible()).toBe(true);
+        await expect
+          .poll(() => expandButton.evaluate((element) => element === document.activeElement))
+          .toBe(true);
       };
       const expectDrawerClosed = async () => {
         await expect
@@ -422,121 +430,71 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
           .poll(() => shellNav.evaluate((element) => element.getBoundingClientRect().right))
           .toBeLessThanOrEqual(0);
       };
-      const expectDismissedWithToggleFocus = async () => {
-        await expect.poll(() => sessionMenu.count()).toBe(0);
-        await expect
-          .poll(() => panelToggle.evaluate((element) => element === document.activeElement))
-          .toBe(true);
-      };
-      const observeHiddenMenuAction = async (
-        shortcut: "p" | "a" | "d",
-        before: { deletes: number; dialogs: number; patches: number },
+      const hiddenActionCounts = async () => ({
+        dialogs: dialogs.length,
+        patches: (await gateway.getRequests("sessions.patch")).length,
+      });
+      const expectHiddenShortcutsInert = async (
+        before: Awaited<ReturnType<typeof hiddenActionCounts>>,
       ) => {
-        const menuMounted = (await sessionMenu.count()) > 0;
-        const toggleFocused = await panelToggle.evaluate(
-          (element) => element === document.activeElement,
+        for (const shortcut of ["p", "a", "d"] as const) {
+          await page.keyboard.press(shortcut);
+        }
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }),
         );
-        await page.keyboard.press(shortcut);
-        await page.waitForTimeout(150);
-        return {
-          deleteDelta: (await gateway.getRequests("sessions.delete")).length - before.deletes,
-          dialogDelta: dialogs.length - before.dialogs,
-          menuMounted,
-          patchDelta: (await gateway.getRequests("sessions.patch")).length - before.patches,
-          shortcut,
-          toggleFocused,
-        };
+        expect(await hiddenActionCounts()).toEqual(before);
       };
 
-      const keyboardObservations = [];
-      for (const shortcut of ["p", "a", "d"] as const) {
-        await openSessionMenu();
-        const before = {
-          deletes: (await gateway.getRequests("sessions.delete")).length,
-          dialogs: dialogs.length,
-          patches: (await gateway.getRequests("sessions.patch")).length,
-        };
-        await page.keyboard.press("Meta+B");
-        await expectPanelCollapsed();
-        keyboardObservations.push(await observeHiddenMenuAction(shortcut, before));
-        await panelToggle.click();
-        await expect.poll(() => sidebar.isVisible()).toBe(true);
-      }
-      expect(keyboardObservations).toEqual(
-        ["p", "a", "d"].map((shortcut) => ({
-          deleteDelta: 0,
-          dialogDelta: 0,
-          menuMounted: false,
-          patchDelta: 0,
-          shortcut,
-          toggleFocused: true,
-        })),
-      );
-
+      // Keyboard collapse bypasses the menu's outside-pointer handler. The shell
+      // must explicitly unmount it before the sidebar becomes display:none.
       await openSessionMenu();
-      const beforePointerCollapse = {
-        deletes: (await gateway.getRequests("sessions.delete")).length,
-        dialogs: dialogs.length,
-        patches: (await gateway.getRequests("sessions.patch")).length,
-      };
-      await panelToggle.click();
-      await expectPanelCollapsed();
-      await expectDismissedWithToggleFocus();
-      for (const shortcut of ["p", "a", "d"] as const) {
-        expect(await observeHiddenMenuAction(shortcut, beforePointerCollapse)).toMatchObject({
-          deleteDelta: 0,
-          dialogDelta: 0,
-          patchDelta: 0,
-          shortcut,
-        });
-      }
+      const beforeKeyboardCollapse = await hiddenActionCounts();
+      await page.keyboard.press("Meta+B");
+      await expectDesktopCollapsed();
+      await expect.poll(() => sessionMenu.count()).toBe(0);
+      await expectHiddenShortcutsInert(beforeKeyboardCollapse);
 
-      await panelToggle.click();
+      await expandButton.click();
       await expect.poll(() => sidebar.isVisible()).toBe(true);
+
+      // The visible desktop control follows the same focus handoff contract.
       await openSessionMenu();
-      const beforeNarrowTransition = {
-        deletes: (await gateway.getRequests("sessions.delete")).length,
-        dialogs: dialogs.length,
-        patches: (await gateway.getRequests("sessions.patch")).length,
-      };
+      await collapseButton.click();
+      await expectDesktopCollapsed();
+      await expect.poll(() => sessionMenu.count()).toBe(0);
+      await expandButton.click();
+      await expect.poll(() => sidebar.isVisible()).toBe(true);
+
+      // Crossing into drawer layout hides the desktop sidebar without toggling
+      // persisted collapse state, so resize owns this dismissal and focus move.
+      await openSessionMenu();
+      const beforeNarrowTransition = await hiddenActionCounts();
       await page.setViewportSize({ height: 900, width: 900 });
       await expectDrawerClosed();
       await expect.poll(() => sessionMenu.count()).toBe(0);
-      for (const shortcut of ["p", "a", "d"] as const) {
-        expect(await observeHiddenMenuAction(shortcut, beforeNarrowTransition)).toMatchObject({
-          deleteDelta: 0,
-          dialogDelta: 0,
-          patchDelta: 0,
-          shortcut,
-        });
-      }
+      await expect
+        .poll(() => drawerToggle.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await expectHiddenShortcutsInert(beforeNarrowTransition);
 
-      const drawerToggle = page.locator(".topbar-nav-toggle");
       await drawerToggle.click();
       await expect.poll(() => shell.getAttribute("class")).toContain("shell--nav-drawer-open");
       await expect
         .poll(() => shellNav.evaluate((element) => element.getBoundingClientRect().left))
         .toBe(0);
       await openSessionMenu();
-      const beforeDrawerCollapse = {
-        deletes: (await gateway.getRequests("sessions.delete")).length,
-        dialogs: dialogs.length,
-        patches: (await gateway.getRequests("sessions.patch")).length,
-      };
+      const beforeDrawerCollapse = await hiddenActionCounts();
       await page.keyboard.press("Meta+B");
       await expectDrawerClosed();
       await expect.poll(() => sessionMenu.count()).toBe(0);
       await expect
         .poll(() => drawerToggle.evaluate((element) => element === document.activeElement))
         .toBe(true);
-      for (const shortcut of ["p", "a", "d"] as const) {
-        expect(await observeHiddenMenuAction(shortcut, beforeDrawerCollapse)).toMatchObject({
-          deleteDelta: 0,
-          dialogDelta: 0,
-          patchDelta: 0,
-          shortcut,
-        });
-      }
+      await expectHiddenShortcutsInert(beforeDrawerCollapse);
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Closes #103499
Related: #103426, #103561, #103612

AI-assisted: implemented and reviewed with Codex.

## What Problem This Solves

Collapsing the Control UI sidebar or closing its narrow drawer could leave an open session menu mounted and keyboard-active after it became invisible. Bare `P`, `A`, or `D` could then pin, archive, or open delete confirmation from hidden UI.

## Why This Change Was Made

The app sidebar now owns one public transient-menu dismissal operation. The shell calls it before desktop collapse, drawer close, and desktop-to-drawer breakpoint hiding, while preserving the keyboard-menu behavior landed in #103612.

Focus moves to the current visible navigation control: `.shell-nav-expand` after desktop collapse and `.topbar-nav-toggle` after drawer or breakpoint hiding. No deleted topbar compatibility path remains.

## User Impact

Invisible sidebar menus no longer respond to session shortcuts. Collapsing navigation or crossing into drawer layout leaves keyboard focus on the visible control that can reopen it.

## Evidence

Final rebased PR head: `e614a08e82a5b340163fb77b7a8fb0804c72debc` on `0bf2c7aedbbb5d86741b53c47f1215f48f897c0d`.

Blacksmith Testbox through Crabbox: `tbx_01kx5p0sze75mw9kbk6z2vfsbz`.

- Current-main baseline: the old regression proof failed waiting for deleted `.topbar-panel-toggle`, proving it no longer exercised #103561's sidebar contract.
- Focused repaired E2E: 1 passed; explicitly verifies hidden `P`, `A`, and `D` produce no patch or dialog.
- Integrated UI proof after #103612: 14 Playwright E2E tests passed across session management and sidebar customization.
- Adjacent unit proof: 22 tests passed across app host, app sidebar, and session menu.
- Targeted formatting passed.
- Path-scoped `check:changed` and fresh branch autoreview run before landing.

## Release Note Context

Control UI: dismiss session menus before hiding the sidebar or drawer so invisible single-key actions cannot mutate sessions, and restore focus to the current navigation toggle.
