### PR TITLE
fix(extensions/anthropic): preserve migrated model entries when inherited keys shadow converted refs

### DIFF
--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -332,6 +332,98 @@ describe("anthropic cli migration", () => {
     });
   });
 
+  it.each([
+    {
+      descriptor: {
+        value: { inherited: true },
+        writable: true,
+      },
+      name: "writable data descriptor",
+    },
+    {
+      descriptor: {
+        value: { inherited: true },
+        writable: false,
+      },
+      name: "non-writable data descriptor",
+    },
+    {
+      descriptor: {
+        get: () => ({ inherited: true }),
+      },
+      name: "getter-only accessor",
+    },
+  ])("writes migrated refs as own entries over an inherited $name", ({ descriptor }) => {
+    // Process-global prototype pollution can expose a converted ref. The
+    // migration must write the converted entry as an own property without
+    // invoking inherited getters/setters or throwing on non-writable descriptors.
+    const convertedRef = "anthropic/claude-opus-4-7";
+    const priorDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, convertedRef);
+    try {
+      Reflect.defineProperty(Object.prototype, convertedRef, {
+        configurable: true,
+        ...descriptor,
+      });
+
+      const result = buildAnthropicCliMigrationResult({
+        agents: {
+          defaults: {
+            model: { primary: "claude-cli/claude-opus-4-7" },
+            models: {
+              "claude-cli/claude-opus-4-7": { alias: "Opus" },
+            },
+          },
+        },
+      });
+
+      const migrated = result.configPatch?.agents?.defaults?.models?.[convertedRef];
+      expect(migrated).toEqual({ alias: "Opus", agentRuntime: { id: "claude-cli" } });
+      expect(Object.hasOwn(result.configPatch?.agents?.defaults?.models, convertedRef)).toBe(true);
+    } finally {
+      if (priorDescriptor) {
+        Reflect.defineProperty(Object.prototype, convertedRef, priorDescriptor);
+      } else {
+        Reflect.deleteProperty(Object.prototype, convertedRef);
+      }
+    }
+  });
+
+  it("writes migrated refs as own entries without invoking an inherited setter", () => {
+    const convertedRef = "anthropic/claude-opus-4-7";
+    let setterCalled = false;
+    const priorDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, convertedRef);
+    try {
+      Reflect.defineProperty(Object.prototype, convertedRef, {
+        configurable: true,
+        set: () => {
+          setterCalled = true;
+        },
+      });
+
+      const result = buildAnthropicCliMigrationResult({
+        agents: {
+          defaults: {
+            model: { primary: "claude-cli/claude-opus-4-7" },
+            models: {
+              "claude-cli/claude-opus-4-7": { alias: "Opus" },
+            },
+          },
+        },
+      });
+
+      const migrated = result.configPatch?.agents?.defaults?.models?.[convertedRef];
+      expect(migrated).toEqual({ alias: "Opus", agentRuntime: { id: "claude-cli" } });
+      expect(Object.hasOwn(result.configPatch?.agents?.defaults?.models, convertedRef)).toBe(true);
+      expect(setterCalled).toBe(false);
+    } finally {
+      if (priorDescriptor) {
+        Reflect.defineProperty(Object.prototype, convertedRef, priorDescriptor);
+      } else {
+        Reflect.deleteProperty(Object.prototype, convertedRef);
+      }
+    }
+  });
+
   it("preserves explicit model runtime policy while filling missing Claude CLI policies", () => {
     const result = buildAnthropicCliMigrationResult({
       agents: {

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -376,9 +376,10 @@ describe("anthropic cli migration", () => {
         },
       });
 
-      const migrated = result.configPatch?.agents?.defaults?.models?.[convertedRef];
+      const models = result.configPatch?.agents?.defaults?.models ?? {};
+      const migrated = models[convertedRef];
       expect(migrated).toEqual({ alias: "Opus", agentRuntime: { id: "claude-cli" } });
-      expect(Object.hasOwn(result.configPatch?.agents?.defaults?.models, convertedRef)).toBe(true);
+      expect(Object.hasOwn(models, convertedRef)).toBe(true);
     } finally {
       if (priorDescriptor) {
         Reflect.defineProperty(Object.prototype, convertedRef, priorDescriptor);
@@ -411,9 +412,10 @@ describe("anthropic cli migration", () => {
         },
       });
 
-      const migrated = result.configPatch?.agents?.defaults?.models?.[convertedRef];
+      const models = result.configPatch?.agents?.defaults?.models ?? {};
+      const migrated = models[convertedRef];
       expect(migrated).toEqual({ alias: "Opus", agentRuntime: { id: "claude-cli" } });
-      expect(Object.hasOwn(result.configPatch?.agents?.defaults?.models, convertedRef)).toBe(true);
+      expect(Object.hasOwn(models, convertedRef)).toBe(true);
       expect(setterCalled).toBe(false);
     } finally {
       if (priorDescriptor) {

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -119,8 +119,13 @@ function rewriteModelEntryMap(models: Record<string, unknown> | undefined): {
     if (converted === rawKey) {
       continue;
     }
-    if (!(converted in next)) {
-      next[converted] = value;
+    if (!Object.hasOwn(next, converted)) {
+      Object.defineProperty(next, converted, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     if (normalizeLowercaseStringOrEmpty(rawKey).startsWith(`${CLAUDE_CLI_BACKEND_ID}/`)) {
       delete next[rawKey];
@@ -149,7 +154,13 @@ function seedClaudeCliAllowlist(
     runtimeRefs.add(ref);
   }
   for (const ref of runtimeRefs) {
-    next[ref] = modelEntryWithClaudeCliRuntime(next[ref]);
+    const current = Object.hasOwn(next, ref) ? next[ref] : undefined;
+    Object.defineProperty(next, ref, {
+      value: modelEntryWithClaudeCliRuntime(current),
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
   return next;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where adopting Claude CLI auth could silently drop a model's custom settings (aliases, parameters, etc.) or throw when the global `Object.prototype` contains an inherited property matching the converted Anthropic model ref.

## Why This Change Was Made

`rewriteModelEntryMap` used `converted in next` to decide whether to copy a legacy `claude-cli/*` entry to its Anthropic equivalent, and then assigned with `next[converted] = value`. The `in` operator follows the prototype chain, and the assignment can throw or invoke an inherited setter when `Object.prototype` is polluted. The migration could therefore skip the copy, delete the original `claude-cli/*` key, and lose the user's model configuration.

The change now:
- checks own-property membership with `Object.hasOwn`;
- writes migrated and seeded entries with `Object.defineProperty` so they become own properties even when `Object.prototype` has a getter-only accessor, non-writable data descriptor, or setter.

This applies the same own-entry invariant that #103373 adds to the Anthropic API-key default-allowlist seeding path.

## User Impact

Users whose runtime has a polluted `Object.prototype` no longer lose per-model aliases or other metadata, and no longer see migration throws, when adopting Claude CLI-backed Anthropic refs.

## Evidence

### Unit tests

```bash
pnpm test extensions/anthropic/cli-migration.test.ts --run
```

Result: 19 passed.

The regression suite covers four Object.prototype descriptor collisions and fails against the parent commit:
- inherited writable data descriptor;
- inherited non-writable data descriptor (throws before the fix);
- inherited getter-only accessor (throws before the fix);
- inherited setter accessor (entry becomes undefined before the fix, setter is not invoked after).

### Type / lint

```bash
pnpm tsgo:extensions        # exit 0
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/anthropic/cli-migration.test.ts extensions/anthropic/cli-migration.ts
```

Both pass.

### Live migration proof

Controlled run with an `Object.prototype` getter-only accessor shadowing the converted ref:

```text
=== Claude CLI auth adoption migration proof ===
Scenario: Object.prototype has a getter-only accessor for the converted ref.
Migrated entry: {
  "alias": "Work Opus",
  "temperature": 0.7,
  "agentRuntime": { "id": "claude-cli" }
}
Entry is own property: true
Alias preserved: true
Parameters preserved: true
```

The alias and `temperature` parameter survive migration, and the resulting entry is an own property of `models` rather than the inherited accessor value.

## Release Note

- Anthropic: preserve migrated model aliases and parameters when inherited prototype keys shadow converted Claude CLI refs.

Related: #103373
