### PR TITLE
fix(plugins): accept null optional metadata in approval requests

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8252,37 +8252,37 @@ public struct ExecApprovalResolveParams: Codable, Sendable {
 }
 
 public struct PluginApprovalRequestParams: Codable, Sendable {
-    public let pluginid: String?
+    public let pluginid: AnyCodable?
     public let title: String
     public let description: String
-    public let severity: String?
-    public let toolname: String?
-    public let toolcallid: String?
-    public let alloweddecisions: [String]?
-    public let agentid: String?
-    public let sessionkey: String?
+    public let severity: AnyCodable?
+    public let toolname: AnyCodable?
+    public let toolcallid: AnyCodable?
+    public let alloweddecisions: AnyCodable?
+    public let agentid: AnyCodable?
+    public let sessionkey: AnyCodable?
     public let approvalreviewerdeviceids: [String]?
-    public let turnsourcechannel: String?
-    public let turnsourceto: String?
-    public let turnsourceaccountid: String?
+    public let turnsourcechannel: AnyCodable?
+    public let turnsourceto: AnyCodable?
+    public let turnsourceaccountid: AnyCodable?
     public let turnsourcethreadid: AnyCodable?
     public let timeoutms: Int?
     public let twophase: Bool?
 
     public init(
-        pluginid: String?,
+        pluginid: AnyCodable?,
         title: String,
         description: String,
-        severity: String?,
-        toolname: String?,
-        toolcallid: String?,
-        alloweddecisions: [String]?,
-        agentid: String? = nil,
-        sessionkey: String?,
+        severity: AnyCodable?,
+        toolname: AnyCodable?,
+        toolcallid: AnyCodable?,
+        alloweddecisions: AnyCodable?,
+        agentid: AnyCodable? = nil,
+        sessionkey: AnyCodable?,
         approvalreviewerdeviceids: [String]? = nil,
-        turnsourcechannel: String?,
-        turnsourceto: String?,
-        turnsourceaccountid: String?,
+        turnsourcechannel: AnyCodable?,
+        turnsourceto: AnyCodable?,
+        turnsourceaccountid: AnyCodable?,
         turnsourcethreadid: AnyCodable?,
         timeoutms: Int?,
         twophase: Bool?)

--- a/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
@@ -13,4 +13,50 @@ describe("plugin approval protocol validators", () => {
       false,
     );
   });
+
+  it("accepts nullable optional metadata the same as omitted metadata", () => {
+    // Callers that normalize missing optional metadata to `null` (e.g. bridge
+    // callers) must be accepted, matching the gateway handler which already
+    // treats every optional field here as `string | null`. See issue #98403.
+    const request = {
+      title: "Run host shell command",
+      description: "The agent wants to execute a sandboxed command.",
+      pluginId: null,
+      severity: null,
+      toolName: null,
+      toolCallId: null,
+      allowedDecisions: null,
+      agentId: null,
+      sessionKey: null,
+      turnSourceChannel: null,
+      turnSourceTo: null,
+      turnSourceAccountId: null,
+      turnSourceThreadId: null,
+      twoPhase: true,
+    };
+
+    expect(validatePluginApprovalRequestParams(request)).toBe(true);
+  });
+
+  it("accepts a single nullable optional field alongside present metadata", () => {
+    expect(
+      validatePluginApprovalRequestParams({
+        title: "Approve file write",
+        description: "Write to the workspace.",
+        pluginId: null,
+        toolName: "write_file",
+      }),
+    ).toBe(true);
+  });
+
+  it("still rejects unknown extra fields and non-null invalid values (surgical relaxation)", () => {
+    const base = { title: "Approve file write", description: "Write to the workspace." };
+
+    // additionalProperties: false is preserved — an unknown field is still rejected.
+    expect(validatePluginApprovalRequestParams({ ...base, unknownField: "nope" })).toBe(false);
+
+    // Only `null` was added as an alternative for optional metadata; a non-string
+    // pluginId (e.g. a number) is still rejected.
+    expect(validatePluginApprovalRequestParams({ ...base, pluginId: 123 })).toBe(false);
+  });
 });

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -16,30 +16,35 @@ const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
 export const PluginApprovalRequestParamsSchema = Type.Object(
   {
-    pluginId: Type.Optional(NonEmptyString),
+    pluginId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
     description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
-    severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
-    toolName: Type.Optional(Type.String()),
-    toolCallId: Type.Optional(Type.String()),
-    allowedDecisions: Type.Optional(
-      Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
-        minItems: 1,
-        maxItems: 3,
-      }),
+    severity: Type.Optional(
+      Type.Union([Type.String({ enum: ["info", "warning", "critical"] }), Type.Null()]),
     ),
-    agentId: Type.Optional(Type.String()),
-    sessionKey: Type.Optional(Type.String()),
+    toolName: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    toolCallId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    allowedDecisions: Type.Optional(
+      Type.Union([
+        Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
+          minItems: 1,
+          maxItems: 3,
+        }),
+        Type.Null(),
+      ]),
+    ),
+    agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     approvalReviewerDeviceIds: Type.Optional(
       Type.Array(NonEmptyString, {
         description:
           "Trusted approval-runtime metadata naming operator devices that may review this approval; ordinary Gateway clients may send the field, but the Gateway only binds it for internal approval-runtime requests.",
       }),
     ),
-    turnSourceChannel: Type.Optional(Type.String()),
-    turnSourceTo: Type.Optional(Type.String()),
-    turnSourceAccountId: Type.Optional(Type.String()),
-    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    turnSourceChannel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    turnSourceTo: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    turnSourceAccountId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
     twoPhase: Type.Optional(Type.Boolean()),
   },


### PR DESCRIPTION
Closes #98403

## What Problem This Solves

Fixes an issue where `plugin.approval.request` rejected requests whose optional metadata fields were serialized as `null`. Callers that normalize missing optional metadata to `null` (for example, bridge callers serializing absent plugin IDs, tool IDs, severity, or turn-source routing fields) received `INVALID_REQUEST` before the approval could be registered or routed — even though the gateway handler already treats every one of these fields as `string | null` and normalizes them via `normalizeOptionalString`.

## Why This Change Was Made

The validation schema was the sole holdout: `PluginApprovalRequestParamsSchema` declared each optional metadata field as `Type.Optional(Type.String())` (or `NonEmptyString` / the decision array) with no `Type.Null()` alternative, under `additionalProperties: false`, so a literal `null` failed validation before the handler's nullable-normalization path could run.

This adds `Type.Null()` to the optional metadata fields (`pluginId`, `severity`, `toolName`, `toolCallId`, `allowedDecisions`, `agentId`, `sessionKey`, `turnSourceChannel/To/AccountId/ThreadId`), mirroring the nullable pattern the sibling `ExecApproval` request schema already uses for the same routing fields. The change is strictly a relaxation: omitted still works, a present string still works, and now `null` is also accepted. `additionalProperties: false` and the required `title` / `description` / `timeoutMs` / `twoPhase` contract are unchanged; `approvalReviewerDeviceIds` is left untouched because the handler does not treat it as nullable.

A focused regression test sends every optional metadata field as `null` and asserts the request validates, plus a guard that an unknown extra field and a non-string `pluginId` are still rejected (so the relaxation is surgical).

## User Impact

Plugin and bridge callers that serialize missing optional approval metadata as `null` (rather than omitting the key) now successfully register approval requests instead of receiving a spurious `INVALID_REQUEST`. Nullable optional approval metadata is now accepted identically to omitted metadata, matching the handler's existing behavior.

## Evidence

Reproduced on a clean checkout of `upstream/main` (`0f3fb9ea58`) before the fix, then re-ran the exact same command after:

`node scripts/run-vitest.mjs run packages/gateway-protocol/src/plugin-approvals-validators.test.ts`

**Before** (schema rejects `null` — the two nullable-acceptance cases fail):

```
FAIL  ... > accepts nullable optional metadata the same as omitted metadata
AssertionError: expected false to be true
FAIL  ... > accepts a single nullable optional field alongside present metadata
AssertionError: expected false to be true
Test Files  1 failed (1)
     Tests  2 failed | 2 passed (4)
```

**After** (all optional metadata as `null` is accepted; the surgical guards still reject unknown fields and non-null invalid values):

```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

The direct consumer suite is unaffected: `node scripts/run-vitest.mjs run src/gateway/server-methods/plugin-approval.test.ts` → 60 passed (2 files). `oxlint` on the changed files is clean.

---

Note: draft #98404 addresses the same issue. It is currently draft, ~8 days stale, and `DIRTY`/conflicting against `main` (the schema has since gained the `approvalReviewerDeviceIds` field and the description max-length changed 256 → 512), and its `Real behavior proof` check fails. This PR is a fresh, non-draft change against current `main` with regression coverage and the PR-body evidence the gate requires. Happy to close this if a maintainer prefers to land #98404 instead.