### PR TITLE
fix(release): bundle AI runtime in installer smoke

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -410,10 +410,17 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
-      - name: Checkout CLI
+      - name: Checkout trusted installer harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Checkout candidate CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          path: candidate
           persist-credentials: false
 
       - name: Log in to GHCR
@@ -471,6 +478,7 @@ jobs:
           OPENCLAW_INSTALL_SMOKE_UPDATE_BASELINE: ${{ inputs.update_baseline_version || 'latest' }}
           OPENCLAW_INSTALL_SMOKE_UPDATE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_INSTALL_SMOKE_UPDATE_SKIP_LOCAL_BUILD: "1"
+          OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: ${{ github.workspace }}/candidate
         run: bash scripts/test-install-sh-docker.sh
 
       - name: Run Rocky Linux installer smoke
@@ -479,7 +487,7 @@ jobs:
             --platform linux/amd64 \
             -e OPENCLAW_NO_ONBOARD=1 \
             -e OPENCLAW_NO_PROMPT=1 \
-            -v "$PWD/scripts/install.sh:/tmp/install.sh:ro" \
+            -v "$PWD/candidate/scripts/install.sh:/tmp/install.sh:ro" \
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install.sh --install-method npm --version latest --no-onboard --no-prompt --verify && openclaw --version'
 
@@ -489,7 +497,7 @@ jobs:
             --platform linux/amd64 \
             -e OPENCLAW_NO_ONBOARD=1 \
             -e OPENCLAW_NO_PROMPT=1 \
-            -v "$PWD/scripts/install-cli.sh:/tmp/install-cli.sh:ro" \
+            -v "$PWD/candidate/scripts/install-cli.sh:/tmp/install-cli.sh:ro" \
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli --version latest --no-onboard && /tmp/openclaw-cli/bin/openclaw --version'
 

--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -7,11 +7,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
 import { LOCAL_BUILD_METADATA_DIST_PATHS } from "./lib/local-build-metadata-paths.mjs";
 import {
   collectPackageDistImports,
   collectPackageDistImportErrors,
-  collectPackageDistModuleSpecifiers,
   expandPackageDistImportClosure,
 } from "./lib/package-dist-imports.mjs";
 
@@ -74,6 +74,22 @@ const PACKAGE_DEPENDENCY_SECTIONS = [
   "devDependencies",
 ];
 const REQUIRED_BUNDLED_WORKSPACE_DEPENDENCIES = ["@openclaw/ai"];
+// Strict Docker artifacts bundle this private runtime rather than resolving it
+// from npm. Keep the concrete load-bearing entries explicit instead of
+// reimplementing Node's conditional package-exports resolver here.
+const REQUIRED_BUNDLED_WORKSPACE_RUNTIME_ENTRIES = new Map([
+  [
+    "@openclaw/ai",
+    [
+      { specifier: "@openclaw/ai", entry: "dist/index.mjs" },
+      { specifier: "@openclaw/ai/providers", entry: "dist/providers.mjs" },
+      {
+        specifier: "@openclaw/ai/internal/runtime",
+        entry: "dist/internal/runtime.mjs",
+      },
+    ],
+  ],
+]);
 
 function collectWorkspaceProtocolDependencyErrors(packageJson, label) {
   const errors = [];
@@ -112,68 +128,36 @@ function listBundleDependencies(packageJson) {
     : [];
 }
 
-function collectRuntimeExportTargets(value) {
-  if (typeof value === "string") {
-    return [value];
+function resolveBundledPackageSpecifiers(packageRoot, specifiers) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `const resolutions = {};
+for (const specifier of JSON.parse(process.argv[1])) {
+  try {
+    resolutions[specifier] = import.meta.resolve(specifier);
+  } catch {
+    resolutions[specifier] = "";
   }
-  if (Array.isArray(value)) {
-    return value.flatMap(collectRuntimeExportTargets);
+}
+process.stdout.write(JSON.stringify(resolutions));`,
+      JSON.stringify(specifiers),
+    ],
+    { cwd: packageRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.status !== 0) {
+    return null;
   }
-  if (!value || typeof value !== "object") {
-    return [];
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
   }
-  return Object.entries(value)
-    .filter(([condition]) => condition !== "types")
-    .flatMap(([, target]) => collectRuntimeExportTargets(target));
 }
 
-function listPackageExportEntries(exportsField) {
-  if (
-    exportsField &&
-    typeof exportsField === "object" &&
-    !Array.isArray(exportsField) &&
-    Object.keys(exportsField).some((key) => key.startsWith("."))
-  ) {
-    return Object.entries(exportsField);
-  }
-  return [[".", exportsField]];
-}
-
-function resolvePackageExportTargets(exportEntries, subpath) {
-  const exact = exportEntries.find(([key]) => key === subpath);
-  if (exact) {
-    return collectRuntimeExportTargets(exact[1]);
-  }
-  for (const [key, value] of exportEntries) {
-    const wildcardIndex = key.indexOf("*");
-    if (wildcardIndex === -1) {
-      continue;
-    }
-    const prefix = key.slice(0, wildcardIndex);
-    const suffix = key.slice(wildcardIndex + 1);
-    if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
-      continue;
-    }
-    const matched = subpath.slice(prefix.length, subpath.length - suffix.length);
-    return collectRuntimeExportTargets(value).map((target) => target.replaceAll("*", matched));
-  }
-  return [];
-}
-
-function normalizeBundledPackageTarget(name, target, errors) {
-  if (!target.startsWith("./")) {
-    errors.push(`bundled ${name} has non-relative runtime export target ${target}`);
-    return "";
-  }
-  const normalized = path.posix.normalize(target.slice(2));
-  if (!normalized || normalized.startsWith("../") || normalized === "..") {
-    errors.push(`bundled ${name} has unsafe runtime export target ${target}`);
-    return "";
-  }
-  return normalized;
-}
-
-function collectBundledPackageRuntimeErrors({ name, entries, files, readText }) {
+function collectBundledPackageRuntimeErrors({ name, entries, files, packageRoot, readText }) {
   const errors = [];
   const packagePrefix = `node_modules/${name}/`;
   const manifestPath = `${packagePrefix}package.json`;
@@ -191,47 +175,30 @@ function collectBundledPackageRuntimeErrors({ name, entries, files, readText }) 
   if (bundledPackageJson.name !== name) {
     errors.push(`bundled ${name} package.json must name ${name}`);
   }
-
-  const exportEntries = listPackageExportEntries(bundledPackageJson.exports);
-  const requiredTargets = new Set();
-  for (const [subpath, value] of exportEntries) {
-    if (subpath.includes("*")) {
+  const runtimeEntries = REQUIRED_BUNDLED_WORKSPACE_RUNTIME_ENTRIES.get(name) ?? [];
+  const resolutions = resolveBundledPackageSpecifiers(
+    packageRoot,
+    runtimeEntries.map(({ specifier }) => specifier),
+  );
+  if (!resolutions) {
+    errors.push(`bundled ${name} runtime specifier resolution failed`);
+  }
+  for (const { entry, specifier } of runtimeEntries) {
+    if (!entries.has(`${packagePrefix}${entry}`)) {
+      errors.push(`bundled ${name} is missing required runtime entry ${entry}`);
+    }
+    const resolvedUrl = resolutions?.[specifier] ?? "";
+    if (!resolvedUrl) {
+      errors.push(`bundled ${name} runtime specifier ${specifier} is not resolvable`);
       continue;
     }
-    for (const target of collectRuntimeExportTargets(value)) {
-      requiredTargets.add(target);
+    const expectedUrl = pathToFileURL(path.join(packageRoot, packagePrefix, entry)).href;
+    if (resolvedUrl !== expectedUrl) {
+      errors.push(
+        `bundled ${name} runtime specifier ${specifier} resolves to ${resolvedUrl} instead of ${expectedUrl}`,
+      );
     }
   }
-
-  const usedSubpaths = new Set();
-  for (const { specifier } of collectPackageDistModuleSpecifiers({ files, readText })) {
-    if (specifier === name) {
-      usedSubpaths.add(".");
-    } else if (specifier.startsWith(`${name}/`)) {
-      usedSubpaths.add(`./${specifier.slice(name.length + 1)}`);
-    }
-  }
-  for (const subpath of usedSubpaths) {
-    const targets = resolvePackageExportTargets(exportEntries, subpath);
-    if (targets.length === 0) {
-      errors.push(`bundled ${name} does not export runtime subpath ${subpath}`);
-      continue;
-    }
-    for (const target of targets) {
-      requiredTargets.add(target);
-    }
-  }
-
-  for (const target of requiredTargets) {
-    if (target.includes("*")) {
-      continue;
-    }
-    const normalizedTarget = normalizeBundledPackageTarget(name, target, errors);
-    if (normalizedTarget && !entries.has(`${packagePrefix}${normalizedTarget}`)) {
-      errors.push(`bundled ${name} is missing runtime export ${normalizedTarget}`);
-    }
-  }
-
   const bundledFiles = files
     .filter((file) => file.startsWith(packagePrefix))
     .map((file) => file.slice(packagePrefix.length));
@@ -244,7 +211,13 @@ function collectBundledPackageRuntimeErrors({ name, entries, files, readText }) 
   return errors;
 }
 
-function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet, files, readText) {
+function collectRequiredBundledWorkspaceDependencyErrors(
+  packageJson,
+  entrySet,
+  files,
+  packageRoot,
+  readText,
+) {
   const errors = [];
   if (!packageJson || typeof packageJson !== "object") {
     return errors;
@@ -274,6 +247,7 @@ function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet, 
         name,
         entries: entrySet,
         files,
+        packageRoot,
         readText,
       }),
     );
@@ -415,6 +389,12 @@ function readTarEntry(entryPath) {
   return "";
 }
 
+const extractedPackageRoot = fs.realpathSync(
+  fs.existsSync(path.join(extractDir, "package", "package.json"))
+    ? path.join(extractDir, "package")
+    : extractDir,
+);
+
 for (const entry of normalized) {
   if (entry.startsWith("/") || entry.split("/").includes("..")) {
     errors.push(`unsafe tar entry: ${entry}`);
@@ -449,6 +429,7 @@ if (entrySet.has("package.json")) {
           packageJson,
           entrySet,
           normalized,
+          extractedPackageRoot,
           readTarEntry,
         ),
       );

--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -11,6 +11,7 @@ import { LOCAL_BUILD_METADATA_DIST_PATHS } from "./lib/local-build-metadata-path
 import {
   collectPackageDistImports,
   collectPackageDistImportErrors,
+  collectPackageDistModuleSpecifiers,
   expandPackageDistImportClosure,
 } from "./lib/package-dist-imports.mjs";
 
@@ -111,7 +112,139 @@ function listBundleDependencies(packageJson) {
     : [];
 }
 
-function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet) {
+function collectRuntimeExportTargets(value) {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(collectRuntimeExportTargets);
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  return Object.entries(value)
+    .filter(([condition]) => condition !== "types")
+    .flatMap(([, target]) => collectRuntimeExportTargets(target));
+}
+
+function listPackageExportEntries(exportsField) {
+  if (
+    exportsField &&
+    typeof exportsField === "object" &&
+    !Array.isArray(exportsField) &&
+    Object.keys(exportsField).some((key) => key.startsWith("."))
+  ) {
+    return Object.entries(exportsField);
+  }
+  return [[".", exportsField]];
+}
+
+function resolvePackageExportTargets(exportEntries, subpath) {
+  const exact = exportEntries.find(([key]) => key === subpath);
+  if (exact) {
+    return collectRuntimeExportTargets(exact[1]);
+  }
+  for (const [key, value] of exportEntries) {
+    const wildcardIndex = key.indexOf("*");
+    if (wildcardIndex === -1) {
+      continue;
+    }
+    const prefix = key.slice(0, wildcardIndex);
+    const suffix = key.slice(wildcardIndex + 1);
+    if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
+      continue;
+    }
+    const matched = subpath.slice(prefix.length, subpath.length - suffix.length);
+    return collectRuntimeExportTargets(value).map((target) => target.replaceAll("*", matched));
+  }
+  return [];
+}
+
+function normalizeBundledPackageTarget(name, target, errors) {
+  if (!target.startsWith("./")) {
+    errors.push(`bundled ${name} has non-relative runtime export target ${target}`);
+    return "";
+  }
+  const normalized = path.posix.normalize(target.slice(2));
+  if (!normalized || normalized.startsWith("../") || normalized === "..") {
+    errors.push(`bundled ${name} has unsafe runtime export target ${target}`);
+    return "";
+  }
+  return normalized;
+}
+
+function collectBundledPackageRuntimeErrors({ name, entries, files, readText }) {
+  const errors = [];
+  const packagePrefix = `node_modules/${name}/`;
+  const manifestPath = `${packagePrefix}package.json`;
+  let bundledPackageJson;
+  try {
+    bundledPackageJson = JSON.parse(readText(manifestPath));
+  } catch (error) {
+    errors.push(
+      `unreadable bundled ${name} package.json: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return errors;
+  }
+  if (bundledPackageJson.name !== name) {
+    errors.push(`bundled ${name} package.json must name ${name}`);
+  }
+
+  const exportEntries = listPackageExportEntries(bundledPackageJson.exports);
+  const requiredTargets = new Set();
+  for (const [subpath, value] of exportEntries) {
+    if (subpath.includes("*")) {
+      continue;
+    }
+    for (const target of collectRuntimeExportTargets(value)) {
+      requiredTargets.add(target);
+    }
+  }
+
+  const usedSubpaths = new Set();
+  for (const { specifier } of collectPackageDistModuleSpecifiers({ files, readText })) {
+    if (specifier === name) {
+      usedSubpaths.add(".");
+    } else if (specifier.startsWith(`${name}/`)) {
+      usedSubpaths.add(`./${specifier.slice(name.length + 1)}`);
+    }
+  }
+  for (const subpath of usedSubpaths) {
+    const targets = resolvePackageExportTargets(exportEntries, subpath);
+    if (targets.length === 0) {
+      errors.push(`bundled ${name} does not export runtime subpath ${subpath}`);
+      continue;
+    }
+    for (const target of targets) {
+      requiredTargets.add(target);
+    }
+  }
+
+  for (const target of requiredTargets) {
+    if (target.includes("*")) {
+      continue;
+    }
+    const normalizedTarget = normalizeBundledPackageTarget(name, target, errors);
+    if (normalizedTarget && !entries.has(`${packagePrefix}${normalizedTarget}`)) {
+      errors.push(`bundled ${name} is missing runtime export ${normalizedTarget}`);
+    }
+  }
+
+  const bundledFiles = files
+    .filter((file) => file.startsWith(packagePrefix))
+    .map((file) => file.slice(packagePrefix.length));
+  errors.push(
+    ...collectPackageDistImportErrors({
+      files: bundledFiles,
+      readText: (file) => readText(`${packagePrefix}${file}`),
+    }).map((error) => `bundled ${name} ${error}`),
+  );
+  return errors;
+}
+
+function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet, files, readText) {
   const errors = [];
   if (!packageJson || typeof packageJson !== "object") {
     return errors;
@@ -134,7 +267,16 @@ function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet) 
     }
     if (!entrySet.has(`node_modules/${name}/package.json`)) {
       errors.push(`package.json dependencies.${name} must be bundled in node_modules/${name}`);
+      continue;
     }
+    errors.push(
+      ...collectBundledPackageRuntimeErrors({
+        name,
+        entries: entrySet,
+        files,
+        readText,
+      }),
+    );
   }
 
   return errors;
@@ -302,7 +444,14 @@ if (entrySet.has("package.json")) {
     packageVersion = typeof packageJson.version === "string" ? packageJson.version : "";
     errors.push(...collectWorkspaceProtocolDependencyErrors(packageJson, "package.json"));
     if (cliArgs.requireBundledWorkspaceDeps) {
-      errors.push(...collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet));
+      errors.push(
+        ...collectRequiredBundledWorkspaceDependencyErrors(
+          packageJson,
+          entrySet,
+          normalized,
+          readTarEntry,
+        ),
+      );
     }
   } catch {
     packageVersion = "";

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -99,6 +99,11 @@ print_install_audit() {
   fi
 }
 
+verify_candidate_ai_runtime() {
+  echo "==> Verify installed AI runtime"
+  OPENCLAW_ALLOW_ROOT=1 openclaw infer image providers --json >/dev/null
+}
+
 run_with_heartbeat() {
   local label="$1"
   shift
@@ -278,6 +283,7 @@ run_install_smoke() {
       fi
     fi
     verify_installed_cli "$PACKAGE_NAME" "$FRESH_VERSION"
+    verify_candidate_ai_runtime
 
     echo "OK"
     return 0
@@ -475,11 +481,16 @@ if (Number(updateStep.exitCode ?? 1) !== 0) {
 if (typeof updateStep.command !== "string" || !updateStep.command.includes(expectedUrl)) {
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
 }
+const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
+if (!doctorStep || Number(doctorStep.exitCode ?? 1) !== 0) {
+  throw new Error(`openclaw doctor step failed: ${JSON.stringify(doctorStep)}`);
+}
 NODE
 
   echo "==> Verify updated version"
   print_install_audit "updated install"
   verify_installed_cli "$PACKAGE_NAME" "$UPDATE_EXPECT_VERSION"
+  verify_candidate_ai_runtime
 
   echo "OK"
 }

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -481,10 +481,6 @@ if (Number(updateStep.exitCode ?? 1) !== 0) {
 if (typeof updateStep.command !== "string" || !updateStep.command.includes(expectedUrl)) {
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
 }
-const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
-if (!doctorStep || Number(doctorStep.exitCode ?? 1) !== 0) {
-  throw new Error(`openclaw doctor step failed: ${JSON.stringify(doctorStep)}`);
-}
 NODE
 
   echo "==> Verify updated version"

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 
 read_positive_int_env() {
   local name="${1:?missing environment variable name}"
@@ -78,113 +78,6 @@ run_with_timeout() {
   node scripts/e2e/lib/bun-global-install/assertions.mjs run-with-timeout "$timeout_ms" "$@"
 }
 
-restore_dist_from_image() {
-  local image="$1"
-  local ai_backup_dir=""
-  local ai_dist_installed=0
-  local backup_dir=""
-  local container_id=""
-  local dist_installed=0
-  local restore_complete=0
-  local temp_dir=""
-
-  cleanup_restore_dist() {
-    if [ -n "$container_id" ]; then
-      docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
-    fi
-    # Both build trees come from one image. A partial swap must restore both or
-    # the following package step could mix artifacts from different builds.
-    if [ "$restore_complete" != "1" ]; then
-      if [ "$dist_installed" = "1" ]; then
-        rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true
-      fi
-      if [ -n "$backup_dir" ] && [ -d "$backup_dir" ]; then
-        if [ ! -e "$ROOT_DIR/dist" ] && mv "$backup_dir" "$ROOT_DIR/dist" >/dev/null 2>&1; then
-          backup_dir=""
-        fi
-      fi
-      if [ "$ai_dist_installed" = "1" ]; then
-        rm -rf "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1 || true
-      fi
-      if [ -n "$ai_backup_dir" ] && [ -d "$ai_backup_dir" ]; then
-        if [ ! -e "$ROOT_DIR/packages/ai/dist" ] && \
-          mv "$ai_backup_dir" "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1; then
-          ai_backup_dir=""
-        fi
-      fi
-    fi
-    if [ -n "$temp_dir" ]; then
-      rm -rf "$temp_dir"
-    fi
-    if [ "$restore_complete" = "1" ] && [ -n "$backup_dir" ]; then
-      rm -rf "$backup_dir"
-    fi
-    if [ "$restore_complete" = "1" ] && [ -n "$ai_backup_dir" ]; then
-      rm -rf "$ai_backup_dir"
-    fi
-  }
-
-  echo "==> Reuse dist/ from Docker image: $image"
-  if ! container_id="$(docker_e2e_docker_cmd create "$image")"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! temp_dir="$(mktemp -d "$ROOT_DIR/.bun-dist.XXXXXX")"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! docker_e2e_docker_cmd cp \
-    "${container_id}:/app/node_modules/@openclaw/ai/dist" \
-    "$temp_dir/ai-dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if [ -e "$ROOT_DIR/dist" ]; then
-    if ! backup_dir="$(mktemp -d "$ROOT_DIR/.dist-backup.XXXXXX")"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! rmdir "$backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! mv "$ROOT_DIR/dist" "$backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-  fi
-  if ! mv "$temp_dir/dist" "$ROOT_DIR/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  dist_installed=1
-  if [ -e "$ROOT_DIR/packages/ai/dist" ]; then
-    if ! ai_backup_dir="$(mktemp -d "$ROOT_DIR/packages/ai/.dist-backup.XXXXXX")"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! rmdir "$ai_backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! mv "$ROOT_DIR/packages/ai/dist" "$ai_backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-  fi
-  if ! mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  ai_dist_installed=1
-  restore_complete=1
-  cleanup_restore_dist
-}
-
 resolve_package_tgz() {
   if [ -n "$PACKAGE_TGZ" ]; then
     if [ ! -f "$PACKAGE_TGZ" ]; then
@@ -196,7 +89,7 @@ resolve_package_tgz() {
   fi
 
   if [ -n "$DIST_IMAGE" ]; then
-    restore_dist_from_image "$DIST_IMAGE"
+    docker_e2e_restore_package_dist_from_image "$DIST_IMAGE"
   elif [ "$HOST_BUILD" != "0" ]; then
     echo "==> Build host package artifacts"
     pnpm build

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -156,6 +156,121 @@ docker_e2e_abs_path() {
   (cd "$(dirname "$file")" && printf '%s/%s\n' "$(pwd)" "$(basename "$file")")
 }
 
+docker_e2e_restore_package_dist_from_image() (
+  local image="$1"
+  local ai_backup_dir=""
+  local ai_dist_installed=0
+  local backup_dir=""
+  local container_id=""
+  local dist_installed=0
+  local requires_ai_dist=0
+  local restore_complete=0
+  local temp_dir=""
+
+  cleanup_restore_package_dist() {
+    if [ -n "$container_id" ]; then
+      docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
+    fi
+    # Root and AI artifacts come from one image. Restore both on partial failure
+    # so the package step cannot combine outputs from different builds.
+    if [ "$restore_complete" != "1" ]; then
+      if [ "$dist_installed" = "1" ]; then
+        rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true
+      fi
+      if [ -n "$backup_dir" ] && [ -d "$backup_dir" ]; then
+        if [ ! -e "$ROOT_DIR/dist" ] && mv "$backup_dir" "$ROOT_DIR/dist" >/dev/null 2>&1; then
+          backup_dir=""
+        fi
+      fi
+      if [ "$ai_dist_installed" = "1" ]; then
+        rm -rf "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1 || true
+      fi
+      if [ -n "$ai_backup_dir" ] && [ -d "$ai_backup_dir" ]; then
+        if [ ! -e "$ROOT_DIR/packages/ai/dist" ] && \
+          mv "$ai_backup_dir" "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1; then
+          ai_backup_dir=""
+        fi
+      fi
+    fi
+    if [ -n "$temp_dir" ]; then
+      rm -rf "$temp_dir"
+    fi
+    if [ "$restore_complete" = "1" ] && [ -n "$backup_dir" ]; then
+      rm -rf "$backup_dir"
+    fi
+    if [ "$restore_complete" = "1" ] && [ -n "$ai_backup_dir" ]; then
+      rm -rf "$ai_backup_dir"
+    fi
+  }
+
+  if [ -f "$ROOT_DIR/packages/ai/package.json" ]; then
+    requires_ai_dist=1
+  fi
+
+  echo "==> Reuse package build artifacts from Docker image: $image"
+  if ! container_id="$(docker_e2e_docker_cmd create "$image")"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if ! temp_dir="$(mktemp -d "$ROOT_DIR/.package-dist.XXXXXX")"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if [ "$requires_ai_dist" = "1" ] && \
+    ! docker_e2e_docker_cmd cp \
+      "${container_id}:/app/node_modules/@openclaw/ai/dist" \
+      "$temp_dir/ai-dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if [ -e "$ROOT_DIR/dist" ]; then
+    if ! backup_dir="$(mktemp -d "$ROOT_DIR/.dist-backup.XXXXXX")"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! rmdir "$backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! mv "$ROOT_DIR/dist" "$backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+  fi
+  if ! mv "$temp_dir/dist" "$ROOT_DIR/dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  dist_installed=1
+  if [ "$requires_ai_dist" = "1" ]; then
+    if [ -e "$ROOT_DIR/packages/ai/dist" ]; then
+      if ! ai_backup_dir="$(mktemp -d "$ROOT_DIR/packages/ai/.dist-backup.XXXXXX")"; then
+        cleanup_restore_package_dist
+        return 1
+      fi
+      if ! rmdir "$ai_backup_dir"; then
+        cleanup_restore_package_dist
+        return 1
+      fi
+      if ! mv "$ROOT_DIR/packages/ai/dist" "$ai_backup_dir"; then
+        cleanup_restore_package_dist
+        return 1
+      fi
+    fi
+    if ! mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    ai_dist_installed=1
+  fi
+  restore_complete=1
+  cleanup_restore_package_dist
+)
+
 docker_e2e_prepare_package_tgz() {
   local label="$1"
   local package_tgz="${2:-${OPENCLAW_CURRENT_PACKAGE_TGZ:-}}"

--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -117,33 +117,17 @@ function collectImportSpecifiers(source) {
       break;
     }
 
-    const isDistDependency =
-      isImportSpecifierContext(source, index) ||
-      isRequireSpecifierContext(source, index) ||
-      (isImportMetaUrlContext(source, index, cursor) && hasJavaScriptFileExtension(value));
-    if (isDistDependency) {
-      specifiers.push(value);
+    if (value.startsWith(".")) {
+      const isDistDependency =
+        isImportSpecifierContext(source, index) ||
+        isRequireSpecifierContext(source, index) ||
+        (isImportMetaUrlContext(source, index, cursor) && hasJavaScriptFileExtension(value));
+      if (isDistDependency) {
+        specifiers.push(value);
+      }
     }
     index = cursor;
   }
-  return specifiers;
-}
-
-/** Collect static module specifiers from package dist JavaScript files. */
-export function collectPackageDistModuleSpecifiers(params) {
-  const files = [...new Set(params.files.map(normalizePackagePath))];
-  const specifiers = [];
-
-  for (const importerPath of files.toSorted((left, right) => left.localeCompare(right))) {
-    if (!JS_DIST_FILE_RE.test(importerPath) || importerPath.includes("/node_modules/")) {
-      continue;
-    }
-    const source = params.readText(importerPath);
-    for (const specifier of collectImportSpecifiers(source)) {
-      specifiers.push({ importerPath, specifier });
-    }
-  }
-
   return specifiers;
 }
 
@@ -165,14 +149,21 @@ export function collectPackageDistImportErrors(params) {
 
 /** Collect relative dist import edges from package JavaScript files. */
 export function collectPackageDistImports(params) {
+  const files = [...new Set(params.files.map(normalizePackagePath))];
   const imports = [];
 
-  for (const { importerPath, specifier } of collectPackageDistModuleSpecifiers(params)) {
-    const importedPath = resolveDistImportPath(importerPath, specifier);
-    if (!importedPath) {
+  for (const importerPath of files.toSorted((left, right) => left.localeCompare(right))) {
+    if (!JS_DIST_FILE_RE.test(importerPath) || importerPath.includes("/node_modules/")) {
       continue;
     }
-    imports.push({ importerPath, importedPath });
+    const source = params.readText(importerPath);
+    for (const specifier of collectImportSpecifiers(source)) {
+      const importedPath = resolveDistImportPath(importerPath, specifier);
+      if (!importedPath) {
+        continue;
+      }
+      imports.push({ importerPath, importedPath });
+    }
   }
 
   return imports;

--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -117,17 +117,33 @@ function collectImportSpecifiers(source) {
       break;
     }
 
-    if (value.startsWith(".")) {
-      const isDistDependency =
-        isImportSpecifierContext(source, index) ||
-        isRequireSpecifierContext(source, index) ||
-        (isImportMetaUrlContext(source, index, cursor) && hasJavaScriptFileExtension(value));
-      if (isDistDependency) {
-        specifiers.push(value);
-      }
+    const isDistDependency =
+      isImportSpecifierContext(source, index) ||
+      isRequireSpecifierContext(source, index) ||
+      (isImportMetaUrlContext(source, index, cursor) && hasJavaScriptFileExtension(value));
+    if (isDistDependency) {
+      specifiers.push(value);
     }
     index = cursor;
   }
+  return specifiers;
+}
+
+/** Collect static module specifiers from package dist JavaScript files. */
+export function collectPackageDistModuleSpecifiers(params) {
+  const files = [...new Set(params.files.map(normalizePackagePath))];
+  const specifiers = [];
+
+  for (const importerPath of files.toSorted((left, right) => left.localeCompare(right))) {
+    if (!JS_DIST_FILE_RE.test(importerPath) || importerPath.includes("/node_modules/")) {
+      continue;
+    }
+    const source = params.readText(importerPath);
+    for (const specifier of collectImportSpecifiers(source)) {
+      specifiers.push({ importerPath, specifier });
+    }
+  }
+
   return specifiers;
 }
 
@@ -149,21 +165,14 @@ export function collectPackageDistImportErrors(params) {
 
 /** Collect relative dist import edges from package JavaScript files. */
 export function collectPackageDistImports(params) {
-  const files = [...new Set(params.files.map(normalizePackagePath))];
   const imports = [];
 
-  for (const importerPath of files.toSorted((left, right) => left.localeCompare(right))) {
-    if (!JS_DIST_FILE_RE.test(importerPath) || importerPath.includes("/node_modules/")) {
+  for (const { importerPath, specifier } of collectPackageDistModuleSpecifiers(params)) {
+    const importedPath = resolveDistImportPath(importerPath, specifier);
+    if (!importedPath) {
       continue;
     }
-    const source = params.readText(importerPath);
-    for (const specifier of collectImportSpecifiers(source)) {
-      const importedPath = resolveDistImportPath(importerPath, specifier);
-      if (!importedPath) {
-        continue;
-      }
-      imports.push({ importerPath, importedPath });
-    }
+    imports.push({ importerPath, importedPath });
   }
 
   return imports;

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${OPENCLAW_INSTALL_SMOKE_SOURCE_DIR:-$HARNESS_ROOT}"
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd)"
 # shellcheck source=./docker/install-sh-common/version-parse.sh
-source "$ROOT_DIR/scripts/docker/install-sh-common/version-parse.sh"
-source "$ROOT_DIR/scripts/lib/docker-build.sh"
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+source "$HARNESS_ROOT/scripts/docker/install-sh-common/version-parse.sh"
+source "$HARNESS_ROOT/scripts/lib/docker-build.sh"
+source "$HARNESS_ROOT/scripts/lib/docker-e2e-package.sh"
 DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_INSTALL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"
 INSTALL_SMOKE_DOCKER_RUN_TIMEOUT="${OPENCLAW_INSTALL_SMOKE_DOCKER_RUN_TIMEOUT:-2700s}"
 
@@ -76,7 +78,9 @@ console.log(
 assert_pack_unpacked_size_budget() {
   local label="$1"
   local pack_json_file="$2"
-  node --input-type=module - "$label" "$pack_json_file" <<'NODE'
+  (
+    cd "$HARNESS_ROOT"
+    node --input-type=module - "$label" "$pack_json_file" <<'NODE'
 import { readFileSync } from "node:fs";
 import { collectPackUnpackedSizeErrors } from "./scripts/lib/npm-pack-budget.mjs";
 
@@ -104,6 +108,7 @@ if (errors.length > 0) {
   process.exit(1);
 }
 NODE
+  )
 }
 
 print_pack_delta_audit() {
@@ -272,31 +277,30 @@ allocate_host_port() {
   '
 }
 
-restore_local_dist_from_image() {
-  local image="$1"
-  local container_id=""
-
-  echo "==> Reuse local dist/ from Docker image: $image"
-  container_id="$(docker_e2e_docker_cmd create "$image")"
-  rm -rf "$ROOT_DIR/dist"
-  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$ROOT_DIR/dist"; then
-    docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
-    return 1
-  fi
-  docker_e2e_docker_cmd rm -f "$container_id" >/dev/null
-}
-
 ensure_local_update_dist_import_closure() {
-  if node scripts/check-package-dist-imports.mjs "$ROOT_DIR"; then
+  if node "$HARNESS_ROOT/scripts/check-package-dist-imports.mjs" "$ROOT_DIR"; then
     return 0
   fi
+  if [[ "$UPDATE_SKIP_LOCAL_BUILD" == "1" ]]; then
+    echo "ERROR: reused Docker image package dist failed import-closure check; exact-image mode forbids a local rebuild" >&2
+    return 1
+  fi
   echo "WARN: reused Docker image dist failed import-closure check; rebuilding local release artifacts" >&2
-  pnpm build
+  (
+    cd "$ROOT_DIR"
+    pnpm build
+  )
+}
+
+read_candidate_version() {
+  node -e '
+const fs = require("node:fs");
+const packageJson = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+process.stdout.write(packageJson.version);
+' "$ROOT_DIR/package.json"
 }
 
 prepare_update_tarball() {
-  local pack_json
-  local baseline_pack_json
   local pack_json_file
   local baseline_pack_json_file
   local package_args
@@ -310,24 +314,28 @@ prepare_update_tarball() {
   else
     echo "==> Build local release artifacts for update smoke"
     if [[ -n "$UPDATE_DIST_IMAGE" ]]; then
-      restore_local_dist_from_image "$UPDATE_DIST_IMAGE"
+      docker_e2e_restore_package_dist_from_image "$UPDATE_DIST_IMAGE"
       ensure_local_update_dist_import_closure
     elif [[ "$UPDATE_SKIP_LOCAL_BUILD" != "1" ]]; then
-      pnpm build
+      (
+        cd "$ROOT_DIR"
+        pnpm build
+      )
     fi
-    UPDATE_EXPECT_VERSION="$(
-      node -p 'JSON.parse(require("node:fs").readFileSync("package.json", "utf8")).version'
-    )"
+    UPDATE_EXPECT_VERSION="$(read_candidate_version)"
     package_args=(
+      --source-dir "$ROOT_DIR"
       --output-dir "$UPDATE_DIR"
       --pack-json "$pack_json_file"
       --skip-build
     )
-    package_tgz="$(node scripts/package-openclaw-for-docker.mjs "${package_args[@]}")"
+    package_tgz="$(
+      node "$HARNESS_ROOT/scripts/package-openclaw-for-docker.mjs" "${package_args[@]}"
+    )"
     UPDATE_TGZ_FILE="$(basename "$package_tgz")"
   fi
   if [[ -z "$UPDATE_PACKAGE_SPEC" ]]; then
-    node scripts/check-openclaw-package-tarball.mjs \
+    node "$HARNESS_ROOT/scripts/check-openclaw-package-tarball.mjs" \
       --require-bundled-workspace-deps \
       "${UPDATE_DIR}/${UPDATE_TGZ_FILE}"
   else
@@ -427,8 +435,8 @@ else
   docker_build_run install-smoke-build \
     --platform "$SMOKE_PLATFORM" \
     -t "$SMOKE_IMAGE" \
-    -f "$ROOT_DIR/scripts/docker/install-sh-smoke/Dockerfile" \
-    "$ROOT_DIR/scripts/docker"
+    -f "$HARNESS_ROOT/scripts/docker/install-sh-smoke/Dockerfile" \
+    "$HARNESS_ROOT/scripts/docker"
 fi
 
 if [[ "$SKIP_UPDATE" == "1" ]]; then
@@ -540,8 +548,8 @@ else
     docker_build_run install-nonroot-build \
       --platform "$NONROOT_PLATFORM" \
       -t "$NONROOT_IMAGE" \
-      -f "$ROOT_DIR/scripts/docker/install-sh-nonroot/Dockerfile" \
-      "$ROOT_DIR/scripts/docker"
+      -f "$HARNESS_ROOT/scripts/docker/install-sh-nonroot/Dockerfile" \
+      "$HARNESS_ROOT/scripts/docker"
   fi
 
   echo "==> Run installer non-root test: $INSTALL_URL"

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -531,8 +531,7 @@ describe("check-openclaw-package-tarball", () => {
     withTarball(
       ["dist/index.js"],
       {
-        "dist/index.js":
-          'import "@openclaw/ai/providers";\nimport "@openclaw/ai/internal/runtime";\n',
+        "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
       },
       (tarball) => {
@@ -544,13 +543,13 @@ describe("check-openclaw-package-tarball", () => {
 
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing runtime export dist/index.mjs",
+          "bundled @openclaw/ai is missing required runtime entry dist/index.mjs",
         );
         expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing runtime export dist/providers.mjs",
+          "bundled @openclaw/ai is missing required runtime entry dist/providers.mjs",
         );
         expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing runtime export dist/internal/runtime.mjs",
+          "bundled @openclaw/ai is missing required runtime entry dist/internal/runtime.mjs",
         );
       },
       "2026.6.11",
@@ -567,8 +566,7 @@ describe("check-openclaw-package-tarball", () => {
     withTarball(
       ["dist/index.js"],
       {
-        "dist/index.js":
-          'import "@openclaw/ai/providers";\nimport "@openclaw/ai/internal/runtime";\n',
+        "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
         "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
@@ -594,11 +592,11 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
-  it("rejects a missing bundled AI subpath imported by OpenClaw dist", () => {
+  it("rejects a missing required bundled AI runtime entry", () => {
     withTarball(
       ["dist/index.js"],
       {
-        "dist/index.js": 'import "@openclaw/ai/providers";\n',
+        "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
@@ -612,7 +610,79 @@ describe("check-openclaw-package-tarball", () => {
 
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing runtime export dist/providers.mjs",
+          "bundled @openclaw/ai is missing required runtime entry dist/providers.mjs",
+        );
+      },
+      "2026.6.11",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("rejects bundled AI entries that its manifest does not export", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js": "export {};\n",
+        "node_modules/@openclaw/ai/package.json": JSON.stringify({
+          name: "@openclaw/ai",
+          version: "2026.6.11",
+          exports: {
+            ".": "./dist/index.mjs",
+            "./providers": null,
+            "./internal/*": "./dist/internal/*.mjs",
+          },
+        }),
+        "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai runtime specifier @openclaw/ai/providers is not resolvable",
+        );
+      },
+      "2026.6.11",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("rejects missing relative imports from bundled AI runtime entries", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js": "export {};\n",
+        "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
+        "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": 'export * from "./missing.mjs";\n',
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai dist/internal/runtime.mjs imports missing dist/internal/missing.mjs",
         );
       },
       "2026.6.11",

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -17,6 +17,15 @@ import { LOCAL_BUILD_METADATA_DIST_PATHS } from "../../scripts/lib/local-build-m
 const CHECK_SCRIPT = "scripts/check-openclaw-package-tarball.mjs";
 const FLAT_PLUGIN_SDK_DECLARATION = "dist/plugin-sdk/provider-entry.d.ts";
 const DEEP_PLUGIN_SDK_DECLARATION = "dist/plugin-sdk/src/plugin-sdk/provider-entry.d.ts";
+const AI_RUNTIME_PACKAGE_JSON = JSON.stringify({
+  name: "@openclaw/ai",
+  version: "2026.6.11",
+  exports: {
+    ".": { import: "./dist/index.mjs" },
+    "./providers": { import: "./dist/providers.mjs" },
+    "./internal/*": { import: "./dist/internal/*.mjs" },
+  },
+});
 
 function withTarball(
   inventory: string[],
@@ -518,21 +527,93 @@ describe("check-openclaw-package-tarball", () => {
     );
   });
 
-  it("accepts private workspace dependencies when bundled in the tarball", () => {
+  it("rejects private workspace dependencies when only metadata is bundled", () => {
     withTarball(
       ["dist/index.js"],
       {
-        "dist/index.js": "export {};\n",
-        "node_modules/@openclaw/ai/package.json": JSON.stringify({
-          name: "@openclaw/ai",
-          version: "2026.6.11",
-        }),
+        "dist/index.js":
+          'import "@openclaw/ai/providers";\nimport "@openclaw/ai/internal/runtime";\n',
+        "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
       },
       (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai is missing runtime export dist/index.mjs",
+        );
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai is missing runtime export dist/providers.mjs",
+        );
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai is missing runtime export dist/internal/runtime.mjs",
+        );
+      },
+      "2026.6.11",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("accepts private workspace dependencies when their runtime is bundled", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js":
+          'import "@openclaw/ai/providers";\nimport "@openclaw/ai/internal/runtime";\n',
+        "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
+        "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      },
+      "2026.6.11",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("rejects a missing bundled AI subpath imported by OpenClaw dist", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js": 'import "@openclaw/ai/providers";\n',
+        "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
+        "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai is missing runtime export dist/providers.mjs",
+        );
       },
       "2026.6.11",
       {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import path, { join } from "node:path";
 import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = "scripts/test-install-sh-docker.sh";
@@ -30,6 +31,7 @@ const NONROOT_DOCKERFILE_PATH = "scripts/docker/install-sh-nonroot/Dockerfile";
 const NONROOT_RUNNER_PATH = "scripts/docker/install-sh-nonroot/run.sh";
 const BUN_GLOBAL_SMOKE_PATH = "scripts/e2e/bun-global-install-smoke.sh";
 const BUN_GLOBAL_ASSERTIONS_PATH = "scripts/e2e/lib/bun-global-install/assertions.mjs";
+const DOCKER_E2E_PACKAGE_HELPER_PATH = "scripts/lib/docker-e2e-package.sh";
 const INSTALL_SMOKE_WORKFLOW_PATH = ".github/workflows/install-smoke.yml";
 const RELEASE_CHECKS_WORKFLOW_PATH = ".github/workflows/openclaw-release-checks.yml";
 const LIVE_E2E_WORKFLOW_PATH = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
@@ -224,6 +226,91 @@ read_pack_tarball_filename "$pack_json_file"`,
   );
 }
 
+function extractEnsureLocalUpdateDistImportClosure(): string {
+  const script = readFileSync(SCRIPT_PATH, "utf8");
+  const match = script.match(
+    /(ensure_local_update_dist_import_closure\(\) \{[\s\S]*?\n\})\n\nread_candidate_version/u,
+  );
+  if (!match) {
+    throw new Error("ensure_local_update_dist_import_closure helper was not found");
+  }
+  return match[1];
+}
+
+function runRestoreLocalDistFixture(options: { failAiSwap?: boolean } = {}) {
+  const fixtureRoot = tempDirs.make("openclaw-install-restore-root-");
+  const imageRoot = tempDirs.make("openclaw-install-restore-image-");
+  for (const [relativePath, contents] of [
+    ["dist/root.txt", "old-root"],
+    ["packages/ai/dist/ai.txt", "old-ai"],
+    ["packages/ai/package.json", "{}"],
+  ]) {
+    const target = join(fixtureRoot, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  for (const [relativePath, contents] of [
+    ["app/dist/root.txt", "new-root"],
+    ["app/node_modules/@openclaw/ai/dist/ai.txt", "new-ai"],
+  ]) {
+    const target = join(imageRoot, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+
+  return spawnSync(
+    "bash",
+    [
+      "--noprofile",
+      "--norc",
+      "-c",
+      `set -euo pipefail
+REPO_ROOT="$FIXTURE_REPO"
+ROOT_DIR="$FIXTURE_ROOT"
+IMAGE_ROOT="$FIXTURE_IMAGE"
+docker_e2e_docker_cmd() {
+  case "$1" in
+    create)
+      printf "fixture"
+      ;;
+    cp)
+      local source="\${2#fixture:}"
+      cp -R "$IMAGE_ROOT$source" "$3"
+      ;;
+    rm)
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+mv() {
+  if [[ "$FAIL_AI_SWAP" == "1" && "$1" == */ai-dist && "$2" == "$ROOT_DIR/packages/ai/dist" ]]; then
+    return 1
+  fi
+  command mv "$@"
+}
+source "$REPO_ROOT/${DOCKER_E2E_PACKAGE_HELPER_PATH}"
+status=0
+docker_e2e_restore_package_dist_from_image fixture-image || status=$?
+printf 'status=%s\\n' "$status"
+printf 'root=%s\\n' "$(cat "$ROOT_DIR/dist/root.txt")"
+printf 'ai=%s\\n' "$(cat "$ROOT_DIR/packages/ai/dist/ai.txt")"
+`,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAIL_AI_SWAP: options.failAiSwap ? "1" : "0",
+        FIXTURE_IMAGE: imageRoot,
+        FIXTURE_REPO: process.cwd(),
+        FIXTURE_ROOT: fixtureRoot,
+      },
+    },
+  );
+}
+
 describe("test-install-sh-docker", () => {
   it("defaults ARM hosts to native arm64 while keeping x64 CI on amd64", () => {
     expect(runDefaultSmokePlatform({ CI: "true" }, "aarch64")).toBe("linux/arm64");
@@ -354,28 +441,94 @@ describe("test-install-sh-docker", () => {
 
   it("can reuse dist from the already-built root Docker smoke image", () => {
     const script = readFileSync(SCRIPT_PATH, "utf8");
+    const packageHelper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
     const dockerfile = readFileSync("Dockerfile", "utf8");
 
+    expect(script).toContain('ROOT_DIR="${OPENCLAW_INSTALL_SMOKE_SOURCE_DIR:-$HARNESS_ROOT}"');
     expect(script).toContain('UPDATE_DIST_IMAGE="${OPENCLAW_INSTALL_SMOKE_UPDATE_DIST_IMAGE:-}"');
-    expect(script).toContain("restore_local_dist_from_image");
-    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"');
+    expect(script).toContain("docker_e2e_restore_package_dist_from_image");
+    expect(script).toContain('source "$HARNESS_ROOT/scripts/lib/docker-e2e-package.sh"');
     expect(script).toContain(
       'DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_INSTALL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"',
     );
-    expect(script).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
-    expect(script).toContain(
-      'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$ROOT_DIR/dist"',
+    expect(packageHelper).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
+    expect(packageHelper).toContain(
+      'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"',
     );
-    expect(script).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
+    expect(packageHelper).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
+    expect(packageHelper).toContain('"$temp_dir/ai-dist"');
+    expect(packageHelper).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
+    expect(packageHelper).toContain("cleanup_restore_package_dist() {");
+    expect(packageHelper).toContain('mv "$ROOT_DIR/dist" "$backup_dir"');
+    expect(packageHelper).toContain('mv "$temp_dir/dist" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true');
+    expect(packageHelper).toContain('mv "$backup_dir" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
     expect(script).not.toContain('container_id="$(docker create "$image")"');
     expect(script).not.toContain('docker cp "${container_id}:/app/dist" "$ROOT_DIR/dist"');
-    expect(script).toContain('echo "==> Reuse local dist/ from Docker image: $image"');
+    expect(packageHelper).toContain(
+      'echo "==> Reuse package build artifacts from Docker image: $image"',
+    );
     expect(script).toContain("ensure_local_update_dist_import_closure");
-    expect(script).toContain('node scripts/check-package-dist-imports.mjs "$ROOT_DIR"');
+    expect(script).toContain(
+      'node "$HARNESS_ROOT/scripts/check-package-dist-imports.mjs" "$ROOT_DIR"',
+    );
     expect(script).toContain("WARN: reused Docker image dist failed import-closure check");
     expect(script).toContain("pnpm build");
     expect(script).not.toContain("pnpm ui:build");
+    expect(script).toContain('-f "$HARNESS_ROOT/scripts/docker/install-sh-smoke/Dockerfile"');
+    expect(script).toContain('-f "$HARNESS_ROOT/scripts/docker/install-sh-nonroot/Dockerfile"');
     expect(dockerfile).toContain("node scripts/check-package-dist-imports.mjs /app");
+  });
+
+  it("restores root and AI build trees from one image", () => {
+    const result = runRestoreLocalDistFixture();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("status=0");
+    expect(result.stdout).toContain("root=new-root");
+    expect(result.stdout).toContain("ai=new-ai");
+  });
+
+  it("rolls both build trees back when the AI swap fails", () => {
+    const result = runRestoreLocalDistFixture({ failAiSwap: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("status=1");
+    expect(result.stdout).toContain("root=old-root");
+    expect(result.stdout).toContain("ai=old-ai");
+  });
+
+  it("fails closed when exact image artifacts fail import closure", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        `set -euo pipefail
+HARNESS_ROOT=/trusted
+ROOT_DIR=/candidate
+UPDATE_SKIP_LOCAL_BUILD=1
+node() {
+  return 1
+}
+pnpm() {
+  printf 'pnpm-called\\n'
+}
+${extractEnsureLocalUpdateDistImportClosure()}
+status=0
+ensure_local_update_dist_import_closure || status=$?
+printf 'status=%s\\n' "$status"
+`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("status=1");
+    expect(result.stdout).not.toContain("pnpm-called");
+    expect(result.stderr).toContain("exact-image mode forbids a local rebuild");
   });
 
   it("bounds installer smoke container runs", () => {
@@ -622,12 +775,13 @@ describe("test-install-sh-docker", () => {
   it("uses the package artifact helper for local update tarballs", () => {
     const script = readFileSync(SCRIPT_PATH, "utf8");
 
-    expect(script).toContain("node scripts/package-openclaw-for-docker.mjs");
+    expect(script).toContain('node "$HARNESS_ROOT/scripts/package-openclaw-for-docker.mjs"');
+    expect(script).toContain('--source-dir "$ROOT_DIR"');
     expect(script).toContain('--pack-json "$pack_json_file"');
     expect(script).toContain("--skip-build");
     expect(script).not.toContain("node --import tsx scripts/write-package-dist-inventory.ts");
     expect(script).not.toContain("quiet_npm pack --ignore-scripts --json");
-    expect(script).toContain("node scripts/check-openclaw-package-tarball.mjs");
+    expect(script).toContain('node "$HARNESS_ROOT/scripts/check-openclaw-package-tarball.mjs"');
     expect(script).toContain("--require-bundled-workspace-deps");
   });
 
@@ -875,6 +1029,7 @@ describe("bun global install smoke", () => {
   it("packs the current tree and verifies image-provider discovery through Bun", () => {
     const script = readFileSync(BUN_GLOBAL_SMOKE_PATH, "utf8");
     const assertions = readFileSync(BUN_GLOBAL_ASSERTIONS_PATH, "utf8");
+    const packageHelper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
 
     expect(script).toContain("node scripts/package-openclaw-for-docker.mjs");
     expect(script).toContain("--skip-build");
@@ -885,29 +1040,28 @@ describe("bun global install smoke", () => {
     expect(script).toContain("assert-image-providers");
     expect(assertions).toContain("image providers output is missing bundled provider");
     expect(script).toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE");
-    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"');
+    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"');
+    expect(script).toContain("docker_e2e_restore_package_dist_from_image");
     expect(script).toContain(
       'COMMAND_TIMEOUT_MS="$(read_positive_int_env OPENCLAW_BUN_GLOBAL_SMOKE_TIMEOUT_MS 180000)"',
     );
     expect(script).toContain(
       'DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_BUN_GLOBAL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"',
     );
-    expect(script).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
-    expect(script).toContain(
+    expect(packageHelper).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
+    expect(packageHelper).toContain(
       'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"',
     );
-    expect(script).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
-    expect(script).toContain('"$temp_dir/ai-dist"');
-    expect(script).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
-    expect(script).toContain("cleanup_restore_dist() {");
-    expect(script).toContain('mv "$ROOT_DIR/dist" "$backup_dir"');
-    expect(script).toContain('mv "$temp_dir/dist" "$ROOT_DIR/dist"');
-    expect(script).toContain('mktemp -d "$ROOT_DIR/.bun-dist.XXXXXX"');
-    expect(script).toContain('rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true');
-    expect(script).toContain('&& mv "$backup_dir" "$ROOT_DIR/dist"');
-    expect(script).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
-    expect(script).toContain("cleanup_restore_dist\n    return 1");
-    expect(script).not.toContain("trap cleanup_restore_dist RETURN");
+    expect(packageHelper).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
+    expect(packageHelper).toContain('"$temp_dir/ai-dist"');
+    expect(packageHelper).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
+    expect(packageHelper).toContain("cleanup_restore_package_dist() {");
+    expect(packageHelper).toContain('mv "$ROOT_DIR/dist" "$backup_dir"');
+    expect(packageHelper).toContain('mv "$temp_dir/dist" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('mktemp -d "$ROOT_DIR/.package-dist.XXXXXX"');
+    expect(packageHelper).toContain('rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true');
+    expect(packageHelper).toContain('mv "$backup_dir" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
     expect(script).not.toContain('container_id="$(docker create "$image")"');
     expect(script).not.toContain('docker cp "${container_id}:/app/dist" "$ROOT_DIR/dist"');
     expect(script).not.toContain('\n  rm -rf "$ROOT_DIR/dist"\n');
@@ -1245,6 +1399,47 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(releaseChecks).toContain("install_smoke_release_checks:");
     expect(releaseChecks).toContain("uses: ./.github/workflows/install-smoke.yml");
     expect(releaseChecks).toContain("run_bun_global_install_smoke: true");
+  });
+
+  it("runs installer packaging from the trusted workflow revision against a nested candidate", () => {
+    const workflow = parse(readFileSync(INSTALL_SMOKE_WORKFLOW_PATH, "utf8"));
+    const steps = workflow.jobs.installer_smoke.steps as Array<{
+      name?: string;
+      uses?: string;
+      with?: Record<string, unknown>;
+      env?: Record<string, unknown>;
+      run?: string;
+    }>;
+    const step = (name: string) => {
+      const found = steps.find((entry) => entry.name === name);
+      expect(found, name).toBeDefined();
+      return found!;
+    };
+
+    expect(step("Checkout trusted installer harness").with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+    });
+    expect(step("Checkout candidate CLI").with).toMatchObject({
+      ref: "${{ inputs.ref || github.ref }}",
+      path: "candidate",
+      "persist-credentials": false,
+    });
+    expect(step("Setup Node environment for installer smoke").uses).toBe(
+      "./.github/actions/setup-node-env",
+    );
+    expect(step("Run installer docker tests").env).toMatchObject({
+      OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
+    });
+    expect(step("Run installer docker tests").run).toBe("bash scripts/test-install-sh-docker.sh");
+    expect(step("Build installer smoke image").run).toContain(
+      "./scripts/docker/install-sh-smoke/Dockerfile",
+    );
+    expect(step("Build installer smoke image").run).not.toContain("candidate/scripts/docker");
+    expect(step("Build installer non-root image").run).not.toContain("candidate/scripts/docker");
+    expect(step("Run Rocky Linux installer smoke").run).toContain(
+      "$PWD/candidate/scripts/install.sh",
+    );
   });
 
   it("kills Bun global install smoke commands that ignore TERM after timeout", () => {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -954,6 +954,10 @@ describe("install-sh smoke runner", () => {
     expect(script).toContain("legacy updater process exited after self-swap");
     expect(script).toContain("parseFirstJsonObject");
     expect(script).toContain("unterminated update JSON object");
+    expect(script).toContain("verify_candidate_ai_runtime");
+    expect(script).toContain("openclaw infer image providers --json");
+    expect(script).toContain('steps.find((step) => step?.name === "openclaw doctor")');
+    expect(script).toContain("openclaw doctor step failed");
   });
 
   it.each([

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -956,8 +956,6 @@ describe("install-sh smoke runner", () => {
     expect(script).toContain("unterminated update JSON object");
     expect(script).toContain("verify_candidate_ai_runtime");
     expect(script).toContain("openclaw infer image providers --json");
-    expect(script).toContain('steps.find((step) => step?.name === "openclaw doctor")');
-    expect(script).toContain("openclaw doctor step failed");
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

The release install-smoke lane could reuse only root `dist/` from the candidate Docker image, then pack a metadata-only bundled `@openclaw/ai`. Stable-to-candidate installation succeeded, but `openclaw doctor` failed because the AI package had no runtime files.

Fixes #103552

## Why This Change Was Made

- Run the installer packaging harness, Docker fixtures, package builder, and integrity checker from the trusted workflow revision.
- Check the candidate out as a nested source tree and keep candidate installers, package metadata, root `dist/`, and AI `dist/` as the product under test.
- Restore root and AI build trees from the same Docker image through one shared rollback-safe helper used by npm and Bun smoke lanes.
- Resolve strict bundled-AI validation from package exports, actual OpenClaw dist imports, and the AI package's relative-import closure.

Exact image-backed proof now fails closed when import closure is broken and local rebuilds are disabled. The updater stage/swap code is unchanged. Installing separately packed root and AI candidates already succeeds; this repairs the harness-only bundled tarball.

## User Impact

Release validation now exercises a complete candidate package for stable-to-candidate npm updates. A malformed metadata-only bundled AI runtime fails during package integrity validation instead of surfacing later as a doctor module-load error.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/29076524932/job/86309758690
- Focused tests: `node scripts/run-vitest.mjs test/scripts/check-openclaw-package-tarball.test.ts test/scripts/check-package-dist-imports.test.ts test/scripts/test-install-sh-docker.test.ts test/scripts/ci-workflow-guards.test.ts` - 134/134 passed
- Static gates: `actionlint .github/workflows/install-smoke.yml`, `bash -n` on the three changed shell scripts, `node --check` on both package-check modules, `shellcheck -S error` on the three shell scripts, targeted `oxfmt --check`, and `git diff --check`
- Fresh structured autoreview: no findings, patch correct, confidence 0.86
- Blacksmith Testbox attempts `29078442062` and `29078741828` both stopped during checkout hydration before the test command ran. Hosted exact-head PR checks remain required before landing.

