### PR TITLE
fix(gateway-client): clamp readiness timeout before client start

### DIFF
--- a/packages/gateway-client/src/readiness.test.ts
+++ b/packages/gateway-client/src/readiness.test.ts
@@ -1,6 +1,7 @@
 // Gateway Client tests cover readiness behavior.
 import { describe, expect, it, vi } from "vitest";
 import { startGatewayClientWithReadinessWait } from "./readiness.js";
+import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
 
 describe("startGatewayClientWithReadinessWait", () => {
   it("uses the injected client env when resolving the readiness timeout", async () => {
@@ -21,6 +22,27 @@ describe("startGatewayClientWithReadinessWait", () => {
 
     expect(waitForReady).toHaveBeenCalledWith({
       maxWaitMs: 6_000,
+      signal: undefined,
+    });
+    expect(client.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps explicit readiness timeouts before invoking the waiter", async () => {
+    const waitForReady = vi.fn(async () => ({
+      ready: true,
+      aborted: false,
+      elapsedMs: 0,
+      checks: 1,
+      maxDriftMs: 0,
+    }));
+    const client = { start: vi.fn() };
+
+    await startGatewayClientWithReadinessWait(waitForReady, client, {
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(waitForReady).toHaveBeenCalledWith({
+      maxWaitMs: MAX_SAFE_TIMEOUT_DELAY_MS,
       signal: undefined,
     });
     expect(client.start).toHaveBeenCalledTimes(1);

--- a/packages/gateway-client/src/readiness.ts
+++ b/packages/gateway-client/src/readiness.ts
@@ -5,7 +5,7 @@ import {
   type EventLoopReadyOptions,
   type EventLoopReadyResult,
 } from "./event-loop-ready.js";
-import { resolveConnectChallengeTimeoutMs } from "./timeouts.js";
+import { resolveConnectChallengeTimeoutMs, resolveFiniteTimeoutDelayMs } from "./timeouts.js";
 
 export type GatewayClientStartable = {
   start(): void;
@@ -30,7 +30,7 @@ function resolveGatewayClientStartReadinessTimeoutMs(
   options: GatewayClientStartReadinessOptions = {},
 ): number {
   if (typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)) {
-    return options.timeoutMs;
+    return resolveFiniteTimeoutDelayMs(options.timeoutMs, 0, { minMs: 0 });
   }
   const clientOptions = options.clientOptions ?? {};
   return resolveConnectChallengeTimeoutMs(clientOptions.connectChallengeTimeoutMs, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers using an explicit gateway client readiness timeout could pass an oversized finite value that reached the readiness waiter without the safe timer clamp used by the default timeout path.

## Why This Change Was Made

The explicit timeout path now reuses the existing finite timeout delay resolver with the same zero-minimum boundary before starting the client. This keeps the gateway-client readiness boundary local and avoids adding new config, fallback behavior, or broader policy.

## User Impact

Developers can pass explicit readiness timeouts without accidentally forwarding timer values above the safe Node.js delay range to alternate readiness waiters.

## Evidence

- Claim proved: explicit gateway-client readiness timeouts are clamped to `MAX_SAFE_TIMEOUT_DELAY_MS` before the exported startup helper invokes an alternate readiness waiter, and startup still proceeds after readiness succeeds.
- Current head: `99a30fa50dca03a62e3aad40ea6c193dec4dcad4`.
- Runtime proof: a Node 24 probe imported `packages/gateway-client/src/readiness.ts` and `packages/gateway-client/src/timeouts.ts`, called `startGatewayClientWithReadinessWait(..., { timeoutMs: Number.MAX_SAFE_INTEGER })`, and observed:

  ```text
  [runtime] head=99a30fa50dca03a62e3aad40ea6c193dec4dcad4
  [runtime] explicit timeout input=9007199254740991
  [runtime] waiter observed maxWaitMs=2147483647
  [runtime] safe timer maximum=2147483647
  [runtime] signal forwarded=true
  [runtime] gateway client start invoked=1
  [runtime] readiness.ready=true
  [runtime] readiness.aborted=false
  [runtime] proof result=PASS: oversized explicit readiness timeout was clamped before startup
  ```

- Diff hygiene: `git diff --check 600ff3acb437b87410bfe39de8a5f83aa1d408b2...HEAD -- packages/gateway-client/src/readiness.ts packages/gateway-client/src/readiness.test.ts` passed.
- Observed result: `timeoutMs: Number.MAX_SAFE_INTEGER` reached the readiness waiter as `2147483647`, the shared safe timer maximum, the abort signal was forwarded, and the client startup path invoked `start()` once after readiness succeeded.