### PR TITLE
fix(sessions): reject malformed history offsets

### DIFF
--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -504,6 +504,12 @@ describe("embedded gateway stub", () => {
         params: { sessionKey: "agent:main:main", offset: 1.5 },
       }),
     ).rejects.toThrow("offset must be a non-negative integer");
+    await expect(
+      callGateway({
+        method: "chat.history",
+        params: { sessionKey: "agent:main:main", offset: "1abc" },
+      }),
+    ).rejects.toThrow("offset must be a non-negative integer");
     expect(runtime.readSessionMessagesAsync).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -511,5 +511,7 @@ describe("embedded gateway stub", () => {
       }),
     ).rejects.toThrow("offset must be a non-negative integer");
     expect(runtime.readSessionMessagesAsync).not.toHaveBeenCalled();
+    expect(runtime.readRecentSessionMessagesWithStatsAsync).not.toHaveBeenCalled();
+    expect(runtime.readSessionMessagesPageWithStatsAsync).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -17,7 +17,7 @@ import type {
 import type { SessionsListResult } from "../../gateway/session-utils.types.js";
 import type { SessionsResolveResult } from "../../gateway/sessions-resolve.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { readNumberParam, readPositiveIntegerParam } from "./common.js";
+import { readNonNegativeIntegerParam, readPositiveIntegerParam } from "./common.js";
 
 type EmbeddedCallGateway = <T = Record<string, unknown>>(opts: CallGatewayOptions) => Promise<T>;
 
@@ -109,10 +109,7 @@ async function getRuntime(): Promise<EmbeddedGatewayRuntime> {
 }
 
 function readOffsetParam(params: Record<string, unknown>): number | undefined {
-  const offset = readNumberParam(params, "offset", {
-    integer: true,
-    nonNegativeInteger: true,
-  });
+  const offset = readNonNegativeIntegerParam(params, "offset");
   if (params.offset !== undefined && offset === undefined) {
     throw new Error("offset must be a non-negative integer");
   }

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -119,11 +119,19 @@ describe("sessions_history redaction", () => {
   });
 
   it.each([-1, 1.5, "1abc"])("rejects invalid offset value %s", async (offset) => {
-    const tool = createHistoryToolWithMessage("hello");
+    const requests: CallGatewayRequest[] = [];
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        return { messages: [] } as T;
+      },
+    });
 
     await expect(tool.execute("call-1", { sessionKey: "main", offset })).rejects.toThrow(
       "offset must be a non-negative integer",
     );
+    expect(requests).toEqual([]);
   });
 
   it("preserves the bounded default history request", async () => {

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -118,7 +118,7 @@ describe("sessions_history redaction", () => {
     );
   });
 
-  it.each([-1, 1.5])("rejects invalid offset value %s", async (offset) => {
+  it.each([-1, 1.5, "1abc"])("rejects invalid offset value %s", async (offset) => {
     const tool = createHistoryToolWithMessage("hello");
 
     await expect(tool.execute("call-1", { sessionKey: "main", offset })).rejects.toThrow(

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -21,7 +21,7 @@ import { stripToolMessages } from "./chat-history-text.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
-  readNumberParam,
+  readNonNegativeIntegerParam,
   readPositiveIntegerParam,
   readStringParam,
   ToolInputError,
@@ -53,10 +53,7 @@ type ChatHistoryPaginationMetadata = {
 };
 
 function readOffsetParam(params: Record<string, unknown>): number | undefined {
-  const offset = readNumberParam(params, "offset", {
-    integer: true,
-    nonNegativeInteger: true,
-  });
+  const offset = readNonNegativeIntegerParam(params, "offset");
   if (params.offset !== undefined && offset === undefined) {
     throw new ToolInputError("offset must be a non-negative integer");
   }


### PR DESCRIPTION
## What Problem This Solves

Authenticated direct Gateway and embedded `sessions_history` calls accepted malformed offsets such as `"1abc"` and silently read page 1. Normal model-originated calls were already strict through the tool schema; the gap was limited to direct invocation boundaries that receive unknown arguments.

## Why This Change Was Made

Both owner-local offset readers now reuse the existing strict non-negative integer helper before dispatching `chat.history` or selecting an embedded transcript reader. This is narrower than changing the generic permissive number reader or adding compatibility-sensitive validation across every direct tool invocation.

Tests also prove malformed offsets stop before the real Gateway dispatch and before all embedded transcript readers.

## User Impact

Malformed and negative session-history offsets now fail clearly instead of selecting an unintended page. Valid numeric offsets and strict numeric strings continue to work.

## Evidence

- Final PR head: `4a686a8f4f367b95f63bd6acdb855aca11d8517e` (four files, +22/-12 after proper rebase).
- Exact-head sanitized AWS/Linux focused proof: `run_b0dd2e031b02`, 73/73 tests passed across Gateway protocol, public tool, and embedded stub suites.
- Exact-head sanitized AWS/Linux live proof: `run_7141aea39890`; real Gateway readiness, unauthenticated 401, authenticated malformed HTTP 400, strict numeric-string control 200, unchanged WebSocket validation, embedded malformed rejection, embedded valid-string control, and full process/state cleanup all passed.
- Matched base proof at `366d09bcc730dffd9ed0783c37df506ac0f35955`: authenticated malformed HTTP and embedded offsets were partially parsed to 1; valid-string controls succeeded; direct WebSocket validation was already strict.
- Source-blind behavior validation: all six behavior and operational-integrity clauses passed against exact head `4a686a8f4f367b95f63bd6acdb855aca11d8517e`.
- Fresh final-tree Codex autoreview: clean, no accepted/actionable findings (correctness confidence 0.91).
- `git diff --check origin/main...HEAD`: passed.

Release-note context is preserved in this PR body; the repository's release-owned changelog remains untouched.
