### PR TITLE
feat(webchat,cli): the lobster notices things — watching, tidying, dressing up, stirring

### DIFF
--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -67,7 +67,13 @@ Collected observations from people who spend too much time watching their sideba
 - People who have used the same browser for a long time report their lobster arrives sooner, stays longer, and waves at them. People who shoo a lot describe a certain distance.
 - After a Gateway upgrade, pay attention to what the first visitor is carrying.
 - The lobster in the sidebar has a cousin in the terminal. It shows up in the `openclaw` banner on days of its own choosing, and no one has successfully predicted which.
+- On the days the cousin appears, sidebar lobsters have been seen dressed nautically. The two refuse to explain the connection.
 - During very long runs, the lobster stops playing and settles in to wait with you. Solidarity.
+- When something crosses the ledge, the resident stops what it is doing and watches. You would too.
+- After bad news, some lobsters tidy the ledge. It seems to help them.
+- Lobsters remember anniversaries even when you do not. If yours shows up in a party hat on an unremarkable day, check the Lobsterdex for the date you met.
+- Devoted hosts report their lobsters acquiring titles over the years. There is no known ceremony.
+- The Dreams-page sleeper is not entirely asleep. Press gently and see.
 
 ## Privacy
 

--- a/src/cli/lobster-art.ts
+++ b/src/cli/lobster-art.ts
@@ -1,7 +1,8 @@
 // The Control UI lobster pet has a CLI cousin: on roughly one day in sixteen
-// the interactive banner gains a tiny ASCII lobster. Deterministic per
-// calendar day (like the holiday taglines) so every terminal agrees on
-// lobster day, and callers can pin the date in tests.
+// the interactive banner gains a tiny ASCII lobster. The day comes from the
+// shared lobster-day hash (the sidebar pet dresses up on the same days), so
+// every surface agrees on the calendar and tests can pin dates.
+import { isLobsterDay, lobsterDayHash } from "../shared/lobster-day.js";
 
 const LOBSTER_ARTS: readonly string[] = [
   // Claws up, saying hi.
@@ -9,15 +10,6 @@ const LOBSTER_ARTS: readonly string[] = [
   // Just the eyestalks, watching from below the waterline.
   ["     o   o", "     )   (", "  ~~~~~~~~~~~"].join("\n"),
 ] as const;
-
-function hashDay(key: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < key.length; i++) {
-    hash ^= key.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
 
 /**
  * Return the ASCII lobster for `now`'s calendar day, or null on non-lobster
@@ -27,10 +19,8 @@ export function pickCliLobsterArt(now: Date, env: NodeJS.ProcessEnv = process.en
   if (env.CI || env.VITEST) {
     return null;
   }
-  const key = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
-  const hash = hashDay(key);
-  if (hash % 16 !== 3) {
+  if (!isLobsterDay(now)) {
     return null;
   }
-  return LOBSTER_ARTS[(hash >>> 8) % LOBSTER_ARTS.length];
+  return LOBSTER_ARTS[(lobsterDayHash(now) >>> 8) % LOBSTER_ARTS.length];
 }

--- a/src/shared/lobster-day.ts
+++ b/src/shared/lobster-day.ts
@@ -1,0 +1,17 @@
+// Shared "lobster day" calendar hash: the CLI banner's ASCII cousin and the
+// Control UI pet coordinate wardrobe through this one function, so both
+// surfaces always agree on the date. Roughly one day in sixteen hits.
+
+export function lobsterDayHash(now: Date): number {
+  const key = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function isLobsterDay(now: Date): boolean {
+  return lobsterDayHash(now) % 16 === 3;
+}

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLobsterdex, getLobsterdexEntries } from "./lobster-dex.ts";
 import {
@@ -12,6 +13,7 @@ import {
   lobsterPetName,
   lobsterPetSeed,
   planLobsterPasser,
+  renderLobsterSvg,
   strangerLookFor,
   resolveLobsterPetMode,
   resolveLobsterRunOutcome,
@@ -869,6 +871,93 @@ describe("lobster pet element", () => {
     expect(element.querySelector(".lobster-pet")?.getAttribute("title")).toBe(
       `Captain ${lobsterPetName(look, 42)}`,
     );
+  });
+
+  it("tidies the ledge after a droop", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(42, "busy");
+    element.runOutcome = "error";
+    await arrive(element);
+
+    element.mode = "idle";
+    await element.updateComplete;
+    expect(spriteClasses(element)).toContain("lobster-pet--act-droop");
+
+    await vi.advanceTimersByTimeAsync(LOBSTER_PET_ACT_DURATION_MS.droop + 50);
+    await element.updateComplete;
+    expect(spriteClasses(element)).toContain("lobster-pet--act-sweep");
+    expect(element.querySelector(".lobster-pet__broom")).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(LOBSTER_PET_ACT_DURATION_MS.sweep + 50);
+    await element.updateComplete;
+    expect(spriteClasses(element)).not.toContain("lobster-pet--act-");
+  });
+
+  it("turns to watch a passer cross the ledge", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    // Seed 300: resident arrives ~70s, a stranger crosses left-to-right at
+    // ~100s while it is still perched (probed via the pure planners).
+    const plan = planLobsterPasser(300);
+    expect(plan?.kind).toBe("stranger");
+    expect(plan?.direction).toBe(1);
+    const element = createPet(300);
+    await arrive(element);
+
+    // Face right first so the watch flip is observable.
+    await vi.advanceTimersByTimeAsync(200);
+    document.dispatchEvent(new MouseEvent("pointermove", { clientX: 400 }));
+    await element.updateComplete;
+    expect(element.querySelector(".lobster-pet")?.getAttribute("style")).toContain("--lob-face:1");
+
+    // Self-clocking: walk forward until the crossing starts (1s steps land
+    // well inside the pre-flip half of the 11s crossing).
+    const crossing = await advanceUntil(
+      element,
+      () => element.querySelector(".lobster-pet--passer") !== null,
+      60_000,
+    );
+    expect(crossing).toBe(true);
+    expect(spritePresent(element)).toBe(true);
+    // Entry side first (ltr enters from the left) ...
+    expect(
+      element.querySelector(".lobster-pet:not(.lobster-pet--passer)")?.getAttribute("style"),
+    ).toContain("--lob-face:-1");
+
+    // ... then it follows the crossing out.
+    await vi.advanceTimersByTimeAsync(6_000);
+    await element.updateComplete;
+    expect(
+      element.querySelector(".lobster-pet:not(.lobster-pet--passer)")?.getAttribute("style"),
+    ).toContain("--lob-face:1");
+  });
+
+  it("wears the sailor cap on lobster days, deferring to rolled headwear", async () => {
+    vi.useFakeTimers();
+    // 2026-01-05 is a probed lobster day; seed 42 rolls the (face-worn)
+    // eyepatch that day, so the cap fits.
+    vi.setSystemTime(new Date("2026-01-05T12:00:00"));
+    const element = createPet(42);
+    await arrive(element);
+    expect(element.querySelector(".lob-cap")).not.toBeNull();
+    element.remove();
+
+    // Ordinary days stay capless.
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const plain = createPet(42);
+    await arrive(plain);
+    expect(plain.querySelector(".lob-cap")).toBeNull();
+  });
+
+  it("ships a hidden peek eye only in sleeping renders", () => {
+    const container = document.createElement("div");
+    const look = createLobsterPetLook(42, new Date("2026-07-09T12:00:00"));
+    render(renderLobsterSvg(look, { sleeping: true }), container);
+    expect(container.querySelector(".lob-eye-peek")).not.toBeNull();
+    render(renderLobsterSvg(look, { standalone: true }), container);
+    expect(container.querySelector(".lob-eye-peek")).toBeNull();
   });
 
   it("stays static when reduced motion is preferred, including visibility resumes", async () => {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -6,6 +6,7 @@
 // every new session hatches a slightly different lobster.
 import { html, LitElement, nothing, svg, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
+import { isLobsterDay } from "../../../src/shared/lobster-day.js";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import {
   LOBSTER_FAMILIARITY_TUNING,
@@ -32,7 +33,8 @@ export type LobsterPetAct =
   | "cheer"
   | "molt"
   | "pet"
-  | "droop";
+  | "droop"
+  | "sweep";
 
 export type LobsterPetMode = "idle" | "busy" | "offline";
 
@@ -110,6 +112,7 @@ export const LOBSTER_PET_ACT_DURATION_MS: Record<LobsterPetAct, number> = {
   molt: 2600,
   pet: 1500,
   droop: 1600,
+  sweep: 1800,
 };
 
 const PERSONALITIES: Record<LobsterPetPersonalityId, ActProfile> = {
@@ -701,6 +704,25 @@ const BINDLE = svg`
   </g>
 `;
 
+// On lobster days (see src/shared/lobster-day.ts, shared with the CLI
+// banner cousin) the pet wears a little sailor cap - unless the seed already
+// rolled headwear, which keeps its place.
+const HEADWEAR: ReadonlySet<LobsterPetAccessory> = new Set([
+  "crown",
+  "sprout",
+  "santa",
+  "pumpkin",
+  "party",
+]);
+
+const SAILOR_CAP = svg`
+  <g class="lob-cap">
+    <path d="M46 10 Q60 -3 74 10 L74 13 Q60 7 46 13 Z" fill="#f5f7fa" />
+    <path d="M45 12 Q60 6 75 12 L75 16 Q60 10.5 45 16 Z" fill="#dfe7ee" />
+    <circle cx="60" cy="2.5" r="1.8" fill="#3b6ea5" />
+  </g>
+`;
+
 // Shown while grumpy (poked too much): angry brows and a frown.
 const GRUMPY_FACE = svg`
   <g stroke="#0a1014" stroke-linecap="round" fill="none">
@@ -774,6 +796,7 @@ export function renderLobsterSvg(
     sleeping?: boolean;
     standalone?: boolean;
     bindle?: boolean;
+    sailorCap?: boolean;
   } = {},
 ) {
   return svg`
@@ -816,6 +839,16 @@ export function renderLobsterSvg(
         <circle cx="46.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
         <circle cx="76.5" cy="30.5" r="2.2" fill="var(--lob-glint, #00e5cc)" />
       </g>
+      ${
+        options.sleeping
+          ? svg`
+            <g class="lob-eye-peek">
+              <circle cx="45" cy="32" r="4" fill="#0a1014" />
+              <circle cx="46" cy="30.8" r="1.6" fill="var(--lob-glint, #00e5cc)" />
+            </g>
+          `
+          : nothing
+      }
       <g
         class="lob-eye-closed"
         stroke="#0a1014"
@@ -843,6 +876,7 @@ export function renderLobsterSvg(
         // The retro grail's mega claw owns the same shoulder; it moves light.
         options.bindle && look.palette.id !== "retro" ? BINDLE : nothing
       }
+      ${options.sailorCap && !options.shell && !HEADWEAR.has(look.accessory) ? SAILOR_CAP : nothing}
     </svg>
   `;
 }
@@ -874,6 +908,7 @@ export class LobsterPet extends LitElement {
   @state() private movingDay = false;
   private movingDayChecked = false;
   @state() private anniversary = false;
+  private sailorDay = false;
   @state() private shellVisible = false;
   private shellSpotPct = 50;
   private shellScale = 2;
@@ -883,6 +918,7 @@ export class LobsterPet extends LitElement {
   private shellTimer: number | null = null;
   private passerTimer: number | null = null;
   private passerEndTimer: number | null = null;
+  private passerWatchTimer: number | null = null;
   private familiarity: LobsterFamiliarity = { tier: "regular", wary: false, visits: 0, shoos: 0 };
   private greetedThisLoad = false;
 
@@ -921,7 +957,13 @@ export class LobsterPet extends LitElement {
       window.clearTimeout(this.shellTimer);
       this.shellTimer = null;
     }
-    for (const timer of [this.vigilTimer, this.holdTimer, this.passerTimer, this.passerEndTimer]) {
+    for (const timer of [
+      this.vigilTimer,
+      this.holdTimer,
+      this.passerTimer,
+      this.passerEndTimer,
+      this.passerWatchTimer,
+    ]) {
       if (timer !== null) {
         window.clearTimeout(timer);
       }
@@ -930,6 +972,7 @@ export class LobsterPet extends LitElement {
     this.holdTimer = null;
     this.passerTimer = null;
     this.passerEndTimer = null;
+    this.passerWatchTimer = null;
     if (this.audioCtx) {
       this.audioCtx.close().catch(() => {});
       this.audioCtx = null;
@@ -970,6 +1013,7 @@ export class LobsterPet extends LitElement {
       this.moltPlanned = isLobsterMoltLoad(this.seed);
       this.twinPlanned = isLobsterTwinLoad(this.seed);
       this.familiarity = getLobsterFamiliarity();
+      this.sailorDay = isLobsterDay(new Date());
       this.greetedThisLoad = false;
       this.scheduleVisits();
       this.schedulePasser();
@@ -1309,13 +1353,14 @@ export class LobsterPet extends LitElement {
   // ---- Pass-through visitors (strangers and the crab) ----
 
   private schedulePasser() {
-    for (const timer of [this.passerTimer, this.passerEndTimer]) {
+    for (const timer of [this.passerTimer, this.passerEndTimer, this.passerWatchTimer]) {
       if (timer !== null) {
         window.clearTimeout(timer);
       }
     }
     this.passerTimer = null;
     this.passerEndTimer = null;
+    this.passerWatchTimer = null;
     this.passer = null;
     const plan = planLobsterPasser(this.seed);
     if (!plan || prefersReducedMotion()) {
@@ -1327,11 +1372,30 @@ export class LobsterPet extends LitElement {
         return;
       }
       this.passer = plan;
+      this.watchPasser(plan);
       this.passerEndTimer = window.setTimeout(() => {
         this.passerEndTimer = null;
         this.passer = null;
+        this.scheduleNextAct();
       }, PASSER_CROSS_MS);
     }, plan.atMs);
+  }
+
+  // The resident notices traffic: it turns toward a passer's entry side,
+  // then follows it out with a mid-crossing flip. Acts, vigil, and absence
+  // all take precedence - the pet is curious, not obsessive.
+  private watchPasser(plan: LobsterPasserPlan) {
+    const watch = (facing: 1 | -1) => {
+      // Scuttle owns facing while it walks; anything else can turn its head.
+      if (this.presence === "in" && this.act !== "scuttle" && !this.vigil) {
+        this.facing = facing;
+      }
+    };
+    watch(plan.direction === 1 ? -1 : 1);
+    this.passerWatchTimer = window.setTimeout(() => {
+      this.passerWatchTimer = null;
+      watch(plan.direction);
+    }, PASSER_CROSS_MS / 2);
   }
 
   // Each arrival re-rolls where the pet shows up: the ledge above the footer
@@ -1369,6 +1433,7 @@ export class LobsterPet extends LitElement {
       !this.look ||
       this.presence !== "in" ||
       this.vigil ||
+      this.passer !== null ||
       this.idleTimer !== null ||
       this.actEndTimer !== null ||
       prefersReducedMotion()
@@ -1383,7 +1448,9 @@ export class LobsterPet extends LitElement {
     this.idleTimer = window.setTimeout(() => {
       this.idleTimer = null;
       const nextProfile = this.actProfile();
-      if (!nextProfile || document.hidden || this.presence !== "in") {
+      // A crossing pauses the fidget loop: the pet is busy watching. The
+      // passer-end timer restarts scheduling.
+      if (!nextProfile || document.hidden || this.presence !== "in" || this.passer !== null) {
         return;
       }
       if (this.moltPlanned && !this.molted && this.mode === "idle") {
@@ -1406,6 +1473,11 @@ export class LobsterPet extends LitElement {
       this.act = null;
       if (act === "molt") {
         this.completeMolt();
+      }
+      if (act === "droop") {
+        // Bad news gets processed lobster-style: tidy the ledge, then move on.
+        this.performAct("sweep");
+        return;
       }
       this.scheduleNextAct();
     }, LOBSTER_PET_ACT_DURATION_MS[act]);
@@ -1526,7 +1598,7 @@ export class LobsterPet extends LitElement {
         @contextmenu=${this.handleShoo}
       >
         <div class="lobster-pet__body">
-          ${renderLobsterSvg(dressed, { grumpy: this.grumpy, bindle })}
+          ${renderLobsterSvg(dressed, { grumpy: this.grumpy, bindle, sailorCap: this.sailorDay })}
           <span class="lobster-pet__z" style="--i:0">z</span>
           <span class="lobster-pet__z" style="--i:1">z</span>
           <span class="lobster-pet__z" style="--i:2">Z</span>
@@ -1534,6 +1606,15 @@ export class LobsterPet extends LitElement {
           <span class="lobster-pet__bubble" style="--i:1"></span>
           <span class="lobster-pet__bubble" style="--i:2"></span>
           <span class="lobster-pet__heart">♥</span>
+          <svg class="lobster-pet__broom" viewBox="0 0 24 40" aria-hidden="true">
+            <path d="M12 2 L12 24" stroke="#8a5a2b" stroke-width="3" stroke-linecap="round" />
+            <path d="M6 24 L18 24 L21 38 L3 38 Z" fill="#e8b04b" />
+            <path
+              d="M7.5 28 L6.5 36 M12 28 L12 36 M16.5 28 L17.5 36"
+              stroke="#b6791f"
+              stroke-width="1.5"
+            />
+          </svg>
         </div>
       </div>
     `;

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -69,6 +69,41 @@
   height: 160px;
 }
 
+/* Stirring: press the sleeper and it half-opens one eye, without quite
+   waking. The peek eye ships hidden inside the sleeping svg. */
+.dreams__lobster .lob-eye-peek {
+  display: none;
+}
+
+.dreams__lobster:active .lob-eye-peek {
+  display: block;
+}
+
+.dreams__lobster:active .lob-eye-closed path:first-of-type {
+  opacity: 0;
+}
+
+.dreams__lobster:active {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .dreams__lobster:active .lob-antennae {
+    animation: dreams-stir-antennae 0.9s ease-in-out infinite;
+    transform-origin: 60px 14px;
+  }
+}
+
+@keyframes dreams-stir-antennae {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(3deg);
+  }
+}
+
 @keyframes dreams-breathe {
   0%,
   100% {

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -266,6 +266,28 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   animation: lobster-pet-heart 1.4s ease-out;
 }
 
+/* Sweep: after the droop, a quick tidy-up of the ledge with a broom. */
+.lobster-pet--act-sweep .lobster-pet__body {
+  animation: lobster-pet-sweep-body 1.8s ease-in-out;
+  animation-delay: var(--lob-act-delay, 0s);
+}
+
+.lobster-pet__broom {
+  position: absolute;
+  left: 74%;
+  bottom: 4%;
+  width: calc(4.4px * var(--lob-scale, 2));
+  height: calc(7.4px * var(--lob-scale, 2));
+  opacity: 0;
+  pointer-events: none;
+  transform-origin: 50% 92%;
+}
+
+.lobster-pet--act-sweep .lobster-pet__broom {
+  animation: lobster-pet-broom 1.8s ease-in-out;
+  animation-delay: var(--lob-act-delay, 0s);
+}
+
 /* Droop: a failed run earns sagging antennae and a slow, sad head shake. */
 .lobster-pet--act-droop .lobster-pet__body {
   animation: lobster-pet-droop 1.6s ease-in-out;
@@ -522,6 +544,49 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
   100% {
     opacity: 0;
     transform: translate(4px, -18px) scale(1.15);
+  }
+}
+
+@keyframes lobster-pet-sweep-body {
+  0%,
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+  20% {
+    transform: translateX(-4%) rotate(-3deg);
+  }
+  40% {
+    transform: translateX(3%) rotate(3deg);
+  }
+  60% {
+    transform: translateX(-3%) rotate(-3deg);
+  }
+  80% {
+    transform: translateX(2%) rotate(2deg);
+  }
+}
+
+@keyframes lobster-pet-broom {
+  0%,
+  100% {
+    opacity: 0;
+    transform: rotate(0deg);
+  }
+  10%,
+  90% {
+    opacity: 1;
+  }
+  25% {
+    transform: rotate(-24deg);
+  }
+  45% {
+    transform: rotate(18deg);
+  }
+  65% {
+    transform: rotate(-20deg);
+  }
+  85% {
+    transform: rotate(12deg);
   }
 }
 


### PR DESCRIPTION
Related: #102754 · Stacked on #103563 (long memory) — lands after it.

## What Problem This Solves

The lobster has a rich inner life but no outer awareness: strangers cross its ledge unacknowledged, bad news gets a droop and then business as usual, and the Dreams sleeper is inert. Pets notice things.

## Why This Change Was Made

- **It watches passers.** When a stranger (or the crab) crosses, the resident pauses its fidget loop entirely — no acts start during a crossing — turns toward the entry side, and follows the visitor out with a mid-crossing head turn. Scuttle keeps ownership of facing while it walks; vigil and absence take precedence. The act loop resumes when the ledge is clear.
- **It tidies up.** After a failed run's droop, the pet chains into a new `sweep` act: a little broom appears and it sweeps the ledge for ~2 seconds before moving on. Processing, lobster-style.
- **The cousins coordinate.** The CLI banner's lobster-day hash moves to `src/shared/lobster-day.ts` (single source, consumed by both surfaces — the CLI art module keeps its art and env gating). On those same days the sidebar pet wears a tiny sailor cap, deferring to any headwear the seed already rolled (crowns, santa hats, and party hats keep their place; the eyepatch composes).
- **The sleeper stirs.** Press and hold the Dreams-page cameo and it half-opens one eye (a hidden peek-eye group ships inside sleeping renders, revealed via `:active` CSS), its antennae twitch, and its breathing pauses — without quite waking. Release and it is out again.
- Docs: eight new spoiler-light field notes covering this two-PR batch (anniversaries, titles, watching, tidying, nautical days, the stirring sleeper).

## User Impact

The sidebar becomes a place where things happen to someone who notices: crossings get watched, failures get swept up, certain days get dressed for, and the sleeping lobster was apparently listening the whole time.

| | |
|---|---|
| Sailor cap + sweep | ![notices](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/notices.png) |
| The sleeper, mid-stir | ![dreams stir](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-pet/dreams-stir.png) |

## Evidence

- Delegated Blacksmith Testbox: `pnpm test src/cli/lobster-art.test.ts src/cli/banner.test.ts ui/src/components/lobster-pet.test.ts ui/src/components/lobster-dex.test.ts ui/src/pages/dreams` — **4 + 9 + 2735** green (new: droop→sweep chain and act-window close; self-clocking passer-watch test on probed seed 300 asserting entry/exit facing; sailor cap on probed lobster day 2026-01-05 with the ordinary-day control — the standard 2026-07-09 test date is probed as a non-lobster day; peek eye present only in sleeping renders); `pnpm tsgo:core`; `pnpm tsgo:test:ui`; `pnpm --dir ui build`. Existing lobster-art/banner tests pass unchanged against the shared hash.
- Live in the mock Control UI: forced crossing flipped resident facing 1 → −1 (entry) → 1 (exit) with the passer on screen; droop chained into `act-sweep` with the broom in DOM; cap rendered; a real held pointer press on `/dreaming` produced `peek display:block` + left lid hidden (screenshot above). CSS animation clocks can't advance in an occluded preview tab, so animation frames were verified via Playwright's visible page instead.
- Codex autoreview clean.
