### PR TITLE
fix(macos): keep old Gateway controls below native titlebar

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -490,13 +490,21 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private static func installNativeChromeScript(into userContentController: WKUserContentController) {
-        // Desktop widths need no rules here: the Control UI's own
-        // `html.openclaw-native-macos` styles inset the topbar past the
-        // traffic lights and keep the brand strip passive under the drag
-        // regions installed in makeWindow (layout.css).
+        // The current Control UI owns its desktop topbar inset. Older remote
+        // Gateways still serve desktop navigation inside the sidebar, so the
+        // app must keep those legacy controls below its native drag regions.
         let css = """
         html.openclaw-native-macos {
           --openclaw-native-titlebar-height: 50px;
+        }
+        @media (min-width: 1101px) {
+          /* Pre-topbar Gateways render desktop controls in these legacy
+             containers. Current desktop UI uses .sidebar-panel and
+             .settings-sidebar__head, so this cannot double-pad its chrome. */
+          html.openclaw-native-macos .shell-nav .sidebar-shell,
+          html.openclaw-native-macos .shell-nav .settings-sidebar__header {
+            padding-top: max(14px, var(--openclaw-native-titlebar-height)) !important;
+          }
         }
         @media (max-width: 1100px) {
           /* The drawer topbar replaces the desktop bar below this breakpoint.

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -313,7 +313,7 @@ struct DashboardWindowSmokeTests {
         #expect(dashboardLogString(for: url) == "http://127.0.0.1:18789/control/")
     }
 
-    @Test func `dashboard native chrome offsets the drawer topbar`() throws {
+    @Test func `dashboard native chrome supports current and legacy dashboard chrome`() throws {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(
             url: url,
@@ -322,13 +322,21 @@ struct DashboardWindowSmokeTests {
             $0.source.contains("openclaw-native-macos-chrome")
         })
 
-        // Desktop widths are styled by the Control UI's own
-        // html.openclaw-native-macos rules; only the drawer topbar needs
-        // native padding injected here.
+        // Current narrow UI: the drawer topbar clears native window controls.
         #expect(chromeScript.source.contains(".topbar"))
         #expect(chromeScript.source.contains("max-width: 1100px"))
         #expect(chromeScript.source.contains("--openclaw-native-titlebar-height"))
-        #expect(!chromeScript.source.contains(".sidebar-shell"))
+
+        // Older remote Gateways: their desktop sidebar controls predate the
+        // topbar and still need the app-provided titlebar clearance.
+        #expect(chromeScript.source.contains("min-width: 1101px"))
+        #expect(chromeScript.source.contains(".shell-nav .sidebar-shell"))
+        #expect(chromeScript.source.contains(".shell-nav .settings-sidebar__header"))
+
+        // Current desktop containers own their clearance in layout.css and
+        // must not receive the legacy padding a second time.
+        #expect(!chromeScript.source.contains(".shell-nav .sidebar-panel"))
+        #expect(!chromeScript.source.contains(".shell-nav .settings-sidebar__head {"))
     }
 
     @Test func `dashboard titlebar hosts back and forward controls`() throws {


### PR DESCRIPTION
Closes #103506

> [!IMPORTANT]
> Hold for coordinated release closeout. #103393 and #103457 are merged; this PR is marked ready only so authoritative CI runs. Do not merge until the parent release lane explicitly clears it.

## What Problem This Solves

Fixes an issue where users opening a remote Gateway dashboard from a newer macOS app could have the older dashboard sidebar and Settings controls covered by the app's native window-drag surface.

## Why This Change Was Made

The macOS app now retains desktop-only titlebar clearance for the two legacy pre-topbar Control UI containers. The selectors are scoped to the old desktop DOM: the current session column uses `.sidebar-panel`, current Settings uses `.settings-sidebar__head`, and the 1101px breakpoint excludes the current drawer, so current chrome is not double-padded.

## User Impact

Users can update the macOS app ahead of a remote Gateway and still click the older dashboard's sidebar actions and Settings exit control reliably. Same-version current dashboards keep their existing topbar, session panel, and Settings layout.

## Evidence

- Real Chromium geometry probe at 1240x860 on Blacksmith Testbox through Crabbox (`tbx_01kx5ckg6nkh69r9s8t7xqwzy0`):
  - native drag region: x=78..254, y=0..46
  - legacy sidebar action: y=14..44 / overlap before; y=50..80 / no overlap after
  - legacy Settings exit: y=14..46 / overlap before; y=50..82 / no overlap after
- `swift test --package-path apps/macos --filter DashboardWindowSmokeTests` on Mac Studio: 18/18 passed, including the current + legacy chrome contract.
- `swiftformat --lint apps/macos/Sources/OpenClaw/DashboardWindowController.swift --config config/swiftformat`: clean.
- Focused SwiftLint on both touched files: exit 0, no serious findings; one pre-existing line-length warning outside this diff.
- `check:changed` on Blacksmith Testbox through Crabbox (`tbx_01kx5ckg6nkh69r9s8t7xqwzy0`): passed in 11m21s.
- Fresh autoreview: clean, no accepted/actionable findings.

No changelog entry: release automation owns release-note generation.
