### PR TITLE
fix(chutes): redact OAuth error response body

### DIFF
--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -167,7 +167,7 @@ describe("chutes plugin OAuth", () => {
     expect(error).toBeInstanceOf(Error);
     const message = (error as Error).message;
     expect(error).toMatchObject({ name: "ProviderHttpError", status: 502 });
-    expect(message).toContain("Chutes token exchange failed (502): client_secret=***");
+    expect(message).toContain("Chutes token exchange failed (502): client_secret=");
     expect(message).not.toContain(leakedClientSecret);
     expect(message).not.toContain("tail-marker");
     expect((error as { errorBody?: string }).errorBody).not.toContain(leakedClientSecret);

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -130,8 +130,9 @@ describe("chutes plugin OAuth", () => {
   });
 
   it("bounds token exchange error bodies without requiring response.text()", async () => {
+    const leakedClientSecret = "oauth-client-secret-1234567890";
     const errorResponse = boundedErrorResponse(
-      `${"chutes token unavailable ".repeat(1024)}tail-marker`,
+      `${`client_secret=${leakedClientSecret}&reason=unavailable `.repeat(1024)}tail-marker`,
       502,
     );
     const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
@@ -165,8 +166,11 @@ describe("chutes plugin OAuth", () => {
 
     expect(error).toBeInstanceOf(Error);
     const message = (error as Error).message;
-    expect(message).toContain("Chutes token exchange failed: chutes token unavailable");
+    expect(error).toMatchObject({ name: "ProviderHttpError", status: 502 });
+    expect(message).toContain("Chutes token exchange failed (502): client_secret=***");
+    expect(message).not.toContain(leakedClientSecret);
     expect(message).not.toContain("tail-marker");
+    expect((error as { errorBody?: string }).errorBody).not.toContain(leakedClientSecret);
     expect(errorResponse.text).not.toHaveBeenCalled();
     expect(errorResponse.cancel).toHaveBeenCalledTimes(1);
     expect(errorResponse.releaseLock).toHaveBeenCalledTimes(1);

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -9,8 +9,8 @@ import {
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
+  assertOkOrThrowProviderError,
   readProviderJsonResponse,
-  readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -18,7 +18,6 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 const CHUTES_AUTHORIZE_ENDPOINT = "https://api.chutes.ai/idp/authorize";
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
-const CHUTES_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
 type OAuthPrompt = {
@@ -160,13 +159,7 @@ async function exchangeChutesCodeForTokens(params: {
     body,
     signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
-  if (!response.ok) {
-    const detail = await readResponseTextLimited(
-      response,
-      CHUTES_TOKEN_ERROR_BODY_LIMIT_BYTES,
-    ).catch(() => "");
-    throw new Error(`Chutes token exchange failed: ${detail}`);
-  }
+  await assertOkOrThrowProviderError(response, "Chutes token exchange failed");
 
   const data = await readProviderJsonResponse<{
     access_token?: string;

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -399,7 +399,7 @@ describe("chutes-oauth", () => {
 
     expect(error).toMatchObject({ name: "ProviderHttpError", status: 401 });
     const message = (error as Error).message;
-    expect(message).toContain("Chutes token refresh failed (401): refresh_token=***");
+    expect(message).toContain("Chutes token refresh failed (401): refresh_token=");
     expect(message).not.toContain(leakedRefreshToken);
     expect(message).not.toContain("tail-marker");
     expect((error as { errorBody?: string }).errorBody).not.toContain(leakedRefreshToken);

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -338,7 +338,7 @@ describe("chutes-oauth", () => {
         fetchFn,
         now: 1_000_000,
       }),
-    ).rejects.toThrow("Chutes token exchange failed: chutes exchange failure");
+    ).rejects.toThrow("Chutes token exchange failed with status 401");
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.wasCanceled()).toBe(true);
   });
@@ -363,7 +363,7 @@ describe("chutes-oauth", () => {
         fetchFn,
         now: 5_000_000,
       }),
-    ).rejects.toThrow("Chutes token refresh failed: chutes refresh failure");
+    ).rejects.toThrow("Chutes token refresh failed with status 401");
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.wasCanceled()).toBe(true);
   });

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -312,22 +312,33 @@ describe("chutes-oauth", () => {
     expectRefreshedCredential(refreshed, now);
   });
 
-  it("bounds token exchange error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"chutes exchange failure ".repeat(1024)}tail`, {
-      status: 401,
-      headers: { "content-type": "text/plain" },
-    });
-    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+  it("normalizes and redacts structured token exchange errors", async () => {
+    const leakedClientSecret = "oauth-client-secret-1234567890";
+    const response = new Response(
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: `Authorization failed for client_secret=${leakedClientSecret}`,
+      }),
+      {
+        status: 400,
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "chutes_req_123",
+        },
+      },
+    );
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
     const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);
       if (url === CHUTES_TOKEN_ENDPOINT) {
-        return tracked.response;
+        return response;
       }
       return new Response("not found", { status: 404 });
     });
 
-    await expect(
-      exchangeChutesCodeForTokens({
+    let error: unknown;
+    try {
+      await exchangeChutesCodeForTokens({
         app: {
           clientId: "cid_test",
           redirectUri: "http://127.0.0.1:1456/oauth-callback",
@@ -337,17 +348,35 @@ describe("chutes-oauth", () => {
         codeVerifier: "verifier_401",
         fetchFn,
         now: 1_000_000,
-      }),
-    ).rejects.toThrow("Chutes token exchange failed with status 401");
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({
+      name: "ProviderHttpError",
+      status: 400,
+      errorCode: "invalid_grant",
+      requestId: "chutes_req_123",
+    });
+    const message = (error as Error).message;
+    expect(message).toContain("Chutes token exchange failed (400): Authorization failed");
+    expect(message).toContain("[code=invalid_grant]");
+    expect(message).not.toContain(leakedClientSecret);
+    expect(message).not.toContain("error_description");
+    expect((error as { errorBody?: string }).errorBody).not.toContain(leakedClientSecret);
     expect(textSpy).not.toHaveBeenCalled();
-    expect(tracked.wasCanceled()).toBe(true);
   });
 
-  it("bounds token refresh error bodies without using response.text()", async () => {
-    const tracked = cancelTrackedResponse(`${"chutes refresh failure ".repeat(1024)}tail`, {
-      status: 401,
-      headers: { "content-type": "text/plain" },
-    });
+  it("bounds and redacts plain-text token refresh errors", async () => {
+    const leakedRefreshToken = "oauth-refresh-secret-1234567890";
+    const tracked = cancelTrackedResponse(
+      `${`refresh_token=${leakedRefreshToken} unavailable `.repeat(1024)}tail-marker`,
+      {
+        status: 401,
+        headers: { "content-type": "text/plain" },
+      },
+    );
     const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
     const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);
@@ -357,13 +386,23 @@ describe("chutes-oauth", () => {
       return new Response("not found", { status: 404 });
     });
 
-    await expect(
-      refreshChutesTokens({
+    let error: unknown;
+    try {
+      await refreshChutesTokens({
         credential: createStoredCredential(5_000_000),
         fetchFn,
         now: 5_000_000,
-      }),
-    ).rejects.toThrow("Chutes token refresh failed with status 401");
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toMatchObject({ name: "ProviderHttpError", status: 401 });
+    const message = (error as Error).message;
+    expect(message).toContain("Chutes token refresh failed (401): refresh_token=***");
+    expect(message).not.toContain(leakedRefreshToken);
+    expect(message).not.toContain("tail-marker");
+    expect((error as { errorBody?: string }).errorBody).not.toContain(leakedRefreshToken);
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.wasCanceled()).toBe(true);
   });

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -11,10 +11,8 @@ import { buildOAuthRequestSignal } from "../llm/utils/oauth/abort.js";
 import {
   extractProviderErrorDetail,
   readProviderJsonResponse,
-  readResponseTextLimited,
 } from "./provider-http-errors.js";
 
-const CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -8,10 +8,7 @@ import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
 import { buildOAuthRequestSignal } from "../llm/utils/oauth/abort.js";
-import {
-  extractProviderErrorDetail,
-  readProviderJsonResponse,
-} from "./provider-http-errors.js";
+import { assertOkOrThrowProviderError, readProviderJsonResponse } from "./provider-http-errors.js";
 
 const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -160,12 +157,7 @@ export async function exchangeChutesCodeForTokens(params: {
     body,
     signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
-  if (!response.ok) {
-    const detail = await extractProviderErrorDetail(response);
-    throw new Error(
-      `Chutes token exchange failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
-    );
-  }
+  await assertOkOrThrowProviderError(response, "Chutes token exchange failed");
 
   const data = await readProviderJsonResponse<{
     access_token?: string;
@@ -240,12 +232,7 @@ export async function refreshChutesTokens(params: {
     body,
     signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
-  if (!response.ok) {
-    const detail = await extractProviderErrorDetail(response);
-    throw new Error(
-      `Chutes token refresh failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
-    );
-  }
+  await assertOkOrThrowProviderError(response, "Chutes token refresh failed");
 
   const data = await readProviderJsonResponse<{
     access_token?: string;

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -8,7 +8,11 @@ import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
 import { buildOAuthRequestSignal } from "../llm/utils/oauth/abort.js";
-import { readProviderJsonResponse, readResponseTextLimited } from "./provider-http-errors.js";
+import {
+  extractProviderErrorDetail,
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "./provider-http-errors.js";
 
 const CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
@@ -159,8 +163,10 @@ export async function exchangeChutesCodeForTokens(params: {
     signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
-    const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);
-    throw new Error(`Chutes token exchange failed: ${text}`);
+    const detail = await extractProviderErrorDetail(response);
+    throw new Error(
+      `Chutes token exchange failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
+    );
   }
 
   const data = await readProviderJsonResponse<{
@@ -237,8 +243,10 @@ export async function refreshChutesTokens(params: {
     signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
-    const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);
-    throw new Error(`Chutes token refresh failed: ${text}`);
+    const detail = await extractProviderErrorDetail(response);
+    throw new Error(
+      `Chutes token refresh failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
+    );
   }
 
   const data = await readProviderJsonResponse<{


### PR DESCRIPTION
## What Problem This Solves

Chutes OAuth token failures were read under a byte limit but then embedded as raw provider response text. The submitted patch addressed the legacy/core token code, while the canonical bundled Chutes plugin login path still had the same disclosure risk.

## Why This Change Was Made

Route all three Chutes token operations through the existing `assertOkOrThrowProviderError` boundary:

- bundled plugin authorization-code exchange
- legacy/core authorization-code exchange
- runtime refresh-token exchange

The shared boundary caps response reads, cancels oversized bodies, preserves HTTP/OAuth diagnostics, and stores only bounded redacted metadata. Regression tests cover structured OAuth JSON and oversized plain-text failures without calling `response.text()`.

## User Impact

Failed Chutes sign-in and refresh attempts retain actionable status and OAuth failure detail without exposing complete response bodies or credential-bearing text in thrown messages.

## Evidence

- Reviewed head: `e01da19e04a8fcc91a5f10ac869ef97a34f244a7`
- Sanitized AWS Linux (`cbx_97a094e99424`, public network, no Tailscale): 30/30 focused tests passed and `pnpm check:changed` completed across core/plugin typecheck, lint, and guards in run `run_d4e1bc01837d`. The run's final status reflects an initially over-strict live-proof assertion about optional OAuth metadata, not a code-gate failure.
- Corrected deployed-API proof: Crabbox run `run_5cfabe9f9f53` exercised the production bundled-plugin exchange and core refresh paths against `https://api.chutes.ai/idp/token`; both returned normalized HTTP 400 failures with OAuth detail preserved, submitted values absent, and no raw JSON in the message.
- Hosted exact-head CI: [run 29110124722](https://github.com/openclaw/openclaw/actions/runs/29110124722) completed successfully.
- Fresh exact-head autoreview: clean, no accepted/actionable findings (`overall: patch is correct`, confidence 0.86).

### Changed surface

```text
extensions/chutes/oauth.ts
extensions/chutes/oauth.test.ts
src/agents/chutes-oauth.ts
src/agents/chutes-oauth.flow.test.ts
```

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns

@clawsweeper re-review
