### PR TITLE
fix(exa): cache disabled content options separately

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -453,8 +453,7 @@ function buildExaCacheKey(params: {
   dateBefore?: string;
   contents?: ExaContentsArgs;
 }): string {
-  const serializeContentOption = (value: unknown): string | undefined =>
-    value === undefined ? undefined : JSON.stringify(value);
+  const contents = params.contents ?? { highlights: true };
 
   return buildSearchCacheKey([
     "exa",
@@ -465,9 +464,7 @@ function buildExaCacheKey(params: {
     params.freshness,
     params.dateAfter,
     params.dateBefore,
-    serializeContentOption(params.contents?.highlights),
-    serializeContentOption(params.contents?.text),
-    serializeContentOption(params.contents?.summary),
+    JSON.stringify(contents),
   ]);
 }
 

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -453,6 +453,9 @@ function buildExaCacheKey(params: {
   dateBefore?: string;
   contents?: ExaContentsArgs;
 }): string {
+  const serializeContentOption = (value: unknown): string | undefined =>
+    value === undefined ? undefined : JSON.stringify(value);
+
   return buildSearchCacheKey([
     "exa",
     params.endpoint,
@@ -462,9 +465,9 @@ function buildExaCacheKey(params: {
     params.freshness,
     params.dateAfter,
     params.dateBefore,
-    params.contents?.highlights ? JSON.stringify(params.contents.highlights) : undefined,
-    params.contents?.text ? JSON.stringify(params.contents.text) : undefined,
-    params.contents?.summary ? JSON.stringify(params.contents.summary) : undefined,
+    serializeContentOption(params.contents?.highlights),
+    serializeContentOption(params.contents?.text),
+    serializeContentOption(params.contents?.summary),
   ]);
 }
 

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -153,7 +153,7 @@ describe("exa web search provider", () => {
     );
   });
 
-  it("partitions Exa cache keys by disabled content options", () => {
+  it("partitions Exa cache keys by effective content options", () => {
     const base = {
       endpoint: "https://api.exa.ai/search",
       type: "auto" as const,
@@ -162,13 +162,17 @@ describe("exa web search provider", () => {
     };
     const defaultKey = testing.buildExaCacheKey(base);
 
-    expect(testing.buildExaCacheKey({ ...base, contents: { highlights: false } })).not.toBe(
-      defaultKey,
-    );
-    expect(testing.buildExaCacheKey({ ...base, contents: { text: false } })).not.toBe(defaultKey);
-    expect(testing.buildExaCacheKey({ ...base, contents: { summary: false } })).not.toBe(
-      defaultKey,
-    );
+    expect(
+      testing.buildExaCacheKey({ ...base, contents: { highlights: true } }),
+    ).toBe(defaultKey);
+
+    const disabledKeys = [
+      testing.buildExaCacheKey({ ...base, contents: { highlights: false } }),
+      testing.buildExaCacheKey({ ...base, contents: { text: false } }),
+      testing.buildExaCacheKey({ ...base, contents: { summary: false } }),
+    ];
+    expect(disabledKeys).not.toContain(defaultKey);
+    expect(new Set(disabledKeys).size).toBe(disabledKeys.length);
   });
 
   it("normalizes Exa result descriptions from highlights before text", () => {

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -153,6 +153,24 @@ describe("exa web search provider", () => {
     );
   });
 
+  it("partitions Exa cache keys by disabled content options", () => {
+    const base = {
+      endpoint: "https://api.exa.ai/search",
+      type: "auto" as const,
+      query: "openclaw",
+      count: 5,
+    };
+    const defaultKey = testing.buildExaCacheKey(base);
+
+    expect(testing.buildExaCacheKey({ ...base, contents: { highlights: false } })).not.toBe(
+      defaultKey,
+    );
+    expect(testing.buildExaCacheKey({ ...base, contents: { text: false } })).not.toBe(defaultKey);
+    expect(testing.buildExaCacheKey({ ...base, contents: { summary: false } })).not.toBe(
+      defaultKey,
+    );
+  });
+
   it("normalizes Exa result descriptions from highlights before text", () => {
     expect(
       testing.resolveExaDescription({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Exa web search requests that explicitly disable a content option could reuse the same cached payload as requests that did not disable that option.

AI-assisted: yes.

## Why This Change Was Made

The Exa cache key now serializes content options whenever they are present, including `false`, instead of only including truthy values. This keeps disabled `highlights`, `text`, and `summary` options separated from the default cache entry while leaving the search execution path unchanged.

## User Impact

Users can expect Exa web search results to respect disabled content options even when similar searches were cached earlier with different content settings.

## Evidence

- `pnpm test:extension exa` passed: 1 test file, 17 tests.
- `pnpm tsgo:test:extensions` was attempted but timed out locally after 184s.
- `pnpm exec tsc -p extensions/exa/tsconfig.json --noEmit` was attempted, but the standalone extension tsconfig could not resolve workspace `openclaw/plugin-sdk/*` modules in this checkout.
- `codex review --base origin/main` was attempted, but local Codex auth returned 401 Unauthorized.
