### PR TITLE
fix(ci): split locale publisher app permissions

### DIFF
--- a/.github/actions/publish-generated-pr/action.yml
+++ b/.github/actions/publish-generated-pr/action.yml
@@ -32,6 +32,9 @@ inputs:
   generated-paths:
     description: Newline-delimited generated paths to commit.
     required: true
+  invalidation-paths:
+    description: Newline-delimited generator input paths that make an older run stale.
+    required: true
 
 runs:
   using: composite
@@ -75,6 +78,7 @@ runs:
         PR_TITLE: ${{ inputs.pr-title }}
         PR_BODY: ${{ inputs.pr-body }}
         GENERATED_PATHS: ${{ inputs.generated-paths }}
+        INVALIDATION_PATHS: ${{ inputs.invalidation-paths }}
       run: |
         set -euo pipefail
         export GH_PROMPT_DISABLED=1
@@ -102,6 +106,16 @@ runs:
           echo "Generated PR publication requires at least one generated path." >&2
           exit 1
         fi
+        invalidation_paths=()
+        while IFS= read -r invalidation_path; do
+          if [[ -n "${invalidation_path}" ]]; then
+            invalidation_paths+=("${invalidation_path}")
+          fi
+        done <<< "${INVALIDATION_PATHS}"
+        if [[ "${#invalidation_paths[@]}" -eq 0 ]]; then
+          echo "Generated PR publication requires at least one invalidation path." >&2
+          exit 1
+        fi
 
         find_open_pr() {
           timeout --signal=TERM --kill-after=10s 60s \
@@ -123,12 +137,6 @@ runs:
             echo "::error::Resolved workflow source is not an ancestor of latest ${BASE_BRANCH}."
             return 1
           fi
-          if ! git diff --quiet "${source_commit}" "${base_ref}" -- "${generated_paths[@]}"; then
-            echo "A newer main-triggered full locale refresh will retire the stale pull request." \
-              >> "${GITHUB_STEP_SUMMARY}"
-            return 0
-          fi
-
           current_head="$(read_remote_head)"
           if [[ -z "${current_head}" ]]; then
             echo "Stale generated pull request is already unmergeable because its branch is absent." \
@@ -194,6 +202,14 @@ runs:
           if ! git merge-base --is-ancestor "${source_commit}" "${base_ref}"; then
             echo "::error::Resolved workflow source is not an ancestor of latest ${BASE_BRANCH}."
             return 1
+          fi
+
+          # A completed older run must never publish output after a newer base changed generator
+          # inputs. Retire any existing deterministic-branch PR and let the newest queued run own it.
+          if ! git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"; then
+            echo "::notice::Deferring stale generated output because generator inputs changed on ${BASE_BRANCH}."
+            prepare_outcome=stale-input
+            return 0
           fi
 
           # Never overwrite a generated path that changed on main after this workflow's source SHA.
@@ -309,9 +325,16 @@ runs:
           > "${changed_paths_file}"
 
         prepare_branch
+        if [[ "${prepare_outcome}" = "stale-input" ]]; then
+          echo "A newer main-triggered full locale refresh will reconcile changed generator inputs." \
+            >> "${GITHUB_STEP_SUMMARY}"
+          neutralize_stale_pr
+          exit 0
+        fi
         if [[ "${prepare_outcome}" = "deferred" ]]; then
           echo "A newer main-triggered full locale refresh will reconcile the generated output." \
             >> "${GITHUB_STEP_SUMMARY}"
+          neutralize_stale_pr
           exit 0
         fi
         if [[ "${prepare_outcome}" = "merged" ]]; then
@@ -334,9 +357,16 @@ runs:
           # A merge can consume and delete the branch after observation. Rebuild from latest base;
           # overlap detection defers to the guaranteed main-triggered full refresh.
           prepare_branch
+          if [[ "${prepare_outcome}" = "stale-input" ]]; then
+            echo "A newer main-triggered full locale refresh will reconcile changed generator inputs." \
+              >> "${GITHUB_STEP_SUMMARY}"
+            neutralize_stale_pr
+            exit 0
+          fi
           if [[ "${prepare_outcome}" = "deferred" ]]; then
             echo "A newer main-triggered full locale refresh will reconcile the generated output." \
               >> "${GITHUB_STEP_SUMMARY}"
+            neutralize_stale_pr
             exit 0
           fi
           if [[ "${prepare_outcome}" = "merged" ]]; then

--- a/.github/actions/publish-generated-pr/action.yml
+++ b/.github/actions/publish-generated-pr/action.yml
@@ -8,6 +8,12 @@ inputs:
   fallback-private-key:
     description: Fallback OpenClaw GitHub App private key.
     required: true
+  pull-request-app-id:
+    description: GitHub App id with pull-request write access.
+    required: true
+  pull-request-private-key:
+    description: GitHub App private key with pull-request write access.
+    required: true
   base-branch:
     description: Target branch for the generated pull request.
     required: true
@@ -30,30 +36,39 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create generated PR app token
-      id: app-token
+    - name: Create generated branch app token
+      id: contents-token
       continue-on-error: true
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: "2729701"
         private-key: ${{ inputs.primary-private-key }}
         permission-contents: write
-        permission-pull-requests: write
 
-    - name: Create generated PR fallback app token
-      id: app-token-fallback
-      if: steps.app-token.outcome == 'failure'
+    - name: Create generated branch fallback app token
+      id: contents-token-fallback
+      if: steps.contents-token.outcome == 'failure'
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: "2971289"
         private-key: ${{ inputs.fallback-private-key }}
         permission-contents: write
+
+    - name: Create generated PR app token
+      id: pull-request-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        app-id: ${{ inputs.pull-request-app-id }}
+        private-key: ${{ inputs.pull-request-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
         permission-pull-requests: write
 
     - name: Publish generated pull request
       shell: bash
       env:
-        GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+        CONTENTS_TOKEN: ${{ steps.contents-token.outputs.token || steps.contents-token-fallback.outputs.token }}
+        GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
         BASE_BRANCH: ${{ inputs.base-branch }}
         HEAD_BRANCH: ${{ inputs.head-branch }}
         COMMIT_MESSAGE: ${{ inputs.commit-message }}
@@ -68,8 +83,12 @@ runs:
         export GIT_SEQUENCE_EDITOR=true
         export GIT_TERMINAL_PROMPT=0
 
+        if [[ -z "${CONTENTS_TOKEN:-}" ]]; then
+          echo "Generated branch publication requires an OpenClaw contents-write App token." >&2
+          exit 1
+        fi
         if [[ -z "${GH_TOKEN:-}" ]]; then
-          echo "Generated PR publication requires an OpenClaw GitHub App token." >&2
+          echo "Generated PR publication requires a pull-request-write App token." >&2
           exit 1
         fi
 
@@ -265,7 +284,16 @@ runs:
         source_commit="$(git rev-parse HEAD)"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        timeout --signal=TERM --kill-after=10s 30s gh auth setup-git
+        # Keep branch transport and PR mutations on separate least-privilege App identities.
+        # App-authored branch pushes preserve pull_request synchronize workflow events.
+        git_auth="$(printf 'x-access-token:%s' "${CONTENTS_TOKEN}" | base64 | tr -d '\n')"
+        printf '::add-mask::%s\n' "${git_auth}"
+        git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${git_auth}"
+        unset git_auth
+        cleanup_git_auth() {
+          git config --local --unset-all http.https://github.com/.extraheader || true
+        }
+        trap cleanup_git_auth EXIT
         git add -A -- "${generated_paths[@]}"
         if git diff --cached --quiet -- "${generated_paths[@]}"; then
           echo "No generated changes."

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -11,6 +11,7 @@ on:
       - ui/src/i18n/lib/types.ts
       - ui/src/i18n/lib/registry.ts
       - scripts/control-ui-i18n.ts
+      - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/control-ui-locale-refresh.yml
   release:
     types:
@@ -24,7 +25,9 @@ permissions:
 
 concurrency:
   group: control-ui-locale-refresh
-  cancel-in-progress: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(ui): refresh control ui locales') }}"
+  # Finish the active full refresh; GitHub retains only the newest pending run for this group.
+  # Publisher overlap checks defer stale generated paths to that queued reconciliation run.
+  cancel-in-progress: false
 
 jobs:
   resolve-base:
@@ -244,6 +247,15 @@ jobs:
           commit-message: "chore(ui): refresh control ui locales"
           pr-title: "chore(ui): refresh control ui locales"
           generated-paths: ui/src/i18n
+          invalidation-paths: |
+            ui/src/i18n/locales/en.ts
+            ui/src/i18n/.i18n/glossary.*.json
+            ui/src/i18n/.i18n/raw-copy-baseline.json
+            ui/src/i18n/lib/types.ts
+            ui/src/i18n/lib/registry.ts
+            scripts/control-ui-i18n.ts
+            .github/actions/publish-generated-pr/action.yml
+            .github/workflows/control-ui-locale-refresh.yml
           pr-body: |
             ## What Problem This Solves
 

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -237,6 +237,8 @@ jobs:
         with:
           primary-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           fallback-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
           head-branch: automation/control-ui-locale-refresh
           commit-message: "chore(ui): refresh control ui locales"

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -242,6 +242,8 @@ jobs:
         with:
           primary-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           fallback-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
           head-branch: automation/native-app-locale-refresh
           commit-message: "chore(i18n): refresh native locales"

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -15,6 +15,7 @@ on:
       - scripts/control-ui-i18n.ts
       - scripts/native-app-i18n.ts
       - ui/src/i18n/.i18n/glossary.*.json
+      - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/native-app-locale-refresh.yml
   workflow_dispatch:
 
@@ -23,7 +24,9 @@ permissions:
 
 concurrency:
   group: native-app-locale-refresh
-  cancel-in-progress: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'chore(i18n): refresh native locales') }}"
+  # Finish the active full refresh; GitHub retains only the newest pending run for this group.
+  # Publisher overlap checks defer stale generated paths to that queued reconciliation run.
+  cancel-in-progress: false
 
 jobs:
   resolve-base:
@@ -251,6 +254,17 @@ jobs:
           generated-paths: |
             apps/.i18n/native
             apps/.i18n/native-source.json
+          invalidation-paths: |
+            apps/android/app/src/main
+            apps/ios
+            apps/macos/Sources
+            apps/macos/Package.swift
+            apps/shared/OpenClawKit/Sources
+            scripts/control-ui-i18n.ts
+            scripts/native-app-i18n.ts
+            ui/src/i18n/.i18n/glossary.*.json
+            .github/actions/publish-generated-pr/action.yml
+            .github/workflows/native-app-locale-refresh.yml
           pr-body: |
             ## What Problem This Solves
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -223,6 +223,7 @@ function runGeneratedPublisherScenario(
         FAKE_PR_STATE: prState,
         FAKE_STALE_HEAD_ONCE: stalePrHeadOnce,
         GENERATED_PATHS: "generated",
+        CONTENTS_TOKEN: "contents-token",
         GH_TOKEN: "test-token",
         GITHUB_REPOSITORY: "openclaw/openclaw",
         GITHUB_REPOSITORY_OWNER: "openclaw",
@@ -234,6 +235,14 @@ function runGeneratedPublisherScenario(
         RUNNER_TEMP: runnerTemp,
       },
     });
+    const authHeader = spawnSync(
+      "git",
+      ["config", "--local", "--get-all", "http.https://github.com/.extraheader"],
+      { cwd: worktree, encoding: "utf8" },
+    );
+    if (authHeader.status !== 1 || authHeader.stdout.trim() !== "") {
+      throw new Error("generated publisher left its Git authorization header configured");
+    }
 
     const branchRef = "refs/heads/automation/locale";
     const branchExists =
@@ -414,42 +423,63 @@ describe("ci workflow guards", () => {
 
     const publishAction = parse(readFileSync(PUBLISH_GENERATED_PR_ACTION, "utf8"));
     const primaryTokenStep = publishAction.runs.steps.find(
-      (step: { name?: string }) => step.name === "Create generated PR app token",
+      (step: { name?: string }) => step.name === "Create generated branch app token",
     );
     const fallbackTokenStep = publishAction.runs.steps.find(
-      (step: { name?: string }) => step.name === "Create generated PR fallback app token",
+      (step: { name?: string }) => step.name === "Create generated branch fallback app token",
+    );
+    const pullRequestTokenStep = publishAction.runs.steps.find(
+      (step: { name?: string }) => step.name === "Create generated PR app token",
     );
     const actionPublishStep = publishAction.runs.steps.find(
       (step: { name?: string }) => step.name === "Publish generated pull request",
     );
 
     expect(primaryTokenStep).toMatchObject({
-      id: "app-token",
+      id: "contents-token",
       "continue-on-error": true,
       uses: CREATE_GITHUB_APP_TOKEN_V3,
       with: {
         "app-id": "2729701",
         "private-key": "${{ inputs.primary-private-key }}",
         "permission-contents": "write",
-        "permission-pull-requests": "write",
       },
     });
     expect(fallbackTokenStep).toMatchObject({
-      id: "app-token-fallback",
-      if: "steps.app-token.outcome == 'failure'",
+      id: "contents-token-fallback",
+      if: "steps.contents-token.outcome == 'failure'",
       uses: CREATE_GITHUB_APP_TOKEN_V3,
       with: {
         "app-id": "2971289",
         "private-key": "${{ inputs.fallback-private-key }}",
         "permission-contents": "write",
+      },
+    });
+    expect(pullRequestTokenStep).toMatchObject({
+      id: "pull-request-token",
+      uses: CREATE_GITHUB_APP_TOKEN_V3,
+      with: {
+        "app-id": "${{ inputs.pull-request-app-id }}",
+        "private-key": "${{ inputs.pull-request-private-key }}",
+        owner: "${{ github.repository_owner }}",
+        repositories: "${{ github.event.repository.name }}",
         "permission-pull-requests": "write",
       },
     });
-    expect(actionPublishStep.env.GH_TOKEN).toBe(
-      "${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}",
+    expect(actionPublishStep.env.CONTENTS_TOKEN).toBe(
+      "${{ steps.contents-token.outputs.token || steps.contents-token-fallback.outputs.token }}",
     );
+    expect(actionPublishStep.env.GH_TOKEN).toBe("${{ steps.pull-request-token.outputs.token }}");
     expect(actionPublishStep.run).toContain("GIT_TERMINAL_PROMPT=0");
-    expect(actionPublishStep.run).toContain("gh auth setup-git");
+    expect(actionPublishStep.run).toContain(
+      'git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${git_auth}"',
+    );
+    expect(actionPublishStep.run).toContain("printf '::add-mask::%s\\n' \"${git_auth}\"");
+    expect(actionPublishStep.run).toContain(
+      "git config --local --unset-all http.https://github.com/.extraheader",
+    );
+    expect(actionPublishStep.run).toContain("trap cleanup_git_auth EXIT");
+    expect(actionPublishStep.run).not.toContain("gh auth setup-git");
     expect(actionPublishStep.run).toContain("timeout --signal=TERM --kill-after=10s 120s");
     expect(actionPublishStep.run).toContain("--force-with-lease=refs/heads/");
     expect(actionPublishStep.run).toContain(
@@ -564,6 +594,8 @@ describe("ci workflow guards", () => {
       expect(publishStep.with).toMatchObject({
         "primary-private-key": "${{ secrets.GH_APP_PRIVATE_KEY }}",
         "fallback-private-key": "${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}",
+        "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+        "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
         "base-branch": "${{ github.event.repository.default_branch }}",
         "head-branch": automationBranch,
         "commit-message": commitMessage,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -125,8 +125,13 @@ function writeExecutable(filePath: string, lines: string[]): void {
 }
 
 function runGeneratedPublisherScenario(
-  baseChangePath: "a" | "b",
-  options: { stalePrHeadOnce?: boolean } = {},
+  baseChangePath: "a" | "b" | null,
+  options: {
+    existingPr?: boolean;
+    noGeneratedChange?: boolean;
+    stalePrHeadOnce?: boolean;
+    updateSource?: boolean;
+  } = {},
 ) {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-generated-pr-"));
   try {
@@ -134,6 +139,7 @@ function runGeneratedPublisherScenario(
     const updater = path.join(root, "updater");
     const worktree = path.join(root, "worktree");
     const generatedDir = path.join(worktree, "generated");
+    const sourceDir = path.join(worktree, "source");
     const fakeBin = path.join(root, "bin");
     const runnerTemp = path.join(root, "runner-temp");
     const prState = path.join(root, "pr-open");
@@ -141,6 +147,7 @@ function runGeneratedPublisherScenario(
     const summary = path.join(root, "summary.md");
 
     mkdirSync(generatedDir, { recursive: true });
+    mkdirSync(sourceDir);
     mkdirSync(fakeBin);
     mkdirSync(runnerTemp);
     writeFileSync(summary, "", "utf8");
@@ -153,23 +160,40 @@ function runGeneratedPublisherScenario(
     runGit(worktree, ["config", "user.email", "publisher@example.com"]);
     writeFileSync(path.join(generatedDir, "a.txt"), "old-a\n", "utf8");
     writeFileSync(path.join(generatedDir, "b.txt"), "old-b\n", "utf8");
-    runGit(worktree, ["add", "generated"]);
+    writeFileSync(path.join(sourceDir, "input.txt"), "old-input\n", "utf8");
+    runGit(worktree, ["add", "generated", "source"]);
     runGit(worktree, ["commit", "-m", "base"]);
     runGit(worktree, ["remote", "add", "origin", origin]);
     runGit(worktree, ["push", "-u", "origin", "main"]);
     runGit(root, ["--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+    if (options.existingPr) {
+      runGit(worktree, ["switch", "-c", "automation/locale"]);
+      writeFileSync(path.join(generatedDir, "a.txt"), "stale-pr-a\n", "utf8");
+      runGit(worktree, ["add", "generated"]);
+      runGit(worktree, ["commit", "-m", "stale generated pull request"]);
+      runGit(worktree, ["push", "-u", "origin", "automation/locale"]);
+      writeFileSync(prState, "", "utf8");
+      runGit(worktree, ["switch", "main"]);
+    }
     runGit(root, ["clone", "--branch", "main", origin, updater]);
     runGit(updater, ["config", "user.name", "Base Updater"]);
     runGit(updater, ["config", "user.email", "updater@example.com"]);
-    writeFileSync(
-      path.join(updater, "generated", `${baseChangePath}.txt`),
-      `newer-${baseChangePath}\n`,
-      "utf8",
-    );
-    runGit(updater, ["add", "generated"]);
+    if (baseChangePath !== null) {
+      writeFileSync(
+        path.join(updater, "generated", `${baseChangePath}.txt`),
+        `newer-${baseChangePath}\n`,
+        "utf8",
+      );
+    }
+    if (options.updateSource) {
+      writeFileSync(path.join(updater, "source", "input.txt"), "newer-input\n", "utf8");
+    }
+    runGit(updater, ["add", "generated", "source"]);
     runGit(updater, ["commit", "-m", "update base"]);
     runGit(updater, ["push", "origin", "main"]);
-    writeFileSync(path.join(generatedDir, "a.txt"), "desired-a\n", "utf8");
+    if (!options.noGeneratedChange) {
+      writeFileSync(path.join(generatedDir, "a.txt"), "desired-a\n", "utf8");
+    }
 
     writeExecutable(path.join(fakeBin, "timeout"), [
       "#!/usr/bin/env bash",
@@ -223,6 +247,7 @@ function runGeneratedPublisherScenario(
         FAKE_PR_STATE: prState,
         FAKE_STALE_HEAD_ONCE: stalePrHeadOnce,
         GENERATED_PATHS: "generated",
+        INVALIDATION_PATHS: "source",
         CONTENTS_TOKEN: "contents-token",
         GH_TOKEN: "test-token",
         GITHUB_REPOSITORY: "openclaw/openclaw",
@@ -247,14 +272,19 @@ function runGeneratedPublisherScenario(
     const branchRef = "refs/heads/automation/locale";
     const branchExists =
       spawnSync("git", ["--git-dir", origin, "show-ref", "--verify", branchRef]).status === 0;
+    const branchHead = branchExists
+      ? runGit(root, ["--git-dir", origin, "rev-parse", branchRef])
+      : "";
     return {
       branchExists,
+      branchHead,
       generatedA: branchExists
         ? runGit(root, ["--git-dir", origin, "show", `${branchRef}:generated/a.txt`])
         : "",
       generatedB: branchExists
         ? runGit(root, ["--git-dir", origin, "show", `${branchRef}:generated/b.txt`])
         : "",
+      mainHead: runGit(root, ["--git-dir", origin, "rev-parse", "refs/heads/main"]),
       summary: readFileSync(summary, "utf8"),
     };
   } finally {
@@ -357,18 +387,14 @@ describe("ci workflow guards", () => {
 
     expect(refresh.if).toBe("needs.resolve-base.result == 'success'");
     expect(refresh.strategy.matrix.locale).toEqual(NATIVE_I18N_LOCALES);
-    expect(controlUiWorkflow.concurrency["cancel-in-progress"]).toContain(
-      "!startsWith(github.event.head_commit.message, 'chore(ui): refresh control ui locales')",
-    );
+    expect(controlUiWorkflow.concurrency["cancel-in-progress"]).toBe(false);
     expect(controlUiWorkflow.concurrency.group).toBe("control-ui-locale-refresh");
     expect(controlUiWorkflow.jobs.plan).toBeUndefined();
     expect(controlUiWorkflow.jobs.refresh.if).toBe("needs.resolve-base.result == 'success'");
     expect(controlUiWorkflow.jobs.refresh.strategy.matrix.locale).toEqual(
       SUPPORTED_LOCALES.filter((locale) => locale !== "en"),
     );
-    expect(workflow.concurrency["cancel-in-progress"]).toContain(
-      "!startsWith(github.event.head_commit.message, 'chore(i18n): refresh native locales')",
-    );
+    expect(workflow.concurrency["cancel-in-progress"]).toBe(false);
     expect(workflow.concurrency.group).toBe("native-app-locale-refresh");
     expect(controlUiResolveBase.if).not.toContain("chore(ui): refresh control ui locales");
     expect(nativeResolveBase.if).not.toContain("chore(i18n): refresh native locales");
@@ -399,6 +425,7 @@ describe("ci workflow guards", () => {
     expect(controlUiRefreshStep.env.OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL).toBe("0");
 
     for (const ownerWorkflow of [controlUiWorkflow, workflow]) {
+      expect(ownerWorkflow.on.push.paths).toContain(PUBLISH_GENERATED_PR_ACTION);
       const resolveBase = ownerWorkflow.jobs["resolve-base"];
       const resolveStep = resolveBase.steps.find(
         (step: { name?: string }) => step.name === "Resolve default branch head",
@@ -470,6 +497,9 @@ describe("ci workflow guards", () => {
       "${{ steps.contents-token.outputs.token || steps.contents-token-fallback.outputs.token }}",
     );
     expect(actionPublishStep.env.GH_TOKEN).toBe("${{ steps.pull-request-token.outputs.token }}");
+    expect(actionPublishStep.env.INVALIDATION_PATHS).toBe(
+      "${{ inputs.invalidation-paths }}",
+    );
     expect(actionPublishStep.run).toContain("GIT_TERMINAL_PROMPT=0");
     expect(actionPublishStep.run).toContain(
       'git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${git_auth}"',
@@ -507,6 +537,10 @@ describe("ci workflow guards", () => {
     expect(actionPublishStep.run).toContain(".head.sha");
     expect(actionPublishStep.run).not.toContain("gh pr list");
     expect(actionPublishStep.run).toContain("neutralize_stale_pr");
+    expect(actionPublishStep.run).toContain(
+      'git diff --quiet "${source_commit}" "${base_ref}" -- "${invalidation_paths[@]}"',
+    );
+    expect(actionPublishStep.run).not.toContain("force_retirement");
     expect(actionPublishStep.run).toContain("unsafe close mutation");
     expect(actionPublishStep.run).not.toContain("gh pr close");
     expect(actionPublishStep.run).toContain('source_commit="$(git rev-parse HEAD)"');
@@ -604,6 +638,14 @@ describe("ci workflow guards", () => {
       expect(publishStep.with["generated-paths"]).toContain(
         automationBranch.includes("native") ? "apps/.i18n/native" : "ui/src/i18n",
       );
+      expect(publishStep.with["invalidation-paths"]).toContain(
+        automationBranch.includes("native")
+          ? "apps/android/app/src/main"
+          : "ui/src/i18n/locales/en.ts",
+      );
+      expect(publishStep.with["invalidation-paths"]).toContain(
+        ".github/actions/publish-generated-pr/action.yml",
+      );
       expect(publishStep.with["pr-body"]).toContain("## What Problem This Solves");
       expect(publishStep.with["pr-body"]).toContain("## Evidence");
       expect(publishStep.with["pr-body"]).toContain("${{ needs.resolve-base.outputs.sha }}");
@@ -643,6 +685,38 @@ describe("ci workflow guards", () => {
       expect(result.branchExists).toBe(true);
       expect(result.generatedA).toBe("desired-a");
       expect(result.summary).toContain("https://github.com/openclaw/openclaw/pull/1");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "defers stale generator inputs and neutralizes an existing pull request",
+    () => {
+      const result = runGeneratedPublisherScenario(null, {
+        existingPr: true,
+        updateSource: true,
+      });
+
+      expect(result.branchHead).toBe(result.mainHead);
+      expect(result.generatedA).toBe("old-a");
+      expect(result.summary).toContain(
+        "A newer main-triggered full locale refresh will reconcile changed generator inputs.",
+      );
+      expect(result.summary).toContain("Neutralized stale generated pull request");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "neutralizes an existing pull request when generation has no changes",
+    () => {
+      const result = runGeneratedPublisherScenario("b", {
+        existingPr: true,
+        noGeneratedChange: true,
+      });
+
+      expect(result.branchHead).toBe(result.mainHead);
+      expect(result.generatedA).toBe("old-a");
+      expect(result.generatedB).toBe("newer-b");
+      expect(result.summary).toContain("Neutralized stale generated pull request");
     },
   );
 


### PR DESCRIPTION
Refs #103570

## What Problem This Solves

Follow-up live verification of #103625 showed that both locale workflows still fail before publishing their generated branch. The two configured branch Apps reject a token request that combines `contents: write` and `pull-requests: write`, so no automation branch or generated PR can be created.

## Why This Change Was Made

The shared publisher now uses separate least-privilege GitHub App identities:

- the existing primary/fallback OpenClaw Apps mint only `contents: write` for exact-leased Git transport;
- the existing Mantis App mints only `pull-requests: write` for same-repository PR lookup, creation, editing, and convergence checks.

Git transport uses a masked, repo-local HTTPS authorization header derived from the contents token. An `EXIT` trap removes that exact header. The PR token never configures Git, and the contents token never reaches `gh` PR operations. App-authored branch pushes continue to produce PR synchronization events; the workflow does not fall back to `GITHUB_TOKEN`, bypass protected `main`, or auto-merge.

Both fixed concurrency groups now finish their active full refresh. GitHub retains only the newest pending run in each group, while the publisher's source-ancestry and generated-path overlap checks defer stale output to that queued reconciliation run. This prevents a busy `main` from starving the long Native matrix.

Each caller also declares its semantic generator-input paths. If a newer base changes any input while an older run finishes, publication is deferred and any exact existing automation PR is CAS-neutralized onto current `main`. The same exact-head retirement now covers overlap, no-change, and already-merged outcomes, so stale deterministic-branch PRs cannot remain mergeable.

## User Impact

Control UI and Native App locale refreshes can publish reviewable generated PRs without requiring one App installation to own both permission families.

## Evidence

- Before: [Control UI Locale Refresh 29086283746](https://github.com/openclaw/openclaw/actions/runs/29086283746) passed base resolution, all 20 locale jobs, artifact assembly, and validation, then both combined-permission token requests failed HTTP 422. No branch or PR was created.
- Before: [Native App Locale Refresh 29086283748](https://github.com/openclaw/openclaw/actions/runs/29086283748) passed base resolution and 12 locales, then a normal main push cancelled the remaining 9 locales and finalizer; repeated cancellation could prevent publication indefinitely.
- Live identity contract: [Mantis run 29046675260, job 86217351207](https://github.com/openclaw/openclaw/actions/runs/29046675260/job/86217351207#step:15:1) successfully minted a repository-scoped App token with `pull-requests: write` and used it for the following PR mutation.
- AWS Crabbox `cbx_da14a30c82b6`, `run_0c8578e3f21c`: 44/44 publisher guard/fixture tests passed, including executable proof for auth-header cleanup, stale-input deferral plus exact PR neutralization, and no-change stale-PR retirement.
- Same remote run: `pnpm check:workflows` and exact changed-file gate passed.
- Local actionlint, extracted composite `bash -n`, oxfmt, and `git diff --check`: passed.
- Fresh Codex autoreview and independent credential/event audit: no actionable findings.

AI-assisted: yes, implemented and reviewed with Codex. No agent transcript is included.
