### PR TITLE
fix(telegram): keep DM reply ids out of thread identity

### DIFF
--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -232,6 +232,9 @@ function resolveOriginThreadIdForPayload(params: {
   // An explicit null means the provider transports its conversation thread
   // through replyToId. Undefined reply ids remain native message references.
   if (transport?.threadId === null) {
+    if (params.provider === "telegram" && params.replyDelivery?.chatType === "direct") {
+      return originThreadId;
+    }
     return normalizeThreadIdForComparison(transport.replyToId);
   }
   return originThreadId;

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -1,8 +1,14 @@
 // Tests reply payload helper behavior and delivery metadata.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelThreadingAdapter } from "../../channels/plugins/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createOutboundTestPlugin,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
+import { getMatchingMessagingToolReplyTargets } from "./reply-payloads-dedupe.js";
 import {
   filterMessagingToolMediaDuplicates,
   resolveMessagingToolPayloadDedupe,
@@ -128,6 +134,11 @@ describe("filterMessagingToolMediaDuplicates", () => {
 });
 
 describe("shouldDedupeMessagingToolRepliesForRoute", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
   const installTelegramSuppressionRegistry = () => {
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(
@@ -142,6 +153,38 @@ describe("shouldDedupeMessagingToolRepliesForRoute", () => {
               targetsMatchForReplySuppression: targetsMatchTelegramReplySuppression,
             },
           }),
+        },
+      ]),
+    );
+  };
+
+  const installTelegramThreadingRegistry = () => {
+    const telegramThreading: ChannelThreadingAdapter = {
+      resolveReplyTransport: ({ threadId, replyToId, replyDelivery }) => {
+        const normalizedThreadId =
+          threadId != null && threadId !== "" ? String(threadId) : undefined;
+        if (replyDelivery?.chatType === "direct") {
+          return {
+            replyToId: replyToId ?? null,
+            threadId: null,
+          };
+        }
+        return {
+          replyToId: replyToId ?? null,
+          threadId: normalizedThreadId ?? null,
+        };
+      },
+    };
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram-threading-plugin",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram" }),
+            threading: telegramThreading,
+          },
         },
       ]),
     );
@@ -275,6 +318,49 @@ describe("shouldDedupeMessagingToolRepliesForRoute", () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it("does not treat Telegram DM replyToId as originatingThreadId for dedupe", () => {
+    installTelegramThreadingRegistry();
+
+    expect(
+      getMatchingMessagingToolReplyTargets({
+        config: {} as never,
+        messageProvider: "telegram",
+        originatingTo: "123",
+        replyToId: "456",
+        replyDelivery: {
+          chatType: "direct",
+          replyToMode: "all",
+        },
+        messagingToolSentTargets: [
+          { tool: "message", provider: "telegram", to: "123" },
+          { tool: "message", provider: "telegram", to: "123", threadId: "456" },
+        ],
+      }),
+    ).toEqual([{ tool: "message", provider: "telegram", to: "123" }]);
+  });
+
+  it("preserves explicit Telegram thread ids for dedupe matching", () => {
+    installTelegramThreadingRegistry();
+
+    expect(
+      getMatchingMessagingToolReplyTargets({
+        config: {} as never,
+        messageProvider: "telegram",
+        originatingTo: "-100123",
+        originatingThreadId: "77",
+        replyToId: "456",
+        replyDelivery: {
+          chatType: "channel",
+          replyToMode: "all",
+        },
+        messagingToolSentTargets: [
+          { tool: "message", provider: "telegram", to: "-100123" },
+          { tool: "message", provider: "telegram", to: "-100123", threadId: "77" },
+        ],
+      }),
+    ).toEqual([{ tool: "message", provider: "telegram", to: "-100123", threadId: "77" }]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Telegram direct-message replies could leak a plain `replyToId` into thread identity during dedupe.

In the current path, when `resolveReplyTransport()` returns `threadId === null`, OpenClaw normalizes `replyToId` into `originatingThreadId`. That behavior is valid for providers like Slack that transport thread identity via reply ids, but it is wrong for Telegram direct chats: a DM reply message id is **not** a topic/thread id.

That leak can later cause queued Telegram sends to emit `message_thread_id` for non-topic DMs, which Telegram rejects with:

- `400 Bad Request: message thread not found`

This patch narrows the exception to **Telegram direct chats only** while preserving the existing `threadId === null => replyToId carries thread identity` behavior for other providers.

## What Changed

- keep reply identity separate from thread identity for `provider === "telegram"` + `chatType === "direct"`
- preserve existing generic `threadId === null` handling for providers such as Slack
- add regression coverage proving:
  - a Telegram DM with `replyToId` and no topic/thread does **not** dedupe as thread-scoped
  - an explicit Telegram thread id still remains thread-scoped
- existing Slack reply-thread behavior remains covered and passing

## Evidence

Ran on a clean branch from `origin/main`:

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/reply-payloads.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts`
  - result: `2` files passed, `94` tests passed
- `pnpm tsgo:core`
- `git diff --check -- src/auto-reply/reply/reply-payloads-dedupe.ts src/auto-reply/reply/reply-payloads.test.ts`
- live reproduction before fix: Telegram outbound DM send failed with `message thread not found`

## Why this matters

This fixes a live Telegram DM delivery failure path without breaking providers that intentionally carry thread identity via reply ids.
