### PR TITLE
fix(discord): recover from failed gateway resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord gateway reconnects:** fall back to a fresh IDENTIFY after three unsuccessful RESUME connection attempts and log every scheduled reconnect with its actual strategy, restoring channel recovery after abnormal WebSocket closes without restarting the Gateway. (#99681)
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord gateway reconnects:** fall back to a fresh IDENTIFY after three unsuccessful RESUME connection attempts and log every scheduled reconnect with its actual strategy, restoring channel recovery after abnormal WebSocket closes without restarting the Gateway. (#99681)
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -70,14 +70,16 @@ class FakeSocket extends EventEmitter {
 class TestGatewayPlugin extends GatewayPlugin {
   sockets: FakeSocket[] = [];
   connectCalls: boolean[] = [];
+  urls: string[] = [];
 
   override connect(resume = false): void {
     this.connectCalls.push(resume);
     super.connect(resume);
   }
 
-  protected override createWebSocket(): never {
+  protected override createWebSocket(url: string): never {
     const socket = new FakeSocket();
+    this.urls.push(url);
     this.sockets.push(socket);
     return socket as never;
   }
@@ -211,7 +213,7 @@ describe("GatewayPlugin", () => {
     originalSocket?.emit("close", 1006);
 
     await vi.advanceTimersByTimeAsync(2_000);
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
     const replacementSocket = gateway.sockets[1];
     replacementSocket?.emit("open");
 
@@ -347,6 +349,7 @@ describe("GatewayPlugin", () => {
     };
     gateway.isConnected = false;
     (gateway as unknown as { reconnectAttempts: number }).reconnectAttempts = 7;
+    (gateway as unknown as { consecutiveResumeFailures: number }).consecutiveResumeFailures = 2;
 
     await (
       gateway as unknown as {
@@ -359,6 +362,9 @@ describe("GatewayPlugin", () => {
 
     expect(gateway.isConnected).toBe(true);
     expect((gateway as unknown as { reconnectAttempts: number }).reconnectAttempts).toBe(0);
+    expect(
+      (gateway as unknown as { consecutiveResumeFailures: number }).consecutiveResumeFailures,
+    ).toBe(0);
   });
 
   it("queues outbound gateway events when the connection window is exhausted", () => {
@@ -462,22 +468,133 @@ describe("GatewayPlugin", () => {
     clearInterval(heartbeat);
   });
 
-  it("reconnects after active remote normal closes", async () => {
+  it("logs and re-identifies after a resumable close without session state", async () => {
     vi.useFakeTimers();
     const gateway = new TestGatewayPlugin({
       autoInteractions: false,
       url: "wss://gateway.example.test",
     });
+    const debugSpy = vi.fn();
+    gateway.emitter.on("debug", debugSpy);
 
     gateway.connect(false);
     gateway.sockets[0]?.emit("open");
     gateway.sockets[0]?.emit("close", 1000);
 
     expect(gateway.sockets).toHaveLength(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway reconnect scheduled in 2000ms (close, resume=false)",
+    );
     await vi.advanceTimersByTimeAsync(2_000);
 
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
     expect(gateway.sockets).toHaveLength(2);
+    const reconnectSocket = gateway.sockets[1];
+    reconnectSocket?.emit("open");
+    reconnectSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sentGatewayOpcodes(reconnectSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    expect(sentGatewayOpcodes(reconnectSocket?.send ?? vi.fn())).not.toContain(
+      GatewayOpcodes.Resume,
+    );
+  });
+
+  it("falls back to a fresh IDENTIFY after three failed resume attempts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+    const debugSpy = vi.fn();
+    gateway.emitter.on("debug", debugSpy);
+    (gateway as unknown as { client: unknown }).client = {
+      options: { token: "token" },
+      dispatchGatewayEvent: vi.fn(async () => {}),
+    };
+
+    gateway.connect(false);
+    const initialSocket = gateway.sockets[0];
+    initialSocket?.emit("open");
+    initialSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sentGatewayOpcodes(initialSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    initialSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Dispatch,
+        t: GatewayDispatchEvents.Ready,
+        s: 42,
+        d: {
+          session_id: "session-1",
+          resume_gateway_url: "wss://resume.example.test",
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (const delayMs of [2_000, 4_000, 8_000]) {
+      gateway.sockets.at(-1)?.emit("close", 1006);
+      await vi.advanceTimersByTimeAsync(delayMs);
+      const resumeSocket = gateway.sockets.at(-1);
+      expect(gateway.urls.at(-1)).toMatch(/^wss:\/\/resume\.example\.test\//);
+      resumeSocket?.emit("open");
+      resumeSocket?.emit(
+        "message",
+        JSON.stringify({
+          op: GatewayOpcodes.Hello,
+          d: { heartbeat_interval: 45_000 },
+          s: null,
+        }),
+      );
+      expect(sentGatewayOpcodes(resumeSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Resume);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Gateway reconnect scheduled in ${delayMs}ms (close, resume=true)`,
+      );
+    }
+
+    gateway.sockets.at(-1)?.emit("close", 1006);
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway forcing fresh IDENTIFY after 3 failed resume attempts",
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway reconnect scheduled in 16000ms (close, resume=false)",
+    );
+
+    await vi.advanceTimersByTimeAsync(16_000);
+    const freshSocket = gateway.sockets.at(-1);
+    expect(gateway.urls.at(-1)).toMatch(/^wss:\/\/gateway\.example\.test\//);
+    freshSocket?.emit("open");
+    freshSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sentGatewayOpcodes(freshSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    expect(sentGatewayOpcodes(freshSocket?.send ?? vi.fn())).not.toContain(GatewayOpcodes.Resume);
+    const sessionState = gatewaySessionState(gateway);
+    expect(sessionState.sessionId).toBeNull();
+    expect(sessionState.resumeGatewayUrl).toBeNull();
+    expect(sessionState.sequence).toBeNull();
   });
 
   it.each([GatewayCloseCodes.InvalidSeq, GatewayCloseCodes.AlreadyAuthenticated])(
@@ -546,7 +663,7 @@ describe("GatewayPlugin", () => {
     expect(gateway.connectCalls).toEqual([false]);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
   });
 
   it("includes close code details when reconnect attempts are exhausted", async () => {

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -43,6 +43,18 @@ type GatewayPluginOptions = {
   shard?: [number, number];
   url?: string;
 };
+type GatewayReconnectReason =
+  | "close"
+  | "identify"
+  | "invalid-session"
+  | "reconnect-opcode"
+  | "zombie";
+type GatewayReconnectOptions = {
+  reason: GatewayReconnectReason;
+  preferResume: boolean;
+  closeCode?: number;
+  minDelayMs?: number;
+};
 
 const READY_STATE_OPEN = 1;
 const DEFAULT_GATEWAY_URL = "wss://gateway.discord.gg/";
@@ -54,6 +66,7 @@ export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
 }) satisfies ws.ClientOptions;
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;
+const RESUME_FAILURE_THRESHOLD = 3;
 
 function ensureGatewayParams(url: string): string {
   const parsed = new URL(url);
@@ -92,6 +105,7 @@ export class GatewayPlugin extends Plugin {
   private sessionId: string | null = null;
   private resumeGatewayUrl: string | null = null;
   private reconnectAttempts = 0;
+  private consecutiveResumeFailures = 0;
   private shouldReconnect = false;
   private isConnecting = false;
   private readonly heartbeatTimers = new GatewayHeartbeatTimers();
@@ -173,6 +187,7 @@ export class GatewayPlugin extends Plugin {
     this.isConnecting = false;
     this.isConnected = false;
     this.reconnectAttempts = 0;
+    this.consecutiveResumeFailures = 0;
   }
 
   protected createWebSocket(url: string): ws.WebSocket {
@@ -224,7 +239,11 @@ export class GatewayPlugin extends Plugin {
       if (!canResume) {
         this.resetSessionState();
       }
-      this.scheduleReconnect(canResume, closeCode);
+      this.scheduleReconnect({
+        reason: "close",
+        preferResume: canResume,
+        closeCode,
+      });
     });
     socket.on("error", (error) => {
       if (socket !== this.ws) {
@@ -243,18 +262,19 @@ export class GatewayPlugin extends Plugin {
       this.sequence = payload.s;
     }
     switch (payload.op) {
-      case GatewayOpcodes.Hello:
+      case GatewayOpcodes.Hello: {
         this.startHeartbeat(
           (payload.d as { heartbeat_interval?: number }).heartbeat_interval ?? 45_000,
         );
-        if (resume && this.sessionId) {
+        const resumeState = resume ? this.getResumeState() : null;
+        if (resumeState) {
           this.send(
             {
               op: GatewayOpcodes.Resume,
               d: {
                 token: this.client?.options.token ?? "",
-                session_id: this.sessionId,
-                seq: this.sequence ?? 0,
+                session_id: resumeState.sessionId,
+                seq: resumeState.sequence,
               },
             } as GatewaySendPayload,
             true,
@@ -268,6 +288,7 @@ export class GatewayPlugin extends Plugin {
           });
         }
         break;
+      }
       case GatewayOpcodes.HeartbeatAck:
         this.lastHeartbeatAck = true;
         break;
@@ -286,14 +307,15 @@ export class GatewayPlugin extends Plugin {
         if (!payload.d) {
           this.resetSessionState();
         }
-        this.scheduleReconnect(
-          payload.d,
-          undefined,
-          INVALID_SESSION_MIN_DELAY_MS + Math.floor(Math.random() * INVALID_SESSION_JITTER_MS),
-        );
+        this.scheduleReconnect({
+          reason: "invalid-session",
+          preferResume: payload.d,
+          minDelayMs:
+            INVALID_SESSION_MIN_DELAY_MS + Math.floor(Math.random() * INVALID_SESSION_JITTER_MS),
+        });
         break;
       case GatewayOpcodes.Reconnect:
-        this.scheduleReconnect(true);
+        this.scheduleReconnect({ reason: "reconnect-opcode", preferResume: true });
         break;
     }
   }
@@ -305,7 +327,7 @@ export class GatewayPlugin extends Plugin {
       onHeartbeat: () => this.sendHeartbeat(),
       onAckTimeout: () => {
         this.emitter.emit("error", new Error("Gateway heartbeat ACK timeout"));
-        this.scheduleReconnect(true);
+        this.scheduleReconnect({ reason: "zombie", preferResume: true });
       },
     });
   }
@@ -351,7 +373,7 @@ export class GatewayPlugin extends Plugin {
       return;
     }
     if (socket.readyState !== READY_STATE_OPEN) {
-      this.scheduleReconnect(false);
+      this.scheduleReconnect({ reason: "identify", preferResume: false });
       return;
     }
     this.identify();
@@ -390,10 +412,12 @@ export class GatewayPlugin extends Plugin {
       this.sessionId = ready.session_id ?? null;
       this.resumeGatewayUrl = ready.resume_gateway_url ?? null;
       this.reconnectAttempts = 0;
+      this.consecutiveResumeFailures = 0;
       this.isConnected = true;
     }
     if (payload.t === GatewayDispatchEvents.Resumed) {
       this.reconnectAttempts = 0;
+      this.consecutiveResumeFailures = 0;
       this.isConnected = true;
     }
     dispatchVoiceGatewayEvent(this.client, payload.t, payload.d);
@@ -408,9 +432,16 @@ export class GatewayPlugin extends Plugin {
     this.sessionId = null;
     this.resumeGatewayUrl = null;
     this.sequence = null;
+    this.consecutiveResumeFailures = 0;
   }
 
-  private scheduleReconnect(resume: boolean, closeCode?: number, minDelayMs = 0): void {
+  private getResumeState(): { sessionId: string; sequence: number } | null {
+    return this.sessionId && this.sequence !== null
+      ? { sessionId: this.sessionId, sequence: this.sequence }
+      : null;
+  }
+
+  private scheduleReconnect(options: GatewayReconnectOptions): void {
     if (!this.shouldReconnect) {
       return;
     }
@@ -427,17 +458,37 @@ export class GatewayPlugin extends Plugin {
       this.emitter.emit(
         "error",
         new Error(
-          `Max reconnect attempts (${maxAttempts}) reached${closeCode !== undefined ? ` after close code ${closeCode}` : ""}`,
+          `Max reconnect attempts (${maxAttempts}) reached${options.closeCode !== undefined ? ` after close code ${options.closeCode}` : ""}`,
         ),
       );
       return;
     }
+    let shouldResume = options.preferResume && this.getResumeState() !== null;
+    // Abnormal closes can leave a cached session permanently rejected. READY or RESUMED
+    // resets this streak; after the threshold, discard the poisoned session and IDENTIFY.
+    if (shouldResume && this.consecutiveResumeFailures >= RESUME_FAILURE_THRESHOLD) {
+      this.resetSessionState();
+      shouldResume = false;
+      this.emitter.emit(
+        "debug",
+        `Gateway forcing fresh IDENTIFY after ${RESUME_FAILURE_THRESHOLD} failed resume attempts`,
+      );
+    }
+    if (shouldResume) {
+      this.consecutiveResumeFailures += 1;
+    } else {
+      this.consecutiveResumeFailures = 0;
+    }
     const delay = Math.max(
-      minDelayMs,
+      options.minDelayMs ?? 0,
       Math.min(30_000, 1_000 * 2 ** Math.min(this.reconnectAttempts, 5)),
     );
+    this.emitter.emit(
+      "debug",
+      `Gateway reconnect scheduled in ${delay}ms (${options.reason}, resume=${String(shouldResume)})`,
+    );
     this.reconnectTimer.schedule(delay, () => {
-      this.connect(resume);
+      this.connect(shouldResume);
     });
   }
 


### PR DESCRIPTION
Closes #99681

AI-assisted: Codex implemented, tested, live-validated, and reviewed this repair.

## What Problem This Solves

Fixes an issue where Discord channels could remain disconnected indefinitely after an abnormal Gateway close when Discord repeatedly rejected the cached RESUME session. Operators also lacked truthful reconnect logs showing whether the next attempt would RESUME or perform a fresh IDENTIFY.

## Why This Change Was Made

The Discord-owned Gateway now treats RESUME eligibility as complete session state, tracks consecutive unsuccessful RESUME connection attempts, and discards the poisoned session after three failures so the next reconnect performs a fresh IDENTIFY. READY, RESUMED, explicit disconnect, and session invalidation reset the streak; reconnect logs report the strategy actually scheduled.

This restores the recovery invariant that was lost when the previous Carbon Gateway dependency was internalized, without adding another lifecycle-controller restart path.

## User Impact

Discord delivery can recover from repeated RESUME rejection without restarting the OpenClaw Gateway process. Operators now see the reconnect reason, delay, and actual `resume=true|false` strategy in normal Gateway logs.

## Evidence

- Focused Blacksmith Testbox proof on current main: 50/50 tests passed across `gateway.test.ts`, `gateway-logging.test.ts`, and `provider.lifecycle.test.ts` (`tbx_01kx5jgs88rfd2apfmaq46b0hs`).
- Targeted extension lint: 0 warnings and 0 errors. Targeted `oxfmt --check`: all three changed files correctly formatted.
- Broad changed gate: all core/extension typechecks and core lint passed; its only finding was a redundant boolean conversion in this patch, which was removed before the final focused/lint reruns.
- Exact synced AWS Crabbox build passed: `run_be3c67948d38`.
- Live Discord fault injection passed on AWS Crabbox: `run_536b7a74e5d4`. The lane completed a real roundtrip, destroyed the active transport, rejected three RESUME reconnects, observed forced fresh IDENTIFY, recovered on the same live Gateway PID with no restart marker, and completed a second real roundtrip.
- Redacted live result: `pidStable=true`, `resumeSchedules=3`, `forcedIdentify=true`, `reconnected=true`, `baselineRoundtrip=true`, `postRecoveryRoundtrip=true`.
- Fresh structured Codex autoreview: clean, no accepted/actionable findings.
