### PR TITLE
fix(compaction): allow compaction under Bedrock aws-sdk auth with no static key

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2215,6 +2215,32 @@ describe("compaction-safeguard extension model fallback", () => {
     expect(retrieved?.model).toEqual(model);
   });
 
+  it("proceeds with keyless SDK-managed auth (ok:true, no apiKey/headers)", async () => {
+    // Regression: aws-sdk/oauth providers sign requests later and resolve with
+    // neither apiKey nor headers. `ok: true` must be trusted so compaction runs
+    // instead of wedging every message with a false "no credentials" cancel.
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("mock summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({ provider: "amazon-bedrock" });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true });
+    const mockContext = createCompactionContext({ sessionManager, getApiKeyAndHeadersMock });
+    const compactionHandler = createCompactionHandler();
+    const event = createCompactionEvent({ messageText: "summarize me", tokensBefore: 1000 });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as { cancel?: boolean };
+
+    expect(result.cancel).not.toBe(true);
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
+    expect(mockSummarizeInStages).toHaveBeenCalled();
+  });
+
   it("cancels compaction when both ctx.model and runtime.model are undefined", async () => {
     const sessionManager = stubSessionManager();
 

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -347,15 +347,10 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${requestAuth.error}`,
     };
   }
-  if (!requestAuth.apiKey && !requestAuth.headers) {
-    log.warn(
-      "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
-    );
-    return {
-      ok: false,
-      reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
-    };
-  }
+  // `ok: true` is the registry's authoritative success signal; it already returns
+  // `ok: false` when auth cannot resolve. Do not re-derive failure from absent
+  // key/headers. SDK-managed modes (aws-sdk, oauth) sign the request later and
+  // legitimately carry neither, so gating on them wedges compaction forever.
   return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
 }
 


### PR DESCRIPTION
Closes #103637
Related: #90179, #90206, #90221, #90187

## What Problem This Solves

Fixes an issue where Bedrock users on `auth: "aws-sdk"` (SigV4 via the AWS SDK credential chain: EC2 instance role, SSO, STS/assumed-role, or `AWS_PROFILE`) lose their agent completely once a session grows large enough to require compaction. Every subsequent message fails with `Preflight compaction required but failed: Compaction safeguard could not resolve request credentials`, and the session logs `Compaction safeguard: no request credentials available; cancelling compaction to preserve history`. Bedrock calls otherwise work throughout the session, so the failure is surprising and has no runtime workaround.

## Why This Change Was Made

`ModelRegistry.getApiKeyAndHeaders` intentionally returns `{ ok: true, apiKey: undefined, headers: undefined }` for `auth: "aws-sdk"` because SigV4 signing happens later at send time; the registry already treats this as valid via `allowsMissingProviderApiKey` (`aws-sdk`, `oauth`). The compaction safeguard, however, ignored that authoritative `ok: true` and re-derived failure from the absence of a static key/header, wedging compaction for every keyless request.

The safeguard now trusts the registry's `ok` signal, which already returns `ok: false` when auth genuinely cannot resolve (for example an `authHeader` provider with no key). This removes the faulty second check rather than adding a parallel path, keeping one authoritative credential-resolution boundary. A regression test covers the keyless SDK-managed auth path.

This is the same defect tracked in #90179. The earlier fix #90206 was accepted in review (cleaner `authMode` threading, `MERGEABLE`/`CLEAN`, Codex "proof: sufficient") but was closed while waiting on live real-behavior Bedrock proof from the original reporter. This PR supplies that missing proof from a live Bedrock `aws-sdk` deployment and takes the minimal form of the fix.

## User Impact

Bedrock-native users on session-based / role-based AWS auth can run long sessions again: compaction proceeds normally and messages no longer fail once the context grows. No config change, no new surface, no behavior change for API-key or `authHeader` providers.

## Evidence

Validated on a live Bedrock `aws-sdk` deployment (EC2 instance role via IMDSv2, no static key, no OpenClaw API key for Bedrock):

- Before: every Telegram/webchat message failed with `Preflight compaction required but failed: ... could not resolve request credentials for amazon-bedrock/global.anthropic.claude-opus-4-6-v1`, while `aws sts get-caller-identity` and a direct `bedrock-runtime converse` both succeeded with the same credentials.
- After: compaction runs and messages succeed; the `no request credentials available` log no longer appears.

Focused tests (`src/agents/agent-hooks/compaction-safeguard.test.ts`): 106 passed, including a new case that drives a keyless `ok: true` auth result and asserts compaction proceeds to summarization instead of cancelling.
