### PR TITLE
fix(exec): reject single-character shell variables in Python scripts

### DIFF
--- a/src/agents/bash-tools.exec-script-preflight.ts
+++ b/src/agents/bash-tools.exec-script-preflight.ts
@@ -1,7 +1,7 @@
-/** Safely reads script files and rejects common shell-to-script bleed. */
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+/** Safely reads script files and rejects common shell-to-script bleed. */
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { shouldFailClosedInterpreterPreflight } from "./bash-tools.exec-script-ambiguity.js";
@@ -39,6 +39,115 @@ const fsSafeModuleLoader = createLazyImportLoader<FsSafeModule>(
 
 async function loadFsSafeModule(): Promise<FsSafeModule> {
   return await fsSafeModuleLoader.load();
+}
+
+function findPythonShellVariable(content: string): RegExpExecArray | null {
+  const shellVariable = /\$[A-Z_][A-Z0-9_]*/y;
+  const pythonIdentifierCharacter = /[\p{ID_Continue}]/u;
+  const contexts: Array<
+    | { kind: "code"; delimiters: string[] | null; lambda: boolean }
+    | { kind: "string"; quote: "'" | '"'; triple: boolean; formatted: boolean }
+    | { kind: "format" }
+  > = [{ kind: "code", delimiters: null, lambda: false }];
+  let index = 0;
+  while (index < content.length) {
+    const context = contexts.at(-1)!;
+    const char = content[index]!;
+    if (context.kind === "string") {
+      const delimiter = context.quote.repeat(context.triple ? 3 : 1);
+      if (content.startsWith(delimiter, index)) {
+        contexts.pop();
+        index += delimiter.length;
+      } else if (context.formatted && char === "\\" && content[index + 1] === "{") {
+        index += 1;
+      } else if (char === "\\") {
+        index += content[index + 1] === "\r" && content[index + 2] === "\n" ? 3 : 2;
+      } else if (!context.triple && (char === "\n" || char === "\r")) {
+        contexts.pop();
+        index += 1;
+      } else if (
+        context.formatted &&
+        ((char === "{" && content[index + 1] === "{") ||
+          (char === "}" && content[index + 1] === "}"))
+      ) {
+        index += 2;
+      } else if (context.formatted && char === "{") {
+        contexts.push({ kind: "code", delimiters: ["}"], lambda: false });
+        index += 1;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+    if (context.kind === "format") {
+      if (char === "{") {
+        contexts.push({ kind: "code", delimiters: ["}"], lambda: false });
+      } else if (char === "}") {
+        contexts.pop();
+      }
+      index += 1;
+      continue;
+    }
+    if (char === "#") {
+      const newline = content.slice(index + 1).search(/[\r\n]/);
+      index = newline === -1 ? content.length : index + newline + 2;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      const prefix = content.slice(Math.max(0, index - 3), index);
+      contexts.push({
+        kind: "string",
+        quote: char,
+        triple: content.startsWith(char.repeat(3), index),
+        formatted: /(?:^|[^A-Z0-9_])(?:F|FR|RF)$/i.test(prefix),
+      });
+      index += content.startsWith(char.repeat(3), index) ? 3 : 1;
+      continue;
+    }
+    if (context.delimiters) {
+      if (
+        context.delimiters.length === 1 &&
+        !pythonIdentifierCharacter.test(content.charAt(index - 1)) &&
+        content.startsWith("lambda", index) &&
+        !pythonIdentifierCharacter.test(content.charAt(index + 6))
+      ) {
+        context.lambda = true;
+      }
+      const closer = char === "(" ? ")" : char === "[" ? "]" : char === "{" ? "}" : null;
+      if (closer) {
+        context.delimiters.push(closer);
+      } else if (context.delimiters.at(-1) === char) {
+        context.delimiters.pop();
+        if (context.delimiters.length === 0) {
+          contexts.pop();
+        }
+      } else if (char === ":" && context.delimiters.length === 1) {
+        if (context.lambda) {
+          context.lambda = false;
+        } else {
+          contexts[contexts.length - 1] = { kind: "format" };
+        }
+      }
+    }
+    if (char === "$") {
+      shellVariable.lastIndex = index;
+      const match = shellVariable.exec(content);
+      if (match) {
+        return match;
+      }
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function findShellVariable(content: string, kind: "python" | "node"): RegExpExecArray | null {
+  if (kind === "python") {
+    // F-strings alternate literal text with executable replacement fields. Keep a lexical stack
+    // so valid text stays invisible while nested replacement code uses the normal token check.
+    return findPythonShellVariable(content);
+  }
+  return /\$[A-Z_][A-Z0-9_]+/.exec(content);
 }
 
 function shouldSkipScriptPreflightPathError(
@@ -175,14 +284,11 @@ export async function validateScriptFileForShellBleed(params: {
       throw error;
     }
 
-    // Common failure mode: shell env var syntax leaking into Python/JS.
-    // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
-    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
-    const first = envVarRegex.exec(content);
+    const first = findShellVariable(content, target.kind);
     if (first) {
       const idx = first.index;
       const before = content.slice(0, idx);
-      const line = before.split("\n").length;
+      const line = before.split(/\r\n?|\n/).length;
       const token = first[0];
       throw new Error(
         [

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -211,20 +211,20 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
-  it("blocks shell env var injection tokens in python scripts before execution", async () => {
+  it.each([
+    ["a bare one-character token", "$A", "payload = $A"],
+    ["a bare multi-character token", "$DM_JSON", "payload = $DM_JSON"],
+    ["a token after a string", "$B", 'text = "$A"\npayload = $B'],
+    ["a token in an f-string replacement", "$P", 'result = f"{ "$A" + $P }"'],
+    ["a token after a backslash in an f-string", "$A", 'result = f"\\{$A}"'],
+    ["a token after a lambda colon in an f-string", "$F", 'result = f"{lambda value: $F}"'],
+    ["a token after a CR-only string line", "$C", 'text = "ok"\rpayload = $C'],
+    ["a token after a CR-only unterminated string", "$E", 'text = "ok\rpayload = $E'],
+    ["a token after a CR-only comment", "$D", "# note\rpayload = $D"],
+  ])("blocks %s in python scripts before execution", async (_name, token, source) => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const pyPath = path.join(tmp, "bad.py");
-
-      await fs.writeFile(
-        pyPath,
-        [
-          "import json",
-          "# model accidentally wrote shell syntax:",
-          "payload = $DM_JSON",
-          "print(payload)",
-        ].join("\n"),
-        "utf-8",
-      );
+      await fs.writeFile(pyPath, source, "utf-8");
 
       const tool = createPreflightTool();
 
@@ -233,7 +233,54 @@ describeNonWin("exec script preflight", () => {
           command: "python bad.py",
           workdir: tmp,
         }),
-      ).rejects.toThrow(/exec preflight: detected likely shell variable injection \(\$DM_JSON\)/);
+      ).rejects.toThrow(`exec preflight: detected likely shell variable injection (${token})`);
+    });
+  });
+
+  it("allows one-character dollar text in Python strings and comments", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(
+        path.join(tmp, "valid.py"),
+        [
+          'value = "$A"',
+          "other = '''$_'''",
+          'raw = r"$Q"',
+          'hash_text = "# $R"',
+          "nested = f\"{ '$S' }\"",
+          'braces = f"{{ $T }}"',
+          'continued = "text \\\r\n$U"',
+          "class Echo:",
+          "    def __format__(self, spec):",
+          "        return spec",
+          'format_text = f"{Echo():$W}"',
+          "élambda = Echo()",
+          'unicode_format = f"{élambda:$Y}"',
+          "# $P",
+          'print(f"{value}:{other}:{raw}:{hash_text}:{nested}:{braces}:{continued}:{format_text}:{unicode_format}")',
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const result = await runExecPreflight({ command: "python3 valid.py", workdir: tmp });
+
+      expect(result.details).toMatchObject({
+        status: "completed",
+        aggregated: "$A:$_:$Q:# $R:$S:{ $T }:text $U:$W:$Y",
+      });
+    });
+  });
+
+  it("allows valid one-character dollar-prefixed identifiers in node scripts", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(
+        path.join(tmp, "valid.js"),
+        'const $A = "node"; const $_ = "ok"; process.stdout.write(`${$A}-${$_}`);',
+        "utf-8",
+      );
+
+      const result = await runExecPreflight({ command: "node valid.js", workdir: tmp });
+
+      expect(result.details).toMatchObject({ status: "completed", aggregated: "node-ok" });
     });
   });
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1237,7 +1237,7 @@ async function validateScriptFileForShellBleed(params: {
 
     // Common failure mode: shell env var syntax leaking into Python/JS.
     // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
-    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
+    const envVarRegex = /\$[A-Z_][A-Z0-9_]{0,}/g;
     const first = envVarRegex.exec(content);
     if (first) {
       const idx = first.index;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Python script containing a leaked one-character shell variable such as `$A` reached Python and failed there instead of being stopped by exec preflight.

## Root Cause

The shared shell-token matcher required a second identifier character. That minimum avoided rejecting valid Node identifiers such as `$A`, but Python has no equivalent identifier syntax. A raw broader matcher also rejects valid Python strings and comments, so the Python path must distinguish code from text.

## Fix

- Use the current split script-preflight owner.
- Use a bounded lexical stack to match one-character shell-style tokens only in executable Python and f-string replacement code.
- Preserve dollar text in Python strings and comments.
- Keep Node's existing minimum so valid `$A` and `$_` identifiers still execute.
- Extend the owner-boundary test with the missing rejection and allowance cases.

## Evidence

- Current main `7bd0903f7a23072726faa0f0a3da4f47f045ddd0`: Python `$A` reached the interpreter and produced a syntax error; Python `$DM_JSON` was stopped; Node `$A` and `$_` printed `node-ok`.
- Repaired head `e1df885c4604b81fc33dc8719d314f5152dcab5e`: bare Python `$A`, `$DM_JSON`, f-string `$P`, backslash-before-brace `$A`, lambda-body `$F`, and CR-only `$C`/`$D` were stopped before spawn; valid Python literal, format, and Unicode identifier text printed `$A:$_:$S:{ $T }:text $U:$W:$Y`; Node `$A` and `$_` printed `node-ok`.
- Focused regression suite: 69 passed, 4 platform-specific skips.
- Production line delta: +112/-6, net +106; tests +60/-13. The added state belongs at the preflight owner because Python f-strings alternate literal text and executable replacement code; no dependency or duplicate execution path is added.

### Sanitized terminal trace

```text
$ exec-preflight-proof --revision 7bd0903f7a23072726faa0f0a3da4f47f045ddd0
python-one-character: executed -> Python syntax error at one.py:1
python-multi-character: rejected -> $DM_JSON
node-one-character-identifiers: executed -> node-ok

$ exec-preflight-proof --revision e1df885c4604b81fc33dc8719d314f5152dcab5e
python-one-character: rejected -> $A
python-multi-character: rejected -> $DM_JSON
python-f-string-replacement: rejected -> $P
python-backslash-f-string-replacement: rejected -> $A
python-lambda-f-string-replacement: rejected -> $F
python-cr-string-to-code: rejected -> $C at line 2
python-cr-comment-to-code: rejected -> $D at line 2
python-one-character-text: executed -> $A:$_:$S:{ $T }:text $U:$W:$Y
node-one-character-identifiers: executed -> node-ok
```
