### PR TITLE
fix(auto-reply): treat U+2028/U+2029 as paragraph boundaries when chunking

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -6,6 +6,7 @@ import * as fences from "../../packages/markdown-core/src/fences.js";
 import { hasBalancedFences } from "../test-utils/chunk-test-helpers.js";
 import {
   chunkByNewline,
+  chunkByParagraph,
   chunkMarkdownText,
   chunkMarkdownTextWithMode,
   chunkText,
@@ -228,6 +229,17 @@ describe("chunkText", () => {
   runChunkCases(chunkText, [
     expectDefined(parentheticalCases[0], "parentheticalCases[0] test invariant"),
   ]);
+});
+
+describe("chunkByParagraph Unicode line/paragraph separators", () => {
+  it("treats U+2028 and U+2029 as paragraph boundaries like a blank line", () => {
+    // Model output can carry LINE SEPARATOR / PARAGRAPH SEPARATOR instead of \n\n.
+    const unicode = chunkByParagraph("paragraph one line\u2028\u2029paragraph two starts here", 40);
+    const newlines = chunkByParagraph("paragraph one line\n\nparagraph two starts here", 40);
+
+    expect(unicode).toEqual(["paragraph one line", "paragraph two starts here"]);
+    expect(unicode).toEqual(newlines);
+  });
 });
 
 describe("resolveTextChunkLimit", () => {

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -232,13 +232,33 @@ describe("chunkText", () => {
 });
 
 describe("chunkByParagraph Unicode line/paragraph separators", () => {
-  it("treats U+2028 and U+2029 as paragraph boundaries like a blank line", () => {
-    // Model output can carry LINE SEPARATOR / PARAGRAPH SEPARATOR instead of \n\n.
-    const unicode = chunkByParagraph("paragraph one line\u2028\u2029paragraph two starts here", 40);
-    const newlines = chunkByParagraph("paragraph one line\n\nparagraph two starts here", 40);
+  it("treats lone U+2029 as a standalone paragraph boundary", () => {
+    // PARAGRAPH SEPARATOR is the semantic equivalent of a blank line.
+    // Use a limit small enough to force the split (normalized text is 40 chars).
+    const result = chunkByParagraph("paragraph one\u2029paragraph two starts here", 39);
+    const expected = chunkByParagraph("paragraph one\n\nparagraph two starts here", 39);
 
-    expect(unicode).toEqual(["paragraph one line", "paragraph two starts here"]);
-    expect(unicode).toEqual(newlines);
+    expect(result).toEqual(["paragraph one", "paragraph two starts here"]);
+    // Output is identical to \n\n (blank-line) input.
+    expect(result).toEqual(expected);
+  });
+
+  it("treats lone U+2028 as a single line break within one paragraph", () => {
+    // LINE SEPARATOR is a single newline \u2014 no blank line, so the paragraph stays intact.
+    const result = chunkByParagraph("paragraph one line\u2028still same paragraph", 50);
+    const expected = chunkByParagraph("paragraph one line\nstill same paragraph", 50);
+
+    expect(result).toEqual(["paragraph one line\nstill same paragraph"]);
+    expect(result).toEqual(expected);
+  });
+
+  it("treats consecutive U+2028 and U+2029 as a paragraph boundary", () => {
+    // U+2029 \u2192 \n\n, U+2028 \u2192 \n \u2192 combined they form a blank line.
+    const result = chunkByParagraph("paragraph one line\u2028\u2029paragraph two starts here", 40);
+    const expected = chunkByParagraph("paragraph one line\n\nparagraph two starts here", 40);
+
+    expect(result).toEqual(["paragraph one line", "paragraph two starts here"]);
+    expect(result).toEqual(expected);
   });
 });
 

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -232,33 +232,33 @@ describe("chunkText", () => {
 });
 
 describe("chunkByParagraph Unicode line/paragraph separators", () => {
-  it("treats lone U+2029 as a standalone paragraph boundary", () => {
-    // PARAGRAPH SEPARATOR is the semantic equivalent of a blank line.
-    // Use a limit small enough to force the split (normalized text is 40 chars).
-    const result = chunkByParagraph("paragraph one\u2029paragraph two starts here", 39);
-    const expected = chunkByParagraph("paragraph one\n\nparagraph two starts here", 39);
+  it.each([
+    {
+      name: "treats lone U+2029 as a standalone paragraph boundary",
+      text: "paragraph one\u2029paragraph two starts here",
+      normalized: "paragraph one\n\nparagraph two starts here",
+      limit: 39,
+      expected: ["paragraph one", "paragraph two starts here"],
+    },
+    {
+      name: "treats lone U+2028 as a line break within one paragraph",
+      text: "paragraph one line\u2028still same paragraph",
+      normalized: "paragraph one line\nstill same paragraph",
+      limit: 50,
+      expected: ["paragraph one line\nstill same paragraph"],
+    },
+    {
+      name: "treats consecutive U+2028 and U+2029 as a paragraph boundary",
+      text: "paragraph one line\u2028\u2029paragraph two starts here",
+      normalized: "paragraph one line\n\nparagraph two starts here",
+      limit: 40,
+      expected: ["paragraph one line", "paragraph two starts here"],
+    },
+  ] as const)("$name", ({ text, normalized, limit, expected }) => {
+    const chunks = chunkByParagraph(text, limit);
 
-    expect(result).toEqual(["paragraph one", "paragraph two starts here"]);
-    // Output is identical to \n\n (blank-line) input.
-    expect(result).toEqual(expected);
-  });
-
-  it("treats lone U+2028 as a single line break within one paragraph", () => {
-    // LINE SEPARATOR is a single newline \u2014 no blank line, so the paragraph stays intact.
-    const result = chunkByParagraph("paragraph one line\u2028still same paragraph", 50);
-    const expected = chunkByParagraph("paragraph one line\nstill same paragraph", 50);
-
-    expect(result).toEqual(["paragraph one line\nstill same paragraph"]);
-    expect(result).toEqual(expected);
-  });
-
-  it("treats consecutive U+2028 and U+2029 as a paragraph boundary", () => {
-    // U+2029 \u2192 \n\n, U+2028 \u2192 \n \u2192 combined they form a blank line.
-    const result = chunkByParagraph("paragraph one line\u2028\u2029paragraph two starts here", 40);
-    const expected = chunkByParagraph("paragraph one line\n\nparagraph two starts here", 40);
-
-    expect(result).toEqual(["paragraph one line", "paragraph two starts here"]);
-    expect(result).toEqual(expected);
+    expect(chunks).toEqual(expected);
+    expect(chunks).toEqual(chunkByParagraph(normalized, limit));
   });
 });
 

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -207,8 +207,9 @@ export function chunkByParagraph(
   }
   const splitLongParagraphs = opts?.splitLongParagraphs !== false;
 
-  // Normalize to \n so blank line detection is consistent.
-  const normalized = text.replace(/\r\n?/g, "\n");
+  // Normalize CR/CRLF and Unicode line/paragraph separators (U+2028/U+2029) to
+  // \n so blank-line paragraph detection is consistent for all line endings.
+  const normalized = text.replace(/\r\n?|[\u2028\u2029]/g, "\n");
 
   // Fast-path: if there are no blank-line paragraph separators, do not split.
   // (We *do not* early-return based on `limit` — newline mode is about paragraph

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -207,9 +207,10 @@ export function chunkByParagraph(
   }
   const splitLongParagraphs = opts?.splitLongParagraphs !== false;
 
-  // Normalize CR/CRLF and Unicode line/paragraph separators (U+2028/U+2029) to
-  // \n so blank-line paragraph detection is consistent for all line endings.
-  const normalized = text.replace(/\r\n?|[\u2028\u2029]/g, "\n");
+  // U+2029 PARAGRAPH SEPARATOR maps to a blank-line boundary; U+2028 LINE
+  // SEPARATOR and CR/CRLF map to a single newline.
+  // Normalize in two steps so consecutive U+2028\u2029 also produces a blank line.
+  const normalized = text.replace(/\u2029/g, "\n\n").replace(/\r\n?|\u2028/g, "\n");
 
   // Fast-path: if there are no blank-line paragraph separators, do not split.
   // (We *do not* early-return based on `limit` — newline mode is about paragraph


### PR DESCRIPTION
## What Problem This Solves

Model output can contain Unicode LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) characters. `chunkByParagraph()` normalizes `\r\n?` to `\n` for blank-line detection, but does not normalize U+2028/U+2029. When these characters appear instead of `\n\n`, the entire block stays as one fused chunk instead of splitting at paragraph boundaries — producing oversized message chunks on line-oriented channels.

## Why This Change Was Made

Two-step normalization:

1. **U+2029 → `\n\n`** (blank line): U+2029 PARAGRAPH SEPARATOR is semantically a paragraph boundary, equivalent to a blank line.
2. **U+2028 → `\n`** (single newline): U+2028 LINE SEPARATOR is a single line break within a paragraph.

The two-step order ensures consecutive U+2028  also produces a blank line (`\n` + `\n\n` = `\n\n\n` — blank line detected by `\n[\t ]*\n+`).

## User Impact

Prevents oversized single-chunk messages on line-oriented channels (WhatsApp, Telegram, Slack, Signal, iMessage, Discord) when model output contains Unicode line/paragraph separators instead of standard `\n\n`.

## Evidence

### Proof: standalone U+2029 splits at paragraph boundary

```
$ node --import tsx -e '
import { chunkByParagraph } from "./src/auto-reply/chunk.ts";
// Lone U+2029: must split (old code: stayed fused as one chunk)
const r = chunkByParagraph("paragraph one paragraph two starts here", 39);
console.log(JSON.stringify(r));
'
["paragraph one","paragraph two starts here"]
```

**Before fix**: standalone ` ` → `\n` (single LF) → blank-line detector `\n\n+` finds nothing → `["paragraph one\nparagraph two starts here"]` — **fused as one chunk**  
**After fix**: standalone ` ` → `\n\n` (blank line) → detector matches → `["paragraph one", "paragraph two starts here"]` — **splits at paragraph boundary**

### Proof: standalone U+2028 stays as intra-paragraph line break

```
$ node --import tsx -e '
import { chunkByParagraph } from "./src/auto-reply/chunk.ts";
const r = chunkByParagraph("line one line two same paragraph", 50);
console.log(JSON.stringify(r));
'
["line one\nline two same paragraph"]
```

**U+2028 → `\n` — single newline, no blank line → stays within one paragraph.** Matches standard `\n` behavior.

### Proof: consecutive U+2028  forms blank line

```
$ node --import tsx -e '
import { chunkByParagraph } from "./src/auto-reply/chunk.ts";
const unicode = chunkByParagraph("paragraph one line  paragraph two starts here", 40);
const newlines = chunkByParagraph("paragraph one line\n\nparagraph two starts here", 40);
console.log(JSON.stringify({unicode, newlines, match: unicode[0] === newlines[0] && unicode[1] === newlines[1]}));
'
{"unicode":["paragraph one line","paragraph two starts here"],"newlines":["paragraph one line","paragraph two starts here"],"match":true}
```

### Observed result

| Input | Behavior | Match \n\n? |
|-------|----------|------------|
| lone U+2029 | → `\n\n` → splits into 2 paragraphs | ✅ |
| lone U+2028 | → `\n` → stays in 1 paragraph | ✅ |
| U+2028  | → `\n\n\n` → splits into 2 paragraphs | ✅ |

### What was not tested

Live model output carrying real Unicode separators on a channel.

## Regression Test Plan

```
$ node scripts/run-vitest.mjs src/auto-reply/chunk.test.ts --run
Test Files  1 passed (1)
     Tests  71 passed (71)
```

```
$ npx oxlint src/auto-reply/chunk.ts src/auto-reply/chunk.test.ts — exit 0
```

```
$ git diff upstream/main --stat — 2 files changed, 30 insertions(+), 9 deletions(-)
```

Three new tests:
1. Lone U+2029 → paragraph boundary (old test only covered consecutive U+2028 )
2. Lone U+2028 → single line break within paragraph
3. Consecutive U+2028  → combined blank line → identical output to \n\n

Branch rebased on upstream main.

## Root Cause

In `chunkByParagraph()` (`src/auto-reply/chunk.ts:209`), the normalization regex `/ \r\n?|[  ]/g` maps both U+2028 and U+2029 to a single `\n`. But paragraph detection requires a blank-line sequence `\n\n+`. Standalone U+2029 produces only one `\n`, so the blank-line detector never fires — the paragraph remains fused. The original test accidentally masked this because it placed U+2028 and U+2029 consecutively, producing two normalized `\n` characters that formed the required blank line. The fix uses a two-step normalization: U+2029 (= paragraph break) maps to `\n\n` first, then U+2028/U+2028/rn? (= line break) map to `\n`.

AI-assisted. Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>