### PR TITLE
fix(ui): hover-only chrome for header icon buttons and a usable bottom-docked rail

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -244,9 +244,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
-  /* Match the sibling refresh/collapse buttons (.btn radius) so the rail
-     header buttons share one corner treatment. */
+  /* Chromeless at rest like the sibling ghost buttons; chrome on hover only. */
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
@@ -259,9 +258,20 @@
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
+/* Overrides the shared .nav-collapse-toggle chrome (border, elevated
+   background, inset highlight): rail header buttons only show chrome on
+   hover. */
 .chat-workspace-rail__collapse-toggle {
   flex: 0 0 auto;
+  border-color: transparent;
+  background: transparent;
   box-shadow: none;
+}
+
+.chat-workspace-rail__collapse-toggle:hover {
+  border-color: transparent;
+  background: var(--bg-hover);
+  transform: none;
 }
 
 .chat-workspace-rail__terminal svg,
@@ -327,6 +337,32 @@
   min-height: 0;
   overflow-y: auto;
   padding-top: 8px;
+}
+
+/* Bottom dock is short and wide: sections sit side by side as their own
+   scroll columns instead of compressing into clipped slivers. */
+.chat-workbench--dock-bottom .chat-workspace-rail__scroll {
+  flex-direction: row;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.chat-workbench--dock-bottom .chat-workspace-rail__scroll > .chat-workspace-rail__section {
+  flex: 1 0 260px;
+  min-width: 0;
+}
+
+.chat-workbench--dock-bottom
+  .chat-workspace-rail__scroll
+  > .chat-workspace-rail__section
+  + .chat-workspace-rail__section {
+  border-left: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
+}
+
+/* The empty-state notice can sit in the row too; keep it readable. */
+.chat-workbench--dock-bottom .chat-workspace-rail__scroll > .chat-workspace-rail__state {
+  flex: 0 0 auto;
+  align-self: flex-start;
 }
 
 .chat-workspace-rail__section-title {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1992,12 +1992,18 @@
   box-shadow: 0 0 0 1px var(--accent-subtle);
 }
 
+/* Ghost stays chromeless in light mode too: without the border-color reset,
+   the higher-specificity light .btn--icon override above re-adds a 1px border
+   that dark mode never shows. Chrome appears on hover only. */
 :root[data-theme-mode="light"] .btn--ghost {
   background: transparent;
+  border-color: transparent;
+  box-shadow: none;
 }
 
 :root[data-theme-mode="light"] .btn--ghost:hover {
   background: var(--bg-hover);
+  border-color: transparent;
 }
 
 /* ===========================================


### PR DESCRIPTION
## What Problem This Solves

Two visual defects in the session workspace rail area, reported from the Mac app (light mode):

1. The pane header and rail header icon buttons render with always-on 1px borders. Root cause: the light theme's `.btn--icon` override (`:root[data-theme-mode="light"] .btn--icon`, specificity 0,2,0) re-adds the border that `.btn--ghost` (0,1,0) removes, and light's ghost override only reset the background. Dark mode has always been chromeless — the themes disagreed.
2. The bottom-docked workspace rail looks broken: its sections are flex children that compress instead of scrolling, so file rows render clipped in half.

## Why This Change Was Made

Maintainer feedback: no borders around these buttons — chrome should appear on hover only.

- `:root[data-theme-mode="light"] .btn--ghost` now also resets `border-color` and `box-shadow`, so ghost icon buttons are chromeless at rest in light mode exactly like dark mode; hover keeps the background tint. This intentionally fixes the whole bug class (every ghost button in light mode), not just the rail.
- The rail's terminal and collapse buttons had their own always-on chrome (an explicit border; the shared `.nav-collapse-toggle` box) — both are now hover-only to match their ghost siblings.
- Bottom dock: sections lay out as side-by-side scroll columns (`Changed | Read | Artifacts | Project files`) with dividers, using the dock's width instead of compressing rows into clipped slivers. Right dock is unchanged.

## User Impact

- Split-pane headers and the rail header read as quiet icon rows; hover reveals the affordance. Light and dark now match.
- The bottom-docked rail shows full, scrollable file rows in columns.

Screenshots (mock gateway):

| Split headers, light (no borders) | Bottom dock columns | Dark parity |
| --- | --- | --- |
| ![light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/rail-polish/01-split-header-light.png) | ![bottom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/rail-polish/02-bottom-dock-light.png) | ![dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/rail-polish/03-split-header-dark.png) |

## Evidence

- Computed-style probe in the harness: pane-header button `border-color: rgba(0,0,0,0)` in light mode after the fix.
- Remote (Blacksmith Testbox): `pnpm check:changed` green, exit 0.
- Local e2e (Playwright Chromium, mock gateway): `chat-flow.e2e.test.ts` full file green (includes rail expand/collapse/dock flows).
- Autoreview (Codex gpt-5.5, thinking high): clean — "no accepted/actionable findings".
- CSS-only diff; no markup, selector, or behavior changes.
