### PR TITLE
test(ui): cover session drops on pane headers

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -273,8 +273,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       // Each pane owns an in-flow header (title + workspace/split/close
       // actions); no fixed toolbar layer mirrors the split geometry.
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
       const headers = page.locator(".chat-pane__header");
-      await expect.poll(() => page.locator(".chat-split-view__pane").count()).toBe(2);
+      await expect.poll(() => panes.count()).toBe(2);
       await expect.poll(() => headers.count()).toBe(2);
       await expect
         .poll(async () => {
@@ -298,10 +299,18 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await lastPane.click({ position: { x: 20, y: 80 } });
       await expect.poll(() => cells.last().getAttribute("class")).toContain("--active");
       await expect.poll(() => headers.last().getAttribute("class")).toContain("--active");
+      const targetHeader = headers.first();
+      await expect
+        .poll(() =>
+          targetHeader.evaluate((header) => {
+            const owner = header.closest("openclaw-chat-pane");
+            return (
+              owner === header.parentElement && owner?.classList.contains("chat-split-view__pane")
+            );
+          }),
+        )
+        .toBe(true);
 
-      // A pane header is part of that pane's visible cell even though it is an
-      // in-flow sibling of openclaw-chat-pane. Start with no retained body
-      // preview and dispatch the session drag directly onto the header.
       const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
       await dataTransfer.evaluate(
         (transfer, data) => {
@@ -309,7 +318,23 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         },
         { mime: SESSION_DRAG_MIME, sessionKey: "agent:main:session-b" },
       );
-      const targetHeader = headers.first();
+      const unrelatedTarget = page.locator(".chat-split-view");
+      const unrelatedDrag = {
+        bubbles: true,
+        clientX: 0,
+        clientY: 0,
+        dataTransfer,
+      };
+      await unrelatedTarget.dispatchEvent("dragenter", unrelatedDrag);
+      await unrelatedTarget.dispatchEvent("dragover", unrelatedDrag);
+      await expect.poll(() => page.locator(".chat-split-view__drop-indicator").count()).toBe(0);
+      await unrelatedTarget.dispatchEvent("drop", unrelatedDrag);
+      await expect.poll(() => panes.count()).toBe(2);
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("session"))
+        .toBe("agent:main:session-a");
+
+      // Start with no retained pane preview and target the visible header.
       const targetBox = await targetHeader.boundingBox();
       if (!targetBox) {
         throw new Error("expected the pane header to have a layout box");
@@ -326,7 +351,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await targetHeader.dispatchEvent("drop", directHeaderDrag);
       await dataTransfer.dispose();
 
-      await expect.poll(() => page.locator(".chat-split-view__pane").count()).toBe(3);
+      await expect.poll(() => panes.count()).toBe(3);
       await expect
         .poll(() => page.locator(".chat-pane__session-title").allTextContents())
         .toContain("Session B");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover chat flow behavior.
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { SESSION_DRAG_MIME } from "../lib/sessions/drag.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -247,6 +248,8 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           timestamp: Date.now(),
         },
       ],
+      methodResponses: { "sessions.list": chatSessionListResponse() },
+      sessionKey: "agent:main:session-a",
     });
 
     try {
@@ -295,6 +298,41 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await lastPane.click({ position: { x: 20, y: 80 } });
       await expect.poll(() => cells.last().getAttribute("class")).toContain("--active");
       await expect.poll(() => headers.last().getAttribute("class")).toContain("--active");
+
+      // A pane header is part of that pane's visible cell even though it is an
+      // in-flow sibling of openclaw-chat-pane. Start with no retained body
+      // preview and dispatch the session drag directly onto the header.
+      const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+      await dataTransfer.evaluate(
+        (transfer, data) => {
+          transfer.setData(data.mime, data.sessionKey);
+        },
+        { mime: SESSION_DRAG_MIME, sessionKey: "agent:main:session-b" },
+      );
+      const targetHeader = headers.first();
+      const targetBox = await targetHeader.boundingBox();
+      if (!targetBox) {
+        throw new Error("expected the pane header to have a layout box");
+      }
+      const directHeaderDrag = {
+        bubbles: true,
+        clientX: targetBox.x + targetBox.width / 2,
+        clientY: targetBox.y + targetBox.height / 2,
+        dataTransfer,
+      };
+      await targetHeader.dispatchEvent("dragenter", directHeaderDrag);
+      await targetHeader.dispatchEvent("dragover", directHeaderDrag);
+      await expect.poll(() => page.locator(".chat-split-view__drop-indicator").count()).toBe(1);
+      await targetHeader.dispatchEvent("drop", directHeaderDrag);
+      await dataTransfer.dispose();
+
+      await expect.poll(() => page.locator(".chat-split-view__pane").count()).toBe(3);
+      await expect
+        .poll(() => page.locator(".chat-pane__session-title").allTextContents())
+        .toContain("Session B");
+      await expect
+        .poll(() => new URL(page.url()).searchParams.get("session"))
+        .toBe("agent:main:session-b");
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -45,6 +45,18 @@ function handleDrop(page: ChatPage, event: DragEvent) {
   (page as unknown as { handleDrop: (event: DragEvent) => void }).handleDrop(event);
 }
 
+function handleDragOver(page: ChatPage, event: DragEvent) {
+  (page as unknown as { handleDragOver: (event: DragEvent) => void }).handleDragOver(event);
+}
+
+function getDropIndicator(page: ChatPage) {
+  return (
+    page as unknown as {
+      dropIndicator: { paneId: string; zone: SplitDropZone } | null;
+    }
+  ).dropIndicator;
+}
+
 function setNavigationContext(page: ChatPage) {
   const navigate = vi.fn();
   const replace = vi.fn();
@@ -355,5 +367,89 @@ describe("chat page split layout host", () => {
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       search: searchForSession("agent:main:work"),
     });
+  });
+
+  it("resolves a direct header drag and drop to the header's owned pane", async () => {
+    const page = new ChatPage();
+    page.data = { sessionKey: "main" };
+    document.body.append(page);
+    setLayout(page, createSplitLayout("main"));
+    const navigation = setNavigationContext(page);
+    await page.updateComplete;
+
+    const pane = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")].find(
+      (candidate) => candidate.paneId === "p1",
+    );
+    const cell = pane?.closest<HTMLElement>(".chat-split-view__cell");
+    const header = cell?.querySelector<HTMLElement>(".chat-pane__header");
+    const container = page.querySelector<HTMLElement>(".chat-split-view__drop-container");
+    expect(pane).toBeDefined();
+    expect(header).not.toBeNull();
+    expect(container).not.toBeNull();
+    const paneRect = { left: 100, top: 50, width: 200, height: 100 } as DOMRect;
+    const containerRect = { left: 100, top: 50, width: 400, height: 100 } as DOMRect;
+    vi.spyOn(pane!, "getBoundingClientRect").mockReturnValue(paneRect);
+    vi.spyOn(container!, "getBoundingClientRect").mockReturnValue(containerRect);
+    let frame: FrameRequestCallback | undefined;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frame = callback;
+      return 1;
+    });
+    const dataTransfer = {
+      dropEffect: "none",
+      getData: (type: string) => (type === SESSION_DRAG_MIME ? "agent:main:work" : ""),
+      types: [SESSION_DRAG_MIME],
+    } as unknown as DataTransfer;
+
+    expect(getDropIndicator(page)).toBeNull();
+    handleDragOver(page, {
+      target: header,
+      clientX: 200,
+      clientY: 100,
+      preventDefault: vi.fn(),
+      dataTransfer,
+    } as unknown as DragEvent);
+    frame?.(0);
+
+    expect(getDropIndicator(page)?.paneId).toBe("p1");
+    expect(getDropIndicator(page)?.zone).toEqual({ kind: "center" });
+
+    handleDrop(page, {
+      target: header,
+      clientX: 200,
+      clientY: 100,
+      preventDefault: vi.fn(),
+      dataTransfer,
+    } as unknown as DragEvent);
+
+    expect(getLayout(page)?.columns[0].panes[0].sessionKey).toBe("agent:main:work");
+    expect(navigation.replace).toHaveBeenCalledWith("chat", {
+      search: searchForSession("agent:main:work"),
+    });
+  });
+
+  it("keeps unrelated session drop targets as no-ops", async () => {
+    const page = new ChatPage();
+    page.data = { sessionKey: "main" };
+    document.body.append(page);
+    const layout = createSplitLayout("main");
+    setLayout(page, layout);
+    const navigation = setNavigationContext(page);
+    await page.updateComplete;
+
+    handleDrop(page, {
+      target: page.querySelector(".chat-split-view"),
+      clientX: 200,
+      clientY: 100,
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        types: [SESSION_DRAG_MIME],
+        getData: (type: string) => (type === SESSION_DRAG_MIME ? "agent:main:work" : ""),
+      } as unknown as DataTransfer,
+    } as unknown as DragEvent);
+
+    expect(getLayout(page)).toBe(layout);
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(navigation.replace).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -369,23 +369,27 @@ describe("chat page split layout host", () => {
     });
   });
 
-  it("resolves a direct header drag and drop to the header's owned pane", async () => {
+  it("accepts an owned header drop and ignores unrelated targets", async () => {
     const page = new ChatPage();
     page.data = { sessionKey: "main" };
     document.body.append(page);
-    setLayout(page, createSplitLayout("main"));
+    const layout = createSplitLayout("main");
+    setLayout(page, layout);
     const navigation = setNavigationContext(page);
     await page.updateComplete;
 
     const pane = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")].find(
       (candidate) => candidate.paneId === "p1",
     );
-    const cell = pane?.closest<HTMLElement>(".chat-split-view__cell");
-    const header = cell?.querySelector<HTMLElement>(".chat-pane__header");
     const container = page.querySelector<HTMLElement>(".chat-split-view__drop-container");
     expect(pane).toBeDefined();
-    expect(header).not.toBeNull();
     expect(container).not.toBeNull();
+    // This host test stubs the stateful chat pane; mirror its exact light-DOM
+    // header ownership while the E2E test proves the real component output.
+    const header = document.createElement("div");
+    header.className = "chat-pane__header";
+    pane!.prepend(header);
+    expect(header.closest("openclaw-chat-pane")).toBe(pane);
     const paneRect = { left: 100, top: 50, width: 200, height: 100 } as DOMRect;
     const containerRect = { left: 100, top: 50, width: 400, height: 100 } as DOMRect;
     vi.spyOn(pane!, "getBoundingClientRect").mockReturnValue(paneRect);
@@ -401,7 +405,26 @@ describe("chat page split layout host", () => {
       types: [SESSION_DRAG_MIME],
     } as unknown as DataTransfer;
 
+    const unrelatedTarget = page.querySelector(".chat-split-view");
     expect(getDropIndicator(page)).toBeNull();
+    handleDragOver(page, {
+      target: unrelatedTarget,
+      clientX: 200,
+      clientY: 100,
+      preventDefault: vi.fn(),
+      dataTransfer,
+    } as unknown as DragEvent);
+    handleDrop(page, {
+      target: unrelatedTarget,
+      clientX: 200,
+      clientY: 100,
+      preventDefault: vi.fn(),
+      dataTransfer,
+    } as unknown as DragEvent);
+    expect(getDropIndicator(page)).toBeNull();
+    expect(getLayout(page)).toBe(layout);
+    expect(navigation.replace).not.toHaveBeenCalled();
+
     handleDragOver(page, {
       target: header,
       clientX: 200,
@@ -426,30 +449,5 @@ describe("chat page split layout host", () => {
     expect(navigation.replace).toHaveBeenCalledWith("chat", {
       search: searchForSession("agent:main:work"),
     });
-  });
-
-  it("keeps unrelated session drop targets as no-ops", async () => {
-    const page = new ChatPage();
-    page.data = { sessionKey: "main" };
-    document.body.append(page);
-    const layout = createSplitLayout("main");
-    setLayout(page, layout);
-    const navigation = setNavigationContext(page);
-    await page.updateComplete;
-
-    handleDrop(page, {
-      target: page.querySelector(".chat-split-view"),
-      clientX: 200,
-      clientY: 100,
-      preventDefault: vi.fn(),
-      dataTransfer: {
-        types: [SESSION_DRAG_MIME],
-        getData: (type: string) => (type === SESSION_DRAG_MIME ? "agent:main:work" : ""),
-      } as unknown as DataTransfer,
-    } as unknown as DragEvent);
-
-    expect(getLayout(page)).toBe(layout);
-    expect(navigation.navigate).not.toHaveBeenCalled();
-    expect(navigation.replace).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -119,8 +119,9 @@ export class ChatPage extends OpenClawLightDomElement {
     if (event.dataTransfer) {
       event.dataTransfer.dropEffect = "copy";
     }
-    const pane = this.resolveDropPane(event.target);
-    if (!pane) {
+    const target = event.target instanceof Element ? event.target : null;
+    const pane = target?.closest<ChatPaneElement>("openclaw-chat-pane");
+    if (!pane || !this.contains(pane)) {
       // Dividers and pane gaps sit between drop targets; keep the last preview
       // instead of flickering it away while the pointer crosses them.
       return;
@@ -169,31 +170,19 @@ export class ChatPage extends OpenClawLightDomElement {
     }
     event.preventDefault();
     const sessionKey = readSessionDragData(event.dataTransfer);
-    const pane = this.resolveDropPane(event.target);
+    const target = event.target instanceof Element ? event.target : null;
+    const pane = target?.closest<ChatPaneElement>("openclaw-chat-pane");
     // Fall back to the retained preview when the drop lands on a divider or
     // gap, so the drop always matches what the indicator promised.
     const indicator =
-      (pane ? this.resolveDropIndicator(pane, event.clientX, event.clientY) : null) ??
-      this.dropIndicator;
+      (pane && this.contains(pane)
+        ? this.resolveDropIndicator(pane, event.clientX, event.clientY)
+        : null) ?? this.dropIndicator;
     this.clearDropIndicator();
     if (sessionKey && indicator) {
       this.applySessionDrop(sessionKey, indicator.paneId, indicator.zone);
     }
   };
-
-  /** A split cell owns one pane plus its in-flow header. Treat both surfaces
-   * as the same drop target without claiming dividers or other page chrome. */
-  private resolveDropPane(target: EventTarget | null): ChatPaneElement | null {
-    if (!(target instanceof Element)) {
-      return null;
-    }
-    const pane =
-      target.closest<ChatPaneElement>("openclaw-chat-pane") ??
-      target
-        .closest<HTMLElement>(".chat-split-view__cell")
-        ?.querySelector<ChatPaneElement>(":scope > openclaw-chat-pane");
-    return pane && this.contains(pane) ? pane : null;
-  }
 
   private readonly handleWindowDragEnd = () => {
     this.clearDropIndicator();

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -119,9 +119,8 @@ export class ChatPage extends OpenClawLightDomElement {
     if (event.dataTransfer) {
       event.dataTransfer.dropEffect = "copy";
     }
-    const target = event.target instanceof Element ? event.target : null;
-    const pane = target?.closest<ChatPaneElement>("openclaw-chat-pane");
-    if (!pane || !this.contains(pane)) {
+    const pane = this.resolveDropPane(event.target);
+    if (!pane) {
       // Dividers and pane gaps sit between drop targets; keep the last preview
       // instead of flickering it away while the pointer crosses them.
       return;
@@ -170,19 +169,31 @@ export class ChatPage extends OpenClawLightDomElement {
     }
     event.preventDefault();
     const sessionKey = readSessionDragData(event.dataTransfer);
-    const target = event.target instanceof Element ? event.target : null;
-    const pane = target?.closest<ChatPaneElement>("openclaw-chat-pane");
+    const pane = this.resolveDropPane(event.target);
     // Fall back to the retained preview when the drop lands on a divider or
     // gap, so the drop always matches what the indicator promised.
     const indicator =
-      (pane && this.contains(pane)
-        ? this.resolveDropIndicator(pane, event.clientX, event.clientY)
-        : null) ?? this.dropIndicator;
+      (pane ? this.resolveDropIndicator(pane, event.clientX, event.clientY) : null) ??
+      this.dropIndicator;
     this.clearDropIndicator();
     if (sessionKey && indicator) {
       this.applySessionDrop(sessionKey, indicator.paneId, indicator.zone);
     }
   };
+
+  /** A split cell owns one pane plus its in-flow header. Treat both surfaces
+   * as the same drop target without claiming dividers or other page chrome. */
+  private resolveDropPane(target: EventTarget | null): ChatPaneElement | null {
+    if (!(target instanceof Element)) {
+      return null;
+    }
+    const pane =
+      target.closest<ChatPaneElement>("openclaw-chat-pane") ??
+      target
+        .closest<HTMLElement>(".chat-split-view__cell")
+        ?.querySelector<ChatPaneElement>(":scope > openclaw-chat-pane");
+    return pane && this.contains(pane) ? pane : null;
+  }
 
   private readonly handleWindowDragEnd = () => {
     this.clearDropIndicator();


### PR DESCRIPTION
Closes #103507

## What Problem This Solves

#103507 reported that a session dragged directly onto a split-pane header was ignored because the header sat outside `openclaw-chat-pane`. Current `main` no longer has that structure: #103561 moved each header into the owning light-DOM pane, so the existing `target.closest("openclaw-chat-pane")` path accepts the header without a second resolver.

The missing piece was durable coverage. Without an exact ownership and browser-flow regression, a later split-header refactor could silently recreate the same drag/drop gap.

## Why This Change Was Made

The stale production fallback from the original branch was removed. This PR now adds only focused regression coverage:

- the split host unit mirrors the stateful pane's exact light-DOM header ownership, proves a clean header drag resolves the correct center preview and session replacement, and proves an unrelated split-layout target leaves layout and navigation unchanged;
- the existing mocked-Gateway Chromium flow proves the real rendered header is directly owned by its pane, an unrelated target is a no-op, and a direct header drop adds the expected pane, renders `Session B`, and updates the URL.

This is the narrow owner-boundary solution after #103561: no dead cell fallback, no duplicate target inference, and no dependency on removed topbar structure.

## User Impact

No runtime behavior changes. The session-drop behavior fixed structurally by #103561 now has unit and real-browser regression protection.

## Evidence

- Exact head: `4e6d26ad215c858fb871800224f6978c63ee1764`.
- Blacksmith Testbox through Crabbox: `tbx_01kx5p362xg5ad7m17mh4vtf4w`.
- `corepack pnpm test ui/src/pages/chat/chat-page.test.ts`: 13/13 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts`: 38/38 passed on the final rebased head.
- `corepack pnpm format:check -- ui/src/pages/chat/chat-page.test.ts ui/src/e2e/chat-flow.e2e.test.ts`: passed.
- `corepack pnpm check:changed`: `coreTests` lane passed typecheck, lint, and guards.
- `git diff --check`: passed.
- Fresh Codex autoreview on the final branch diff: clean, no accepted/actionable findings.
- Hosted exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29084451881

No changelog entry: test-only coverage for behavior already fixed on `main`.

AI-assisted: implemented and independently reviewed with Codex; the maintainer understands the test changes.
