### PR TITLE
fix(qa): keep runtime parity tiers flow-compatible

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -281,6 +281,8 @@ jobs:
 
           output_dir=".artifacts/qa-e2e/runtime-token-efficiency-live-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
+          mkdir -p "${output_dir}"
+          printf 'Runtime token-efficiency lane started.\n' > "${output_dir}/runtime-lane-started.txt"
 
           pnpm openclaw qa suite \
             --repo-root . \
@@ -296,7 +298,7 @@ jobs:
             --output-dir "${output_dir}/runtime-suite"
 
       - name: Generate live runtime token-efficiency report
-        if: always() && steps.run_lane.outcome != 'skipped' && steps.run_lane.outcome != 'cancelled'
+        if: steps.run_lane.outcome == 'success'
         shell: bash
         run: |
           set -euo pipefail
@@ -309,7 +311,7 @@ jobs:
             --output-dir "${{ steps.run_lane.outputs.output_dir }}/runtime-report"
 
       - name: Upload live runtime token-efficiency artifacts
-        if: always()
+        if: always() && steps.run_lane.outputs.output_dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: qa-live-runtime-token-efficiency-${{ github.run_id }}-${{ github.run_attempt }}

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -123,6 +123,8 @@ import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js"
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
 
+const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+
 function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
   const [arg] = calls[0] ?? [];
@@ -2500,8 +2502,8 @@ describe("qa cli runtime", () => {
       repoRoot: path.resolve("/tmp/openclaw-repo"),
       transportId: "qa-channel",
       providerMode: "live-frontier",
-      primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      primaryModel: DEFAULT_LIVE_FRONTIER_MODEL,
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: undefined,
       message: "read qa kickoff and reply short",
       timeoutMs: undefined,

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QaScenarioPack } from "./scenario-catalog.js";
 
 const {
   runQaManualLane,
@@ -19,6 +20,7 @@ const {
   buildQaDockerHarnessImage,
   runQaDockerUp,
   defaultQaRuntimeModelForMode,
+  readQaScenarioPack,
 } = vi.hoisted(() => ({
   runQaManualLane: vi.fn(),
   runQaFlowSuiteFromRuntime: vi.fn(),
@@ -35,6 +37,7 @@ const {
   runQaDockerUp: vi.fn(),
   defaultQaRuntimeModelForMode:
     vi.fn<(mode: string, options?: { alternate?: boolean }) => string>(),
+  readQaScenarioPack: vi.fn<() => QaScenarioPack>(),
 }));
 
 vi.mock("./manual-lane.runtime.js", () => ({
@@ -88,6 +91,15 @@ vi.mock("./docker-up.runtime.js", () => ({
 vi.mock("./model-selection.runtime.js", () => ({
   defaultQaRuntimeModelForMode,
 }));
+
+vi.mock("./scenario-catalog.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./scenario-catalog.js")>();
+  readQaScenarioPack.mockImplementation(actual.readQaScenarioPack);
+  return {
+    ...actual,
+    readQaScenarioPack,
+  };
+});
 
 import { resolveRepoRelativeOutputDir } from "./cli-paths.js";
 import {
@@ -251,6 +263,7 @@ describe("qa cli runtime", () => {
       (mode: string, options?: { alternate?: boolean }) =>
         defaultQaProviderModelForMode(mode as QaProviderModeInput, options),
     );
+    readQaScenarioPack.mockClear();
     runQaSuite.mockResolvedValue(
       flowSuiteRuntimeResult({
         reportPath: suiteReportPath,
@@ -1538,6 +1551,67 @@ describe("qa cli runtime", () => {
         "runtime-tool-tts",
       ],
     });
+  });
+
+  it("keeps runtime-pair tier selection on flow scenarios and reports exclusions", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      runtimePair: "openclaw,codex",
+      runtimeParityTier: ["standard", "live-only"],
+    });
+
+    const scenarioIds = mockFirstObjectArg(runQaSuite).scenarioIds as string[];
+    expect(scenarioIds).toContain("runtime-first-hour-20-turn");
+    expect(scenarioIds).toContain("streaming-final-integrity");
+    expect(scenarioIds).not.toContain("hosted-image-generation-providers-live");
+    expect(scenarioIds).not.toContain("hosted-video-generation-providers-live");
+    expectFields(mockFirstObjectArg(runQaSuite), {
+      runtimePair: ["openclaw", "codex"],
+    });
+    expectWriteContains(
+      stderrWrite,
+      "excluded incompatible non-flow scenario(s): hosted-image-generation-providers-live (script), hosted-video-generation-providers-live (script)",
+    );
+  });
+
+  it("rejects explicit runtime-pair scenarios with no compatible flow execution", async () => {
+    await expect(
+      runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        runtimePair: "openclaw,codex",
+        scenarioIds: ["hosted-image-generation-providers-live"],
+      }),
+    ).rejects.toThrow(
+      "--runtime-pair requires execution.kind: flow scenarios; unsupported scenario(s): hosted-image-generation-providers-live (script)",
+    );
+
+    expect(runQaSuite).not.toHaveBeenCalled();
+  });
+
+  it("rejects runtime-pair tiers with no compatible flow scenarios", async () => {
+    const catalog = readQaScenarioPack();
+    const hostedImageScenario = catalog.scenarios.find(
+      (scenario) => scenario.id === "hosted-image-generation-providers-live",
+    );
+    if (!hostedImageScenario) {
+      throw new Error("missing hosted image scenario fixture");
+    }
+    readQaScenarioPack.mockReturnValueOnce({
+      ...catalog,
+      scenarios: [hostedImageScenario],
+    });
+
+    await expect(
+      runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        runtimePair: "openclaw,codex",
+        runtimeParityTier: ["live-only"],
+      }),
+    ).rejects.toThrow(
+      "--runtime-parity-tier matched no execution.kind: flow scenarios for live-only; incompatible scenario(s): hosted-image-generation-providers-live (script).",
+    );
+
+    expect(runQaSuite).not.toHaveBeenCalled();
   });
 
   it("rejects unknown runtime parity tier filters", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -314,25 +314,47 @@ function parseQaRuntimeParityTierFilters(input: string[] | undefined): QaRuntime
 function resolveQaRuntimeParityTierScenarioIds(params: {
   scenarioIds: string[];
   runtimeParityTiers: readonly QaRuntimeParityTier[];
-}): string[] {
+  runtimePair: boolean;
+}): { scenarioIds: string[]; excludedNonFlowScenarios: string[] } {
   if (params.runtimeParityTiers.length === 0) {
-    return params.scenarioIds;
+    return { scenarioIds: params.scenarioIds, excludedNonFlowScenarios: [] };
   }
   const tierSet = new Set(params.runtimeParityTiers);
-  const matchingScenarioIds = readQaScenarioPack()
-    .scenarios.filter(
-      (scenario) => scenario.runtimeParityTier && tierSet.has(scenario.runtimeParityTier),
-    )
-    .map((scenario) => scenario.id);
-  if (matchingScenarioIds.length === 0) {
+  const matchingScenarios = readQaScenarioPack().scenarios.filter(
+    (scenario) => scenario.runtimeParityTier && tierSet.has(scenario.runtimeParityTier),
+  );
+  if (matchingScenarios.length === 0) {
     throw new Error(
       `--runtime-parity-tier matched no scenarios for ${params.runtimeParityTiers.join(", ")}.`,
     );
   }
-  return uniqueStrings([...params.scenarioIds, ...matchingScenarioIds]);
+  const compatibleScenarios = params.runtimePair
+    ? matchingScenarios.filter((scenario) => scenario.execution.kind === "flow")
+    : matchingScenarios;
+  const excludedNonFlowScenarios = params.runtimePair
+    ? matchingScenarios
+        .filter((scenario) => scenario.execution.kind !== "flow")
+        .map((scenario) => `${scenario.id} (${scenario.execution.kind})`)
+    : [];
+  if (compatibleScenarios.length === 0) {
+    throw new Error(
+      `--runtime-parity-tier matched no execution.kind: flow scenarios for ${params.runtimeParityTiers.join(", ")}; incompatible scenario(s): ${excludedNonFlowScenarios.join(", ")}.`,
+    );
+  }
+  return {
+    scenarioIds: uniqueStrings([
+      ...params.scenarioIds,
+      ...compatibleScenarios.map((scenario) => scenario.id),
+    ]),
+    excludedNonFlowScenarios,
+  };
 }
 
-function rejectNonFlowScenarioIdsForMultipass(scenarioIds: readonly string[]) {
+function rejectNonFlowScenarioIds(params: {
+  option: "--runner multipass" | "--runtime-pair";
+  scenarioIds: readonly string[];
+}) {
+  const scenarioIds = params.scenarioIds;
   if (scenarioIds.length === 0) {
     return;
   }
@@ -347,7 +369,7 @@ function rejectNonFlowScenarioIdsForMultipass(scenarioIds: readonly string[]) {
   });
   if (nonFlowScenarios.length > 0) {
     throw new Error(
-      `--runner multipass requires execution.kind: flow scenarios; unsupported scenario(s): ${nonFlowScenarios.join(", ")}`,
+      `${params.option} requires execution.kind: flow scenarios; unsupported scenario(s): ${nonFlowScenarios.join(", ")}`,
     );
   }
 }
@@ -881,6 +903,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
   const runner = (opts.runner ?? "host").trim().toLowerCase();
+  const runtimePair = parseQaRuntimePair(opts.runtimePair);
   const explicitScenarioIds = resolveQaScenarioPackScenarioIds({
     pack: opts.pack,
     scenarioIds: resolveQaParityPackScenarioIds({
@@ -889,13 +912,22 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     }),
   });
   const runtimeParityTiers = parseQaRuntimeParityTierFilters(opts.runtimeParityTier);
-  const scenarioIds = resolveQaRuntimeParityTierScenarioIds({
+  const runtimeParityTierSelection = resolveQaRuntimeParityTierScenarioIds({
     scenarioIds: explicitScenarioIds,
     runtimeParityTiers,
+    runtimePair: runtimePair !== undefined,
   });
+  const scenarioIds = runtimeParityTierSelection.scenarioIds;
+  if (runtimePair) {
+    rejectNonFlowScenarioIds({ option: "--runtime-pair", scenarioIds });
+  }
+  if (runtimeParityTierSelection.excludedNonFlowScenarios.length > 0) {
+    process.stderr.write(
+      `QA runtime-pair tier selection excluded incompatible non-flow scenario(s): ${runtimeParityTierSelection.excludedNonFlowScenarios.join(", ")}\n`,
+    );
+  }
   const allowFailures = opts.allowFailures === true;
   const providerMode = normalizeQaProviderMode(opts.providerMode);
-  const runtimePair = parseQaRuntimePair(opts.runtimePair);
   const claudeCliAuthMode = parseQaCliBackendAuthMode(opts.cliAuthMode);
   const primaryModel = normalizeQaOptionalModelRef(opts.primaryModel);
   const alternateModel = normalizeQaOptionalModelRef(opts.alternateModel);
@@ -959,7 +991,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     throw new Error("--runtime-pair is not supported with a live QA adapter.");
   }
   if (runner === "multipass") {
-    rejectNonFlowScenarioIdsForMultipass(scenarioIds);
+    rejectNonFlowScenarioIds({ option: "--runner multipass", scenarioIds });
     const thinkingDefault = parseQaThinkingLevel("--thinking", opts.thinking);
     const result = await runQaMultipass({
       repoRoot,

--- a/extensions/qa-lab/src/run-config.test.ts
+++ b/extensions/qa-lab/src/run-config.test.ts
@@ -19,6 +19,8 @@ import {
   type QaProviderModeInput,
 } from "./run-config.js";
 
+const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+
 const scenarios = [
   {
     id: "dm-chat-baseline",
@@ -60,8 +62,8 @@ describe("qa run config", () => {
   it("creates a live-by-default selection that arms flow scenarios", () => {
     expect(createDefaultQaRunSelection(scenarios)).toEqual({
       providerMode: "live-frontier",
-      primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      primaryModel: DEFAULT_LIVE_FRONTIER_MODEL,
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: true,
       scenarioIds: ["dm-chat-baseline", "thread-lifecycle"],
     });
@@ -82,7 +84,7 @@ describe("qa run config", () => {
     ).toEqual({
       providerMode: "live-frontier",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: true,
       scenarioIds: ["thread-lifecycle"],
     });
@@ -130,8 +132,8 @@ describe("qa run config", () => {
 
     const selection = createIdleQaRunnerSnapshot(scenarios).selection;
     expect(selection.providerMode).toBe("live-frontier");
-    expect(selection.primaryModel).toBe("openai/gpt-5.5");
-    expect(selection.alternateModel).toBe("openai/gpt-5.5");
+    expect(selection.primaryModel).toBe(DEFAULT_LIVE_FRONTIER_MODEL);
+    expect(selection.alternateModel).toBe(DEFAULT_LIVE_FRONTIER_MODEL);
     expect(defaultQaRuntimeModelForMode).not.toHaveBeenCalled();
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1687,22 +1687,38 @@ describe("package artifact reuse", () => {
 
   it("requires QA live evidence artifacts when lanes run", () => {
     const cases = [
-      ["run_mock_parity", "Upload parity artifacts"],
-      ["run_live_runtime_token_efficiency", "Upload live runtime token-efficiency artifacts"],
-      ["run_live_matrix", "Upload Matrix QA artifacts"],
-      ["run_live_matrix_sharded", "Upload Matrix QA shard artifacts"],
-      ["run_live_telegram", "Upload Telegram QA artifacts"],
-      ["run_live_discord", "Upload Discord QA artifacts"],
-      ["run_live_whatsapp", "Upload WhatsApp QA artifacts"],
-      ["run_live_slack", "Upload Slack QA artifacts"],
+      ["run_mock_parity", "Upload parity artifacts", "always()"],
+      [
+        "run_live_runtime_token_efficiency",
+        "Upload live runtime token-efficiency artifacts",
+        "always() && steps.run_lane.outputs.output_dir != ''",
+      ],
+      ["run_live_matrix", "Upload Matrix QA artifacts", "always()"],
+      ["run_live_matrix_sharded", "Upload Matrix QA shard artifacts", "always()"],
+      ["run_live_telegram", "Upload Telegram QA artifacts", "always()"],
+      ["run_live_discord", "Upload Discord QA artifacts", "always()"],
+      ["run_live_whatsapp", "Upload WhatsApp QA artifacts", "always()"],
+      ["run_live_slack", "Upload Slack QA artifacts", "always()"],
     ];
 
-    for (const [jobName, stepName] of cases) {
+    for (const [jobName, stepName, uploadCondition] of cases) {
       const uploadStep = workflowStep(workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, jobName), stepName);
 
-      expect(uploadStep.if, jobName).toBe("always()");
+      expect(uploadStep.if, jobName).toBe(uploadCondition);
       expect(uploadStep.with?.["if-no-files-found"], jobName).toBe("error");
     }
+  });
+
+  it("preserves the primary runtime token-efficiency failure", () => {
+    const job = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_runtime_token_efficiency");
+    const runStep = workflowStep(job, "Run live runtime parity lane");
+    const reportStep = workflowStep(job, "Generate live runtime token-efficiency report");
+
+    expect(runStep.run).toContain('mkdir -p "${output_dir}"');
+    expect(runStep.run).toContain(
+      "printf 'Runtime token-efficiency lane started.\\n' > \"${output_dir}/runtime-lane-started.txt\"",
+    );
+    expect(reportStep.if).toBe("steps.run_lane.outcome == 'success'");
   });
 
   it("requires release-check QA evidence artifacts when lanes run", () => {


### PR DESCRIPTION
## What Problem This Solves

The scheduled QA token-efficiency lane requested the `standard` and `live-only` runtime parity tiers together with the `openclaw,codex` runtime pair. Tier expansion included two native script scenarios, but runtime-pair comparison only supports flow scenarios, so the lane failed before executing any model calls. Follow-up report and artifact steps then obscured that selector error with missing-file failures.

Closes #103588.

## Why This Change Was Made

- Filter tier-derived runtime-pair selections to flow-compatible scenarios while reporting every excluded non-flow scenario.
- Reject explicit incompatible scenario requests and zero-compatible tier selections with actionable errors.
- Create the lane artifact directory and marker before execution, report only successful lane runs, and still upload the marker/artifacts after failures.
- Repair current-main QA expectations to read the canonical live-frontier default after the GPT-5.6 default change, while retaining assertions over CLI/config wiring.

## User Impact

Scheduled release QA can run runtime-pair tiers without deterministic selector failure. Operators get the original lane error plus durable failure artifacts instead of secondary missing-report noise. Product runtime behavior is unchanged.

## Evidence

- Fresh Testbox `tbx_01kx5p0nw21ga02bj89dhea1s6` on head `d07718d74ae0`: focused QA/workflow proof passed, 161/161 tests.
- Same Testbox: `check:changed` passed extension production/test typechecks, extension/script lint, Docker E2E boundary checks, storage guards, and runtime import-cycle checks.
- Hydration run: https://github.com/openclaw/openclaw/actions/runs/29083466928
- `actionlint .github/workflows/qa-live-transports-convex.yml`
- `git diff --check origin/main...HEAD`
- Fresh branch autoreview: clean, no accepted/actionable findings; correctness 0.93.

No changelog entry: internal QA/release-CI behavior only.
