### PR TITLE
fix(tool-call-repair): preserve stream content order after repair

### DIFF
--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1023,6 +1023,7 @@ function parseAllowedOverCapPlainTextToolCallPrefix(
 
 function replacePlainTextToolCallCandidateWithVisibleText(
   record: Record<string, unknown>,
+  candidateText: string,
   visibleText: string,
 ): Record<string, unknown> {
   if (typeof record.content === "string") {
@@ -1031,18 +1032,44 @@ function replacePlainTextToolCallCandidateWithVisibleText(
   if (!Array.isArray(record.content)) {
     return record;
   }
-  const hasVisibleText = Boolean(visibleText.trim());
-  let retainedVisibleText = false;
-  const content = record.content.flatMap((block) => {
+  if (!visibleText.trim()) {
+    return {
+      ...record,
+      content: record.content.filter((block) => asRecord(block)?.type !== "text"),
+    };
+  }
+  // Terminal snapshots must preserve the content indexes already emitted by stream events.
+  // Project the recovered suffix back onto the original text blocks instead of collapsing it.
+  const textParts = record.content.flatMap((block) => {
+    const blockRecord = asRecord(block);
+    return blockRecord?.type === "text" && typeof blockRecord.text === "string"
+      ? [blockRecord.text]
+      : [];
+  });
+  const joinedText = textParts.filter((text) => text.trim()).join("");
+  const candidateStart = joinedText.length - joinedText.trimStart().length;
+  const visibleStart = candidateStart + candidateText.length - visibleText.length;
+  const visibleEnd = candidateStart + candidateText.length;
+  let textOffset = 0;
+  const content = record.content.map((block) => {
     const blockRecord = asRecord(block);
     if (blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
-      return [block];
+      return block;
     }
-    if (!retainedVisibleText && hasVisibleText) {
-      retainedVisibleText = true;
-      return [{ ...blockRecord, text: visibleText }];
+    if (!blockRecord.text.trim()) {
+      return { ...blockRecord, text: "" };
     }
-    return [];
+    const blockStart = textOffset;
+    textOffset += blockRecord.text.length;
+    const sliceStart = Math.max(blockStart, visibleStart);
+    const sliceEnd = Math.min(textOffset, visibleEnd);
+    return {
+      ...blockRecord,
+      text:
+        sliceStart < sliceEnd
+          ? visibleText.slice(sliceStart - visibleStart, sliceEnd - visibleStart)
+          : "",
+    };
   });
   return { ...record, content };
 }
@@ -1095,7 +1122,11 @@ export function scrubOverCapPlainTextToolCallMessage(params: {
     return undefined;
   }
   if (byteOverCapPrefix) {
-    return replacePlainTextToolCallCandidateWithVisibleText(record, byteOverCapPrefix.visibleText);
+    return replacePlainTextToolCallCandidateWithVisibleText(
+      record,
+      candidateText,
+      byteOverCapPrefix.visibleText,
+    );
   }
   if (bufferState !== "over-cap") {
     return undefined;

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -1003,6 +1003,61 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain(marker);
   });
 
+  it("keeps a byte-over-cap visible suffix at its streamed content index in done messages", async () => {
+    const marker = "<function=read>";
+    const visibleText = "Visible answer";
+    const firstChunk = `${marker}${"\u00a0".repeat(100_000)}`;
+    const secondChunk = `${"\u00a0".repeat(28_001)}</function>\n${visibleText}`;
+    const content = [
+      { type: "text", text: firstChunk },
+      { type: "thinking", thinking: "checking" },
+      { type: "text", text: secondChunk },
+    ];
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: firstChunk },
+        {
+          type: "text_delta",
+          contentIndex: 2,
+          delta: secondChunk,
+          partial: { role: "assistant", content },
+        },
+        {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content, stopReason: "stop" },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    const expectedContent = [
+      { type: "text", text: "" },
+      { type: "thinking", thinking: "checking" },
+      { type: "text", text: visibleText },
+    ];
+    expect(requireRecord(events[0], "text event")).toMatchObject({
+      delta: visibleText,
+      partial: { content: expectedContent },
+    });
+    expect(requireRecord(events[1], "done event").message).toMatchObject({
+      content: expectedContent,
+    });
+    expect(JSON.stringify(events)).not.toContain(marker);
+  });
+
   it("scrubs split byte-over-cap XML prefixes from terminal errors without visible text", async () => {
     const marker = "<function=read>";
     const firstChunk = `${marker}${"\u00a0".repeat(100_000)}`;


### PR DESCRIPTION
Related: #103220
Related: #102975
Related: #102933

## What Problem This Solves

Fixes an issue where users receiving streamed plain-text tool-call repairs could see the repaired visible answer move to the wrong content index when the original stream included non-text content between text chunks.

## Why This Change Was Made

The repair now projects the recovered visible suffix back onto the original text blocks instead of collapsing all replacement text into the first text block. This keeps streamed partial events and terminal done snapshots aligned without changing the existing tool-call scrubbing boundary.

## User Impact

Users get the visible answer in the same message position that was streamed, preserving surrounding non-text content order after over-cap tool-call cleanup.

## Evidence

- Autoreview: clean, no accepted/actionable findings.
- AWS Crabbox run run_bec0bf9fc2a1: focused tests passed for src/plugin-sdk/provider-stream-shared.test.ts and packages/tool-call-repair/src before an unrelated late Vitest worker exit in broad changed tests.
- Focused regression added: byte-over-cap visible suffix remains at content index 2 while thinking content at index 1 is preserved.
