### PR TITLE
fix(media): normalize uppercase FILE:// URI schemes in media directives

### DIFF
--- a/src/media/local-media-path.ts
+++ b/src/media/local-media-path.ts
@@ -12,7 +12,7 @@ export function resolveLocalMediaPath(source: string): string | undefined {
   if (!trimmed || isPassThroughRemoteMediaSource(trimmed) || DATA_URL_RE.test(trimmed)) {
     return undefined;
   }
-  if (trimmed.startsWith("file://")) {
+  if (/^file:\/\//i.test(trimmed)) {
     try {
       return safeFileURLToPath(trimmed);
     } catch {

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -66,6 +66,8 @@ describe("splitMediaFromOutput", () => {
       String.raw`MEDIA:/path/to/image.png\"}],\"details\":{\"provider\":\"openai\"}`,
     ],
     ["/tmp/render,final.png", "MEDIA:/tmp/render,final.png"],
+    ["/tmp/generated.png", "MEDIA:FILE:///tmp/generated.png"],
+    ["/tmp/generated.png", "MEDIA:File:///tmp/generated.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -33,9 +33,11 @@ export type SplitMediaFromOutputOptions = {
   extractMediaDirectives?: boolean;
 };
 
+const FILE_URI_SCHEME_RE = /^file:\/\//i;
+
 /** Converts file URLs into plain local paths before downstream media validation. */
 export function normalizeMediaSource(src: string): string {
-  return src.startsWith("file://") ? src.replace("file://", "") : src;
+  return FILE_URI_SCHEME_RE.test(src) ? src.replace(FILE_URI_SCHEME_RE, "") : src;
 }
 
 const TRAILING_SERIALIZED_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})\\?"(?=[\]},:]|$).*/s;
@@ -603,7 +605,7 @@ export function splitMediaFromOutput(
 
       const trimmedPayload = payloadValue.trim();
       const looksLikeLocalPath =
-        looksLikeLocalFilePath(trimmedPayload) || trimmedPayload.startsWith("file://");
+        looksLikeLocalFilePath(trimmedPayload) || FILE_URI_SCHEME_RE.test(trimmedPayload);
       if (
         !unwrapped &&
         validCount === 1 &&

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -872,7 +872,7 @@ async function loadWebMediaInternal(
   mediaUrl = stripLegacyMediaDirectivePrefix(mediaUrl);
   mediaUrl = (await resolveMediaStoreUriToPath(mediaUrl)) ?? mediaUrl;
   // Use fileURLToPath for proper handling of file:// URLs (handles file://localhost/path, etc.)
-  if (mediaUrl.startsWith("file://")) {
+  if (/^file:\/\//i.test(mediaUrl)) {
     try {
       mediaUrl = safeFileURLToPath(mediaUrl);
     } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

`MEDIA:` directives using an uppercase `FILE://` URI scheme are left in assistant text instead of being extracted as local media attachments. URI schemes are case-insensitive per RFC 3986.

Closes #103473

## Why This Change Was Made

Four locations in the media pipeline used case-sensitive `startsWith("file://")` checks:
- `normalizeMediaSource` in `src/media/parse.ts`
- The local-path heuristic in `splitMediaFromOutput` in `src/media/parse.ts`
- `resolveLocalMediaPath` in `src/media/local-media-path.ts`
- File-URL detection in `resolveLocalMediaFile` in `src/media/web-media.ts`

When a model outputs `MEDIA:FILE:///tmp/image.png` (uppercase scheme), none of these checks matched, so the directive remained as visible text.

## User Impact

Models that output `FILE://` (uppercase or mixed-case) URI schemes in media directives will now correctly have their attachments extracted, matching the behavior of lowercase `file://`. This fixes a case where a valid local media file would appear as raw text in the assistant response.

## Evidence

- Added test cases for `FILE://` and `File://` URI schemes in the media path acceptance table
- All 59 existing media parse tests pass
- Lint passes on all changed files