### PR TITLE
fix(ci): run live suites from manual dispatches

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -112,6 +112,11 @@ on:
         required: false
         default: false
         type: boolean
+      live_advisory:
+        description: Treat only live-provider suite failures as advisory for the caller; repo and Docker E2E stay blocking
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       advisory:

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -89,6 +89,30 @@ function staticProfileMatrixJobs() {
 }
 
 describe("scripts/plan-release-workflow-matrix.mjs", () => {
+  it("declares every job input for both workflow entry points", () => {
+    const definition = workflow();
+    const referencedInputs = new Set<string>();
+    for (const match of JSON.stringify(definition.jobs).matchAll(/\binputs\.([a-zA-Z0-9_]+)/gu)) {
+      if (match[1]) {
+        referencedInputs.add(match[1]);
+      }
+    }
+
+    for (const trigger of ["workflow_call", "workflow_dispatch"]) {
+      expect(Object.keys(definition.on[trigger].inputs)).toEqual(
+        expect.arrayContaining([...referencedInputs]),
+      );
+    }
+    expect(definition.on.workflow_dispatch.inputs.live_advisory).toEqual(
+      definition.on.workflow_call.inputs.live_advisory,
+    );
+    expect(definition.on.workflow_dispatch.inputs.live_advisory).toMatchObject({
+      default: false,
+      required: false,
+      type: "boolean",
+    });
+  });
+
   it.each(PROFILE_EXPECTATIONS)(
     "keeps $profile release jobs to profile-enabled Docker E2E chunks and live model providers",
     ({ profile, dockerE2eChunks, liveModelProviders }) => {


### PR DESCRIPTION
Closes #103652

## What Problem This Solves

Fixes an issue where maintainers manually rerunning a focused live-provider release shard would get a failed workflow with no provider job when the reusable Live and E2E workflow was triggered through `workflow_dispatch`.

## Why This Change Was Made

The manual entry point now declares the same scoped `live_advisory` Boolean already supported by reusable-workflow callers, defaulting to blocking behavior. A workflow contract test also verifies that every `inputs.*` property referenced by jobs is declared for both entry points, preventing another trigger-specific planning failure.

## User Impact

There is no product runtime change. Maintainers can dispatch focused live-provider suites directly again; selected jobs run and remain blocking by default, while reusable caller behavior is unchanged.

## Evidence

- Before: [run 29087583398](https://github.com/openclaw/openclaw/actions/runs/29087583398) validated `native-live-src-gateway-profiles-minimax`, then failed before creating `validate_live_provider_suites`. GitHub annotated line 2032 with `Unexpected value ''` while evaluating the job's `continue-on-error` expression.
- Reproduced independently: [run 29087869351](https://github.com/openclaw/openclaw/actions/runs/29087869351) omitted the same provider job.
- Blacksmith Testbox `tbx_01kx5v7wsn81be352p94fg297x`: focused workflow contract test passed 12/12; exact rebased `pnpm check:changed` tooling lane passed with zero lint errors.
- Targeted Oxfmt check passed for `test/scripts/release-workflow-matrix-plan.test.ts`.
- `actionlint`, YAML contract probe, and `git diff --check` passed.
- Fresh branch autoreview against `7b03a2ae201ab9c27dc3bc39569e97c9f9582360` was clean with no accepted/actionable findings.
- After: exact-head [workflow dispatch 29088948604](https://github.com/openclaw/openclaw/actions/runs/29088948604) passed and instantiated the previously missing [MiniMax provider job 86349671863](https://github.com/openclaw/openclaw/actions/runs/29088948604/job/86349671863). Both selected M2.7 routes completed prompt, tool-read, and tool-exec proof; 120/120 tests passed with zero selected candidates skipped.

Exact focused workflow-dispatch proof is green at the PR head.

AI-assisted: diagnosis, implementation, and validation were prepared with Codex. The linked issue contains the exact hosted reproductions and impact.
