### PR TITLE
fix(agents): surface provider server-side model fallbacks as lifecycle fallback_step events

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -31,6 +31,7 @@ import type {
 } from "./embedded-agent-subscribe.handlers.types.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
+import { emitProviderFallbackLifecycleSteps } from "./embedded-agent-subscribe.provider-fallback-notice.js";
 import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import { warnIfAssistantEmittedToolText } from "./embedded-agent-subscribe.tool-text-diagnostics.js";
 import {
@@ -1055,6 +1056,13 @@ export function handleMessageEnd(
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
+  // Surface provider-served (server-side) model fallbacks before any
+  // visible-output suppression: a served-by-fallback turn should update
+  // status surfaces even when the reply text itself is suppressed.
+  emitProviderFallbackLifecycleSteps(
+    ctx,
+    assistantMessage as { model?: unknown; diagnostics?: unknown },
+  );
   if (suppressVisibleAssistantOutput) {
     const commentaryText = coerceChatContentText(extractAssistantCommentaryText(assistantMessage));
     appendRawStream({

--- a/src/agents/embedded-agent-subscribe.provider-fallback-notice.test.ts
+++ b/src/agents/embedded-agent-subscribe.provider-fallback-notice.test.ts
@@ -1,0 +1,153 @@
+// Covers bridging provider_fallback assistant-message diagnostics to
+// lifecycle fallback_step events (Anthropic server-side Fable 5 -> Opus 4.8).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitProviderFallbackLifecycleSteps } from "./embedded-agent-subscribe.provider-fallback-notice.js";
+
+const { emitAgentEventMock } = vi.hoisted(() => ({
+  emitAgentEventMock: vi.fn(),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: emitAgentEventMock,
+}));
+
+function createContext(
+  overrides?: Partial<{ sessionKey: string; agentId: string }>,
+) {
+  return {
+    params: {
+      runId: "run-1",
+      sessionKey: overrides?.sessionKey ?? "agent:main:main",
+      sessionId: "session-1",
+      ...(overrides?.agentId ? { agentId: overrides.agentId } : {}),
+    },
+  };
+}
+
+function providerFallbackMessage(details: Record<string, unknown>) {
+  return {
+    role: "assistant",
+    model: "claude-fable-5",
+    diagnostics: [
+      { type: "provider_fallback", timestamp: Date.now(), details },
+    ],
+  };
+}
+
+describe("emitProviderFallbackLifecycleSteps", () => {
+  beforeEach(() => {
+    emitAgentEventMock.mockClear();
+  });
+
+  it("emits a lifecycle fallback_step event for a provider_fallback diagnostic", () => {
+    const emitted = emitProviderFallbackLifecycleSteps(
+      createContext(),
+      providerFallbackMessage({
+        provider: "anthropic",
+        fromModel: "claude-fable-5",
+        toModel: "claude-opus-4-8",
+      }),
+    );
+
+    expect(emitted).toBe(1);
+    expect(emitAgentEventMock).toHaveBeenCalledTimes(1);
+    expect(emitAgentEventMock).toHaveBeenCalledWith({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        fallbackStepSource: "provider_server_side",
+        fallbackStepFromModel: "anthropic/claude-fable-5",
+        fallbackStepToModel: "anthropic/claude-opus-4-8",
+        fallbackStepFromFailureDetail:
+          "provider safety classifier declined the request; the provider served the response on its fallback model",
+        fallbackStepFinalOutcome: "succeeded",
+      },
+    });
+  });
+
+  it("falls back to the message model when the boundary omits fromModel", () => {
+    const emitted = emitProviderFallbackLifecycleSteps(
+      createContext(),
+      providerFallbackMessage({
+        provider: "anthropic",
+        fromModel: null,
+        toModel: "claude-opus-4-8",
+      }),
+    );
+
+    expect(emitted).toBe(1);
+    const data = emitAgentEventMock.mock.calls[0]?.[0]?.data;
+    expect(data?.fallbackStepFromModel).toBe("anthropic/claude-fable-5");
+    expect(data?.fallbackStepToModel).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("omits fromModel when neither the boundary nor the message name one", () => {
+    const emitted = emitProviderFallbackLifecycleSteps(
+      { params: { runId: "run-1" } },
+      {
+        diagnostics: [
+          {
+            type: "provider_fallback",
+            timestamp: Date.now(),
+            details: {
+              provider: "anthropic",
+              fromModel: null,
+              toModel: "claude-opus-4-8",
+            },
+          },
+        ],
+      },
+    );
+
+    expect(emitted).toBe(1);
+    const data = emitAgentEventMock.mock.calls[0]?.[0]?.data;
+    expect(data).not.toHaveProperty("fallbackStepFromModel");
+    expect(data?.fallbackStepToModel).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("does not emit without a provider_fallback diagnostic", () => {
+    expect(
+      emitProviderFallbackLifecycleSteps(createContext(), {
+        model: "claude-fable-5",
+        diagnostics: [{ type: "other_diagnostic", timestamp: Date.now() }],
+      }),
+    ).toBe(0);
+    expect(
+      emitProviderFallbackLifecycleSteps(createContext(), {
+        model: "claude-fable-5",
+      }),
+    ).toBe(0);
+    expect(emitAgentEventMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit when the diagnostic lacks a serving model", () => {
+    const emitted = emitProviderFallbackLifecycleSteps(
+      createContext(),
+      providerFallbackMessage({
+        provider: "anthropic",
+        fromModel: "claude-fable-5",
+        toModel: null,
+      }),
+    );
+
+    expect(emitted).toBe(0);
+    expect(emitAgentEventMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit when the diagnostic lacks a provider", () => {
+    const emitted = emitProviderFallbackLifecycleSteps(
+      createContext(),
+      providerFallbackMessage({
+        fromModel: "claude-fable-5",
+        toModel: "claude-opus-4-8",
+      }),
+    );
+
+    expect(emitted).toBe(0);
+    expect(emitAgentEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-subscribe.provider-fallback-notice.ts
+++ b/src/agents/embedded-agent-subscribe.provider-fallback-notice.ts
@@ -1,0 +1,103 @@
+/**
+ * Surfaces provider-side (server-side) model fallbacks as lifecycle
+ * fallback_step events.
+ *
+ * Anthropic can re-serve a Claude Fable 5 request that its safety classifiers
+ * declined on Claude Opus 4.8 within a single API call (server-side fallback).
+ * The transport layer records that switch as a `provider_fallback` diagnostic
+ * on the assistant message and re-attributes `responseModel`, but nothing
+ * announced it: status surfaces kept showing the requested model and the turn
+ * looked like a normal reply. This module bridges the recorded diagnostic to
+ * the same lifecycle `fallback_step` event shape the model-failover chain
+ * emits, so existing consumers (TUI model indicator, observability sinks)
+ * present provider-served fallbacks exactly like chain fallbacks.
+ */
+import { emitAgentEvent } from "../infra/agent-events.js";
+
+/** Session identity fields forwarded onto the lifecycle event. */
+export type ProviderFallbackLifecycleRunParams = {
+  runId: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  lifecycleGeneration?: string;
+};
+
+type ProviderFallbackDetails = {
+  provider?: unknown;
+  fromModel?: unknown;
+  toModel?: unknown;
+};
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Formats a `provider/model` ref, the shape fallback_step consumers parse. */
+function formatProviderModelRef(
+  provider: string,
+  model: unknown,
+): string | undefined {
+  const id = readNonEmptyString(model);
+  return id ? `${provider}/${id}` : undefined;
+}
+
+/**
+ * Emits one lifecycle fallback_step event per provider_fallback diagnostic on
+ * the assistant message. Returns the number of events emitted.
+ */
+export function emitProviderFallbackLifecycleSteps(
+  ctx: { params: ProviderFallbackLifecycleRunParams },
+  message: { model?: unknown; diagnostics?: unknown },
+): number {
+  const diagnostics = Array.isArray(message?.diagnostics)
+    ? message.diagnostics
+    : [];
+  let emitted = 0;
+  for (const diagnostic of diagnostics) {
+    if (!diagnostic || typeof diagnostic !== "object") {
+      continue;
+    }
+    const record = diagnostic as { type?: unknown; details?: unknown };
+    if (record.type !== "provider_fallback") {
+      continue;
+    }
+    const details = (record.details ?? {}) as ProviderFallbackDetails;
+    const provider = readNonEmptyString(details.provider);
+    if (!provider) {
+      continue;
+    }
+    const toModel = formatProviderModelRef(provider, details.toModel);
+    if (!toModel) {
+      // Without a serving model there is nothing for consumers to present.
+      continue;
+    }
+    const fromModel =
+      formatProviderModelRef(provider, details.fromModel) ??
+      formatProviderModelRef(provider, message?.model);
+    emitAgentEvent({
+      runId: ctx.params.runId,
+      ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
+      ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
+      ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
+      ...(ctx.params.lifecycleGeneration
+        ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
+        : {}),
+      stream: "lifecycle",
+      data: {
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        // Distinguishes provider-served fallbacks from OpenClaw chain steps
+        // without changing how existing consumers parse the shared fields.
+        fallbackStepSource: "provider_server_side",
+        ...(fromModel ? { fallbackStepFromModel: fromModel } : {}),
+        fallbackStepToModel: toModel,
+        fallbackStepFromFailureDetail:
+          "provider safety classifier declined the request; the provider served the response on its fallback model",
+        fallbackStepFinalOutcome: "succeeded",
+      },
+    });
+    emitted += 1;
+  }
+  return emitted;
+}


### PR DESCRIPTION
## Problem

Since #99906, Anthropic can re-serve a Claude Fable 5 request that its safety classifiers declined on Claude Opus 4.8 within a single API call (server-side fallback). The transport layer records the switch as a `provider_fallback` diagnostic on the assistant message and re-attributes `responseModel` — but nothing announces it. The TUI model indicator keeps showing the requested model, and the turn looks like a normal reply. Operators only discover the capability swap by inspecting webchat message details or the raw transcript.

This matters in practice: the `cyber`/`bio` classifiers are documented to false-positive on benign security and life-sciences work, so users doing exactly that work silently get Opus-served answers mid-conversation.

## Fix

Bridge the recorded diagnostic to the lifecycle `fallback_step` event shape the model-failover chain already emits (`phase: "fallback_step"`, `fallbackStepToModel: "provider/model"`). Existing consumers — the TUI model indicator (`applyFallbackStepModelUpdate`) and observability sinks — then present provider-served fallbacks exactly like chain fallbacks, with zero TUI changes.

- New `embedded-agent-subscribe.provider-fallback-notice.ts`: scans assistant-message diagnostics for `provider_fallback`, emits one lifecycle event per diagnostic. `fallbackStepSource: "provider_server_side"` distinguishes provider-served steps from chain steps without changing how current consumers parse the shared fields. Falls back to the message model when the boundary block omits `fromModel`; skips entries without a serving model.
- Wired into `handleMessageEnd` before visible-output suppression, so a served-by-fallback turn updates status surfaces even when reply text is suppressed.

## Relationship to in-flight work

#99472 (refusals trigger the OpenClaw fallback chain) covers the *client-side* chain path, which already has visible UX via these same events. This PR covers the *server-side* path from #99906, reusing the identical event shape so both mechanisms present uniformly. No conflict — different emission points.

## Testing

- New unit tests (6 cases: happy path, fromModel fallback, fromModel omission, no-diagnostic, missing toModel, missing provider) — pass in both shards
- `embedded-agent-subscribe.handlers.messages.test.ts` — 90/90 pass with the wire-in
- `pnpm tsgo:core` clean, oxlint clean, prettier applied