### PR TITLE
fix(cron): emit scheduled events after durable wake changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ Docs: https://docs.openclaw.ai
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
-- **Cron scheduling hooks:** emit `cron_changed` `scheduled` events only after durable next-wake changes so plugins can reconcile external wake schedulers without polling. (#103205)
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
+- **Cron scheduling hooks:** emit `cron_changed` `scheduled` events only after durable next-wake changes so plugins can reconcile external wake schedulers without polling. (#103205)
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a7adff0a04aadb99a36d086485b5f5a7fc4dc23b1d810b18c18fbdff4beb281f  plugin-sdk-api-baseline.json
-5cc6f42ede5ba0803067384f083f9f1f292f1c56c694e832bbd8d4acaba0b362  plugin-sdk-api-baseline.jsonl
+73531cdb2e35f3b37f7e1f1838792920457a5e950aed4a6232701ce47dcbf4b5  plugin-sdk-api-baseline.json
+2f465b3acc86fe710a9716215034e812fc870cdd6046afce257f002b88ad914d  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -49,8 +49,11 @@ export default definePluginEntry({
 });
 ```
 
-Handlers run sequentially in descending `priority`; same-priority handlers
-keep registration order.
+Handlers that can return decisions or modifications run sequentially in
+descending `priority`; same-priority handlers keep registration order.
+Observation-only handlers run in parallel, and fire-and-forget observation
+dispatches can overlap with later events. Do not use priority to order
+observation side effects.
 
 `api.on(name, handler, opts?)` accepts:
 
@@ -585,9 +588,16 @@ snapshot (including `state.nextRunAtMs`, `state.lastRunStatus`, and
 `state.lastError` when present) plus a `PluginHookGatewayCronDeliveryStatus`
 of `not-requested` | `delivered` | `not-delivered` | `unknown`. Removed events
 still carry the deleted job snapshot so external schedulers can reconcile
-state. Use `ctx.getCron?.()` and `ctx.config` from the runtime context when
-syncing external wake schedulers, and keep OpenClaw as the source of truth
-for due checks and execution.
+state.
+
+A `scheduled` event is post-commit: it fires only after a successful durable
+write changes an existing job's effective `nextRunAtMs`, excluding that job's
+explicit `added`, `updated`, or `removed` lifecycle event. The top-level
+`event.nextRunAtMs` is the committed next wake; when it is absent, the job has
+no next wake. Treat these events as reconciliation hints, not an ordered delta
+log. Use `ctx.getCron?.()` and `ctx.config` from the runtime context when
+syncing external wake schedulers, and keep OpenClaw as the source of truth for
+due checks and execution.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -493,7 +493,20 @@ cover CLI and Gateway-backed install or update paths.
 - `message_received`: use the typed `threadId` field when you need inbound thread/topic routing. Keep `metadata` for channel-specific extras.
 - `message_sending`: use typed `replyToId` / `threadId` routing fields before falling back to channel-specific `metadata`.
 - `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks.
-- `cron_changed`: observe gateway-owned cron lifecycle changes. Use `event.job?.state?.nextRunAtMs` and `ctx.getCron?.()` when syncing external wake schedulers, and keep OpenClaw as the source of truth for due checks and execution.
+- `cron_changed`: observe gateway-owned cron lifecycle changes. A `scheduled` event is a post-commit reconciliation hint for an existing job's durable next wake, not an ordered delta log. Its `event.nextRunAtMs` is absent when the job has no next wake.
+
+External wake schedulers should debounce or coalesce `cron_changed` events by
+`jobId`, then reconcile the full durable view:
+
+```typescript
+const jobs = await ctx.getCron?.()?.list({ includeDisabled: true });
+```
+
+Perform the same full reconciliation from `gateway_start` to recover changes
+made while the plugin was offline. Observation handlers run in parallel, and
+fire-and-forget dispatches can overlap, so consumers must not depend on event
+completion order. Keep OpenClaw as the source of truth for due checks and
+execution.
 
 ### API object fields
 

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -232,6 +232,7 @@ export function createMockCronStateForJobs(params: {
   const nowMs = params.nowMs ?? Date.now();
   return {
     store: { version: 1, jobs: params.jobs },
+    durableNextRunAtMsByJobId: new Map<string, number | undefined>(),
     running: false,
     stopped: false,
     restartRecoveryPending: false,

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -4,6 +4,7 @@ import type { CronEvent, CronServiceDeps } from "./service.js";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
 import { computeJobNextRunAtMs } from "./service/jobs.js";
+import { loadCronStore } from "./store.js";
 import type { CronJobCreate } from "./types.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-trigger-eval-" });
@@ -42,7 +43,7 @@ async function createHarness(params: {
     requestHeartbeat: vi.fn(),
     runIsolatedAgentJob,
     ...(params.evaluateCronTrigger ? { evaluateCronTrigger: params.evaluateCronTrigger } : {}),
-    onEvent: (event) => events.push(event),
+    onEvent: (event) => events.push(structuredClone(event)),
   });
   await cron.start();
   return { cron, enqueueSystemEvent, events, runIsolatedAgentJob, storePath };
@@ -68,10 +69,14 @@ describe("cron trigger evaluation", () => {
     try {
       const job = await harness.cron.add(watcher());
       const dueAt = job.state.nextRunAtMs ?? 0;
+      harness.events.length = 0;
 
       expect(await runWhenDue(harness.cron, job.id)).toEqual({ ok: true, ran: true });
 
       const stored = harness.cron.getJob(job.id);
+      const persisted = (await loadCronStore(harness.storePath)).jobs.find(
+        (entry) => entry.id === job.id,
+      );
       expect(stored?.state).toMatchObject({
         lastTriggerEvalAtMs: dueAt,
         triggerEvalCount: 1,
@@ -82,7 +87,13 @@ describe("cron trigger evaluation", () => {
       expect(stored?.state.lastRunAtMs).toBeUndefined();
       expect((stored?.state.nextRunAtMs ?? 0) - dueAt).toBeGreaterThanOrEqual(30_000);
       expect(harness.runIsolatedAgentJob).not.toHaveBeenCalled();
-      expect(harness.events.filter((event) => event.action === "finished")).toHaveLength(0);
+      expect(harness.events.map((event) => event.action)).toEqual(["started", "scheduled"]);
+      expect(harness.events.at(-1)).toMatchObject({
+        jobId: job.id,
+        action: "scheduled",
+        nextRunAtMs: persisted?.state.nextRunAtMs,
+        job: { state: { nextRunAtMs: persisted?.state.nextRunAtMs } },
+      });
       expect(readCronRunLogEntriesSync({ storePath: harness.storePath, jobId: job.id })).toEqual(
         [],
       );
@@ -174,17 +185,33 @@ describe("cron trigger evaluation", () => {
     try {
       const job = await harness.cron.add(watcher());
       const dueAt = job.state.nextRunAtMs ?? 0;
+      harness.events.length = 0;
       await runWhenDue(harness.cron, job.id);
 
-      expect(harness.cron.getJob(job.id)?.state).toMatchObject({
+      const stored = harness.cron.getJob(job.id);
+      const persisted = (await loadCronStore(harness.storePath)).jobs.find(
+        (entry) => entry.id === job.id,
+      );
+      expect(stored?.state).toMatchObject({
         consecutiveErrors: 1,
         triggerEvalCount: 1,
         lastRunStatus: "error",
       });
-      expect(harness.cron.getJob(job.id)?.state.nextRunAtMs).toBeGreaterThan(dueAt);
+      expect(stored?.state.nextRunAtMs).toBeGreaterThan(dueAt);
       expect(harness.events.find((event) => event.action === "finished")).toMatchObject({
         status: "error",
         error: expect.stringContaining("deadline exceeded"),
+      });
+      expect(harness.events.map((event) => event.action)).toEqual([
+        "started",
+        "finished",
+        "scheduled",
+      ]);
+      expect(harness.events.at(-1)).toMatchObject({
+        jobId: job.id,
+        action: "scheduled",
+        nextRunAtMs: persisted?.state.nextRunAtMs,
+        job: { state: { nextRunAtMs: persisted?.state.nextRunAtMs } },
       });
     } finally {
       harness.cron.stop();

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -502,6 +502,71 @@ describe("cron service ops regressions", () => {
     clearCommandLane(CommandLane.Cron);
   });
 
+  it("keeps a queued quiet schedule event separate from its one terminal event", async () => {
+    vi.useRealTimers();
+    clearCommandLane(CommandLane.Cron);
+    setCommandLaneConcurrency(CommandLane.Cron, 1);
+
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:02.000Z");
+    const job = {
+      ...createIsolatedRegressionJob({
+        id: "queued-quiet-trigger",
+        name: "queued quiet trigger",
+        scheduledAt: dueAt,
+        schedule: { kind: "every" as const, everyMs: 60_000, anchorMs: dueAt - 60_000 },
+        payload: { kind: "agentTurn" as const, message: "watch" },
+        state: { nextRunAtMs: dueAt },
+      }),
+      trigger: { script: "return false" },
+    };
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const terminal = createDeferred<void>();
+    const events: CronEvent[] = [];
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { triggers: { enabled: true, minIntervalMs: 30_000 } },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      evaluateCronTrigger: vi.fn(async () => ({
+        kind: "evaluated" as const,
+        fire: false,
+      })),
+      runIsolatedAgentJob,
+      onEvent: (event) => {
+        events.push(structuredClone(event));
+        if (event.action === "finished") {
+          terminal.resolve();
+        }
+      },
+    });
+
+    try {
+      const ack = await enqueueRun(state, job.id, "due");
+      const runId = expectQueuedRunAck(ack);
+      await terminal.promise;
+      await waitForActiveTasks(5_000);
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(events.map((event) => event.action)).toEqual(["started", "scheduled", "finished"]);
+      expect(events.filter((event) => event.action === "finished")).toEqual([
+        expect.objectContaining({
+          jobId: job.id,
+          runId,
+          status: "skipped",
+          error: "queued manual run skipped: trigger condition not met",
+        }),
+      ]);
+    } finally {
+      clearCommandLane(CommandLane.Cron);
+    }
+  });
+
   it("skips queued manual runs when the old cron service stops before lane admission", async () => {
     vi.useRealTimers();
     clearCommandLane(CommandLane.Cron);

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -13,7 +13,7 @@ import * as cronStoreModule from "../store.js";
 import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { add, list, remove, run, start, stop, update } from "./ops.js";
-import { createCronServiceState } from "./state.js";
+import { createCronServiceState, type CronEvent } from "./state.js";
 import { runMissedJobs } from "./timer.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -47,7 +47,12 @@ function createTimedOutIsolatedCronState(params: { storePath: string; now: numbe
   });
 }
 
-function createOkIsolatedCronState(params: { storePath: string; now: number; summary?: string }) {
+function createOkIsolatedCronState(params: {
+  storePath: string;
+  now: number;
+  summary?: string;
+  onEvent?: (event: CronEvent) => void;
+}) {
   return createCronServiceState({
     storePath: params.storePath,
     cronEnabled: true,
@@ -59,7 +64,23 @@ function createOkIsolatedCronState(params: { storePath: string; now: number; sum
       status: "ok" as const,
       ...(params.summary === undefined ? {} : { summary: params.summary }),
     })),
+    ...(params.onEvent ? { onEvent: params.onEvent } : {}),
   });
+}
+
+function createFutureEveryJob(params: { id: string; now: number; nextRunAtMs?: number }): CronJob {
+  return {
+    id: params.id,
+    name: params.id,
+    enabled: true,
+    createdAtMs: params.now - 60_000,
+    updatedAtMs: params.now - 60_000,
+    schedule: { kind: "every", everyMs: 60_000, anchorMs: params.now },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: params.id },
+    state: params.nextRunAtMs === undefined ? {} : { nextRunAtMs: params.nextRunAtMs },
+  };
 }
 
 function createInterruptedMainJob(now: number): CronJob {
@@ -827,6 +848,100 @@ describe("cron service ops seam coverage", () => {
     }
 
     expect(job.state.nextRunAtMs).toBeGreaterThan(finalBaseRunAtMs);
+  });
+
+  it("uses explicit lifecycle events instead of scheduled duplicates for the target job", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const events: CronEvent[] = [];
+    const state = createOkIsolatedCronState({
+      storePath,
+      now,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    const job = await add(state, {
+      id: "lifecycle-target",
+      name: "lifecycle target",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: now },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+    expect(events.map((event) => event.action)).toEqual(["added"]);
+
+    events.length = 0;
+    await update(state, job.id, {
+      schedule: { kind: "every", everyMs: 120_000, anchorMs: now },
+    });
+    expect(events.map((event) => event.action)).toEqual(["updated"]);
+
+    events.length = 0;
+    await remove(state, job.id);
+    expect(events.map((event) => event.action)).toEqual(["removed"]);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  });
+
+  it("emits repaired sibling schedules during add before the target lifecycle event", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const sibling = createFutureEveryJob({ id: "repair-during-add", now });
+    await writeCronStoreSnapshot({ storePath, jobs: [sibling] });
+    const events: CronEvent[] = [];
+    const state = createOkIsolatedCronState({
+      storePath,
+      now,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    const added = await add(state, {
+      id: "added-target",
+      name: "added target",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: now },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "added" },
+    });
+
+    expect(events.map(({ jobId, action }) => ({ jobId, action }))).toEqual([
+      { jobId: sibling.id, action: "scheduled" },
+      { jobId: added.id, action: "added" },
+    ]);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  });
+
+  it("emits repaired sibling schedules during remove before the target lifecycle event", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-06-09T00:00:00.000Z");
+    const sibling = createFutureEveryJob({ id: "repair-during-remove", now });
+    const target = createFutureEveryJob({
+      id: "removed-target",
+      now,
+      nextRunAtMs: now + 60_000,
+    });
+    await writeCronStoreSnapshot({ storePath, jobs: [sibling, target] });
+    const events: CronEvent[] = [];
+    const state = createOkIsolatedCronState({
+      storePath,
+      now,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    await remove(state, target.id);
+
+    expect(events.map(({ jobId, action }) => ({ jobId, action }))).toEqual([
+      { jobId: sibling.id, action: "scheduled" },
+      { jobId: target.id, action: "removed" },
+    ]);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
   });
 });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -58,6 +58,7 @@ import type {
   CronUpdatePrecondition,
   CronWakeMode,
 } from "./state.js";
+import { emit } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 import {
@@ -65,7 +66,6 @@ import {
   applyTriggerNoFireResult,
   applyTriggerRunResult,
   armTimer,
-  emit,
   executeJobCoreWithTimeout,
   type IsolatedAgentSetupTimeoutSignal,
   maybeNotifyIsolatedAgentSetupTimeout,
@@ -501,16 +501,24 @@ type CronRollbackSnapshot = {
 async function persistOrRestore(
   state: CronServiceState,
   snapshot: CronRollbackSnapshot,
-  postPersistAutoDisableNotifications: Array<() => void> = [],
+  opts: {
+    postPersistAutoDisableNotifications?: Array<() => void>;
+    suppressScheduledJobId?: string;
+  } = {},
 ) {
   try {
-    await persist(state);
+    await persist(
+      state,
+      opts.suppressScheduledJobId === undefined
+        ? undefined
+        : { suppressScheduledJobId: opts.suppressScheduledJobId },
+    );
   } catch (err) {
     state.store = snapshot.store;
     state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
     throw err;
   }
-  for (const notify of postPersistAutoDisableNotifications) {
+  for (const notify of opts.postPersistAutoDisableNotifications ?? []) {
     notify();
   }
 }
@@ -596,7 +604,7 @@ async function persistUpdatedJob(params: {
     }
   }
 
-  await persistOrRestore(state, snapshot);
+  await persistOrRestore(state, snapshot, { suppressScheduledJobId: nextJob.id });
   armTimer(state);
   emit(state, {
     jobId: nextJob.id,
@@ -685,7 +693,10 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
       deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
     });
 
-    await persistOrRestore(state, snapshot, postPersistAutoDisableNotifications);
+    await persistOrRestore(state, snapshot, {
+      postPersistAutoDisableNotifications,
+      suppressScheduledJobId: job.id,
+    });
     armTimer(state);
 
     state.deps.log.info(
@@ -775,7 +786,10 @@ export async function remove(state: CronServiceState, id: string) {
       deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
     });
 
-    await persistOrRestore(state, snapshot, postPersistAutoDisableNotifications);
+    await persistOrRestore(state, snapshot, {
+      postPersistAutoDisableNotifications,
+      suppressScheduledJobId: id,
+    });
     armTimer(state);
     if (removed) {
       emit(state, { jobId: id, action: "removed", job: removedJob });

--- a/src/cron/service/state.test.ts
+++ b/src/cron/service/state.test.ts
@@ -30,6 +30,7 @@ describe("cron service state seam coverage", () => {
     });
 
     expect(state.store).toBeNull();
+    expect(state.durableNextRunAtMsByJobId.size).toBe(0);
     expect(state.timer).toBeNull();
     expect(state.running).toBe(false);
     expect(state.warnedDisabled).toBe(false);

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -24,7 +24,7 @@ import type {
 /** Event payload emitted for cron lifecycle changes and completed runs. */
 export type CronEvent = {
   jobId: string;
-  action: "added" | "updated" | "removed" | "started" | "finished";
+  action: "added" | "updated" | "removed" | "started" | "finished" | "scheduled";
   /** Snapshot of the job at the time of the event. Present for all actions where the job is accessible. */
   job?: CronJob;
   runAtMs?: number;
@@ -200,6 +200,9 @@ export type CronServiceDepsInternal = Omit<CronServiceDeps, "nowMs"> & {
 export type CronServiceState = {
   deps: CronServiceDepsInternal;
   store: CronStoreFile | null;
+  /** Last known durable wake for each persisted job. Map presence distinguishes
+   * a durably unscheduled job from one that is not part of durable topology. */
+  durableNextRunAtMsByJobId: Map<string, number | undefined>;
   timer: NodeJS.Timeout | null;
   running: boolean;
   stopped: boolean;
@@ -227,6 +230,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
   return {
     deps: { ...deps, nowMs: deps.nowMs ?? (() => Date.now()) },
     store: null,
+    durableNextRunAtMsByJobId: new Map<string, number | undefined>(),
     timer: null,
     running: false,
     stopped: false,
@@ -241,6 +245,15 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     lastQuarantineFailureWarnKey: null,
     storeLoadedAtMs: null,
   };
+}
+
+/** Dispatches a cron event without letting subscriber errors escape scheduler work. */
+export function emit(state: CronServiceState, evt: CronEvent) {
+  try {
+    state.deps.onEvent?.(evt);
+  } catch {
+    /* ignore */
+  }
 }
 
 /** Direct-run mode: respect due time or force execution. */

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -1,7 +1,8 @@
 // Cron service store tests cover persisted service state loading and writes.
 import fs from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "../service.test-harness.js";
+import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { findJobOrThrow } from "./jobs.js";
@@ -29,7 +30,7 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   await expect(fs.stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
 }
 
-function createStoreTestState(storePath: string) {
+function createStoreTestState(storePath: string, onEvent = vi.fn()) {
   return createCronServiceState({
     storePath,
     cronEnabled: true,
@@ -38,6 +39,7 @@ function createStoreTestState(storePath: string) {
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    onEvent,
   });
 }
 
@@ -57,6 +59,10 @@ function createReloadCronJob(params?: Partial<CronJob>): CronJob {
   };
 }
 describe("cron service store seam coverage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("loads stored jobs, recomputes next runs, and does not rewrite the store on load", async () => {
     const { storePath } = await makeStorePath();
 
@@ -107,6 +113,241 @@ describe("cron service store seam coverage", () => {
     await expectPathMissing(storePath);
 
     await persist(state);
+  });
+
+  it("publishes durable wake changes only after save and exactly once after retry", async () => {
+    const { storePath } = await makeStorePath();
+    const initialNextRunAtMs = STORE_TEST_NOW + 60_000;
+    const changedNextRunAtMs = STORE_TEST_NOW + 120_000;
+    await writeSingleJobStore(
+      storePath,
+      createReloadCronJob({
+        id: "durable-wake-job",
+        state: { nextRunAtMs: initialNextRunAtMs },
+      }),
+    );
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
+    await ensureLoaded(state, { skipRecompute: true });
+    const job = findJobOrThrow(state, "durable-wake-job");
+    job.state.nextRunAtMs = changedNextRunAtMs;
+
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
+    await expect(persist(state)).rejects.toThrow("disk full");
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.get(job.id)).toBe(initialNextRunAtMs);
+
+    await persist(state);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: job.id,
+        nextRunAtMs: changedNextRunAtMs,
+      }),
+    );
+    expect(state.durableNextRunAtMsByJobId.get(job.id)).toBe(changedNextRunAtMs);
+
+    await persist(state);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+
+    job.state.nextRunAtMs = undefined;
+    await persist(state);
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: job.id,
+        nextRunAtMs: undefined,
+      }),
+    );
+    expect(state.durableNextRunAtMsByJobId.has(job.id)).toBe(true);
+    expect(state.durableNextRunAtMsByJobId.get(job.id)).toBeUndefined();
+  });
+
+  it("advances durable wake state while suppressing duplicate scheduled delivery", async () => {
+    const { storePath } = await makeStorePath();
+    const initialNextRunAtMs = STORE_TEST_NOW + 60_000;
+    const suppressedNextRunAtMs = STORE_TEST_NOW + 120_000;
+    const publishedNextRunAtMs = STORE_TEST_NOW + 180_000;
+    await writeSingleJobStore(
+      storePath,
+      createReloadCronJob({
+        id: "suppressed-scheduled-job",
+        state: { nextRunAtMs: initialNextRunAtMs },
+      }),
+    );
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
+    await ensureLoaded(state, { skipRecompute: true });
+    const job = findJobOrThrow(state, "suppressed-scheduled-job");
+
+    job.state.nextRunAtMs = suppressedNextRunAtMs;
+    await persist(state, { suppressScheduledJobId: job.id });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.get(job.id)).toBe(suppressedNextRunAtMs);
+
+    job.state.nextRunAtMs = publishedNextRunAtMs;
+    await persist(state);
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: job.id,
+        nextRunAtMs: publishedNextRunAtMs,
+      }),
+    );
+  });
+
+  it("does not publish scheduled events for full-save topology changes", async () => {
+    const { storePath } = await makeStorePath();
+    const firstNextRunAtMs = STORE_TEST_NOW + 60_000;
+    const readdedNextRunAtMs = STORE_TEST_NOW + 180_000;
+    await writeSingleJobStore(
+      storePath,
+      createReloadCronJob({
+        id: "existing-job",
+        state: { nextRunAtMs: firstNextRunAtMs },
+      }),
+    );
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
+    await ensureLoaded(state, { skipRecompute: true });
+    if (!state.store) {
+      throw new Error("expected loaded cron store");
+    }
+
+    const topologyJob = createReloadCronJob({
+      id: "topology-job",
+      state: { nextRunAtMs: STORE_TEST_NOW + 120_000 },
+    });
+    state.store.jobs.push(topologyJob);
+    await persist(state);
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.has(topologyJob.id)).toBe(true);
+
+    state.store.jobs = state.store.jobs.filter((job) => job.id !== topologyJob.id);
+    await persist(state);
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.has(topologyJob.id)).toBe(false);
+
+    const readdedJob = createReloadCronJob({
+      id: topologyJob.id,
+      state: { nextRunAtMs: readdedNextRunAtMs },
+    });
+    state.store.jobs.push(readdedJob);
+    await persist(state);
+    expect(onEvent).not.toHaveBeenCalled();
+
+    readdedJob.state.nextRunAtMs = readdedNextRunAtMs + 60_000;
+    await persist(state);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: topologyJob.id,
+        nextRunAtMs: readdedNextRunAtMs + 60_000,
+      }),
+    );
+  });
+
+  it("keeps state-only wake publication aligned with persisted topology", async () => {
+    const { storePath } = await makeStorePath();
+    const initialNextRunAtMs = STORE_TEST_NOW + 60_000;
+    const changedNextRunAtMs = STORE_TEST_NOW + 180_000;
+    await writeSingleJobStore(
+      storePath,
+      createReloadCronJob({
+        id: "durable-state-only-job",
+        state: { nextRunAtMs: initialNextRunAtMs },
+      }),
+    );
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
+    await ensureLoaded(state, { skipRecompute: true });
+    if (!state.store) {
+      throw new Error("expected loaded cron store");
+    }
+
+    state.store.jobs = [
+      createReloadCronJob({
+        id: "new-state-only-job",
+        state: { nextRunAtMs: STORE_TEST_NOW + 120_000 },
+      }),
+    ];
+    await persist(state, { stateOnly: true });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect([...state.durableNextRunAtMsByJobId.keys()]).toEqual(["durable-state-only-job"]);
+    expect((await loadCronStore(storePath)).jobs.map((job) => job.id)).toEqual([
+      "durable-state-only-job",
+    ]);
+
+    state.store.jobs = [
+      createReloadCronJob({
+        id: "durable-state-only-job",
+        state: { nextRunAtMs: changedNextRunAtMs },
+      }),
+    ];
+    await persist(state, { stateOnly: true });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: "durable-state-only-job",
+        nextRunAtMs: changedNextRunAtMs,
+      }),
+    );
+    expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(changedNextRunAtMs);
+  });
+
+  it("does not advance durable wake state when quarantine prevents a save", async () => {
+    const { storePath } = await makeStorePath();
+    const initialNextRunAtMs = STORE_TEST_NOW + 60_000;
+    const changedNextRunAtMs = STORE_TEST_NOW + 120_000;
+    await writeSingleJobStore(
+      storePath,
+      createReloadCronJob({
+        id: "quarantine-retry-job",
+        state: { nextRunAtMs: initialNextRunAtMs },
+      }),
+    );
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
+    await ensureLoaded(state, { skipRecompute: true });
+    const job = findJobOrThrow(state, "quarantine-retry-job");
+    job.state.nextRunAtMs = changedNextRunAtMs;
+    state.pendingQuarantineConfigJobs = [
+      { sourceIndex: 0, reason: "invalid-schedule", job: { id: "quarantined-job" } },
+    ];
+    vi.spyOn(cronStoreModule, "saveCronQuarantineFile").mockRejectedValueOnce(
+      new Error("quarantine unavailable"),
+    );
+    const saveStore = vi.spyOn(cronStoreModule, "saveCronJobsStore");
+
+    await persist(state, { stateOnly: true });
+
+    expect(saveStore).not.toHaveBeenCalled();
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.get(job.id)).toBe(initialNextRunAtMs);
+    expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(initialNextRunAtMs);
+
+    await persist(state, { stateOnly: true });
+
+    expect(saveStore).toHaveBeenCalledWith(storePath, state.store, undefined);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: job.id,
+        nextRunAtMs: changedNextRunAtMs,
+      }),
+    );
+    expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(changedNextRunAtMs);
   });
 
   it("loads normalized jobId-only jobs from SQLite so scheduler lookups resolve by stable id", async () => {
@@ -208,7 +449,8 @@ describe("cron service store seam coverage", () => {
       ],
     });
 
-    const state = createStoreTestState(storePath);
+    const onEvent = vi.fn();
+    const state = createStoreTestState(storePath, onEvent);
     await ensureLoaded(state, { skipRecompute: true });
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(staleNextRunAtMs);
 
@@ -218,7 +460,7 @@ describe("cron service store seam coverage", () => {
         createReloadCronJob({
           updatedAtMs: STORE_TEST_NOW - 30_000,
           schedule: { kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" },
-          state: {},
+          state: { nextRunAtMs: staleNextRunAtMs },
         }),
       ],
     });
@@ -228,6 +470,18 @@ describe("cron service store seam coverage", () => {
     const reloadedJob = findJobOrThrow(state, "reload-cron-expr-job");
     expect(reloadedJob.schedule).toEqual({ kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" });
     expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(state.durableNextRunAtMsByJobId.get(reloadedJob.id)).toBe(staleNextRunAtMs);
+
+    await persist(state);
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "scheduled",
+        jobId: reloadedJob.id,
+        nextRunAtMs: undefined,
+      }),
+    );
   });
 
   it("preserves nextRunAtMs after force reload when cron schedule key order changes only", async () => {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -12,7 +12,60 @@ import {
 } from "../store.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
-import type { CronServiceState } from "./state.js";
+import { emit, type CronServiceState } from "./state.js";
+
+type PersistOptions = {
+  stateOnly?: boolean;
+  suppressScheduledJobId?: string;
+};
+
+function durableNextRunsFromJobs(jobs: readonly CronJob[]) {
+  return new Map(jobs.map((job) => [job.id, job.state.nextRunAtMs] as const));
+}
+
+function publishDurableNextRunChanges(params: {
+  state: CronServiceState;
+  storeJobs: readonly CronJob[];
+  stateOnly: boolean;
+  suppressScheduledJobId?: string;
+}) {
+  const previous = params.state.durableNextRunAtMsByJobId;
+  const next = params.stateOnly ? new Map(previous) : durableNextRunsFromJobs(params.storeJobs);
+
+  if (params.stateOnly) {
+    const currentJobsById = new Map(params.storeJobs.map((job) => [job.id, job] as const));
+    // State-only writes cannot create or delete rows. Preserve durable topology
+    // and update only rows that both snapshots know SQLite already contains.
+    for (const jobId of previous.keys()) {
+      const job = currentJobsById.get(jobId);
+      if (job) {
+        next.set(jobId, job.state.nextRunAtMs);
+      }
+    }
+  }
+
+  const changedJobs = params.storeJobs.filter((job) => {
+    if (!previous.has(job.id) || !next.has(job.id)) {
+      return false;
+    }
+    return previous.get(job.id) !== next.get(job.id);
+  });
+
+  // Advance durable truth before callbacks so re-entrant observers cannot
+  // publish the same committed transition twice.
+  params.state.durableNextRunAtMsByJobId = next;
+  for (const job of changedJobs) {
+    if (job.id === params.suppressScheduledJobId) {
+      continue;
+    }
+    emit(params.state, {
+      jobId: job.id,
+      action: "scheduled",
+      job,
+      nextRunAtMs: job.state.nextRunAtMs,
+    });
+  }
+}
 
 function invalidateStaleNextRunOnScheduleChange(params: {
   previousJobsById: ReadonlyMap<string, CronJob>;
@@ -108,6 +161,7 @@ export async function ensureLoaded(
   // store boundary and only trust the CronJob shape after validation below.
   const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
   const jobs: CronJob[] = [];
+  const durableNextRunAtMsByJobId = new Map<string, number | undefined>();
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, raw] of loadedJobs.entries()) {
     const rawConfigJob = loaded.configJobs[index] ?? structuredClone(raw);
@@ -157,12 +211,16 @@ export async function ensureLoaded(
     // Validated above, so the raw record is now a trusted CronJob.
     const hydrated = hydratedRaw as unknown as CronJob;
     jobs.push(hydrated);
+    // Capture the value SQLite actually held before schedule-identity repair
+    // mutates the runtime view. A later save can then publish that transition.
+    durableNextRunAtMsByJobId.set(hydrated.id, hydrated.state.nextRunAtMs);
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
   }
   state.store = {
     version: 1,
     jobs,
   };
+  state.durableNextRunAtMsByJobId = durableNextRunAtMsByJobId;
   state.storeLoadedAtMs = state.deps.nowMs();
 
   if (quarantinedConfigJobs.length > 0) {
@@ -170,7 +228,7 @@ export async function ensureLoaded(
     const quarantinePath = await flushPendingQuarantine(state, state.storeLoadedAtMs);
     if (quarantinePath) {
       try {
-        await saveCronJobsStore(state.deps.storePath, state.store);
+        await persist(state);
         state.deps.log.warn(
           {
             storePath: state.deps.storePath,
@@ -212,8 +270,9 @@ export function warnIfDisabled(state: CronServiceState, action: string) {
 }
 
 /** Persists the in-memory cron store, flushing pending quarantine records first. */
-export async function persist(state: CronServiceState, opts?: { stateOnly?: boolean }) {
-  if (!state.store) {
+export async function persist(state: CronServiceState, opts?: PersistOptions) {
+  const store = state.store;
+  if (!store) {
     return;
   }
   let flushedPendingQuarantine = false;
@@ -224,9 +283,12 @@ export async function persist(state: CronServiceState, opts?: { stateOnly?: bool
     }
     flushedPendingQuarantine = true;
   }
-  await saveCronJobsStore(
-    state.deps.storePath,
-    state.store,
-    flushedPendingQuarantine ? undefined : opts,
-  );
+  const stateOnly = !flushedPendingQuarantine && opts?.stateOnly === true;
+  await saveCronJobsStore(state.deps.storePath, store, stateOnly ? { stateOnly: true } : undefined);
+  publishDurableNextRunChanges({
+    state,
+    storeJobs: store.jobs,
+    stateOnly,
+    suppressScheduledJobId: opts?.suppressScheduledJobId,
+  });
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -79,7 +79,7 @@ import {
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
-import type { CronEvent, CronServiceState, CronSystemEventEnqueueResult } from "./state.js";
+import { emit, type CronServiceState, type CronSystemEventEnqueueResult } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 import {
   resolveMainSessionCronRunSessionKey,
@@ -2416,13 +2416,4 @@ export function stopTimer(state: CronServiceState) {
     clearTimeout(state.timer);
   }
   state.timer = null;
-}
-
-/** Dispatches a cron event to the optional subscriber without letting subscriber errors escape. */
-export function emit(state: CronServiceState, evt: CronEvent) {
-  try {
-    state.deps.onEvent?.(evt);
-  } catch {
-    /* ignore */
-  }
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { createDeferred } from "../test-utils/deferred.js";
 
 type RunCronIsolatedAgentTurnMock = (params: {
   abortSignal?: AbortSignal;
@@ -353,6 +354,7 @@ describe("buildGatewayCronService", () => {
 
   it("backs off isolated cron setup timeout without gateway restart", async () => {
     vi.useFakeTimers();
+    const runnerEntered = createDeferred();
     const cfg = createCronConfig("server-cron-isolated-setup-timeout");
     loadConfigMock.mockReturnValue(cfg);
     const state = buildGatewayCronService({
@@ -372,11 +374,13 @@ describe("buildGatewayCronService", () => {
       runCronIsolatedAgentTurnMock.mockImplementationOnce(
         async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
           abortSignal?.addEventListener("abort", () => undefined, { once: true });
+          runnerEntered.resolve();
           return await new Promise<never>(() => {});
         },
       );
 
       const runPromise = state.cron.run(job.id, "force");
+      await runnerEntered.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       const runResult = await runPromise;
 
@@ -423,6 +427,62 @@ describe("buildGatewayCronService", () => {
       expectHookContext(0, { config: cfg, hasGetCron: true });
     } finally {
       state.cron.stop();
+    }
+  });
+
+  it("forwards durable recurring wake changes to cron_changed hooks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00.000Z"));
+    const cfg = createCronConfig("server-cron-hook-scheduled");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "scheduled-hook",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: Date.now() },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "advance external wake" },
+      });
+      const dueAtMs = job.state.nextRunAtMs;
+      if (dueAtMs === undefined) {
+        throw new Error("expected recurring job to have a next run");
+      }
+
+      runCronChangedMock.mockClear();
+      vi.setSystemTime(dueAtMs);
+      expect(await state.cron.run(job.id, "due")).toEqual({ ok: true, ran: true });
+
+      const scheduledCallIndex = runCronChangedMock.mock.calls.findIndex(([candidate]) => {
+        return requireRecord(candidate, "cron_changed event").action === "scheduled";
+      });
+      expect(scheduledCallIndex).toBeGreaterThanOrEqual(0);
+      const event = requireRecord(
+        callArg(runCronChangedMock, scheduledCallIndex, 0, "scheduled cron_changed event"),
+        "scheduled cron_changed event",
+      );
+      const persistedNextRunAtMs = state.cron.getJob(job.id)?.state.nextRunAtMs;
+      expect(persistedNextRunAtMs).toBeGreaterThan(dueAtMs);
+      expect(event).toMatchObject({
+        action: "scheduled",
+        jobId: job.id,
+        nextRunAtMs: persistedNextRunAtMs,
+        sessionTarget: "main",
+      });
+      const eventJob = requireRecord(event.job, "scheduled cron_changed job");
+      expect(requireRecord(eventJob.state, "scheduled cron_changed job state").nextRunAtMs).toBe(
+        persistedNextRunAtMs,
+      );
+      expectHookContext(scheduledCallIndex, { config: cfg, hasGetCron: true });
+    } finally {
+      state.cron.stop();
+      vi.useRealTimers();
     }
   });
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -931,7 +931,7 @@ export type PluginHookGatewayCronJob = {
 };
 
 export type PluginHookCronChangedEvent = {
-  action: "added" | "updated" | "removed" | "started" | "finished";
+  action: "added" | "updated" | "removed" | "started" | "finished" | "scheduled";
   jobId: string;
   job?: PluginHookGatewayCronJob;
   /** Top-level session target for downstream routing (mirrors job.sessionTarget). */

--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -84,6 +84,28 @@ describe("gateway hook runner methods", () => {
     expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
   });
 
+  it("runCronChanged passes scheduled events with the durable wake snapshot", async () => {
+    const handler = vi.fn();
+    const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_changed", handler }]);
+    const event: PluginHookCronChangedEvent = {
+      action: "scheduled",
+      jobId: "job-scheduled",
+      nextRunAtMs: 456,
+      sessionTarget: "session:ops",
+      agentId: "reporter",
+      job: {
+        id: "job-scheduled",
+        agentId: "reporter",
+        sessionTarget: "session:ops",
+        state: { nextRunAtMs: 456 },
+      },
+    };
+
+    await runner.runCronChanged(event, gatewayCtx);
+
+    expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
+  });
+
   it("runCronChanged passes finished events with delivery and error fields", async () => {
     const handler = vi.fn();
     const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_changed", handler }]);


### PR DESCRIPTION
Closes #103205.

## What Problem This Solves

External scheduler plugins can observe cron jobs being added, updated, removed, started, and finished, but they are not notified when OpenClaw changes an existing job's durable `nextRunAtMs` internally.

That leaves external wake schedulers stale after quiet trigger evaluation, recurring completion, retry backoff, startup deferral, or maintenance repair unless they poll the full cron list.

## Why This Change Was Made

This adds the already-documented `scheduled` action to the public `cron_changed` hook contract and emits it from the cron persistence boundary after an existing job's next wake actually commits.

The service keeps a process-local projection of durable next-run values, compares it only after successful saves, and publishes one reconciliation signal for each changed existing job. Explicit CRUD targets retain their existing `added`, `updated`, or `removed` event without a duplicate `scheduled` event; schedule repairs to sibling jobs still emit `scheduled`.

The implementation introduces no new config, environment variable, Gateway protocol method, or storage format.

## User Impact

Plugins can react promptly when OpenClaw durably reschedules or cancels an existing cron wake. A `scheduled` event includes the public job snapshot and `nextRunAtMs`; an absent value means the job is durably unscheduled.

`scheduled` is a best-effort post-commit reconciliation signal, not an ordered event log. Multiple committed transitions can occur close together, and hook handlers run asynchronously. Consumers should debounce or coalesce notifications, reconcile the full list through `ctx.getCron?.()?.list({ includeDisabled: true })`, and perform a full reconciliation on `gateway_start`.

Existing `finished` and automatic `removed` events keep their current lifecycle semantics; this change guarantees post-commit behavior specifically for `scheduled`.

## Evidence

- Store-level coverage for changed, cancelled, unchanged, failed-save/retry, force-reload, quarantine, topology, and explicit-update suppression behavior.
- Cron behavior coverage for quiet trigger evaluation, recurring completion/error backoff, retained one-shot cancellation, delete-after-run, and sibling schedule repair.
- Gateway hook propagation coverage verifies the public job snapshot and top-level `nextRunAtMs` match the committed job.
- Plugin hook typing and generated Plugin SDK API baseline include `scheduled`.
- Exact rebased-head focused proof: Blacksmith Testbox `tbx_01kx5ssjbv6rt3esxkmy459d1s`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29087038631). All 137 cron, Gateway, and plugin tests passed.
- Exact rebased-head gates: Blacksmith Testbox `tbx_01kx5sx8hzbzpp0pdsxpfkjttp`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29087142449). `pnpm check:changed` and `pnpm build` passed; the public Plugin SDK declaration graph is 4,985,688 / 5,000,000 bytes.
- Broad dependent proof: Blacksmith Testbox `tbx_01kx5rv905atrvrbvve5vmdvg8`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29086170953). Every touched cron, Gateway, hook, and plugin lane passed; the run stopped on one unrelated model-fallback probe logging assertion. Its exact 20-test file passed immediately in isolation on Testbox `tbx_01kx5skw54e0fk7pf7m4n79xa3`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29086879328).
- Fresh high-reasoning branch review: no accepted/actionable findings.
