### PR TITLE
fix(qa): keep non-assistant fixtures out of token usage gate

### DIFF
--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -962,6 +962,68 @@ status=done`,
     expect(report.scenarios[0]?.status).toBe("fail");
   });
 
+  it("renders explicit non-assistant parity usage as N/A without weakening parity", () => {
+    const summary = makeRuntimeParitySummary();
+    summary.run = {
+      ...summary.run,
+      providerMode: "live-frontier",
+    };
+    const scenario = summary.scenarios[0];
+    if (!scenario?.runtimeParity) {
+      throw new Error("runtime parity fixture missing");
+    }
+    scenario.runtimeParity.runtimeParityUsage = {
+      expectation: "not-applicable",
+      reason: "Local fixture only; no assistant turn runs.",
+    };
+    scenario.runtimeParity.cells.openclaw.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+    scenario.runtimeParity.cells.codex.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+
+    const report = buildQaRuntimeParityReport({ summary });
+    const markdown = renderQaRuntimeParityMarkdownReport(report);
+
+    expect(report.pass).toBe(true);
+    expect(report.failures).toEqual([]);
+    expect(report.scenarios[0]?.status).toBe("pass");
+    expect(markdown).toContain("- openclaw: pass (1 tool calls, N/A tokens)");
+    expect(markdown).toContain(
+      "- assistant-message usage: N/A (Local fixture only; no assistant turn runs.)",
+    );
+  });
+
+  it("keeps non-assistant parity runtime failures red", () => {
+    const summary = makeRuntimeParitySummary();
+    summary.run = {
+      ...summary.run,
+      providerMode: "live-frontier",
+    };
+    const scenario = summary.scenarios[0];
+    if (!scenario?.runtimeParity) {
+      throw new Error("runtime parity fixture missing");
+    }
+    scenario.runtimeParity.runtimeParityUsage = {
+      expectation: "not-applicable",
+      reason: "Local fixture only; no assistant turn runs.",
+    };
+    scenario.runtimeParity.cells.openclaw.usage.totalTokens = 0;
+    scenario.runtimeParity.cells.codex.usage.totalTokens = 0;
+    scenario.runtimeParity.cells.codex.runtimeErrorClass = "auth";
+
+    const report = buildQaRuntimeParityReport({ summary });
+
+    expect(report.pass).toBe(false);
+    expect(report.failedScenarios).toBe(1);
+    expect(report.failures).toContain("Approval turn tool followthrough drift=none.");
+  });
+
   it("fails runtime parity reports with no executed scenarios", () => {
     const report = buildQaRuntimeParityReport({
       summary: {

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -3,8 +3,17 @@ import {
   QA_AGENTIC_PARITY_SCENARIO_TITLES,
   QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
 } from "./agentic-parity.js";
-import type { RuntimeId, RuntimeParityDrift, RuntimeParityResult } from "./runtime-parity.js";
-import { isRuntimeParityResultPass, runtimeParityCellStatus } from "./runtime-parity.js";
+import type {
+  RuntimeId,
+  RuntimeParityDrift,
+  RuntimeParityResult,
+  RuntimeParityUsagePolicy,
+} from "./runtime-parity.js";
+import {
+  isRuntimeParityResultPass,
+  resolveRuntimeParityUsagePolicy,
+  runtimeParityCellStatus,
+} from "./runtime-parity.js";
 
 type QaParityReportStep = {
   name: string;
@@ -57,6 +66,7 @@ export type QaRuntimeParitySuiteSummary = Omit<QaParitySuiteSummary, "scenarios"
 type QaRuntimeParityScenarioReport = {
   name: string;
   status: "pass" | "fail";
+  runtimeParityUsage: RuntimeParityUsagePolicy;
   drift: RuntimeParityDrift | "missing";
   driftDetails?: string;
   openclawStatus: "pass" | "fail" | "missing";
@@ -651,6 +661,7 @@ export function buildQaRuntimeParityReport(params: {
       return {
         name: scenario.name,
         status: scenario.status === "pass" ? "pass" : "fail",
+        runtimeParityUsage: resolveRuntimeParityUsagePolicy(undefined),
         drift: "missing",
         driftDetails: scenario.details,
         openclawStatus: "missing",
@@ -667,9 +678,11 @@ export function buildQaRuntimeParityReport(params: {
     const openclawStatus = runtimeParityCellStatus(openclawCell);
     const codexStatus = runtimeParityCellStatus(codexCell);
     const parityStatus = isRuntimeParityResultPass(parity) ? "pass" : "fail";
+    const runtimeParityUsage = resolveRuntimeParityUsagePolicy(parity.runtimeParityUsage);
     const reportScenario = {
       name: scenario.name,
       status: parityStatus,
+      runtimeParityUsage,
       drift: parity.drift,
       driftDetails: parity.driftDetails,
       openclawStatus,
@@ -684,9 +697,10 @@ export function buildQaRuntimeParityReport(params: {
         `${scenario.name} drift=${parity.drift}${parity.driftDetails ? ` (${parity.driftDetails})` : ""}.`,
       );
     }
-    const usageFailure = requiresLiveUsage
-      ? describeLiveUsageFailure(scenario.name, reportScenario)
-      : undefined;
+    const usageFailure =
+      requiresLiveUsage && runtimeParityUsage.expectation === "assistant-message-required"
+        ? describeLiveUsageFailure(scenario.name, reportScenario)
+        : undefined;
     if (usageFailure) {
       failures.push(usageFailure);
       return { ...reportScenario, status: "fail" };
@@ -755,15 +769,21 @@ export function renderQaRuntimeParityMarkdownReport(report: QaRuntimeParityRepor
 
   lines.push("## Scenario Comparison", "");
   for (const scenario of report.scenarios) {
+    const usageNotApplicable = scenario.runtimeParityUsage.expectation === "not-applicable";
+    const openclawTokens = usageNotApplicable ? "N/A" : String(scenario.openclawTokens);
+    const codexTokens = usageNotApplicable ? "N/A" : String(scenario.codexTokens);
     lines.push(`### ${scenario.name}`, "");
     lines.push(`- status: ${scenario.status}`);
     lines.push(`- drift: ${scenario.drift}`);
     lines.push(
-      `- openclaw: ${scenario.openclawStatus} (${scenario.openclawToolCalls} tool calls, ${scenario.openclawTokens} tokens)`,
+      `- openclaw: ${scenario.openclawStatus} (${scenario.openclawToolCalls} tool calls, ${openclawTokens} tokens)`,
     );
     lines.push(
-      `- codex: ${scenario.codexStatus} (${scenario.codexToolCalls} tool calls, ${scenario.codexTokens} tokens)`,
+      `- codex: ${scenario.codexStatus} (${scenario.codexToolCalls} tool calls, ${codexTokens} tokens)`,
     );
+    if (scenario.runtimeParityUsage.expectation === "not-applicable") {
+      lines.push(`- assistant-message usage: N/A (${scenario.runtimeParityUsage.reason})`);
+    }
     if (scenario.driftDetails) {
       lines.push(`- details: ${scenario.driftDetails}`);
     }

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -4,6 +4,7 @@ import {
   __testing,
   captureRuntimeParityCell,
   isRuntimeParityResultPass,
+  resolveRuntimeParityUsagePolicy,
   runRuntimeParityScenario,
   type RuntimeId,
   type RuntimeParityCell,
@@ -100,6 +101,37 @@ describe("runtime parity", () => {
     });
 
     expect(result.drift).toBe("none");
+    expect(result.runtimeParityUsage).toEqual({
+      expectation: "assistant-message-required",
+    });
+  });
+
+  it("preserves explicit usage-not-applicable metadata on parity results", async () => {
+    const result = await runRuntimeParityScenario({
+      scenarioId: "local-fixture",
+      runtimeParityUsage: {
+        expectation: "not-applicable",
+        reason: " Local fixture only; no assistant turn runs. ",
+      },
+      runCell: async (runtime) => ({
+        scenarioStatus: "pass",
+        cell: makeRuntimeParityCell(runtime, []),
+      }),
+    });
+
+    expect(result.runtimeParityUsage).toEqual({
+      expectation: "not-applicable",
+      reason: "Local fixture only; no assistant turn runs.",
+    });
+  });
+
+  it("defaults malformed usage metadata to assistant-message-required", () => {
+    expect(resolveRuntimeParityUsagePolicy({ expectation: "not-applicable" })).toEqual({
+      expectation: "assistant-message-required",
+    });
+    expect(
+      resolveRuntimeParityUsagePolicy({ expectation: "not-applicable", reason: "   " }),
+    ).toEqual({ expectation: "assistant-message-required" });
   });
 
   it("classifies planned-only matching tool calls as failure-mode", async () => {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -31,6 +31,10 @@ export type RuntimeParityUsage = {
   cacheWrite?: number;
 };
 
+export type RuntimeParityUsagePolicy =
+  | { expectation: "assistant-message-required" }
+  | { expectation: "not-applicable"; reason: string };
+
 export type RuntimeParityCell = {
   runtime: RuntimeId;
   transcriptBytes: string;
@@ -54,6 +58,7 @@ export type RuntimeParityDrift =
 
 export type RuntimeParityResult = {
   scenarioId: string;
+  runtimeParityUsage?: RuntimeParityUsagePolicy;
   cells: {
     openclaw: RuntimeParityCell;
     codex: RuntimeParityCell;
@@ -61,6 +66,22 @@ export type RuntimeParityResult = {
   drift: RuntimeParityDrift;
   driftDetails?: string;
 };
+
+export function resolveRuntimeParityUsagePolicy(value: unknown): RuntimeParityUsagePolicy {
+  // Legacy or malformed summaries must not silently disable live-usage proof.
+  if (!value || typeof value !== "object") {
+    return { expectation: "assistant-message-required" };
+  }
+  const candidate = value as { expectation?: unknown; reason?: unknown };
+  if (
+    candidate.expectation === "not-applicable" &&
+    typeof candidate.reason === "string" &&
+    candidate.reason.trim()
+  ) {
+    return { expectation: "not-applicable", reason: candidate.reason.trim() };
+  }
+  return { expectation: "assistant-message-required" };
+}
 
 export type RuntimeParityScenarioExecution = {
   scenarioStatus: "pass" | "fail";
@@ -1065,6 +1086,7 @@ export async function captureRuntimeParityCell(
 
 export async function runRuntimeParityScenario(params: {
   scenarioId: string;
+  runtimeParityUsage?: RuntimeParityUsagePolicy;
   runCell: (runtime: RuntimeId) => Promise<RuntimeParityScenarioExecution>;
 }): Promise<RuntimeParityResult> {
   const openclaw = await params.runCell("openclaw");
@@ -1077,6 +1099,7 @@ export async function runRuntimeParityScenario(params: {
   });
   return {
     scenarioId: params.scenarioId,
+    runtimeParityUsage: resolveRuntimeParityUsagePolicy(params.runtimeParityUsage),
     cells: {
       openclaw: openclaw.cell,
       codex: codex.cell,

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -305,6 +305,37 @@ describe("qa scenario catalog", () => {
     expect(readQaScenarioExecutionConfig(soak.id)).toMatchObject({ turnCount: 100 });
   });
 
+  it("marks only non-assistant runtime parity fixtures as usage not applicable", () => {
+    const notApplicable = readQaScenarioPack()
+      .scenarios.filter((scenario) => scenario.runtimeParityUsage?.expectation === "not-applicable")
+      .map((scenario) => scenario.id)
+      .toSorted();
+
+    expect(notApplicable).toStrictEqual(
+      [
+        "auth-profile-codex-mixed-profiles",
+        "auth-profile-doctor-migration-safety",
+        "codex-plugin-cold-install",
+        "codex-plugin-install-race",
+        "codex-plugin-pinned-new",
+        "codex-plugin-pinned-old",
+        "plugin-manifest-contract-health",
+      ].toSorted(),
+    );
+    for (const scenarioId of notApplicable) {
+      const scenario = readQaScenarioById(scenarioId);
+      expect(scenario.runtimeParityTier).toBeDefined();
+      expect(scenario.runtimeParityUsage).toMatchObject({
+        expectation: "not-applicable",
+      });
+      if (scenario.runtimeParityUsage?.expectation === "not-applicable") {
+        expect(scenario.runtimeParityUsage.reason).toContain("no assistant turn runs");
+      }
+    }
+    expect(readQaScenarioById("runtime-tool-fs-read").runtimeParityUsage).toBeUndefined();
+    expect(readQaScenarioById("plugin-hook-health-sentinel").runtimeParityUsage).toBeUndefined();
+  });
+
   it("loads runtime tool fixture metadata for standard and optional lanes", () => {
     const applyPatch = readQaScenarioById("runtime-tool-apply-patch");
     const messageTool = readQaScenarioById("runtime-tool-message-tool");

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -161,6 +161,15 @@ const qaScenarioGatewayRuntimeSchema = z.object({
 
 export const QA_RUNTIME_PARITY_TIERS = ["standard", "optional", "live-only", "soak"] as const;
 const qaRuntimeParityTierSchema = z.enum(QA_RUNTIME_PARITY_TIERS);
+const qaRuntimeParityUsageSchema = z.discriminatedUnion("expectation", [
+  z.object({
+    expectation: z.literal("assistant-message-required"),
+  }),
+  z.object({
+    expectation: z.literal("not-applicable"),
+    reason: z.string().trim().min(1),
+  }),
+]);
 
 const qaFlowCallActionSchema = z.object({
   call: z.string().trim().min(1),
@@ -271,6 +280,7 @@ const qaSeedScenarioBodySchema = z.object({
   surface: z.string().trim().min(1),
   category: z.string().trim().min(1).optional(),
   runtimeParityTier: qaRuntimeParityTierSchema.optional(),
+  runtimeParityUsage: qaRuntimeParityUsageSchema.optional(),
   coverage: qaScenarioCoverageSchema.optional(),
   surfaces: z.array(z.string().trim().min(1)).min(1).optional(),
   risk: z.enum(["low", "medium", "high"]).optional(),
@@ -292,11 +302,21 @@ const qaSeedScenarioSchema = qaSeedScenarioBodySchema.extend({
   title: z.string().trim().min(1),
 });
 
-const qaScenarioFileSchema = z.object({
-  title: z.string().trim().min(1),
-  scenario: qaSeedScenarioBodySchema,
-  flow: qaFlowSchema.optional(),
-});
+const qaScenarioFileSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    scenario: qaSeedScenarioBodySchema,
+    flow: qaFlowSchema.optional(),
+  })
+  .superRefine((file, ctx) => {
+    if (file.scenario.runtimeParityUsage && !file.scenario.runtimeParityTier) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["scenario", "runtimeParityUsage"],
+        message: "runtimeParityUsage requires runtimeParityTier",
+      });
+    }
+  });
 
 const qaScenarioPackSchema = z.object({
   version: z.number().int().positive(),
@@ -318,6 +338,7 @@ const qaScenarioPackFileSchema = z.object({
 export type QaScenarioExecution = z.infer<typeof qaScenarioExecutionSchema>;
 export type QaScenarioFlow = z.infer<typeof qaFlowSchema>;
 export type QaRuntimeParityTier = z.infer<typeof qaRuntimeParityTierSchema>;
+export type QaRuntimeParityUsage = z.infer<typeof qaRuntimeParityUsageSchema>;
 export type QaSeedScenario = z.infer<typeof qaSeedScenarioSchema>;
 export type QaSeedScenarioWithSource = QaSeedScenario & {
   sourcePath: string;

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -175,6 +175,10 @@ describe("buildQaSuiteSummaryJson", () => {
           steps: [],
           runtimeParity: {
             scenarioId: "scenario-a",
+            runtimeParityUsage: {
+              expectation: "not-applicable" as const,
+              reason: "Local fixture only; no assistant turn runs.",
+            },
             drift: "none" as const,
             cells: {
               openclaw: {
@@ -204,6 +208,10 @@ describe("buildQaSuiteSummaryJson", () => {
     expect(json.scenarios[0]).toMatchObject({
       runtimeParity: {
         scenarioId: "scenario-a",
+        runtimeParityUsage: {
+          expectation: "not-applicable",
+          reason: "Local fixture only; no assistant turn runs.",
+        },
         drift: "none",
       },
     });

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -846,6 +846,7 @@ async function runQaRuntimeParitySuite(params: {
 
         const parity = await runRuntimeParityScenario({
           scenarioId: scenario.id,
+          runtimeParityUsage: scenario.runtimeParityUsage,
           runCell: async (runtime) => {
             const cellOutputDir = path.join(
               params.outputDir,

--- a/extensions/qa-lab/src/token-efficiency-report.test.ts
+++ b/extensions/qa-lab/src/token-efficiency-report.test.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeParityCell,
   RuntimeParityResult,
   RuntimeParityToolCall,
+  RuntimeParityUsagePolicy,
 } from "./runtime-parity.js";
 import {
   buildTokenEfficiencyReport,
@@ -40,9 +41,11 @@ function makeRuntimeParity(
   scenarioId: string,
   openclaw: RuntimeParityCell,
   codex: RuntimeParityCell,
+  runtimeParityUsage?: RuntimeParityUsagePolicy,
 ): RuntimeParityResult {
   return {
     scenarioId,
+    ...(runtimeParityUsage ? { runtimeParityUsage } : {}),
     drift: "none",
     cells: { openclaw, codex },
   };
@@ -132,6 +135,65 @@ describe("token efficiency report", () => {
       "missing-live-usage openclaw live usage totalTokens=0",
       "missing-live-usage codex live usage totalTokens=0",
     ]);
+  });
+
+  it("excludes explicit non-assistant scenarios from live usage aggregates", () => {
+    const report = buildTokenEfficiencyReport({
+      summary: makeLiveSummary([
+        makeRuntimeParity(
+          "usage-applicable",
+          makeCell("openclaw", { inputTokens: 80, outputTokens: 20, totalTokens: 100 }),
+          makeCell("codex", { inputTokens: 85, outputTokens: 20, totalTokens: 105 }),
+        ),
+        makeRuntimeParity(
+          "local-fixture",
+          makeCell("openclaw", { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+          makeCell("codex", { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+          {
+            expectation: "not-applicable",
+            reason: "Local fixture only; no assistant turn runs.",
+          },
+        ),
+      ]),
+    });
+
+    expect(report.pass).toBe(true);
+    expect(report.rows.map((row) => row.scenarioId)).toEqual(["usage-applicable"]);
+    expect(report.aggregate.openclaw.totalTokens).toBe(100);
+    expect(report.aggregate.codex.totalTokens).toBe(105);
+    expect(report.notApplicableScenarios).toEqual([
+      {
+        scenarioId: "local-fixture",
+        reason: "Local fixture only; no assistant turn runs.",
+      },
+    ]);
+    expect(renderTokenEfficiencyMarkdownReport(report)).toContain(
+      "- local-fixture: Local fixture only; no assistant turn runs.",
+    );
+  });
+
+  it("fails live reports with only usage-not-applicable captures", () => {
+    const report = buildTokenEfficiencyReport({
+      summary: makeLiveSummary([
+        makeRuntimeParity(
+          "local-fixture",
+          makeCell("openclaw", { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+          makeCell("codex", { inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+          {
+            expectation: "not-applicable",
+            reason: "Local fixture only; no assistant turn runs.",
+          },
+        ),
+      ]),
+    });
+
+    expect(report.status).toBe("evaluated");
+    expect(report.pass).toBe(false);
+    expect(report.rows).toEqual([]);
+    expect(report.failures).toEqual([
+      "No usage-applicable runtime parity captures were present in the suite summary.",
+    ]);
+    expect(renderTokenEfficiencyMarkdownReport(report)).toContain("- Verdict: fail");
   });
 
   it("fails live reports with non-integer token usage evidence", () => {

--- a/extensions/qa-lab/src/token-efficiency-report.ts
+++ b/extensions/qa-lab/src/token-efficiency-report.ts
@@ -1,5 +1,6 @@
 // Qa Lab plugin module implements token efficiency report behavior.
 import type { RuntimeId, RuntimeParityCell, RuntimeParityResult } from "./runtime-parity.js";
+import { resolveRuntimeParityUsagePolicy } from "./runtime-parity.js";
 
 export type TokenEfficiencyRuntimeUsage = {
   inputTokens: number;
@@ -26,6 +27,7 @@ export type TokenEfficiencyReport = {
   providerMode?: string;
   thresholdPercent: number;
   rows: TokenEfficiencyRow[];
+  notApplicableScenarios: Array<{ scenarioId: string; reason: string }>;
   aggregate: {
     openclaw: { totalTokens: number; p50PerScenario: number; p90PerScenario: number };
     codex: { totalTokens: number; p50PerScenario: number; p90PerScenario: number };
@@ -222,6 +224,7 @@ export function buildTokenEfficiencyReport(
       ...(providerMode ? { providerMode } : {}),
       thresholdPercent,
       rows: [],
+      notApplicableScenarios: [],
       aggregate: ZERO_AGGREGATE,
       pass: !liveUsage,
       failures: liveUsage ? [noCapturesReason] : [],
@@ -230,7 +233,37 @@ export function buildTokenEfficiencyReport(
     };
   }
 
-  const rows = parityResults.map((result) =>
+  const notApplicableScenarios = parityResults.flatMap((result) => {
+    const usage = resolveRuntimeParityUsagePolicy(result.runtimeParityUsage);
+    return usage.expectation === "not-applicable"
+      ? [{ scenarioId: result.scenarioId, reason: usage.reason }]
+      : [];
+  });
+  const usageApplicableResults = parityResults.filter(
+    (result) =>
+      resolveRuntimeParityUsagePolicy(result.runtimeParityUsage).expectation ===
+      "assistant-message-required",
+  );
+  if (usageApplicableResults.length === 0) {
+    const noApplicableReason =
+      "No usage-applicable runtime parity captures were present in the suite summary.";
+    return {
+      status: liveUsage ? "evaluated" : "skipped",
+      runtimePair,
+      generatedAt: params.generatedAt ?? new Date().toISOString(),
+      ...(providerMode ? { providerMode } : {}),
+      thresholdPercent,
+      rows: [],
+      notApplicableScenarios,
+      aggregate: ZERO_AGGREGATE,
+      pass: !liveUsage,
+      failures: liveUsage ? [noApplicableReason] : [],
+      ...(liveUsage ? {} : { skipReason: noApplicableReason }),
+      notes: ["Token efficiency requires at least one assistant-message usage capture."],
+    };
+  }
+
+  const rows = usageApplicableResults.map((result) =>
     buildRow({
       result,
       thresholdPercent,
@@ -239,7 +272,7 @@ export function buildTokenEfficiencyReport(
   );
   const aggregate = buildAggregate(rows);
   const failures = rows.flatMap((row, index) => {
-    const result = parityResults[index];
+    const result = usageApplicableResults[index];
     const rowFailures =
       liveUsage && result
         ? [
@@ -263,6 +296,7 @@ export function buildTokenEfficiencyReport(
     ...(providerMode ? { providerMode } : {}),
     thresholdPercent,
     rows,
+    notApplicableScenarios,
     aggregate,
     pass: failures.length === 0,
     failures,
@@ -314,6 +348,14 @@ export function renderTokenEfficiencyMarkdownReport(report: TokenEfficiencyRepor
       lines.push(
         `| ${row.scenarioId} | ${row.usageSource} | ${row.openclaw.inputTokens}/${row.openclaw.outputTokens}/${row.openclaw.totalTokens}/${row.openclaw.toolCallCount} | ${row.codex.inputTokens}/${row.codex.outputTokens}/${row.codex.totalTokens}/${row.codex.toolCallCount} | ${formatPercent(row.deltaPercent)} | ${row.classification} | ${row.flagged ? "yes" : "no"} | ${row.toolsUsed.join(", ")} |`,
       );
+    }
+    lines.push("");
+  }
+
+  if (report.notApplicableScenarios.length > 0) {
+    lines.push("## Usage Not Applicable", "");
+    for (const scenario of report.notApplicableScenarios) {
+      lines.push(`- ${scenario.scenarioId}: ${scenario.reason}`);
     }
     lines.push("");
   }

--- a/qa/scenarios/plugins/plugin-manifest-contract-health.yaml
+++ b/qa/scenarios/plugins/plugin-manifest-contract-health.yaml
@@ -4,6 +4,9 @@ scenario:
   id: plugin-manifest-contract-health
   surface: runtime
   runtimeParityTier: live-only
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Startup-log sentinel only; no assistant turn runs.
   coverage:
     primary:
       - runtime.gateway-log-sentinel.plugin-contracts

--- a/qa/scenarios/runtime/auth-profile-codex-mixed-profiles.yaml
+++ b/qa/scenarios/runtime/auth-profile-codex-mixed-profiles.yaml
@@ -4,6 +4,9 @@ scenario:
   id: auth-profile-codex-mixed-profiles
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local auth-selection fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.auth

--- a/qa/scenarios/runtime/auth-profile-doctor-migration-safety.yaml
+++ b/qa/scenarios/runtime/auth-profile-doctor-migration-safety.yaml
@@ -4,6 +4,9 @@ scenario:
   id: auth-profile-doctor-migration-safety
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local doctor-migration fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.doctor-repair

--- a/qa/scenarios/runtime/codex-plugin-cold-install.yaml
+++ b/qa/scenarios/runtime/codex-plugin-cold-install.yaml
@@ -4,6 +4,9 @@ scenario:
   id: codex-plugin-cold-install
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local plugin-lifecycle fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.lifecycle

--- a/qa/scenarios/runtime/codex-plugin-install-race.yaml
+++ b/qa/scenarios/runtime/codex-plugin-install-race.yaml
@@ -4,6 +4,9 @@ scenario:
   id: codex-plugin-install-race
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local install-ordering fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.lifecycle

--- a/qa/scenarios/runtime/codex-plugin-pinned-new.yaml
+++ b/qa/scenarios/runtime/codex-plugin-pinned-new.yaml
@@ -4,6 +4,9 @@ scenario:
   id: codex-plugin-pinned-new
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local version-mismatch fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.version

--- a/qa/scenarios/runtime/codex-plugin-pinned-old.yaml
+++ b/qa/scenarios/runtime/codex-plugin-pinned-old.yaml
@@ -4,6 +4,9 @@ scenario:
   id: codex-plugin-pinned-old
   surface: runtime
   runtimeParityTier: standard
+  runtimeParityUsage:
+    expectation: not-applicable
+    reason: Local version-mismatch fixture only; no assistant turn runs.
   coverage:
     primary:
       - runtime.codex-plugin.version


### PR DESCRIPTION
Closes #103641

## What Problem This Solves

Resolves a release-validation problem where runtime token-efficiency proof treated deterministic startup and local fixture scenarios as missing assistant-message usage, even though those scenarios intentionally run no assistant turn.

## Why This Change Was Made

Adds explicit, per-scenario usage applicability metadata and carries it in the runtime-parity artifact. Only seven cataloged non-assistant fixtures are marked not applicable. Missing or malformed metadata remains fail-closed as assistant-message-required; runtime failures, drift, required zero usage, and live reports containing only not-applicable captures still fail.

## User Impact

Release operators get token aggregates based only on scenarios that can produce assistant usage, while parity failures and insufficient live evidence remain blocking.

## Evidence

- Exact live proof at `4bc300843d5ec9f071257c2900701f91df44e1c3` identified seven deterministic zero-usage fixture scenarios.
- Blacksmith Testbox through Crabbox `tbx_01kx5qan3y2kpr49rd9h4c5ajb`: 111 focused QA Lab tests passed on rebased head `257c96b1e0c6a260f653855398d848a5ee6a59ae`.
- Blacksmith Testbox through Crabbox: changed typecheck, all lint shards, repository guards, and import-cycle analysis passed.
- Fresh autoreview after rebase: no accepted or actionable findings.
