### PR TITLE
fix(ui): restore sidebar pin editor keyboard controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
-- **Control UI sidebar menu keyboard controls:** restore wrapping Arrow/Home/End focus, Escape focus return, and Tab dismissal for sidebar pin and session menus after the desktop topbar removal. (#103602)
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
+- **Control UI sidebar menu keyboard controls:** restore wrapping Arrow/Home/End focus, Escape focus return, and Tab dismissal for sidebar pin and session menus after the desktop topbar removal. (#103602)
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -925,14 +925,60 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     this.closeSessionSortMenu();
   };
 
+  // Registered only while one of the transient menus is open. Keeping this
+  // listener lifecycle-bound prevents menu shortcuts from consuming page keys.
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
+      event.preventDefault();
       event.stopPropagation();
       this.closeCustomizeMenu({ restoreFocus: true });
       this.closeSessionGroupMenu({ restoreFocus: true });
       this.closeSessionSortMenu({ restoreFocus: true });
+      return;
     }
+    if (event.key === "Tab") {
+      // Menu items stay outside the page tab order. Restore the durable trigger
+      // before the browser performs its normal forward/backward Tab movement.
+      this.closeCustomizeMenu({ restoreFocus: true });
+      this.closeSessionGroupMenu({ restoreFocus: true });
+      this.closeSessionSortMenu({ restoreFocus: true });
+      return;
+    }
+    this.moveTransientMenuFocus(event);
   };
+
+  private moveTransientMenuFocus(event: KeyboardEvent) {
+    const menu = this.querySelector<HTMLElement>(
+      ".sidebar-customize-menu, .sidebar-session-group-menu, .sidebar-session-sort-menu",
+    );
+    if (!menu) {
+      return;
+    }
+    const items = Array.from(
+      menu.querySelectorAll<HTMLElement>(
+        '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]',
+      ),
+    ).filter((item) => !item.matches(":disabled"));
+    if (items.length === 0) {
+      return;
+    }
+    const activeIndex = items.indexOf(document.activeElement as HTMLElement);
+    let nextIndex: number;
+    if (event.key === "ArrowDown") {
+      nextIndex = (activeIndex + 1) % items.length;
+    } else if (event.key === "ArrowUp") {
+      nextIndex = activeIndex <= 0 ? items.length - 1 : activeIndex - 1;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = items.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    items[nextIndex]?.focus();
+  }
 
   private togglePinnedRoute(routeId: SidebarNavRoute) {
     const pinned = this.sidebarPinnedRoutes;
@@ -962,6 +1008,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               type="button"
               class="sidebar-customize-menu__item"
               role="menuitemcheckbox"
+              tabindex="-1"
               aria-checked=${String(pinned)}
               @click=${() => this.togglePinnedRoute(routeId)}
             >
@@ -980,6 +1027,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           type="button"
           class="sidebar-customize-menu__item"
           role="menuitem"
+          tabindex="-1"
           @click=${() => {
             this.onUpdatePinnedRoutes?.([...DEFAULT_SIDEBAR_PINNED_ROUTES]);
             this.closeCustomizeMenu({ restoreFocus: true });
@@ -1082,6 +1130,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           type="button"
           class="session-menu__item"
           role="menuitem"
+          tabindex="-1"
           ?disabled=${!this.connected}
           @click=${() => {
             this.closeSessionGroupMenu();
@@ -1095,6 +1144,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           type="button"
           class="session-menu__item"
           role="menuitem"
+          tabindex="-1"
           @click=${() => {
             this.closeSessionGroupMenu();
             this.createSessionGroup();
@@ -1108,6 +1158,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           type="button"
           class="session-menu__item session-menu__item--destructive"
           role="menuitem"
+          tabindex="-1"
           ?disabled=${!this.connected}
           @click=${() => {
             this.closeSessionGroupMenu();
@@ -1144,6 +1195,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               type="button"
               class="sidebar-session-sort-menu__item"
               role="menuitemradio"
+              tabindex="-1"
               aria-checked=${String(this.sessionsGrouping === option.grouping)}
               @click=${() => {
                 this.setSessionsGrouping(option.grouping);
@@ -1165,6 +1217,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               type="button"
               class="sidebar-session-sort-menu__item"
               role="menuitemradio"
+              tabindex="-1"
               aria-checked=${String(this.sessionSortMode === option.mode)}
               @click=${() => {
                 this.sessionSortMode = option.mode;

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -63,7 +63,7 @@ async function holdUiProof(page: Page, durationMs = 600) {
   }
 }
 
-async function openTopbarTestPage() {
+async function openSidebarTestPage() {
   const context = await browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
@@ -436,7 +436,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     }
   });
 
-  it("passes failed run outcomes to both desktop and drawer lobsters", async () => {
+  it("passes failed run outcomes through the desktop and drawer sidebar", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -473,51 +473,33 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     try {
       await page.goto(`${server.baseUrl}overview`);
       const sidebar = page.locator("openclaw-app-sidebar");
-      const desktopPet = sidebar.locator(".sidebar-panel openclaw-lobster-pet");
-      await expect.poll(() => outcome(desktopPet)).toBe("error");
+      const pet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
+      await expect.poll(() => pet.count()).toBe(1);
+      await expect.poll(() => outcome(pet)).toBe("error");
+      await expect.poll(() => page.locator(".topbar").isVisible()).toBe(false);
 
       await page.setViewportSize({ height: 900, width: 900 });
-      await page.locator(".topbar-nav-toggle").click();
-      const drawerPet = sidebar.locator(".sidebar-shell openclaw-lobster-pet");
-      await expect.poll(() => outcome(drawerPet)).toBe("error");
+      const drawerButton = page.locator(".topbar-nav-toggle");
+      await expect.poll(() => drawerButton.isVisible()).toBe(true);
+      await drawerButton.click();
+      await expect.poll(() => sidebar.isVisible()).toBe(true);
+      await expect.poll(() => pet.count()).toBe(1);
+      await expect.poll(() => outcome(pet)).toBe("error");
     } finally {
       await context.close();
     }
   });
 
-  it("dismisses the desktop More menu when the viewport enters drawer layout", async () => {
-    const { context, page } = await openTopbarTestPage();
+  it("restores focus to Edit pinned items after closing its menu with Escape", async () => {
+    const { context, page } = await openSidebarTestPage();
 
     try {
-      const moreButton = page.locator(".topbar-nav").getByRole("button", { name: "More" });
+      const sidebar = page.locator("openclaw-app-sidebar");
+      const moreButton = sidebar.getByRole("button", { name: "More" });
       await moreButton.click();
-      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(1);
-      await captureUiProof(page, "07-topbar-menu-open.png");
-
-      await page.setViewportSize({ height: 900, width: 900 });
-      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(0);
-      await captureUiProof(page, "08-drawer-with-menu-dismissed.png");
-
-      await page.setViewportSize({ height: 900, width: 1440 });
-      await expect.poll(() => moreButton.isVisible()).toBe(true);
-      await moreButton.click();
-      await page.getByRole("menuitem", { name: "Edit pinned items" }).click();
-      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(1);
-      await page.setViewportSize({ height: 900, width: 900 });
-      await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(0);
-    } finally {
-      await context.close();
-    }
-  });
-
-  it("restores focus to More after closing the pin editor with Escape", async () => {
-    const { context, page } = await openTopbarTestPage();
-
-    try {
-      const moreButton = page.locator(".topbar-nav").getByRole("button", { name: "More" });
-      await moreButton.click();
-      await page.getByRole("menuitem", { name: "Edit pinned items" }).click();
-      const pinItems = page
+      const editPinnedButton = sidebar.getByRole("button", { name: "Edit pinned items" });
+      await editPinnedButton.click();
+      const pinItems = sidebar
         .getByRole("menu", { name: "Edit pinned items" })
         .locator('[role="menuitem"], [role="menuitemcheckbox"]');
       await page.keyboard.press("End");
@@ -532,19 +514,22 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
 
       await expect.poll(() => page.locator(".sidebar-customize-menu").count()).toBe(0);
       await expect
-        .poll(() => moreButton.evaluate((element) => element === document.activeElement))
+        .poll(() => editPinnedButton.evaluate((element) => element === document.activeElement))
         .toBe(true);
     } finally {
       await context.close();
     }
   });
 
-  it("moves focus through the More menu with arrow keys", async () => {
-    const { context, page } = await openTopbarTestPage();
+  it("moves focus through the sidebar pin editor with menu keys", async () => {
+    const { context, page } = await openSidebarTestPage();
 
     try {
-      await page.locator(".topbar-nav").getByRole("button", { name: "More" }).click();
-      const menuItems = page.locator(".topbar-menu").getByRole("menuitem");
+      const sidebar = page.locator("openclaw-app-sidebar");
+      await sidebar.getByRole("button", { name: "More" }).click();
+      await sidebar.getByRole("button", { name: "Edit pinned items" }).click();
+      const menu = sidebar.getByRole("menu", { name: "Edit pinned items" });
+      const menuItems = menu.locator('[role="menuitem"], [role="menuitemcheckbox"]');
       await expect
         .poll(() => menuItems.evaluateAll((items) => items.every((item) => item.tabIndex === -1)))
         .toBe(true);
@@ -565,12 +550,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
         .poll(() => menuItems.first().evaluate((element) => element === document.activeElement))
         .toBe(true);
       await page.keyboard.press("Tab");
-      await expect.poll(() => page.locator(".topbar-menu").count()).toBe(0);
-      await expect
-        .poll(() =>
-          page.locator(".topbar-search").evaluate((element) => element === document.activeElement),
-        )
-        .toBe(true);
+      await expect.poll(() => menu.count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -200,7 +200,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await settingsSearch.fill("system");
       await expect
         .poll(() => trimmedTextContents(settingsLinks))
-        .toEqual(["Infrastructure", "Worktrees", "Debug", "Logs"]);
+        .toEqual(["Infrastructure", "Worktrees", "Debug", "Logs", "About"]);
       await captureSettingsSidebarProof(settingsSidebar, "01c-settings-search-group.png");
       await holdUiProof(page);
       await settingsSearch.fill("does-not-exist");


### PR DESCRIPTION
## What Problem This Solves

Closes #103602.

The full Control UI E2E lane had four deterministic failures after #103561 removed the desktop topbar and moved the pin editor into the sidebar. Retargeting the stale assertions also exposed a real accessibility regression: the moved ARIA menu lost its roving-focus keyboard behavior and left its items in the page tab order.

## Why This Change Was Made

- Restore the sidebar owner's Arrow Up/Down, Home, End, Escape, and Tab handling for its transient menus.
- Keep menu items at `tabindex="-1"` so the durable trigger remains the page's tab stop.
- Replace deleted `.topbar-nav`, `.topbar-menu`, and `.sidebar-panel` assumptions with the current desktop sidebar and narrow drawer contract.
- Assert that one lobster preserves a failed run outcome across the desktop-to-drawer transition.
- Keep the settings-search assertion aligned with the newly added About route discovered by the exact-head full run.

This does not restore compatibility for the intentionally deleted desktop topbar.

## User Impact

Keyboard users can navigate and dismiss the sidebar pin editor consistently again. Release validation no longer waits on impossible selectors, and the E2E coverage now follows the current sidebar ownership model.

## Evidence

### Before

- Exact red `main`: `8755077fe45b8e3ddfb0bc1e93dd306b7417e7fa`; the affected sidebar ownership remained unchanged through the repaired branch base.
- Blacksmith Testbox `tbx_01kx5mz31twacrg795rnhz0qm5`.
- `pnpm test:ui:e2e`: 1 failed / 30 passed files; 4 failed / 98 passed tests; deterministic timeouts on the deleted sidebar panel and topbar menu.

### After

- `pnpm test ui/src/components/app-sidebar.test.ts`: 8/8 passed.
- `node scripts/run-vitest.mjs ui/src/e2e/sidebar-customization.e2e.test.ts`: 5/5 passed.
- `pnpm test:ui:e2e`: 32/32 files, 102/102 tests passed on Blacksmith Testbox after the repair.
- `pnpm check:changed`: passed on Blacksmith Testbox in 10m31s.
- Fresh autoreview: clean; no accepted/actionable findings.
