### PR TITLE
fix(google-meet): actually leave the Meet call in the browser on leave (#103386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Google Meet browser departure:** leave and confirm the exact recorded Meet tab, preserve reused user-owned tabs, close plugin-owned tabs, and serialize shared-tab handoff and teardown so ended sessions cannot remain in calls. (#103386, #103522) Thanks @lonexreb.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.
 - **Gateway chat typecheck:** import chat event types from their owning protocol schema after the retired aggregate type module was removed, restoring full project typechecks.
 - **Packaged Crabbox commands:** include the lease-freshness helper imported by the published wrapper so `crabbox:*` commands do not fail with `ERR_MODULE_NOT_FOUND` in npm installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Google Meet browser departure:** leave and confirm the exact recorded Meet tab, preserve reused user-owned tabs, close plugin-owned tabs, and serialize shared-tab handoff and teardown so ended sessions cannot remain in calls. (#103386, #103522) Thanks @lonexreb.
+- **Google Meet browser departure:** leave and confirm the exact recorded Meet tab, preserve reused user-owned tabs, close plugin-owned tabs, serialize shared-tab handoff and teardown, and keep agent-triggered browser control inside the trusted Gateway runtime so ended sessions cannot remain in calls. (#103386, #103522) Thanks @lonexreb.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.
 - **Gateway chat typecheck:** import chat event types from their owning protocol schema after the retired aggregate type module was removed, restoring full project typechecks.
 - **Packaged Crabbox commands:** include the lease-freshness helper imported by the published wrapper so `crabbox:*` commands do not fail with `ERR_MODULE_NOT_FOUND` in npm installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Google Meet browser departure:** leave and confirm the exact recorded Meet tab, preserve reused user-owned tabs, close plugin-owned tabs, serialize shared-tab handoff and teardown, and keep agent-triggered browser control inside the trusted Gateway runtime so ended sessions cannot remain in calls. (#103386, #103522) Thanks @lonexreb.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.
 - **Gateway chat typecheck:** import chat event types from their owning protocol schema after the retired aggregate type module was removed, restoring full project typechecks.
 - **Packaged Crabbox commands:** include the lease-freshness helper imported by the published wrapper so `crabbox:*` commands do not fail with `ERR_MODULE_NOT_FOUND` in npm installs.

--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -838,13 +838,15 @@ Agents use the `google_meet` tool:
 | `attendance`            | List participants and participant sessions                                                        |
 | `export`                | Write the artifacts/attendance/transcript/manifest bundle; set `"dryRun": true` for manifest-only |
 | `recover_current_tab`   | Focus/inspect an existing Meet tab without opening a new one                                      |
-| `leave`                 | End a session (hangs up the underlying Twilio call for delegated sessions)                        |
+| `leave`                 | End a session (Chrome clicks Leave; closes only tabs it opened; Twilio hangs up)                  |
 | `end_active_conference` | End the active Google Meet conference for an API-managed space                                    |
 | `speak`                 | Make the realtime agent speak immediately, given `sessionId` and `message`                        |
 | `test_speech`           | Create/reuse a session, trigger a known phrase, return Chrome health                              |
 | `test_listen`           | Create/reuse an observe-only session, wait for caption/transcript movement                        |
 
 `test_speech` always forces `mode: "agent"` or `"bidi"` and fails if asked to run in `mode: "transcribe"`, because observe-only sessions cannot emit speech. Its `speechOutputVerified` result is based on realtime audio output bytes increasing during that call, so a reused session with older audio does not count as a fresh check.
+
+For Chrome transports, `leave` keeps a reused user-owned tab open after clicking Meet's Leave call button. Tabs opened by OpenClaw are closed after departure.
 
 Use `transport: "chrome"` when Chrome runs on the Gateway host, `transport: "chrome-node"` when it runs on a paired node. In both cases the model providers and `openclaw_agent_consult` run on the Gateway host, so model credentials stay there. Agent-mode logs include the resolved transcription provider/model at bridge startup and the TTS provider/model/voice/output format/sample rate after each synthesized reply. Raw `mode: "realtime"` is still accepted as a legacy compatibility alias for `mode: "agent"`, but it is no longer advertised in the tool's `mode` enum.
 

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -1472,6 +1472,33 @@ describe("google-meet plugin", () => {
     expect(gatewayJoinParams.requesterSessionKey).toBe("agent:main:discord:channel:general");
   });
 
+  it("requests admin scope only for the bundled tool Gateway fallback", async () => {
+    const { tools } = setup(
+      {},
+      { toolContext: { sessionKey: "agent:main:discord:channel:general" } },
+    );
+    const callGatewayFromCli = vi.fn(async () => ({ ok: true }));
+    googleMeetPluginTesting.setCallGatewayFromCliForTests(callGatewayFromCli);
+    const tool = tools[0] as {
+      execute: (id: string, params: unknown) => Promise<unknown>;
+    };
+
+    await tool.execute("id", {
+      action: "join",
+      url: "https://meet.google.com/abc-defg-hij",
+      mode: "transcribe",
+    });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "googlemeet.join",
+      expect.any(Object),
+      expect.objectContaining({
+        requesterSessionKey: "agent:main:discord:channel:general",
+      }),
+      { progress: false, scopes: ["operator.admin"] },
+    );
+  });
+
   it("keeps Twilio calls on the agent that invoked the tool", async () => {
     const { tools, gatewayRequest } = setup(
       { defaultTransport: "twilio" },
@@ -1496,13 +1523,42 @@ describe("google-meet plugin", () => {
         agentId: "support",
         requesterSessionKey: "agent:support:main",
       }),
-      { timeoutMs: 60_000 },
+      { timeoutMs: 60_000, scopes: ["operator.admin"] },
     );
     expect(voiceCallMocks.joinMeetViaVoiceCallGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "support",
         sessionKey: `agent:support:google-meet:${result.details.session.id}`,
       }),
+    );
+  });
+
+  it("derives trusted agent ownership from the invoking session key", async () => {
+    const { tools, gatewayRequest } = setup(
+      { defaultTransport: "twilio" },
+      {
+        gatewayAvailable: true,
+        toolContext: { sessionKey: "agent:support:pr103522-live" },
+      },
+    );
+    const tool = tools[0] as {
+      execute: (id: string, params: unknown) => Promise<{ details: { session: { id: string } } }>;
+    };
+
+    await tool.execute("id", {
+      action: "join",
+      url: "https://meet.google.com/abc-defg-hij",
+      dialInNumber: "+15551234567",
+      agentId: "spoofed",
+    });
+
+    expect(gatewayRequest).toHaveBeenCalledWith(
+      "googlemeet.join",
+      expect.objectContaining({
+        agentId: "support",
+        requesterSessionKey: "agent:support:pr103522-live",
+      }),
+      { timeoutMs: 60_000, scopes: ["operator.admin"] },
     );
   });
 
@@ -1564,7 +1620,7 @@ describe("google-meet plugin", () => {
         agentId: "support",
         requesterSessionKey: "agent:support:main",
       }),
-      { timeoutMs: 60_000 },
+      { timeoutMs: 60_000, scopes: ["operator.admin"] },
     );
     expect(result.details.session.agentId).toBe("support");
     expect(result.details.listenVerified).toBe(true);
@@ -5239,6 +5295,7 @@ describe("google-meet plugin", () => {
       await Promise.all([runtime.leave(first.session.id), runtime.leave(second.session.id)]);
       expect(leaveChromeMeet).toHaveBeenCalledOnce();
       expect(leaveChromeMeet).toHaveBeenCalledWith({
+        runtime: expect.any(Object),
         config: expect.any(Object),
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         tab: { targetId: "shared-meet-tab", openedByPlugin: true },
@@ -5301,6 +5358,7 @@ describe("google-meet plugin", () => {
       expect(stop).toHaveBeenCalledOnce();
       expect(leaveChromeMeet).toHaveBeenCalledOnce();
       expect(leaveChromeMeet).toHaveBeenCalledWith({
+        runtime: expect.any(Object),
         config: expect.any(Object),
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         tab: { targetId: "old-meet-tab", openedByPlugin: true },
@@ -5361,6 +5419,7 @@ describe("google-meet plugin", () => {
       expect(first.session.state).toBe("ended");
       expect(first.session.browserLeft).toBe(true);
       expect(leaveChromeMeet).toHaveBeenCalledWith({
+        runtime: expect.any(Object),
         config: expect.any(Object),
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         tab: { targetId: "retained-meet-tab", openedByPlugin: true },
@@ -5428,6 +5487,7 @@ describe("google-meet plugin", () => {
       expect(replacementStop).toHaveBeenCalledOnce();
       expect(leaveChromeMeet).toHaveBeenCalledTimes(2);
       expect(leaveChromeMeet).toHaveBeenLastCalledWith({
+        runtime: expect.any(Object),
         config: expect.any(Object),
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         tab: { targetId: "replacement-meet-tab", openedByPlugin: true },
@@ -5610,6 +5670,7 @@ describe("google-meet plugin", () => {
       await expect(runtime.leave(joined.session.id)).rejects.toThrow("bridge stop failed");
 
       expect(leaveChromeMeet).toHaveBeenCalledWith({
+        runtime: expect.any(Object),
         config: expect.any(Object),
         meetingUrl: "https://meet.google.com/abc-defg-hij",
         tab: { targetId: "meet-tab", openedByPlugin: true },

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -46,6 +46,7 @@ import {
   noopLogger,
   setupGoogleMeetPlugin,
 } from "./src/test-support/plugin-harness.js";
+import * as chromeCreateTransport from "./src/transports/chrome-create.js";
 import * as chromeTransport from "./src/transports/chrome.js";
 import { testing as chromeTransportTesting } from "./src/transports/chrome.js";
 import {
@@ -2560,6 +2561,399 @@ describe("google-meet plugin", () => {
     }
   });
 
+  function mockLocalMeetBrowserRequestWithTabState(options?: {
+    reused?: boolean;
+    tabClosesAfterJoin?: boolean;
+    tabUrlAfterJoin?: string;
+    leaveClicked?: boolean;
+    leaveConfirmationRequired?: boolean;
+  }) {
+    let joined = false;
+    let leaveStep = 0;
+    let openedTabUrl = options?.reused ? "https://meet.google.com/abc-defg-hij?hl=en" : undefined;
+    const callGatewayFromCli = vi.fn(
+      async (
+        _method: string,
+        _opts: unknown,
+        params?: unknown,
+        _extra?: unknown,
+      ): Promise<Record<string, unknown>> => {
+        const request = params as {
+          method?: string;
+          path?: string;
+          body?: { fn?: string; targetId?: string; url?: string };
+        };
+        if (request.path === "/tabs") {
+          const tabExists = openedTabUrl && !(options?.tabClosesAfterJoin && joined);
+          const currentTabUrl = joined ? (options?.tabUrlAfterJoin ?? openedTabUrl) : openedTabUrl;
+          return {
+            tabs: tabExists
+              ? [{ targetId: "local-meet-tab", title: "Meet", url: currentTabUrl }]
+              : [],
+          };
+        }
+        if (request.path === "/tabs/open") {
+          openedTabUrl = request.body?.url;
+          return { targetId: "local-meet-tab", title: "Meet", url: openedTabUrl };
+        }
+        if (request.path === "/tabs/focus") {
+          return { ok: true };
+        }
+        if (request.path === "/navigate") {
+          openedTabUrl = request.body?.url ?? openedTabUrl;
+          return { targetId: request.body?.targetId, url: openedTabUrl };
+        }
+        if (request.path === "/permissions/grant") {
+          return { ok: true };
+        }
+        if (request.method === "DELETE" && request.path === "/tabs/local-meet-tab") {
+          if (options?.reused) {
+            throw new Error("leave must not close a reused user-owned tab");
+          }
+          openedTabUrl = undefined;
+          return { ok: true };
+        }
+        if (request.path === "/act") {
+          if (String(request.body?.fn).includes("leaveAction")) {
+            const currentUrl = options?.tabUrlAfterJoin ?? openedTabUrl;
+            const urlMatched = currentUrl?.includes("/abc-defg-hij") === true;
+            if (!urlMatched) {
+              return { result: JSON.stringify({ departed: true, urlMatched: false }) };
+            }
+            if (options?.leaveClicked === false) {
+              return { result: JSON.stringify({ departed: false, urlMatched: true }) };
+            }
+            leaveStep += 1;
+            if (leaveStep === 1) {
+              return {
+                result: JSON.stringify({
+                  departed: false,
+                  leaveAction: "leave",
+                  urlMatched: true,
+                }),
+              };
+            }
+            if (options?.leaveConfirmationRequired && leaveStep === 2) {
+              return {
+                result: JSON.stringify({
+                  departed: false,
+                  leaveAction: "confirm",
+                  urlMatched: true,
+                }),
+              };
+            }
+            return {
+              result: JSON.stringify({ departed: true, urlMatched: true }),
+            };
+          }
+          joined = true;
+          return {
+            result: JSON.stringify({
+              inCall: true,
+              micMuted: true,
+              title: "Meet call",
+              url: "https://meet.google.com/abc-defg-hij",
+            }),
+          };
+        }
+        throw new Error(`unexpected browser request path ${request.path}`);
+      },
+    );
+    chromeTransportTesting.setDepsForTest({ callGatewayFromCli });
+    return callGatewayFromCli;
+  }
+
+  it("leaves the Meet call in the browser when a chrome session leaves", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState();
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string; chrome?: { browserTab?: unknown } } };
+      expect(joined.session.chrome?.browserTab).toEqual({
+        targetId: "local-meet-tab",
+        openedByPlugin: true,
+      });
+
+      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
+
+      expect(left.found).toBe(true);
+      expect(left.session.state).toBe("ended");
+      expect(left.browserLeft).toBe(true);
+      expect(left.session.notes).toContain(
+        "Clicked Meet's Leave call button and closed the Meet tab.",
+      );
+      const leaveActCall = callGatewayFromCli.mock.calls.find((call) =>
+        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+      );
+      expect(
+        requireRecord(requireRecord(leaveActCall?.[2], "leave act request").body, "leave act body")
+          .targetId,
+      ).toBe("local-meet-tab");
+      const closeCall = callGatewayFromCli.mock.calls.find(
+        (call) => (call[2] as { method?: string }).method === "DELETE",
+      );
+      expect((closeCall?.[2] as { path?: string } | undefined)?.path).toBe("/tabs/local-meet-tab");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("still ends the chrome session when its Meet tab is already closed on leave", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+        tabClosesAfterJoin: true,
+      });
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string } };
+
+      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
+
+      expect(left.found).toBe(true);
+      expect(left.session.state).toBe("ended");
+      expect(left.browserLeft).toBe(true);
+      expect(left.session.notes).toContain("Meet tab is already closed.");
+      expect(
+        callGatewayFromCli.mock.calls.some(
+          (call) => (call[2] as { method?: string }).method === "DELETE",
+        ),
+      ).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("confirms host leave and keeps the reused Meet tab open", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+        reused: true,
+        leaveConfirmationRequired: true,
+      });
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string; chrome?: Record<string, unknown> } };
+      expect(joined.session.chrome?.browserTab).toEqual({
+        targetId: "local-meet-tab",
+        openedByPlugin: false,
+      });
+
+      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
+
+      expect(left.found).toBe(true);
+      expect(left.session.state).toBe("ended");
+      expect(left.browserLeft).toBe(true);
+      expect(left.session.notes).toContain(
+        "Clicked Meet's Leave call button; kept the reused browser tab open.",
+      );
+      const leaveActCall = callGatewayFromCli.mock.calls.find((call) =>
+        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+      );
+      expect(
+        requireRecord(requireRecord(leaveActCall?.[2], "leave act request").body, "leave act body")
+          .targetId,
+      ).toBe("local-meet-tab");
+      const leaveSteps = callGatewayFromCli.mock.calls.filter((call) =>
+        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+      );
+      expect(leaveSteps).toHaveLength(3);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("reports browserLeft false when the reused tab's Leave call click fails", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      mockLocalMeetBrowserRequestWithTabState({
+        reused: true,
+        leaveClicked: false,
+      });
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string } };
+
+      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
+
+      expect(left.found).toBe(true);
+      expect(left.session.state).toBe("ended");
+      expect(left.browserLeft).toBe(false);
+      expect(left.session.notes).toContain(
+        "Could not find Meet's Leave call button in the reused browser tab; leave it manually.",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("does not touch a reused tab after it moves to another meeting", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+        reused: true,
+        tabUrlAfterJoin: "https://meet.google.com/xyz-abcd-efg?hl=en",
+      });
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string } };
+
+      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { browserLeft?: boolean; session: { notes: string[] } };
+
+      expect(left.browserLeft).toBe(true);
+      expect(left.session.notes).toContain(
+        "Meet tab moved away from this session; left its current page untouched.",
+      );
+      expect(
+        callGatewayFromCli.mock.calls.some((call) =>
+          String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+        ),
+      ).toBe(true);
+      expect(
+        callGatewayFromCli.mock.calls.some(
+          (call) => (call[2] as { method?: string }).method === "DELETE",
+        ),
+      ).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("does not leave the browser twice when an ended session is retried", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({ reused: true });
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: "https://meet.google.com/abc-defg-hij",
+      })) as { session: { id: string } };
+
+      const first = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { browserLeft?: boolean };
+      const second = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+        sessionId: joined.session.id,
+      })) as { browserLeft?: boolean };
+
+      expect(first.browserLeft).toBe(true);
+      expect(second.browserLeft).toBe(true);
+      const leaveCalls = callGatewayFromCli.mock.calls.filter((call) =>
+        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+      );
+      expect(leaveCalls).toHaveLength(2);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  it("meet leave script clicks the enabled Leave call button", () => {
+    const makeButton = (label: string, disabled = false, iconText?: string) => ({
+      disabled,
+      innerText: "",
+      textContent: "",
+      click: vi.fn(),
+      getAttribute: vi.fn((name: string) => (name === "aria-label" ? label : null)),
+      querySelector: vi.fn((selector: string) =>
+        selector === "i" && iconText !== undefined ? { textContent: iconText } : null,
+      ),
+    });
+    const leaveButton = makeButton("Leave call");
+    const document = {
+      querySelectorAll: vi.fn((selector: string) =>
+        selector === "button" ? [makeButton("Turn on captions"), leaveButton] : [],
+      ),
+    };
+    const context = createContext({
+      JSON,
+      String,
+      URL,
+      location: { href: "https://meet.google.com/abc-defg-hij?hl=en" },
+      document,
+    });
+    const leaveScript = chromeTransportTesting.meetLeaveScriptForTest(
+      "https://meet.google.com/abc-defg-hij",
+    );
+    const run = new Script(`(${leaveScript})()`).runInContext(context) as string;
+
+    expect(leaveButton.click).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(run)).toEqual({
+      departed: false,
+      leaveAction: "leave",
+      urlMatched: true,
+    });
+
+    document.querySelectorAll.mockImplementation((selector: string) =>
+      selector === "button" ? [makeButton("Leave call", true)] : [],
+    );
+    const runDisabled = new Script(`(${leaveScript})()`).runInContext(context) as string;
+    expect(JSON.parse(runDisabled)).toEqual({ departed: false, urlMatched: true });
+
+    // Localized UI: no English label anywhere, but the Material Symbols
+    // "call_end" icon ligature identifies the leave control in any language.
+    const localizedLeave = makeButton("Anruf verlassen", false, "call_end");
+    document.querySelectorAll.mockImplementation((selector: string) =>
+      selector === "button"
+        ? [makeButton("Untertitel aktivieren", false, "closed_caption_off"), localizedLeave]
+        : [],
+    );
+    const runLocalized = new Script(`(${leaveScript})()`).runInContext(context) as string;
+    expect(localizedLeave.click).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(runLocalized)).toEqual({
+      departed: false,
+      leaveAction: "leave",
+      urlMatched: true,
+    });
+
+    const confirmLeave = makeButton("Leave meeting");
+    document.querySelectorAll.mockImplementation((selector: string) =>
+      selector === "button" ? [makeButton("End meeting for all"), confirmLeave] : [],
+    );
+    const runConfirmation = new Script(`(${leaveScript})()`).runInContext(context) as string;
+    expect(confirmLeave.click).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(runConfirmation)).toEqual({
+      departed: false,
+      leaveAction: "confirm",
+      urlMatched: true,
+    });
+
+    document.querySelectorAll.mockImplementation((selector: string) =>
+      selector === "button" ? [makeButton("Rejoin")] : [],
+    );
+    const runDeparted = new Script(`(${leaveScript})()`).runInContext(context) as string;
+    expect(JSON.parse(runDeparted)).toEqual({ departed: true, urlMatched: true });
+
+    leaveButton.click.mockClear();
+    context.location.href = "https://meet.google.com/xyz-abcd-efg?hl=en";
+    document.querySelectorAll.mockImplementation((selector: string) =>
+      selector === "button" ? [leaveButton] : [],
+    );
+    const runMoved = new Script(`(${leaveScript})()`).runInContext(context) as string;
+    expect(leaveButton.click).not.toHaveBeenCalled();
+    expect(JSON.parse(runMoved)).toEqual({ departed: true, urlMatched: false });
+  });
+
   it("starts the local realtime audio bridge after Meet is inspected", async () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
@@ -4544,12 +4938,100 @@ describe("google-meet plugin", () => {
     expect(result.listenTimedOut).toBe(false);
   });
 
+  it("preserves plugin ownership from browser create through join and leave", async () => {
+    const createMeet = vi
+      .spyOn(chromeCreateTransport, "createMeetWithBrowserProxyOnNode")
+      .mockResolvedValueOnce({
+        source: "browser",
+        nodeId: "meet-node",
+        targetId: "created-meet-tab-a",
+        openedByPlugin: true,
+        meetingUri: "https://meet.google.com/drf-ihtb-pad",
+      })
+      .mockResolvedValueOnce({
+        source: "browser",
+        nodeId: "meet-node",
+        targetId: "created-meet-tab-b",
+        openedByPlugin: true,
+        meetingUri: "https://meet.google.com/qwe-rtyu-iop",
+      });
+    const launchChromeMeetOnNode = vi
+      .spyOn(chromeTransport, "launchChromeMeetOnNode")
+      .mockResolvedValueOnce({
+        nodeId: "meet-node",
+        launched: true,
+        tab: { targetId: "created-meet-tab-a", openedByPlugin: false },
+        browser: { inCall: true, micMuted: true },
+      })
+      .mockResolvedValueOnce({
+        nodeId: "meet-node",
+        launched: true,
+        tab: { targetId: "created-meet-tab-b", openedByPlugin: false },
+        browser: { inCall: true, micMuted: true },
+      });
+    const leaveChromeMeetOnNode = vi
+      .spyOn(chromeTransport, "leaveChromeMeetOnNode")
+      .mockResolvedValue({ left: true, note: "left created tab" });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome-node",
+          defaultMode: "transcribe",
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+
+      const createdA = await runtime.createViaBrowser();
+      const createdB = await runtime.createViaBrowser();
+      const joinedA = await runtime.join({
+        url: createdA.meetingUri,
+        transport: "chrome-node",
+      });
+      const joinedB = await runtime.join({
+        url: createdB.meetingUri,
+        transport: "chrome-node",
+      });
+
+      expect(joinedA.session.chrome?.browserTab).toEqual({
+        targetId: "created-meet-tab-a",
+        openedByPlugin: true,
+      });
+      expect(joinedB.session.chrome?.browserTab).toEqual({
+        targetId: "created-meet-tab-b",
+        openedByPlugin: true,
+      });
+      await runtime.leave(joinedA.session.id);
+      await runtime.leave(joinedB.session.id);
+      expect(leaveChromeMeetOnNode).toHaveBeenNthCalledWith(1, {
+        runtime: expect.any(Object),
+        nodeId: "meet-node",
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/drf-ihtb-pad",
+        tab: { targetId: "created-meet-tab-a", openedByPlugin: true },
+      });
+      expect(leaveChromeMeetOnNode).toHaveBeenNthCalledWith(2, {
+        runtime: expect.any(Object),
+        nodeId: "meet-node",
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/qwe-rtyu-iop",
+        tab: { targetId: "created-meet-tab-b", openedByPlugin: true },
+      });
+    } finally {
+      leaveChromeMeetOnNode.mockRestore();
+      launchChromeMeetOnNode.mockRestore();
+      createMeet.mockRestore();
+    }
+  });
+
   it("stops the old Chrome bridge before reassigning a Meet tab to another agent", async () => {
     const stop = vi.fn(async () => {});
     const launchChromeMeet = vi
       .spyOn(chromeTransport, "launchChromeMeet")
       .mockResolvedValueOnce({
         launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: true },
         browser: { inCall: true, micMuted: false },
         audioBridge: {
           type: "command-pair",
@@ -4563,6 +5045,7 @@ describe("google-meet plugin", () => {
       })
       .mockResolvedValueOnce({
         launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: false },
         browser: { inCall: true, micMuted: false },
       });
     try {
@@ -4589,6 +5072,10 @@ describe("google-meet plugin", () => {
       expect(first.session.agentId).toBe("support");
       expect(second.session.agentId).toBe("main");
       expect(first.session.state).toBe("ended");
+      expect(second.session.chrome?.browserTab).toEqual({
+        targetId: "shared-meet-tab",
+        openedByPlugin: true,
+      });
       expect(first.session.notes).toContain(
         "Ended before the same Meet tab was reassigned to another agent.",
       );
@@ -4596,6 +5083,540 @@ describe("google-meet plugin", () => {
       expect(stop).toHaveBeenCalledTimes(1);
       expect(launchChromeMeet).toHaveBeenCalledTimes(2);
     } finally {
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("stops the old Chrome bridge when the same agent changes talk-back mode", async () => {
+    const stop = vi.fn(async () => {});
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+        audioBridge: {
+          type: "command-pair",
+          providerId: "openai",
+          inputCommand: ["capture-meet"],
+          outputCommand: ["play-meet"],
+          speak: vi.fn(),
+          getHealth: vi.fn(() => ({})),
+          stop,
+        },
+      })
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: false },
+        browser: { inCall: true, micMuted: false },
+      });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const first = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+        mode: "agent",
+      });
+
+      const second = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+        mode: "bidi",
+      });
+
+      expect(first.session.state).toBe("ended");
+      expect(second.session.mode).toBe("bidi");
+      expect(second.session.chrome?.browserTab).toEqual({
+        targetId: "shared-meet-tab",
+        openedByPlugin: true,
+      });
+      expect(stop).toHaveBeenCalledOnce();
+    } finally {
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("reassigns an externally managed browser participant without requiring a tracked tab", async () => {
+    const stop = vi.fn(async () => {});
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: false,
+        audioBridge: {
+          type: "command-pair",
+          providerId: "openai",
+          inputCommand: ["capture-meet"],
+          outputCommand: ["play-meet"],
+          speak: vi.fn(),
+          getHealth: vi.fn(() => ({})),
+          stop,
+        },
+      })
+      .mockResolvedValueOnce({ launched: false });
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet");
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          chrome: { launch: false },
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const first = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+
+      const second = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+      });
+
+      expect(first.session.state).toBe("ended");
+      expect(second.session.state).toBe("active");
+      expect(stop).toHaveBeenCalledOnce();
+      expect(leaveChromeMeet).not.toHaveBeenCalled();
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("carries plugin tab ownership through ordinary shared-tab reuse", async () => {
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: true },
+      })
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: false },
+        browser: { inCall: true, micMuted: true },
+      });
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet").mockResolvedValue({
+      left: true,
+      note: "left browser",
+    });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "transcribe",
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+
+      const first = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+      const second = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+      });
+
+      expect(second.session.chrome?.browserTab).toEqual({
+        targetId: "shared-meet-tab",
+        openedByPlugin: true,
+      });
+      await Promise.all([runtime.leave(first.session.id), runtime.leave(second.session.id)]);
+      expect(leaveChromeMeet).toHaveBeenCalledOnce();
+      expect(leaveChromeMeet).toHaveBeenCalledWith({
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        tab: { targetId: "shared-meet-tab", openedByPlugin: true },
+      });
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("leaves the old tab before reassignment when tab reuse is disabled", async () => {
+    const stop = vi.fn(async () => {});
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "old-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+        audioBridge: {
+          type: "command-pair",
+          providerId: "openai",
+          inputCommand: ["capture-meet"],
+          outputCommand: ["play-meet"],
+          speak: vi.fn(),
+          getHealth: vi.fn(() => ({})),
+          stop,
+        },
+      })
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "new-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+      });
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet").mockResolvedValue({
+      left: true,
+      note: "left old browser tab",
+    });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          chrome: { reuseExistingTab: false },
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+
+      const second = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+      });
+
+      expect(stop).toHaveBeenCalledOnce();
+      expect(leaveChromeMeet).toHaveBeenCalledOnce();
+      expect(leaveChromeMeet).toHaveBeenCalledWith({
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        tab: { targetId: "old-meet-tab", openedByPlugin: true },
+      });
+      expect(second.session.chrome?.browserTab?.targetId).toBe("new-meet-tab");
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("releases a retained tab when replacement launch fails", async () => {
+    const stop = vi.fn(async () => {});
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "retained-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+        audioBridge: {
+          type: "command-pair",
+          providerId: "openai",
+          inputCommand: ["capture-meet"],
+          outputCommand: ["play-meet"],
+          speak: vi.fn(),
+          getHealth: vi.fn(() => ({})),
+          stop,
+        },
+      })
+      .mockRejectedValueOnce(new Error("replacement launch failed"));
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet").mockResolvedValue({
+      left: true,
+      note: "released retained tab",
+    });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const first = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+
+      await expect(
+        runtime.join({
+          url: "https://meet.google.com/abc-defg-hij",
+          agentId: "main",
+        }),
+      ).rejects.toThrow("replacement launch failed");
+
+      expect(first.session.state).toBe("ended");
+      expect(first.session.browserLeft).toBe(true);
+      expect(leaveChromeMeet).toHaveBeenCalledWith({
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        tab: { targetId: "retained-meet-tab", openedByPlugin: true },
+      });
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("stops the replacement bridge when retained-tab cleanup fails", async () => {
+    const oldStop = vi.fn(async () => {});
+    const replacementStop = vi.fn(async () => {});
+    const audioBridge = (stop: () => Promise<void>) => ({
+      type: "command-pair" as const,
+      providerId: "openai",
+      inputCommand: ["capture-meet"],
+      outputCommand: ["play-meet"],
+      speak: vi.fn(),
+      getHealth: vi.fn(() => ({})),
+      stop,
+    });
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "retained-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+        audioBridge: audioBridge(oldStop),
+      })
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "replacement-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: false },
+        audioBridge: audioBridge(replacementStop),
+      });
+    const leaveChromeMeet = vi
+      .spyOn(chromeTransport, "leaveChromeMeet")
+      .mockResolvedValueOnce({ left: false, note: "old tab cleanup failed" })
+      .mockResolvedValueOnce({ left: true, note: "replacement tab released" });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+
+      await expect(
+        runtime.join({
+          url: "https://meet.google.com/abc-defg-hij",
+          agentId: "main",
+        }),
+      ).rejects.toThrow("Could not leave the previous Meet browser tab before reassignment.");
+
+      expect(oldStop).toHaveBeenCalledOnce();
+      expect(replacementStop).toHaveBeenCalledOnce();
+      expect(leaveChromeMeet).toHaveBeenCalledTimes(2);
+      expect(leaveChromeMeet).toHaveBeenLastCalledWith({
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        tab: { targetId: "replacement-meet-tab", openedByPlugin: true },
+      });
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("shares one in-flight browser leave and blocks a same-meeting join until it settles", async () => {
+    let resolveBrowserLeave: ((result: { left: boolean; note: string }) => void) | undefined;
+    const browserLeave = new Promise<{ left: boolean; note: string }>((resolve) => {
+      resolveBrowserLeave = resolve;
+    });
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "leaving-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: true },
+      })
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "replacement-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: true },
+      });
+    const leaveChromeMeet = vi
+      .spyOn(chromeTransport, "leaveChromeMeet")
+      .mockReturnValue(browserLeave);
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "transcribe",
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const joined = await runtime.join({ url: "https://meet.google.com/abc-defg-hij" });
+
+      const firstLeave = runtime.leave(joined.session.id);
+      const secondLeave = runtime.leave(joined.session.id);
+      const replacementJoin = runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+      await vi.waitFor(() => {
+        expect(leaveChromeMeet).toHaveBeenCalledOnce();
+      });
+      expect(launchChromeMeet).toHaveBeenCalledOnce();
+      resolveBrowserLeave?.({ left: false, note: "browser leave failed" });
+
+      const [firstResult, secondResult, replacement] = await Promise.all([
+        firstLeave,
+        secondLeave,
+        replacementJoin,
+      ]);
+      expect(firstResult.browserLeft).toBe(false);
+      expect(secondResult.browserLeft).toBe(false);
+      expect(replacement.session.chrome?.browserTab?.targetId).toBe("replacement-meet-tab");
+      expect(launchChromeMeet).toHaveBeenCalledTimes(2);
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("does not let a leave tear down a tab while another session adopts it", async () => {
+    let resolveReplacementLaunch:
+      | ((result: {
+          launched: true;
+          tab: { targetId: string; openedByPlugin: boolean };
+          browser: { inCall: true; micMuted: true };
+        }) => void)
+      | undefined;
+    const replacementLaunch = new Promise<{
+      launched: true;
+      tab: { targetId: string; openedByPlugin: boolean };
+      browser: { inCall: true; micMuted: true };
+    }>((resolve) => {
+      resolveReplacementLaunch = resolve;
+    });
+    const launchChromeMeet = vi
+      .spyOn(chromeTransport, "launchChromeMeet")
+      .mockResolvedValueOnce({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: true },
+        browser: { inCall: true, micMuted: true },
+      })
+      .mockReturnValueOnce(replacementLaunch);
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet").mockResolvedValue({
+      left: true,
+      note: "left browser",
+    });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "transcribe",
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const first = await runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "support",
+      });
+
+      const replacement = runtime.join({
+        url: "https://meet.google.com/abc-defg-hij",
+        agentId: "main",
+      });
+      await vi.waitFor(() => {
+        expect(launchChromeMeet).toHaveBeenCalledTimes(2);
+      });
+      const oldLeave = runtime.leave(first.session.id);
+      await Promise.resolve();
+      expect(leaveChromeMeet).not.toHaveBeenCalled();
+
+      resolveReplacementLaunch?.({
+        launched: true,
+        tab: { targetId: "shared-meet-tab", openedByPlugin: false },
+        browser: { inCall: true, micMuted: true },
+      });
+      const adopted = await replacement;
+      await oldLeave;
+
+      expect(adopted.session.chrome?.browserTab).toEqual({
+        targetId: "shared-meet-tab",
+        openedByPlugin: true,
+      });
+      expect(leaveChromeMeet).not.toHaveBeenCalled();
+
+      await runtime.leave(adopted.session.id);
+      expect(leaveChromeMeet).toHaveBeenCalledOnce();
+    } finally {
+      leaveChromeMeet.mockRestore();
+      launchChromeMeet.mockRestore();
+    }
+  });
+
+  it("still leaves the browser when the Chrome bridge stop fails", async () => {
+    const stop = vi.fn(async () => {
+      throw new Error("bridge stop failed");
+    });
+    const launchChromeMeet = vi.spyOn(chromeTransport, "launchChromeMeet").mockResolvedValue({
+      launched: true,
+      tab: { targetId: "meet-tab", openedByPlugin: true },
+      browser: { inCall: true, micMuted: false },
+      audioBridge: {
+        type: "command-pair",
+        providerId: "openai",
+        inputCommand: ["capture-meet"],
+        outputCommand: ["play-meet"],
+        speak: vi.fn(),
+        getHealth: vi.fn(() => ({})),
+        stop,
+      },
+    });
+    const leaveChromeMeet = vi.spyOn(chromeTransport, "leaveChromeMeet").mockResolvedValue({
+      left: true,
+      note: "left browser",
+    });
+    try {
+      const runtime = new GoogleMeetRuntime({
+        config: resolveGoogleMeetConfig({
+          defaultTransport: "chrome",
+          defaultMode: "agent",
+          realtime: { introMessage: "" },
+        }),
+        fullConfig: {} as never,
+        runtime: {} as never,
+        logger: noopLogger,
+      });
+      const joined = await runtime.join({ url: "https://meet.google.com/abc-defg-hij" });
+
+      await expect(runtime.leave(joined.session.id)).rejects.toThrow("bridge stop failed");
+
+      expect(leaveChromeMeet).toHaveBeenCalledWith({
+        config: expect.any(Object),
+        meetingUrl: "https://meet.google.com/abc-defg-hij",
+        tab: { targetId: "meet-tab", openedByPlugin: true },
+      });
+      expect(joined.session.state).toBe("ended");
+    } finally {
+      leaveChromeMeet.mockRestore();
       launchChromeMeet.mockRestore();
     }
   });

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -12,7 +12,7 @@ import {
 } from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { normalizeAgentId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
@@ -480,9 +480,14 @@ async function callGoogleMeetGatewayFromTool(params: {
       return await params.runtime.gateway.request(
         googleMeetGatewayMethodForToolAction(params.action),
         params.raw,
-        { timeoutMs: resolveGoogleMeetGatewayOperationTimeoutMs(params.config) },
+        {
+          timeoutMs: resolveGoogleMeetGatewayOperationTimeoutMs(params.config),
+          scopes: ["operator.admin"],
+        },
       );
     }
+    // Standalone agent workers connect as this bundled plugin, not as the
+    // model session; its Gateway methods remain the only exposed actions.
     return await googleMeetToolDeps.callGatewayFromCli(
       googleMeetGatewayMethodForToolAction(params.action),
       {
@@ -490,7 +495,7 @@ async function callGoogleMeetGatewayFromTool(params: {
         timeout: String(resolveGoogleMeetGatewayOperationTimeoutMs(params.config)),
       },
       params.raw,
-      { progress: false },
+      { progress: false, scopes: ["operator.admin"] },
     );
   } catch (err) {
     const details = readGatewayErrorDetails(err);
@@ -1051,10 +1056,19 @@ export default definePluginEntry({
         async execute(_toolCallId, params) {
           const raw = asParamRecord(params);
           const requesterSessionKey = normalizeOptionalString(toolContext.sessionKey);
-          const agentId = toolContext.agentId ? normalizeAgentId(toolContext.agentId) : undefined;
+          // Agent ownership comes from trusted tool context, never model-supplied params.
+          // Some harnesses omit agentId but still provide its canonical session key.
+          const contextAgentId =
+            toolContext.agentId ?? parseAgentSessionKey(requesterSessionKey)?.agentId;
+          const agentId = contextAgentId ? normalizeAgentId(contextAgentId) : undefined;
           try {
-            const useTrustedRuntime = agentId ? await api.runtime.gateway.isAvailable() : false;
-            if (agentId && agentId !== "main" && !useTrustedRuntime) {
+            // Main-agent sessions belong to the persistent Gateway runtime. Only
+            // non-default identities need trusted in-process routing metadata.
+            const needsTrustedAgentRouting = Boolean(agentId && agentId !== "main");
+            const useTrustedRuntime = needsTrustedAgentRouting
+              ? await api.runtime.gateway.isAvailable()
+              : false;
+            if (needsTrustedAgentRouting && !useTrustedRuntime) {
               throw new Error("Per-agent Google Meet routing requires a Gateway-hosted agent run.");
             }
             const rawWithRequester = {

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -634,6 +634,17 @@ function writeRecoverCurrentTabResult(
   }
 }
 
+function writeLeaveResult(sessionId: string, result: { browserLeft?: boolean }): void {
+  if (result.browserLeft === false) {
+    writeStdoutLine(
+      "left %s, but the browser participant may still be in the call; check session notes",
+      sessionId,
+    );
+    return;
+  }
+  writeStdoutLine("left %s", sessionId);
+}
+
 function resolveMeetingInput(config: GoogleMeetConfig, value?: string): string {
   const meeting = value?.trim() || config.defaults.meeting;
   if (!meeting) {
@@ -2328,11 +2339,11 @@ export function registerGoogleMeetCli(params: {
         payload: { sessionId },
       });
       if (delegated.ok) {
-        const result = delegated.payload as { found?: boolean };
+        const result = delegated.payload as { found?: boolean; browserLeft?: boolean };
         if (!result.found) {
           throw new Error("session not found");
         }
-        writeStdoutLine("left %s", sessionId);
+        writeLeaveResult(sessionId, result);
         return;
       }
       const rt = await params.ensureRuntime();
@@ -2340,7 +2351,7 @@ export function registerGoogleMeetCli(params: {
       if (!result.found) {
         throw new Error("session not found");
       }
-      writeStdoutLine("left %s", sessionId);
+      writeLeaveResult(sessionId, result);
     });
 
   root

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -13,12 +13,18 @@ import type {
   GoogleMeetTransport,
 } from "./config.js";
 import { addGoogleMeetSetupCheck, getGoogleMeetSetupStatus } from "./setup.js";
-import { isSameMeetUrlForReuse, resolveChromeNodeInfo } from "./transports/chrome-browser-proxy.js";
+import {
+  isSameMeetUrlForReuse,
+  normalizeMeetUrlForReuse,
+  resolveChromeNodeInfo,
+} from "./transports/chrome-browser-proxy.js";
 import { createMeetWithBrowserProxyOnNode } from "./transports/chrome-create.js";
 import {
   assertBlackHole2chAvailable,
   launchChromeMeet,
   launchChromeMeetOnNode,
+  leaveChromeMeet,
+  leaveChromeMeetOnNode,
   recoverCurrentMeetTab,
   recoverCurrentMeetTabOnNode,
 } from "./transports/chrome.js";
@@ -28,6 +34,7 @@ import {
   prefixDtmfWait,
 } from "./transports/twilio.js";
 import type {
+  GoogleMeetBrowserTab,
   GoogleMeetChromeHealth,
   GoogleMeetJoinRequest,
   GoogleMeetJoinResult,
@@ -47,6 +54,21 @@ type ChromeAudioBridgeResult = NonNullable<
   | Awaited<ReturnType<typeof launchChromeMeet>>["audioBridge"]
   | Awaited<ReturnType<typeof launchChromeMeetOnNode>>["audioBridge"]
 >;
+
+type ChromeLaunchResult =
+  | Awaited<ReturnType<typeof launchChromeMeet>>
+  | Awaited<ReturnType<typeof launchChromeMeetOnNode>>;
+
+type GoogleMeetLeaveResult = {
+  found: boolean;
+  session?: GoogleMeetSession;
+  browserLeft?: boolean;
+};
+
+type RetainedBrowserTab = {
+  session: GoogleMeetSession;
+  tab: GoogleMeetBrowserTab;
+};
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -259,6 +281,9 @@ async function commandExists(runtime: PluginRuntime, command: string): Promise<b
 
 export class GoogleMeetRuntime {
   readonly #sessions = new Map<string, GoogleMeetSession>();
+  readonly #sessionLeaves = new Map<string, Promise<GoogleMeetLeaveResult>>();
+  readonly #browserMeetingLocks = new Map<string, Promise<void>>();
+  readonly #createdBrowserTabs = new Map<string, string>();
   readonly #sessionStops = new Map<string, () => Promise<void>>();
   readonly #sessionSpeakers = new Map<string, (instructions?: string) => void>();
   readonly #sessionHealth = new Map<string, () => GoogleMeetChromeHealth>();
@@ -385,10 +410,14 @@ export class GoogleMeetRuntime {
   }
 
   async createViaBrowser() {
-    return createMeetWithBrowserProxyOnNode({
+    const result = await createMeetWithBrowserProxyOnNode({
       runtime: this.params.runtime,
       config: this.params.config,
     });
+    if (result.openedByPlugin && result.targetId) {
+      this.#createdBrowserTabs.set(`${result.nodeId}:${result.targetId}`, result.meetingUri);
+    }
+    return result;
   }
 
   async recoverCurrentTab(request: { url?: string; transport?: GoogleMeetTransport } = {}) {
@@ -415,20 +444,63 @@ export class GoogleMeetRuntime {
     const transport = resolveTransport(request.transport, this.params.config);
     const mode = resolveMode(request.mode, this.params.config);
     const agentId = resolveSessionAgentId(request, this.params.config);
+    if (!isBrowserTransport(transport)) {
+      return await this.#joinUnlocked(request, { url, transport, mode, agentId });
+    }
+    return await this.#withBrowserMeetingLock(
+      transport,
+      url,
+      async () => await this.#joinUnlocked(request, { url, transport, mode, agentId }),
+    );
+  }
+
+  async #joinUnlocked(
+    request: GoogleMeetJoinRequest,
+    resolved: {
+      url: string;
+      transport: GoogleMeetTransport;
+      mode: GoogleMeetMode;
+      agentId: string;
+    },
+  ): Promise<GoogleMeetJoinResult> {
+    const { url, transport, mode, agentId } = resolved;
     const activeSessions = this.list().filter(
       (session) =>
         session.state === "active" &&
         isSameMeetUrlForReuse(session.url, url) &&
         session.transport === transport,
     );
+    const retainedBrowserTabs: RetainedBrowserTab[] = [];
     if (isBrowserTransport(transport) && isGoogleMeetTalkBackMode(mode)) {
       for (const session of activeSessions) {
-        if (session.agentId === agentId || !isGoogleMeetTalkBackMode(session.mode)) {
+        if (
+          !isGoogleMeetTalkBackMode(session.mode) ||
+          isReusableMeetSession(session, { url, transport, mode, agentId })
+        ) {
           continue;
         }
         // A reused browser tab can only host one live talk-back bridge safely.
         // End the previous owner before the tab is reused for another agent.
-        await this.leave(session.id);
+        // Keep the tab: the new session takes it over without re-admission.
+        const tab = this.params.config.chrome.reuseExistingTab
+          ? session.chrome?.browserTab
+          : undefined;
+        const keepBrowserParticipant = Boolean(tab) || session.chrome?.launched === false;
+        if (tab) {
+          retainedBrowserTabs.push({ session, tab });
+        }
+        try {
+          const left = await this.#leaveUnlocked(
+            session.id,
+            keepBrowserParticipant ? { keepBrowserTab: true } : undefined,
+          );
+          if (left.browserLeft === false) {
+            throw new Error("Could not leave the previous Meet browser tab before reassignment.");
+          }
+        } catch (error) {
+          await this.#settleRetainedBrowserTabs(retainedBrowserTabs);
+          throw error;
+        }
         noteSession(session, "Ended before the same Meet tab was reassigned to another agent.");
       }
     }
@@ -493,36 +565,64 @@ export class GoogleMeetRuntime {
         // Session ownership must outlive the original request so later bridge
         // startup and reuse stay on the same workspace and tool policy.
         const chromeConfig = withSessionAgentConfig(this.params.config, agentId);
-        const result =
-          transport === "chrome-node"
-            ? await launchChromeMeetOnNode({
-                runtime: this.params.runtime,
-                config: chromeConfig,
-                fullConfig: this.params.fullConfig,
-                meetingSessionId: session.id,
-                requesterSessionKey: request.requesterSessionKey,
-                mode,
-                url,
-                logger: this.params.logger,
-              })
-            : await launchChromeMeet({
-                runtime: this.params.runtime,
-                config: chromeConfig,
-                fullConfig: this.params.fullConfig,
-                meetingSessionId: session.id,
-                requesterSessionKey: request.requesterSessionKey,
-                mode,
-                url,
-                logger: this.params.logger,
-              });
+        let result: ChromeLaunchResult;
+        try {
+          result =
+            transport === "chrome-node"
+              ? await launchChromeMeetOnNode({
+                  runtime: this.params.runtime,
+                  config: chromeConfig,
+                  fullConfig: this.params.fullConfig,
+                  meetingSessionId: session.id,
+                  requesterSessionKey: request.requesterSessionKey,
+                  mode,
+                  url,
+                  logger: this.params.logger,
+                })
+              : await launchChromeMeet({
+                  runtime: this.params.runtime,
+                  config: chromeConfig,
+                  fullConfig: this.params.fullConfig,
+                  meetingSessionId: session.id,
+                  requesterSessionKey: request.requesterSessionKey,
+                  mode,
+                  url,
+                  logger: this.params.logger,
+                });
+        } catch (error) {
+          await this.#settleRetainedBrowserTabs(retainedBrowserTabs);
+          throw error;
+        }
+        const resultNodeId = "nodeId" in result ? result.nodeId : undefined;
+        const browserTab = this.#inheritBrowserTabOwnership({
+          transport,
+          nodeId: resultNodeId,
+          meetingUrl: url,
+          tab: result.tab,
+        });
         session.chrome = {
           audioBackend: this.params.config.chrome.audioBackend,
           launched: result.launched,
-          nodeId: "nodeId" in result ? result.nodeId : undefined,
+          nodeId: resultNodeId,
           browserProfile: this.params.config.chrome.browserProfile,
+          browserTab,
           health: "browser" in result ? result.browser : undefined,
         };
         this.#attachChromeAudioBridge(session, result.audioBridge);
+        const retainedTabsSettled = await this.#settleRetainedBrowserTabs(
+          retainedBrowserTabs,
+          browserTab ? { transport, nodeId: resultNodeId, tab: browserTab } : undefined,
+        );
+        if (!retainedTabsSettled) {
+          try {
+            await this.#leaveSession(session);
+          } catch (error) {
+            this.params.logger.warn(
+              `[google-meet] replacement cleanup failed: ${formatErrorMessage(error)}`,
+            );
+          }
+          throw new Error("Could not leave the previous Meet browser tab before reassignment.");
+        }
         session.notes.push(
           result.audioBridge
             ? transport === "chrome-node"
@@ -616,26 +716,239 @@ export class GoogleMeetRuntime {
     return { session, spoken };
   }
 
-  async leave(sessionId: string): Promise<{ found: boolean; session?: GoogleMeetSession }> {
+  async leave(
+    sessionId: string,
+    opts?: { keepBrowserTab?: boolean },
+  ): Promise<GoogleMeetLeaveResult> {
     const session = this.#sessions.get(sessionId);
     if (!session) {
       return { found: false };
     }
-    const stop = this.#sessionStops.get(sessionId);
-    if (stop) {
-      this.#sessionStops.delete(sessionId);
-      this.#sessionSpeakers.delete(sessionId);
-      this.#sessionHealth.delete(sessionId);
-      try {
-        await stop();
-      } finally {
-        session.state = "ended";
-        session.updatedAt = nowIso();
+    if (!isBrowserTransport(session.transport)) {
+      return await this.#leaveUnlocked(sessionId, opts);
+    }
+    return await this.#withBrowserMeetingLock(
+      session.transport,
+      session.url,
+      async () => await this.#leaveUnlocked(sessionId, opts),
+    );
+  }
+
+  async #leaveUnlocked(
+    sessionId: string,
+    opts?: { keepBrowserTab?: boolean },
+  ): Promise<GoogleMeetLeaveResult> {
+    const inFlight = this.#sessionLeaves.get(sessionId);
+    if (inFlight) {
+      return await inFlight;
+    }
+    const session = this.#sessions.get(sessionId);
+    if (!session) {
+      return { found: false };
+    }
+    // Mark terminal before awaiting teardown so retries and concurrent callers
+    // cannot act on the same browser tab twice.
+    if (session.state === "ended") {
+      return {
+        found: true,
+        session,
+        ...(session.browserLeft === undefined ? {} : { browserLeft: session.browserLeft }),
+      };
+    }
+    const leave = this.#leaveSession(session, opts);
+    this.#sessionLeaves.set(sessionId, leave);
+    try {
+      return await leave;
+    } finally {
+      if (this.#sessionLeaves.get(sessionId) === leave) {
+        this.#sessionLeaves.delete(sessionId);
       }
     }
+  }
+
+  async #withBrowserMeetingLock<T>(
+    transport: GoogleMeetTransport,
+    url: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    // Logical sessions may share one physical tab. Serialize adoption and
+    // departure for the canonical meeting so neither can invalidate the other.
+    const meeting = normalizeMeetUrlForReuse(url) ?? url;
+    const key = `${transport}:${meeting}`;
+    const previous = this.#browserMeetingLocks.get(key) ?? Promise.resolve();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    this.#browserMeetingLocks.set(key, tail);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release?.();
+      if (this.#browserMeetingLocks.get(key) === tail) {
+        this.#browserMeetingLocks.delete(key);
+      }
+    }
+  }
+
+  async #leaveSession(
+    session: GoogleMeetSession,
+    opts?: { keepBrowserTab?: boolean },
+  ): Promise<GoogleMeetLeaveResult> {
     session.state = "ended";
     session.updatedAt = nowIso();
-    return { found: true, session };
+    const stop = this.#sessionStops.get(session.id);
+    this.#sessionStops.delete(session.id);
+    this.#sessionSpeakers.delete(session.id);
+    this.#sessionHealth.delete(session.id);
+    let browserLeft: boolean | undefined;
+    try {
+      await stop?.();
+    } finally {
+      // A bridge teardown failure must not leave the browser participant behind.
+      if (!opts?.keepBrowserTab) {
+        browserLeft = await this.#releaseBrowserTab(session);
+      }
+    }
+    return { found: true, session, ...(browserLeft === undefined ? {} : { browserLeft }) };
+  }
+
+  #inheritBrowserTabOwnership(params: {
+    transport: GoogleMeetTransport;
+    nodeId?: string;
+    meetingUrl: string;
+    tab?: GoogleMeetBrowserTab;
+  }): GoogleMeetBrowserTab | undefined {
+    if (!params.tab) {
+      return undefined;
+    }
+    const tab = params.tab;
+    const createdTabKey =
+      params.transport === "chrome-node" && params.nodeId
+        ? `${params.nodeId}:${tab.targetId}`
+        : undefined;
+    const createdMeetingUrl = createdTabKey
+      ? this.#createdBrowserTabs.get(createdTabKey)
+      : undefined;
+    const inheritedFromCreate = isSameMeetUrlForReuse(createdMeetingUrl, params.meetingUrl);
+    if (createdMeetingUrl && createdTabKey) {
+      this.#createdBrowserTabs.delete(createdTabKey);
+    }
+    const inheritedFromSession = [...this.#sessions.values()].some((session) => {
+      const trackedTab = session.chrome?.browserTab;
+      if (!trackedTab) {
+        return false;
+      }
+      return (
+        session.transport === params.transport &&
+        isSameMeetUrlForReuse(session.url, params.meetingUrl) &&
+        session.chrome?.nodeId === params.nodeId &&
+        trackedTab.targetId === tab.targetId &&
+        trackedTab.openedByPlugin
+      );
+    });
+    return inheritedFromCreate || inheritedFromSession ? { ...tab, openedByPlugin: true } : tab;
+  }
+
+  async #settleRetainedBrowserTabs(
+    retained: RetainedBrowserTab[],
+    adopted?: {
+      transport: GoogleMeetTransport;
+      nodeId?: string;
+      tab: GoogleMeetBrowserTab;
+    },
+  ): Promise<boolean> {
+    let settled = true;
+    for (const { session, tab } of retained.splice(0)) {
+      const adoptedThisTab =
+        adopted?.transport === session.transport &&
+        adopted.nodeId === session.chrome?.nodeId &&
+        adopted.tab.targetId === tab.targetId;
+      if (adoptedThisTab) {
+        if (session.chrome) {
+          session.chrome.browserTab = undefined;
+        }
+        continue;
+      }
+      if ((await this.#releaseBrowserTab(session)) === false) {
+        settled = false;
+      }
+    }
+    return settled;
+  }
+
+  async #releaseBrowserTab(session: GoogleMeetSession): Promise<boolean | undefined> {
+    let browserLeft: boolean | undefined;
+    try {
+      browserLeft = await this.#leaveBrowserMeetTab(session);
+    } catch (error) {
+      noteSession(
+        session,
+        `Browser control could not leave the Meet tab: ${formatErrorMessage(error)}`,
+      );
+      browserLeft = false;
+    }
+    session.browserLeft = browserLeft;
+    if (session.chrome && browserLeft !== false) {
+      // Ownership has either been consumed, transferred to an active session,
+      // or released to the user. Never let a stale session act on it again.
+      session.chrome.browserTab = undefined;
+    }
+    return browserLeft;
+  }
+
+  // Chrome transports have no stop hook that touches the meeting itself, so
+  // without this the browser participant stays in the call after `leave`
+  // reports success (#103386). Twilio ends the real call via its stop hook.
+  // Acts only on the exact tab identity persisted at join; URL rediscovery
+  // could hit a different tab in another browser context.
+  // Returns undefined when no browser departure applies (non-browser transport,
+  // tab intentionally kept for another session), else whether the participant
+  // actually left. Callers must not report plain success on false.
+  async #leaveBrowserMeetTab(session: GoogleMeetSession): Promise<boolean | undefined> {
+    if (!isBrowserTransport(session.transport)) {
+      return undefined;
+    }
+    const tab = session.chrome?.browserTab;
+    if (!tab) {
+      noteSession(
+        session,
+        "No tracked Meet browser tab for this session; close the Meet tab manually if it is still in the call.",
+      );
+      return false;
+    }
+    // Same URL is not the same tab: only sessions on the same target in the
+    // same browser context (local vs a specific node) truly share it.
+    const sharedWithActiveSession = this.list().some(
+      (other) =>
+        other.id !== session.id &&
+        other.state === "active" &&
+        isBrowserTransport(other.transport) &&
+        other.chrome?.browserTab?.targetId === tab.targetId &&
+        other.chrome?.nodeId === session.chrome?.nodeId,
+    );
+    if (sharedWithActiveSession) {
+      noteSession(session, "Kept the shared Meet tab open because another active session uses it.");
+      return undefined;
+    }
+    const result =
+      session.transport === "chrome-node"
+        ? await leaveChromeMeetOnNode({
+            runtime: this.params.runtime,
+            nodeId: session.chrome?.nodeId,
+            config: this.params.config,
+            meetingUrl: session.url,
+            tab,
+          })
+        : await leaveChromeMeet({
+            config: this.params.config,
+            meetingUrl: session.url,
+            tab,
+          });
+    noteSession(session, result.note);
+    return result.left;
   }
 
   async speak(

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -434,6 +434,7 @@ export class GoogleMeetRuntime {
       });
     }
     return recoverCurrentMeetTab({
+      runtime: this.params.runtime,
       config: this.params.config,
       url,
     });
@@ -943,6 +944,7 @@ export class GoogleMeetRuntime {
             tab,
           })
         : await leaveChromeMeet({
+            runtime: this.params.runtime,
             config: this.params.config,
             meetingUrl: session.url,
             tab,
@@ -1280,6 +1282,7 @@ export class GoogleMeetRuntime {
               url: session.url,
             })
           : await recoverCurrentMeetTab({
+              runtime: this.params.runtime,
               config: this.params.config,
               mode: session.mode,
               readOnly: options.readOnly,

--- a/extensions/google-meet/src/transports/chrome-create.ts
+++ b/extensions/google-meet/src/transports/chrome-create.ts
@@ -32,6 +32,7 @@ type GoogleMeetBrowserCreateResult = {
   meetingUri: string;
   nodeId: string;
   targetId?: string;
+  openedByPlugin: boolean;
   browserUrl?: string;
   browserTitle?: string;
   notes?: string[];
@@ -272,6 +273,7 @@ export async function createMeetWithBrowserProxyOnNode(params: {
     params.config.chrome.joinTimeoutMs,
   );
   const stepTimeoutMs = Math.min(timeoutMs, GOOGLE_MEET_BROWSER_STEP_TIMEOUT_MS);
+  let openedByPlugin = false;
   let tab = await findGoogleMeetCreateTab({
     runtime: params.runtime,
     nodeId,
@@ -318,6 +320,7 @@ export async function createMeetWithBrowserProxyOnNode(params: {
         timeoutMs: stepTimeoutMs,
       }),
     );
+    openedByPlugin = Boolean(tab?.targetId);
   }
   const targetId = tab?.targetId;
   if (!targetId) {
@@ -351,6 +354,7 @@ export async function createMeetWithBrowserProxyOnNode(params: {
           source: "browser",
           nodeId,
           targetId,
+          openedByPlugin,
           meetingUri: result.meetingUri,
           browserUrl: result.browserUrl,
           browserTitle: result.browserTitle,

--- a/extensions/google-meet/src/transports/chrome.test.ts
+++ b/extensions/google-meet/src/transports/chrome.test.ts
@@ -1,9 +1,12 @@
 // Google Meet tests cover chrome plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
-import { describe, expect, it } from "vitest";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing } from "./chrome.js";
 
 describe("google meet chrome transport", () => {
+  afterEach(() => testing.setDepsForTest(null));
+
   it("wraps malformed browser status JSON", () => {
     expect(() =>
       testing.parseMeetBrowserStatusForTest({
@@ -17,5 +20,32 @@ describe("google meet chrome transport", () => {
     expect(testing.resolveBrowserGatewayTimeoutMsForTest(Number.MAX_SAFE_INTEGER)).toBe(
       MAX_TIMER_TIMEOUT_MS,
     );
+  });
+
+  it("keeps Gateway-hosted local browser calls inside the trusted runtime", async () => {
+    const callGatewayFromCli = vi.fn();
+    const gatewayRequest = vi.fn(async () => ({ tabs: [] }));
+    const runtime = {
+      gateway: {
+        isAvailable: vi.fn(async () => true),
+        request: gatewayRequest,
+      },
+    } as unknown as PluginRuntime;
+    testing.setDepsForTest({ callGatewayFromCli });
+
+    const callBrowser = await testing.resolveLocalBrowserRequestForTest(runtime);
+    await callBrowser({ method: "GET", path: "/tabs", timeoutMs: 5_000 });
+
+    expect(gatewayRequest).toHaveBeenCalledWith(
+      "browser.request",
+      {
+        method: "GET",
+        path: "/tabs",
+        body: undefined,
+        timeoutMs: 5_000,
+      },
+      { timeoutMs: 10_000, scopes: ["operator.admin"] },
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
   });
 });

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -31,7 +31,7 @@ import {
   resolveChromeNode,
   type BrowserTab,
 } from "./chrome-browser-proxy.js";
-import type { GoogleMeetChromeHealth } from "./types.js";
+import type { GoogleMeetBrowserTab, GoogleMeetChromeHealth } from "./types.js";
 
 type BrowserRequestParams = {
   method: "GET" | "POST" | "DELETE";
@@ -53,6 +53,7 @@ export const testing = {
     chromeTransportDeps.callGatewayFromCli = deps?.callGatewayFromCli ?? callGatewayFromCli;
   },
   meetStatusScriptForTest: meetStatusScript,
+  meetLeaveScriptForTest: meetLeaveScript,
   parseMeetBrowserStatusForTest: parseMeetBrowserStatus,
   resolveBrowserGatewayTimeoutMsForTest: resolveBrowserGatewayTimeoutMs,
 };
@@ -118,6 +119,7 @@ export async function launchChromeMeet(params: {
     | { type: "external-command" }
     | ({ type: "command-pair" } & ChromeRealtimeAudioBridgeHandle);
   browser?: GoogleMeetChromeHealth;
+  tab?: GoogleMeetBrowserTab;
 }> {
   const checkRealtimeAudioPrerequisites = async () => {
     if (!isGoogleMeetTalkBackMode(params.mode)) {
@@ -647,13 +649,278 @@ function meetStatusScript(params: {
 }`;
 }
 
+function meetLeaveScript(meetingUrl: string) {
+  const expectedMeetingUrl = normalizeMeetUrlForReuse(meetingUrl);
+  return `() => {
+  const expectedMeetingUrl = ${JSON.stringify(expectedMeetingUrl)};
+  let currentMeetingUrl;
+  try {
+    const currentUrl = new URL(location.href);
+    currentMeetingUrl = currentUrl.origin + currentUrl.pathname.toLowerCase().replace(/\\/$/, "");
+  } catch {
+    return JSON.stringify({ departed: false });
+  }
+  if (!expectedMeetingUrl || currentMeetingUrl !== expectedMeetingUrl) {
+    return JSON.stringify({ departed: true, urlMatched: false });
+  }
+  const text = (node) => (node?.innerText || node?.textContent || "").trim();
+  // Locale-independent fallback: Meet renders the leave control as a Material
+  // Symbols icon whose ligature text is "call_end" in every UI language, so a
+  // localized aria-label (e.g. "Anruf verlassen") still resolves to the button.
+  const hasLeaveIcon = (button) => {
+    const icon = button.querySelector ? button.querySelector("i") : null;
+    return icon ? (icon.textContent || "").trim() === "call_end" : false;
+  };
+  const buttons = [...document.querySelectorAll('button')];
+  const label = (button) => [
+    button.getAttribute("aria-label"),
+    button.getAttribute("data-tooltip"),
+    text(button),
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const postCall = buttons.some((button) => /\\b(rejoin|return to home screen)\\b/i.test(label(button)));
+  if (postCall) {
+    return JSON.stringify({ departed: true, urlMatched: true });
+  }
+  // Managed join tabs are reused only after the English-tab gate or opened
+  // through the English-UI helper, so follow-up labels are pinned to English.
+  const confirmation = buttons.find((button) => {
+    return !button.disabled && /\\bleave meeting\\b/i.test(label(button));
+  });
+  if (confirmation) {
+    confirmation.click();
+    return JSON.stringify({ departed: false, leaveAction: "confirm", urlMatched: true });
+  }
+  const leave = buttons.find((button) => {
+    if (button.disabled) return false;
+    return /leave call/i.test(label(button)) || hasLeaveIcon(button);
+  });
+  if (leave) {
+    leave.click();
+    return JSON.stringify({ departed: false, leaveAction: "leave", urlMatched: true });
+  }
+  return JSON.stringify({ departed: false, urlMatched: true });
+}`;
+}
+
+function parseMeetLeaveResult(result: unknown): {
+  departed: boolean;
+  leaveAction?: "leave" | "confirm";
+  urlMatched?: boolean;
+} {
+  const record = result && typeof result === "object" ? (result as Record<string, unknown>) : {};
+  const raw = record.result;
+  if (typeof raw !== "string" || !raw.trim()) {
+    return { departed: false };
+  }
+  try {
+    const parsed = JSON.parse(raw) as {
+      departed?: boolean;
+      leaveAction?: string;
+      urlMatched?: boolean;
+    };
+    const leaveAction =
+      parsed.leaveAction === "leave" || parsed.leaveAction === "confirm"
+        ? parsed.leaveAction
+        : undefined;
+    return {
+      departed: parsed.departed === true,
+      ...(leaveAction ? { leaveAction } : {}),
+      ...(typeof parsed.urlMatched === "boolean" ? { urlMatched: parsed.urlMatched } : {}),
+    };
+  } catch {
+    return { departed: false };
+  }
+}
+
+async function leaveMeetInPage(params: {
+  callBrowser: BrowserRequestCaller;
+  meetingUrl: string;
+  targetId: string;
+  timeoutMs: number;
+}): Promise<{
+  departed: boolean;
+  clickedLeave: boolean;
+  clickedConfirmation: boolean;
+  urlMatched?: boolean;
+}> {
+  const deadline = Date.now() + params.timeoutMs;
+  let clickedLeave = false;
+  let clickedConfirmation = false;
+  do {
+    const evaluated = await params.callBrowser({
+      method: "POST",
+      path: "/act",
+      body: {
+        kind: "evaluate",
+        targetId: params.targetId,
+        fn: meetLeaveScript(params.meetingUrl),
+      },
+      timeoutMs: params.timeoutMs,
+    });
+    const step = parseMeetLeaveResult(evaluated);
+    clickedLeave ||= step.leaveAction === "leave";
+    clickedConfirmation ||= step.leaveAction === "confirm";
+    if (step.departed || step.urlMatched !== true) {
+      return {
+        departed: step.departed,
+        clickedLeave,
+        clickedConfirmation,
+        urlMatched: step.urlMatched,
+      };
+    }
+    if (!step.leaveAction && !clickedLeave) {
+      return { departed: false, clickedLeave, clickedConfirmation, urlMatched: true };
+    }
+    if (!step.leaveAction) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
+  } while (Date.now() < deadline);
+  return { departed: false, clickedLeave, clickedConfirmation, urlMatched: true };
+}
+
+// `leave` must remove the browser participant from the call, not just flip local
+// session state; otherwise the tab keeps sitting in the meeting after the CLI
+// reports "left" (#103386). It acts on the exact tab identity persisted at join:
+// clicking Leave call is the graceful path, and the tab is closed afterwards only
+// when the plugin opened it — a reused tab belongs to the user and stays open.
+async function leaveMeetWithBrowserRequest(params: {
+  callBrowser: BrowserRequestCaller;
+  config: GoogleMeetConfig;
+  meetingUrl: string;
+  tab: GoogleMeetBrowserTab;
+}): Promise<{ left: boolean; note: string }> {
+  if (!params.config.chrome.launch) {
+    return {
+      left: false,
+      note: "Browser leave skipped because chrome.launch is disabled.",
+    };
+  }
+  const timeoutMs = Math.min(Math.max(1_000, params.config.chrome.joinTimeoutMs), 5_000);
+  const { targetId, openedByPlugin } = params.tab;
+  try {
+    const tabs = asBrowserTabs(
+      await params.callBrowser({ method: "GET", path: "/tabs", timeoutMs }),
+    );
+    const currentTab = tabs.find((entry) => entry.targetId === targetId);
+    if (!currentTab) {
+      return {
+        left: true,
+        note: "Meet tab is already closed.",
+      };
+    }
+    let leaveResult: Awaited<ReturnType<typeof leaveMeetInPage>>;
+    try {
+      leaveResult = await leaveMeetInPage({
+        callBrowser: params.callBrowser,
+        meetingUrl: params.meetingUrl,
+        targetId,
+        timeoutMs,
+      });
+    } catch (error) {
+      return {
+        left: false,
+        note: `Browser control could not verify the Meet tab before leaving: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+    if (leaveResult.urlMatched === false) {
+      return {
+        left: true,
+        note: "Meet tab moved away from this session; left its current page untouched.",
+      };
+    }
+    if (leaveResult.urlMatched !== true) {
+      return {
+        left: false,
+        note: "Browser control could not verify that the tracked tab still showed this meeting.",
+      };
+    }
+    const { clickedLeave, departed } = leaveResult;
+    if (!openedByPlugin) {
+      return {
+        left: departed,
+        note: departed
+          ? "Clicked Meet's Leave call button; kept the reused browser tab open."
+          : clickedLeave
+            ? "Clicked Meet's Leave call button, but could not verify departure; leave it manually."
+            : "Could not find Meet's Leave call button in the reused browser tab; leave it manually.",
+      };
+    }
+    await params.callBrowser({
+      method: "DELETE",
+      path: `/tabs/${targetId}`,
+      timeoutMs,
+    });
+    return {
+      left: true,
+      note: clickedLeave
+        ? "Clicked Meet's Leave call button and closed the Meet tab."
+        : "Closed the Meet tab to leave the meeting (Leave call button was not found).",
+    };
+  } catch (error) {
+    return {
+      left: false,
+      note: `Browser control could not leave the Meet tab: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
+export async function leaveChromeMeet(params: {
+  config: GoogleMeetConfig;
+  meetingUrl: string;
+  tab: GoogleMeetBrowserTab;
+}): Promise<{ left: boolean; note: string }> {
+  return await leaveMeetWithBrowserRequest({
+    callBrowser: callLocalBrowserRequest,
+    config: params.config,
+    meetingUrl: params.meetingUrl,
+    tab: params.tab,
+  });
+}
+
+export async function leaveChromeMeetOnNode(params: {
+  runtime: PluginRuntime;
+  nodeId?: string;
+  config: GoogleMeetConfig;
+  meetingUrl: string;
+  tab: GoogleMeetBrowserTab;
+}): Promise<{ left: boolean; note: string }> {
+  const nodeId =
+    params.nodeId ??
+    (await resolveChromeNode({
+      runtime: params.runtime,
+      requestedNode: params.config.chromeNode.node,
+    }));
+  return await leaveMeetWithBrowserRequest({
+    callBrowser: async (request) =>
+      await callBrowserProxyOnNode({
+        runtime: params.runtime,
+        nodeId,
+        method: request.method,
+        path: request.path,
+        body: request.body,
+        timeoutMs: request.timeoutMs,
+      }),
+    config: params.config,
+    meetingUrl: params.meetingUrl,
+    tab: params.tab,
+  });
+}
+
 async function openMeetWithBrowserProxy(params: {
   runtime: PluginRuntime;
   nodeId: string;
   config: GoogleMeetConfig;
   mode: GoogleMeetMode;
   url: string;
-}): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth }> {
+}): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth; tab?: GoogleMeetBrowserTab }> {
   return await openMeetWithBrowserRequest({
     callBrowser: async (request) =>
       await callBrowserProxyOnNode({
@@ -675,7 +942,7 @@ async function openMeetWithBrowserRequest(params: {
   config: GoogleMeetConfig;
   mode: GoogleMeetMode;
   url: string;
-}): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth }> {
+}): Promise<{ launched: boolean; browser?: GoogleMeetChromeHealth; tab?: GoogleMeetBrowserTab }> {
   if (!params.config.chrome.launch) {
     return { launched: false };
   }
@@ -684,6 +951,7 @@ async function openMeetWithBrowserRequest(params: {
   let targetId: string | undefined;
   let tab: BrowserTab | undefined;
   let openUrl = params.url;
+  let openedByPlugin = false;
   if (params.config.chrome.reuseExistingTab) {
     const tabs = asBrowserTabs(
       await params.callBrowser({
@@ -725,6 +993,7 @@ async function openMeetWithBrowserRequest(params: {
       }),
     );
     targetId = tab?.targetId;
+    openedByPlugin = Boolean(targetId);
   }
   if (!targetId) {
     return {
@@ -738,6 +1007,7 @@ async function openMeetWithBrowserRequest(params: {
     };
   }
 
+  const tabIdentity: GoogleMeetBrowserTab = { targetId, openedByPlugin };
   const permissionNotes = await grantMeetMediaPermissions({
     allowMicrophone: isGoogleMeetTalkBackMode(params.mode),
     callBrowser: params.callBrowser,
@@ -773,10 +1043,10 @@ async function openMeetWithBrowserRequest(params: {
         browser?.inCall === true &&
         (!isGoogleMeetTalkBackMode(params.mode) || browser.micMuted !== true)
       ) {
-        return { launched: true, browser };
+        return { launched: true, browser, tab: tabIdentity };
       }
       if (browser?.manualActionRequired === true) {
-        return { launched: true, browser };
+        return { launched: true, browser, tab: tabIdentity };
       }
     } catch (error) {
       browser = {
@@ -802,7 +1072,7 @@ async function openMeetWithBrowserRequest(params: {
       });
     }
   } while (Date.now() < deadline);
-  return { launched: true, browser };
+  return { launched: true, browser, tab: tabIdentity };
 }
 
 function isRecoverableMeetTab(tab: BrowserTab, url?: string): boolean {
@@ -1041,6 +1311,7 @@ export async function launchChromeMeetOnNode(params: {
     | { type: "external-command" }
     | ({ type: "node-command-pair" } & ChromeNodeRealtimeAudioBridgeHandle);
   browser?: GoogleMeetChromeHealth;
+  tab?: GoogleMeetBrowserTab;
 }> {
   const nodeId = await resolveChromeNode({
     runtime: params.runtime,
@@ -1116,6 +1387,7 @@ export async function launchChromeMeetOnNode(params: {
       launched: browserControl.launched || result.launched === true,
       audioBridge: bridge,
       browser: browserControl.browser ?? result.browser,
+      tab: browserControl.tab,
     };
   }
   if (result.audioBridge?.type === "external-command") {
@@ -1124,12 +1396,14 @@ export async function launchChromeMeetOnNode(params: {
       launched: browserControl.launched || result.launched === true,
       audioBridge: { type: "external-command" },
       browser: browserControl.browser ?? result.browser,
+      tab: browserControl.tab,
     };
   }
   return {
     nodeId,
     launched: browserControl.launched || result.launched === true,
     browser: browserControl.browser ?? result.browser,
+    tab: browserControl.tab,
   };
 }
 export { testing as __testing };

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -56,6 +56,7 @@ export const testing = {
   meetLeaveScriptForTest: meetLeaveScript,
   parseMeetBrowserStatusForTest: parseMeetBrowserStatus,
   resolveBrowserGatewayTimeoutMsForTest: resolveBrowserGatewayTimeoutMs,
+  resolveLocalBrowserRequestForTest: resolveLocalBrowserRequest,
 };
 
 function isGoogleMeetTalkBackMode(mode: GoogleMeetMode): boolean {
@@ -209,7 +210,7 @@ export async function launchChromeMeet(params: {
   }
 
   const result = await openMeetWithBrowserRequest({
-    callBrowser: callLocalBrowserRequest,
+    callBrowser: await resolveLocalBrowserRequest(params.runtime),
     config: params.config,
     mode: params.mode,
     url: params.url,
@@ -319,6 +320,28 @@ async function callLocalBrowserRequest(params: BrowserRequestParams) {
     },
     { progress: false },
   );
+}
+
+async function resolveLocalBrowserRequest(runtime: PluginRuntime): Promise<BrowserRequestCaller> {
+  // Gateway-hosted plugin work stays in-process; otherwise agent tools would
+  // need an external operator.admin token just to reach the local browser.
+  if (!(await runtime.gateway.isAvailable())) {
+    return callLocalBrowserRequest;
+  }
+  return async (params) =>
+    await runtime.gateway.request(
+      "browser.request",
+      {
+        method: params.method,
+        path: params.path,
+        body: params.body,
+        timeoutMs: params.timeoutMs,
+      },
+      {
+        timeoutMs: resolveBrowserGatewayTimeoutMs(params.timeoutMs),
+        scopes: ["operator.admin"],
+      },
+    );
 }
 
 function resolveBrowserGatewayTimeoutMs(timeoutMs: number): number {
@@ -873,12 +896,13 @@ async function leaveMeetWithBrowserRequest(params: {
 }
 
 export async function leaveChromeMeet(params: {
+  runtime: PluginRuntime;
   config: GoogleMeetConfig;
   meetingUrl: string;
   tab: GoogleMeetBrowserTab;
 }): Promise<{ left: boolean; note: string }> {
   return await leaveMeetWithBrowserRequest({
-    callBrowser: callLocalBrowserRequest,
+    callBrowser: await resolveLocalBrowserRequest(params.runtime),
     config: params.config,
     meetingUrl: params.meetingUrl,
     tab: params.tab,
@@ -1183,6 +1207,7 @@ async function inspectRecoverableMeetTab(params: {
 }
 
 export async function recoverCurrentMeetTab(params: {
+  runtime: PluginRuntime;
   config: GoogleMeetConfig;
   mode?: GoogleMeetMode;
   readOnly?: boolean;
@@ -1197,8 +1222,9 @@ export async function recoverCurrentMeetTab(params: {
   message: string;
 }> {
   const timeoutMs = Math.max(1_000, params.config.chrome.joinTimeoutMs);
+  const callBrowser = await resolveLocalBrowserRequest(params.runtime);
   const tabs = asBrowserTabs(
-    await callLocalBrowserRequest({
+    await callBrowser({
       method: "GET",
       path: "/tabs",
       timeoutMs: Math.min(timeoutMs, 5_000),
@@ -1219,7 +1245,7 @@ export async function recoverCurrentMeetTab(params: {
   return {
     transport: "chrome",
     ...(await inspectRecoverableMeetTab({
-      callBrowser: callLocalBrowserRequest,
+      callBrowser,
       config: params.config,
       mode: params.mode,
       readOnly: params.readOnly,

--- a/extensions/google-meet/src/transports/types.ts
+++ b/extensions/google-meet/src/transports/types.ts
@@ -107,6 +107,11 @@ export type GoogleMeetChromeHealth = {
   notes?: string[];
 };
 
+export type GoogleMeetBrowserTab = {
+  targetId: string;
+  openedByPlugin: boolean;
+};
+
 export type GoogleMeetSession = {
   id: string;
   url: string;
@@ -115,6 +120,8 @@ export type GoogleMeetSession = {
   /** Canonical agent owner for every later consult and bridge restart. */
   agentId: string;
   state: GoogleMeetSessionState;
+  /** Terminal browser-departure result, retained so repeated leave calls stay idempotent. */
+  browserLeft?: boolean;
   createdAt: string;
   updatedAt: string;
   participantIdentity: string;
@@ -131,6 +138,8 @@ export type GoogleMeetSession = {
     launched: boolean;
     nodeId?: string;
     browserProfile?: string;
+    /** Exact joined tab and whether OpenClaw may close it on leave. */
+    browserTab?: GoogleMeetBrowserTab;
     audioBridge?: {
       type: "command-pair" | "node-command-pair" | "external-command";
       provider?: string;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -996,6 +996,26 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
   });
 
+  test("lets trusted official plugins request explicit Gateway scopes", async () => {
+    loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
+    loadGatewayStartupPluginsForTest();
+    serverPluginsModule.setFallbackGatewayContext(createTestContext("plugin-gateway-admin"));
+    const runtime = runtimeModule.createPluginRuntime();
+
+    await gatewayRequestScopeModule.withPluginRuntimePluginScope(
+      { pluginId: "google-meet", pluginOrigin: "bundled" },
+      () =>
+        runtime.gateway.request(
+          "browser.request",
+          { method: "GET", path: "/tabs" },
+          { scopes: ["operator.admin"] },
+        ),
+    );
+
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
+  });
+
   test("reports whether trusted in-process Gateway dispatch is available", async () => {
     const runtime = runtimeModule.createPluginRuntime();
 
@@ -1066,7 +1086,12 @@ describe("loadGatewayPlugins", () => {
     await expect(
       gatewayRequestScopeModule.withPluginRuntimePluginScope(
         { pluginId: "third-party", pluginOrigin: "global" },
-        () => runtime.gateway.request("voicecall.start", { to: "+15550001234" }),
+        () =>
+          runtime.gateway.request(
+            "voicecall.start",
+            { to: "+15550001234" },
+            { scopes: ["operator.admin"] },
+          ),
       ),
     ).rejects.toThrow("bundled or trusted official plugins");
     expect(handleGatewayRequest).not.toHaveBeenCalled();

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -529,9 +529,11 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
   if (!canTrustedOfficialPluginRequestScopes(scope ?? {})) {
     throw new Error("Gateway requests are only available to bundled or trusted official plugins.");
   }
+  const syntheticScopes = normalizeOperatorScopeList(options?.scopes);
   return await dispatchGatewayMethod<T>(method, params, {
     forceSyntheticClient: true,
     pluginRuntimeOwnerId: pluginId,
+    ...(syntheticScopes ? { syntheticScopes } : {}),
     ...(options?.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
   });
 }

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -92,6 +92,8 @@ export type RuntimeNodeInvokeParams = {
 
 export type RuntimeGatewayRequestOptions = {
   timeoutMs?: number;
+  /** Requested Gateway scopes. Honored only for bundled or trusted official plugins. */
+  scopes?: OperatorScope[];
 };
 
 /** Trusted in-process runtime surface injected into native plugins. */


### PR DESCRIPTION
## Summary

Fixes #103386.

`openclaw googlemeet leave <session-id>` on the Chrome transports printed `left <session-id>` and marked the session `ended`, but only ran the registered stop hook (the realtime audio bridge; in transcribe mode nothing at all). No code path touched the meeting, so the browser participant kept sitting in the call — a ghost participant receiving audio/captions after the operator was told it left. Twilio sessions already end the real call via their stop hook, so the transports were inconsistent.

### Change

- `extensions/google-meet/src/transports/types.ts` + `chrome.ts`: join now persists the exact tab identity on the session — `browserTargetId` plus `browserTabOpenedByPlugin` (opened via `/tabs/open` vs adopted via `reuseExistingTab`). `openMeetWithBrowserRequest` returns it through both the local and node launch paths.
- `chrome.ts`: new `leaveChromeMeet` / `leaveChromeMeetOnNode` (shared `leaveMeetWithBrowserRequest` core). Leave acts on the persisted target only: verifies the tab still exists (already-closed is a clean no-op), clicks Meet's **Leave call** button via browser evaluate (reliable now that tabs are pinned to `?hl=en`), then closes the tab **only when the plugin opened it** — reused user-owned tabs get the click but stay open. Failures degrade to session notes instead of throwing.
- `extensions/google-meet/src/runtime.ts`: `leave()` calls the browser leave for `chrome`/`chrome-node` sessions and records the outcome in session notes. Guards:
  - sessions with no tracked tab (e.g. `chrome.launch: false`, or browser control never returned a targetId) get an explicit note instead of a guessy URL match;
  - the internal tab-reassignment path in `join()` passes `keepBrowserTab: true` so agent handoff keeps the in-call tab and avoids lobby re-admission;
  - the shared-tab guard compares the persisted `browserTargetId` + node context — same meeting URL in a different browser/node no longer suppresses departure.
- `docs/plugins/google-meet.md`: `leave` row now documents the Chrome-transport behavior.

### Review follow-up (b95168f8ece)

All three ClawSweeper P1 findings addressed: leave no longer rediscovers tabs by URL (persisted `targetId` from join), never closes tabs it did not open (opened-vs-reused ownership tracked), and the shared-tab guard is scoped to the actual target + browser context. A reused-tab regression test now covers the default `reuseExistingTab: true` path end to end.

## Verification

- `pnpm test extensions/google-meet` — 17 files, 209 tests passed. New/updated regressions: plugin-opened tab leave (click + close on the exact persisted target), reused user-owned tab leave (click, `DELETE` throws in the mock if attempted, tab stays open), already-closed tab leave (clean note, no `DELETE`), and a vm test that the leave script clicks only an enabled Leave call button.
- `pnpm tsgo:extensions && pnpm tsgo:extensions:test` — clean.
- oxfmt / oxlint on touched files — clean.

## Real behavior proof

Behavior addressed: `googlemeet leave` leaves the browser participant in the Google Meet call on chrome/chrome-node transports while reporting `left`.
Real environment tested: No live Google Meet call was run; behavior is proven at the browser-proxy request boundary with the plugin's existing stubbed-gateway test harness (same harness the join/status paths use), covering opened, reused, and already-closed tab lifecycles.
Exact steps or command run after this patch: `pnpm test extensions/google-meet` and `pnpm test extensions/google-meet/index.test.ts`.
Evidence after fix: "leaves the Meet call in the browser when a chrome session leaves" asserts the `/act` evaluate carries the leave-click script against the persisted join target and that `DELETE /tabs/local-meet-tab` is issued; "keeps a reused Meet tab open on leave" asserts the same click against an adopted pre-existing tab with a mock that throws on any `DELETE`.
Observed result after fix: 209/209 tests pass; leave issues real browser actions scoped to the session's own tab and records an explanatory note in every fallback path.
What was not tested: A live Meet meeting (real Chrome, real Google account) and the chrome-node transport against a physical node; both share `leaveMeetWithBrowserRequest`, which is covered by the harness. Live-call proof of actual participant departure is pending a real Meet setup.
