### PR TITLE
fix(gateway): enforce plugin-ownership check in sessions.patch

### DIFF
--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -212,6 +212,9 @@ export async function applySessionPatchProjection<
   assertCurrent?: () => void;
   storePath: string;
   resolveTarget: (snapshot: SessionPatchProjectionSnapshot) => SessionPatchProjectionTarget;
+  authorize?: (
+    context: SessionPatchProjectionContext,
+  ) => Promise<TFailure | undefined> | TFailure | undefined;
   project: (
     context: SessionPatchProjectionContext,
   ) => Promise<SessionPatchProjectionResult<TFailure>> | SessionPatchProjectionResult<TFailure>;
@@ -224,11 +227,18 @@ export async function applySessionPatchProjection<
   );
   const target = params.resolveTarget({ entries });
   const existingEntry = resolveProjectionExistingEntry(entries, target);
-  const projected = await params.project({
+  const context: SessionPatchProjectionContext = {
     ...target,
     entries,
     ...(existingEntry ? { existingEntry } : {}),
-  });
+  };
+  if (params.authorize) {
+    const authorizationFailure = await params.authorize(context);
+    if (authorizationFailure) {
+      return authorizationFailure;
+    }
+  }
+  const projected = await params.project(context);
   if (!projected.ok) {
     return projected;
   }

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -32,7 +32,7 @@ import { emitSessionsChanged } from "./session-change-event.js";
 import {
   loadAccessorSessionEntryForGatewayTarget,
   loadSessionsRuntimeModule,
-  rejectPluginRuntimeDeleteMismatch,
+  rejectPluginRuntimeSessionMismatch,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
   resolveSessionWorkerPlacementMutationError,
@@ -181,11 +181,12 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
       return;
     }
     if (
-      rejectPluginRuntimeDeleteMismatch({
+      rejectPluginRuntimeSessionMismatch({
         client,
         key: target.canonicalKey ?? key,
         entry: initialDeleteEntry,
         respond,
+        action: "delete",
       })
     ) {
       return;
@@ -304,11 +305,12 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
           return undefined;
         }
         if (
-          rejectPluginRuntimeDeleteMismatch({
+          rejectPluginRuntimeSessionMismatch({
             client,
             key: canonicalKey ?? key,
             entry,
             respond,
+            action: "delete",
           })
         ) {
           return undefined;

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -45,6 +45,8 @@ import { resolveOperatorSessionCreation } from "./session-creation-provenance.js
 import {
   isAgentMainSessionKey,
   loadSessionsRuntimeModule,
+  pluginRuntimeSessionMismatchError,
+  rejectPluginRuntimeSessionMismatch,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
   resolveSessionWorkerPlacementPatchError,
@@ -96,6 +98,18 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     });
     if (initialPlacementPatchError) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, initialPlacementPatchError));
+      return;
+    }
+    const pluginOwnerId = normalizeOptionalString(client?.internal?.pluginRuntimeOwnerId);
+    if (
+      rejectPluginRuntimeSessionMismatch({
+        client,
+        key: canonicalKey,
+        entry: lifecycleEntry,
+        respond,
+        action: "patch",
+      })
+    ) {
       return;
     }
     const lifecycleIdentities = [canonicalKey, key, lifecycleEntry?.sessionId];
@@ -181,6 +195,15 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
         assertCurrent: sessionMutationAuthorization?.assertCurrent,
         storePath,
         resolveTarget: resolvePatchTarget,
+        authorize: ({ existingEntry }) => {
+          const mismatchError = pluginRuntimeSessionMismatchError({
+            client,
+            key: canonicalKey,
+            entry: existingEntry,
+            action: "patch",
+          });
+          return mismatchError ? { ok: false, error: mismatchError } : undefined;
+        },
         project: async ({ primaryKey, existingEntry, entries }) => {
           wasArchivedBeforePatch = existingEntry?.archivedAt !== undefined;
           const projected = await projectSessionsPatchEntry({
@@ -192,6 +215,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
             patch: p,
             archivedBy: archiveActor,
             loadGatewayModelCatalog: loadPatchModelCatalog,
+            pluginOwnerId,
           });
           if (!projected.ok) {
             return projected;

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -161,27 +161,39 @@ export function requireSessionKey(key: unknown, respond: RespondFn): string | nu
   return normalized;
 }
 
-export function rejectPluginRuntimeDeleteMismatch(params: {
+export function pluginRuntimeSessionMismatchError(params: {
+  client: GatewayClient | null;
+  key: string;
+  entry: SessionEntry | undefined;
+  action: "patch" | "delete";
+}): ReturnType<typeof errorShape> | undefined {
+  const pluginOwnerId = normalizeOptionalString(params.client?.internal?.pluginRuntimeOwnerId);
+  if (!pluginOwnerId || !params.entry) {
+    return undefined;
+  }
+  // Fail closed: plugin-runtime callers may only mutate rows they created.
+  // Legacy ownerless rows have no safe plugin authority and are rejected.
+  if (normalizeOptionalString(params.entry.pluginOwnerId) === pluginOwnerId) {
+    return undefined;
+  }
+  return errorShape(
+    ErrorCodes.INVALID_REQUEST,
+    `Plugin "${pluginOwnerId}" cannot ${params.action} session "${params.key}" because it did not create it.`,
+  );
+}
+
+export function rejectPluginRuntimeSessionMismatch(params: {
   client: GatewayClient | null;
   key: string;
   entry: SessionEntry | undefined;
   respond: RespondFn;
+  action: "patch" | "delete";
 }): boolean {
-  const pluginOwnerId = normalizeOptionalString(params.client?.internal?.pluginRuntimeOwnerId);
-  if (!pluginOwnerId || !params.entry) {
+  const mismatchError = pluginRuntimeSessionMismatchError(params);
+  if (!mismatchError) {
     return false;
   }
-  if (normalizeOptionalString(params.entry.pluginOwnerId) === pluginOwnerId) {
-    return false;
-  }
-  params.respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `Plugin "${pluginOwnerId}" cannot delete session "${params.key}" because it did not create it.`,
-    ),
-  );
+  params.respond(false, undefined, mismatchError);
   return true;
 }
 

--- a/src/gateway/server.sessions.patch-plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.patch-plugin-ownership.test.ts
@@ -1,0 +1,218 @@
+// Plugin-runtime sessions.patch ownership tests protect the fail-closed rule
+// that plugin callers may only mutate session rows they created.
+import { afterEach, expect, test, vi } from "vitest";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import * as sessionUtils from "../gateway/session-utils.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  setupGatewaySessionsTestHarness,
+  directSessionReq,
+  sessionStoreEntry,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+test("sessions.patch limits plugin-runtime mutations to sessions owned by that plugin", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "agent:main:dreaming-narrative-owned": sessionStoreEntry("sess-owned", {
+        pluginOwnerId: "memory-core",
+      }),
+      "agent:main:dreaming-narrative-foreign": sessionStoreEntry("sess-foreign", {
+        pluginOwnerId: "other-plugin",
+      }),
+      "agent:main:dreaming-narrative-foreign-archived": sessionStoreEntry("sess-foreign-archived", {
+        pluginOwnerId: "other-plugin",
+        archivedAt: Date.now(),
+      }),
+    },
+  });
+
+  const pluginClient = {
+    connect: {
+      scopes: ["operator.admin"],
+    },
+    internal: {
+      pluginRuntimeOwnerId: "memory-core",
+    },
+  } as never;
+
+  const archiveForeign = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-foreign",
+      archived: true,
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(archiveForeign.ok).toBe(false);
+  expect(archiveForeign.error?.message).toContain("did not create it");
+
+  const unarchiveForeign = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-foreign-archived",
+      archived: false,
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(unarchiveForeign.ok).toBe(false);
+  expect(unarchiveForeign.error?.message).toContain("did not create it");
+
+  const patchOwned = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-owned",
+      label: "patched by owner",
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(patchOwned.ok).toBe(true);
+  expect(
+    loadSessionEntry({
+      agentId: "main",
+      sessionKey: "agent:main:dreaming-narrative-owned",
+      storePath,
+    })?.label,
+  ).toBe("patched by owner");
+});
+
+test("sessions.patch rejects plugin-runtime patches on legacy ownerless sessions", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const originalEntry = sessionStoreEntry("sess-ownerless");
+  await writeSessionStore({
+    entries: {
+      "agent:main:dreaming-narrative-ownerless": originalEntry,
+    },
+  });
+
+  const pluginClient = {
+    connect: {
+      scopes: ["operator.admin"],
+    },
+    internal: {
+      pluginRuntimeOwnerId: "memory-core",
+    },
+  } as never;
+
+  const patchOwnerless = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-ownerless",
+      label: "patched by plugin",
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(patchOwnerless.ok).toBe(false);
+  expect(patchOwnerless.error?.message).toContain("did not create it");
+  expect(
+    loadSessionEntry({
+      agentId: "main",
+      sessionKey: "agent:main:dreaming-narrative-ownerless",
+      storePath,
+    }),
+  ).toMatchObject(originalEntry);
+});
+
+test("sessions.patch rejects a foreign-owned row missed by the initial handler lookup", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const originalEntry = sessionStoreEntry("sess-concurrent", {
+    pluginOwnerId: "other-plugin",
+  });
+  await writeSessionStore({
+    entries: {
+      "agent:main:dreaming-narrative-concurrent": originalEntry,
+    },
+  });
+
+  const pluginClient = {
+    connect: {
+      scopes: ["operator.admin"],
+    },
+    internal: {
+      pluginRuntimeOwnerId: "memory-core",
+    },
+  } as never;
+
+  // Simulate the foreign-owned row being absent from the handler's preliminary
+  // lookup but present in the accessor snapshot used for authorization.
+  const loadSessionEntrySpy = vi
+    .spyOn(sessionUtils, "loadSessionEntry")
+    .mockImplementationOnce(() => ({
+      cfg: {} as never,
+      storePath: "",
+      store: {},
+      entry: undefined,
+      canonicalKey: "agent:main:dreaming-narrative-concurrent",
+      storeKeys: ["agent:main:dreaming-narrative-concurrent"],
+      legacyKey: undefined,
+    }));
+
+  const patchConcurrent = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-concurrent",
+      label: "patched by plugin",
+    },
+    {
+      client: pluginClient,
+    },
+  );
+
+  loadSessionEntrySpy.mockRestore();
+
+  expect(patchConcurrent.ok).toBe(false);
+  expect(patchConcurrent.error?.message).toContain("did not create it");
+  expect(
+    loadSessionEntry({
+      agentId: "main",
+      sessionKey: "agent:main:dreaming-narrative-concurrent",
+      storePath,
+    }),
+  ).toMatchObject(originalEntry);
+});
+
+test("sessions.patch stamps pluginOwnerId when patch creates a new session", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const pluginClient = {
+    connect: {
+      scopes: ["operator.admin"],
+    },
+    internal: {
+      pluginRuntimeOwnerId: "memory-core",
+    },
+  } as never;
+
+  const patchCreate = await directSessionReq(
+    "sessions.patch",
+    {
+      key: "agent:main:dreaming-narrative-new",
+      label: "created by patch",
+    },
+    {
+      client: pluginClient,
+    },
+  );
+  expect(patchCreate.ok).toBe(true);
+  const created = loadSessionEntry({
+    agentId: "main",
+    sessionKey: "agent:main:dreaming-narrative-new",
+    storePath,
+  });
+  expect(created?.pluginOwnerId).toBe("memory-core");
+  expect(created?.label).toBe("created by patch");
+});

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -41,6 +41,7 @@ async function runPatch(params: {
   agentId?: string;
   loadGatewayModelCatalog?: ApplySessionsPatchArgs["loadGatewayModelCatalog"];
   archivedBy?: SessionCreatedActor;
+  pluginOwnerId?: string;
 }) {
   return applySessionsPatchToStore({
     cfg: params.cfg ?? EMPTY_CFG,
@@ -50,6 +51,7 @@ async function runPatch(params: {
     patch: params.patch,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
     archivedBy: params.archivedBy,
+    pluginOwnerId: params.pluginOwnerId,
   });
 }
 
@@ -1590,6 +1592,46 @@ describe("gateway sessions patch", () => {
     expect(entry.providerOverride).toBe("opencode-go");
     expect(entry.modelOverride).toBe("kimi-k2.6");
     expect(entry.authProfileOverride).toBe("work");
+  });
+
+  describe("plugin ownership", () => {
+    test("stamps pluginOwnerId when creating a new session entry", async () => {
+      const store: Record<string, SessionEntry> = {};
+      const entry = expectPatchOk(
+        await runPatch({
+          store,
+          storeKey: MAIN_SESSION_KEY,
+          patch: { key: MAIN_SESSION_KEY, label: "new" },
+          pluginOwnerId: "plugin-a",
+        }),
+      );
+      expect(entry.pluginOwnerId).toBe("plugin-a");
+      expect(store[MAIN_SESSION_KEY]?.pluginOwnerId).toBe("plugin-a");
+    });
+
+    test("does not stamp pluginOwnerId on existing entries", async () => {
+      const store = mainStoreEntry({ pluginOwnerId: "plugin-a" });
+      const entry = expectPatchOk(
+        await runPatch({
+          store,
+          patch: { key: MAIN_SESSION_KEY, label: "renamed" },
+          pluginOwnerId: "plugin-b",
+        }),
+      );
+      expect(entry.pluginOwnerId).toBe("plugin-a");
+    });
+
+    test("does not stamp pluginOwnerId when none is provided", async () => {
+      const store: Record<string, SessionEntry> = {};
+      const entry = expectPatchOk(
+        await runPatch({
+          store,
+          storeKey: MAIN_SESSION_KEY,
+          patch: { key: MAIN_SESSION_KEY, label: "new" },
+        }),
+      );
+      expect(entry.pluginOwnerId).toBeUndefined();
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -141,6 +141,8 @@ export async function projectSessionsPatchEntry(params: {
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
+  /** Owner to stamp on a newly created session row. */
+  pluginOwnerId?: string;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
   const { cfg, storeKey, patch } = params;
   const authorizedHarnessCreation =
@@ -198,6 +200,7 @@ export async function projectSessionsPatchEntry(params: {
   };
 
   const existing = params.existingEntry;
+  const pluginOwnerId = normalizeOptionalString(params.pluginOwnerId);
   // Existing entries without session ids are placeholder aliases; assigning an id makes them real.
   const next: SessionEntry = existing?.sessionId
     ? {
@@ -209,6 +212,7 @@ export async function projectSessionsPatchEntry(params: {
         sessionId: randomUUID(),
         sessionFile: undefined,
         updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+        ...(pluginOwnerId ? { pluginOwnerId } : {}),
       };
   if (existing && !existing.sessionId) {
     delete next.label;
@@ -666,6 +670,8 @@ export async function applySessionsPatchToStore(params: {
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
+  /** Owner to stamp on a newly created session row. */
+  pluginOwnerId?: string;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
   const projected = await projectSessionsPatchEntry({
     cfg: params.cfg,
@@ -677,6 +683,7 @@ export async function applySessionsPatchToStore(params: {
     archivedBy: params.archivedBy,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
     authorizedAgentHarnessId: params.authorizedAgentHarnessId,
+    pluginOwnerId: params.pluginOwnerId,
   });
   if (projected.ok) {
     params.store[params.storeKey] = projected.entry;


### PR DESCRIPTION
Closes #103077.

## What Problem This Solves

Fixes an issue where an in-process plugin-runtime caller could use `sessions.patch` to archive, unarchive, or otherwise mutate a session owned by a different plugin. `sessions.delete` already rejects cross-plugin cleanup, but `sessions.patch` performed the mutation with no ownership check.

## Why This Change Was Made

`sessions.patch` now checks ownership during the handler lookup and again through an `authorize` callback against the accessor snapshot used to build the projection. The lifecycle mutation lock still serializes gateway session mutations; this PR does not claim that the callback itself runs inside the SQLite write transaction.

**ClawSweeper review follow-up:**
1. `sessions.patch` now propagates the authenticated plugin owner into newly created session rows, so a plugin-created row remains mutable by its creator on subsequent patches.
2. Plugin-runtime callers now fail closed on legacy ownerless rows. Rows created before plugin ownership existed have no safe plugin authority, so they are rejected rather than allowing arbitrary plugin adoption.

## User Impact

Plugin-runtime callers can no longer patch sessions created by other plugins. Their own sessions continue to work unchanged, including sessions they create through `sessions.patch`. Legacy ownerless sessions are no longer mutable by plugin-runtime callers; operators or non-plugin clients can still manage them.

## Evidence

- Regression tests in `src/gateway/server.sessions.patch-plugin-ownership.test.ts`: owned mutation allowed; foreign-owned archive and unarchive rejected; legacy ownerless row rejected; initial handler lookup miss rejected against the accessor authorization snapshot; `pluginOwnerId` stamped when patch creates a new session.
- Unit coverage in `src/gateway/sessions-patch.test.ts` for `pluginOwnerId` stamping behavior.
- Exact head after maintainer fixup: `f8ed69034a1ebea0690b9899eb15e947d4d380ac`.
- Focused local runs on the exact head (Node 24.15.0):
  - `node scripts/run-vitest.mjs run src/gateway/server.sessions.patch-plugin-ownership.test.ts` → 4 passed.
  - `node scripts/run-vitest.mjs run src/gateway/sessions-patch.test.ts` → 81 passed.
  - `node scripts/run-vitest.mjs run src/gateway/sessions-patch.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts` → 103 passed, 1 failed (`sessions.delete removes clean session worktrees…`; host `/usr/bin/git` is 2.27 and lacks `git init -b`; test and helper untouched by this PR, green on CI).
- `oxlint` 0 warnings / 0 errors and `oxfmt --check` clean on all 7 changed files.

## Real behavior proof

Deployed-gateway trace on the exact head: a real gateway process (worktree `dist` build, stamp head `9305961be4b`) with isolated `HOME` / `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`, loopback bind, random ports, token auth, and a mock OpenAI provider (`scripts/e2e/mock-openai-server.mjs`), no real credentials. Two temporary bundled proof plugins (`sessions-patch-proof-alpha` / `-beta`) were loaded by the normal plugin loader and called `sessions.patch` through the trusted in-process plugin-runtime path (`api.runtime.gateway.request`), driven over real WebSocket RPC via `openclaw gateway call`:

- Plugin patches a session it owns → succeeds; newly created rows are stamped with the caller's `pluginOwnerId`.
- Plugin patches a session owned by another plugin → `INVALID_REQUEST` ("did not create it"); the foreign row is unchanged.
- Plugin patches a legacy ownerless row → `INVALID_REQUEST` (fail closed); a non-plugin operator client can still create and patch that row.

Full redacted transcripts, persisted SQLite before/after state, and test output are in https://github.com/openclaw/openclaw/pull/103534#issuecomment-4983631786. Remaining before merge: explicit maintainer approval of the intentional fail-closed ownerless-row compatibility boundary (P1), plus coordination with the sibling sessions.create ownership PR #103148.
