### PR TITLE
fix(update): prevent Gateway respawn during package replacement

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -43,6 +43,7 @@ const readPackageName = vi.fn();
 const readPackageVersion = vi.fn();
 const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
+const serviceEnabled = vi.fn();
 const serviceStop = vi.fn();
 const serviceRestart = vi.fn();
 const isDefaultInstallIdentity = vi.hoisted(() =>
@@ -380,6 +381,7 @@ vi.mock("../daemon/service.js", () => ({
   },
   resolveGatewayService: vi.fn(() => ({
     isLoaded: (...args: unknown[]) => serviceLoaded(...args),
+    isEnabled: (...args: unknown[]) => serviceEnabled(...args),
     readCommand: (...args: unknown[]) => serviceReadCommand(...args),
     readRuntime: (...args: unknown[]) => serviceReadRuntime(...args),
     stop: (...args: unknown[]) => serviceStop(...args),
@@ -1337,6 +1339,7 @@ describe("update-cli", () => {
     delete process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
     restartHealthTestControl.snapshot = undefined;
     vi.clearAllMocks();
+    serviceEnabled.mockResolvedValue(true);
     readPersistedInstalledPluginIndex.mockResolvedValue(null);
     restorePersistedInstalledPluginIndex.mockResolvedValue(undefined);
     restorePersistedInstalledPluginIndexIfCurrent.mockResolvedValue(true);
@@ -1729,7 +1732,7 @@ describe("update-cli", () => {
       },
     });
     serviceLoaded.mockResolvedValue(true);
-    serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     pathExists.mockImplementation(
       async (candidate: string) =>
         entrypoints.includes(candidate) || candidate.endsWith("package.json"),
@@ -1747,6 +1750,7 @@ describe("update-cli", () => {
     );
 
     expect(serviceStop).not.toHaveBeenCalled();
+    expect(serviceEnabled).not.toHaveBeenCalled();
     expect(spawnCall()?.[2]?.env).toMatchObject({
       OPENCLAW_PROFILE: "personal",
       OPENCLAW_STATE_DIR: "/tmp/openclaw-update-tests/personal-profile",
@@ -4728,6 +4732,34 @@ describe("update-cli", () => {
     expect(packageInstallCallOrder).toBeLessThan(
       requireValue(serviceRestart.mock.invocationCallOrder[0], "service restart call order"),
     );
+  });
+
+  it("leaves a disabled stopped LaunchAgent disabled when package replacement fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const tempDir = await createTrackedTempDir("openclaw-update-disabled-launchagent-failure-");
+    const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
+    primeServiceCommand(["node", entryPath, "gateway", "run"]);
+    serviceLoaded.mockResolvedValue(true);
+    serviceEnabled.mockResolvedValue(false);
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    mockFileBackedPathExists();
+    mockNpmGlobalRoot(nodeModules);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
+        throw new Error("package replacement failed");
+      }
+      return commandResult();
+    });
+
+    try {
+      await expect(updateCommand({ yes: true })).rejects.toThrow("package replacement failed");
+    } finally {
+      platformSpy.mockRestore();
+    }
+
+    expect(serviceEnabled).toHaveBeenCalledOnce();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(serviceRestart).not.toHaveBeenCalled();
   });
 
   it("does not inspect or mutate a Windows host service from an isolated install", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4599,6 +4599,137 @@ describe("update-cli", () => {
     processOffSpy.mockRestore();
   });
 
+  it.each([
+    { platform: "darwin" as const, handoff: undefined },
+    { platform: "linux" as const, handoff: "1" },
+    { platform: "win32" as const, handoff: "1" },
+  ])(
+    "quiesces a stopped loaded managed gateway on $platform before package replacement",
+    async ({ platform, handoff }) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const tempDir = await createTrackedTempDir(`openclaw-update-stopped-loaded-${platform}-`);
+      const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
+      primeServiceCommand(["node", entryPath, "gateway", "run"], {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      });
+      serviceLoaded.mockResolvedValue(true);
+      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+      mockFileBackedPathExists();
+      mockNpmGlobalRoot(nodeModules);
+      let finishStop: (() => void) | undefined;
+      let markStopStarted: (() => void) | undefined;
+      const stopStarted = new Promise<void>((resolve) => {
+        markStopStarted = resolve;
+      });
+      serviceStop.mockImplementationOnce(() => {
+        markStopStarted?.();
+        return new Promise<void>((resolve) => {
+          finishStop = resolve;
+        });
+      });
+
+      try {
+        await withEnvAsync({ OPENCLAW_UPDATE_RUN_HANDOFF: handoff }, async () => {
+          const updatePromise = updateCommand({ yes: true });
+          const firstOutcome = await Promise.race([
+            stopStarted.then(() => "stop" as const),
+            updatePromise.then(() => "update" as const),
+          ]);
+
+          expect(firstOutcome).toBe("stop");
+          expect(serviceStop).toHaveBeenCalledOnce();
+          expect(packageInstallCommandCall()).toBeUndefined();
+          const pluginRecordCallsBeforeStop =
+            loadInstalledPluginIndexInstallRecords.mock.calls.length;
+          if (!finishStop) {
+            throw new Error("expected the managed service stop to remain pending");
+          }
+          finishStop();
+          await updatePromise;
+          expect(loadInstalledPluginIndexInstallRecords.mock.calls.length).toBeGreaterThan(
+            pluginRecordCallsBeforeStop,
+          );
+        });
+      } finally {
+        platformSpy.mockRestore();
+      }
+
+      expect(packageInstallCommandCall()).toBeDefined();
+      expect(loadInstalledPluginIndexInstallRecords).toHaveBeenCalled();
+      expect(serviceStop.mock.invocationCallOrder[0]).toBeLessThan(
+        requireValue(
+          loadInstalledPluginIndexInstallRecords.mock.invocationCallOrder.at(-1),
+          "owned managed update context capture order",
+        ),
+      );
+    },
+  );
+
+  it.each([
+    { name: "an unloaded Darwin LaunchAgent", platform: "darwin" as const, loaded: false },
+    { name: "an ordinary stopped systemd unit", platform: "linux" as const, loaded: true },
+    { name: "an ordinary stopped Scheduled Task", platform: "win32" as const, loaded: true },
+  ])("leaves $name stopped during package replacement", async ({ platform, loaded }) => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+    const tempDir = await createTrackedTempDir(`openclaw-update-stopped-${platform}-`);
+    const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
+    primeServiceCommand(["node", entryPath, "gateway", "run"]);
+    serviceLoaded.mockResolvedValue(loaded);
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    mockFileBackedPathExists();
+    mockNpmGlobalRoot(nodeModules);
+
+    try {
+      await withEnvAsync({ OPENCLAW_UPDATE_RUN_HANDOFF: undefined }, async () => {
+        await updateCommand({ yes: true });
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(serviceRestart).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeDefined();
+  });
+
+  it("restarts a quiesced stopped LaunchAgent after package replacement fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const tempDir = await createTrackedTempDir("openclaw-update-stopped-launchagent-failure-");
+    const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
+    primeServiceCommand(["node", entryPath, "gateway", "run"]);
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    mockFileBackedPathExists();
+    mockNpmGlobalRoot(nodeModules);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
+        throw new Error("package replacement failed");
+      }
+      return commandResult();
+    });
+
+    try {
+      await expect(updateCommand({ yes: true })).rejects.toThrow("package replacement failed");
+    } finally {
+      platformSpy.mockRestore();
+    }
+
+    expect(serviceStop).toHaveBeenCalledOnce();
+    expect(serviceRestart).toHaveBeenCalledOnce();
+    const packageInstallCallIndex = commandCalls().findIndex(
+      ([argv]) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g",
+    );
+    const packageInstallCallOrder = requireValue(
+      vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[packageInstallCallIndex],
+      "package replacement call order",
+    );
+    expect(serviceStop.mock.invocationCallOrder[0]).toBeLessThan(packageInstallCallOrder);
+    expect(packageInstallCallOrder).toBeLessThan(
+      requireValue(serviceRestart.mock.invocationCallOrder[0], "service restart call order"),
+    );
+  });
+
   it("does not inspect or mutate a Windows host service from an isolated install", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const tempDir = await createTrackedTempDir("openclaw-update-isolated-service-");

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -464,11 +464,35 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     };
   }
 
+  if (serviceMatchesMutationRoot === false) {
+    if (!params.jsonMode) {
+      defaultRuntime.log(
+        theme.muted(
+          `Managed gateway service points at a different OpenClaw root; leaving it running during this ${params.updateInstallKind} update.`,
+        ),
+      );
+    }
+    return {
+      stopped: false,
+      inspected: true,
+      runtimeInspected: true,
+      // Keep checking additional git mutation roots for this active supervisor.
+      running: true,
+      ...serviceOwnership,
+      serviceEnv: serviceState.env,
+    };
+  }
+
   // A loaded LaunchAgent can be between KeepAlive respawns. Other supervisors
   // need the handoff marker to distinguish that transition from operator-stopped state.
-  const supervisorMayRespawn =
+  const launchAgentMayRespawn =
+    process.platform === "darwin" &&
     serviceState.loaded &&
-    (process.platform === "darwin" || process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1");
+    (await service.isEnabled?.({ env: serviceState.env })) === true;
+  const handoffSupervisorMayRespawn =
+    process.platform !== "darwin" && process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1";
+  const supervisorMayRespawn =
+    serviceState.loaded && (launchAgentMayRespawn || handoffSupervisorMayRespawn);
   if (!serviceState.running && !supervisorMayRespawn) {
     const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
       updateInstallKind: params.updateInstallKind,
@@ -494,24 +518,6 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       running: true,
       ...serviceOwnership,
       blockMessage,
-      serviceEnv: serviceState.env,
-    };
-  }
-
-  if (serviceMatchesMutationRoot === false) {
-    if (!params.jsonMode) {
-      defaultRuntime.log(
-        theme.muted(
-          `Managed gateway service points at a different OpenClaw root; leaving it running during this ${params.updateInstallKind} update.`,
-        ),
-      );
-    }
-    return {
-      stopped: false,
-      inspected: true,
-      runtimeInspected: true,
-      running: true,
-      ...serviceOwnership,
       serviceEnv: serviceState.env,
     };
   }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -464,7 +464,12 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     };
   }
 
-  if (!serviceState.running) {
+  // A loaded LaunchAgent can be between KeepAlive respawns. Other supervisors
+  // need the handoff marker to distinguish that transition from operator-stopped state.
+  const supervisorMayRespawn =
+    serviceState.loaded &&
+    (process.platform === "darwin" || process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1");
+  if (!serviceState.running && !supervisorMayRespawn) {
     const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
       updateInstallKind: params.updateInstallKind,
       serviceEnv: serviceState.env,
@@ -554,7 +559,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     stopped: true,
     inspected: true,
     runtimeInspected: true,
-    running: true,
+    running: serviceState.running,
     ...serviceOwnership,
     serviceEnv: serviceState.env,
     serviceDefinitionEnv: serviceState.command?.environment,

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -15,8 +15,10 @@ import {
   disableCurrentOpenClawUpdateLaunchdJob,
   disableOpenClawUpdateLaunchdJob,
   findStaleOpenClawUpdateLaunchdJobs,
+  isLaunchAgentEnabled,
   isLaunchAgentLoaded,
   parkCurrentLaunchAgentForMaintenance,
+  parseLaunchAgentEnabled,
   parseLaunchctlPrint,
   parseLaunchctlListOpenClawUpdateJobs,
   readLaunchAgentProgramArguments,
@@ -34,6 +36,9 @@ const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
   listOutput: "",
   printOutput: "",
+  printDisabledOutput: "",
+  printDisabledError: "",
+  printDisabledCode: 0,
   printNotLoadedRemaining: 0,
   printError: "",
   printCode: 1,
@@ -340,6 +345,13 @@ function executeLaunchctlMock(file: string, args: string[]) {
   if (call[0] === "list") {
     return { stdout: state.listOutput, stderr: "", code: 0 };
   }
+  if (call[0] === "print-disabled") {
+    return {
+      stdout: state.printDisabledOutput,
+      stderr: state.printDisabledError,
+      code: state.printDisabledCode,
+    };
+  }
   if (call[0] === "print") {
     if (state.printNotLoadedRemaining > 0) {
       state.printNotLoadedRemaining -= 1;
@@ -584,6 +596,9 @@ beforeEach(() => {
   state.launchctlCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
+  state.printDisabledOutput = 'disabled services = {\n\t"ai.openclaw.gateway" => enabled\n}';
+  state.printDisabledError = "";
+  state.printDisabledCode = 0;
   state.printNotLoadedRemaining = 0;
   state.printError = "";
   state.printCode = 1;
@@ -651,6 +666,42 @@ beforeEach(() => {
 });
 
 describe("launchd runtime parsing", () => {
+  it.each([
+    ['disabled services = {\n\t"ai.openclaw.gateway" => enabled\n}', true],
+    ['disabled services = {\n\t"ai.openclaw.gateway" => disabled\n}', false],
+    ['disabled services = {\n\t"other.service" => disabled\n}', true],
+  ])("parses the LaunchAgent enabled override", (output, expected) => {
+    expect(parseLaunchAgentEnabled(output, "ai.openclaw.gateway")).toBe(expected);
+  });
+
+  it("rejects an unrecognized LaunchAgent enabled override", () => {
+    expect(() =>
+      parseLaunchAgentEnabled(
+        'disabled services = {\n\t"ai.openclaw.gateway" => unexpected\n}',
+        "ai.openclaw.gateway",
+      ),
+    ).toThrow("unrecognized state");
+  });
+
+  it("reads the persistent LaunchAgent enabled state", async () => {
+    state.printDisabledOutput = 'disabled services = {\n\t"ai.openclaw.gateway" => disabled\n}';
+
+    await expect(isLaunchAgentEnabled({ env: createDefaultLaunchdEnv() })).resolves.toBe(false);
+    expect(state.launchctlCalls).toContainEqual([
+      "print-disabled",
+      typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501",
+    ]);
+  });
+
+  it("fails closed when the LaunchAgent enabled state cannot be read", async () => {
+    state.printDisabledError = "Operation not permitted";
+    state.printDisabledCode = 1;
+
+    await expect(isLaunchAgentEnabled({ env: createDefaultLaunchdEnv() })).rejects.toThrow(
+      "launchctl print-disabled failed: Operation not permitted",
+    );
+  });
+
   it("parses state, pid, and exit status", () => {
     const output = [
       "state = running",

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -816,6 +816,36 @@ export function parseLaunchctlPrint(output: string): LaunchctlPrintInfo {
   return info;
 }
 
+export function parseLaunchAgentEnabled(output: string, label: string): boolean {
+  const labelPrefix = `"${label}"`;
+  for (const line of output.split("\n")) {
+    const entry = line.trim();
+    if (!entry.startsWith(labelPrefix)) {
+      continue;
+    }
+    const state = entry.slice(labelPrefix.length).trim();
+    if (state === "=> enabled") {
+      return true;
+    }
+    if (state === "=> disabled") {
+      return false;
+    }
+    throw new Error(`launchctl print-disabled returned an unrecognized state for ${label}`);
+  }
+  // No persisted override means launchd uses the plist's normal enabled state.
+  return true;
+}
+
+export async function isLaunchAgentEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
+  const domain = resolveGuiDomain();
+  const label = resolveLaunchAgentLabel(args.env);
+  const res = await execLaunchctl(["print-disabled", domain]);
+  if (res.code !== 0) {
+    throw new Error(`launchctl print-disabled failed: ${formatLaunchctlResultDetail(res)}`);
+  }
+  return parseLaunchAgentEnabled(res.stdout || res.stderr || "", label);
+}
+
 export async function isLaunchAgentLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel(args.env);

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -8,6 +8,7 @@ import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
 import { assertFutureConfigActionAllowed } from "./future-config-guard.js";
 import {
   installLaunchAgent,
+  isLaunchAgentEnabled,
   isLaunchAgentLoaded,
   readLaunchAgentProgramArguments,
   readLaunchAgentRuntime,
@@ -82,6 +83,7 @@ export type GatewayService = {
   stop: (args: GatewayServiceControlArgs) => Promise<void>;
   restart: (args: GatewayServiceControlArgs) => Promise<GatewayServiceRestartResult>;
   isLoaded: (args: GatewayServiceEnvArgs) => Promise<boolean>;
+  isEnabled?: (args: GatewayServiceEnvArgs) => Promise<boolean>;
   readCommand: (env: GatewayServiceEnv) => Promise<GatewayServiceCommandConfig | null>;
   readRuntime: (
     env: GatewayServiceEnv,
@@ -337,6 +339,7 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
     stop: stopLaunchAgent,
     restart: restartLaunchAgent,
     isLoaded: isLaunchAgentLoaded,
+    isEnabled: isLaunchAgentEnabled,
     readCommand: readLaunchAgentProgramArguments,
     readRuntime: readLaunchAgentRuntime,
   },


### PR DESCRIPTION
Closes #103447

Related: #85133

## What Problem This Solves

A managed update could replace package or checkout files while a loaded supervisor was between Gateway process instances. On macOS, a loaded enabled LaunchAgent uses `KeepAlive`; on Linux and Windows, the managed-update handoff records the same transition. The previous patch also risked restarting a persistently disabled LaunchAgent after a failed package replacement.

## Why This Change Was Made

The launchd service owner now reads the authoritative persistent enabled state through `launchctl print-disabled`. The updater treats only loaded, enabled Darwin jobs as respawn-pending; a loaded but disabled job remains untouched, so generic failure recovery cannot revive it. Non-Darwin supervisors require the existing managed-update handoff marker. A definite foreign mutation root returns before any enabled-state probe or stop.

The rewrite builds on `OwnedManagedUpdateContext` and the existing service-control/recovery flow rather than introducing a second rollback owner. It deletes the stale PR's parallel signal, launcher-respawn, monolithic update, and exact-state snapshot machinery. The production surface is +64/-20 (net +44): the growth is required by the launchd service-control ownership boundary, which alone can authoritatively distinguish persistent operator disablement from a transient KeepAlive respawn window.

## User Impact

Managed updates no longer race a respawned Gateway against package replacement, and failed updates do not enable or start a Gateway the operator persistently disabled. Ordinary stopped systemd units, ordinary stopped Scheduled Tasks, unloaded LaunchAgents, and services belonging to another mutation root remain untouched.

## Evidence

- Regression red proof: with the old Darwin predicate (`loaded` implies respawn-capable), the disabled-LaunchAgent failure test failed; the updater skipped the enabled-state probe and entered the stop/restart path.
- Focused green proof: `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/cli/update-cli.test.ts` passed 159/159 daemon tests and 236/236 update CLI tests after the final rebase.
- The regression holds service stop pending to prove mutation ordering, covers enabled and disabled Darwin jobs, explicit Linux/Windows handoffs, foreign-root isolation, `print-disabled` parsing/errors, and failed-update restart ordering.
- `node scripts/check-changed.mjs -- <five changed paths>` passed all selected typecheck, lint, boundary, database-first, import-cycle, env-count, and guard checks on Testbox `tbx_01kzmxdbsfktzk17yrq88gtdhx`; Actions run https://github.com/openclaw/openclaw/actions/runs/31354316652.
- Final full-branch Codex autoreview: clean, no accepted/actionable findings, confidence 0.96.
- Production/test delta: production +64/-20 (net +44); tests +215/-1 (net +214).
- ClawSweeper moves addressed: foreign-root isolation precedes quiescence; persistently disabled LaunchAgents are never stopped or restarted; focused disabled-and-loaded failure coverage is present; release-owned changelog and stale rollback paths remain removed.
- No config, environment, protocol, public API, default, or schema changes.
