### PR TITLE
test: prevent startup mocks from poisoning co-sharded logging

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -171,9 +171,13 @@ vi.mock("../infra/is-main.js", () => ({
   isMainModule: () => false,
 }));
 
-vi.mock("../logging/console.js", () => ({
-  routeLogsToStderr: () => mockState.routeLogsToStderr(),
-}));
+vi.mock("../logging/console.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/console.js")>();
+  return {
+    ...actual,
+    routeLogsToStderr: () => mockState.routeLogsToStderr(),
+  };
+});
 
 vi.mock("../state/openclaw-state-db.js", () => ({
   closeOpenClawStateDatabase: () => mockState.closeOpenClawStateDatabase(),
@@ -339,6 +343,14 @@ describe("serveAcpGateway startup", () => {
         password: undefined,
       },
     });
+  });
+
+  it("preserves console exports for a co-sharded subsystem logger", async () => {
+    const { createSubsystemLogger } = await import("../logging/subsystem.js");
+
+    expect(() =>
+      createSubsystemLogger("test/acp-startup").isEnabled("info", "console"),
+    ).not.toThrow();
   });
 
   it("waits for gateway hello before creating AgentSideConnection", async () => {

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -9,9 +9,13 @@ vi.mock("./banner.js", () => ({
   emitCliBanner: emitCliBannerMock,
 }));
 
-vi.mock("../logging/console.js", () => ({
-  routeLogsToStderr: routeLogsToStderrMock,
-}));
+vi.mock("../logging/console.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/console.js")>();
+  return {
+    ...actual,
+    routeLogsToStderr: routeLogsToStderrMock,
+  };
+});
 
 vi.mock("./command-bootstrap.js", () => ({
   ensureCliCommandBootstrap: ensureCliCommandBootstrapMock,
@@ -24,6 +28,14 @@ describe("command-execution-startup", () => {
     vi.clearAllMocks();
     vi.resetModules();
     mod = await import("./command-execution-startup.js");
+  });
+
+  it("preserves console exports for a co-sharded subsystem logger", async () => {
+    const { createSubsystemLogger } = await import("../logging/subsystem.js");
+
+    expect(() =>
+      createSubsystemLogger("test/cli-startup").isEnabled("info", "console"),
+    ).not.toThrow();
   });
 
   it("resolves startup context from argv and mode", () => {


### PR DESCRIPTION
## Summary

Preserve the real `logging/console.js` module surface in the CLI and ACP startup tests while overriding only `routeLogsToStderr`.

## Issue / Motivation

The two startup suites used partial `vi.mock` factories that removed every console export except `routeLogsToStderr`. Under Vitest's shared-worker/co-sharded execution, a later subsystem logger could receive that poisoned module and fail when it called `getConsoleSettings`.

## Changes

- Convert both partial console mocks to typed `importOriginal` spreads.
- Keep the existing `routeLogsToStderr` spies unchanged.
- Add a regression in each suite that imports a subsystem logger in the same worker and exercises its console settings path.

## Testing

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/command-execution-startup.test.ts src/acp/server.startup.test.ts src/skills/workshop/tool-policy-diagnostic.test.ts` — 38 passed across 3 files / 2 Vitest shards.
- `CI=true node scripts/test-projects.mjs --changed origin/main` — 28 passed across the 2 changed Vitest shards.
- `./node_modules/.bin/oxfmt --check --threads=1 src/cli/command-execution-startup.test.ts src/acp/server.startup.test.ts` — clean.
- `./node_modules/.bin/oxlint src/cli/command-execution-startup.test.ts src/acp/server.startup.test.ts` — 0 warnings, 0 errors.
- `git diff --check origin/main...HEAD` — clean.
- Committed-diff secret scan — clean.

### Maintainer reproduction and current-main proof

- Before: unit-fast sequence seed 2, with `src/acp/server.startup.test.ts` co-sharded with the five reported agent victim files, failed 5 files / 8 tests because the partial mock omitted `getConsoleSettings`.
- After: the same current-main co-shard and seed passed 56/56 tests, repeated five consecutive times for 280/280 total.
- Full current unit-fast project: 1,198/1,198 files green once. A second repetition stopped only on the independent memory-host remote-fetch mock leak already reproducible on unmodified main; no agent victim failed after this patch.
- Fresh exact PR-head CI: https://github.com/openclaw/openclaw/actions/runs/29081309646
- Fresh Workflow Sanity: https://github.com/openclaw/openclaw/actions/runs/29081309665

## What Problem This Solves

Co-sharded tests can safely log through `createSubsystemLogger` after either startup suite runs. The startup tests still observe calls to `routeLogsToStderr`, but no longer hide `getConsoleSettings` or other production exports from tests sharing the worker.

## Evidence

Each affected suite now deterministically imports `logging/subsystem.js` under its own mocked module graph and calls `isEnabled(..., "console")`. This traverses `getConsoleSettings`; the regression would fail with the previous partial factory and passes with the import-original mock. A combined run with both affected files and the reported subsystem-logging victim passed.

AI-assisted; I reviewed and understand the changes.

Fixes #103551
