### PR TITLE
fix(discord): retry reply session init conflicts to prevent silent message loss

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -46,6 +46,24 @@ function isContextAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
 }
 
+function removeReplayedMessageFromPendingHistory(params: {
+  historyMap: DiscordMessagePreflightContext["guildHistories"];
+  historyKey: string;
+  messageId: string;
+}): void {
+  const history = params.historyMap.get(params.historyKey);
+  if (!history) {
+    return;
+  }
+  // An exhausted dispatch can release its replay claim after pending history
+  // was recorded. Remove that copy before rebuilding the same inbound turn.
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    if (history[index]?.messageId === params.messageId) {
+      history.splice(index, 1);
+    }
+  }
+}
+
 export async function buildDiscordMessageProcessContext(params: {
   ctx: DiscordMessagePreflightContext;
   text: string;
@@ -169,6 +187,11 @@ export async function buildDiscordMessageProcessContext(params: {
     !isDirectMessage &&
     (isRoomEvent || !(isGuildMessage && channelConfig?.autoThread && !threadChannel));
   if (shouldIncludeChannelHistory) {
+    removeReplayedMessageFromPendingHistory({
+      historyMap: guildHistories,
+      historyKey: messageChannelId,
+      messageId: message.id,
+    });
     combinedBody = channelHistory.buildPendingContext({
       historyKey: messageChannelId,
       limit: historyLimit,

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -24,6 +24,7 @@ import {
   createDiscordSupplementalContextAccessChecker,
 } from "./inbound-context.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
+import { removeDiscordReplayHistoryEntry } from "./message-handler.retry.js";
 import {
   resolveReferencedReplyMediaList,
   resolveDiscordMessageText,
@@ -44,24 +45,6 @@ function normalizeDiscordDmOwnerEntry(entry: string): string | undefined {
 
 function isContextAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
-}
-
-function removeReplayedMessageFromPendingHistory(params: {
-  historyMap: DiscordMessagePreflightContext["guildHistories"];
-  historyKey: string;
-  messageId: string;
-}): void {
-  const history = params.historyMap.get(params.historyKey);
-  if (!history) {
-    return;
-  }
-  // An exhausted dispatch can release its replay claim after pending history
-  // was recorded. Remove that copy before rebuilding the same inbound turn.
-  for (let index = history.length - 1; index >= 0; index -= 1) {
-    if (history[index]?.messageId === params.messageId) {
-      history.splice(index, 1);
-    }
-  }
 }
 
 export async function buildDiscordMessageProcessContext(params: {
@@ -129,7 +112,6 @@ export async function buildDiscordMessageProcessContext(params: {
     Boolean(threadChannelId && isForumParent && forumParentSlug) && message.id === threadChannelId;
   const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
   const groupChannel = isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
-  const groupSubject = isDirectMessage ? undefined : groupChannel;
   const senderName = sender.isPluralKit
     ? (sender.name ?? author.username)
     : (data.member?.nickname ?? author.globalName ?? author.username);
@@ -172,7 +154,6 @@ export async function buildDiscordMessageProcessContext(params: {
     sessionKey: route.sessionKey,
   });
   const channelHistory = createChannelHistoryWindow({ historyMap: guildHistories });
-  const isRoomEvent = ctx.inboundEventKind === "room_event";
   let combinedBody = formatInboundEnvelope({
     channel: "Discord",
     from: fromLabel,
@@ -185,13 +166,10 @@ export async function buildDiscordMessageProcessContext(params: {
   });
   const shouldIncludeChannelHistory =
     !isDirectMessage &&
-    (isRoomEvent || !(isGuildMessage && channelConfig?.autoThread && !threadChannel));
+    (ctx.inboundEventKind === "room_event" ||
+      !(isGuildMessage && channelConfig?.autoThread && !threadChannel));
   if (shouldIncludeChannelHistory) {
-    removeReplayedMessageFromPendingHistory({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      messageId: message.id,
-    });
+    removeDiscordReplayHistoryEntry(guildHistories, messageChannelId, message.id);
     combinedBody = channelHistory.buildPendingContext({
       historyKey: messageChannelId,
       limit: historyLimit,
@@ -292,7 +270,7 @@ export async function buildDiscordMessageProcessContext(params: {
     message,
     messageChannelId,
     isGuildMessage,
-    channelConfig: isRoomEvent ? null : channelConfig,
+    channelConfig: ctx.inboundEventKind === "room_event" ? null : channelConfig,
     threadChannel,
     channelType: channelInfo?.type,
     channelName: channelInfo?.name,
@@ -358,9 +336,7 @@ export async function buildDiscordMessageProcessContext(params: {
       tag: sender.tag,
       roles: memberRoleIds,
       displayLabel: senderLabel,
-      // PluralKit proxies post under a bot author but represent a human member,
-      // whose identity already replaced the sender fields here; only mark
-      // genuine (non-PluralKit) bot authors as bots.
+      // PluralKit replaces bot authors with human identity; mark only genuine non-PluralKit bots.
       isBot: author.bot && !sender.isPluralKit ? true : undefined,
     },
     conversation: {
@@ -450,7 +426,7 @@ export async function buildDiscordMessageProcessContext(params: {
     },
     extra: {
       ...(preflightAudioTranscript !== undefined ? { Transcript: preflightAudioTranscript } : {}),
-      GroupSubject: groupSubject,
+      GroupSubject: isDirectMessage ? undefined : groupChannel,
       GroupChannel: groupChannel,
       ...(isGuildMessage ? { GroupRequireMention: ctx.groupRequireMention } : {}),
       UntrustedStructuredContext: untrustedContext,
@@ -458,7 +434,7 @@ export async function buildDiscordMessageProcessContext(params: {
     },
   });
   const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
-  if (isRoomEvent && shouldIncludeChannelHistory) {
+  if (ctx.inboundEventKind === "room_event" && shouldIncludeChannelHistory) {
     await channelHistory.recordWithMedia({
       historyKey: messageChannelId,
       limit: historyLimit,

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -117,7 +117,8 @@ vi.mock("../draft-stream.js", () => ({
   createDiscordDraftStream: (params: unknown) => deliveryMocks.createDiscordDraftStream(params),
 }));
 
-vi.mock("./reply-delivery.js", () => ({
+vi.mock("./reply-delivery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./reply-delivery.js")>()),
   deliverDiscordReply: (params: unknown) => deliveryMocks.deliverDiscordReply(params),
 }));
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -4,6 +4,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import * as runtimeEnvModule from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 
 const sendMocks = vi.hoisted(() => ({
@@ -534,6 +535,7 @@ function getLastRouteUpdate():
 
 function getLastDispatchCtx():
   | {
+      Body?: string;
       BodyForAgent?: string;
       ChatType?: string;
       CommandBody?: string;
@@ -558,6 +560,7 @@ function getLastDispatchCtx():
   const params = callArgs?.[0] as
     | {
         ctx?: {
+          Body?: string;
           BodyForAgent?: string;
           ChatType?: string;
           CommandBody?: string;
@@ -4247,5 +4250,138 @@ describe("processDiscordMessage deliver-lambda abort logging", () => {
     // Restore so other tests sharing this worker (isolate=false) keep the
     // real logVerbose binding.
     verboseSpy.mockRestore();
+  });
+});
+
+describe("processDiscordMessage reply session init conflict retry", () => {
+  const conflictError = () =>
+    new Error("reply session initialization conflicted for agent:main:discord:channel:c1");
+
+  it("retries only dispatch while recording, acknowledging, and adding history once", async () => {
+    const sleepSpy = vi.spyOn(runtimeEnvModule, "sleepWithAbort").mockResolvedValue(undefined);
+    dispatchInboundMessage
+      .mockRejectedValueOnce(conflictError())
+      .mockRejectedValueOnce(conflictError())
+      .mockResolvedValueOnce(createNoQueuedDispatchResult());
+    const guildHistories = new Map();
+    const ctx = await createBaseContext({
+      guildHistories,
+      historyLimit: 10,
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      inboundEventKind: "room_event",
+      ackReactionScope: "all",
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          ackReactionScope: "all",
+        },
+      },
+      baseSessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(3);
+    expect(sleepSpy).toHaveBeenNthCalledWith(1, 250, undefined);
+    expect(sleepSpy).toHaveBeenNthCalledWith(2, 1_000, undefined);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(getReactionEmojis()).toEqual(["👀"]);
+    expect(guildHistories.get("c1")).toHaveLength(1);
+    expect(guildHistories.get("c1")?.[0]).toMatchObject({
+      body: "hi",
+      messageId: "m1",
+    });
+    sleepSpy.mockRestore();
+  });
+
+  it("commits replay ownership after a visible terminal failure notice", async () => {
+    const sleepSpy = vi.spyOn(runtimeEnvModule, "sleepWithAbort").mockResolvedValue(undefined);
+    const originalError = conflictError();
+    dispatchInboundMessage.mockRejectedValue(originalError);
+
+    const ctx = await createBaseContext();
+    await expect(runProcessDiscordMessage(ctx)).resolves.toBeUndefined();
+
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(4);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(sleepSpy).toHaveBeenNthCalledWith(1, 250, undefined);
+    expect(sleepSpy).toHaveBeenNthCalledWith(2, 1_000, undefined);
+    expect(sleepSpy).toHaveBeenNthCalledWith(3, 2_500, undefined);
+    expectFreshFinalText(
+      "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+    );
+    sleepSpy.mockRestore();
+  });
+
+  it("keeps exhaustion retryable when the visible failure notice cannot land", async () => {
+    const sleepSpy = vi.spyOn(runtimeEnvModule, "sleepWithAbort").mockResolvedValue(undefined);
+    const originalError = conflictError();
+    dispatchInboundMessage.mockRejectedValue(originalError);
+    deliverDiscordReply.mockRejectedValueOnce(new Error("Discord unavailable"));
+
+    const ctx = await createBaseContext();
+    let thrown: unknown;
+    try {
+      await runProcessDiscordMessage(ctx);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(DiscordRetryableInboundError);
+    expect(thrown).toMatchObject({ cause: originalError });
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(4);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    sleepSpy.mockRestore();
+  });
+
+  it("rebuilds a released replay without duplicating its pending history", async () => {
+    const sleepSpy = vi.spyOn(runtimeEnvModule, "sleepWithAbort").mockResolvedValue(undefined);
+    dispatchInboundMessage.mockRejectedValue(conflictError());
+    deliverDiscordReply.mockRejectedValueOnce(new Error("Discord unavailable"));
+    const guildHistories = new Map();
+    const createReplayContext = () =>
+      createBaseContext({
+        guildHistories,
+        historyLimit: 10,
+        inboundEventKind: "room_event",
+      });
+
+    await expect(runProcessDiscordMessage(await createReplayContext())).rejects.toBeInstanceOf(
+      DiscordRetryableInboundError,
+    );
+    expect(guildHistories.get("c1")).toHaveLength(1);
+
+    dispatchInboundMessage.mockResolvedValue(createNoQueuedDispatchResult());
+    await runProcessDiscordMessage(await createReplayContext());
+
+    expect(getLastDispatchCtx()?.Body).not.toContain("[Chat messages since your last reply");
+    expect(guildHistories.get("c1")).toHaveLength(1);
+    expect(guildHistories.get("c1")?.[0]?.messageId).toBe("m1");
+    sleepSpy.mockRestore();
+  });
+
+  it("preserves unrelated dispatch errors", async () => {
+    const originalError = new Error("some other dispatch error");
+    dispatchInboundMessage.mockRejectedValueOnce(originalError);
+
+    const ctx = await createBaseContext();
+    await expect(runProcessDiscordMessage(ctx)).rejects.toBe(originalError);
+
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats an aborted conflict as cancellation", async () => {
+    const abortController = new AbortController();
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      abortController.abort();
+      throw conflictError();
+    });
+
+    const ctx = await createBaseContext({ abortSignal: abortController.signal });
+    await expect(runProcessDiscordMessage(ctx)).resolves.toBeUndefined();
+
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -57,6 +57,10 @@ import {
 import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
+import {
+  dispatchDiscordReplyWithSessionConflictRetry,
+  DiscordReplySessionConflictExhaustedError,
+} from "./message-handler.retry.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 import { createDiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
@@ -65,6 +69,8 @@ const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-s
 const TARGETED_ONLY_ALLOWED_MENTIONS = {
   parse: ["users", "roles"],
 } as APIAllowedMentions;
+const DISCORD_SESSION_CONFLICT_FAILURE_TEXT =
+  "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
 
 function isProcessAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
@@ -1040,7 +1046,16 @@ async function processDiscordMessageInner(
       ctxPayload,
       recordInboundSession,
       afterRecord: queueInitialAckReactionAfterRecord,
-      dispatchReplyWithBufferedBlockDispatcher,
+      dispatchReplyWithBufferedBlockDispatcher: (params) =>
+        dispatchDiscordReplyWithSessionConflictRetry({
+          dispatch: () => dispatchReplyWithBufferedBlockDispatcher(params),
+          abortSignal,
+          onRetry: (attempt, delayMs) => {
+            logVerbose(
+              `discord: reply session init conflict; retrying dispatch ${attempt} after ${delayMs}ms`,
+            );
+          },
+        }),
       dispatcherOptions: {
         ...replyPipeline,
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
@@ -1303,6 +1318,20 @@ async function processDiscordMessageInner(
       return;
     }
     dispatchError = true;
+    if (err instanceof DiscordReplySessionConflictExhaustedError) {
+      try {
+        await deliverDiscordPayload(
+          { text: DISCORD_SESSION_CONFLICT_FAILURE_TEXT, isError: true },
+          { kind: "final" },
+        );
+        // A visible terminal notice owns this event. Returning commits replay
+        // ownership so Discord redelivery cannot produce a second outcome.
+        return;
+      } catch (deliveryError) {
+        // Keep the conflict retryable even when its visible fallback cannot land.
+        onDiscordDeliveryError(deliveryError, { kind: "final" });
+      }
+    }
     throw err;
   } finally {
     endDiscordInboundEventDeliveryCorrelation();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -58,10 +58,10 @@ import { buildDiscordMessageProcessContext } from "./message-handler.context.js"
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 import {
-  dispatchDiscordReplyWithSessionConflictRetry,
-  DiscordReplySessionConflictExhaustedError,
+  completeDiscordSessionConflict,
+  withDiscordSessionRetry,
 } from "./message-handler.retry.js";
-import { deliverDiscordReply } from "./reply-delivery.js";
+import { deliverDiscordReply, formatDiscordReplyDeliveryFailure } from "./reply-delivery.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 import { createDiscordReplyTypingFeedback } from "./reply-typing-feedback.js";
 
@@ -69,26 +69,9 @@ const loadReplyRuntime = createLazyRuntimeModule(() => import("openclaw/plugin-s
 const TARGETED_ONLY_ALLOWED_MENTIONS = {
   parse: ["users", "roles"],
 } as APIAllowedMentions;
-const DISCORD_SESSION_CONFLICT_FAILURE_TEXT =
-  "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
 
 function isProcessAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
-}
-
-function formatDiscordReplyDeliveryFailure(params: {
-  kind: string;
-  err: unknown;
-  target: string;
-  sessionKey?: string;
-}) {
-  const context = [
-    `target=${params.target}`,
-    params.sessionKey ? `session=${params.sessionKey}` : undefined,
-  ]
-    .filter(Boolean)
-    .join(" ");
-  return `discord ${params.kind} reply failed (${context}): ${String(params.err)}`;
 }
 
 function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
@@ -207,7 +190,7 @@ async function processDiscordMessageInner(
   if (boundThreadId && typeof threadBindings.touchThread === "function") {
     threadBindings.touchThread({ threadId: boundThreadId });
   }
-  const { dispatchReplyWithBufferedBlockDispatcher } = await loadReplyRuntime();
+  const { dispatchReplyWithBufferedBlockDispatcher: dispatchReply } = await loadReplyRuntime();
   const sourceReplyDeliveryMode = resolveChannelMessageSourceReplyDeliveryMode({
     cfg,
     ctx: {
@@ -1011,8 +994,7 @@ async function processDiscordMessageInner(
   };
 
   const resolvedBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(discordConfig);
-  let dispatchResult: Awaited<ReturnType<typeof dispatchReplyWithBufferedBlockDispatcher>> | null =
-    null;
+  let dispatchResult: Awaited<ReturnType<typeof dispatchReply>> | null = null;
   let dispatchError = false;
   let dispatchAborted = false;
   const deliverPendingToolWarningFinalIfNeeded = async () => {
@@ -1046,16 +1028,7 @@ async function processDiscordMessageInner(
       ctxPayload,
       recordInboundSession,
       afterRecord: queueInitialAckReactionAfterRecord,
-      dispatchReplyWithBufferedBlockDispatcher: (params) =>
-        dispatchDiscordReplyWithSessionConflictRetry({
-          dispatch: () => dispatchReplyWithBufferedBlockDispatcher(params),
-          abortSignal,
-          onRetry: (attempt, delayMs) => {
-            logVerbose(
-              `discord: reply session init conflict; retrying dispatch ${attempt} after ${delayMs}ms`,
-            );
-          },
-        }),
+      dispatchReplyWithBufferedBlockDispatcher: withDiscordSessionRetry(dispatchReply, abortSignal),
       dispatcherOptions: {
         ...replyPipeline,
         humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
@@ -1318,19 +1291,9 @@ async function processDiscordMessageInner(
       return;
     }
     dispatchError = true;
-    if (err instanceof DiscordReplySessionConflictExhaustedError) {
-      try {
-        await deliverDiscordPayload(
-          { text: DISCORD_SESSION_CONFLICT_FAILURE_TEXT, isError: true },
-          { kind: "final" },
-        );
-        // A visible terminal notice owns this event. Returning commits replay
-        // ownership so Discord redelivery cannot produce a second outcome.
-        return;
-      } catch (deliveryError) {
-        // Keep the conflict retryable even when its visible fallback cannot land.
-        onDiscordDeliveryError(deliveryError, { kind: "final" });
-      }
+    if (await completeDiscordSessionConflict(err, deliverDiscordPayload, onDiscordDeliveryError)) {
+      // The visible terminal notice owns this event, so replay can commit.
+      return;
     }
     throw err;
   } finally {

--- a/extensions/discord/src/monitor/message-handler.retry.ts
+++ b/extensions/discord/src/monitor/message-handler.retry.ts
@@ -1,0 +1,46 @@
+// Discord plugin module implements narrow inbound dispatch retry behavior.
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
+
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
+const DISCORD_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [250, 1_000, 2_500] as const;
+
+function isReplySessionInitConflictError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
+}
+
+export class DiscordReplySessionConflictExhaustedError extends DiscordRetryableInboundError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DiscordReplySessionConflictExhaustedError";
+  }
+}
+
+export async function dispatchDiscordReplyWithSessionConflictRetry<T>(params: {
+  dispatch: () => Promise<T>;
+  abortSignal?: AbortSignal;
+  onRetry?: (attempt: number, delayMs: number) => void;
+}): Promise<T> {
+  for (let retryIndex = 0; ; retryIndex += 1) {
+    try {
+      return await params.dispatch();
+    } catch (error) {
+      if (!isReplySessionInitConflictError(error)) {
+        throw error;
+      }
+      const delayMs = DISCORD_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS[retryIndex];
+      if (delayMs === undefined) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Let the caller either complete with a visible terminal notice or
+        // reopen replay ownership when that notice cannot land.
+        throw new DiscordReplySessionConflictExhaustedError(
+          `discord: reply session init conflict persisted after shared and channel retries: ${message}`,
+          { cause: error },
+        );
+      }
+      params.onRetry?.(retryIndex + 1, delayMs);
+      await sleepWithAbort(delayMs, params.abortSignal);
+    }
+  }
+}

--- a/extensions/discord/src/monitor/message-handler.retry.ts
+++ b/extensions/discord/src/monitor/message-handler.retry.ts
@@ -1,9 +1,18 @@
 // Discord plugin module implements narrow inbound dispatch retry behavior.
-import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
 
 const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
 const DISCORD_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [250, 1_000, 2_500] as const;
+const DISCORD_SESSION_CONFLICT_FAILURE_TEXT =
+  "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
+
+type AsyncDispatch<TParams, TResult> = (params: TParams) => Promise<TResult>;
+type TerminalFailureDelivery = (
+  payload: { text: string; isError: true },
+  info: { kind: "final" },
+) => Promise<unknown>;
+type DeliveryErrorHandler = (error: unknown, info: { kind: string }) => void;
 
 function isReplySessionInitConflictError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -17,7 +26,7 @@ export class DiscordReplySessionConflictExhaustedError extends DiscordRetryableI
   }
 }
 
-export async function dispatchDiscordReplyWithSessionConflictRetry<T>(params: {
+async function dispatchDiscordReplyWithSessionConflictRetry<T>(params: {
   dispatch: () => Promise<T>;
   abortSignal?: AbortSignal;
   onRetry?: (attempt: number, delayMs: number) => void;
@@ -41,6 +50,61 @@ export async function dispatchDiscordReplyWithSessionConflictRetry<T>(params: {
       }
       params.onRetry?.(retryIndex + 1, delayMs);
       await sleepWithAbort(delayMs, params.abortSignal);
+    }
+  }
+}
+
+export function withDiscordSessionRetry<TParams, TResult>(
+  dispatch: AsyncDispatch<TParams, TResult>,
+  abortSignal: AbortSignal | undefined,
+): AsyncDispatch<TParams, TResult> {
+  return (dispatchParams) =>
+    dispatchDiscordReplyWithSessionConflictRetry({
+      dispatch: () => dispatch(dispatchParams),
+      abortSignal,
+      onRetry: (attempt, delayMs) => {
+        logVerbose(
+          `discord: reply session init conflict; retrying dispatch ${attempt} after ${delayMs}ms`,
+        );
+      },
+    });
+}
+
+export async function completeDiscordSessionConflict(
+  error: unknown,
+  deliver: TerminalFailureDelivery,
+  onDeliveryError: DeliveryErrorHandler,
+): Promise<boolean> {
+  if (!(error instanceof DiscordReplySessionConflictExhaustedError)) {
+    return false;
+  }
+  try {
+    await deliver(
+      { text: DISCORD_SESSION_CONFLICT_FAILURE_TEXT, isError: true },
+      { kind: "final" },
+    );
+    return true;
+  } catch (deliveryError) {
+    // Keep the conflict retryable when its visible terminal notice cannot land.
+    onDeliveryError(deliveryError, { kind: "final" });
+    return false;
+  }
+}
+
+export function removeDiscordReplayHistoryEntry<T extends { messageId?: string }>(
+  historyMap: Map<string, T[]>,
+  historyKey: string,
+  messageId: string,
+): void {
+  const history = historyMap.get(historyKey);
+  if (!history) {
+    return;
+  }
+  // An exhausted dispatch can release its replay claim after pending history
+  // was recorded. Remove that copy before rebuilding the same inbound turn.
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    if (history[index]?.messageId === messageId) {
+      history.splice(index, 1);
     }
   }
 }

--- a/extensions/discord/src/monitor/message-handler.retry.ts
+++ b/extensions/discord/src/monitor/message-handler.retry.ts
@@ -19,7 +19,7 @@ function isReplySessionInitConflictError(error: unknown): boolean {
   return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
 }
 
-export class DiscordReplySessionConflictExhaustedError extends DiscordRetryableInboundError {
+class DiscordReplySessionConflictExhaustedError extends DiscordRetryableInboundError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "DiscordReplySessionConflictExhaustedError";

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -38,6 +38,21 @@ export type DiscordThreadBindingLookup = {
   touchThread?: (params: { threadId: string; at?: number; persist?: boolean }) => unknown;
 };
 
+export function formatDiscordReplyDeliveryFailure(params: {
+  kind: string;
+  err: unknown;
+  target: string;
+  sessionKey?: string;
+}) {
+  const context = [
+    `target=${params.target}`,
+    params.sessionKey ? `session=${params.sessionKey}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return `discord ${params.kind} reply failed (${context}): ${String(params.err)}`;
+}
+
 function resolveTargetChannelId(target: string): string | undefined {
   if (!target.startsWith("channel:")) {
     return undefined;


### PR DESCRIPTION
Closes #102381

## What Problem This Solves

Discord inbound messages could disappear when reply-session initialization exhausted the shared transient-conflict retry budget. The old PR shape retried the whole inbound pipeline, which could repeat session recording, acknowledgement work, and room-history insertion.

## Why This Change Was Made

The shared channel core from #105754 remains the owner of session-initialization conflict retries. Discord now adds a bounded transport-local retry only around the inner reply dispatch, after recording and history preparation have already completed.

The retry recognizes only the exact session-initialization conflict, uses abort-aware delays of 250 ms, 1 s, and 2.5 s, and preserves unrelated error identity. Exhaustion posts a visible terminal notice. If that notice lands, the inbound replay claim is committed; if delivery also fails, the claim is released so Discord may redeliver. A repeated event removes its earlier pending-history copy before rebuilding context, preventing duplicate user text.

## User Impact

Brief Discord session races retry without silently losing the message or duplicating inbound work. Persistent contention produces a clear retry notice instead of silence. Cancellation remains immediate.

## Evidence

- Exact head: `3678444361518b6bcb9537691c9c57c5237cf2fd`
- Blacksmith Testbox `tbx_01kxe4x89jmcqqvrcn8hynmnv1` ([run](https://github.com/openclaw/openclaw/actions/runs/29266533757)):
  - 174 focused Discord process/abort/queue/reply-delivery tests passed
  - dead-export validation passed
  - extension production and test `tsgo` gates passed
  - targeted `oxfmt` and `oxlint` passed
- Regression coverage proves dispatch-only retry, one record/ack/history insertion across in-process conflicts, terminal-notice replay commit, failed-notice replay release, replay history de-duplication, unrelated-error identity, and cancellation.
- Fresh maintainer autoreviews: full branch clean at 0.91 confidence; final export-visibility fixup clean at 0.94 confidence.
- Independent live Discord proof: [four rapid messages answered with zero conflicts after the fix](https://github.com/openclaw/openclaw/pull/103562#issuecomment-4953245513).

The live proof did not inject a session-store CAS fault. Deterministic fault injection covers that exact failure path; the live run covers Discord transport behavior.
