### PR TITLE
fix(gateway): enforce plugin-runtime ownership on sessions.patch (#103077)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -35,13 +35,13 @@ import {
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../../agents/agent-runtime-metadata.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import {
   abortEmbeddedAgentRun,
   isEmbeddedAgentRunActive,
   waitForEmbeddedAgentRunEnd,
 } from "../../agents/embedded-agent-runner/runs.js";
 import { compactEmbeddedAgentSession } from "../../agents/embedded-agent.js";
+import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { insideGitCheckout } from "../../agents/worktrees/git.js";
 import { managedWorktrees } from "../../agents/worktrees/service.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
@@ -196,7 +196,11 @@ function requireSessionKey(key: unknown, respond: RespondFn): string | null {
   return normalized;
 }
 
-function rejectPluginRuntimeDeleteMismatch(params: {
+// In-process plugin-runtime callers are fenced to sessions their plugin created.
+// Both delete and patch enforce it: patch flips archive state and rewrites
+// key/label/category, so an unfenced patch would bypass the delete fence.
+function rejectPluginRuntimeSessionMismatch(params: {
+  action: "delete" | "patch";
   client: GatewayClient | null;
   key: string;
   entry: SessionEntry | undefined;
@@ -214,7 +218,7 @@ function rejectPluginRuntimeDeleteMismatch(params: {
     undefined,
     errorShape(
       ErrorCodes.INVALID_REQUEST,
-      `Plugin "${pluginOwnerId}" cannot delete session "${params.key}" because it did not create it.`,
+      `Plugin "${pluginOwnerId}" cannot ${params.action} session "${params.key}" because it did not create it.`,
     ),
   );
   return true;
@@ -2008,6 +2012,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     });
     const canonicalKey = target.canonicalKey ?? key;
     const lifecycleEntry = loadSessionEntry(key, { agentId: requestedAgentId }).entry;
+    if (
+      rejectPluginRuntimeSessionMismatch({
+        action: "patch",
+        client,
+        key: canonicalKey,
+        entry: lifecycleEntry,
+        respond,
+      })
+    ) {
+      return;
+    }
     const lifecycleIdentities = [canonicalKey, key, lifecycleEntry?.sessionId];
     if (p.archived === true && isSessionLifecycleMutationActive(storePath, lifecycleIdentities)) {
       respond(
@@ -2036,6 +2051,19 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           undefined,
           errorShape(ErrorCodes.INVALID_REQUEST, `Session ${key} changed before patch. Retry.`),
         );
+        return null;
+      }
+      // Recheck under the lifecycle lock, mirroring delete: ownership must not
+      // change hands between the pre-lock check and the mutation.
+      if (
+        rejectPluginRuntimeSessionMismatch({
+          action: "patch",
+          client,
+          key: canonicalKey,
+          entry: currentLifecycleEntry,
+          respond,
+        })
+      ) {
         return null;
       }
       if (p.archived === true) {
@@ -2363,7 +2391,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     if (
-      rejectPluginRuntimeDeleteMismatch({
+      rejectPluginRuntimeSessionMismatch({
+        action: "delete",
         client,
         key: target.canonicalKey ?? key,
         entry: initialDeleteEntry,
@@ -2428,7 +2457,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           return undefined;
         }
         if (
-          rejectPluginRuntimeDeleteMismatch({
+          rejectPluginRuntimeSessionMismatch({
+            action: "delete",
             client,
             key: canonicalKey ?? key,
             entry,
@@ -2852,8 +2882,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
               spawnedBy: latestEntry.spawnedBy,
               workspaceDir: latestEntry.spawnedWorkspaceDir,
               cwd: latestEntry.spawnedCwd,
-            }) ??
-            resolveAgentWorkspaceDir(cfg, target.agentId);
+            }) ?? resolveAgentWorkspaceDir(cfg, target.agentId);
           const operationId = randomUUID();
           emitSessionOperation(context, {
             operationId,

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -674,6 +674,86 @@ test("sessions.delete limits plugin-runtime cleanup to sessions owned by that pl
   expect(deleted.payload?.deleted).toBe(true);
 });
 
+test("sessions.patch limits plugin-runtime mutations to sessions owned by that plugin", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-owned", "owned");
+  await writeSingleLineSession(dir, "sess-foreign", "foreign");
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:dreaming-narrative-owned": sessionStoreEntry("sess-owned", {
+        pluginOwnerId: "memory-core",
+      }),
+      "agent:main:dreaming-narrative-foreign": sessionStoreEntry("sess-foreign", {
+        pluginOwnerId: "other-plugin",
+      }),
+    },
+  });
+
+  const pluginClient = {
+    connect: {
+      scopes: ["operator.admin"],
+    },
+    internal: {
+      pluginRuntimeOwnerId: "memory-core",
+    },
+  } as never;
+
+  const archiveDenied = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-foreign",
+      archived: true,
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(archiveDenied.ok).toBe(false);
+  expect(archiveDenied.error?.message).toContain(
+    'cannot patch session "agent:main:dreaming-narrative-foreign" because it did not create it',
+  );
+
+  const unarchiveDenied = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-foreign",
+      archived: false,
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(unarchiveDenied.ok).toBe(false);
+  expect(unarchiveDenied.error?.message).toContain("did not create it");
+
+  const labelDenied = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-foreign",
+      label: "hijacked",
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(labelDenied.ok).toBe(false);
+  expect(labelDenied.error?.message).toContain("did not create it");
+
+  const ownedPatch = await directSessionReq<{ ok: true; entry?: { archivedAt?: number } }>(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-owned",
+      archived: true,
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(ownedPatch.ok).toBe(true);
+  expect(ownedPatch.payload?.entry?.archivedAt).toBeDefined();
+});
+
 test("sessions.delete scopes selected global deletes to the requested agent", async () => {
   const globalStores = await createConfiguredGlobalAgentSessionStore({ writePrimeStore: true });
 


### PR DESCRIPTION
## Summary

Fixes #103077.

`sessions.delete` fences in-process plugin-runtime callers (`client.internal.pluginRuntimeOwnerId`) to sessions their plugin created, enforcing it twice — pre-lock and re-checked under the lifecycle lock. `sessions.patch` had no ownership check at all, so the same client identity that delete refuses could archive a foreign plugin's session (making it read-only for every future chat/agent/cron path), un-archive a session the owner deliberately fenced, or rewrite its `label`/`category`/`pinned`/`key`.

### Change

`src/gateway/server-methods/sessions.ts`:
- Generalized `rejectPluginRuntimeDeleteMismatch` into `rejectPluginRuntimeSessionMismatch({ action: "delete" | "patch", ... })` — same invariant, same error shape, action-specific message (`Plugin "X" cannot patch session "Y" because it did not create it.`).
- `sessions.patch` now enforces the fence pre-lock (right after the target entry loads) and re-checks under the lifecycle lock via the already-loaded `currentLifecycleEntry`, mirroring the delete handler's race guard.
- Both delete call sites updated to the generalized helper; no behavior change for delete.

Sibling surfaces (per the issue's analysis, verified against current main): `sessions.pluginPatch` is a separate `operator.admin`-gated method for namespaced plugin KV data and does not touch archive state or `pluginOwnerId`; `sessions.reset` does not flip archive or ownership-adjacent fields. Neither is changed here.

## Verification

- `pnpm test src/gateway/server.sessions.delete-lifecycle.test.ts` — 46 passed, including the new regression `sessions.patch limits plugin-runtime mutations to sessions owned by that plugin` (archive, un-archive, and label rewrite all refused against a foreign-owned entry with the exact expected message; same-owner archive still succeeds).
- `pnpm test` across all gateway suites exercising `sessions.patch` (store-rpc, reset-cleanup, permissions-hooks, compaction, config-patch, list-changed, method-scopes) — 612 passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt, oxlint — clean.

## Real behavior proof

Behavior addressed: `sessions.patch` mutated sessions owned by a different plugin with no ownership check, unlike `sessions.delete`.
Real environment tested: real gateway `sessions.patch`/`sessions.delete` RPC handlers driven through the same `directSessionReq` harness the shipped delete-ownership regression uses (client with `internal.pluginRuntimeOwnerId: "memory-core"` and `connect.scopes: ["operator.admin"]` against a store entry with `pluginOwnerId: "other-plugin"`).
Exact steps or command run after this patch: `pnpm test src/gateway/server.sessions.delete-lifecycle.test.ts`
Evidence after fix: new test asserts `sessions.patch { archived: true }`, `{ archived: false }`, and `{ label: "hijacked" }` against the foreign entry all return `ok: false` with `Plugin "memory-core" cannot patch session "agent:main:dreaming-narrative-foreign" because it did not create it.`, while the same patch against the plugin's own session returns `ok: true` with `archivedAt` set.
Observed result after fix: 46/46 tests in the lifecycle suite pass; patch now matches delete's refusal for the identical client/entry pair from the issue repro.
What was not tested: production plugin-runtime process wiring (`server-plugins.ts`) end-to-end; the harness builds the client identity exactly the way the shipped delete regression does, which is how that trust boundary is already validated.
