### PR TITLE
fix: keep gateway model probes stateless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway infer model runs:** keep `openclaw infer model run --gateway` genuinely stateless by suppressing session, task, and session-change state, keeping transcript and trajectory artifacts private, and deleting them after success or failure. (#103081) Thanks @jzmudzinski.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Exec safe-bin flags:** auto-approve curated read-only boolean flags for default stdin-only filters while keeping unknown flags, tail follow/retry modes, file operands, and custom profiles fail-closed. (#88953) Thanks @yetval.
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway infer model runs:** keep `openclaw infer model run --gateway` genuinely stateless by suppressing session, task, and session-change state, keeping transcript and trajectory artifacts private, and deleting them after success or failure. (#103081) Thanks @jzmudzinski.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Exec safe-bin flags:** auto-approve curated read-only boolean flags for default stdin-only filters while keeping unknown flags, tail follow/retry modes, file operands, and custom profiles fail-closed. (#88953) Thanks @yetval.
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -52,8 +52,10 @@ const state = vi.hoisted(() => ({
   resolveAgentDeliveryPlanMock: vi.fn(),
   resolveAgentOutboundTargetMock: vi.fn(),
   resolveMessageChannelSelectionMock: vi.fn(),
+  createTrajectoryRuntimeRecorderMock: vi.fn(),
   trajectoryRecordEventMock: vi.fn(),
   trajectoryFlushMock: vi.fn(async () => undefined),
+  removeSessionTrajectoryArtifactsMock: vi.fn(async (..._args: unknown[]) => []),
   persistSessionEntryMock: vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined),
   clearSessionAuthProfileOverrideMock: vi.fn(),
   isThinkingLevelSupportedMock: vi.fn((_args: unknown) => true),
@@ -277,10 +279,14 @@ vi.mock("../config/sessions/transcript-resolve.runtime.js", () => ({
 }));
 
 vi.mock("./internal-session-effects.js", () => ({
+  isInternalSessionEffectsTranscriptPath: (sessionFile: string | undefined) =>
+    sessionFile?.startsWith("/tmp/openclaw-internal-") === true,
   prepareInternalSessionEffectsTranscript: (...args: unknown[]) =>
     state.prepareInternalSessionEffectsTranscriptMock(...args),
   removeInternalSessionEffectsTranscript: (...args: unknown[]) =>
     state.removeInternalSessionEffectsTranscriptMock(...args),
+  resolveInternalSessionEffectsTranscriptPath: (runId: string) =>
+    `/tmp/openclaw-internal-${runId}.jsonl`,
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
@@ -374,13 +380,21 @@ vi.mock("../terminal/ansi.js", () => ({
   sanitizeForLog: (s: string) => s,
 }));
 
+vi.mock("../trajectory/cleanup.js", () => ({
+  removeSessionTrajectoryArtifacts: (...args: unknown[]) =>
+    state.removeSessionTrajectoryArtifactsMock(...args),
+}));
+
 vi.mock("../trajectory/runtime.js", () => ({
-  createTrajectoryRuntimeRecorder: () => ({
-    enabled: true,
-    filePath: "/tmp/session.trajectory.jsonl",
-    recordEvent: (...args: unknown[]) => state.trajectoryRecordEventMock(...args),
-    flush: () => state.trajectoryFlushMock(),
-  }),
+  createTrajectoryRuntimeRecorder: (params: unknown) => {
+    state.createTrajectoryRuntimeRecorderMock(params);
+    return {
+      enabled: true,
+      filePath: "/tmp/session.trajectory.jsonl",
+      recordEvent: (...args: unknown[]) => state.trajectoryRecordEventMock(...args),
+      flush: () => state.trajectoryFlushMock(),
+    };
+  },
 }));
 
 vi.mock("../utils/message-channel.js", () => ({
@@ -1104,6 +1118,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
     state.updateSessionStoreAfterAgentRunMock.mockResolvedValue(undefined);
     state.trajectoryFlushMock.mockResolvedValue(undefined);
+    state.removeSessionTrajectoryArtifactsMock.mockResolvedValue([]);
     state.prepareInternalSessionEffectsTranscriptMock.mockResolvedValue(
       "/tmp/openclaw-internal-run.jsonl",
     );
@@ -2665,6 +2680,137 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         sessionId: "session-1",
         isControlUiVisible: false,
       }),
+    );
+    expect(state.removeSessionTrajectoryArtifactsMock).not.toHaveBeenCalled();
+    expect(state.removeInternalSessionEffectsTranscriptMock).not.toHaveBeenCalled();
+  });
+
+  it("removes one-shot internal model-run artifacts after success", async () => {
+    setupSingleAttemptFallback();
+    state.prepareInternalSessionEffectsTranscriptMock.mockResolvedValueOnce(
+      "/tmp/openclaw-internal-model-run-success.jsonl",
+    );
+    const result = makeSuccessResult("openai", "gpt-5.4");
+    state.runAgentAttemptMock.mockResolvedValue({
+      ...result,
+      meta: {
+        ...result.meta,
+        executionTrace: {
+          runner: "embedded",
+          fallbackUsed: false,
+          winnerProvider: "openai",
+          winnerModel: "gpt-5.4",
+        },
+        finalAssistantVisibleText: "ok",
+        agentMeta: {
+          provider: "openai",
+          model: "gpt-5.4",
+          sessionId: "rotated-model-run-session",
+          sessionFile: "/tmp/openclaw-internal-rotated.jsonl",
+        },
+      },
+    });
+
+    await agentCommand({
+      message: "probe",
+      to: "+1234567890",
+      runId: "model-run-success",
+      modelRun: true,
+      promptMode: "none",
+      sessionEffects: "internal",
+    });
+
+    expect(state.createTrajectoryRuntimeRecorderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/openclaw-internal-model-run-success.jsonl",
+      }),
+    );
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "rotated-model-run-session",
+        sessionFile: "/tmp/openclaw-internal-rotated.jsonl",
+      }),
+    );
+    const transcriptCall = mockCallArg(state.persistCliTurnTranscriptMock) as {
+      sessionEntry?: SessionEntry;
+    };
+    expect(transcriptCall.sessionEntry?.sessionFile).toBeUndefined();
+    expect(state.removeSessionTrajectoryArtifactsMock).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      sessionFile: "/tmp/openclaw-internal-model-run-success.jsonl",
+      storePath: "/tmp/openclaw-internal-model-run-success.jsonl",
+    });
+    expect(state.removeSessionTrajectoryArtifactsMock).toHaveBeenCalledWith({
+      sessionId: "rotated-model-run-session",
+      sessionFile: "/tmp/openclaw-internal-rotated.jsonl",
+      storePath: "/tmp/openclaw-internal-rotated.jsonl",
+    });
+    expect(state.removeInternalSessionEffectsTranscriptMock).toHaveBeenCalledWith(
+      "/tmp/openclaw-internal-model-run-success.jsonl",
+    );
+    expect(state.removeInternalSessionEffectsTranscriptMock).toHaveBeenCalledWith(
+      "/tmp/openclaw-internal-rotated.jsonl",
+    );
+    const deliveryOrder = state.deliverAgentCommandResultMock.mock.invocationCallOrder[0] ?? 0;
+    const trajectoryCleanupOrder =
+      state.removeSessionTrajectoryArtifactsMock.mock.invocationCallOrder.at(-1) ?? 0;
+    const transcriptCleanupOrder =
+      state.removeInternalSessionEffectsTranscriptMock.mock.invocationCallOrder[0] ?? 0;
+    expect(deliveryOrder).toBeLessThan(trajectoryCleanupOrder);
+    expect(trajectoryCleanupOrder).toBeLessThan(transcriptCleanupOrder);
+  });
+
+  it("removes one-shot internal model-run artifacts after provider failure", async () => {
+    setupSingleAttemptFallback();
+    state.prepareInternalSessionEffectsTranscriptMock.mockResolvedValueOnce(
+      "/tmp/openclaw-internal-model-run-failure.jsonl",
+    );
+    state.runAgentAttemptMock.mockRejectedValueOnce(new Error("probe failed"));
+
+    await expect(
+      agentCommand({
+        message: "probe",
+        to: "+1234567890",
+        runId: "model-run-failure",
+        modelRun: true,
+        promptMode: "none",
+        sessionEffects: "internal",
+      }),
+    ).rejects.toThrow("probe failed");
+
+    expect(state.removeSessionTrajectoryArtifactsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/openclaw-internal-model-run-failure.jsonl",
+      }),
+    );
+    expect(state.removeInternalSessionEffectsTranscriptMock).toHaveBeenCalledWith(
+      "/tmp/openclaw-internal-model-run-failure.jsonl",
+    );
+  });
+
+  it("cleans the deterministic model-run path when transcript preparation fails", async () => {
+    state.prepareInternalSessionEffectsTranscriptMock.mockRejectedValueOnce(
+      new Error("transcript chmod failed"),
+    );
+
+    await expect(
+      agentCommand({
+        message: "probe",
+        to: "+1234567890",
+        runId: "model-run-prepare-failure",
+        modelRun: true,
+        promptMode: "none",
+        sessionEffects: "internal",
+      }),
+    ).rejects.toThrow("transcript chmod failed");
+
+    expect(state.removeSessionTrajectoryArtifactsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/openclaw-internal-model-run-prepare-failure.jsonl",
+      }),
+    );
+    expect(state.removeInternalSessionEffectsTranscriptMock).toHaveBeenCalledWith(
+      "/tmp/openclaw-internal-model-run-prepare-failure.jsonl",
     );
   });
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -65,6 +65,7 @@ import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
 } from "../tasks/task-status-access.js";
+import { removeSessionTrajectoryArtifacts } from "../trajectory/cleanup.js";
 import { createTrajectoryRuntimeRecorder } from "../trajectory/runtime.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -120,7 +121,12 @@ import { resolveFastModeState } from "./fast-mode.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
-import { prepareInternalSessionEffectsTranscript } from "./internal-session-effects.js";
+import {
+  isInternalSessionEffectsTranscriptPath,
+  prepareInternalSessionEffectsTranscript,
+  removeInternalSessionEffectsTranscript,
+  resolveInternalSessionEffectsTranscriptPath,
+} from "./internal-session-effects.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch.js";
 import { loadManifestModelCatalog } from "./model-catalog.js";
@@ -956,6 +962,24 @@ async function agentCommandInternal(
   let currentRunDeliveryContext: DeliveryContext | undefined;
   const preparedSessionId = sessionEntry?.sessionId;
   const sessionStoreRuntime = storePath && sessionKey ? await loadSessionStoreRuntime() : undefined;
+  const internalModelRunArtifacts =
+    initialOpts.modelRun === true && suppressVisibleSessionEffects
+      ? new Map<string, { sessionFile: string; sessionId: string }>()
+      : undefined;
+  const trackInternalModelRunArtifact = (
+    sessionFile: string | undefined,
+    artifactSessionId: string,
+  ) => {
+    if (!internalModelRunArtifacts || !isInternalSessionEffectsTranscriptPath(sessionFile)) {
+      return;
+    }
+    internalModelRunArtifacts.set(`${artifactSessionId}\n${sessionFile}`, {
+      sessionFile,
+      sessionId: artifactSessionId,
+    });
+  };
+  // Precompute the owned path so even a partially failed prepare can be cleaned.
+  trackInternalModelRunArtifact(resolveInternalSessionEffectsTranscriptPath(runId), sessionId);
 
   // Reset marks its mutation before interrupting work. An aborted run must not
   // queue behind that mutation or reset would wait on the run holding the queue.
@@ -1215,17 +1239,6 @@ async function agentCommandInternal(
                 runId,
               })
             : undefined;
-          const transcriptSessionEntry: SessionEntry | undefined = internalSessionFile
-            ? {
-                ...(sessionEntry ?? {
-                  sessionId,
-                  updatedAt: Date.now(),
-                  sessionStartedAt: Date.now(),
-                }),
-                sessionId,
-                sessionFile: internalSessionFile,
-              }
-            : sessionEntry;
           const transcriptResult = await attemptExecutionRuntime.persistAcpTurnTranscript({
             body,
             transcriptBody,
@@ -1241,7 +1254,8 @@ async function agentCommandInternal(
             finalText: finalTextRaw,
             sessionId,
             sessionKey,
-            sessionEntry: transcriptSessionEntry,
+            sessionFile: internalSessionFile,
+            sessionEntry,
             sessionStore: suppressVisibleSessionEffects ? undefined : sessionStore,
             storePath: suppressVisibleSessionEffects ? undefined : storePath,
             sessionAgentId,
@@ -1837,6 +1851,7 @@ async function agentCommandInternal(
       const attemptSessionFile = suppressVisibleSessionEffects
         ? await prepareInternalSessionEffectsTranscript({ sessionFile, runId })
         : sessionFile;
+      trackInternalModelRunArtifact(attemptSessionFile, sessionId);
 
       const startedAt = Date.now();
       const attemptLifecycleState: AgentAttemptLifecycleState = {
@@ -2013,7 +2028,7 @@ async function agentCommandInternal(
         runId,
         sessionId,
         sessionKey,
-        sessionFile,
+        sessionFile: attemptSessionFile,
         provider,
         modelId: model,
         workspaceDir,
@@ -2364,6 +2379,7 @@ async function agentCommandInternal(
           ? (result.meta.agentMeta?.sessionId ?? sessionId)
           : sessionId;
         const effectiveSessionFile = rotatedSessionFile ?? attemptSessionFile;
+        trackInternalModelRunArtifact(effectiveSessionFile, effectiveSessionId);
 
         // Update token+model fields in the session store.
         if (sessionStore && sessionKey && !suppressVisibleSessionEffects) {
@@ -2406,24 +2422,14 @@ async function agentCommandInternal(
         ) {
           let persistedCliTurnTranscript = false;
           try {
-            const transcriptSessionEntry: SessionEntry | undefined = suppressVisibleSessionEffects
-              ? {
-                  ...(sessionEntry ?? {
-                    sessionId: effectiveSessionId,
-                    updatedAt: Date.now(),
-                    sessionStartedAt: Date.now(),
-                  }),
-                  sessionId: effectiveSessionId,
-                  sessionFile: effectiveSessionFile,
-                }
-              : sessionEntry;
             const transcriptResult = await attemptExecutionRuntime.persistCliTurnTranscript({
               body,
               transcriptBody,
               result,
               sessionId: effectiveSessionId,
               sessionKey: sessionKey ?? effectiveSessionId,
-              sessionEntry: transcriptSessionEntry,
+              sessionFile: suppressVisibleSessionEffects ? effectiveSessionFile : undefined,
+              sessionEntry,
               sessionStore: suppressVisibleSessionEffects ? undefined : sessionStore,
               storePath: suppressVisibleSessionEffects ? undefined : storePath,
               sessionAgentId,
@@ -2598,6 +2604,30 @@ async function agentCommandInternal(
     });
   } finally {
     sessionWorkAdmission.release();
+    if (internalModelRunArtifacts) {
+      // Compaction may rotate a private transcript. Clean every owned identity
+      // only after delivery, then remove each transcript after its sidecars.
+      for (const artifact of internalModelRunArtifacts.values()) {
+        try {
+          await removeSessionTrajectoryArtifacts({
+            sessionId: artifact.sessionId,
+            sessionFile: artifact.sessionFile,
+            storePath: artifact.sessionFile,
+          });
+        } catch (error) {
+          log.warn(
+            `failed to remove model-run trajectory artifacts: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      for (const sessionFile of new Set(
+        Array.from(internalModelRunArtifacts.values(), (artifact) => artifact.sessionFile),
+      )) {
+        await removeInternalSessionEffectsTranscript(sessionFile);
+      }
+    }
     if (
       !sessionReboundDuringRun &&
       trackedRestartRecoveryDeliveryContext &&

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import { clearSessionStoreCacheForTest } from "../../config/sessions/store.js";
+import { resolveSessionTranscriptPath } from "../../config/sessions/paths.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
@@ -287,7 +288,7 @@ describe("CLI attempt execution", () => {
   }
 
   beforeEach(async () => {
-    homeEnvSnapshot = captureEnv(["HOME"]);
+    homeEnvSnapshot = captureEnv(["HOME", "OPENCLAW_STATE_DIR"]);
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-attempt-"));
     storePath = path.join(tmpDir, "sessions.json");
     runCliAgentMock.mockReset();
@@ -1337,6 +1338,63 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().provider).toBe("google-gemini-cli");
     expect(firstRunCliAgentArg().authProfileId).toBe("google:api-key");
   });
+
+  it.each(["CLI", "ACP"] as const)(
+    "keeps an explicit internal %s transcript out of the visible session path",
+    async (runtime) => {
+      const sessionId = `session-explicit-internal-${runtime.toLowerCase()}`;
+      const sessionKey = `agent:main:direct:${sessionId}`;
+      setTestEnvValue("HOME", tmpDir);
+      setTestEnvValue("OPENCLAW_STATE_DIR", path.join(tmpDir, "state"));
+      const visibleSessionFile = resolveSessionTranscriptPath(sessionId, "main");
+      const internalSessionFile = path.join(
+        tmpDir,
+        "internal-agent-runs",
+        `${sessionId}.jsonl`,
+      );
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        sessionFile: visibleSessionFile,
+        updatedAt: Date.now(),
+      };
+      await fs.mkdir(path.dirname(internalSessionFile), { recursive: true });
+
+      if (runtime === "CLI") {
+        await persistCliTurnTranscript({
+          body: "internal prompt",
+          result: makeCliResult("internal reply"),
+          sessionId,
+          sessionKey,
+          sessionFile: internalSessionFile,
+          sessionEntry,
+          sessionAgentId: "main",
+          sessionCwd: tmpDir,
+          config: {},
+          embeddedAssistantGapFill: true,
+        });
+      } else {
+        await persistAcpTurnTranscript({
+          body: "internal prompt",
+          finalText: "internal reply",
+          sessionId,
+          sessionKey,
+          sessionFile: internalSessionFile,
+          sessionEntry,
+          sessionAgentId: "main",
+          sessionCwd: tmpDir,
+          config: {},
+        });
+      }
+
+      expect(await readSessionMessages(internalSessionFile)).toContainEqual(
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "internal reply" }],
+        }),
+      );
+      await expect(fs.stat(visibleSessionFile)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 
   it("persists CLI replies into the session transcript", async () => {
     const sessionKey = "agent:main:subagent:cli-transcript";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -132,6 +132,7 @@ type PersistTextTurnTranscriptParams = {
   finalText: string;
   sessionId: string;
   sessionKey: string;
+  sessionFile?: string;
   sessionEntry: SessionEntry | undefined;
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
@@ -372,6 +373,7 @@ async function persistTextTurnTranscript(
     {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
+      sessionFile: params.sessionFile,
       sessionEntry: params.sessionEntry,
       sessionStore: params.sessionStore,
       storePath: params.storePath,
@@ -418,6 +420,7 @@ export async function persistAcpTurnTranscript(params: {
   finalText: string;
   sessionId: string;
   sessionKey: string;
+  sessionFile?: string;
   sessionEntry: SessionEntry | undefined;
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
@@ -444,6 +447,7 @@ export async function persistCliTurnTranscript(params: {
   result: EmbeddedAgentRunResult;
   sessionId: string;
   sessionKey: string;
+  sessionFile?: string;
   sessionEntry: SessionEntry | undefined;
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
@@ -467,6 +471,7 @@ export async function persistCliTurnTranscript(params: {
     finalText: replyText,
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sessionFile: params.sessionFile,
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
     storePath: params.storePath,

--- a/src/agents/internal-session-effects.test.ts
+++ b/src/agents/internal-session-effects.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  isInternalSessionEffectsTranscriptPath,
   prepareInternalSessionEffectsTranscript,
   removeInternalSessionEffectsTranscript,
 } from "./internal-session-effects.js";
@@ -20,6 +21,8 @@ describe("prepareInternalSessionEffectsTranscript", () => {
         // The run id is filesystem-normalized and the transcript is private
         // because internal side effects may contain hidden agent context.
         expect(sessionFile).toBe(path.join(dir, "internal-agent-runs", "run_with_space.jsonl"));
+        expect(isInternalSessionEffectsTranscriptPath(sessionFile)).toBe(true);
+        expect(isInternalSessionEffectsTranscriptPath(path.join(dir, "visible.jsonl"))).toBe(false);
         expect(await fs.readFile(sessionFile, "utf8")).toBe("");
         expect((await fs.stat(sessionFile)).mode & 0o777).toBe(0o600);
 

--- a/src/agents/internal-session-effects.ts
+++ b/src/agents/internal-session-effects.ts
@@ -5,10 +5,23 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 
+function resolveInternalSessionEffectsDir(): string {
+  return path.resolve(resolveStateDir(), "internal-agent-runs");
+}
+
 /** Resolves the private transcript path for an internal session-effect run. */
 export function resolveInternalSessionEffectsTranscriptPath(runId: string): string {
   const safeRunId = runId.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120) || "run";
-  return path.join(resolveStateDir(), "internal-agent-runs", `${safeRunId}.jsonl`);
+  return path.join(resolveInternalSessionEffectsDir(), `${safeRunId}.jsonl`);
+}
+
+/** Checks whether a transcript belongs to the private internal-run directory. */
+export function isInternalSessionEffectsTranscriptPath(
+  sessionFile: string | undefined,
+): sessionFile is string {
+  return Boolean(
+    sessionFile && path.dirname(path.resolve(sessionFile)) === resolveInternalSessionEffectsDir(),
+  );
 }
 
 /** Copies or creates a private transcript for internal session-effect recovery. */
@@ -43,11 +56,10 @@ export async function prepareInternalSessionEffectsTranscript(params: {
 export async function removeInternalSessionEffectsTranscript(
   sessionFile: string | undefined,
 ): Promise<void> {
-  const dir = path.join(resolveStateDir(), "internal-agent-runs");
-  const resolved = sessionFile ? path.resolve(sessionFile) : "";
-  if (!resolved || path.dirname(resolved) !== path.resolve(dir)) {
+  if (!isInternalSessionEffectsTranscriptPath(sessionFile)) {
     return;
   }
+  const resolved = path.resolve(sessionFile);
   try {
     await fs.rm(resolved, { force: true });
   } catch {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -626,6 +626,22 @@ function operatorWriteGatewayClient(): AgentHandlerArgs["client"] {
   } as AgentHandlerArgs["client"];
 }
 
+function operatorWriteCliClient(): AgentHandlerArgs["client"] {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "cli",
+        version: "test",
+        platform: "test",
+        mode: "cli",
+      },
+      scopes: ["operator.write"],
+    },
+  } as AgentHandlerArgs["client"];
+}
+
 async function waitForAgentCommandCall<
   T extends AgentCommandCall = AgentCommandCall,
 >(): Promise<T> {
@@ -3815,6 +3831,11 @@ describe("gateway agent handler", () => {
     for (const params of [
       { sessionEffects: "internal" as const, idempotencyKey: "test-public-internal-effects" },
       { suppressPromptPersistence: true, idempotencyKey: "test-public-prompt-suppress" },
+      {
+        modelRun: true,
+        suppressPromptPersistence: true,
+        idempotencyKey: "test-model-run-public-prompt-suppress",
+      },
     ]) {
       const respond = await invokeAgent(
         {
@@ -4073,6 +4094,75 @@ describe("gateway agent handler", () => {
     expect(callArgs.message).not.toContain("[Inter-session message]");
 
     resetTimeConfig();
+  });
+
+  it("keeps CLI model runs out of durable and visible gateway state", async () => {
+    const sessionId = "model-run-123e4567-e89b-12d3-a456-426614174000";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: undefined,
+      canonicalKey: sessionKey,
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "pong" }],
+      meta: { durationMs: 100 },
+    });
+    mocks.updateSessionStore.mockClear();
+    mocks.registerAgentRunContext.mockClear();
+    mocks.getLatestSubagentRunByChildSessionKey.mockClear();
+    mocks.replaceSubagentRunAfterSteer.mockClear();
+
+    const defaultRuntime = getDetachedTaskLifecycleRuntime();
+    const createRunningTaskRunSpy = vi.fn(
+      (...args: Parameters<typeof defaultRuntime.createRunningTaskRun>) =>
+        defaultRuntime.createRunningTaskRun(...args),
+    );
+    setDetachedTaskLifecycleRuntime({
+      ...defaultRuntime,
+      createRunningTaskRun: createRunningTaskRunSpy,
+    });
+
+    const context = makeContext();
+    context.getSessionEventSubscriberConnIds = () => new Set(["conn-1"]);
+    await invokeAgent(
+      {
+        message: "Reply exactly: pong",
+        agentId: "main",
+        sessionId,
+        sessionKey,
+        modelRun: true,
+        promptMode: "none",
+        idempotencyKey: "test-stateless-model-run",
+      },
+      {
+        reqId: "stateless-model-run",
+        client: operatorWriteCliClient(),
+        context,
+      },
+    );
+
+    const callArgs = await waitForAgentCommandCall<{
+      modelRun?: boolean;
+      promptMode?: string;
+      sessionEffects?: string;
+    }>();
+    expectRecordFields(callArgs, {
+      modelRun: true,
+      promptMode: "none",
+      sessionEffects: "internal",
+    });
+    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
+    expect(context.addChatRun).not.toHaveBeenCalled();
+    expect(createRunningTaskRunSpy).not.toHaveBeenCalled();
+    expect(context.broadcastToConnIds).not.toHaveBeenCalled();
+    expect(mocks.getLatestSubagentRunByChildSessionKey).not.toHaveBeenCalled();
+    expect(mocks.replaceSubagentRunAfterSteer).not.toHaveBeenCalled();
+    expect(mocks.registerAgentRunContext).toHaveBeenCalledWith("test-stateless-model-run", {
+      isControlUiVisible: false,
+      lifecycleGeneration: "test-generation",
+    });
   });
 
   it("respects explicit bestEffortDeliver=false for main session runs", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -720,7 +720,13 @@ function resolveGatewayAgentTaskTrackingMode(params: {
   sessionKey?: string;
   inputProvenance?: InputProvenance;
   confirmedAcpManualSpawn?: boolean;
+  modelRun?: boolean;
 }): GatewayAgentTaskTrackingMode {
+  // Model probes are stateless one-shot work. A terminal CLI task row would
+  // outlive the probe even when its session/transcript effects are internal.
+  if (params.modelRun === true) {
+    return "none";
+  }
   if (!params.sessionKey?.trim() || params.inputProvenance?.kind === "inter_session") {
     return "none";
   }
@@ -1317,7 +1323,8 @@ export const agentHandlers: GatewayRequestHandlers = {
     const requestedModelOverride = Boolean(request.provider || request.model);
     const requestedInternalSessionEffects = request.sessionEffects === "internal";
     const requestedPromptPersistenceSuppression = request.suppressPromptPersistence === true;
-    const isRawModelRun = request.modelRun === true || request.promptMode === "none";
+    const isOneShotModelRun = request.modelRun === true;
+    const isRawModelRun = isOneShotModelRun || request.promptMode === "none";
     if (requestedModelOverride && !allowModelOverride) {
       respond(
         false,
@@ -1374,7 +1381,10 @@ export const agentHandlers: GatewayRequestHandlers = {
     const preserveUserFacingSessionModelState =
       canUseInternalRuntimeHandoff &&
       shouldPreserveUserFacingSessionStateForInputProvenance(inputProvenance);
-    const sessionEffects = requestedInternalSessionEffects ? "internal" : request.sessionEffects;
+    // `modelRun` is the existing stateless probe contract. Derive its hidden
+    // effects here without granting the caller any backend-only handoff controls.
+    const sessionEffects =
+      isOneShotModelRun || requestedInternalSessionEffects ? "internal" : request.sessionEffects;
     const suppressVisibleSessionEffects = sessionEffects === "internal";
     const agentDedupeKeys = resolveAgentDedupeKeys({
       idempotencyKey: idem,
@@ -3572,6 +3582,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         sessionKey: resolvedSessionKey,
         inputProvenance,
         confirmedAcpManualSpawn,
+        modelRun: isOneShotModelRun,
       });
       let dispatchTaskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent"> =
         taskTrackingMode === "cli" ? "cli" : "none";
@@ -3661,7 +3672,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             return;
           }
 
-          if (resolvedSessionKey) {
+          if (!isOneShotModelRun && resolvedSessionKey) {
             await reactivateCompletedSubagentSession({
               sessionKey: resolvedSessionKey,
               runId,
@@ -3669,14 +3680,19 @@ export const agentHandlers: GatewayRequestHandlers = {
             });
           }
 
-          if (requestedSessionKey && resolvedSessionKey && isNewSession) {
+          if (
+            !suppressVisibleSessionEffects &&
+            requestedSessionKey &&
+            resolvedSessionKey &&
+            isNewSession
+          ) {
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               ...(resolvedSessionKey === "global" ? { agentId: activeSessionAgentId } : {}),
               reason: "create",
             });
           }
-          if (resolvedSessionKey) {
+          if (!suppressVisibleSessionEffects && resolvedSessionKey) {
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               ...(resolvedSessionKey === "global" ? { agentId: activeSessionAgentId } : {}),


### PR DESCRIPTION
Fixes #103081

## What Problem This Solves

Fixes an issue where users running `openclaw infer model run --gateway` would accumulate a durable session, task row, transcript, and trajectory artifacts for every supposedly stateless probe.

## Why This Change Was Made

Gateway model probes now derive the existing internal session-effects mode server-side without exposing privileged controls to public callers. The run stays outside visible session/task/event state, writes only to explicitly owned private transcript targets, skips subagent reactivation, and removes every private transcript and trajectory identity after success or failure, including compaction rotations.

## User Impact

`openclaw infer model run --gateway` is genuinely one-shot: repeated probes no longer clutter session or task lists or grow transcript and trajectory state on disk. Ordinary agent turns and durable internal subagent recovery retain their existing lifecycle behavior.

## Evidence

- Blacksmith Testbox `tbx_01kx5p72ve2reqhp9x6f0vvzjs`: focused Gateway suite, 436 assertions passed.
- Blacksmith Testbox `tbx_01kx5p72ve2reqhp9x6f0vvzjs`: agent/helper suites, 143 assertions passed.
- Blacksmith Testbox: path-scoped `check:changed` passed production/test typechecks, 242-rule lint, database-first guard, runtime sidecar guard, and zero import cycles.
- Blacksmith Testbox: full `pnpm build` passed.
- Live Gateway proof: two sequential CLI-mode `infer model run --gateway` calls reached the mock OpenAI provider twice and returned twice; before and after snapshots both had zero session rows, task rows, visible transcript artifacts, private transcript artifacts, and trajectory artifacts.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
