### PR TITLE
fix(agents): prevent transcript redaction from corrupting signed reasoning

### DIFF
--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -28,6 +28,21 @@ function cfg(mode: "tools" | "off", patterns?: string[]): OpenClawConfig {
   } satisfies OpenClawConfig;
 }
 
+function googleCompatCfg(): OpenClawConfig {
+  return {
+    ...cfg("tools"),
+    models: {
+      providers: {
+        "google-compatible-proxy": {
+          api: "openai-completions",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+          models: [],
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
+}
+
 const EMAIL_PATTERN = String.raw`([\w]|[-.])+@([\w]|[-.])+\.\w+`;
 const IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAARcnVOZAAAAKIDABCDEFGHIJKLMNOP8JJRuAAAAABJRU5ErkJggg==";
@@ -39,6 +54,10 @@ const CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES =
   "gAAAAABpQnQrXzzZqcAfo3unbAY-ku84xgsvB0fpLkbDvSh3WS5qzfSCmcgwr8_abcdefghijvK2RyV2GQ4ohzcfYwhRwTvY76TvR7Tvr_";
 const GOOGLE_THOUGHT_SIGNATURE = Buffer.from(`thought-${"x".repeat(32)}`).toString("base64");
 const SHORT_GOOGLE_THOUGHT_SIGNATURE = "c2ln";
+const GOOGLE_CREDENTIAL_COLLISION = `AAAAAIza${"A".repeat(20)}`;
+const ALIBABA_CREDENTIAL_COLLISION = `AAAALTAI${"B".repeat(12)}`;
+const OPAQUE_CREDENTIAL_COLLISION = `signature.v2:${GOOGLE_CREDENTIAL_COLLISION}`;
+const OPENAI_COMPAT_OPAQUE_COLLISION = `SIG-${GOOGLE_CREDENTIAL_COLLISION}`;
 const COPILOT_CONNECTION_BOUND_ID = Buffer.from(`message-${"y".repeat(24)}`).toString("base64");
 const OPENAI_REASONING_REPLAY_METADATA = {
   v: 1,
@@ -317,7 +336,7 @@ describe("redactTranscriptMessage", () => {
           type: "toolCall",
           id: "call_1",
           name: "send_request",
-          thoughtSignature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          thoughtSignature: GOOGLE_THOUGHT_SIGNATURE,
           arguments: {
             apiKey: "plainsecretvalue123",
             thinkingSignature: "sk-abcdef1234567890xyz",
@@ -345,7 +364,7 @@ describe("redactTranscriptMessage", () => {
         arguments: Record<string, string>;
       }>
     )[0];
-    expect(block.thoughtSignature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(block.thoughtSignature).toBe(GOOGLE_THOUGHT_SIGNATURE);
     expect(JSON.stringify(block.arguments)).not.toContain("sk-abcdef1234567890xyz");
     expect(block.arguments.apiKey).toBe("plains…e123");
   });
@@ -369,7 +388,7 @@ describe("redactTranscriptMessage", () => {
         {
           type: "thinking",
           thinking: "secret sk-abcdef1234567890xyz",
-          thought_signature: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+          thought_signature: SHORT_GOOGLE_THOUGHT_SIGNATURE,
         },
       ],
     } as unknown as AgentMessage;
@@ -380,7 +399,7 @@ describe("redactTranscriptMessage", () => {
     expect(blocks[0].textSignature).toBe(GOOGLE_THOUGHT_SIGNATURE);
     expect(blocks[1].textSignature).not.toContain("sk-abcdef1234567890xyz");
     expect(blocks[2].thinking).not.toContain("sk-abcdef1234567890xyz");
-    expect(blocks[2].thought_signature).toBe(CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES);
+    expect(blocks[2].thought_signature).toBe(SHORT_GOOGLE_THOUGHT_SIGNATURE);
   });
 
   it.each(["openai-responses", "openclaw-openai-responses-transport"])(
@@ -444,14 +463,13 @@ describe("redactTranscriptMessage", () => {
     expect(redactedBlock.metadata.accessToken).toBe("nested…t123");
   });
 
-  it("redacts credential-shaped values even on provider signature fields", () => {
-    const googleApiKey = `AIza${"a".repeat(32)}`;
+  it("preserves credential-shaped bytes in recognized provider replay fields", () => {
     const githubToken = `ghp_${"b".repeat(36)}`;
-    const awsAccessKey = "AKIAIOSFODNN7EXAMPLE";
     const encryptedDetail = JSON.stringify({
       type: "reasoning.encrypted",
       data: githubToken,
       id: "reasoning-encrypted-1",
+      secret: "sk-abcdef1234567890xyz",
     });
     const googleMsg = {
       role: "assistant",
@@ -463,22 +481,27 @@ describe("redactTranscriptMessage", () => {
           id: "call_1",
           name: "send_request",
           arguments: {},
-          thoughtSignature: awsAccessKey,
+          thoughtSignature: GOOGLE_CREDENTIAL_COLLISION,
         },
         {
-          type: "toolCall",
-          id: "call_2",
-          name: "send_request",
-          arguments: {},
-          thoughtSignature: googleApiKey,
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: ALIBABA_CREDENTIAL_COLLISION,
         },
       ],
     } as unknown as AgentMessage;
     const anthropicMsg = {
       role: "assistant",
-      api: "anthropic-messages",
-      provider: "anthropic",
-      content: [{ type: "redacted_thinking", data: githubToken }],
+      api: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      content: [
+        {
+          type: "thinking",
+          thinking: "visible",
+          signature: OPENAI_COMPAT_OPAQUE_COLLISION,
+        },
+        { type: "redacted_thinking", data: githubToken },
+      ],
     } as unknown as AgentMessage;
     const openAICompletionsMsg = {
       role: "assistant",
@@ -492,8 +515,93 @@ describe("redactTranscriptMessage", () => {
           arguments: {},
           thoughtSignature: encryptedDetail,
         },
+        {
+          type: "toolCall",
+          id: "call_secret",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: githubToken,
+        },
       ],
     } as unknown as AgentMessage;
+    const googleOpenAICompletionsMsg = {
+      role: "assistant",
+      api: "openclaw-openai-completions-transport",
+      model: "gemini-3.1-pro",
+      provider: "google-compatible-proxy",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_2",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: OPENAI_COMPAT_OPAQUE_COLLISION,
+        },
+      ],
+    } as unknown as AgentMessage;
+    const openAIResponsesMsg = {
+      role: "assistant",
+      api: "openai-responses",
+      model: "gpt-5.5",
+      provider: "openai",
+      content: [
+        {
+          type: "thinking",
+          thinking: "visible",
+          thinkingSignature: JSON.stringify({
+            id: "reasoning-1",
+            type: "reasoning",
+            encrypted_content: GOOGLE_CREDENTIAL_COLLISION,
+            summary: [{ type: "summary_text", text: "secret sk-abcdef1234567890xyz" }],
+            secret: "sk-abcdef1234567890xyz",
+          }),
+        },
+      ],
+    } as unknown as AgentMessage;
+
+    const googleBlocks = msgContent(redactTranscriptMessage(googleMsg, cfg("tools"))) as Array<
+      Record<string, string>
+    >;
+    expect(googleBlocks[0].thoughtSignature).toBe(GOOGLE_CREDENTIAL_COLLISION);
+    expect(googleBlocks[1].thinkingSignature).toBe(ALIBABA_CREDENTIAL_COLLISION);
+
+    const anthropicBlocks = msgContent(
+      redactTranscriptMessage(anthropicMsg, cfg("tools")),
+    ) as Array<Record<string, string>>;
+    expect(anthropicBlocks[0].signature).toBe(OPENAI_COMPAT_OPAQUE_COLLISION);
+    expect(anthropicBlocks[1].data).toBe(githubToken);
+
+    const completionsBlocks = msgContent(
+      redactTranscriptMessage(openAICompletionsMsg, cfg("tools")),
+    ) as Array<{ thoughtSignature: string }>;
+    expect(JSON.parse(completionsBlocks[0].thoughtSignature)).toEqual({
+      type: "reasoning.encrypted",
+      data: githubToken,
+      id: "reasoning-encrypted-1",
+    });
+    expect(completionsBlocks[1].thoughtSignature).not.toBe(githubToken);
+
+    const googleCompletionsBlock = (
+      msgContent(redactTranscriptMessage(googleOpenAICompletionsMsg, googleCompatCfg())) as Array<{
+        thoughtSignature: string;
+      }>
+    )[0];
+    expect(googleCompletionsBlock.thoughtSignature).toBe(OPENAI_COMPAT_OPAQUE_COLLISION);
+
+    const responsesBlock = (
+      msgContent(redactTranscriptMessage(openAIResponsesMsg, cfg("tools"))) as Array<{
+        thinkingSignature: string;
+      }>
+    )[0];
+    expect(JSON.parse(responsesBlock.thinkingSignature)).toEqual({
+      id: "reasoning-1",
+      type: "reasoning",
+      summary: [],
+      encrypted_content: GOOGLE_CREDENTIAL_COLLISION,
+    });
+  });
+
+  it("keeps unknown and malformed replay fields credential-safe", () => {
     const customProviderMsg = {
       role: "assistant",
       api: "custom-provider-api",
@@ -503,26 +611,81 @@ describe("redactTranscriptMessage", () => {
         {
           type: "thinking",
           thinking: "visible",
-          thinkingSignature: awsAccessKey,
+          thinkingSignature: ALIBABA_CREDENTIAL_COLLISION,
+        },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: JSON.stringify({
+            type: "reasoning.encrypted",
+            data: GOOGLE_CREDENTIAL_COLLISION,
+            id: "reasoning-encrypted-1",
+          }),
         },
       ],
     } as unknown as AgentMessage;
+    const malformedGoogleMsg = {
+      role: "assistant",
+      api: "google-generative-ai",
+      model: "gemini-3.1-pro",
+      provider: "google",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: OPAQUE_CREDENTIAL_COLLISION,
+        },
+      ],
+    } as unknown as AgentMessage;
+    const malformedKnownOpaqueMessages = [
+      {
+        role: "assistant",
+        api: "anthropic-messages",
+        model: "claude-opus-4-8",
+        provider: "anthropic",
+        content: [
+          {
+            type: "thinking",
+            thinking: "visible",
+            thinkingSignature: "secret sk-abcdef1234567890xyz",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        api: "openai-completions",
+        model: "gemini-3.1-pro",
+        provider: "google",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "send_request",
+            arguments: {},
+            thoughtSignature: "secret sk-abcdef1234567890xyz",
+          },
+        ],
+      },
+    ] as unknown as AgentMessage[];
 
     expect(
-      JSON.stringify(msgContent(redactTranscriptMessage(googleMsg, cfg("tools")))),
-    ).not.toContain(awsAccessKey);
-    expect(
-      JSON.stringify(msgContent(redactTranscriptMessage(googleMsg, cfg("tools")))),
-    ).not.toContain(googleApiKey);
-    expect(
-      JSON.stringify(msgContent(redactTranscriptMessage(anthropicMsg, cfg("tools")))),
-    ).not.toContain(githubToken);
-    expect(
-      JSON.stringify(msgContent(redactTranscriptMessage(openAICompletionsMsg, cfg("tools")))),
-    ).not.toContain(githubToken);
+      JSON.stringify(msgContent(redactTranscriptMessage(customProviderMsg, cfg("tools")))),
+    ).not.toContain(ALIBABA_CREDENTIAL_COLLISION);
     expect(
       JSON.stringify(msgContent(redactTranscriptMessage(customProviderMsg, cfg("tools")))),
-    ).not.toContain(awsAccessKey);
+    ).not.toContain(GOOGLE_CREDENTIAL_COLLISION);
+    expect(
+      JSON.stringify(msgContent(redactTranscriptMessage(malformedGoogleMsg, cfg("tools")))),
+    ).not.toContain(OPAQUE_CREDENTIAL_COLLISION);
+    for (const message of malformedKnownOpaqueMessages) {
+      expect(
+        JSON.stringify(msgContent(redactTranscriptMessage(message, cfg("tools")))),
+      ).not.toContain("sk-abcdef1234567890xyz");
+    }
   });
 
   it("redacts provider-shaped fields when the assistant route is missing", () => {

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -7,6 +7,7 @@ import {
   sanitizeInlineImageBase64,
   sanitizeInlineImageDataUrlForStorage,
 } from "@openclaw/media-core/inline-image-data-url";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readLoggingConfig } from "../logging/config.js";
 import {
@@ -14,6 +15,8 @@ import {
   redactSensitiveFieldValue,
   redactSensitiveText,
 } from "../logging/redact.js";
+import type { ProviderEndpointClass } from "./provider-attribution.js";
+import { resolveProviderEndpoint } from "./provider-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
 
 function resolveTranscriptRedactPatterns(patterns?: string[]) {
@@ -192,6 +195,7 @@ type TranscriptValueLocation =
 
 type TranscriptAssistantRoute = {
   api?: string;
+  endpointClass?: ProviderEndpointClass;
   model?: string;
   provider?: string;
 };
@@ -219,6 +223,8 @@ const OPENAI_COMPLETIONS_APIS = new Set([
   "openclaw-openai-completions-transport",
 ]);
 const OPAQUE_REPLAY_TOKEN_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;
+const GOOGLE_THOUGHT_SIGNATURE_RE =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 const OPENAI_REPLAY_CONTEXT_HASH_RE = /^[a-f0-9]{16}$/;
 
 function isOpenAIResponsesRoute(route: TranscriptAssistantRoute | undefined): boolean {
@@ -235,6 +241,15 @@ function isAnthropicReasoningRoute(route: TranscriptAssistantRoute | undefined):
 
 function isOpenAICompletionsRoute(route: TranscriptAssistantRoute | undefined): boolean {
   return typeof route?.api === "string" && OPENAI_COMPLETIONS_APIS.has(route.api);
+}
+
+function isGoogleOpenAICompletionsRoute(route: TranscriptAssistantRoute | undefined): boolean {
+  return (
+    isOpenAICompletionsRoute(route) &&
+    (route?.provider === "google" ||
+      route?.endpointClass === "google-generative-ai" ||
+      route?.endpointClass === "google-vertex")
+  );
 }
 
 function isCustomProviderRoute(route: TranscriptAssistantRoute | undefined): boolean {
@@ -255,19 +270,56 @@ function isGitHubCopilotResponsesRoute(route: TranscriptAssistantRoute | undefin
   );
 }
 
-function isOpaqueReplayToken(value: string): boolean {
-  if (
-    value.length === 0 ||
-    value !== value.trim() ||
-    !OPAQUE_REPLAY_TOKEN_RE.test(value) ||
-    value.includes("\u2026")
-  ) {
+function isStructurallyValidOpaqueReplayToken(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value === value.trim() &&
+    OPAQUE_REPLAY_TOKEN_RE.test(value) &&
+    !value.includes("\u2026")
+  );
+}
+
+function isCredentialSafeOpaqueReplayToken(value: string): boolean {
+  if (!isStructurallyValidOpaqueReplayToken(value)) {
     return false;
   }
   // OpenAI encrypted reasoning is commonly Fernet-shaped and intentionally
-  // matches the generic gAAAA secret detector. Other known credential forms
-  // must never gain a transcript-redaction bypass.
+  // matches the generic gAAAA secret detector. Custom routes retain the
+  // credential-sensitive gate because their opaque fields are not attributable
+  // to a known provider contract.
   return value.startsWith("gAAAA") || redactSensitiveText(value, { mode: "tools" }) === value;
+}
+
+function isGoogleThoughtSignature(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value === value.trim() &&
+    !value.includes("\u2026") &&
+    GOOGLE_THOUGHT_SIGNATURE_RE.test(value)
+  );
+}
+
+function resolveTranscriptAssistantRoute(
+  source: Record<string, unknown>,
+  cfg: OpenClawConfig | undefined,
+): TranscriptAssistantRoute {
+  const api = typeof source.api === "string" ? source.api : undefined;
+  const model = typeof source.model === "string" ? source.model : undefined;
+  const provider = typeof source.provider === "string" ? source.provider : undefined;
+  const providerConfig = provider
+    ? findNormalizedProviderValue(cfg?.models?.providers, provider)
+    : undefined;
+  const modelConfig = model
+    ? providerConfig?.models.find((candidate) => candidate.id === model)
+    : undefined;
+  const baseUrl = modelConfig?.baseUrl ?? providerConfig?.baseUrl;
+  const endpointClass = baseUrl ? resolveProviderEndpoint(baseUrl).endpointClass : undefined;
+  return {
+    ...(api ? { api } : {}),
+    ...(endpointClass ? { endpointClass } : {}),
+    ...(model ? { model } : {}),
+    ...(provider ? { provider } : {}),
+  };
 }
 
 function isSafeReplayIdentifier(value: string, maxLength = 512): boolean {
@@ -383,30 +435,39 @@ function shouldPreserveOpaqueProviderPayload(
   location: TranscriptValueLocation,
   route: TranscriptAssistantRoute | undefined,
 ): boolean {
-  if (
-    location !== "assistant-content-block" ||
-    typeof item !== "string" ||
-    !isOpaqueReplayToken(item)
-  ) {
+  if (location !== "assistant-content-block" || typeof item !== "string") {
     return false;
   }
   const type = source.type;
-  const customRoute = isCustomProviderRoute(route);
-  return (
-    (type === "text" &&
-      key === "textSignature" &&
-      (isGoogleReasoningRoute(route) || customRoute)) ||
-    (type === "thinking" &&
-      ((key === "thinkingSignature" &&
-        (isAnthropicReasoningRoute(route) || isGoogleReasoningRoute(route) || customRoute)) ||
-        (key === "signature" && (isAnthropicReasoningRoute(route) || customRoute)) ||
-        (key === "thought_signature" && (isGoogleReasoningRoute(route) || customRoute)))) ||
+  const isAnthropicSlot =
+    (type === "thinking" && (key === "thinkingSignature" || key === "signature")) ||
     (type === "redacted_thinking" &&
-      (isAnthropicReasoningRoute(route) || customRoute) &&
+      (key === "data" || key === "signature" || key === "thinkingSignature"));
+  if (isAnthropicReasoningRoute(route) && isAnthropicSlot) {
+    return isStructurallyValidOpaqueReplayToken(item);
+  }
+  const isGoogleSlot =
+    (type === "text" && key === "textSignature") ||
+    (type === "thinking" && (key === "thinkingSignature" || key === "thought_signature")) ||
+    (type === "toolCall" && key === "thoughtSignature");
+  if (isGoogleReasoningRoute(route) && isGoogleSlot) {
+    return isGoogleThoughtSignature(item);
+  }
+  if (isGoogleOpenAICompletionsRoute(route) && type === "toolCall" && key === "thoughtSignature") {
+    // The OpenAI-compatible transport captures provider-owned opaque signatures
+    // such as SIG-OPAQUE-ABC==; native Google routes require standard base64.
+    return isStructurallyValidOpaqueReplayToken(item);
+  }
+  if (!isCustomProviderRoute(route) || !isCredentialSafeOpaqueReplayToken(item)) {
+    return false;
+  }
+  return (
+    (type === "text" && key === "textSignature") ||
+    (type === "thinking" &&
+      (key === "thinkingSignature" || key === "signature" || key === "thought_signature")) ||
+    (type === "redacted_thinking" &&
       (key === "data" || key === "signature" || key === "thinkingSignature")) ||
-    (type === "toolCall" &&
-      key === "thoughtSignature" &&
-      (isGoogleReasoningRoute(route) || isOpenAICompletionsRoute(route) || customRoute))
+    (type === "toolCall" && key === "thoughtSignature")
   );
 }
 
@@ -431,10 +492,13 @@ function sanitizeOpenAIReasoningSignature(
   }
   const encryptedContent = parsed.encrypted_content;
   const hasEncryptedContent = Object.hasOwn(parsed, "encrypted_content");
+  const isValidEncryptedContent = isOpenAIResponsesRoute(route)
+    ? isStructurallyValidOpaqueReplayToken
+    : isCredentialSafeOpaqueReplayToken;
   if (
     encryptedContent !== undefined &&
     encryptedContent !== null &&
-    (typeof encryptedContent !== "string" || !isOpaqueReplayToken(encryptedContent))
+    (typeof encryptedContent !== "string" || !isValidEncryptedContent(encryptedContent))
   ) {
     return undefined;
   }
@@ -469,20 +533,26 @@ function sanitizeOpenAIReasoningSignature(
   });
 }
 
-function sanitizeOpenAICompletionsToolSignature(value: string): string | undefined {
+function sanitizeOpenAICompletionsToolSignature(
+  value: string,
+  route: TranscriptAssistantRoute | undefined,
+): string | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(value);
   } catch {
     return undefined;
   }
+  const isValidEncryptedData = isOpenAICompletionsRoute(route)
+    ? isStructurallyValidOpaqueReplayToken
+    : isCredentialSafeOpaqueReplayToken;
   if (
     !parsed ||
     typeof parsed !== "object" ||
     !isPlainTranscriptObject(parsed) ||
     parsed.type !== "reasoning.encrypted" ||
     typeof parsed.data !== "string" ||
-    !isOpaqueReplayToken(parsed.data) ||
+    !isValidEncryptedData(parsed.data) ||
     (parsed.id !== undefined &&
       parsed.id !== null &&
       (typeof parsed.id !== "string" || !isSafeReplayIdentifier(parsed.id))) ||
@@ -561,11 +631,7 @@ function redactTranscriptStructuredValue(
   const source = sanitizedImageRecord ?? value;
   const currentAssistantRoute =
     location === "root" && source.role === "assistant"
-      ? {
-          ...(typeof source.api === "string" ? { api: source.api } : {}),
-          ...(typeof source.model === "string" ? { model: source.model } : {}),
-          ...(typeof source.provider === "string" ? { provider: source.provider } : {}),
-        }
+      ? resolveTranscriptAssistantRoute(source, cfg)
       : assistantRoute;
   let next: Record<string, unknown> | null = null;
   if (source !== value) {
@@ -624,7 +690,10 @@ function redactTranscriptStructuredValue(
       key === "thoughtSignature" &&
       typeof item === "string"
     ) {
-      const sanitizedSignature = sanitizeOpenAICompletionsToolSignature(item);
+      const sanitizedSignature = sanitizeOpenAICompletionsToolSignature(
+        item,
+        currentAssistantRoute,
+      );
       if (sanitizedSignature !== undefined) {
         if (sanitizedSignature !== item) {
           next ??= { ...source };


### PR DESCRIPTION
Closes #102244

AI-assisted: Yes (Codex). I reviewed and understand the implementation.

## What Problem This Solves

Transcript redaction could mistake credential-shaped substrings inside provider-minted reasoning signatures for secrets. Rewriting those signed bytes made persisted Anthropic and Bedrock sessions fail replay with invalid-signature errors.

## Why This Change Was Made

This change preserves only structurally valid opaque replay payloads in route-specific provider signature fields. OpenAI structured replay envelopes are normalized to the minimal replay metadata while their encrypted payload remains exact.

Ordinary text, malformed payloads, unknown routes, and credential-shaped values outside recognized signed fields continue through normal redaction. Existing poisoned histories continue to use the existing replay recovery path.

This does not change signature capture behavior. In particular, OpenRouter streams that use a reasoning-detail ID distinct from the tool-call ID remain a separate adapter concern.

## User Impact

Users can continue Bedrock/Anthropic, Gemini, OpenAI Responses, and compatible tool-reasoning sessions across persistence, restart, and compaction without transcript redaction corrupting valid replay signatures.

## Evidence

- Focused transcript-redaction and regression suite: 421 tests passed.
- Changed checks passed; pre-commit autoreview completed with no actionable findings.
- Live Bedrock contract proof: exact replay accepted; missing or corrupted signatures rejected; a poisoned persisted session recovered (`run_6b68bef9025b`).
- Live tool/restart replay passed for Bedrock, Anthropic, Google native, and Google OpenAI-compatible routes (`run_a3439a8dee0b`).
- Packaged `npm-pack:` Bedrock install preserved and replayed a 2,556-character signature (`run_1130e4b0c914`).
- Live OpenAI Responses ciphertext remained byte-exact through redaction and replayed in a fresh process (`run_5754946d4f04`).
- Live OpenRouter Completions ciphertext remained byte-exact through redaction and replayed through the OpenClaw adapter in a fresh process (`run_ae547a8a6dd1`).
- Live manual compaction reduced 29,114 tokens to 1,187 tokens, retained valid signatures, and completed a post-compaction turn (`run_795c6e6608f7`).
- Live security-boundary proof redacted a credential-shaped user canary while preserving the provider signature and successful replay (`run_201fe0daff8d`).
- Maintained Google/Anthropic replay and OpenAI tool-projection live suites passed (`run_8a1125fe54eb`, `run_7ab63f698054`).
