### PR TITLE
fix(agents): stop warning about recovered exec failures after a successful reply

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -623,10 +623,9 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[1]?.text).toContain("Write");
   });
 
-  it("still shows exec tool errors when timedOut is true (no file-write boundary)", () => {
-    // Exec timeouts never set `fileTarget`, so the new file-write boundary
-    // never matches. Exec/message/cron/gateway tools keep the visible
-    // warning because the disk-write idempotency reasoning does not apply.
+  it("does not warn for timed-out exec errors when a successful user-facing reply exists", () => {
+    // Exec/bash use the generic recovery rule, not the mutating-tool branch:
+    // a successful final reply is proof the agent recovered (#103574).
     const payloads = buildPayloads({
       assistantTexts: ["The script is ready."],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
@@ -638,29 +637,79 @@ describe("buildEmbeddedRunPayloads", () => {
       },
     });
 
-    expect(payloads).toHaveLength(2);
-    expect(payloads[1]?.isError).toBe(true);
-    expect(payloads[1]?.text).toContain("Exec");
+    expectSinglePayloadSummary(payloads, { text: "The script is ready." });
   });
 
-  it("shows exec tool errors when assistant output claims success", () => {
+  it("does not warn for exec-like tool errors when a successful user-facing reply exists", () => {
+    // Production repro: mid-run bash/exec failure recovered with a correct final answer.
     const payloads = buildPayloads({
       assistantTexts: ["The script is ready to use and saved in your workspace."],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
       lastToolError: {
         toolName: "exec",
         error: "/bin/bash: line 1: python: command not found",
+        mutatingAction: true,
       },
     });
 
-    expect(payloads).toHaveLength(2);
-    expect(payloads[0]?.text).toBe("The script is ready to use and saved in your workspace.");
-    expect(payloads[1]?.isError).toBe(true);
-    expect(payloads[1]?.text).toContain("Exec");
-    expect(payloads[1]?.text).not.toContain("python: command not found");
-    expect(getReplyPayloadMetadata(payloads[1] as object)?.nonTerminalToolErrorWarning).toBe(
-      undefined,
-    );
+    expectSinglePayloadSummary(payloads, {
+      text: "The script is ready to use and saved in your workspace.",
+    });
+  });
+
+  it("does not warn for bash tool errors when a successful user-facing reply exists", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Recovered after the command failed."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "bash",
+        error: "exit code 1",
+        mutatingAction: true,
+      },
+    });
+
+    expectSinglePayloadSummary(payloads, { text: "Recovered after the command failed." });
+  });
+
+  it("keeps exec-like tool error warnings when there is no user-facing reply", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        error: "/bin/bash: line 1: python: command not found",
+        mutatingAction: true,
+      },
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      absentDetail: "python: command not found",
+    });
+  });
+
+  it("keeps exec-like tool error warnings for recoverable-looking errors when there is no reply", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "bash",
+        error: "invalid argument: missing required flag --agent",
+        mutatingAction: true,
+      },
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Bash",
+      absentDetail: "missing required flag",
+    });
+  });
+
+  it("suppresses exec-like tool errors when messages.suppressToolErrors is enabled", () => {
+    expectNoPayloads({
+      lastToolError: {
+        toolName: "bash",
+        error: "command not found",
+        mutatingAction: true,
+      },
+      config: { messages: { suppressToolErrors: true } },
+    });
   });
 
   it("shows mutating tool errors when assistant output does not acknowledge the failure", () => {
@@ -1058,18 +1107,20 @@ describe("buildEmbeddedRunPayloads", () => {
   });
 
   it("wraps markdown-capable mutating tool warnings so mention-looking names stay inert", () => {
+    // Non-recoverable error so the generic exec-like rule still surfaces a warning
+    // for this no-reply formatting case (recoverable keywords would suppress it).
     const payloads = buildPayloads({
       lastToolError: {
         toolName: "bash",
         meta: "show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)",
-        error: "file missing",
+        error: "Command exited with code 1",
         mutatingAction: true,
       },
       toolResultFormat: "markdown",
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Bash failed: `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt` (workspace)",
+      text: "⚠️ 🛠️ Bash failed: `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt` (workspace) (exit 1)",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -512,13 +512,15 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
 
   it("marks middleware tool-error warnings after assistant output as non-terminal", () => {
     // Middleware failures after useful assistant output warn the user without
-    // replacing the successful answer as the terminal payload.
+    // replacing the successful answer as the terminal payload. Uses a non-exec
+    // mutating tool so the warning still surfaces under the recovery policy.
     const payloads = buildPayloads({
       assistantTexts: ["Queued 3 topics."],
       lastToolError: {
-        toolName: "exec",
+        toolName: "write",
         error: "Tool output unavailable due to post-processing error",
         middlewareError: true,
+        mutatingAction: true,
       },
       verboseLevel: "off",
     });
@@ -528,7 +530,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads[1]).toMatchObject({
       isError: true,
     });
-    expect(payloads[1]?.text).toContain("Exec failed");
+    expect(payloads[1]?.text).toContain("Write failed");
     expect(getReplyPayloadMetadata(payloads[1] as object)).toMatchObject({
       nonTerminalToolErrorWarning: true,
     });

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -527,6 +527,16 @@ function resolveToolErrorWarningPolicy(params: {
   if (params.suppressToolErrors) {
     return { showWarning: false, includeDetails };
   }
+  // Mutating branch protects "assistant claims success while a user-visible mutation
+  // silently failed". Shell/exec are the agent's own workspace actions: the model sees
+  // the exit code in-context, and a successful final reply is recovery proof (#103574).
+  // Deliberately ignores mutatingAction for exec: codex marks every commandExecution
+  // mutating fail-closed (replay metadata, not display signal).
+  if (isExecLikeToolName(params.lastToolError.toolName)) {
+    // No recoverable-keyword suppression here: with no reply at all, the exec
+    // warning may be the run's only failure signal.
+    return { showWarning: !params.hasUserFacingReply, includeDetails };
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
@@ -534,9 +544,6 @@ function resolveToolErrorWarningPolicy(params: {
       showWarning: !params.hasUserFacingErrorReply && !params.hasUserFacingFailureAcknowledgement,
       includeDetails,
     };
-  }
-  if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
-    return { showWarning: false, includeDetails };
   }
   return {
     showWarning: !params.hasUserFacingReply && !isRecoverableToolError(params.lastToolError.error),


### PR DESCRIPTION
## What Problem This Solves

Fixes #103574. On the codex app-server harness, a mid-run Bash failure the agent fully recovers from (different command, run completes, correct answer streams) still emitted a standalone trailing message after the final answer:

> ⚠️ 🛠️ Bash failed: openclaw agent (agent)

The codex projector classifies every `commandExecution` as mutating fail-closed (replay metadata, `extensions/codex/src/app-server/event-projector.ts:2800-2811`) and clears `lastToolError` only on a byte-identical retry, so `resolveToolErrorWarningPolicy`'s mutating branch warned despite the successful reply. claude-cli never feeds `lastToolError` into reply payloads, so this was codex-harness-visible.

## Why This Change Was Made

`resolveToolErrorWarningPolicy` (`src/agents/embedded-agent-runner/run/payloads.ts`) now checks exec-like tools before the mutating branch: shell failures warn only when the run produced **no** user-facing reply. Shell commands are the agent's own workspace actions — the model sees the exit code in-context, and a coherent successful final reply is the recovery proof. The mutating branch is unchanged for message sends / file writes / deletes (the real "assistant claims success while a user-visible mutation silently failed" contract). Decision order is now: suppress-config → exec-like → mutating → generic. `mutatingAction` is deliberately ignored for exec because codex sets it on every command (replay metadata, not a display signal). Exec warnings with no reply also no longer apply the recoverable-keyword suppression — with no reply, the warning may be the run's only failure signal (autoreview finding, fixed + pinned).

Projector error-clearing, `resolveEmbeddedRunFailureSignal` (cron/heartbeat fatality), cron's recovered-warning detection, and the `messages.suppressToolErrors` gate are untouched.

## User Impact

Codex-harness users stop receiving a scary failure bubble after successfully recovered runs. Warnings for silent mutation failures, no-reply failures, and the global suppress config all behave as before.

## Evidence

- Net +8 prod LOC (branch reorder + comments).
- Tests: recovered exec/bash/timed-out-exec with reply → no warning (production repro shape: `bash` + `mutatingAction: true`); exec with no reply → warning kept, including recoverable-keyword error text; non-exec mutating with successful reply → warning kept; `suppressToolErrors` gate unchanged; failure-acknowledgement suppression suite unchanged.
- Testbox (lease `tbx_01kx5mdjnkkp8c8eg8y16tsq1z`): `pnpm test src/agents/embedded-agent-runner/run src/cron/isolated-agent src/cron/run-diagnostics.test.ts` → all shards green.
- Autoreview (Codex/gpt-5.5): first pass P2 (recoverable-keyword suppression could silence no-reply failures) accepted and fixed with regression test; second pass P1 ("keep exec on the mutating path") consciously rejected — it assumes `mutatingAction` is a trustworthy display signal for exec, which codex's fail-closed classification makes false; honoring it reproduces the reported bug. Rationale encoded at the decision point.
- `tsgo` core + extensions, oxlint, oxfmt, `git diff --check` all clean.
