### PR TITLE
fix(ci): keep ClawRouter release E2E deterministic

### DIFF
--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
+import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -49,6 +50,7 @@ describe("ClawRouter managed gateway contract", () => {
       },
     });
     instances.push(instance);
+    const logFile = path.join(instance.stateDir, "clawrouter.log");
 
     const patchPath = await instance.state.writeText(
       "clawrouter.patch.json5",
@@ -67,6 +69,7 @@ describe("ClawRouter managed gateway contract", () => {
               },
             },
           },
+          logging: { file: logFile },
           agents: { defaults: { model: { primary: MODEL_REF } } },
         },
         null,
@@ -188,10 +191,13 @@ describe("ClawRouter managed gateway contract", () => {
     expect(String(sessionId).length).toBeGreaterThan(0);
     expect(String(sessionId).length).toBeLessThanOrEqual(256);
 
-    expect(instance.logs()).toContain(
+    // File logging is synchronous at the transport boundary. The gateway's
+    // piped stdout can be delivered after the agent RPC has already completed.
+    const fileLog = await fs.readFile(logFile, "utf8");
+    expect(fileLog).toContain(
       `[model-fetch] start provider=clawrouter api=openai-responses model=${MODEL_ID} method=POST url=${router.baseUrl}/v1/responses`,
     );
-    expect(instance.logs()).toContain(
+    expect(fileLog).toContain(
       `[model-fetch] response provider=clawrouter api=openai-responses model=${MODEL_ID} status=200`,
     );
     expect(
@@ -206,6 +212,7 @@ describe("ClawRouter managed gateway contract", () => {
         probe.stderr,
         agent.stdout,
         agent.stderr,
+        fileLog,
         instance.logs(),
       ].join("\n"),
     ).not.toContain(API_KEY);


### PR DESCRIPTION
Closes #103533

## What Problem This Solves

Fixes an issue where scheduled release validation could report a ClawRouter E2E failure after the routed model request and response had already succeeded. The test sampled the Gateway's asynchronous stdout pipe before its `model-fetch` lines were delivered.

## Why This Change Was Made

The E2E now configures a log file inside its isolated test state and verifies the start/response metadata in that synchronous file-log sink. It preserves the real request, attribution, response, and observability checks, and adds the canonical file log to the API-key leak assertion without changing product behavior.

## User Impact

Release maintainers get deterministic ClawRouter validation instead of a false-negative release lane. Runtime routing and logging behavior are unchanged.

AI-assisted: yes.

## Evidence

- Before: scheduled run https://github.com/openclaw/openclaw/actions/runs/29072098143 failed only `test/clawrouter-managed-gateway.e2e.test.ts`; the fake router and agent success assertions passed, then stdout lacked the expected log lines. The repository E2E otherwise passed 61 files and 991 tests.
- Relevant test/helper/transport paths are byte-identical between failing `9d4fb60e9063` and the branch base on current `main`.
- Testbox-through-Crabbox `tbx_01kx5f1bpt7vqbnh7mnt3b88e5`: focused E2E passed 4/4 across one initial and three repeated runs.
- Same Testbox: `pnpm check:changed` passed; targeted `oxfmt --check` passed.
- Fresh autoreview: clean, confidence 0.95.
- `git diff --check`: passed.
