### PR TITLE
feat: allow skipping hybrid memory CLI plugin

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -9727,4 +9727,40 @@ export const runtimeValue = helperValue;`,
       platformSpy.mockRestore();
     }
   });
+  it("skips openclaw-hybrid-memory when OPENCLAW_SKIP_HYBRID_MEMORY_CLI is enabled", () => {
+    const bundledDir = makeTempDir();
+    writePlugin({
+      id: "openclaw-hybrid-memory",
+      body: 'module.exports = { id: "openclaw-hybrid-memory", kind: "memory", register() { throw new Error("should not load"); } };',
+      dir: path.join(bundledDir, "openclaw-hybrid-memory"),
+      filename: "index.cjs",
+    });
+    writePlugin({
+      id: "other-memory",
+      body: 'module.exports = { id: "other-memory", kind: "memory", register() {} };',
+      dir: path.join(bundledDir, "other-memory"),
+      filename: "index.cjs",
+    });
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const registry = loadOpenClawPlugins({
+      workspaceDir: bundledDir,
+      cache: false,
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+        OPENCLAW_SKIP_HYBRID_MEMORY_CLI: "1",
+      },
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["openclaw-hybrid-memory", "other-memory"],
+          slots: { memory: "any" },
+        },
+      },
+    });
+
+    expect(registry.plugins.some((plugin) => plugin.id === "openclaw-hybrid-memory")).toBe(false);
+    expect(registry.plugins.some((plugin) => plugin.id === "other-memory")).toBe(true);
+  });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1809,6 +1809,11 @@ function maybeThrowOnPluginLoadError(
   throw new PluginLoadFailureError(registry);
 }
 
+function shouldSkipHybridMemoryCliPlugin(env: NodeJS.ProcessEnv): boolean {
+  const value = env.OPENCLAW_SKIP_HYBRID_MEMORY_CLI;
+  return value === "1" || value === "true";
+}
+
 function activatePluginRegistry(
   registry: PluginRegistry,
   cacheKey: string,
@@ -2098,6 +2103,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         continue;
       }
       const pluginId = manifestRecord.id;
+      if (pluginId === "openclaw-hybrid-memory" && shouldSkipHybridMemoryCliPlugin(env)) {
+        continue;
+      }
       const matchesRequestedScope = matchesScopedPluginOrDreamingSidecar({
         onlyPluginIdSet,
         pluginId,


### PR DESCRIPTION
## Summary
- adds an opt-in `OPENCLAW_SKIP_HYBRID_MEMORY_CLI=1|true` loader fast-path
- skips only the `openclaw-hybrid-memory` plugin before import/registration
- covers the behavior in plugin loader tests

## Audit notes
This upstreams the local `patch-openclaw-skip-hybrid-cli.cjs` behavior in core. It is kept separate from hybrid-memory fixes because this belongs to OpenClaw core.

## Local validation
- `pnpm install --frozen-lockfile` ✅
- `git diff --check` ✅
- Targeted Vitest attempts were not green locally: current shard/config routing excludes `src/plugins/loader.test.ts` from several direct configs, and full `vitest.config.ts` runs did not complete in the local 2-3 minute window. CI readback should be used as the source of truth.