### PR TITLE
fix: reasoning-only and empty-response retries duplicate the user message in the session

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -10,6 +10,7 @@ import {
   useOpenAIPlatformAuthFixture,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
+import { REASONING_ONLY_RETRY_INSTRUCTION } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
@@ -129,6 +130,46 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces an incomplete-turn continuation with a finalize revision", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "end_turn",
+            provider: "openai",
+            model: "gpt-5.5",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: JSON.stringify({ id: "rs_before_finalize", type: "reasoning" }),
+              },
+            ],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        finalAnswerAttempt("Visible draft.", {
+          beforeAgentFinalizeRevisionReason: "Tighten the recovered answer.",
+        }),
+      )
+      .mockResolvedValueOnce(finalAnswerAttempt("Revised recovered answer."));
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-after-incomplete-turn",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(attemptCall(1).prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+    expect(attemptCall(2).prompt).toContain("Tighten the recovered answer.");
+    expect(attemptCall(2).prompt).not.toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("does not retry finalize revisions after a timed-out attempt", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,5 +1,5 @@
 // Coverage for incomplete-turn safety, retry instructions, and liveness states.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
@@ -77,14 +77,17 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(warnMessages().join("\n")).not.toContain(text);
   }
 
-  function runAttemptCall(index: number): { prompt?: string } {
+  function runAttemptCall(index: number): {
+    prompt?: string;
+    suppressNextUserMessagePersistence?: boolean;
+  } {
     // Continuation prompt assertions read the exact prompt passed to the runner
     // attempt rather than derived result metadata.
     const call = mockedRunEmbeddedAttempt.mock.calls[index];
     if (!call) {
       throw new Error(`Expected run embedded attempt call ${index}`);
     }
-    return call[0] as { prompt?: string };
+    return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
   }
 
   it("counts failed tool results in trace tool summaries", async () => {
@@ -848,6 +851,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toContain(REASONING_ONLY_RETRY_INSTRUCTION);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
@@ -1105,6 +1109,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
     expectWarnMessageWith("empty response detected");
   });
 
@@ -1151,6 +1156,47 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta?.finalAssistantVisibleText).toBe("Recovered answer.");
     expectWarnMessageWith("empty response detected");
     expectNoWarnMessageWith("missing assistant terminal message detected");
+    expectNoWarnMessageWith("incomplete turn detected");
+  });
+
+  it("retries missing terminal assistant turns with the same prompt without re-persisting the user message", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+    const recoveredAssistant = {
+      role: "assistant",
+      stopReason: "end_turn",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Recovered answer." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered answer."],
+        lastAssistant: recoveredAssistant,
+        currentAttemptAssistant: recoveredAssistant,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-missing-assistant-same-prompt-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    // The same-prompt replay must not append the inbound user message a second time.
+    expect(runAttemptCall(1).prompt).toBe(runAttemptCall(0).prompt);
+    expect(runAttemptCall(1).suppressNextUserMessagePersistence).toBe(true);
+    expect(result.meta?.finalAssistantVisibleText).toBe("Recovered answer.");
+    expectWarnMessageWith("missing assistant terminal message detected");
+    expectNoWarnMessageWith("empty response detected");
     expectNoWarnMessageWith("incomplete turn detected");
   });
 
@@ -1471,6 +1517,112 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         isError: true,
       },
     ]);
+  });
+
+  describe("OPENCLAW_REASONING_ONLY_RETRY_LIMIT override", () => {
+    const previousLimitEnv = process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
+
+    afterEach(() => {
+      if (previousLimitEnv === undefined) {
+        delete process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
+      } else {
+        process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = previousLimitEnv;
+      }
+    });
+
+    it("surfaces the incomplete-turn error on the first reasoning-only turn with no retries when set to 0", async () => {
+      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = "0";
+      const { runEmbeddedAgent: freshRunEmbeddedAgent } = await loadRunOverflowCompactionHarness();
+      await warmRunOverflowCompactionHarness(freshRunEmbeddedAgent);
+      mockedClassifyFailoverReason.mockReturnValue(null);
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "end_turn",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: JSON.stringify({
+                  id: "rs_env_limit_zero",
+                  type: "reasoning",
+                }),
+              },
+            ],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      );
+
+      const result = await freshRunEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "openai",
+        model: "gpt-5.4",
+        reasoningLevel: "on",
+        runId: "run-reasoning-only-env-limit-zero",
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      expect(result.payloads?.[0]?.isError).toBe(true);
+      expect(result.payloads?.[0]?.text).toContain("Please try again");
+      expectWarnMessageWith("reasoning-only retries exhausted");
+    });
+  });
+
+  describe("retry limit env var parsing", () => {
+    const RETRY_LIMIT_ENV_VARS = [
+      "OPENCLAW_REASONING_ONLY_RETRY_LIMIT",
+      "OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT",
+    ] as const;
+    const previousEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of RETRY_LIMIT_ENV_VARS) {
+        previousEnv[key] = process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of RETRY_LIMIT_ENV_VARS) {
+        if (previousEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previousEnv[key];
+        }
+      }
+    });
+
+    async function importIncompleteTurnFresh(): Promise<typeof import("./run/incomplete-turn.js")> {
+      vi.resetModules();
+      return import("./run/incomplete-turn.js");
+    }
+
+    it("reads valid non-negative integer overrides from env", async () => {
+      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = "5";
+      process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT = "0";
+      const mod = await importIncompleteTurnFresh();
+      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(5);
+      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(0);
+    });
+
+    it.each(["abc", "-1"])("falls back to the default for invalid value %s", async (value) => {
+      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = value;
+      process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT = value;
+      const mod = await importIncompleteTurnFresh();
+      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(2);
+      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
+    });
+
+    it("falls back to the default when unset", async () => {
+      delete process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
+      delete process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT;
+      const mod = await importIncompleteTurnFresh();
+      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(2);
+      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
+    });
   });
 
   it("marks incomplete-turn retries as replay-invalid abandoned runs", () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -90,6 +90,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
   }
 
+  function markUserMessagePersisted(attemptParams: unknown): void {
+    (
+      attemptParams as {
+        onUserMessagePersisted?: (message: { role: "user"; content: string }) => void;
+      }
+    ).onUserMessagePersisted?.({ role: "user", content: "test prompt" });
+  }
+
   it("counts failed tool results in trace tool summaries", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -810,8 +818,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("retries reasoning-only GPT turns with a visible-answer continuation instruction", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
         assistantTexts: [],
         lastAssistant: {
           role: "assistant",
@@ -826,8 +835,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             },
           ],
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-      }),
-    );
+      });
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
@@ -1074,8 +1083,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("retries generic empty GPT turns with a visible-answer continuation instruction", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
         assistantTexts: [],
         lastAssistant: {
           role: "assistant",
@@ -1084,8 +1094,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           model: "gpt-5.4",
           content: [{ type: "text", text: "" }],
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-      }),
-    );
+      });
+    });
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Visible answer."],
@@ -1161,13 +1171,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("retries missing terminal assistant turns with the same prompt without re-persisting the user message", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
         assistantTexts: [],
         lastAssistant: undefined,
         currentAttemptAssistant: undefined,
-      }),
-    );
+      });
+    });
     const recoveredAssistant = {
       role: "assistant",
       stopReason: "end_turn",
@@ -1198,6 +1209,41 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("missing assistant terminal message detected");
     expectNoWarnMessageWith("empty response detected");
     expectNoWarnMessageWith("incomplete turn detected");
+  });
+
+  it("persists a missing-turn retry when the first attempt never persisted the user message", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+    const recoveredAssistant = {
+      role: "assistant",
+      stopReason: "end_turn",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Recovered answer." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered answer."],
+        lastAssistant: recoveredAssistant,
+        currentAttemptAssistant: recoveredAssistant,
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-missing-assistant-unpersisted-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).suppressNextUserMessagePersistence).toBe(false);
   });
 
   it("retries zero-token empty Claude stop turns with a visible-answer continuation instruction", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,5 +1,5 @@
 // Coverage for incomplete-turn safety, retry instructions, and liveness states.
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
@@ -1517,114 +1517,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         isError: true,
       },
     ]);
-  });
-
-  describe("OPENCLAW_REASONING_ONLY_RETRY_LIMIT override", () => {
-    const previousLimitEnv = process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
-
-    afterEach(() => {
-      if (previousLimitEnv === undefined) {
-        delete process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
-      } else {
-        process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = previousLimitEnv;
-      }
-    });
-
-    it("surfaces the incomplete-turn error on the first reasoning-only turn with no retries when set to 0", async () => {
-      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = "0";
-      const { runEmbeddedAgent: freshRunEmbeddedAgent } = await loadRunOverflowCompactionHarness();
-      await warmRunOverflowCompactionHarness(freshRunEmbeddedAgent);
-      resetRunOverflowCompactionHarnessMocks();
-      mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
-      mockedClassifyFailoverReason.mockReturnValue(null);
-      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-        makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: {
-            role: "assistant",
-            stopReason: "end_turn",
-            provider: "openai",
-            model: "gpt-5.4",
-            content: [
-              {
-                type: "thinking",
-                thinking: "internal reasoning",
-                thinkingSignature: JSON.stringify({
-                  id: "rs_env_limit_zero",
-                  type: "reasoning",
-                }),
-              },
-            ],
-          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        }),
-      );
-
-      const result = await freshRunEmbeddedAgent({
-        ...overflowBaseRunParams,
-        provider: "openai",
-        model: "gpt-5.4",
-        reasoningLevel: "on",
-        runId: "run-reasoning-only-env-limit-zero",
-      });
-
-      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-      expect(result.payloads?.[0]?.isError).toBe(true);
-      expect(result.payloads?.[0]?.text).toContain("Please try again");
-      expectWarnMessageWith("reasoning-only retries exhausted");
-    });
-  });
-
-  describe("retry limit env var parsing", () => {
-    const RETRY_LIMIT_ENV_VARS = [
-      "OPENCLAW_REASONING_ONLY_RETRY_LIMIT",
-      "OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT",
-    ] as const;
-    const previousEnv: Record<string, string | undefined> = {};
-
-    beforeEach(() => {
-      for (const key of RETRY_LIMIT_ENV_VARS) {
-        previousEnv[key] = process.env[key];
-      }
-    });
-
-    afterEach(() => {
-      for (const key of RETRY_LIMIT_ENV_VARS) {
-        if (previousEnv[key] === undefined) {
-          delete process.env[key];
-        } else {
-          process.env[key] = previousEnv[key];
-        }
-      }
-    });
-
-    async function importIncompleteTurnFresh(): Promise<typeof import("./run/incomplete-turn.js")> {
-      vi.resetModules();
-      return import("./run/incomplete-turn.js");
-    }
-
-    it("reads valid non-negative integer overrides from env", async () => {
-      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = "5";
-      process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT = "0";
-      const mod = await importIncompleteTurnFresh();
-      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(5);
-      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(0);
-    });
-
-    it.each(["abc", "-1"])("falls back to the default for invalid value %s", async (value) => {
-      process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = value;
-      process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT = value;
-      const mod = await importIncompleteTurnFresh();
-      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(2);
-      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
-    });
-
-    it("falls back to the default when unset", async () => {
-      delete process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT;
-      delete process.env.OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT;
-      const mod = await importIncompleteTurnFresh();
-      expect(mod.DEFAULT_REASONING_ONLY_RETRY_LIMIT).toBe(2);
-      expect(mod.DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
-    });
   });
 
   it("marks incomplete-turn retries as replay-invalid abandoned runs", () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -859,8 +859,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
-    expect(secondCall.prompt).toContain(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
+    expect(secondCall.prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
@@ -1118,8 +1118,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     const secondCall = runAttemptCall(1);
-    expect(secondCall.prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expect(secondCall.suppressNextUserMessagePersistence).toBe(true);
+    expect(secondCall.prompt).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
     expectWarnMessageWith("empty response detected");
   });
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1211,6 +1211,83 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("incomplete turn detected");
   });
 
+  it("waits for asynchronous user persistence before retrying a missing terminal turn", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const persistedMessage = { role: "user" as const, content: "test prompt" };
+    let resolvePersistApproved:
+      | ((result: {
+          sessionFile: string;
+          sessionEntry: undefined;
+          messageId: string;
+          message: typeof persistedMessage;
+        }) => void)
+      | undefined;
+    let pendingPersistence: Promise<void> | undefined;
+    const persistApproved = vi.fn(
+      () =>
+        new Promise<{
+          sessionFile: string;
+          sessionEntry: undefined;
+          messageId: string;
+          message: typeof persistedMessage;
+        }>((resolve) => {
+          resolvePersistApproved = resolve;
+        }),
+    );
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+      });
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ assistantTexts: ["Recovered answer."] }),
+    );
+
+    const runPromise = runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-missing-assistant-delayed-persistence",
+      userTurnTranscriptRecorder: {
+        message: persistedMessage,
+        resolveMessage: vi.fn(async () => persistedMessage),
+        markRuntimePersistencePending: vi.fn((pending) => {
+          pendingPersistence = pending;
+        }),
+        markRuntimePersisted: vi.fn(),
+        markBlocked: vi.fn(),
+        hasPersisted: vi.fn(() => false),
+        isBlocked: vi.fn(() => false),
+        hasRuntimePersistencePending: vi.fn(() => pendingPersistence !== undefined),
+        waitForRuntimePersistence: vi.fn(async () => {
+          await pendingPersistence;
+        }),
+        persistApproved,
+        persistBlocked: vi.fn(async () => undefined),
+        persistFallback: vi.fn(async () => undefined),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(persistApproved).toHaveBeenCalledOnce();
+    });
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+
+    resolvePersistApproved?.({
+      sessionFile: "/tmp/openclaw-transcript.jsonl",
+      sessionEntry: undefined,
+      messageId: "msg-user-delayed",
+      message: persistedMessage,
+    });
+    await runPromise;
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).suppressNextUserMessagePersistence).toBe(true);
+  });
+
   it("persists a missing-turn retry when the first attempt never persisted the user message", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1272,7 +1272,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
   it("waits for asynchronous user persistence before retrying a missing terminal turn", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    const persistedMessage = { role: "user" as const, content: "test prompt" };
+    const persistedMessage = { role: "user" as const, content: "test prompt", timestamp: 1 };
     let resolvePersistApproved:
       | ((result: {
           sessionFile: string;

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -80,6 +80,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   function runAttemptCall(index: number): {
     prompt?: string;
     suppressNextUserMessagePersistence?: boolean;
+    skipPreparedUserTurnMessage?: boolean;
   } {
     // Continuation prompt assertions read the exact prompt passed to the runner
     // attempt rather than derived result metadata.
@@ -87,7 +88,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     if (!call) {
       throw new Error(`Expected run embedded attempt call ${index}`);
     }
-    return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
+    return call[0] as {
+      prompt?: string;
+      suppressNextUserMessagePersistence?: boolean;
+      skipPreparedUserTurnMessage?: boolean;
+    };
   }
 
   function markUserMessagePersisted(attemptParams: unknown): void {
@@ -861,6 +866,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
     expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
@@ -901,6 +907,58 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
     expect(result.meta.terminalReplyKind).toBe("silent-empty");
     expect(result.meta.livenessState).toBe("working");
+  });
+
+  it("replays an unpersisted reasoning continuation across a missing-assistant retry", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({ id: "rs_retry_boundary", type: "reasoning" }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ assistantTexts: ["Visible answer."] }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-reasoning-continuation-missing-assistant",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(runAttemptCall(1)).toMatchObject({
+      prompt: REASONING_ONLY_RETRY_INSTRUCTION,
+      skipPreparedUserTurnMessage: true,
+      suppressNextUserMessagePersistence: false,
+    });
+    expect(runAttemptCall(2)).toMatchObject({
+      prompt: REASONING_ONLY_RETRY_INSTRUCTION,
+      skipPreparedUserTurnMessage: true,
+      suppressNextUserMessagePersistence: false,
+    });
   });
 
   it("does not retry or warn on reasoning-only turns when a messaging tool already delivered", async () => {
@@ -1120,6 +1178,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expect(secondCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(secondCall.skipPreparedUserTurnMessage).toBe(true);
     expectWarnMessageWith("empty response detected");
   });
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1534,6 +1534,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       process.env.OPENCLAW_REASONING_ONLY_RETRY_LIMIT = "0";
       const { runEmbeddedAgent: freshRunEmbeddedAgent } = await loadRunOverflowCompactionHarness();
       await warmRunOverflowCompactionHarness(freshRunEmbeddedAgent);
+      resetRunOverflowCompactionHarnessMocks();
+      mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
       mockedClassifyFailoverReason.mockReturnValue(null);
       mockedRunEmbeddedAttempt.mockResolvedValueOnce(
         makeAttemptResult({

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -11,6 +11,7 @@ import {
   overflowBaseRunParams as baseParams,
   loadRunOverflowCompactionHarness,
   mockedCompactDirect,
+  mockedClassifyFailoverReason,
   mockedContextEngine,
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
@@ -23,6 +24,7 @@ import {
   resetRunOverflowCompactionHarnessMocks,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
+import { REASONING_ONLY_RETRY_INSTRUCTION } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
@@ -595,6 +597,78 @@ describe("overflow compaction in run loop", () => {
     expect(retryParams.prompt).toBe(baseParams.prompt);
     expect(retryParams.suppressNextUserMessagePersistence).toBe(false);
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("does not suppress an unpersisted reasoning continuation after precheck compaction", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedResolveModelAsync.mockResolvedValue({
+      model: {
+        id: "kimi-for-coding",
+        provider: "kimi",
+        contextWindow: 262144,
+        api: "anthropic-messages",
+      },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    });
+    const overflowError = makeOverflowError(
+      "Context overflow: prompt too large for the model (precheck).",
+    );
+    mockedRunEmbeddedAttempt
+      .mockImplementationOnce(async (attemptParams) => {
+        (
+          attemptParams as {
+            onUserMessagePersisted?: (message: ReturnType<typeof makeUserMessage>) => void;
+          }
+        ).onUserMessagePersisted?.(makeUserMessage());
+        return makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "end_turn",
+            provider: "kimi",
+            model: "kimi-for-coding",
+            api: "anthropic-messages",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning",
+                thinkingSignature: JSON.stringify({ id: "rs_precheck", type: "reasoning" }),
+              },
+            ],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        });
+      })
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: overflowError,
+          promptErrorSource: "precheck",
+          preflightRecovery: { route: "compact_only" },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted before continuation submission",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 150000,
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...baseParams,
+      currentMessageId: "telegram-msg-continuation-precheck",
+      provider: "kimi",
+      model: "kimi-for-coding",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    for (const index of [1, 2]) {
+      const retryParams = requireMockCallArg(mockedRunEmbeddedAttempt, index);
+      expect(retryParams.prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+      expect(retryParams.suppressNextUserMessagePersistence).toBe(false);
+    }
   });
 
   it("retries after successful compaction on likely-overflow promptError variants", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2875,6 +2875,9 @@ async function runEmbeddedAgentInternal(
               params.suppressTranscriptOnlyAssistantPersistence,
             suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
             onUserMessagePersisted,
+            onUserMessagePersistenceInvalidated: () => {
+              activePromptPersisted = false;
+            },
             onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
           })
             .catch((err: unknown): never => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2169,6 +2169,9 @@ async function runEmbeddedAgentInternal(
         };
         const blockedBeforeAgentRun = messageMetadata["__openclaw"]?.beforeAgentRunBlocked;
         const markCurrentUserMessagePersisted = () => {
+          // Once this turn is in the transcript, every later attempt must reuse it.
+          // Re-appending on any retry path would duplicate the same user message.
+          suppressNextUserMessagePersistence = true;
           if (params.currentMessageId !== undefined) {
             lastPersistedCurrentMessageId = params.currentMessageId;
           }
@@ -4548,7 +4551,6 @@ async function runEmbeddedAgentInternal(
           ) {
             reasoningOnlyRetryAttempts += 1;
             reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
-            suppressNextUserMessagePersistence = true;
             log.warn(
               `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
@@ -4571,7 +4573,6 @@ async function runEmbeddedAgentInternal(
             missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
           ) {
             missingAssistantRetryAttempts += 1;
-            suppressNextUserMessagePersistence = true;
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
@@ -4585,7 +4586,6 @@ async function runEmbeddedAgentInternal(
           ) {
             emptyResponseRetryAttempts += 1;
             emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
-            suppressNextUserMessagePersistence = true;
             log.warn(
               `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2096,6 +2096,7 @@ async function runEmbeddedAgentInternal(
       };
       let lastRetryFailoverReason: FailoverReason | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
+      let incompleteTurnContinuationPrompt: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
       let rateLimitProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
@@ -2156,7 +2157,7 @@ async function runEmbeddedAgentInternal(
       };
       let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
       // Same-prompt retries may reuse the user leaf only after its write is confirmed.
-      let currentUserMessagePersisted = suppressNextUserMessagePersistence;
+      let activePromptPersisted = suppressNextUserMessagePersistence;
       // Compaction continuation also needs to know whether the current inbound turn is durable.
       let lastPersistedCurrentMessageId: string | number | undefined;
       const onUserMessagePersisted: RunEmbeddedAgentParams["onUserMessagePersisted"] = (
@@ -2167,7 +2168,7 @@ async function runEmbeddedAgentInternal(
         };
         const blockedBeforeAgentRun = messageMetadata["__openclaw"]?.beforeAgentRunBlocked;
         const markCurrentUserMessagePersisted = () => {
-          currentUserMessagePersisted = true;
+          activePromptPersisted = true;
           if (params.currentMessageId !== undefined) {
             lastPersistedCurrentMessageId = params.currentMessageId;
           }
@@ -2532,6 +2533,7 @@ async function runEmbeddedAgentInternal(
 
           const basePrompt =
             nextAttemptPromptOverride ??
+            incompleteTurnContinuationPrompt ??
             resolveEmbeddedAttemptBasePrompt({
               nativeModelOwned,
               provider,
@@ -2725,6 +2727,7 @@ async function runEmbeddedAgentInternal(
             prompt,
             transcriptPrompt: params.transcriptPrompt,
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+            skipPreparedUserTurnMessage: incompleteTurnContinuationPrompt !== null,
             currentInboundEventKind: params.currentInboundEventKind,
             currentInboundContext: params.currentInboundContext,
             images: params.images,
@@ -2890,6 +2893,7 @@ async function runEmbeddedAgentInternal(
           }
           const attempt = normalizeEmbeddedRunAttemptResult(rawAttempt);
           await waitForCurrentUserMessagePersistence();
+          suppressNextUserMessagePersistence = activePromptPersisted;
           if (attemptCancellationRequested) {
             throwIfAborted();
             throw createAgentRunDirectAbortError();
@@ -4539,7 +4543,8 @@ async function runEmbeddedAgentInternal(
           ) {
             reasoningOnlyRetryAttempts += 1;
             // The assistant leaf is already durable, so persist a new user boundary.
-            nextAttemptPromptOverride = nextReasoningOnlyRetryInstruction;
+            incompleteTurnContinuationPrompt = nextReasoningOnlyRetryInstruction;
+            activePromptPersisted = false;
             suppressNextUserMessagePersistence = false;
             log.warn(
               `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
@@ -4564,7 +4569,7 @@ async function runEmbeddedAgentInternal(
           ) {
             missingAssistantRetryAttempts += 1;
             // Same-prompt retries reuse the canonical user leaf only when it was written.
-            suppressNextUserMessagePersistence = currentUserMessagePersisted;
+            suppressNextUserMessagePersistence = activePromptPersisted;
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
@@ -4578,7 +4583,8 @@ async function runEmbeddedAgentInternal(
           ) {
             emptyResponseRetryAttempts += 1;
             // The assistant leaf is already durable, so persist a new user boundary.
-            nextAttemptPromptOverride = nextEmptyResponseRetryInstruction;
+            incompleteTurnContinuationPrompt = nextEmptyResponseRetryInstruction;
+            activePromptPersisted = false;
             suppressNextUserMessagePersistence = false;
             log.warn(
               `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3578,7 +3578,10 @@ async function runEmbeddedAgentInternal(
                   continueFromCurrentTranscript();
                 } else {
                   await waitForCurrentUserMessagePersistence();
-                  if (
+                  if (incompleteTurnContinuationPrompt !== null) {
+                    // Compaction must not suppress a continuation that never reached JSONL.
+                    suppressNextUserMessagePersistence = activePromptPersisted;
+                  } else if (
                     params.currentMessageId !== undefined &&
                     params.currentMessageId === lastPersistedCurrentMessageId
                   ) {
@@ -4813,6 +4816,7 @@ async function runEmbeddedAgentInternal(
             nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
               beforeAgentFinalizeRevisionReason,
             );
+            incompleteTurnContinuationPrompt = null;
             suppressNextUserMessagePersistence = true;
             compactionContinuationRetryInstruction = null;
             log.warn(

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2157,8 +2157,9 @@ async function runEmbeddedAgentInternal(
         adoptActiveSessionId(resolvedTarget.sessionId);
       };
       let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
-      // The embedded agent owns JSONL persistence; this marker lets the outer retry avoid
-      // replaying the same inbound channel message after overflow compaction.
+      // The embedded agent owns JSONL persistence; this marker lets same-content retry paths
+      // (overflow compaction, before_agent_finalize revision, reasoning-only/missing-assistant/
+      // empty-response continuations) avoid replaying the same inbound user message twice.
       let lastPersistedCurrentMessageId: string | number | undefined;
       const onUserMessagePersisted: RunEmbeddedAgentParams["onUserMessagePersisted"] = (
         message,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -4547,6 +4547,7 @@ async function runEmbeddedAgentInternal(
           ) {
             reasoningOnlyRetryAttempts += 1;
             reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
+            suppressNextUserMessagePersistence = true;
             log.warn(
               `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
@@ -4569,6 +4570,7 @@ async function runEmbeddedAgentInternal(
             missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
           ) {
             missingAssistantRetryAttempts += 1;
+            suppressNextUserMessagePersistence = true;
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
@@ -4582,6 +4584,7 @@ async function runEmbeddedAgentInternal(
           ) {
             emptyResponseRetryAttempts += 1;
             emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
+            suppressNextUserMessagePersistence = true;
             log.warn(
               `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2095,8 +2095,6 @@ async function runEmbeddedAgentInternal(
         }
       };
       let lastRetryFailoverReason: FailoverReason | null = null;
-      let reasoningOnlyRetryInstruction: string | null = null;
-      let emptyResponseRetryInstruction: string | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
       let rateLimitProfileRotations = 0;
@@ -2157,9 +2155,9 @@ async function runEmbeddedAgentInternal(
         adoptActiveSessionId(resolvedTarget.sessionId);
       };
       let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
-      // The embedded agent owns JSONL persistence; this marker lets same-content retry paths
-      // (overflow compaction, before_agent_finalize revision, reasoning-only/missing-assistant/
-      // empty-response continuations) avoid replaying the same inbound user message twice.
+      // Same-prompt retries may reuse the user leaf only after its write is confirmed.
+      let currentUserMessagePersisted = suppressNextUserMessagePersistence;
+      // Compaction continuation also needs to know whether the current inbound turn is durable.
       let lastPersistedCurrentMessageId: string | number | undefined;
       const onUserMessagePersisted: RunEmbeddedAgentParams["onUserMessagePersisted"] = (
         message,
@@ -2169,9 +2167,7 @@ async function runEmbeddedAgentInternal(
         };
         const blockedBeforeAgentRun = messageMetadata["__openclaw"]?.beforeAgentRunBlocked;
         const markCurrentUserMessagePersisted = () => {
-          // Once this turn is in the transcript, every later attempt must reuse it.
-          // Re-appending on any retry path would duplicate the same user message.
-          suppressNextUserMessagePersistence = true;
+          currentUserMessagePersisted = true;
           if (params.currentMessageId !== undefined) {
             lastPersistedCurrentMessageId = params.currentMessageId;
           }
@@ -2542,17 +2538,9 @@ async function runEmbeddedAgentInternal(
               prompt: params.prompt,
             });
           nextAttemptPromptOverride = null;
-          const promptAdditions = [
-            reasoningOnlyRetryInstruction,
-            emptyResponseRetryInstruction,
-            compactionContinuationRetryInstruction,
-          ].filter(
-            (value): value is string => typeof value === "string" && value.trim().length > 0,
-          );
-          const prompt =
-            promptAdditions.length > 0
-              ? `${basePrompt}\n\n${promptAdditions.join("\n\n")}`
-              : basePrompt;
+          const prompt = compactionContinuationRetryInstruction
+            ? `${basePrompt}\n\n${compactionContinuationRetryInstruction}`
+            : basePrompt;
           const resolvedStreamApiKey = resolveAttemptDispatchApiKey({
             apiKeyInfo,
             runtimeAuthState,
@@ -4550,7 +4538,9 @@ async function runEmbeddedAgentInternal(
             reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
           ) {
             reasoningOnlyRetryAttempts += 1;
-            reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
+            // The assistant leaf is already durable, so persist a new user boundary.
+            nextAttemptPromptOverride = nextReasoningOnlyRetryInstruction;
+            suppressNextUserMessagePersistence = false;
             log.warn(
               `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
@@ -4573,6 +4563,8 @@ async function runEmbeddedAgentInternal(
             missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
           ) {
             missingAssistantRetryAttempts += 1;
+            // Same-prompt retries reuse the canonical user leaf only when it was written.
+            suppressNextUserMessagePersistence = currentUserMessagePersisted;
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
@@ -4585,7 +4577,9 @@ async function runEmbeddedAgentInternal(
             emptyResponseRetryAttempts < maxEmptyResponseRetryAttempts
           ) {
             emptyResponseRetryAttempts += 1;
-            emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
+            // The assistant leaf is already durable, so persist a new user boundary.
+            nextAttemptPromptOverride = nextEmptyResponseRetryInstruction;
+            suppressNextUserMessagePersistence = false;
             log.warn(
               `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
@@ -4814,8 +4808,6 @@ async function runEmbeddedAgentInternal(
               beforeAgentFinalizeRevisionReason,
             );
             suppressNextUserMessagePersistence = true;
-            reasoningOnlyRetryInstruction = null;
-            emptyResponseRetryInstruction = null;
             compactionContinuationRetryInstruction = null;
             log.warn(
               `before_agent_finalize requested one more pass: ` +

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2096,8 +2096,6 @@ async function runEmbeddedAgentInternal(
       };
       let lastRetryFailoverReason: FailoverReason | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
-      let incompleteTurnContinuationPrompt: string | null = null;
-      let nextAttemptPromptOverride: string | null = null;
       let rateLimitProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
       let codexAppServerRecoveryRetries = 0;
@@ -2156,10 +2154,18 @@ async function runEmbeddedAgentInternal(
         adoptActiveSessionId(resolvedTarget.sessionId);
       };
       let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
-      // Same-prompt retries may reuse the user leaf only after its write is confirmed.
-      let activePromptPersisted = suppressNextUserMessagePersistence;
-      // Compaction continuation also needs to know whether the current inbound turn is durable.
-      let lastPersistedCurrentMessageId: string | number | undefined;
+      let activePrompt: {
+        override?: string;
+        persisted: boolean;
+        internal: boolean;
+      } = {
+        persisted: suppressNextUserMessagePersistence,
+        internal: false,
+      };
+      const activateInternalPrompt = (prompt: string, persisted: boolean) => {
+        activePrompt = { override: prompt, persisted, internal: true };
+        suppressNextUserMessagePersistence = persisted;
+      };
       const onUserMessagePersisted: RunEmbeddedAgentParams["onUserMessagePersisted"] = (
         message,
       ) => {
@@ -2168,10 +2174,7 @@ async function runEmbeddedAgentInternal(
         };
         const blockedBeforeAgentRun = messageMetadata["__openclaw"]?.beforeAgentRunBlocked;
         const markCurrentUserMessagePersisted = () => {
-          activePromptPersisted = true;
-          if (params.currentMessageId !== undefined) {
-            lastPersistedCurrentMessageId = params.currentMessageId;
-          }
+          activePrompt.persisted = true;
           params.onUserMessagePersisted?.(message);
         };
         const recorder = params.userTurnTranscriptRecorder;
@@ -2211,8 +2214,7 @@ async function runEmbeddedAgentInternal(
         recorder.markRuntimePersistencePending(canonicalPersistence);
       };
       const continueFromCurrentTranscript = () => {
-        nextAttemptPromptOverride = MID_TURN_PRECHECK_CONTINUATION_PROMPT;
-        suppressNextUserMessagePersistence = true;
+        activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT, true);
       };
       const waitForCurrentUserMessagePersistence = async () => {
         if (params.userTurnTranscriptRecorder?.hasRuntimePersistencePending() === true) {
@@ -2532,14 +2534,12 @@ async function runEmbeddedAgentInternal(
           }
 
           const basePrompt =
-            nextAttemptPromptOverride ??
-            incompleteTurnContinuationPrompt ??
+            activePrompt.override ??
             resolveEmbeddedAttemptBasePrompt({
               nativeModelOwned,
               provider,
               prompt: params.prompt,
             });
-          nextAttemptPromptOverride = null;
           const prompt = compactionContinuationRetryInstruction
             ? `${basePrompt}\n\n${compactionContinuationRetryInstruction}`
             : basePrompt;
@@ -2727,7 +2727,7 @@ async function runEmbeddedAgentInternal(
             prompt,
             transcriptPrompt: params.transcriptPrompt,
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
-            skipPreparedUserTurnMessage: incompleteTurnContinuationPrompt !== null,
+            skipPreparedUserTurnMessage: activePrompt.internal,
             currentInboundEventKind: params.currentInboundEventKind,
             currentInboundContext: params.currentInboundContext,
             images: params.images,
@@ -2876,7 +2876,7 @@ async function runEmbeddedAgentInternal(
             suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
             onUserMessagePersisted,
             onUserMessagePersistenceInvalidated: () => {
-              activePromptPersisted = false;
+              activePrompt.persisted = false;
             },
             onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
           })
@@ -2896,7 +2896,7 @@ async function runEmbeddedAgentInternal(
           }
           const attempt = normalizeEmbeddedRunAttemptResult(rawAttempt);
           await waitForCurrentUserMessagePersistence();
-          suppressNextUserMessagePersistence = activePromptPersisted;
+          suppressNextUserMessagePersistence = activePrompt.persisted;
           if (attemptCancellationRequested) {
             throwIfAborted();
             throw createAgentRunDirectAbortError();
@@ -3581,18 +3581,14 @@ async function runEmbeddedAgentInternal(
                   continueFromCurrentTranscript();
                 } else {
                   await waitForCurrentUserMessagePersistence();
-                  if (incompleteTurnContinuationPrompt !== null) {
-                    // Compaction must not suppress a continuation that never reached JSONL.
-                    suppressNextUserMessagePersistence = activePromptPersisted;
-                  } else if (
-                    params.currentMessageId !== undefined &&
-                    params.currentMessageId === lastPersistedCurrentMessageId
-                  ) {
+                  if (activePrompt.internal) {
+                    // Retry the same internal prompt and preserve its exact durability state.
+                    suppressNextUserMessagePersistence = activePrompt.persisted;
+                  } else if (activePrompt.persisted) {
                     // The first attempt reached the embedded agent far enough to persist this user turn.
                     // Retrying the original prompt would replay it, so resume from the
                     // compacted transcript and suppress the next user append.
-                    nextAttemptPromptOverride = MID_TURN_PRECHECK_CONTINUATION_PROMPT;
-                    suppressNextUserMessagePersistence = true;
+                    activateInternalPrompt(MID_TURN_PRECHECK_CONTINUATION_PROMPT, true);
                   }
                 }
                 continue;
@@ -4549,9 +4545,7 @@ async function runEmbeddedAgentInternal(
           ) {
             reasoningOnlyRetryAttempts += 1;
             // The assistant leaf is already durable, so persist a new user boundary.
-            incompleteTurnContinuationPrompt = nextReasoningOnlyRetryInstruction;
-            activePromptPersisted = false;
-            suppressNextUserMessagePersistence = false;
+            activateInternalPrompt(nextReasoningOnlyRetryInstruction, false);
             log.warn(
               `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
@@ -4575,7 +4569,7 @@ async function runEmbeddedAgentInternal(
           ) {
             missingAssistantRetryAttempts += 1;
             // Same-prompt retries reuse the canonical user leaf only when it was written.
-            suppressNextUserMessagePersistence = activePromptPersisted;
+            suppressNextUserMessagePersistence = activePrompt.persisted;
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
@@ -4589,9 +4583,7 @@ async function runEmbeddedAgentInternal(
           ) {
             emptyResponseRetryAttempts += 1;
             // The assistant leaf is already durable, so persist a new user boundary.
-            incompleteTurnContinuationPrompt = nextEmptyResponseRetryInstruction;
-            activePromptPersisted = false;
-            suppressNextUserMessagePersistence = false;
+            activateInternalPrompt(nextEmptyResponseRetryInstruction, false);
             log.warn(
               `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
@@ -4816,11 +4808,10 @@ async function runEmbeddedAgentInternal(
             !emptyAssistantReplyIsSilent;
           if (beforeAgentFinalizeRevisionReason && shouldHonorBeforeAgentFinalizeRevision) {
             beforeAgentFinalizeRevisionAttempts += 1;
-            nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
-              beforeAgentFinalizeRevisionReason,
+            activateInternalPrompt(
+              buildBeforeAgentFinalizeRetryPrompt(beforeAgentFinalizeRevisionReason),
+              true,
             );
-            incompleteTurnContinuationPrompt = null;
-            suppressNextUserMessagePersistence = true;
             compactionContinuationRetryInstruction = null;
             log.warn(
               `before_agent_finalize requested one more pass: ` +

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1334,6 +1334,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       message: { role: "user", content: "orphaned ask", timestamp: 1 },
     });
     const seen: { modelMessages?: unknown[]; prompt?: string; messages?: unknown[] } = {};
+    const onUserMessagePersistenceInvalidated = vi.fn();
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
@@ -1342,6 +1343,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       attemptOverrides: {
         prompt: "visible ask",
         suppressNextUserMessagePersistence: true,
+        onUserMessagePersistenceInvalidated,
       },
       sessionPrompt: async (session, prompt) => {
         seen.prompt = prompt;
@@ -1375,6 +1377,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(
       hoisted.sessionManager.clearNextUserMessagePersistenceSuppression,
     ).toHaveBeenCalledOnce();
+    expect(onUserMessagePersistenceInvalidated).toHaveBeenCalledOnce();
   });
 
   it("targets the latest active prompt after orphan repair reaches the embedded provider", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1341,6 +1341,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       tempPaths,
       attemptOverrides: {
         prompt: "visible ask",
+        suppressNextUserMessagePersistence: true,
       },
       sessionPrompt: async (session, prompt) => {
         seen.prompt = prompt;
@@ -1371,6 +1372,9 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(JSON.stringify(seen.messages)).not.toContain("dynamic hook context");
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("dynamic hook tail");
     expect(hoisted.sessionManager.branch).toHaveBeenCalledWith("parent-leaf");
+    expect(
+      hoisted.sessionManager.clearNextUserMessagePersistenceSuppression,
+    ).toHaveBeenCalledOnce();
   });
 
   it("targets the latest active prompt after orphan repair reaches the embedded provider", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -236,6 +236,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     replacePersistedTranscript: vi.fn(),
     flushPendingToolResults: vi.fn(),
     clearPendingToolResults: vi.fn(),
+    clearNextUserMessagePersistenceSuppression: vi.fn(),
     removeTrailingEntries: vi.fn(() => 0),
   };
   return {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -72,6 +72,7 @@ type SessionManagerMocks = {
   replacePersistedTranscript: UnknownMock;
   flushPendingToolResults: UnknownMock;
   clearPendingToolResults: UnknownMock;
+  clearNextUserMessagePersistenceSuppression: UnknownMock;
   removeTrailingEntries: UnknownMock;
 };
 type AttemptSpawnWorkspaceHoisted = {
@@ -1107,6 +1108,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.branch.mockReset();
   hoisted.sessionManager.resetLeaf.mockReset();
+  hoisted.sessionManager.clearNextUserMessagePersistenceSuppression.mockReset();
   hoisted.sessionManager.buildSessionContext
     .mockReset()
     .mockReturnValue({ messages: params.sessionMessages ?? [] });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2993,6 +2993,7 @@ export async function runEmbeddedAttempt(
         // Suppression assumes the canonical user turn still exists. Orphan repair
         // removed it, so the replacement prompt must become the one durable copy.
         sessionManager.clearNextUserMessagePersistenceSuppression?.();
+        params.onUserMessagePersistenceInvalidated?.();
         activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
       }
       // Single source for the per-message timestamp prefix (issue #3658):

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2603,7 +2603,9 @@ export async function runEmbeddedAttempt(
         params.model.api === "openai-chatgpt-responses";
 
       await prewarmSessionFile(params.sessionFile);
-      const preparedUserTurnMessage = await params.userTurnTranscriptRecorder?.resolveMessage();
+      const preparedUserTurnMessage = params.skipPreparedUserTurnMessage
+        ? undefined
+        : await params.userTurnTranscriptRecorder?.resolveMessage();
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2988,6 +2988,9 @@ export async function runEmbeddedAttempt(
           sessionManager.resetLeaf();
         }
         replayTrailingEntriesForOrphanRepair(sessionManager, orphanRepair.trailingEntries);
+        // Suppression assumes the canonical user turn still exists. Orphan repair
+        // removed it, so the replacement prompt must become the one durable copy.
+        sessionManager.clearNextUserMessagePersistenceSuppression?.();
         activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
       }
       // Single source for the per-message timestamp prefix (issue #3658):

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -1,10 +1,7 @@
 /**
  * Classifies incomplete terminal assistant turns and retry instructions.
  */
-import {
-  asFiniteNumber,
-  parseStrictNonNegativeInteger,
-} from "@openclaw/normalization-core/number-coercion";
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   isSilentReplyPayloadText,
@@ -131,24 +128,10 @@ const RETRY_GUARD_MODEL_APIS = new Set([
   "openclaw-openai-responses-transport",
   "openclaw-azure-openai-responses-transport",
 ]);
-function resolveRetryLimitFromEnv(envVar: string, fallback: number): number {
-  const raw = process.env[envVar]?.trim();
-  if (!raw) {
-    return fallback;
-  }
-  return parseStrictNonNegativeInteger(raw) ?? fallback;
-}
-
 // Allow one immediate continuation plus one follow-up continuation before
 // surfacing the existing incomplete-turn error path.
-export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = resolveRetryLimitFromEnv(
-  "OPENCLAW_REASONING_ONLY_RETRY_LIMIT",
-  2,
-);
-export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = resolveRetryLimitFromEnv(
-  "OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT",
-  1,
-);
+export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
+export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
 export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -1,7 +1,10 @@
 /**
  * Classifies incomplete terminal assistant turns and retry instructions.
  */
-import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import {
+  asFiniteNumber,
+  parseStrictNonNegativeInteger,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   isSilentReplyPayloadText,
@@ -128,10 +131,24 @@ const RETRY_GUARD_MODEL_APIS = new Set([
   "openclaw-openai-responses-transport",
   "openclaw-azure-openai-responses-transport",
 ]);
+function resolveRetryLimitFromEnv(envVar: string, fallback: number): number {
+  const raw = process.env[envVar]?.trim();
+  if (!raw) {
+    return fallback;
+  }
+  return parseStrictNonNegativeInteger(raw) ?? fallback;
+}
+
 // Allow one immediate continuation plus one follow-up continuation before
 // surfacing the existing incomplete-turn error path.
-export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
-export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
+export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = resolveRetryLimitFromEnv(
+  "OPENCLAW_REASONING_ONLY_RETRY_LIMIT",
+  2,
+);
+export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = resolveRetryLimitFromEnv(
+  "OPENCLAW_EMPTY_RESPONSE_RETRY_LIMIT",
+  1,
+);
 export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -311,6 +311,8 @@ export type RunEmbeddedAgentParams = {
   suppressTranscriptOnlyAssistantPersistence?: boolean;
   suppressAssistantErrorPersistence?: boolean;
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
+  /** Keep an internal continuation prompt from being replaced by the original prepared turn. */
+  skipPreparedUserTurnMessage?: boolean;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   onAssistantErrorMessagePersisted?: (
     message: Extract<AgentMessage, { role: "assistant" }>,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -314,6 +314,7 @@ export type RunEmbeddedAgentParams = {
   /** Keep an internal continuation prompt from being replaced by the original prepared turn. */
   skipPreparedUserTurnMessage?: boolean;
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
+  onUserMessagePersistenceInvalidated?: () => void;
   onAssistantErrorMessagePersisted?: (
     message: Extract<AgentMessage, { role: "assistant" }>,
   ) => void;

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -31,6 +31,8 @@ type GuardedSessionManager = SessionManager & {
   flushPendingToolResults?: () => void;
   /** Clear pending tool calls without persisting synthetic tool results. Idempotent. */
   clearPendingToolResults?: () => void;
+  /** Persist the next user message when an earlier canonical entry was removed. */
+  clearNextUserMessagePersistenceSuppression?: () => void;
 };
 
 /**
@@ -183,5 +185,7 @@ export function guardSessionManager(
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;
+  (sessionManager as GuardedSessionManager).clearNextUserMessagePersistenceSuppression =
+    guard.clearNextUserMessagePersistenceSuppression;
   return sessionManager as GuardedSessionManager;
 }

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -625,6 +625,26 @@ describe("installSessionToolResultGuard", () => {
     expect((persisted[0] as { content?: unknown } | undefined)?.content).toBe("second");
   });
 
+  it("re-enables the next user write after the canonical entry is removed", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      suppressNextUserMessagePersistence: true,
+    });
+
+    guard.clearNextUserMessagePersistenceSuppression();
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "replacement",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    expect((persisted[0] as { content?: unknown } | undefined)?.content).toBe("replacement");
+  });
+
   it("suppresses assistant error stubs when requested", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -645,6 +645,7 @@ export function installSessionToolResultGuard(
 ): {
   flushPendingToolResults: () => void;
   clearPendingToolResults: () => void;
+  clearNextUserMessagePersistenceSuppression: () => void;
   getPendingIds: () => string[];
 } {
   const originalAppend = getRawSessionAppendMessage(sessionManager);
@@ -935,6 +936,9 @@ export function installSessionToolResultGuard(
   return {
     flushPendingToolResults,
     clearPendingToolResults,
+    clearNextUserMessagePersistenceSuppression: () => {
+      suppressNextUserMessagePersistence = false;
+    },
     getPendingIds: pendingState.getPendingIds,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Incomplete model turns could corrupt the durable transcript during retries. Reasoning-only and empty-response continuations could re-persist the inbound user message, while missing-assistant, nested compaction, provider retry, finalize revision, and orphan-repair combinations could suppress the first write, replace an internal continuation with the prepared inbound prompt, or leave invalid user/assistant boundaries.

Contributor live evidence showed one exhausted reasoning-only episode persisting the same user request three times, after which later turns repeatedly answered the duplicated backlog.

## Why This Change Was Made

The original suppression toggles fixed the direct duplicate but did not model whether the active prompt was the inbound request or an internal continuation, whether its user leaf was already durable, or whether prepared-message merging remained valid.

The maintainer refactor replaces those parallel toggles with one closed active-prompt state that owns:

- the exact retry-stable prompt,
- whether its canonical user leaf is durable, and
- whether the next attempt may merge the prepared inbound message.

Reasoning-only and empty-response retries persist an internal continuation boundary. Missing-assistant same-prompt retries reuse the canonical user leaf only after confirmed persistence. Compaction, provider, finalize, and orphan-repair paths carry or explicitly invalidate that state at their owner boundary. The proposed retry-limit environment variables were removed; defaults and public configuration remain unchanged.

## User Impact

- Incomplete-turn recovery no longer duplicates or silently drops user turns.
- Compound retries retain valid transcript alternation and the exact active prompt.
- Retry counts, public config, and ordinary successful turns remain unchanged.

## Evidence

- Contributor live before/after: an exhausted reasoning-only episode changed from three persisted copies of one inbound request to one canonical user record; the later backlog re-answering symptom disappeared.
- Blacksmith Testbox `tbx_01kxb3qb3gar01dmvxrq0nprhm`: 277 focused incomplete-turn, finalize, compaction, orphan-repair, and session-guard tests passed.
- Latest focused rebase Testbox `tbx_01kxb79fkt8m7kwnn9vrte0eq9`, Actions 29193973806: 277/277 passed.
- Earlier full Testbox `tbx_01kxb7q8hmqhcg8r7b9zvyvd88`, Actions 29194196774: build/check passed; the only suite failure was the independent browser mock baseline now landed in #105398.
- First exact-head CI 29196194759: every runtime test shard passed; the only failure exposed current test-contract typing drift after rebase.
- Testbox `tbx_01kxbbzsbse88fj07jy0h1epd9`, Actions 29196492540: all test typechecks passed after adding the required user-message timestamp and completing the shared mock surface.
- Testbox `tbx_01kxbc6rre2k2qxvh1v9mg9a7n`, Actions 29196616274: 200/200 affected tests passed.
- Whole-branch autoreview: clean, 0.86 confidence. Every later rebase retains patch id `b8f54fe2793b9d644f0d04c5a4a5baef9e7ab68a`; fresh reruns fail closed before model invocation on an unchanged secret-like identifier in surrounding context.
- Fresh fix-only autoreview: clean, 0.95 confidence.
- `git diff --check`: passed.

This change was developed with AI assistance and reviewed before submission.
