### PR TITLE
fix(browser): stale Chrome MCP handles survive reconnect

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -735,6 +735,16 @@ Notes:
 - Existing-session can attach on the selected host or through a connected
   browser node. If Chrome lives elsewhere and no browser node is connected, use
   remote CDP or a node host instead.
+- Chrome MCP targets and snapshot refs are scoped to one MCP subprocess. After
+  that process restarts, run `browser tabs` again, explicitly select a fresh
+  target before target-specific work, and take a new snapshot before using refs.
+  Each ref is valid only for its target and latest snapshot. Old aliases are not
+  transferred to a replacement tab, even when its URL matches.
+- Chrome DevTools MCP currently routes page tools by a process-local numeric page
+  ID. Process-scoped handles prevent reuse across subprocess replacement, but an
+  in-process browser-context replacement between adjacent tool calls can still
+  retarget an action. Fully atomic routing requires upstream page-tool support
+  for stable target IDs.
 
 ### Custom Chrome MCP launch
 

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -304,27 +304,28 @@ function isChromeStaleTargetError(profile: string | undefined, err: unknown): bo
   return isTabNotFound;
 }
 
-function stripTargetIdFromActRequest(
-  request: Parameters<typeof browserAct>[1],
-): Parameters<typeof browserAct>[1] | null {
-  const targetId = normalizeOptionalString(request.targetId);
-  if (!targetId) {
+function replaceStaleTargetIdInActRequest(
+  request: BrowserActRequest,
+  targetId: string,
+): BrowserActRequest | null {
+  if (!normalizeOptionalString(request.targetId) || !targetId) {
     return null;
   }
-  const retryRequest = { ...request };
-  delete retryRequest.targetId;
-  return retryRequest as Parameters<typeof browserAct>[1];
+  return { ...request, targetId } as BrowserActRequest;
 }
 
-function canRetryChromeActWithoutTargetId(request: Parameters<typeof browserAct>[1]): boolean {
-  const typedRequest = request as Partial<Record<"kind" | "action", unknown>>;
-  const kind =
-    typeof typedRequest.kind === "string"
-      ? typedRequest.kind
-      : typeof typedRequest.action === "string"
-        ? typedRequest.action
-        : "";
-  return kind === "hover" || kind === "scrollIntoView" || kind === "wait";
+function canRetryChromeActAfterSoleTargetRefresh(request: BrowserActRequest): boolean {
+  if (request.kind !== "wait" || normalizeNonNegativeDurationMs(request.timeMs) === undefined) {
+    return false;
+  }
+  return [
+    request.fn,
+    request.text,
+    request.textGone,
+    request.selector,
+    request.url,
+    request.loadState,
+  ].every((value) => !normalizeOptionalString(value));
 }
 
 function isAriaRefsUnsupportedError(err: unknown): boolean {
@@ -685,7 +686,6 @@ export async function executeActAction(params: {
     return jsonResult(result);
   } catch (err) {
     if (isChromeStaleTargetError(profile, err)) {
-      const retryRequest = stripTargetIdFromActRequest(effectiveRequest);
       const tabs = proxyRequest
         ? ((
             (await proxyRequest({
@@ -695,29 +695,37 @@ export async function executeActAction(params: {
             })) as { tabs?: unknown[] }
           ).tabs ?? [])
         : await browserToolActionDeps.browserTabs(baseUrl, { profile }).catch(() => []);
-      // Some user-browser targetIds can go stale between snapshots and actions.
-      // Only retry safe read-only actions, and only when exactly one tab remains attached.
-      if (retryRequest && canRetryChromeActWithoutTargetId(effectiveRequest) && tabs.length === 1) {
-        try {
-          const retryResult = proxyRequest
-            ? await proxyRequest({
-                method: "POST",
-                path: "/act",
-                profile,
-                body: retryRequest,
-                timeoutMs: resolveActProxyTimeoutMs(retryRequest),
-              })
-            : await browserToolActionDeps.browserAct(baseUrl, retryRequest, {
-                profile,
-              });
-          params.onTabActivity?.(
-            readStringValue((retryResult as { targetId?: unknown }).targetId) ??
-              readStringValue(retryRequest.targetId),
-          );
-          return jsonResult(retryResult);
-        } catch {
-          // Fall through to explicit stale-target guidance.
-        }
+      const freshTargetId =
+        tabs.length === 1
+          ? readStringValue((tabs[0] as { targetId?: unknown } | undefined)?.targetId)
+          : undefined;
+      const retryRequest = freshTargetId
+        ? replaceStaleTargetIdInActRequest(effectiveRequest, freshTargetId)
+        : null;
+      // This is same-agent continuity, not identity recovery: only target-independent
+      // waits may retry, against the one freshly listed tab. Ref-scoped and scripted
+      // operations require explicit fresh selection (and a fresh snapshot for refs).
+      if (
+        retryRequest &&
+        canRetryChromeActAfterSoleTargetRefresh(effectiveRequest) &&
+        tabs.length === 1
+      ) {
+        const retryResult = proxyRequest
+          ? await proxyRequest({
+              method: "POST",
+              path: "/act",
+              profile,
+              body: retryRequest,
+              timeoutMs: resolveActProxyTimeoutMs(retryRequest),
+            })
+          : await browserToolActionDeps.browserAct(baseUrl, retryRequest, {
+              profile,
+            });
+        params.onTabActivity?.(
+          readStringValue((retryResult as { targetId?: unknown }).targetId) ??
+            readStringValue(retryRequest.targetId),
+        );
+        return jsonResult(retryResult);
       }
       if (!tabs.length) {
         throw new Error(

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2164,7 +2164,7 @@ describe("browser tool external content wrapping", () => {
 describe("browser tool act stale target recovery", () => {
   registerBrowserToolAfterEachReset();
 
-  it("retries safe user-browser act once without targetId when exactly one tab remains", async () => {
+  it("retries a target-independent wait once against the one freshly listed tab", async () => {
     browserActionsMocks.browserAct
       .mockRejectedValueOnce(new Error("404: tab not found"))
       .mockResolvedValueOnce({ ok: true });
@@ -2175,37 +2175,74 @@ describe("browser tool act stale target recovery", () => {
       action: "act",
       profile: "user",
       request: {
-        kind: "hover",
+        kind: "wait",
         targetId: "stale-tab",
-        ref: "btn-1",
+        timeMs: 1,
       },
     });
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
     expect(mockCallArg(browserActionsMocks.browserAct, 0, 0)).toBeUndefined();
-    const firstRequest = mockCallArg<{ kind?: string; ref?: string; targetId?: string }>(
+    const firstRequest = mockCallArg<{ kind?: string; targetId?: string; timeMs?: number }>(
       browserActionsMocks.browserAct,
       0,
       1,
     );
     expect(firstRequest.targetId).toBe("stale-tab");
-    expect(firstRequest.kind).toBe("hover");
-    expect(firstRequest.ref).toBe("btn-1");
+    expect(firstRequest.kind).toBe("wait");
+    expect(firstRequest.timeMs).toBe(1);
     const firstOptions = mockCallArg<{ profile?: string }>(browserActionsMocks.browserAct, 0, 2);
     expect(firstOptions.profile).toBe("user");
 
     expect(mockCallArg(browserActionsMocks.browserAct, 1, 0)).toBeUndefined();
-    const secondRequest = mockCallArg<{ kind?: string; ref?: string; targetId?: string }>(
+    const secondRequest = mockCallArg<{ kind?: string; targetId?: string; timeMs?: number }>(
       browserActionsMocks.browserAct,
       1,
       1,
     );
-    expect(secondRequest.targetId).toBeUndefined();
-    expect(secondRequest.kind).toBe("hover");
-    expect(secondRequest.ref).toBe("btn-1");
+    expect(secondRequest.targetId).toBe("only-tab");
+    expect(secondRequest.kind).toBe("wait");
+    expect(secondRequest.timeMs).toBe(1);
     const secondOptions = mockCallArg<{ profile?: string }>(browserActionsMocks.browserAct, 1, 2);
     expect(secondOptions.profile).toBe("user");
     expect((result?.details as { ok?: unknown } | undefined)?.ok).toBe(true);
+  });
+
+  it("does not rebind ref-scoped or scripted actions to a replacement tab", async () => {
+    browserActionsMocks.browserAct.mockRejectedValue(new Error("404: tab not found"));
+    browserClientMocks.browserTabs.mockResolvedValue([{ targetId: "only-tab" }]);
+    const tool = createBrowserTool();
+
+    for (const request of [
+      { kind: "hover" as const, targetId: "stale-tab", ref: "btn-1" },
+      { kind: "wait" as const, targetId: "stale-tab", fn: "() => true" },
+      { kind: "wait" as const, targetId: "stale-tab", text: "ready" },
+      { kind: "wait" as const, targetId: "stale-tab", url: "**/ready" },
+    ]) {
+      await expect(
+        tool.execute?.("call-1", { action: "act", profile: "user", request }),
+      ).rejects.toThrow(/Run action=tabs profile="user"/i);
+    }
+
+    expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(4);
+  });
+
+  it("preserves a target-independent retry failure", async () => {
+    browserActionsMocks.browserAct
+      .mockRejectedValueOnce(new Error("404: tab not found"))
+      .mockRejectedValueOnce(new Error("wait condition failed"));
+    browserClientMocks.browserTabs.mockResolvedValueOnce([{ targetId: "only-tab" }]);
+    const tool = createBrowserTool();
+
+    await expect(
+      tool.execute?.("call-1", {
+        action: "act",
+        profile: "user",
+        request: { kind: "wait", targetId: "stale-tab", timeMs: 1 },
+      }),
+    ).rejects.toThrow(/wait condition failed/);
+
+    expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(2);
   });
 
   it("retries stale targetIds returned through the node browser proxy", async () => {
@@ -2247,9 +2284,8 @@ describe("browser tool act stale target recovery", () => {
     expect(nodeInvokeCall(1).request.params?.path).toBe("/tabs");
     expect(nodeInvokeCall(2).request.params).toMatchObject({
       path: "/act",
-      body: { kind: "wait", timeMs: 1 },
+      body: { kind: "wait", targetId: "only-tab", timeMs: 1 },
     });
-    expect(nodeInvokeCall(2).request.params?.body).not.toHaveProperty("targetId");
     expect(result?.details).toMatchObject({ ok: true, targetId: "only-tab" });
   });
 

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -8,9 +8,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clickChromeMcpCoords,
   clickChromeMcpElement,
+  closeChromeMcpTab,
+  closeChromeMcpSession,
+  countChromeMcpTabs,
   decodeChromeMcpStderrTail,
+  dragChromeMcpElement,
   ensureChromeMcpAvailable,
   evaluateChromeMcpScript,
+  fillChromeMcpElement,
+  fillChromeMcpForm,
+  hoverChromeMcpElement,
   listChromeMcpTabs,
   navigateChromeMcpPage,
   openChromeMcpTab,
@@ -20,6 +27,7 @@ import {
   setChromeMcpSessionFactoryForTest,
   takeChromeMcpScreenshot,
   takeChromeMcpSnapshot,
+  uploadChromeMcpFile,
 } from "./chrome-mcp.js";
 
 type ToolCall = {
@@ -44,11 +52,21 @@ function createSdkTimeoutCallTool() {
   );
 }
 
+function fakeListPagesResult() {
+  return {
+    content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+  };
+}
+
 type ChromeMcpSessionFactory = Exclude<
   Parameters<typeof setChromeMcpSessionFactoryForTest>[0],
   null
 >;
 type ChromeMcpSession = Awaited<ReturnType<ChromeMcpSessionFactory>>;
+const FAKE_TARGET_1 = "chrome-mcp:000000000001:1";
+const FAKE_TARGET_2 = "chrome-mcp:000000000001:2";
+const FAKE_TARGET_3 = "chrome-mcp:000000000001:3";
+const FAKE_REF = "mcp-ref:000000000001:1";
 
 function createFakeSession(): ChromeMcpSession {
   let currentUrl =
@@ -129,6 +147,20 @@ function createFakeSession(): ChromeMcpSession {
       pid: 123,
     },
     ready: Promise.resolve(),
+    // Legacy cases exercise unrelated call plumbing. Seed one real-shaped
+    // process-scoped routing generation so they stay terse.
+    routing: {
+      sessionNonce: "000000000001",
+      withOperationLock: async <T>(operation: () => Promise<T>) => await operation(),
+      targetIdByPageId: new Map([
+        [1, FAKE_TARGET_1],
+        [2, FAKE_TARGET_2],
+        [3, FAKE_TARGET_3],
+      ]),
+      nextTargetHandleId: 4,
+      snapshotRefById: new Map([[FAKE_REF, { targetId: FAKE_TARGET_1, uid: "btn-1" }]]),
+      nextSnapshotRefId: 2,
+    },
   } as unknown as ChromeMcpSession;
 }
 
@@ -147,6 +179,42 @@ function createToolErrorSession(message: string): ChromeMcpSession {
     transport: {
       pid: 123,
     },
+    ready: Promise.resolve(),
+  } as unknown as ChromeMcpSession;
+}
+
+type SessionPage = { id: number; url: string; selected?: boolean };
+
+function createPageSession(params: {
+  pages: SessionPage[];
+  pid: number;
+  onTool?: (call: ToolCall) => Promise<unknown> | unknown;
+}): ChromeMcpSession {
+  const callTool = vi.fn(async (call: ToolCall) => {
+    const custom = await params.onTool?.(call);
+    if (custom !== undefined) {
+      return custom;
+    }
+    if (call.name === "list_pages") {
+      return {
+        structuredContent: {
+          pages: params.pages.map(({ id, url, selected }) => ({ id, url, selected })),
+        },
+      };
+    }
+    if (call.name === "evaluate_script") {
+      return { content: [{ type: "text", text: "```json\nnull\n```" }] };
+    }
+    throw new Error(`unexpected tool ${call.name}`);
+  });
+  return {
+    client: {
+      callTool,
+      listTools: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+      connect: vi.fn(),
+    },
+    transport: { pid: params.pid },
     ready: Promise.resolve(),
   } as unknown as ChromeMcpSession;
 }
@@ -170,18 +238,703 @@ describe("chrome MCP page parsing", () => {
 
     expect(tabs).toEqual([
       {
-        targetId: "1",
+        targetId: FAKE_TARGET_1,
         title: "",
         url: "https://developer.chrome.com/blog/chrome-devtools-mcp-debug-your-browser-session",
         type: "page",
       },
       {
-        targetId: "2",
+        targetId: FAKE_TARGET_2,
         title: "",
         url: "https://github.com/openclaw/openclaw/pull/45318",
         type: "page",
       },
     ]);
+  });
+
+  it("expires process-scoped targets when the MCP subprocess changes", async () => {
+    let factoryCalls = 0;
+    let evaluateCalls = 0;
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return createPageSession({
+        pid: 120 + factoryCalls,
+        pages: [
+          {
+            id: 1,
+            url: factoryCalls === 1 ? "https://a.example" : "https://decoy.example",
+          },
+        ],
+        onTool: (call) => {
+          if (call.name === "evaluate_script") {
+            evaluateCalls += 1;
+          }
+          return undefined;
+        },
+      });
+    });
+
+    const oldTargetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId;
+    expect(oldTargetId).toMatch(/^chrome-mcp:/);
+    await closeChromeMcpSession("chrome-live");
+
+    await expect(
+      evaluateChromeMcpScript({
+        profileName: "chrome-live",
+        targetId: oldTargetId ?? "",
+        fn: "() => document.body.dataset.marker",
+      }),
+    ).rejects.toThrow(/tab not found/);
+    expect(evaluateCalls).toBe(0);
+
+    const freshTargetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId;
+    expect(freshTargetId).toMatch(/^chrome-mcp:/);
+    expect(freshTargetId).not.toBe(oldTargetId);
+  });
+
+  it("keeps a target stable within one MCP subprocess as its URL and list order change", async () => {
+    const pages: SessionPage[] = [
+      { id: 1, url: "https://a.example/one" },
+      { id: 2, url: "https://b.example" },
+    ];
+    let evaluatedPageId: unknown;
+    const session = createPageSession({
+      pid: 130,
+      pages,
+      onTool: (call) => {
+        if (call.name === "evaluate_script") {
+          evaluatedPageId = call.arguments?.pageId;
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const firstTargetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    pages[0] = { id: 1, url: "https://a.example/two" };
+    pages.reverse();
+    const relisted = await listChromeMcpTabs("chrome-live");
+    expect(relisted.find((tab) => tab.url.endsWith("/two"))?.targetId).toBe(firstTargetId);
+
+    await evaluateChromeMcpScript({
+      profileName: "chrome-live",
+      targetId: firstTargetId,
+      fn: "() => document.URL",
+    });
+    expect(evaluatedPageId).toBe(1);
+    const callTool = session.client.callTool as unknown as ToolCallMock;
+    expect(callTool.mock.calls.filter(([call]) => call.name === "list_pages")).toHaveLength(2);
+  });
+
+  it("routes an opaque target to its numeric page for close without replay", async () => {
+    let closedPageId: unknown;
+    const session = createPageSession({
+      pid: 131,
+      pages: [
+        { id: 1, url: "https://a.example" },
+        { id: 2, url: "https://b.example" },
+      ],
+      onTool: (call) => {
+        if (call.name === "close_page") {
+          closedPageId = call.arguments?.pageId;
+          return { content: [{ type: "text", text: "closed" }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[1]?.targetId ?? "";
+
+    await closeChromeMcpTab("chrome-live", targetId);
+
+    expect(closedPageId).toBe(2);
+    const calls = (session.client.callTool as unknown as ToolCallMock).mock.calls.map(
+      ([call]) => call.name,
+    );
+    expect(calls).toEqual(["list_pages", "close_page"]);
+  });
+
+  it("retires a closed target and issues a new handle when Chrome reuses its page id", async () => {
+    const pages: SessionPage[] = [
+      { id: 1, url: "https://a.example" },
+      { id: 2, url: "https://b.example" },
+    ];
+    let clickCalls = 0;
+    const session = createPageSession({
+      pid: 132,
+      pages,
+      onTool: (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: {
+              snapshot: { id: "uid-b", role: "button", name: "Run B" },
+            },
+          };
+        }
+        if (call.name === "close_page") {
+          const index = pages.findIndex((page) => page.id === call.arguments?.pageId);
+          if (index >= 0) {
+            pages.splice(index, 1);
+          }
+          return { content: [{ type: "text", text: "closed" }] };
+        }
+        if (call.name === "click") {
+          clickCalls += 1;
+          return { content: [{ type: "text", text: "clicked" }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const oldTarget = (await listChromeMcpTabs("chrome-live"))[1]?.targetId ?? "";
+    const snapshot = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId: oldTarget,
+    });
+    await closeChromeMcpTab("chrome-live", oldTarget);
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: oldTarget,
+        uid: snapshot.id ?? "",
+      }),
+    ).rejects.toThrow(/tab not found/i);
+    expect(clickCalls).toBe(0);
+
+    pages.push({ id: 2, url: "https://replacement.example" });
+    const replacement = (await listChromeMcpTabs("chrome-live")).find(
+      (tab) => tab.url === "https://replacement.example",
+    );
+    expect(replacement?.targetId).not.toBe(oldTarget);
+  });
+
+  it("fails closed for duplicate numeric page ids", async () => {
+    setChromeMcpSessionFactoryForTest(async () =>
+      createPageSession({
+        pid: 131,
+        pages: [
+          { id: 1, url: "https://a.example" },
+          { id: 1, url: "https://b.example" },
+        ],
+      }),
+    );
+
+    await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(/duplicate numeric page id 1/);
+  });
+
+  it("serializes compound operations on one MCP session", async () => {
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let listCalls = 0;
+    const session = createPageSession({
+      pid: 132,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: async (call) => {
+        if (call.name !== "list_pages") {
+          return undefined;
+        }
+        listCalls += 1;
+        if (listCalls === 1) {
+          markFirstStarted();
+          await firstGate;
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const first = listChromeMcpTabs("chrome-live");
+    await firstStarted;
+    const second = listChromeMcpTabs("chrome-live");
+    await Promise.resolve();
+    expect(listCalls).toBe(1);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(listCalls).toBe(2);
+  });
+
+  it("fails queued work closed after transport loss and reconnects on the next call", async () => {
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let factoryCalls = 0;
+    let firstSession: ChromeMcpSession | undefined;
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      const session = createPageSession({
+        pid: 135 + factoryCalls,
+        pages: [{ id: 1, url: `https://session-${factoryCalls}.example` }],
+        onTool: async (call) => {
+          if (factoryCalls === 1 && call.name === "list_pages") {
+            markFirstStarted();
+            await firstGate;
+            throw new Error("connection reset after list dispatch");
+          }
+          return undefined;
+        },
+      });
+      firstSession ??= session;
+      return session;
+    });
+
+    const first = listChromeMcpTabs("chrome-live");
+    const firstExpectation = expect(first).rejects.toThrow(/connection reset after list dispatch/);
+    await firstStarted;
+    const queued = listChromeMcpTabs("chrome-live");
+    const queuedExpectation = expect(queued).rejects.toThrow(/changed before the operation/);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    releaseFirst();
+
+    await firstExpectation;
+    await queuedExpectation;
+    await expect(listChromeMcpTabs("chrome-live")).resolves.toEqual([
+      expect.objectContaining({ url: "https://session-2.example" }),
+    ]);
+    expect(factoryCalls).toBe(2);
+    const firstCalls = (firstSession?.client.callTool as unknown as ToolCallMock).mock.calls;
+    expect(firstCalls.filter(([call]) => call.name === "list_pages")).toHaveLength(1);
+  });
+
+  it("stops a session without waiting for a hung active operation", async () => {
+    let markListStarted!: () => void;
+    let rejectList!: (reason: Error) => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const pendingList = new Promise<never>((_resolve, reject) => {
+      rejectList = reject;
+    });
+    const session = createPageSession({
+      pid: 138,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: async (call) => {
+        if (call.name === "list_pages") {
+          markListStarted();
+          return await pendingList;
+        }
+        return undefined;
+      },
+    });
+    const close = vi.mocked(session.client.close).mockImplementation(async () => {
+      rejectList(new Error("session closed by explicit stop"));
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const active = listChromeMcpTabs("chrome-live");
+    const activeExpectation = expect(active).rejects.toThrow(/session closed by explicit stop/);
+    await listStarted;
+
+    await expect(closeChromeMcpSession("chrome-live")).resolves.toBe(true);
+    await activeExpectation;
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let work queued before stop recreate the session", async () => {
+    let markListStarted!: () => void;
+    let releaseList!: () => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    let factoryCalls = 0;
+    let listCalls = 0;
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return createPageSession({
+        pid: 139,
+        pages: [{ id: 1, url: "https://a.example" }],
+        onTool: async (call) => {
+          if (call.name === "list_pages") {
+            listCalls += 1;
+            if (listCalls === 1) {
+              markListStarted();
+              await listGate;
+            }
+          }
+          return undefined;
+        },
+      });
+    });
+
+    const active = listChromeMcpTabs("chrome-live");
+    await listStarted;
+    const queued = listChromeMcpTabs("chrome-live");
+    const queuedExpectation = expect(queued).rejects.toThrow(/changed before the operation/);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(closeChromeMcpSession("chrome-live")).resolves.toBe(true);
+    releaseList();
+    await active;
+    await queuedExpectation;
+    expect(factoryCalls).toBe(1);
+    expect(listCalls).toBe(1);
+  });
+
+  it("fails queued work closed while a transport failure is closing", async () => {
+    let markListStarted!: () => void;
+    let releaseList!: () => void;
+    let markCloseStarted!: () => void;
+    let releaseClose!: () => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const listGate = new Promise<void>((resolve) => {
+      releaseList = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    let factoryCalls = 0;
+    const session = createPageSession({
+      pid: 141,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: async (call) => {
+        if (call.name === "list_pages") {
+          markListStarted();
+          await listGate;
+          throw new Error("transport failed before stop");
+        }
+        return undefined;
+      },
+    });
+    vi.mocked(session.client.close).mockImplementation(async () => {
+      markCloseStarted();
+      await closeGate;
+    });
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return session;
+    });
+
+    const active = listChromeMcpTabs("chrome-live");
+    const activeExpectation = expect(active).rejects.toThrow(/transport failed before stop/);
+    await listStarted;
+    const queued = listChromeMcpTabs("chrome-live");
+    const queuedExpectation = expect(queued).rejects.toThrow(/changed before the operation/);
+    releaseList();
+    await closeStarted;
+
+    await expect(closeChromeMcpSession("chrome-live")).resolves.toBe(false);
+    releaseClose();
+    await activeExpectation;
+    await queuedExpectation;
+    expect(factoryCalls).toBe(1);
+  });
+
+  it("cancels queued admission before dispatch on abort or timeout", async () => {
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let listCalls = 0;
+    const session = createPageSession({
+      pid: 138,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: async (call) => {
+        if (call.name !== "list_pages") {
+          return undefined;
+        }
+        listCalls += 1;
+        if (listCalls === 1) {
+          markFirstStarted();
+          await firstGate;
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const first = listChromeMcpTabs("chrome-live");
+    await firstStarted;
+    const ctrl = new AbortController();
+    const aborted = listChromeMcpTabs("chrome-live", undefined, { signal: ctrl.signal });
+    const timedOut = listChromeMcpTabs("chrome-live", undefined, { timeoutMs: 20 });
+    const abortedExpectation = expect(aborted).rejects.toThrow(/queued caller cancelled/);
+    const timedOutExpectation = expect(timedOut).rejects.toThrow(
+      /timed out after 20ms while waiting/,
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    ctrl.abort(new Error("queued caller cancelled"));
+
+    await abortedExpectation;
+    await timedOutExpectation;
+    expect(listCalls).toBe(1);
+    releaseFirst();
+    await first;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(listCalls).toBe(1);
+  });
+
+  it("wraps snapshot refs and rejects stale or cross-target refs before dispatch", async () => {
+    const clickedUids: unknown[] = [];
+    const session = createPageSession({
+      pid: 140,
+      pages: [
+        { id: 1, url: "https://a.example" },
+        { id: 2, url: "https://b.example" },
+      ],
+      onTool: (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: {
+              snapshot: {
+                id: "root",
+                role: "document",
+                children: [{ id: "1_2", role: "button", name: "Run" }],
+              },
+            },
+          };
+        }
+        if (call.name === "click") {
+          clickedUids.push(call.arguments?.uid);
+          return { content: [{ type: "text", text: "clicked" }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const [targetA, targetB] = (await listChromeMcpTabs("chrome-live")).map((tab) => tab.targetId);
+    const first = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId: targetA ?? "",
+    });
+    const firstRef = first.children?.[0]?.id;
+    expect(firstRef).toMatch(/^mcp-ref:/);
+    await clickChromeMcpElement({
+      profileName: "chrome-live",
+      targetId: targetA ?? "",
+      uid: firstRef ?? "",
+    });
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: targetB ?? "",
+        uid: firstRef ?? "",
+      }),
+    ).rejects.toThrow(/Run a new snapshot/);
+
+    const second = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId: targetA ?? "",
+    });
+    const secondRef = second.children?.[0]?.id;
+    expect(secondRef).not.toBe(firstRef);
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: targetA ?? "",
+        uid: firstRef ?? "",
+      }),
+    ).rejects.toThrow(/Run a new snapshot/);
+    await clickChromeMcpElement({
+      profileName: "chrome-live",
+      targetId: targetA ?? "",
+      uid: secondRef ?? "",
+    });
+    expect(clickedUids).toEqual(["1_2", "1_2"]);
+  });
+
+  it("unwraps current snapshot refs for every ref-scoped MCP adapter", async () => {
+    const session = createPageSession({
+      pid: 141,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: async (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: {
+              snapshot: {
+                id: "root",
+                role: "document",
+                children: [
+                  { id: "uid-a", role: "textbox", name: "A" },
+                  { id: "uid-b", role: "textbox", name: "B" },
+                ],
+              },
+            },
+          };
+        }
+        if (call.name === "take_screenshot") {
+          await fs.writeFile(`${String(call.arguments?.filePath)}.png`, Buffer.from("png"));
+          return { content: [{ type: "text", text: "saved" }] };
+        }
+        if (call.name === "evaluate_script") {
+          return { content: [{ type: "text", text: "```json\nnull\n```" }] };
+        }
+        if (["fill", "fill_form", "hover", "drag", "upload_file"].includes(call.name)) {
+          return { content: [{ type: "text", text: "ok" }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    const snapshot = await takeChromeMcpSnapshot({ profileName: "chrome-live", targetId });
+    const refA = snapshot.children?.[0]?.id ?? "";
+    const refB = snapshot.children?.[1]?.id ?? "";
+
+    await takeChromeMcpScreenshot({ profileName: "chrome-live", targetId, uid: refA });
+    await fillChromeMcpElement({ profileName: "chrome-live", targetId, uid: refA, value: "x" });
+    await fillChromeMcpForm({
+      profileName: "chrome-live",
+      targetId,
+      elements: [
+        { uid: refA, value: "x" },
+        { uid: refB, value: "y" },
+      ],
+    });
+    await hoverChromeMcpElement({ profileName: "chrome-live", targetId, uid: refA });
+    await dragChromeMcpElement({
+      profileName: "chrome-live",
+      targetId,
+      fromUid: refA,
+      toUid: refB,
+    });
+    await uploadChromeMcpFile({
+      profileName: "chrome-live",
+      targetId,
+      uid: refA,
+      filePath: "/tmp/input.txt",
+    });
+    await evaluateChromeMcpScript({
+      profileName: "chrome-live",
+      targetId,
+      fn: "(a, b) => [a, b]",
+      args: [refA, refB],
+    });
+
+    const calls = (session.client.callTool as unknown as ToolCallMock).mock.calls.map(
+      ([call]) => call,
+    );
+    const argsFor = (name: string) => calls.find((call) => call.name === name)?.arguments;
+    expect(argsFor("take_screenshot")).toMatchObject({ pageId: 1, uid: "uid-a" });
+    expect(argsFor("fill")).toMatchObject({ pageId: 1, uid: "uid-a", value: "x" });
+    expect(argsFor("fill_form")).toMatchObject({
+      pageId: 1,
+      elements: [
+        { uid: "uid-a", value: "x" },
+        { uid: "uid-b", value: "y" },
+      ],
+    });
+    expect(argsFor("hover")).toMatchObject({ pageId: 1, uid: "uid-a" });
+    expect(argsFor("drag")).toMatchObject({ pageId: 1, from_uid: "uid-a", to_uid: "uid-b" });
+    expect(argsFor("upload_file")).toMatchObject({
+      pageId: 1,
+      uid: "uid-a",
+      filePath: "/tmp/input.txt",
+    });
+    expect(argsFor("evaluate_script")).toMatchObject({
+      pageId: 1,
+      args: ["uid-a", "uid-b"],
+    });
+  });
+
+  it("rejects a pre-reconnect ref against the freshly listed target", async () => {
+    let factoryCalls = 0;
+    let clickCalls = 0;
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return createPageSession({
+        pid: 141 + factoryCalls,
+        pages: [{ id: 1, url: "https://a.example" }],
+        onTool: (call) => {
+          if (call.name === "take_snapshot") {
+            return {
+              structuredContent: {
+                snapshot: { id: "1_2", role: "button", name: "Run" },
+              },
+            };
+          }
+          if (call.name === "click") {
+            clickCalls += 1;
+          }
+          return undefined;
+        },
+      });
+    });
+
+    const oldTargetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    const snapshot = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId: oldTargetId,
+    });
+    await closeChromeMcpSession("chrome-live");
+    const freshTargetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId: freshTargetId,
+        uid: snapshot.id ?? "",
+      }),
+    ).rejects.toThrow(/Run a new snapshot/);
+    expect(factoryCalls).toBe(2);
+    expect(clickCalls).toBe(0);
+  });
+
+  it("does not replay a mutation after its transport reports an uncertain outcome", async () => {
+    let factoryCalls = 0;
+    let clickCalls = 0;
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return createPageSession({
+        pid: 150 + factoryCalls,
+        pages: [{ id: 1, url: "https://a.example" }],
+        onTool: (call) => {
+          if (call.name === "take_snapshot") {
+            return {
+              structuredContent: {
+                snapshot: { id: "1_2", role: "button", name: "Run" },
+              },
+            };
+          }
+          if (call.name === "click") {
+            clickCalls += 1;
+            throw new Error("connection reset after dispatch");
+          }
+          return undefined;
+        },
+      });
+    });
+
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    const snapshot = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId,
+    });
+    await expect(
+      clickChromeMcpElement({
+        profileName: "chrome-live",
+        targetId,
+        uid: snapshot.id ?? "",
+      }),
+    ).rejects.toThrow(/connection reset after dispatch/);
+    expect(clickCalls).toBe(1);
+    expect(factoryCalls).toBe(1);
+
+    await listChromeMcpTabs("chrome-live");
+    expect(factoryCalls).toBe(2);
   });
 
   it("suggests cdpUrl when auto-connect cannot read DevToolsActivePort", async () => {
@@ -218,7 +971,7 @@ describe("chrome MCP page parsing", () => {
     await expect(
       takeChromeMcpScreenshot({
         profileName: "chrome-live",
-        targetId: "1",
+        targetId: FAKE_TARGET_1,
         format: "jpeg",
       }),
     ).resolves.toEqual(Buffer.from("screenshot:jpeg"));
@@ -415,17 +1168,21 @@ describe("chrome MCP page parsing", () => {
   });
 
   it("parses new_page text responses and returns the created tab", async () => {
-    const factory: ChromeMcpSessionFactory = async () => createFakeSession();
+    const session = createFakeSession();
+    const factory: ChromeMcpSessionFactory = async () => session;
     setChromeMcpSessionFactoryForTest(factory);
 
     const tab = await openChromeMcpTab("chrome-live", "https://example.com/");
 
     expect(tab).toEqual({
-      targetId: "3",
+      targetId: expect.stringMatching(/^chrome-mcp:/),
       title: "",
       url: "https://example.com/",
       type: "page",
     });
+    const calls = (session.client.callTool as unknown as ToolCallMock).mock.calls;
+    expect(calls.map(([call]) => call.name)).toEqual(["new_page", "navigate_page", "list_pages"]);
+    expect(calls[2]?.[2]?.timeout).toBe(25_000);
   });
 
   it("opens about:blank directly without an extra navigate", async () => {
@@ -436,7 +1193,7 @@ describe("chrome MCP page parsing", () => {
     const tab = await openChromeMcpTab("chrome-live", "about:blank");
 
     expect(tab).toEqual({
-      targetId: "3",
+      targetId: expect.stringMatching(/^chrome-mcp:/),
       title: "",
       url: "about:blank",
       type: "page",
@@ -447,7 +1204,55 @@ describe("chrome MCP page parsing", () => {
     });
     const callToolMock = session.client["callTool"] as unknown as ToolCallMock;
     const callNames = callToolMock.mock.calls.map(([call]) => call.name);
-    expect(callNames).not.toContain("navigate_page");
+    expect(callNames).toEqual(["new_page"]);
+  });
+
+  it("preserves unrelated targets and refs when new_page returns only the created page", async () => {
+    let clickedUid: unknown;
+    const session = createPageSession({
+      pid: 160,
+      pages: [{ id: 1, url: "https://a.example" }],
+      onTool: (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: {
+              snapshot: { id: "uid-a", role: "button", name: "Run A" },
+            },
+          };
+        }
+        if (call.name === "new_page") {
+          return {
+            structuredContent: {
+              pages: [{ id: 2, url: "about:blank", selected: true }],
+            },
+          };
+        }
+        if (call.name === "click") {
+          clickedUid = call.arguments?.uid;
+          return { content: [{ type: "text", text: "clicked" }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+
+    const originalTarget = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    const snapshot = await takeChromeMcpSnapshot({
+      profileName: "chrome-live",
+      targetId: originalTarget,
+    });
+    await openChromeMcpTab("chrome-live", "about:blank");
+    await clickChromeMcpElement({
+      profileName: "chrome-live",
+      targetId: originalTarget,
+      uid: snapshot.id ?? "",
+    });
+
+    expect(clickedUid).toBe("uid-a");
+    const calls = (session.client.callTool as unknown as ToolCallMock).mock.calls.map(
+      ([call]) => call.name,
+    );
+    expect(calls).toEqual(["list_pages", "take_snapshot", "new_page", "click"]);
   });
 
   it("parses evaluate_script text responses when structuredContent is missing", async () => {
@@ -456,7 +1261,7 @@ describe("chrome MCP page parsing", () => {
 
     const result = await evaluateChromeMcpScript({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       fn: "() => 123",
     });
 
@@ -466,6 +1271,9 @@ describe("chrome MCP page parsing", () => {
   it("defaults non-finite coordinate click delays before injecting the browser script", async () => {
     const session = createFakeSession();
     const callTool = vi.fn(async ({ name }: ToolCall) => {
+      if (name === "list_pages") {
+        return fakeListPagesResult();
+      }
       if (name === "evaluate_script") {
         return { content: [{ type: "text", text: "```json\nnull\n```" }] };
       }
@@ -476,7 +1284,7 @@ describe("chrome MCP page parsing", () => {
 
     await clickChromeMcpCoords({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       x: 10,
       y: 20,
       delayMs: Number.NaN,
@@ -486,6 +1294,29 @@ describe("chrome MCP page parsing", () => {
     const evaluateCall = callToolMock.mock.calls.find(([call]) => call.name === "evaluate_script");
     const fn = evaluateCall?.[0].arguments?.function;
     expect(typeof fn === "string" ? fn : "").toContain("const delayMs = 0;");
+  });
+
+  it("keeps handle-producing list calls persistent even if a legacy caller passes ephemeral", async () => {
+    let factoryCalls = 0;
+    const session = createFakeSession();
+    const close = vi.mocked(session.client.close);
+    setChromeMcpSessionFactoryForTest(async () => {
+      factoryCalls += 1;
+      return session;
+    });
+    const legacyOptions = { ephemeral: true } as unknown as Parameters<typeof listChromeMcpTabs>[2];
+
+    const targetId = (await listChromeMcpTabs("chrome-live", undefined, legacyOptions))[0]
+      ?.targetId;
+    await expect(
+      evaluateChromeMcpScript({
+        profileName: "chrome-live",
+        targetId: targetId ?? "",
+        fn: "() => 123",
+      }),
+    ).resolves.toBe(123);
+    expect(factoryCalls).toBe(1);
+    expect(close).not.toHaveBeenCalled();
   });
 
   it("does not cache an ephemeral availability probe before the next real attach", async () => {
@@ -539,7 +1370,7 @@ describe("chrome MCP page parsing", () => {
     setChromeMcpSessionFactoryForTest(factory);
 
     await expect(
-      listChromeMcpTabs("chrome-live", undefined, {
+      countChromeMcpTabs("chrome-live", undefined, {
         ephemeral: true,
       }),
     ).rejects.toThrow(/No page selected/);
@@ -558,6 +1389,9 @@ describe("chrome MCP page parsing", () => {
     const factory: ChromeMcpSessionFactory = async () => {
       const session = createFakeSession();
       const callTool = vi.fn(async ({ name }: ToolCall) => {
+        if (name === "list_pages") {
+          return fakeListPagesResult();
+        }
         if (name === "evaluate_script") {
           return {
             content: [
@@ -579,7 +1413,7 @@ describe("chrome MCP page parsing", () => {
     await expect(
       evaluateChromeMcpScript({
         profileName: "chrome-live",
-        targetId: "1",
+        targetId: FAKE_TARGET_1,
         fn: "() => document.getElementById('missing').value",
       }),
     ).rejects.toThrow(/Cannot read properties of null/);
@@ -605,7 +1439,7 @@ describe("chrome MCP page parsing", () => {
     const tabsPromise = listChromeMcpTabs("chrome-live");
     const evalPromise = evaluateChromeMcpScript({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       fn: "() => 123",
     });
 
@@ -1172,7 +2006,11 @@ describe("chrome MCP page parsing", () => {
 
     // First call: tool error (isError: true) — should NOT destroy session
     await expect(
-      evaluateChromeMcpScript({ profileName: "chrome-live", targetId: "1", fn: "() => null" }),
+      evaluateChromeMcpScript({
+        profileName: "chrome-live",
+        targetId: FAKE_TARGET_1,
+        fn: "() => null",
+      }),
     ).rejects.toThrow(/element not found/);
 
     // Second call: should reuse the same session (factory called only once)
@@ -1239,8 +2077,8 @@ describe("chrome MCP page parsing", () => {
     await expect(
       clickChromeMcpElement({
         profileName: "chrome-live",
-        targetId: "1",
-        uid: "btn-1",
+        targetId: FAKE_TARGET_1,
+        uid: FAKE_REF,
         timeoutMs: 25,
       }),
     ).rejects.toThrow(/timed out/i);
@@ -1286,7 +2124,7 @@ describe("chrome MCP page parsing", () => {
     const ctrl = new AbortController();
     const evaluatePromise = evaluateChromeMcpScript({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       fn: "() => window.location.href",
       signal: ctrl.signal,
     });
@@ -1313,8 +2151,8 @@ describe("chrome MCP page parsing", () => {
     await expect(
       clickChromeMcpElement({
         profileName: "chrome-live",
-        targetId: "1",
-        uid: "btn-1",
+        targetId: FAKE_TARGET_1,
+        uid: FAKE_REF,
         signal: ctrl.signal,
       }),
     ).rejects.toThrow(/aborted before click/i);
@@ -1399,7 +2237,7 @@ describe("chrome MCP page parsing", () => {
     expect(factoryCalls).toBe(2);
     expect(tabs).toEqual([
       {
-        targetId: "1",
+        targetId: FAKE_TARGET_1,
         title: "",
         url: "https://example.com",
         type: "page",
@@ -1451,7 +2289,7 @@ describe("chrome MCP page parsing", () => {
 
     await navigateChromeMcpPage({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       url: "https://example.com",
       // intentionally no timeoutMs
     });
@@ -1475,7 +2313,15 @@ describe("chrome MCP page parsing", () => {
       factoryCalls += 1;
       const session = createFakeSession();
       if (factoryCalls === 1) {
-        session.client.callTool = createSdkTimeoutCallTool() as typeof session.client.callTool;
+        const timeoutCall = createSdkTimeoutCallTool();
+        session.client.callTool = vi.fn(
+          async (call: ToolCall, resultSchema?: unknown, options?: { timeout?: number }) => {
+            if (call.name === "list_pages") {
+              return fakeListPagesResult();
+            }
+            return await timeoutCall(call, resultSchema, options);
+          },
+        ) as typeof session.client.callTool;
       }
       return session;
     };
@@ -1484,7 +2330,7 @@ describe("chrome MCP page parsing", () => {
     // Start navigation — will hang.
     const navPromise = navigateChromeMcpPage({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       url: "https://slow-site.example",
     });
     // Suppress unhandled-rejection detection: navPromise rejects during timer
@@ -1508,12 +2354,20 @@ describe("chrome MCP page parsing", () => {
   it("forwards an explicit timeoutMs to take_snapshot through the SDK", async () => {
     vi.useFakeTimers();
     const session = createFakeSession();
-    session.client.callTool = createSdkTimeoutCallTool() as typeof session.client.callTool;
+    const timeoutCall = createSdkTimeoutCallTool();
+    session.client.callTool = vi.fn(
+      async (call: ToolCall, resultSchema?: unknown, options?: { timeout?: number }) => {
+        if (call.name === "list_pages") {
+          return fakeListPagesResult();
+        }
+        return await timeoutCall(call, resultSchema, options);
+      },
+    ) as typeof session.client.callTool;
     setChromeMcpSessionFactoryForTest(async () => session);
 
     const snapshotPromise = takeChromeMcpSnapshot({
       profileName: "chrome-live",
-      targetId: "1",
+      targetId: FAKE_TARGET_1,
       timeoutMs: 75,
     });
     void snapshotPromise.catch(() => {});

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -188,7 +188,7 @@ type SessionPage = { id: number; url: string; selected?: boolean };
 function createPageSession(params: {
   pages: SessionPage[];
   pid: number;
-  onTool?: (call: ToolCall) => Promise<unknown> | unknown;
+  onTool?: (call: ToolCall) => unknown;
 }): ChromeMcpSession {
   const callTool = vi.fn(async (call: ToolCall) => {
     const custom = await params.onTool?.(call);
@@ -322,8 +322,11 @@ describe("chrome MCP page parsing", () => {
       fn: "() => document.URL",
     });
     expect(evaluatedPageId).toBe(1);
-    const callTool = session.client.callTool as unknown as ToolCallMock;
-    expect(callTool.mock.calls.filter(([call]) => call.name === "list_pages")).toHaveLength(2);
+    expect(
+      (session.client.callTool as unknown as ToolCallMock).mock.calls.filter(
+        ([call]) => call.name === "list_pages",
+      ),
+    ).toHaveLength(2);
   });
 
   it("routes an opaque target to its numeric page for close without replay", async () => {
@@ -494,7 +497,9 @@ describe("chrome MCP page parsing", () => {
     await firstStarted;
     const queued = listChromeMcpTabs("chrome-live");
     const queuedExpectation = expect(queued).rejects.toThrow(/changed before the operation/);
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     releaseFirst();
 
     await firstExpectation;
@@ -503,7 +508,10 @@ describe("chrome MCP page parsing", () => {
       expect.objectContaining({ url: "https://session-2.example" }),
     ]);
     expect(factoryCalls).toBe(2);
-    const firstCalls = (firstSession?.client.callTool as unknown as ToolCallMock).mock.calls;
+    if (!firstSession) {
+      throw new Error("Expected the first Chrome MCP session to be created");
+    }
+    const firstCalls = (firstSession.client.callTool as unknown as ToolCallMock).mock.calls;
     expect(firstCalls.filter(([call]) => call.name === "list_pages")).toHaveLength(1);
   });
 
@@ -527,9 +535,10 @@ describe("chrome MCP page parsing", () => {
         return undefined;
       },
     });
-    const close = vi.mocked(session.client.close).mockImplementation(async () => {
+    const close = vi.fn(async () => {
       rejectList(new Error("session closed by explicit stop"));
     });
+    session.client.close = close as typeof session.client.close;
     setChromeMcpSessionFactoryForTest(async () => session);
 
     const active = listChromeMcpTabs("chrome-live");
@@ -574,7 +583,9 @@ describe("chrome MCP page parsing", () => {
     await listStarted;
     const queued = listChromeMcpTabs("chrome-live");
     const queuedExpectation = expect(queued).rejects.toThrow(/changed before the operation/);
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
     await expect(closeChromeMcpSession("chrome-live")).resolves.toBe(true);
     releaseList();
@@ -614,10 +625,11 @@ describe("chrome MCP page parsing", () => {
         return undefined;
       },
     });
-    vi.mocked(session.client.close).mockImplementation(async () => {
+    const close = vi.fn(async () => {
       markCloseStarted();
       await closeGate;
     });
+    session.client.close = close as typeof session.client.close;
     setChromeMcpSessionFactoryForTest(async () => {
       factoryCalls += 1;
       return session;
@@ -674,7 +686,9 @@ describe("chrome MCP page parsing", () => {
     const timedOutExpectation = expect(timedOut).rejects.toThrow(
       /timed out after 20ms while waiting/,
     );
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     ctrl.abort(new Error("queued caller cancelled"));
 
     await abortedExpectation;
@@ -682,7 +696,9 @@ describe("chrome MCP page parsing", () => {
     expect(listCalls).toBe(1);
     releaseFirst();
     await first;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(listCalls).toBe(1);
   });
 
@@ -1299,7 +1315,8 @@ describe("chrome MCP page parsing", () => {
   it("keeps handle-producing list calls persistent even if a legacy caller passes ephemeral", async () => {
     let factoryCalls = 0;
     const session = createFakeSession();
-    const close = vi.mocked(session.client.close);
+    const close = vi.fn().mockResolvedValue(undefined);
+    session.client.close = close as typeof session.client.close;
     setChromeMcpSessionFactoryForTest(async () => {
       factoryCalls += 1;
       return session;

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -14,9 +14,9 @@ import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
 import {
   addTimerTimeoutGraceMs,
-  parseStrictPositiveInteger,
   resolveNonNegativeIntegerOption,
 } from "openclaw/plugin-sdk/number-runtime";
 import {
@@ -54,6 +54,16 @@ type ChromeMcpSession = {
   transport: StdioClientTransport;
   ready: Promise<void>;
   ownsProcessTree?: boolean;
+  routing?: ChromeMcpRoutingState;
+};
+
+type ChromeMcpRoutingState = {
+  sessionNonce: string;
+  withOperationLock: ReturnType<typeof createAsyncLock>;
+  targetIdByPageId: Map<number, string>;
+  nextTargetHandleId: number;
+  snapshotRefById: Map<string, { targetId: string; uid: string }>;
+  nextSnapshotRefId: number;
 };
 
 export type ChromeMcpOperationOptions = {
@@ -161,6 +171,10 @@ const CHROME_CONNECTION_TOOL_ERROR_RE =
   /(?:Could not connect to Chrome|DevToolsActivePort|ECONNREFUSED|ECONNRESET|websocket|timed out)/i;
 const STALE_SELECTED_PAGE_ERROR =
   "The selected page has been closed. Call list_pages to see open pages.";
+const CHROME_MCP_SESSION_TARGET_PREFIX = "chrome-mcp:";
+const CHROME_MCP_SNAPSHOT_REF_PREFIX = "mcp-ref:";
+
+class ChromeMcpReconnectRequiredError extends Error {}
 
 const execFileAsync = promisify(execFile);
 const sessions = new Map<string, ChromeMcpSession>();
@@ -192,21 +206,158 @@ function asPages(value: unknown): ChromeMcpStructuredPage[] {
   return out;
 }
 
-function parsePageId(targetId: string): number {
-  const parsed = parseStrictPositiveInteger(targetId);
-  if (parsed === undefined) {
-    throw new BrowserTabNotFoundError();
-  }
-  return parsed;
+function getChromeMcpRoutingState(session: ChromeMcpSession): ChromeMcpRoutingState {
+  // Routing state lives exactly as long as one stdio subprocess. The compact
+  // nonce expires old handles/refs; the lock keeps remote actions aligned with
+  // local mappings and snapshot refs.
+  session.routing ??= {
+    sessionNonce: randomUUID().replaceAll("-", "").slice(0, 12),
+    withOperationLock: createAsyncLock(),
+    targetIdByPageId: new Map(),
+    nextTargetHandleId: 1,
+    snapshotRefById: new Map(),
+    nextSnapshotRefId: 1,
+  };
+  return session.routing;
 }
 
-function toBrowserTabs(pages: ChromeMcpStructuredPage[]): BrowserTab[] {
-  return pages.map((page) => ({
-    targetId: String(page.id),
-    title: "",
-    url: page.url ?? "",
-    type: "page",
-  }));
+async function withChromeMcpOperationLock<T>(
+  session: ChromeMcpSession,
+  options: ChromeMcpOperationOptions,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const signal = options.signal;
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("aborted");
+  }
+
+  let started = false;
+  let cancelled = false;
+  let cancelReason: Error | undefined;
+  const queued = getChromeMcpRoutingState(session).withOperationLock(async () => {
+    if (cancelled) {
+      throw cancelReason ?? new Error("Chrome MCP operation cancelled before it started.");
+    }
+    started = true;
+    if (signal?.aborted) {
+      throw signal.reason ?? new Error("aborted");
+    }
+    return await operation();
+  });
+
+  const timeoutMs = options.timeoutMs;
+  if (!signal && !(timeoutMs !== undefined && timeoutMs > 0)) {
+    return await queued;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  const cancelBeforeStart = new Promise<never>((_resolve, reject) => {
+    const cancel = (reason: unknown) => {
+      if (started || cancelled) {
+        return;
+      }
+      cancelled = true;
+      cancelReason = toLintErrorObject(reason, "Chrome MCP operation cancelled");
+      reject(cancelReason);
+    };
+    if (signal) {
+      abortListener = () => cancel(signal.reason ?? new Error("aborted"));
+      signal.addEventListener("abort", abortListener, { once: true });
+    }
+    if (timeoutMs !== undefined && timeoutMs > 0) {
+      timer = setTimeout(
+        () =>
+          cancel(
+            new Error(
+              `Chrome MCP operation timed out after ${timeoutMs}ms while waiting for another operation.`,
+            ),
+          ),
+        timeoutMs,
+      );
+      timer.unref?.();
+    }
+  });
+
+  try {
+    return await Promise.race([queued, cancelBeforeStart]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (signal && abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+    if (cancelled) {
+      void queued.catch(() => {});
+    }
+  }
+}
+
+function clearChromeMcpSnapshotRefsForTarget(
+  routing: ChromeMcpRoutingState,
+  targetId: string,
+): void {
+  for (const [refId, ref] of routing.snapshotRefById) {
+    if (ref.targetId === targetId) {
+      routing.snapshotRefById.delete(refId);
+    }
+  }
+}
+
+function updateChromeMcpTargetMappings(
+  routing: ChromeMcpRoutingState,
+  targetIdByPageId: Map<number, string>,
+): void {
+  for (const [pageId, targetId] of routing.targetIdByPageId) {
+    if (!targetIdByPageId.has(pageId)) {
+      clearChromeMcpSnapshotRefsForTarget(routing, targetId);
+    }
+  }
+  routing.targetIdByPageId = targetIdByPageId;
+}
+
+function wrapChromeMcpSnapshotRefs(
+  session: ChromeMcpSession,
+  targetId: string,
+  root: ChromeMcpSnapshotNode,
+): ChromeMcpSnapshotNode {
+  const routing = getChromeMcpRoutingState(session);
+  clearChromeMcpSnapshotRefsForTarget(routing, targetId);
+  const wrappedByUid = new Map<string, string>();
+
+  const visit = (node: ChromeMcpSnapshotNode): ChromeMcpSnapshotNode => {
+    const rawUid = normalizeOptionalString(node.id);
+    let id: string | undefined;
+    if (rawUid) {
+      id = wrappedByUid.get(rawUid);
+      if (!id) {
+        id = `${CHROME_MCP_SNAPSHOT_REF_PREFIX}${routing.sessionNonce}:${routing.nextSnapshotRefId}`;
+        routing.nextSnapshotRefId += 1;
+        wrappedByUid.set(rawUid, id);
+        routing.snapshotRefById.set(id, { targetId, uid: rawUid });
+      }
+    }
+    return {
+      ...node,
+      ...(id ? { id } : {}),
+      ...(node.children ? { children: node.children.map(visit) } : {}),
+    };
+  };
+
+  return visit(root);
+}
+
+function resolveChromeMcpSnapshotRef(
+  session: ChromeMcpSession,
+  targetId: string,
+  refId: string,
+): string {
+  const resolved = getChromeMcpRoutingState(session).snapshotRefById.get(refId);
+  if (!resolved || resolved.targetId !== targetId) {
+    throw new Error(`Unknown ref "${refId}". Run a new snapshot and use a ref from that snapshot.`);
+  }
+  return resolved.uid;
 }
 
 function extractStructuredContent(result: ChromeMcpToolResult): Record<string, unknown> {
@@ -728,7 +879,6 @@ async function createRealSession(
     },
     {},
   );
-
   let getStderr = () => "";
   const ready = (async () => {
     try {
@@ -1205,102 +1355,204 @@ async function leaseSession(
 
 async function callTool(
   profileName: string,
-  profileOptions: ChromeMcpOptionsInput | undefined,
+  profileOptions: NormalizedChromeMcpProfileOptions,
   name: string,
-  args: Record<string, unknown> = {},
-  options: ChromeMcpCallOptions = {},
+  args: Record<string, unknown>,
+  options: ChromeMcpCallOptions,
+  lease: ChromeMcpSessionLease,
 ): Promise<ChromeMcpToolResult> {
   const timeoutMs = options.timeoutMs;
   const signal = options.signal;
   if (signal?.aborted) {
     throw signal.reason ?? new Error("aborted");
   }
-  const normalizedProfileOptions = normalizeChromeMcpOptions(profileOptions);
+  // SDK-owned cancellation removes its request correlation entry. An outer race would return
+  // early while leaving the underlying MCP request pending after a target-browser crash.
+  const request = { name, arguments: args };
+  const rawCall = (
+    (timeoutMs !== undefined && timeoutMs > 0) || signal
+      ? lease.session.client.callTool(request, undefined, {
+          ...(timeoutMs !== undefined && timeoutMs > 0 ? { timeout: timeoutMs } : {}),
+          ...(signal ? { signal } : {}),
+        })
+      : lease.session.client.callTool(request)
+  ) as Promise<ChromeMcpToolResult>;
 
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const lease = await leaseSession(profileName, normalizedProfileOptions, options);
-    // SDK-owned cancellation removes its request correlation entry. An outer race would return
-    // early while leaving the underlying MCP request pending after a target-browser crash.
-    const request = { name, arguments: args };
-    const rawCall = (
-      (timeoutMs !== undefined && timeoutMs > 0) || signal
-        ? lease.session.client.callTool(request, undefined, {
-            ...(timeoutMs !== undefined && timeoutMs > 0 ? { timeout: timeoutMs } : {}),
-            ...(signal ? { signal } : {}),
-          })
-        : lease.session.client.callTool(request)
-    ) as Promise<ChromeMcpToolResult>;
-
-    let result: ChromeMcpToolResult;
-    try {
-      result = await rawCall;
-    } catch (err) {
-      // Transport/connection error, timeout, or abort: tear down session so it reconnects.
-      // Transport-identity check prevents clobbering a replacement session created concurrently.
+  let result: ChromeMcpToolResult;
+  try {
+    result = await rawCall;
+  } catch (err) {
+    // Transport/connection error, timeout, or abort: tear down the cached session.
+    if (!lease.temporary) {
+      const current = sessions.get(lease.cacheKey);
+      if (current?.transport === lease.session.transport) {
+        sessions.delete(lease.cacheKey);
+        await closeChromeMcpSessionHandle(lease.session);
+      }
+    }
+    if (signal?.aborted) {
+      throw toLintErrorObject(signal.reason ?? err, "Non-Error abort reason");
+    }
+    if (timeoutMs && err instanceof McpError && err.code === MCP_REQUEST_TIMEOUT_CODE) {
+      throw new Error(
+        `Chrome MCP "${name}" timed out after ${timeoutMs}ms. Session reset for reconnect.`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+  // Ordinary tool errors leave the session usable. A stale selected-page list
+  // poisons it, so the outer pre-operation list may reconnect once.
+  if (result.isError) {
+    const message = extractToolErrorMessage(result, name);
+    if (shouldReconnectForToolError(name, message)) {
       if (!lease.temporary) {
-        const cur = sessions.get(lease.cacheKey);
-        if (cur?.transport === lease.session.transport) {
+        const current = sessions.get(lease.cacheKey);
+        if (current?.transport === lease.session.transport) {
           sessions.delete(lease.cacheKey);
           await closeChromeMcpSessionHandle(lease.session);
         }
       }
-      if (signal?.aborted) {
-        throw toLintErrorObject(signal.reason ?? err, "Non-Error abort reason");
-      }
-      if (timeoutMs && err instanceof McpError && err.code === MCP_REQUEST_TIMEOUT_CODE) {
-        throw new Error(
-          `Chrome MCP "${name}" timed out after ${timeoutMs}ms. Session reset for reconnect.`,
-          { cause: err },
-        );
-      }
-      throw err;
-    } finally {
-      if (lease.temporary) {
-        await closeChromeMcpSessionHandle(lease.session);
-      }
+      throw new ChromeMcpReconnectRequiredError(message);
     }
-    // Tool-level errors (element not found, script error, etc.) don't indicate a
-    // broken connection. A stale selected-page error does poison the Chrome MCP
-    // session, so reconnect and retry that one once.
-    if (result.isError) {
-      const message = extractToolErrorMessage(result, name);
-      if (shouldReconnectForToolError(name, message)) {
-        if (!lease.temporary) {
-          const cur = sessions.get(lease.cacheKey);
-          if (cur?.transport === lease.session.transport) {
-            sessions.delete(lease.cacheKey);
-            await closeChromeMcpSessionHandle(lease.session);
-          }
-        }
-        if (attempt === 0) {
-          continue;
-        }
-      }
-      throw new Error(
-        formatChromeMcpToolErrorMessage({
-          profileName,
-          options: normalizedProfileOptions,
-          toolName: name,
-          message,
-        }),
-      );
-    }
-    return result;
+    throw new Error(
+      formatChromeMcpToolErrorMessage({
+        profileName,
+        options: profileOptions,
+        toolName: name,
+        message,
+      }),
+    );
   }
-  throw new Error(`Chrome MCP tool "${name}" failed after reconnect.`);
+  return result;
 }
 
 async function callTargetTool(
   params: ChromeMcpTargetOperation,
   name: string,
-  args: Record<string, unknown>,
+  args: Record<string, unknown> | ((session: ChromeMcpSession) => Record<string, unknown>),
 ): Promise<ChromeMcpToolResult> {
-  return await callTool(
+  return await withChromeMcpTarget(params, async (target) => {
+    const resolvedArgs = typeof args === "function" ? args(target.lease.session) : args;
+    return await callTool(
+      params.profileName,
+      target.profileOptions,
+      name,
+      { ...resolvedArgs, pageId: target.pageId },
+      params,
+      target.lease,
+    );
+  });
+}
+
+type ChromeMcpPinnedTarget = {
+  lease: ChromeMcpSessionLease;
+  profileOptions: NormalizedChromeMcpProfileOptions;
+  pageId: number;
+};
+
+async function withChromeMcpLease<T>(
+  profileName: string,
+  profileOptions: ChromeMcpOptionsInput | undefined,
+  options: ChromeMcpCallOptions,
+  operation: (
+    lease: ChromeMcpSessionLease,
+    normalizedProfileOptions: NormalizedChromeMcpProfileOptions,
+  ) => Promise<T>,
+): Promise<T> {
+  const normalizedProfileOptions = normalizeChromeMcpOptions(profileOptions);
+  const lease = await leaseSession(profileName, normalizedProfileOptions, options);
+  try {
+    return await withChromeMcpOperationLock(lease.session, options, async () => {
+      if (!lease.temporary) {
+        const current = sessions.get(lease.cacheKey);
+        if (
+          current?.transport !== lease.session.transport ||
+          lease.session.transport.pid === null
+        ) {
+          forgetCachedChromeMcpSessionIfCurrent(lease.cacheKey, lease.session);
+          throw new BrowserProfileUnavailableError(
+            `Chrome MCP session for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}" changed before the operation could start. Run the browser command again to reconnect.`,
+          );
+        }
+      }
+      return await operation(lease, normalizedProfileOptions);
+    });
+  } finally {
+    if (lease.temporary) {
+      await closeChromeMcpSessionHandle(lease.session);
+    }
+  }
+}
+
+async function listChromeMcpTargetsWithLease(params: {
+  profileName: string;
+  profileOptions: NormalizedChromeMcpProfileOptions;
+  lease: ChromeMcpSessionLease;
+  options: ChromeMcpCallOptions;
+}): Promise<Array<{ page: ChromeMcpStructuredPage; targetId: string }>> {
+  const result = await callTool(
     params.profileName,
-    chromeMcpProfileOptionsFromParams(params),
-    name,
-    args,
+    params.profileOptions,
+    "list_pages",
+    {},
+    params.options,
+    params.lease,
+  );
+  return registerChromeMcpTargets(params.lease.session, extractStructuredPages(result));
+}
+
+function registerChromeMcpTargets(
+  session: ChromeMcpSession,
+  pages: ChromeMcpStructuredPage[],
+  options: { authoritative?: boolean } = {},
+): Array<{ page: ChromeMcpStructuredPage; targetId: string }> {
+  const routing = getChromeMcpRoutingState(session);
+  const targetIdByPageId =
+    options.authoritative === false ? new Map(routing.targetIdByPageId) : new Map<number, string>();
+  const returnedPageIds = new Set<number>();
+  const targets: Array<{ page: ChromeMcpStructuredPage; targetId: string }> = [];
+
+  for (const page of pages) {
+    if (returnedPageIds.has(page.id)) {
+      throw new Error(`Chrome MCP returned duplicate numeric page id ${page.id}.`);
+    }
+    returnedPageIds.add(page.id);
+    let targetId = routing.targetIdByPageId.get(page.id);
+    if (!targetId) {
+      targetId = `${CHROME_MCP_SESSION_TARGET_PREFIX}${routing.sessionNonce}:${routing.nextTargetHandleId}`;
+      routing.nextTargetHandleId += 1;
+    }
+    targetIdByPageId.set(page.id, targetId);
+    targets.push({ page, targetId });
+  }
+  updateChromeMcpTargetMappings(routing, targetIdByPageId);
+  return targets;
+}
+
+async function withChromeMcpTarget<T>(
+  params: ChromeMcpTargetOperation,
+  operation: (target: ChromeMcpPinnedTarget) => Promise<T>,
+): Promise<T> {
+  const profileOptions = chromeMcpProfileOptionsFromParams(params);
+  return await withChromeMcpLease(
+    params.profileName,
+    profileOptions,
     params,
+    async (lease, normalizedProfileOptions) => {
+      const routing = getChromeMcpRoutingState(lease.session);
+      const pageId = [...routing.targetIdByPageId].find(
+        ([, targetId]) => targetId === params.targetId,
+      )?.[0];
+      if (pageId === undefined) {
+        throw new BrowserTabNotFoundError({ input: params.targetId });
+      }
+      return await operation({
+        lease,
+        profileOptions: normalizedProfileOptions,
+        pageId,
+      });
+    },
   );
 }
 
@@ -1314,30 +1566,13 @@ async function withTempFile<T>(fn: (filePath: string) => Promise<T>): Promise<T>
   }
 }
 
-async function findPageById(
-  profileName: string,
-  pageId: number,
-  profileOptions?: string | ChromeMcpProfileOptions,
-  options: ChromeMcpOperationOptions = {},
-): Promise<ChromeMcpStructuredPage> {
-  const pages = await listChromeMcpPages(profileName, profileOptions, options);
-  const page = pages.find((entry) => entry.id === pageId);
-  if (!page) {
-    throw new BrowserTabNotFoundError();
-  }
-  return page;
-}
-
 /** Ensure a Chrome MCP session can be started for the profile. */
 export async function ensureChromeMcpAvailable(
   profileName: string,
   profileOptions?: string | ChromeMcpProfileOptions,
   options: ChromeMcpCallOptions = {},
 ): Promise<void> {
-  const lease = await leaseSession(profileName, profileOptions, options);
-  if (lease.temporary) {
-    await closeChromeMcpSessionHandle(lease.session);
-  }
+  await withChromeMcpLease(profileName, profileOptions, options, async () => {});
 }
 
 /** Return the cached Chrome MCP process pid for a profile, when present. */
@@ -1363,23 +1598,61 @@ async function stopAllChromeMcpSessions(): Promise<void> {
   }
 }
 
-/** List raw Chrome MCP pages for a profile. */
-async function listChromeMcpPages(
-  profileName: string,
-  profileOptions?: string | ChromeMcpProfileOptions,
-  options: ChromeMcpCallOptions = {},
-): Promise<ChromeMcpStructuredPage[]> {
-  const result = await callTool(profileName, profileOptions, "list_pages", {}, options);
-  return extractStructuredPages(result);
-}
-
-/** List Chrome MCP pages converted to BrowserTab records. */
-export async function listChromeMcpTabs(
+async function readChromeMcpTabs(
   profileName: string,
   profileOptions?: string | ChromeMcpProfileOptions,
   options: ChromeMcpCallOptions = {},
 ): Promise<BrowserTab[]> {
-  return toBrowserTabs(await listChromeMcpPages(profileName, profileOptions, options));
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await withChromeMcpLease(
+        profileName,
+        profileOptions,
+        options,
+        async (lease, normalizedProfileOptions) =>
+          (
+            await listChromeMcpTargetsWithLease({
+              profileName,
+              profileOptions: normalizedProfileOptions,
+              lease,
+              options,
+            })
+          ).map(({ page, targetId }) => ({
+            targetId,
+            title: "",
+            url: page.url ?? "",
+            type: "page",
+          })),
+      );
+    } catch (err) {
+      if (err instanceof ChromeMcpReconnectRequiredError && attempt === 0) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  return [];
+}
+
+/** List Chrome MCP pages converted to persistent BrowserTab handles. */
+export async function listChromeMcpTabs(
+  profileName: string,
+  profileOptions?: string | ChromeMcpProfileOptions,
+  options: ChromeMcpOperationOptions = {},
+): Promise<BrowserTab[]> {
+  return await readChromeMcpTabs(profileName, profileOptions, {
+    timeoutMs: options.timeoutMs,
+    signal: options.signal,
+  });
+}
+
+/** Count Chrome MCP pages without returning handles from an ephemeral session. */
+export async function countChromeMcpTabs(
+  profileName: string,
+  profileOptions?: string | ChromeMcpProfileOptions,
+  options: ChromeMcpCallOptions = {},
+): Promise<number> {
+  return (await readChromeMcpTabs(profileName, profileOptions, options)).length;
 }
 
 /** Open a new Chrome MCP tab and navigate it to the requested URL. */
@@ -1389,35 +1662,70 @@ export async function openChromeMcpTab(
   profileOptions?: string | ChromeMcpProfileOptions,
 ): Promise<BrowserTab> {
   const targetUrl = url.trim() || "about:blank";
-  const result = await callTool(profileName, profileOptions, "new_page", {
-    url: "about:blank",
-    timeout: CHROME_MCP_NEW_PAGE_TIMEOUT_MS,
-  });
-  const pages = extractStructuredPages(result);
-  const chosen = pages.find((page) => page.selected) ?? pages.at(-1);
-  if (!chosen) {
-    throw new Error("Chrome MCP did not return the created page.");
-  }
-  const targetId = String(chosen.id);
-  const finalUrl =
-    targetUrl === "about:blank"
-      ? (chosen.url ?? targetUrl)
-      : (
-          await navigateChromeMcpPage({
-            profileName,
-            profile: typeof profileOptions === "string" ? undefined : profileOptions,
-            userDataDir: typeof profileOptions === "string" ? profileOptions : undefined,
-            targetId,
-            url: targetUrl,
-            timeoutMs: CHROME_MCP_NAVIGATE_TIMEOUT_MS,
-          })
-        ).url;
-  return {
-    targetId,
-    title: "",
-    url: finalUrl,
-    type: "page",
-  };
+  return await withChromeMcpLease(
+    profileName,
+    profileOptions,
+    {},
+    async (lease, normalizedProfileOptions) => {
+      const result = await callTool(
+        profileName,
+        normalizedProfileOptions,
+        "new_page",
+        { url: "about:blank", timeout: CHROME_MCP_NEW_PAGE_TIMEOUT_MS },
+        {},
+        lease,
+      );
+      // new_page may return only its created page. Merge that partial response;
+      // only list_pages may prune unrelated live target and ref mappings.
+      const createdPages = registerChromeMcpTargets(lease.session, extractStructuredPages(result), {
+        authoritative: false,
+      });
+      const created = createdPages.find(({ page }) => page.selected) ?? createdPages.at(-1);
+      if (!created) {
+        throw new Error("Chrome MCP did not return the created page.");
+      }
+      if (targetUrl === "about:blank") {
+        return {
+          targetId: created.targetId,
+          title: "",
+          url: created.page.url ?? targetUrl,
+          type: "page",
+        };
+      }
+      const navigateCallTimeoutMs = resolveChromeMcpNavigateCallTimeoutMs(
+        CHROME_MCP_NAVIGATE_TIMEOUT_MS,
+      );
+      await callTool(
+        profileName,
+        normalizedProfileOptions,
+        "navigate_page",
+        {
+          pageId: created.page.id,
+          type: "url",
+          url: targetUrl,
+          timeout: CHROME_MCP_NAVIGATE_TIMEOUT_MS,
+        },
+        { timeoutMs: navigateCallTimeoutMs },
+        lease,
+      );
+      const verified = await listChromeMcpTargetsWithLease({
+        profileName,
+        profileOptions: normalizedProfileOptions,
+        lease,
+        options: { timeoutMs: navigateCallTimeoutMs },
+      });
+      const finalPage = verified.find((entry) => entry.targetId === created.targetId);
+      if (!finalPage) {
+        throw new Error("Chrome MCP created page identity changed before navigation completed.");
+      }
+      return {
+        targetId: created.targetId,
+        title: "",
+        url: finalPage.page.url ?? targetUrl,
+        type: "page",
+      };
+    },
+  );
 }
 
 /** Bring a Chrome MCP page to the foreground. */
@@ -1427,15 +1735,16 @@ export async function focusChromeMcpTab(
   profileOptions?: string | ChromeMcpProfileOptions,
   options: ChromeMcpOperationOptions = {},
 ): Promise<void> {
-  await callTool(
-    profileName,
-    profileOptions,
-    "select_page",
+  await callTargetTool(
     {
-      pageId: parsePageId(targetId),
-      bringToFront: true,
+      profileName,
+      profile: typeof profileOptions === "string" ? undefined : profileOptions,
+      userDataDir: typeof profileOptions === "string" ? profileOptions : undefined,
+      targetId,
+      ...options,
     },
-    options,
+    "select_page",
+    { bringToFront: true },
   );
 }
 
@@ -1446,12 +1755,32 @@ export async function closeChromeMcpTab(
   profileOptions?: string | ChromeMcpProfileOptions,
   options: ChromeMcpOperationOptions = {},
 ): Promise<void> {
-  await callTool(
-    profileName,
-    profileOptions,
-    "close_page",
-    { pageId: parsePageId(targetId) },
-    options,
+  const profile = typeof profileOptions === "string" ? undefined : profileOptions;
+  const userDataDir = typeof profileOptions === "string" ? profileOptions : undefined;
+  await withChromeMcpTarget(
+    {
+      profileName,
+      profile,
+      userDataDir,
+      targetId,
+      ...options,
+    },
+    async (target) => {
+      await callTool(
+        profileName,
+        target.profileOptions,
+        "close_page",
+        { pageId: target.pageId },
+        options,
+        target.lease,
+      );
+      // Retire inside the same operation lock so queued work cannot dispatch
+      // against a closed page id. A later list gets a new opaque handle even if
+      // Chrome reuses that numeric id.
+      const routing = getChromeMcpRoutingState(target.lease.session);
+      routing.targetIdByPageId.delete(target.pageId);
+      clearChromeMcpSnapshotRefsForTarget(routing, targetId);
+    },
   );
 }
 
@@ -1467,25 +1796,34 @@ export async function navigateChromeMcpPage(params: {
 }): Promise<{ url: string }> {
   const resolvedTimeoutMs = params.timeoutMs ?? CHROME_MCP_NAVIGATE_TIMEOUT_MS;
   const callTimeoutMs = resolveChromeMcpNavigateCallTimeoutMs(resolvedTimeoutMs);
-  await callTool(
-    params.profileName,
-    chromeMcpProfileOptionsFromParams(params),
-    "navigate_page",
-    {
-      pageId: parsePageId(params.targetId),
-      type: "url",
-      url: params.url,
-      timeout: resolvedTimeoutMs,
-    },
-    { timeoutMs: callTimeoutMs, signal: params.signal },
-  );
-  const page = await findPageById(
-    params.profileName,
-    parsePageId(params.targetId),
-    chromeMcpProfileOptionsFromParams(params),
-    { timeoutMs: callTimeoutMs, signal: params.signal },
-  );
-  return { url: page.url ?? params.url };
+  return await withChromeMcpTarget({ ...params, timeoutMs: callTimeoutMs }, async (target) => {
+    await callTool(
+      params.profileName,
+      target.profileOptions,
+      "navigate_page",
+      {
+        pageId: target.pageId,
+        type: "url",
+        url: params.url,
+        timeout: resolvedTimeoutMs,
+      },
+      { timeoutMs: callTimeoutMs, signal: params.signal },
+      target.lease,
+    );
+    const pages = await listChromeMcpTargetsWithLease({
+      profileName: params.profileName,
+      profileOptions: target.profileOptions,
+      lease: target.lease,
+      options: { timeoutMs: callTimeoutMs, signal: params.signal },
+    });
+    const page = pages.find((entry) => entry.targetId === params.targetId)?.page;
+    if (!page) {
+      throw new Error(
+        "Chrome MCP tab identity changed while navigation was running; the navigation outcome is unknown.",
+      );
+    }
+    return { url: page.url ?? params.url };
+  });
 }
 
 /** Add call-level grace around the MCP navigate timeout. */
@@ -1497,10 +1835,21 @@ export function resolveChromeMcpNavigateCallTimeoutMs(timeoutMs: number): number
 export async function takeChromeMcpSnapshot(
   params: ChromeMcpTargetOperation,
 ): Promise<ChromeMcpSnapshotNode> {
-  const result = await callTargetTool(params, "take_snapshot", {
-    pageId: parsePageId(params.targetId),
+  return await withChromeMcpTarget(params, async (target) => {
+    const result = await callTool(
+      params.profileName,
+      target.profileOptions,
+      "take_snapshot",
+      { pageId: target.pageId },
+      params,
+      target.lease,
+    );
+    return wrapChromeMcpSnapshotRefs(
+      target.lease.session,
+      params.targetId,
+      extractSnapshot(result),
+    );
   });
-  return extractSnapshot(result);
 }
 
 /** Take a screenshot via Chrome MCP and return the image bytes. */
@@ -1513,13 +1862,14 @@ export async function takeChromeMcpScreenshot(
 ): Promise<Buffer> {
   return await withTempFile(async (filePath) => {
     const format = params.format ?? "png";
-    await callTargetTool(params, "take_screenshot", {
-      pageId: parsePageId(params.targetId),
+    await callTargetTool(params, "take_screenshot", (session) => ({
       filePath,
       format,
-      ...(params.uid ? { uid: params.uid } : {}),
+      ...(params.uid
+        ? { uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.uid) }
+        : {}),
       ...(params.fullPage ? { fullPage: true } : {}),
-    });
+    }));
     return await fs.readFile(`${filePath}.${format}`);
   });
 }
@@ -1531,11 +1881,10 @@ export async function clickChromeMcpElement(
     doubleClick?: boolean;
   },
 ): Promise<void> {
-  await callTargetTool(params, "click", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
+  await callTargetTool(params, "click", (session) => ({
+    uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.uid),
     ...(params.doubleClick ? { dblClick: true } : {}),
-  });
+  }));
 }
 
 /** Dispatch mouse events at page coordinates through an in-page script. */
@@ -1599,11 +1948,10 @@ export async function clickChromeMcpCoords(
 export async function fillChromeMcpElement(
   params: ChromeMcpTargetOperation & { uid: string; value: string },
 ): Promise<void> {
-  await callTargetTool(params, "fill", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
+  await callTargetTool(params, "fill", (session) => ({
+    uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.uid),
     value: params.value,
-  });
+  }));
 }
 
 /** Fill multiple Chrome MCP form elements in one tool call. */
@@ -1612,42 +1960,41 @@ export async function fillChromeMcpForm(
     elements: Array<{ uid: string; value: string }>;
   },
 ): Promise<void> {
-  await callTargetTool(params, "fill_form", {
-    pageId: parsePageId(params.targetId),
-    elements: params.elements,
-  });
+  await callTargetTool(params, "fill_form", (session) => ({
+    elements: params.elements.map((element) => ({
+      ...element,
+      uid: resolveChromeMcpSnapshotRef(session, params.targetId, element.uid),
+    })),
+  }));
 }
 
 /** Hover a Chrome MCP snapshot element by uid. */
 export async function hoverChromeMcpElement(
   params: ChromeMcpTargetOperation & { uid: string },
 ): Promise<void> {
-  await callTargetTool(params, "hover", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-  });
+  await callTargetTool(params, "hover", (session) => ({
+    uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.uid),
+  }));
 }
 
 /** Drag between two Chrome MCP snapshot element uids. */
 export async function dragChromeMcpElement(
   params: ChromeMcpTargetOperation & { fromUid: string; toUid: string },
 ): Promise<void> {
-  await callTargetTool(params, "drag", {
-    pageId: parsePageId(params.targetId),
-    from_uid: params.fromUid,
-    to_uid: params.toUid,
-  });
+  await callTargetTool(params, "drag", (session) => ({
+    from_uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.fromUid),
+    to_uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.toUid),
+  }));
 }
 
 /** Upload a local file into a Chrome MCP file input by uid. */
 export async function uploadChromeMcpFile(
   params: ChromeMcpTargetOperation & { uid: string; filePath: string },
 ): Promise<void> {
-  await callTargetTool(params, "upload_file", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
+  await callTargetTool(params, "upload_file", (session) => ({
+    uid: resolveChromeMcpSnapshotRef(session, params.targetId, params.uid),
     filePath: params.filePath,
-  });
+  }));
 }
 
 /** Press a keyboard key in a Chrome MCP page. */
@@ -1655,7 +2002,6 @@ export async function pressChromeMcpKey(
   params: ChromeMcpTargetOperation & { key: string },
 ): Promise<void> {
   await callTargetTool(params, "press_key", {
-    pageId: parsePageId(params.targetId),
     key: params.key,
   });
 }
@@ -1665,7 +2011,6 @@ export async function resizeChromeMcpPage(
   params: ChromeMcpTargetOperation & { width: number; height: number },
 ): Promise<void> {
   await callTargetTool(params, "resize_page", {
-    pageId: parsePageId(params.targetId),
     width: params.width,
     height: params.height,
   });
@@ -1675,11 +2020,16 @@ export async function resizeChromeMcpPage(
 export async function evaluateChromeMcpScript(
   params: ChromeMcpTargetOperation & { fn: string; args?: string[] },
 ): Promise<unknown> {
-  const result = await callTargetTool(params, "evaluate_script", {
-    pageId: parsePageId(params.targetId),
+  const result = await callTargetTool(params, "evaluate_script", (session) => ({
     function: params.fn,
-    ...(params.args?.length ? { args: params.args } : {}),
-  });
+    ...(params.args?.length
+      ? {
+          args: params.args.map((ref) =>
+            resolveChromeMcpSnapshotRef(session, params.targetId, ref),
+          ),
+        }
+      : {}),
+  }));
   return extractJsonMessage(result);
 }
 

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -9,7 +9,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   clickChromeMcpElement,
   clickChromeMcpCoords,
-  closeChromeMcpTab,
   dragChromeMcpElement,
   evaluateChromeMcpScript,
   fillChromeMcpElement,
@@ -622,12 +621,10 @@ export function registerBrowserAgentActRoutes(
                 return await jsonOk({ result });
               }
               case "close":
-                await closeChromeMcpTab(
-                  profileName,
-                  tab.targetId,
-                  profileCtx.profile,
-                  existingSessionCallOptions,
-                );
+                await profileCtx.closeTab(tab.targetId, {
+                  ...existingSessionCallOptions,
+                  exactTargetId: true,
+                });
                 return await jsonOk();
               case "batch":
                 return jsonActError(

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -143,6 +143,7 @@ function expectExistingSessionProfile(value: unknown) {
 
 describe("existing-session browser routes", () => {
   beforeEach(() => {
+    routeState.profileCtx.closeTab.mockClear();
     routeState.profileCtx.ensureTabAvailable.mockClear();
     routeState.profileCtx.listTabs.mockClear();
     chromeMcpMocks.clickChromeMcpCoords.mockClear();
@@ -241,6 +242,29 @@ describe("existing-session browser routes", () => {
       ssrfPolicy: { allowPrivateNetwork: false },
     });
     expect(chromeMcpMocks.takeChromeMcpSnapshot).toHaveBeenCalled();
+  });
+
+  it("routes close through profile selection state with exact call options", async () => {
+    const handler = getActPostHandler();
+    const response = createBrowserRouteResponse();
+    const ctrl = new AbortController();
+
+    await handler?.(
+      {
+        params: {},
+        query: {},
+        body: { kind: "close", targetId: "7", timeoutMs: 4321 },
+        signal: ctrl.signal,
+      },
+      response.res,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(routeState.profileCtx.closeTab).toHaveBeenCalledWith("7", {
+      exactTargetId: true,
+      signal: ctrl.signal,
+      timeoutMs: undefined,
+    });
   });
 
   it("allows existing-session snapshots under the default SSRF policy object", async () => {

--- a/extensions/browser/src/browser/routes/existing-session.test-support.ts
+++ b/extensions/browser/src/browser/routes/existing-session.test-support.ts
@@ -29,6 +29,7 @@ export const existingSessionRouteState = {
       targetId: "7",
       url: "https://example.com",
     })),
+    closeTab: vi.fn(async () => {}),
   },
   tab: {
     targetId: "7",

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -182,10 +182,10 @@ export function createProfileAvailability({
   ) => {
     await ensureExtensionRelay();
     if (capabilities.usesChromeMcp) {
-      // listChromeMcpTabs creates the session if needed — no separate ensureChromeMcpAvailable call required.
+      // countChromeMcpTabs creates the session if needed — no separate availability call required.
       // Status probes opt into ephemeral so they reuse a cached attach session if one exists,
       // but do not seed a new persistent session as a side effect of read-only status calls.
-      const { listChromeMcpTabs } = await getChromeMcpModule();
+      const { countChromeMcpTabs } = await getChromeMcpModule();
       const callOptions: { timeoutMs?: number; ephemeral?: boolean; signal?: AbortSignal } = {};
       if (timeoutMs != null) {
         callOptions.timeoutMs = timeoutMs;
@@ -196,7 +196,7 @@ export function createProfileAvailability({
       if (options?.signal) {
         callOptions.signal = options.signal;
       }
-      await listChromeMcpTabs(profile.name, profile, callOptions);
+      await countChromeMcpTabs(profile.name, profile, callOptions);
       return true;
     }
     const { httpTimeoutMs, wsTimeoutMs } = resolveTimeouts(timeoutMs);

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -6,6 +6,7 @@ import type { BrowserServerState } from "./server-context.js";
 
 const chromeMcpMock = vi.hoisted(() => ({
   closeChromeMcpSession: vi.fn(async () => true),
+  countChromeMcpTabs: vi.fn(async () => 1),
   ensureChromeMcpAvailable: vi.fn(async () => {}),
   focusChromeMcpTab: vi.fn(async () => {}),
   listChromeMcpTabs: vi.fn(async () => [
@@ -95,6 +96,10 @@ beforeEach(() => {
   ]) {
     vi.stubEnv(key, "");
   }
+  vi.mocked(chromeMcp.listChromeMcpTabs)
+    .mockReset()
+    .mockResolvedValue([{ targetId: "7", title: "", url: "https://example.com", type: "page" }]);
+  vi.mocked(chromeMcp.countChromeMcpTabs).mockReset().mockResolvedValue(1);
   vi.clearAllMocks();
 });
 
@@ -110,7 +115,7 @@ describe("browser server-context existing-session profile", () => {
     const ctx = createBrowserRouteContext({ getState: () => state });
 
     vi.mocked(chromeMcp.ensureChromeMcpAvailable).mockResolvedValueOnce();
-    vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
+    vi.mocked(chromeMcp.countChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
 
     const profiles = await ctx.listProfiles();
     expect(profiles).toHaveLength(1);
@@ -129,16 +134,16 @@ describe("browser server-context existing-session profile", () => {
     expect(ensuredProfile?.driver).toBe("existing-session");
     expect(ensuredProfile?.userDataDir).toBe("/tmp/brave-profile");
     expect(ensureOptions).toEqual({ ephemeral: true, timeoutMs: 300 });
-    const [, listedProfile, listOptions] =
+    const [, countedProfile, countOptions] =
       (
-        vi.mocked(chromeMcp.listChromeMcpTabs).mock.calls as unknown as Array<
+        vi.mocked(chromeMcp.countChromeMcpTabs).mock.calls as unknown as Array<
           [string, ChromeLiveProfile, { ephemeral?: boolean }]
         >
       )[0] ?? [];
-    expect(listedProfile?.name).toBe("chrome-live");
-    expect(listedProfile?.driver).toBe("existing-session");
-    expect(listedProfile?.userDataDir).toBe("/tmp/brave-profile");
-    expect(listOptions).toEqual({ ephemeral: true });
+    expect(countedProfile?.name).toBe("chrome-live");
+    expect(countedProfile?.driver).toBe("existing-session");
+    expect(countedProfile?.userDataDir).toBe("/tmp/brave-profile");
+    expect(countOptions).toEqual({ ephemeral: true });
   });
 
   it("reports endpoint cdpUrl for existing-session profiles", async () => {
@@ -171,7 +176,7 @@ describe("browser server-context existing-session profile", () => {
     const ctx = createBrowserRouteContext({ getState: () => state });
     const live = ctx.forProfile("chrome-live");
 
-    vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
+    vi.mocked(chromeMcp.countChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
 
     const profiles = await ctx.listProfiles();
     expect(profiles).toHaveLength(1);
@@ -270,6 +275,131 @@ describe("browser server-context existing-session profile", () => {
     expect(focusCall?.[2]?.name).toBe("chrome-live");
     expect(focusCall?.[2]?.driver).toBe("existing-session");
     expect(chromeMcp.closeChromeMcpSession).toHaveBeenCalledWith("chrome-live");
+  });
+
+  it("expires Chrome MCP aliases instead of transferring them to a replacement tab", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const originalTab = {
+      targetId: "TARGET-A",
+      title: "Checkout",
+      url: "https://shop.example/checkout",
+      type: "page" as const,
+    };
+    const replacementTab = { ...originalTab, targetId: "TARGET-B" };
+    let currentTabs = [originalTab];
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockImplementation(async () => currentTabs);
+    const state = makeState();
+    const live = createBrowserRouteContext({ getState: () => state }).forProfile("chrome-live");
+
+    await expect(live.listTabs()).resolves.toEqual([
+      expect.objectContaining({ targetId: "TARGET-A", tabId: "t1" }),
+    ]);
+    await live.labelTab("t1", "checkout");
+    await live.ensureTabAvailable("t1");
+
+    currentTabs = [replacementTab];
+    await expect(live.listTabs()).resolves.toEqual([
+      expect.objectContaining({
+        targetId: "TARGET-B",
+        tabId: "t2",
+        suggestedTargetId: "t2",
+      }),
+    ]);
+    await expect(live.ensureTabAvailable()).rejects.toThrow(/tab not found/i);
+    await expect(live.ensureTabAvailable("t1")).rejects.toThrow(/tab not found/i);
+    await expect(live.ensureTabAvailable("checkout")).rejects.toThrow(/tab not found/i);
+    await expect(live.ensureTabAvailable("TARGET-B")).resolves.toEqual(
+      expect.objectContaining({ targetId: "TARGET-B", tabId: "t2" }),
+    );
+  });
+
+  it("allows targetless selection when a fresh Chrome MCP profile has no stale identity", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const freshTab = {
+      targetId: "chrome-mcp:fresh:1",
+      title: "Fresh",
+      url: "https://example.com",
+      type: "page" as const,
+    };
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockResolvedValue([freshTab]);
+    const state = makeState();
+    const live = createBrowserRouteContext({ getState: () => state }).forProfile("chrome-live");
+
+    await expect(live.ensureTabAvailable()).resolves.toEqual(
+      expect.objectContaining({ targetId: "chrome-mcp:fresh:1", tabId: "t1" }),
+    );
+    expect(state.profiles.get("chrome-live")?.lastTargetId).toBe("chrome-mcp:fresh:1");
+  });
+
+  it("clears only the sticky Chrome MCP target after a successful close", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const tabA = {
+      targetId: "chrome-mcp:fresh:1",
+      title: "A",
+      url: "https://a.example",
+      type: "page" as const,
+    };
+    const tabB = {
+      targetId: "chrome-mcp:fresh:2",
+      title: "B",
+      url: "https://b.example",
+      type: "page" as const,
+    };
+    let currentTabs = [tabA, tabB];
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockImplementation(async () => currentTabs);
+    const state = makeState();
+    const live = createBrowserRouteContext({ getState: () => state }).forProfile("chrome-live");
+
+    await live.ensureTabAvailable(tabA.targetId);
+    await live.closeTab(tabA.targetId);
+    expect(chromeMcp.closeChromeMcpTab).toHaveBeenNthCalledWith(
+      1,
+      "chrome-live",
+      tabA.targetId,
+      expect.objectContaining({ driver: "existing-session" }),
+      undefined,
+    );
+    currentTabs = [tabB];
+    await expect(live.ensureTabAvailable()).resolves.toEqual(
+      expect.objectContaining({ targetId: tabB.targetId }),
+    );
+
+    currentTabs = [tabA, tabB];
+    await live.ensureTabAvailable(tabA.targetId);
+    await live.closeTab(tabB.targetId);
+    expect(chromeMcp.closeChromeMcpTab).toHaveBeenNthCalledWith(
+      2,
+      "chrome-live",
+      tabB.targetId,
+      expect.objectContaining({ driver: "existing-session" }),
+      undefined,
+    );
+    currentTabs = [tabA];
+    await expect(live.ensureTabAvailable()).resolves.toEqual(
+      expect.objectContaining({ targetId: tabA.targetId }),
+    );
+  });
+
+  it("keeps the sticky Chrome MCP target when close fails", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const tab = {
+      targetId: "chrome-mcp:fresh:1",
+      title: "A",
+      url: "https://a.example",
+      type: "page" as const,
+    };
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockResolvedValue([tab]);
+    vi.mocked(chromeMcp.closeChromeMcpTab).mockRejectedValueOnce(new Error("close failed"));
+    const state = makeState();
+    const live = createBrowserRouteContext({ getState: () => state }).forProfile("chrome-live");
+
+    await live.ensureTabAvailable(tab.targetId);
+    await expect(live.closeTab(tab.targetId)).rejects.toThrow(/close failed/);
+
+    expect(state.profiles.get("chrome-live")?.lastTargetId).toBe(tab.targetId);
+    await expect(live.ensureTabAvailable()).resolves.toEqual(
+      expect.objectContaining({ targetId: tab.targetId }),
+    );
   });
 
   it("surfaces DevToolsActivePort attach failures instead of a generic tab timeout", async () => {

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -201,6 +201,11 @@ export function createProfileSelectionOps({
       if (lastResolved && lastResolved !== "AMBIGUOUS") {
         return lastResolved;
       }
+      // Chrome MCP identity is authoritative. Once a selected target disappears,
+      // require a fresh explicit choice instead of guessing another tab.
+      if (last && capabilities.usesChromeMcp) {
+        return null;
+      }
       // Prefer a real page tab first (avoid service workers/background targets).
       const page = candidates.find((t) => (t.type ?? "page") === "page");
       return page ?? candidates.at(0) ?? null;
@@ -222,7 +227,7 @@ export function createProfileSelectionOps({
     targetId: string,
     options?: BrowserTabTargetOptions,
   ): Promise<string> => {
-    const tabs = await listTabs();
+    const tabs = await listTabs(options);
     if (options?.exactTargetId) {
       const exactTarget = tabs.find((tab) => tab.targetId === targetId);
       if (!exactTarget) {
@@ -245,7 +250,7 @@ export function createProfileSelectionOps({
 
     if (capabilities.usesChromeMcp) {
       const { focusChromeMcpTab } = await getChromeMcpModule();
-      await focusChromeMcpTab(profile.name, resolvedTargetId, profile);
+      await focusChromeMcpTab(profile.name, resolvedTargetId, profile, options);
       const profileState = getProfileState();
       profileState.lastTargetId = resolvedTargetId;
       return;
@@ -282,31 +287,40 @@ export function createProfileSelectionOps({
 
     if (capabilities.usesChromeMcp) {
       const { closeChromeMcpTab } = await getChromeMcpModule();
-      await closeChromeMcpTab(profile.name, resolvedTargetId, profile);
-      return;
-    }
+      await closeChromeMcpTab(profile.name, resolvedTargetId, profile, options);
+    } else {
+      let closedViaPlaywright = false;
+      // For remote profiles, use Playwright's persistent connection to close tabs.
+      if (capabilities.usesPersistentPlaywright) {
+        const mod = await getPwAiModule({ mode: "strict" });
+        const closePageByTargetIdViaPlaywright = (mod as Partial<PwAiModule> | null)
+          ?.closePageByTargetIdViaPlaywright;
+        if (typeof closePageByTargetIdViaPlaywright === "function") {
+          await closePageByTargetIdViaPlaywright({
+            cdpUrl: profile.cdpUrl,
+            targetId: resolvedTargetId,
+            ssrfPolicy: getCdpControlPolicy(),
+          });
+          closedViaPlaywright = true;
+        }
+      }
 
-    // For remote profiles, use Playwright's persistent connection to close tabs
-    if (capabilities.usesPersistentPlaywright) {
-      const mod = await getPwAiModule({ mode: "strict" });
-      const closePageByTargetIdViaPlaywright = (mod as Partial<PwAiModule> | null)
-        ?.closePageByTargetIdViaPlaywright;
-      if (typeof closePageByTargetIdViaPlaywright === "function") {
-        await closePageByTargetIdViaPlaywright({
-          cdpUrl: profile.cdpUrl,
-          targetId: resolvedTargetId,
-          ssrfPolicy: getCdpControlPolicy(),
-        });
-        return;
+      if (!closedViaPlaywright) {
+        await fetchOk(
+          appendCdpPath(cdpHttpBase, `/json/close/${resolvedTargetId}`),
+          undefined,
+          undefined,
+          getCdpControlPolicy(),
+        );
       }
     }
 
-    await fetchOk(
-      appendCdpPath(cdpHttpBase, `/json/close/${resolvedTargetId}`),
-      undefined,
-      undefined,
-      getCdpControlPolicy(),
-    );
+    const profileState = getProfileState();
+    if (profileState.lastTargetId === resolvedTargetId) {
+      // Retire only the closed sticky identity; otherwise an unprovable session
+      // handle can block every later targetless action.
+      profileState.lastTargetId = null;
+    }
   };
 
   return {

--- a/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
+++ b/extensions/browser/src/browser/server-context.stop-running-browser.test.ts
@@ -19,6 +19,7 @@ vi.mock("./chrome.js", () => ({
 }));
 vi.mock("./chrome-mcp.js", () => ({
   closeChromeMcpSession: vi.fn(async () => false),
+  countChromeMcpTabs: vi.fn(async () => 0),
   ensureChromeMcpAvailable: vi.fn(async () => {}),
   listChromeMcpTabs: vi.fn(async () => []),
 }));

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -135,7 +135,11 @@ function isConfidentReplacement(params: {
   return params.staleCount === 1 && params.newCandidateCount === 1;
 }
 
-function assignTabAliases(profileState: ProfileRuntimeState, tabs: BrowserTab[]): BrowserTab[] {
+function assignTabAliases(
+  profileState: ProfileRuntimeState,
+  tabs: BrowserTab[],
+  migrateReplacements: boolean,
+): BrowserTab[] {
   const aliases = getTabAliasState(profileState);
   const liveTargetIds = new Set(tabs.map((tab) => tab.targetId));
   const staleEntries = Object.entries(aliases.byTargetId).filter(
@@ -144,25 +148,27 @@ function assignTabAliases(profileState: ProfileRuntimeState, tabs: BrowserTab[])
   const newCandidates = tabs.filter((tab) => !aliases.byTargetId[tab.targetId]);
   const claimedTargetIds = new Set<string>();
 
-  for (const [oldTargetId, staleEntry] of staleEntries) {
-    const candidate = newCandidates.find(
-      (tab) =>
-        !claimedTargetIds.has(tab.targetId) &&
-        isConfidentReplacement({
-          staleEntry,
-          tab,
-          staleCount: staleEntries.length,
-          newCandidateCount: newCandidates.length,
-        }),
-    );
-    if (!candidate) {
-      continue;
-    }
-    aliases.byTargetId[candidate.targetId] = staleEntry;
-    delete aliases.byTargetId[oldTargetId];
-    claimedTargetIds.add(candidate.targetId);
-    if (profileState.lastTargetId === oldTargetId) {
-      profileState.lastTargetId = candidate.targetId;
+  if (migrateReplacements) {
+    for (const [oldTargetId, staleEntry] of staleEntries) {
+      const candidate = newCandidates.find(
+        (tab) =>
+          !claimedTargetIds.has(tab.targetId) &&
+          isConfidentReplacement({
+            staleEntry,
+            tab,
+            staleCount: staleEntries.length,
+            newCandidateCount: newCandidates.length,
+          }),
+      );
+      if (!candidate) {
+        continue;
+      }
+      aliases.byTargetId[candidate.targetId] = staleEntry;
+      delete aliases.byTargetId[oldTargetId];
+      claimedTargetIds.add(candidate.targetId);
+      if (profileState.lastTargetId === oldTargetId) {
+        profileState.lastTargetId = candidate.targetId;
+      }
     }
   }
 
@@ -267,7 +273,9 @@ export function createProfileTabOps({
 
   const listTabs = async (options?: BrowserOperationOptions): Promise<BrowserTab[]> => {
     const tabs = await readTabs(options);
-    return assignTabAliases(getProfileState(), tabs);
+    // Chrome MCP target identity is authoritative. A replacement tab cannot
+    // inherit an alias safely, even when its URL matches the closed tab.
+    return assignTabAliases(getProfileState(), tabs, !capabilities.usesChromeMcp);
   };
 
   const enforceManagedTabLimit = async (keepTargetId: string): Promise<void> => {

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -25,7 +25,6 @@ import { createProfileTabOps } from "./server-context.tab-ops.js";
 import type {
   BrowserServerState,
   BrowserRouteContext,
-  BrowserTab,
   ContextOptions,
   ProfileContext,
   ProfileRuntimeState,

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -8,7 +8,7 @@ import {
 } from "./cdp-reachability-policy.js";
 import { usesFastLoopbackCdpProbeClass } from "./cdp-timeouts.js";
 import { redactCdpUrl } from "./cdp.helpers.js";
-import { listChromeMcpTabs } from "./chrome-mcp.js";
+import { countChromeMcpTabs } from "./chrome-mcp.js";
 import { isChromeReachable, resolveOpenClawUserDataDir } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { resolveProfile } from "./config.js";
@@ -189,10 +189,9 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
         try {
           running = await profileCtx.isTransportAvailable(300);
           if (running) {
-            const tabs = await listChromeMcpTabs(profile.name, profile, {
+            tabCount = await countChromeMcpTabs(profile.name, profile, {
               ephemeral: true,
-            }).catch(() => [] as BrowserTab[]);
-            tabCount = tabs.filter((t) => t.type === "page").length;
+            }).catch(() => 0);
           }
         } catch {
           // Chrome MCP not available

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -11,7 +11,7 @@ import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
 
 export type { BrowserTab };
 
-export type BrowserTabTargetOptions = {
+export type BrowserTabTargetOptions = BrowserOperationOptions & {
   /** Resolve only the raw target-id namespace for an id already selected internally. */
   exactTargetId?: true;
 };


### PR DESCRIPTION
Closes #103575

## What Problem This Solves

Fixes an issue where agents using a Chrome MCP existing-session browser could act on the wrong tab or element after the MCP subprocess reconnected and reused its process-local numeric page or snapshot IDs.

## Why This Change Was Made

Chrome MCP targets are now opaque handles scoped to one subprocess and one page lifecycle, while snapshot refs are scoped to that target's latest snapshot. Routing-sensitive operations are serialized, stale queued work fails before dispatch, old aliases are not transferred across MCP replacement, and mutation failures are never replayed automatically.

The refactor also keeps ephemeral status probes count-only, merges partial `new_page` responses without pruning unrelated tabs, and retires a closed target/ref atomically. Managed CDP and remote Playwright behavior remain unchanged. The narrower upstream case where Chrome DevTools MCP replaces `McpContext` inside a surviving process is documented as a residual; fully atomic coverage there requires upstream stable target routing.

## User Impact

After a Chrome MCP reconnect, agents must relist tabs and take a fresh snapshot before reusing target-specific refs. Stale handles now fail closed with actionable guidance instead of silently binding to a different tab or element; normal fresh tab, snapshot, and action workflows continue to work.

## Evidence

- Exact rebased head: `87bad7358e1`
- Focused regression suite: 5 files, 179 tests passed
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome-mcp.test.ts extensions/browser/src/browser/server-context.existing-session.test.ts extensions/browser/src/browser/server-context.stop-running-browser.test.ts extensions/browser/src/browser/routes/agent.existing-session.test.ts extensions/browser/src/browser-tool.test.ts`
- Incremental build passed: `node scripts/tsdown-build.mjs --no-clean`
- Targeted `oxlint` passed for the changed production/test files.
- `git diff --check` passed
- Fresh local autoreview and independent lifecycle review reported no actionable findings.
- Live proof against source digest `1e6277e77fd387a3c94998bd91779d522075120c09cf5356ecf2970d32d48b7e`:
  - real Google Chrome plus `chrome-devtools-mcp` 1.5.0
  - real OpenClaw Gateway and OpenAI `openai/gpt-5.4` agent turns
  - MCP PID changed while raw Chrome A/B target IDs stayed alive
  - saved pre-reconnect alias rejected
  - saved pre-reconnect ref caused zero side effects
  - fresh tab selection plus fresh snapshot ref clicked A exactly once
  - B remained untouched and final Gateway health passed

AI-assisted: yes. I reviewed the full implementation, upstream Chrome DevTools MCP 1.5.0 routing contract, tests, and live proof.
