### PR TITLE
fix(openai): redact token exchange error response body

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -274,4 +274,51 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
       await closeServer(server);
     }
   });
+
+  it("bounds and redacts secrets in token exchange error responses (#103567)", async () => {
+    const leakedSecret = "oauth-client-secret-abc123xyz";
+    const errorBody = JSON.stringify({
+      error: "invalid_grant",
+      error_description: `Authorization failed for client_secret=${leakedSecret}`,
+    });
+    const oversizedSuffix = "x".repeat(32 * 1024);
+    const body = `${errorBody}${oversizedSuffix}`;
+
+    const server = createServer((_req, res) => {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(body);
+    });
+    const port = await listenLoopbackServer(server);
+    const release = vi.fn(async () => undefined);
+
+    try {
+      ssrfMocks.fetchWithSsrFGuard.mockImplementation(async ({ init, signal }) => {
+        const response = await globalThis.fetch(`http://127.0.0.1:${port}`, {
+          ...init,
+          signal,
+        });
+        return { response, release };
+      });
+
+      const result = await testing.exchangeAuthorizationCode(
+        "code-secret-test",
+        "verifier-secret-test",
+        "http://localhost:1455/auth/callback",
+        { timeoutMs: 5000 },
+      );
+
+      expect(result).toMatchObject({ type: "failed" });
+      const message = (result as { type: "failed"; message: string }).message;
+      expect(message).toContain("OpenAI Codex token exchange failed");
+      expect(message).toContain("invalid_grant");
+      // Secret must be redacted from the error message.
+      expect(message).not.toContain(leakedSecret);
+      // Error body is bounded at 16 KiB — the full 32 KiB suffix should not appear.
+      expect(message.length).toBeLessThan(body.length);
+      expect(message.length).toBeLessThan(18 * 1024);
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      await closeServer(server);
+    }
+  });
 });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { extractProviderErrorDetail } from "openclaw/plugin-sdk/provider-http";
 import {
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
@@ -227,11 +228,12 @@ async function exchangeAuthorizationCode(
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
+    const detail = await extractProviderErrorDetail(response).catch(() => "");
     return {
       type: "failed",
       status: response.status,
-      message: `OpenAI Codex token exchange failed (${response.status}): ${text || response.statusText}`,
+      message:
+        `OpenAI Codex token exchange failed (${response.status})` + (detail ? `: ${detail}` : ""),
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

OpenAI Codex OAuth token exchange reads the full error response body via
`response.text()` on failed requests with no size limit and no redaction.
Secrets in error responses (e.g. `client_secret` in `error_description`)
are exposed in the error message.

## Why This Change Was Made

Replace the unbounded `response.text()` with `extractProviderErrorDetail` —
the canonical bounded provider error helper — so error body consumption is
capped at 16 KiB and sensitive values are redacted.

The maintainer applied the same pattern to the merged Chutes OAuth fix
(#103569): `readResponseTextLimited` → `assertOkOrThrowProviderError`,
with secret redaction tests.

## User Impact

**Before:** unbounded error body read, secrets in error responses logged
**After:** bounded at 16 KiB via `extractProviderErrorDetail`, secrets redacted

## Evidence

Branch: `fix/openai-oauth-exchange-error-body` | Base: `upstream/main`

### Redaction proof (real loopback HTTP server)

```
$ node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts --reporter=verbose

 ✓ bounds and redacts secrets in token exchange error responses (#103567)
 ✓ rejects oversized token exchange responses from a real loopback HTTP server
 ✓ reads under-cap token exchange responses from a real loopback HTTP server

 Test Files  1 passed (1)  Tests  13 passed (13)
```

The new test sends a 400 error response containing a real-looking
`client_secret=oauth-client-secret-abc123xyz` with 32 KiB of padding.
Verifies: (1) secret is not in the message, (2) message is bounded < body length,
(3) `invalid_grant` error code is preserved.

### Diff summary

```
extensions/openai/openai-chatgpt-oauth-flow.runtime.ts      | 6 +++--
extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts | 47 +++++++
```

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
