### PR TITLE
fix(qa): keep retry passes terminally successful

### DIFF
--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   __testing,
+  captureRuntimeParityCell,
   isRuntimeParityResultPass,
   runRuntimeParityScenario,
   type RuntimeId,
@@ -29,6 +30,38 @@ function makeRuntimeParityCell(
 }
 
 describe("runtime parity", () => {
+  it("keeps a retry pass diagnostic from failing the captured cell", async () => {
+    const cell = await captureRuntimeParityCell({
+      runtime: "openclaw",
+      gateway: {
+        tempRoot: `/tmp/openclaw-qa-runtime-parity-missing-${process.pid}`,
+      },
+      scenarioResult: {
+        status: "pass",
+        details: "ok | passed on retry; first attempt: timed out after 20000ms",
+      },
+      wallClockMs: 10,
+    });
+
+    expect(cell.runtimeErrorClass).toBeUndefined();
+  });
+
+  it("still classifies terminal scenario failure diagnostics", async () => {
+    const cell = await captureRuntimeParityCell({
+      runtime: "openclaw",
+      gateway: {
+        tempRoot: `/tmp/openclaw-qa-runtime-parity-missing-${process.pid}`,
+      },
+      scenarioResult: {
+        status: "fail",
+        details: "timed out after 20000ms",
+      },
+      wallClockMs: 10,
+    });
+
+    expect(cell.runtimeErrorClass).toBe("timeout");
+  });
+
   it("marks planned mock tool calls without outputs as missing tool results", () => {
     const toolCalls = __testing.resolveToolCallOrderFromMockRequests([
       {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1041,7 +1041,12 @@ export async function captureRuntimeParityCell(
     ...scanGatewayLogSentinels(gatewayLogs),
     ...scanDirectReplyTranscriptSentinels(transcriptBytes),
   ];
-  const scenarioErrorClass = classifyScenarioError(params.scenarioResult.details);
+  // Retry passes retain first-attempt diagnostics; only terminal failures may
+  // classify that historical text as the cell's runtime error.
+  const scenarioErrorClass =
+    params.scenarioResult.status === "fail"
+      ? classifyScenarioError(params.scenarioResult.details)
+      : undefined;
   const sentinelErrorClass = summarizeSentinelErrorClass(sentinelFindings);
   return {
     runtime: params.runtime,


### PR DESCRIPTION
## What Problem This Solves

QA flow retries preserve first-attempt diagnostics when the second attempt passes. Runtime-parity capture classified that historical text as the cell's terminal error, turning a final pass into failure-mode drift.

Closes #103631.

## Why This Change Was Made

Runtime-parity cells now derive a scenario error class only when the final scenario status is `fail`. Gateway/transcript sentinel failures remain independent. Regression coverage proves both sides of the contract: a retry-pass diagnostic stays successful, while a terminal timeout is still classified.

## User Impact

Release QA no longer reports false runtime-parity failures for scenarios that pass their bounded retry. Real final failures and sentinel findings continue to fail.

## Evidence

- Exact failure observed in landed token-efficiency proof `4bc300843d5ec9f071257c2900701f91df44e1c3`: `webchat-direct-reply-routing` logged retry then pass but captured `runtimeErrorClass=scenario-failure`.
- Testbox `tbx_01kx5qan3y2kpr49rd9h4c5ajb`: `runtime-parity.test.ts` and `suite.test.ts`, 37/37 passed.
- Same Testbox: scoped `check:changed` passed extension production/test typechecks, changed-file lint, storage guards, and runtime import cycles.
- Fresh autoreview: clean, no accepted/actionable findings; correctness 0.91.
- `git diff --check` and oxfmt check passed.

No changelog entry: internal QA/release-CI behavior only.
