### PR TITLE
fix(agents): pass attemptNumber instead of apiKeyIndex to retry callbacks (#102938)

### DIFF
--- a/src/agents/api-key-rotation.test.ts
+++ b/src/agents/api-key-rotation.test.ts
@@ -312,4 +312,41 @@ describe("executeWithApiKeyRotation", () => {
       }),
     );
   });
+
+  it("passes apiKeyIndex and attemptNumber to rotation callbacks", async () => {
+    const shouldRetry = vi.fn(() => true);
+    const onRetry = vi.fn();
+    const execute = vi
+      .fn<(apiKey: string) => Promise<string>>()
+      .mockRejectedValueOnce(new Error("Rate limit"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      executeWithApiKeyRotation({
+        provider: "openai",
+        apiKeys: ["key-1", "key-2"],
+        shouldRetry,
+        onRetry,
+        execute,
+      }),
+    ).resolves.toBe("ok");
+
+    // shouldRetry receives apiKeyIndex (0) and attemptNumber (1)
+    expect(shouldRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        apiKeyIndex: 0,
+        attemptNumber: 1,
+      }),
+    );
+
+    // onRetry receives apiKeyIndex (0) and attemptNumber (1)
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 0,
+        apiKeyIndex: 0,
+        attemptNumber: 1,
+      }),
+    );
+  });
 });

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -18,7 +18,12 @@ import { collectProviderApiKeys, isApiKeyRateLimitError } from "./live-auth-keys
 type ApiKeyRetryParams = {
   apiKey: string;
   error: unknown;
+  /** @deprecated Use apiKeyIndex for key-rotation position or attemptNumber for per-key retry count. */
   attempt: number;
+  /** Zero-based index of the current key in the rotation array. */
+  apiKeyIndex: number;
+  /** One-based attempt count for the current key (resets to 1 when rotating to a new key). */
+  attemptNumber: number;
 };
 
 type ExecuteWithApiKeyRotationOptions<T> = {
@@ -65,7 +70,14 @@ export async function executeWithApiKeyRotation<T>(
         lastError = error;
         const message = formatErrorMessage(error);
         const rotateKey = params.shouldRetry
-          ? params.shouldRetry({ apiKey, error, attempt: apiKeyIndex, message })
+          ? params.shouldRetry({
+              apiKey,
+              error,
+              attempt: apiKeyIndex,
+              apiKeyIndex,
+              attemptNumber,
+              message,
+            })
           : isApiKeyRateLimitError(message);
 
         if (rotateKey) {
@@ -74,7 +86,14 @@ export async function executeWithApiKeyRotation<T>(
           if (apiKeyIndex + 1 >= keys.length) {
             break;
           }
-          params.onRetry?.({ apiKey, error, attempt: apiKeyIndex, message });
+          params.onRetry?.({
+            apiKey,
+            error,
+            attempt: apiKeyIndex,
+            apiKeyIndex,
+            attemptNumber,
+            message,
+          });
           break;
         }
 


### PR DESCRIPTION
## Summary

- Add explicit `apiKeyIndex` (0-based key position) and `attemptNumber` (1-based per-key retry count) fields to `ApiKeyRetryParams` rotation callbacks.
- Preserve existing `attempt` field for backward compatibility, marking it as `@deprecated`.
- Add regression test verifying both fields are passed correctly.

## What Problem This Solves

In `src/agents/api-key-rotation.ts`, `executeWithApiKeyRotation` executes operations with key rotation and same-key retries. The `shouldRetry` and `onRetry` callbacks receive `{ apiKey, error, attempt, message }`, but `attempt` tracks the key-rotation position (0-based index), not the per-key retry count. This prevents custom retry logic from accurately calculating retry backoffs or logging the actual attempt number.

Changing `attempt` semantics would break existing plugin consumers. Instead, add explicit fields while preserving backward compatibility.

## User Impact

- **Why it matters / User impact:** Custom retry logic can now use `apiKeyIndex` for key-rotation position and `attemptNumber` for per-key retry count, without breaking existing code that uses `attempt`.
- **What did NOT change:** The existing `attempt` field behavior is preserved. The key rotation logic, transient retry logic, and error handling are unchanged.
- **Architecture / source-of-truth check:** The `ApiKeyRetryParams` type now has three fields: `attempt` (deprecated, same as `apiKeyIndex`), `apiKeyIndex` (0-based key position), and `attemptNumber` (1-based per-key retry count).

## Origin / follow-up

Fixes #102938. The issue reports that `apiKeyIndex` is passed as `attempt` instead of `attemptNumber`.

## Competition / linked PR analysis

No overlapping PRs found.

## Real behavior proof

- **Behavior or issue addressed:** Rotation callbacks now receive explicit `apiKeyIndex` and `attemptNumber` fields alongside the existing `attempt` field.
- **Real environment tested:** Local worktree on Node v22.22.0, using real `executeWithApiKeyRotation` with mocked callbacks.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/agents/api-key-rotation.test.ts
```

- **Evidence after fix:**

```json
{
  "proof": "api-key-retry-attempt",
  "boundary": "executeWithApiKeyRotation rotation callbacks",
  "caller": "src/agents/api-key-rotation.ts",
  "fix": "add apiKeyIndex and attemptNumber fields, preserve attempt",
  "backwardCompatible": true
}
```

```text
Test Files  1 passed (1)
Tests  20 passed (20)
```

- **Observed result after fix:** `shouldRetry` and `onRetry` callbacks receive `{ attempt: 0, apiKeyIndex: 0, attemptNumber: 1 }`. Existing code using `attempt` continues to work. New code can use `apiKeyIndex` or `attemptNumber`.
- **What was not tested:** A live provider API call with real retry logic was not run. The fix was validated through unit tests covering the callback parameters.
- **Fix classification:** Root cause fix (additive, backward-compatible)

## Regression Test Plan

- **Target test file:** `src/agents/api-key-rotation.test.ts`
- **Scenario locked in:** Rotation callbacks receive `apiKeyIndex` (0-based) and `attemptNumber` (1-based) alongside existing `attempt`.
- **Why this is the smallest reliable guardrail:** Tests directly assert callback parameters for both `shouldRetry` and `onRetry`.

## Merge risk

- **Risk labels considered:** Low risk — additive change with backward compatibility.
- **Risk explanation:** New fields are added to the callback params. Existing code using `attempt` continues to work unchanged.
- **Why acceptable:** The change is purely additive. No existing behavior is changed.

## What was not changed

- Key rotation logic was not changed.
- Transient retry logic was not changed.
- Error handling was not changed.
- Existing `attempt` field behavior was not changed (only marked as deprecated).