### PR TITLE
fix(release): restore bundled AI runtime in update smoke

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -73,6 +73,11 @@ const PACKAGE_DEPENDENCY_SECTIONS = [
   "devDependencies",
 ];
 const REQUIRED_BUNDLED_WORKSPACE_DEPENDENCIES = ["@openclaw/ai"];
+// Packaged core startup and doctor retain this bare import, so a manifest-only
+// bundled AI package is not runnable even when npm accepts the tarball.
+const REQUIRED_BUNDLED_WORKSPACE_DEPENDENCY_ENTRIES = {
+  "@openclaw/ai": ["dist/internal/runtime.mjs"],
+};
 
 function collectWorkspaceProtocolDependencyErrors(packageJson, label) {
   const errors = [];
@@ -134,6 +139,12 @@ function collectRequiredBundledWorkspaceDependencyErrors(packageJson, entrySet) 
     }
     if (!entrySet.has(`node_modules/${name}/package.json`)) {
       errors.push(`package.json dependencies.${name} must be bundled in node_modules/${name}`);
+    }
+    for (const relativePath of REQUIRED_BUNDLED_WORKSPACE_DEPENDENCY_ENTRIES[name] ?? []) {
+      const entryPath = `node_modules/${name}/${relativePath}`;
+      if (!entrySet.has(entryPath)) {
+        errors.push(`bundled ${name} is missing required runtime entry ${relativePath}`);
+      }
     }
   }
 

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -99,6 +99,11 @@ print_install_audit() {
   fi
 }
 
+verify_candidate_ai_runtime() {
+  echo "==> Verify installed AI runtime"
+  OPENCLAW_ALLOW_ROOT=1 openclaw infer image providers --json >/dev/null
+}
+
 run_with_heartbeat() {
   local label="$1"
   shift
@@ -278,6 +283,7 @@ run_install_smoke() {
       fi
     fi
     verify_installed_cli "$PACKAGE_NAME" "$FRESH_VERSION"
+    verify_candidate_ai_runtime
 
     echo "OK"
     return 0
@@ -475,11 +481,16 @@ if (Number(updateStep.exitCode ?? 1) !== 0) {
 if (typeof updateStep.command !== "string" || !updateStep.command.includes(expectedUrl)) {
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
 }
+const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
+if (!doctorStep || Number(doctorStep.exitCode ?? 1) !== 0) {
+  throw new Error(`openclaw doctor step failed: ${JSON.stringify(doctorStep)}`);
+}
 NODE
 
   echo "==> Verify updated version"
   print_install_audit "updated install"
   verify_installed_cli "$PACKAGE_NAME" "$UPDATE_EXPECT_VERSION"
+  verify_candidate_ai_runtime
 
   echo "OK"
 }

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 
 read_positive_int_env() {
   local name="${1:?missing environment variable name}"
@@ -78,113 +78,6 @@ run_with_timeout() {
   node scripts/e2e/lib/bun-global-install/assertions.mjs run-with-timeout "$timeout_ms" "$@"
 }
 
-restore_dist_from_image() {
-  local image="$1"
-  local ai_backup_dir=""
-  local ai_dist_installed=0
-  local backup_dir=""
-  local container_id=""
-  local dist_installed=0
-  local restore_complete=0
-  local temp_dir=""
-
-  cleanup_restore_dist() {
-    if [ -n "$container_id" ]; then
-      docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
-    fi
-    # Both build trees come from one image. A partial swap must restore both or
-    # the following package step could mix artifacts from different builds.
-    if [ "$restore_complete" != "1" ]; then
-      if [ "$dist_installed" = "1" ]; then
-        rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true
-      fi
-      if [ -n "$backup_dir" ] && [ -d "$backup_dir" ]; then
-        if [ ! -e "$ROOT_DIR/dist" ] && mv "$backup_dir" "$ROOT_DIR/dist" >/dev/null 2>&1; then
-          backup_dir=""
-        fi
-      fi
-      if [ "$ai_dist_installed" = "1" ]; then
-        rm -rf "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1 || true
-      fi
-      if [ -n "$ai_backup_dir" ] && [ -d "$ai_backup_dir" ]; then
-        if [ ! -e "$ROOT_DIR/packages/ai/dist" ] && \
-          mv "$ai_backup_dir" "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1; then
-          ai_backup_dir=""
-        fi
-      fi
-    fi
-    if [ -n "$temp_dir" ]; then
-      rm -rf "$temp_dir"
-    fi
-    if [ "$restore_complete" = "1" ] && [ -n "$backup_dir" ]; then
-      rm -rf "$backup_dir"
-    fi
-    if [ "$restore_complete" = "1" ] && [ -n "$ai_backup_dir" ]; then
-      rm -rf "$ai_backup_dir"
-    fi
-  }
-
-  echo "==> Reuse dist/ from Docker image: $image"
-  if ! container_id="$(docker_e2e_docker_cmd create "$image")"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! temp_dir="$(mktemp -d "$ROOT_DIR/.bun-dist.XXXXXX")"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if ! docker_e2e_docker_cmd cp \
-    "${container_id}:/app/node_modules/@openclaw/ai/dist" \
-    "$temp_dir/ai-dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  if [ -e "$ROOT_DIR/dist" ]; then
-    if ! backup_dir="$(mktemp -d "$ROOT_DIR/.dist-backup.XXXXXX")"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! rmdir "$backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! mv "$ROOT_DIR/dist" "$backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-  fi
-  if ! mv "$temp_dir/dist" "$ROOT_DIR/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  dist_installed=1
-  if [ -e "$ROOT_DIR/packages/ai/dist" ]; then
-    if ! ai_backup_dir="$(mktemp -d "$ROOT_DIR/packages/ai/.dist-backup.XXXXXX")"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! rmdir "$ai_backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-    if ! mv "$ROOT_DIR/packages/ai/dist" "$ai_backup_dir"; then
-      cleanup_restore_dist
-      return 1
-    fi
-  fi
-  if ! mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"; then
-    cleanup_restore_dist
-    return 1
-  fi
-  ai_dist_installed=1
-  restore_complete=1
-  cleanup_restore_dist
-}
-
 resolve_package_tgz() {
   if [ -n "$PACKAGE_TGZ" ]; then
     if [ ! -f "$PACKAGE_TGZ" ]; then
@@ -196,7 +89,7 @@ resolve_package_tgz() {
   fi
 
   if [ -n "$DIST_IMAGE" ]; then
-    restore_dist_from_image "$DIST_IMAGE"
+    docker_e2e_restore_package_dist_from_image "$DIST_IMAGE"
   elif [ "$HOST_BUILD" != "0" ]; then
     echo "==> Build host package artifacts"
     pnpm build

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -156,6 +156,113 @@ docker_e2e_abs_path() {
   (cd "$(dirname "$file")" && printf '%s/%s\n' "$(pwd)" "$(basename "$file")")
 }
 
+docker_e2e_restore_package_dist_from_image() (
+  local image="$1"
+  local ai_backup_dir=""
+  local ai_dist_installed=0
+  local backup_dir=""
+  local container_id=""
+  local dist_installed=0
+  local restore_complete=0
+  local temp_dir=""
+
+  cleanup_restore_package_dist() {
+    if [ -n "$container_id" ]; then
+      docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
+    fi
+    # Both build trees come from one image. A partial swap must restore both or
+    # the following package step could mix artifacts from different builds.
+    if [ "$restore_complete" != "1" ]; then
+      if [ "$dist_installed" = "1" ]; then
+        rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true
+      fi
+      if [ -n "$backup_dir" ] && [ -d "$backup_dir" ]; then
+        if [ ! -e "$ROOT_DIR/dist" ] && mv "$backup_dir" "$ROOT_DIR/dist" >/dev/null 2>&1; then
+          backup_dir=""
+        fi
+      fi
+      if [ "$ai_dist_installed" = "1" ]; then
+        rm -rf "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1 || true
+      fi
+      if [ -n "$ai_backup_dir" ] && [ -d "$ai_backup_dir" ]; then
+        if [ ! -e "$ROOT_DIR/packages/ai/dist" ] && \
+          mv "$ai_backup_dir" "$ROOT_DIR/packages/ai/dist" >/dev/null 2>&1; then
+          ai_backup_dir=""
+        fi
+      fi
+    fi
+    if [ -n "$temp_dir" ]; then
+      rm -rf "$temp_dir"
+    fi
+    if [ "$restore_complete" = "1" ] && [ -n "$backup_dir" ]; then
+      rm -rf "$backup_dir"
+    fi
+    if [ "$restore_complete" = "1" ] && [ -n "$ai_backup_dir" ]; then
+      rm -rf "$ai_backup_dir"
+    fi
+  }
+
+  echo "==> Reuse package dist from Docker image: $image"
+  if ! container_id="$(docker_e2e_docker_cmd create "$image")"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if ! temp_dir="$(mktemp -d "$ROOT_DIR/.package-dist.XXXXXX")"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if ! docker_e2e_docker_cmd cp \
+    "${container_id}:/app/node_modules/@openclaw/ai/dist" \
+    "$temp_dir/ai-dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  if [ -e "$ROOT_DIR/dist" ]; then
+    if ! backup_dir="$(mktemp -d "$ROOT_DIR/.dist-backup.XXXXXX")"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! rmdir "$backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! mv "$ROOT_DIR/dist" "$backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+  fi
+  if ! mv "$temp_dir/dist" "$ROOT_DIR/dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  dist_installed=1
+  if [ -e "$ROOT_DIR/packages/ai/dist" ]; then
+    if ! ai_backup_dir="$(mktemp -d "$ROOT_DIR/packages/ai/.dist-backup.XXXXXX")"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! rmdir "$ai_backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+    if ! mv "$ROOT_DIR/packages/ai/dist" "$ai_backup_dir"; then
+      cleanup_restore_package_dist
+      return 1
+    fi
+  fi
+  if ! mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"; then
+    cleanup_restore_package_dist
+    return 1
+  fi
+  ai_dist_installed=1
+  restore_complete=1
+  cleanup_restore_package_dist
+)
+
 docker_e2e_prepare_package_tgz() {
   local label="$1"
   local package_tgz="${2:-${OPENCLAW_CURRENT_PACKAGE_TGZ:-}}"

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=./docker/install-sh-common/version-parse.sh
 source "$ROOT_DIR/scripts/docker/install-sh-common/version-parse.sh"
 source "$ROOT_DIR/scripts/lib/docker-build.sh"
-source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_INSTALL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"
 INSTALL_SMOKE_DOCKER_RUN_TIMEOUT="${OPENCLAW_INSTALL_SMOKE_DOCKER_RUN_TIMEOUT:-2700s}"
 
@@ -272,25 +272,12 @@ allocate_host_port() {
   '
 }
 
-restore_local_dist_from_image() {
-  local image="$1"
-  local container_id=""
-
-  echo "==> Reuse local dist/ from Docker image: $image"
-  container_id="$(docker_e2e_docker_cmd create "$image")"
-  rm -rf "$ROOT_DIR/dist"
-  if ! docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$ROOT_DIR/dist"; then
-    docker_e2e_docker_cmd rm -f "$container_id" >/dev/null 2>&1 || true
-    return 1
-  fi
-  docker_e2e_docker_cmd rm -f "$container_id" >/dev/null
-}
-
 ensure_local_update_dist_import_closure() {
-  if node scripts/check-package-dist-imports.mjs "$ROOT_DIR"; then
+  if [[ -f "$ROOT_DIR/packages/ai/dist/internal/runtime.mjs" ]] && \
+    node scripts/check-package-dist-imports.mjs "$ROOT_DIR"; then
     return 0
   fi
-  echo "WARN: reused Docker image dist failed import-closure check; rebuilding local release artifacts" >&2
+  echo "WARN: reused Docker image package dist failed import-closure check; rebuilding local release artifacts" >&2
   pnpm build
 }
 
@@ -310,7 +297,7 @@ prepare_update_tarball() {
   else
     echo "==> Build local release artifacts for update smoke"
     if [[ -n "$UPDATE_DIST_IMAGE" ]]; then
-      restore_local_dist_from_image "$UPDATE_DIST_IMAGE"
+      docker_e2e_restore_package_dist_from_image "$UPDATE_DIST_IMAGE"
       ensure_local_update_dist_import_closure
     elif [[ "$UPDATE_SKIP_LOCAL_BUILD" != "1" ]]; then
       pnpm build

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -527,12 +527,49 @@ describe("check-openclaw-package-tarball", () => {
           name: "@openclaw/ai",
           version: "2026.6.11",
         }),
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
       },
       (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      },
+      "2026.6.11",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("rejects a bundled AI package without the runtime imported by core", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js": "export {};\n",
+        "node_modules/@openclaw/ai/package.json": JSON.stringify({
+          name: "@openclaw/ai",
+          version: "2026.6.11",
+        }),
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "bundled @openclaw/ai is missing required runtime entry dist/internal/runtime.mjs",
+        );
       },
       "2026.6.11",
       {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1551,6 +1551,176 @@ stderr="$(<"$TMPDIR/stderr")"
     }
   });
 
+  it("restores root and AI package dist from one Docker image", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-package-dist-restore-"));
+
+    try {
+      const checkoutDir = join(workDir, "checkout");
+      mkdirSync(join(checkoutDir, "dist"), { recursive: true });
+      mkdirSync(join(checkoutDir, "packages", "ai", "dist", "internal"), { recursive: true });
+      mkdirSync(join(workDir, "image-root-dist"), { recursive: true });
+      mkdirSync(join(workDir, "image-ai-dist", "internal"), { recursive: true });
+      writeFileSync(join(checkoutDir, "dist", "old.js"), "old root\n");
+      writeFileSync(join(checkoutDir, "packages", "ai", "dist", "internal", "old.mjs"), "old ai\n");
+      writeFileSync(join(workDir, "image-root-dist", "index.js"), "new root\n");
+      writeFileSync(join(workDir, "image-ai-dist", "internal", "runtime.mjs"), "new ai runtime\n");
+
+      const repoRoot = process.cwd();
+      const script = `
+set -euo pipefail
+REPO_ROOT=${shellQuote(repoRoot)}
+ROOT_DIR=${shellQuote(checkoutDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+
+docker_e2e_docker_cmd() {
+  local operation="$1"
+  shift
+  case "$operation" in
+    create)
+      printf fixture-container
+      ;;
+    cp)
+      case "$1" in
+        *:/app/dist)
+          cp -R "$TMPDIR/image-root-dist" "$2"
+          ;;
+        *:/app/node_modules/@openclaw/ai/dist)
+          cp -R "$TMPDIR/image-ai-dist" "$2"
+          ;;
+        *)
+          return 2
+          ;;
+      esac
+      ;;
+    rm)
+      printf '%s\n' "$operation $*" >>"$TMPDIR/docker-commands"
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+export -f docker_e2e_docker_cmd
+
+source "$REPO_ROOT/scripts/lib/docker-e2e-package.sh"
+docker_e2e_restore_package_dist_from_image fixture-image
+`;
+
+      execFileSync("bash", ["--noprofile", "--norc", "-c", script], { encoding: "utf8" });
+
+      expect(readFileSync(join(checkoutDir, "dist", "index.js"), "utf8")).toBe("new root\n");
+      expect(
+        readFileSync(
+          join(checkoutDir, "packages", "ai", "dist", "internal", "runtime.mjs"),
+          "utf8",
+        ),
+      ).toBe("new ai runtime\n");
+      expect(existsSync(join(checkoutDir, "dist", "old.js"))).toBe(false);
+      expect(existsSync(join(checkoutDir, "packages", "ai", "dist", "internal", "old.mjs"))).toBe(
+        false,
+      );
+      expect(readFileSync(join(workDir, "docker-commands"), "utf8")).toContain(
+        "rm -f fixture-container",
+      );
+      expect(readdirSync(checkoutDir).some((entry) => entry.startsWith(".package-dist."))).toBe(
+        false,
+      );
+      expect(readdirSync(checkoutDir).some((entry) => entry.startsWith(".dist-backup."))).toBe(
+        false,
+      );
+      expect(
+        readdirSync(join(checkoutDir, "packages", "ai")).some((entry) =>
+          entry.startsWith(".dist-backup."),
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves both existing dist trees when the AI image copy fails", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-package-dist-rollback-"));
+
+    try {
+      const checkoutDir = join(workDir, "checkout");
+      mkdirSync(join(checkoutDir, "dist"), { recursive: true });
+      mkdirSync(join(checkoutDir, "packages", "ai", "dist", "internal"), { recursive: true });
+      mkdirSync(join(workDir, "image-root-dist"), { recursive: true });
+      writeFileSync(join(checkoutDir, "dist", "old.js"), "old root\n");
+      writeFileSync(
+        join(checkoutDir, "packages", "ai", "dist", "internal", "runtime.mjs"),
+        "old ai runtime\n",
+      );
+      writeFileSync(join(workDir, "image-root-dist", "index.js"), "new root\n");
+
+      const repoRoot = process.cwd();
+      const script = `
+set -euo pipefail
+REPO_ROOT=${shellQuote(repoRoot)}
+ROOT_DIR=${shellQuote(checkoutDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+
+docker_e2e_docker_cmd() {
+  local operation="$1"
+  shift
+  case "$operation" in
+    create)
+      printf fixture-container
+      ;;
+    cp)
+      case "$1" in
+        *:/app/dist)
+          cp -R "$TMPDIR/image-root-dist" "$2"
+          ;;
+        *:/app/node_modules/@openclaw/ai/dist)
+          return 17
+          ;;
+        *)
+          return 2
+          ;;
+      esac
+      ;;
+    rm)
+      printf '%s\n' "$operation $*" >>"$TMPDIR/docker-commands"
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+export -f docker_e2e_docker_cmd
+
+source "$REPO_ROOT/scripts/lib/docker-e2e-package.sh"
+set +e
+docker_e2e_restore_package_dist_from_image fixture-image
+status="$?"
+set -e
+[[ "$status" -eq 1 ]]
+`;
+
+      execFileSync("bash", ["--noprofile", "--norc", "-c", script], { encoding: "utf8" });
+
+      expect(readFileSync(join(checkoutDir, "dist", "old.js"), "utf8")).toBe("old root\n");
+      expect(
+        readFileSync(
+          join(checkoutDir, "packages", "ai", "dist", "internal", "runtime.mjs"),
+          "utf8",
+        ),
+      ).toBe("old ai runtime\n");
+      expect(existsSync(join(checkoutDir, "dist", "index.js"))).toBe(false);
+      expect(readFileSync(join(workDir, "docker-commands"), "utf8")).toContain(
+        "rm -f fixture-container",
+      );
+      expect(readdirSync(checkoutDir).some((entry) => entry.startsWith(".package-dist."))).toBe(
+        false,
+      );
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects invalid package-backed Docker run pids limits before invoking docker", () => {
     const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-pids-"));
 

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -30,6 +30,7 @@ const NONROOT_DOCKERFILE_PATH = "scripts/docker/install-sh-nonroot/Dockerfile";
 const NONROOT_RUNNER_PATH = "scripts/docker/install-sh-nonroot/run.sh";
 const BUN_GLOBAL_SMOKE_PATH = "scripts/e2e/bun-global-install-smoke.sh";
 const BUN_GLOBAL_ASSERTIONS_PATH = "scripts/e2e/lib/bun-global-install/assertions.mjs";
+const DOCKER_E2E_PACKAGE_HELPER_PATH = "scripts/lib/docker-e2e-package.sh";
 const INSTALL_SMOKE_WORKFLOW_PATH = ".github/workflows/install-smoke.yml";
 const RELEASE_CHECKS_WORKFLOW_PATH = ".github/workflows/openclaw-release-checks.yml";
 const LIVE_E2E_WORKFLOW_PATH = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
@@ -354,27 +355,31 @@ describe("test-install-sh-docker", () => {
 
   it("can reuse dist from the already-built root Docker smoke image", () => {
     const script = readFileSync(SCRIPT_PATH, "utf8");
+    const packageHelper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
     const dockerfile = readFileSync("Dockerfile", "utf8");
 
     expect(script).toContain('UPDATE_DIST_IMAGE="${OPENCLAW_INSTALL_SMOKE_UPDATE_DIST_IMAGE:-}"');
-    expect(script).toContain("restore_local_dist_from_image");
-    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"');
+    expect(script).toContain("docker_e2e_restore_package_dist_from_image");
+    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"');
     expect(script).toContain(
       'DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_INSTALL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"',
     );
-    expect(script).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
-    expect(script).toContain(
-      'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$ROOT_DIR/dist"',
+    expect(packageHelper).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
+    expect(packageHelper).toContain(
+      'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"',
     );
-    expect(script).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
-    expect(script).not.toContain('container_id="$(docker create "$image")"');
-    expect(script).not.toContain('docker cp "${container_id}:/app/dist" "$ROOT_DIR/dist"');
-    expect(script).toContain('echo "==> Reuse local dist/ from Docker image: $image"');
+    expect(packageHelper).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
+    expect(packageHelper).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
+    expect(packageHelper).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
     expect(script).toContain("ensure_local_update_dist_import_closure");
+    expect(script).toContain('[[ -f "$ROOT_DIR/packages/ai/dist/internal/runtime.mjs" ]]');
     expect(script).toContain('node scripts/check-package-dist-imports.mjs "$ROOT_DIR"');
-    expect(script).toContain("WARN: reused Docker image dist failed import-closure check");
+    expect(script).toContain("WARN: reused Docker image package dist failed import-closure check");
     expect(script).toContain("pnpm build");
     expect(script).not.toContain("pnpm ui:build");
+    expect(script.indexOf("docker_e2e_restore_package_dist_from_image")).toBeLessThan(
+      script.indexOf("node scripts/package-openclaw-for-docker.mjs"),
+    );
     expect(dockerfile).toContain("node scripts/check-package-dist-imports.mjs /app");
   });
 
@@ -800,6 +805,10 @@ describe("install-sh smoke runner", () => {
     expect(script).toContain("legacy updater process exited after self-swap");
     expect(script).toContain("parseFirstJsonObject");
     expect(script).toContain("unterminated update JSON object");
+    expect(script).toContain("verify_candidate_ai_runtime");
+    expect(script).toContain("openclaw infer image providers --json");
+    expect(script).toContain('steps.find((step) => step?.name === "openclaw doctor")');
+    expect(script).toContain("openclaw doctor step failed");
   });
 
   it.each([
@@ -875,6 +884,7 @@ describe("bun global install smoke", () => {
   it("packs the current tree and verifies image-provider discovery through Bun", () => {
     const script = readFileSync(BUN_GLOBAL_SMOKE_PATH, "utf8");
     const assertions = readFileSync(BUN_GLOBAL_ASSERTIONS_PATH, "utf8");
+    const packageHelper = readFileSync(DOCKER_E2E_PACKAGE_HELPER_PATH, "utf8");
 
     expect(script).toContain("node scripts/package-openclaw-for-docker.mjs");
     expect(script).toContain("--skip-build");
@@ -885,32 +895,28 @@ describe("bun global install smoke", () => {
     expect(script).toContain("assert-image-providers");
     expect(assertions).toContain("image providers output is missing bundled provider");
     expect(script).toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE");
-    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"');
+    expect(script).toContain('source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"');
+    expect(script).toContain("docker_e2e_restore_package_dist_from_image");
     expect(script).toContain(
       'COMMAND_TIMEOUT_MS="$(read_positive_int_env OPENCLAW_BUN_GLOBAL_SMOKE_TIMEOUT_MS 180000)"',
     );
     expect(script).toContain(
       'DOCKER_COMMAND_TIMEOUT="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_BUN_GLOBAL_SMOKE_DOCKER_COMMAND_TIMEOUT:-600s}}"',
     );
-    expect(script).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
-    expect(script).toContain(
+    expect(packageHelper).toContain('container_id="$(docker_e2e_docker_cmd create "$image")"');
+    expect(packageHelper).toContain(
       'docker_e2e_docker_cmd cp "${container_id}:/app/dist" "$temp_dir/dist"',
     );
-    expect(script).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
-    expect(script).toContain('"$temp_dir/ai-dist"');
-    expect(script).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
-    expect(script).toContain("cleanup_restore_dist() {");
-    expect(script).toContain('mv "$ROOT_DIR/dist" "$backup_dir"');
-    expect(script).toContain('mv "$temp_dir/dist" "$ROOT_DIR/dist"');
-    expect(script).toContain('mktemp -d "$ROOT_DIR/.bun-dist.XXXXXX"');
-    expect(script).toContain('rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true');
-    expect(script).toContain('&& mv "$backup_dir" "$ROOT_DIR/dist"');
-    expect(script).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
-    expect(script).toContain("cleanup_restore_dist\n    return 1");
-    expect(script).not.toContain("trap cleanup_restore_dist RETURN");
-    expect(script).not.toContain('container_id="$(docker create "$image")"');
-    expect(script).not.toContain('docker cp "${container_id}:/app/dist" "$ROOT_DIR/dist"');
-    expect(script).not.toContain('\n  rm -rf "$ROOT_DIR/dist"\n');
+    expect(packageHelper).toContain('"${container_id}:/app/node_modules/@openclaw/ai/dist"');
+    expect(packageHelper).toContain('"$temp_dir/ai-dist"');
+    expect(packageHelper).toContain('mv "$temp_dir/ai-dist" "$ROOT_DIR/packages/ai/dist"');
+    expect(packageHelper).toContain("cleanup_restore_package_dist() {");
+    expect(packageHelper).toContain('mv "$ROOT_DIR/dist" "$backup_dir"');
+    expect(packageHelper).toContain('mv "$temp_dir/dist" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('mktemp -d "$ROOT_DIR/.package-dist.XXXXXX"');
+    expect(packageHelper).toContain('rm -rf "$ROOT_DIR/dist" >/dev/null 2>&1 || true');
+    expect(packageHelper).toContain('&& mv "$backup_dir" "$ROOT_DIR/dist"');
+    expect(packageHelper).toContain('docker_e2e_docker_cmd rm -f "$container_id"');
   });
 
   it("rejects invalid Bun global install command timeouts before Bun setup", () => {


### PR DESCRIPTION
Related: #103552

Backport counterpart to #103556 for `release/2026.7.1`.

## What Problem This Solves

Fixes an issue where release installer validation could build a metadata-only bundled `@openclaw/ai` package when it reused an exact candidate Docker image. A stable-to-candidate update installed and swapped successfully, then `openclaw doctor` failed because `dist/internal/runtime.mjs` was absent.

## Why This Change Was Made

Restore the root and bundled AI build trees together from the same candidate image through one rollback-safe helper, reject bundled tarballs that omit the AI runtime entry, and exercise the installed runtime after both fresh installation and update. The updater itself and release/version metadata are unchanged.

## User Impact

Release validation now packages the same AI runtime bytes already present in the exact candidate image. Incomplete candidate tarballs fail at integrity validation, while valid stable-to-candidate updates complete doctor and an installed AI-runtime probe.

## Evidence

- Red: Release Checks run https://github.com/openclaw/openclaw/actions/runs/29076524932, installer job https://github.com/openclaw/openclaw/actions/runs/29076524932/job/86309758690. The `2026.6.11 -> 2026.7.1-beta.3` update installed and swapped, then doctor failed with `ERR_MODULE_NOT_FOUND` for `@openclaw/ai/dist/internal/runtime.mjs`.
- Exact candidate: `66215056e56708f122f813db456fe742c0ea933f` was pushed and independently verified as the Testbox checkout HEAD before proof.
- Focused Testbox proof: 251/251 passed across `test/scripts/docker-build-helper.test.ts`, `test/scripts/test-install-sh-docker.test.ts`, and `test/scripts/check-openclaw-package-tarball.test.ts`.
- Full exact installer proof: `2026.6.11 -> 2026.7.1-beta.3` completed in 2m17.9s with the exact failing candidate image `ghcr.io/openclaw/openclaw-dockerfile-smoke:811ddd96180583bae00001f71971419182ae0520`; fresh runtime probe, update, swap, `doctor --non-interactive --fix`, and post-update runtime probe all exited 0. The repaired package contained 42 additional AI runtime files.
- Path-scoped exact-head gate: `pnpm check:changed --base a7485183330c121ef4b20adc844b186dad757e67 --head HEAD -- <8 touched paths>` exited 0 on fresh Testbox lease `tbx_01kx5hvvr9f4gthgjkbrx4gz6s`.
- Static proof: `bash -n` on all touched shell scripts, `node --check scripts/check-openclaw-package-tarball.mjs`, targeted `oxfmt`, and `git diff --check` passed.
- Fresh committed-branch autoreview: no accepted or actionable findings; patch judged correct (0.91).

