### PR TITLE
fix(qa): derive smoke plan scenario coverage

### DIFF
--- a/extensions/qa-lab/src/ci-smoke-plan.test.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.test.ts
@@ -1,8 +1,13 @@
 // Qa Lab tests cover bounded CI smoke shard planning.
 import { describe, expect, it } from "vitest";
 import { createQaSmokeCiMatrix } from "./ci-smoke-plan.js";
+import { defaultQaModelForMode } from "./model-selection.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
-import { scenarioRequiresIsolatedQaSuiteWorker } from "./suite-planning.js";
+import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
+import {
+  scenarioMatchesQaProviderLane,
+  scenarioRequiresIsolatedQaSuiteWorker,
+} from "./suite-planning.js";
 
 describe("createQaSmokeCiMatrix", () => {
   it("partitions every smoke scenario into bounded channel-compatible shards", () => {
@@ -18,10 +23,34 @@ describe("createQaSmokeCiMatrix", () => {
     expect(first.include).toHaveLength(3);
 
     const scenarioIds = first.include.flatMap((shard) => shard.scenario_ids);
-    expect(scenarioIds).toHaveLength(98);
+    const scenarioPack = readQaScenarioPack();
+    const taxonomy = readQaScorecardTaxonomyReport(scenarioPack.scenarios);
+    const smokeProfile = taxonomy.profiles.find((profile) => profile.id === "smoke-ci");
+    if (!smokeProfile) {
+      throw new Error("missing smoke-ci taxonomy profile");
+    }
+    const smokeScenarioPaths = new Set(
+      taxonomy.categories
+        .filter((category) => category.profiles.includes(smokeProfile.id))
+        .flatMap((category) => category.scenarioRefs),
+    );
+    const expectedScenarioIds = scenarioPack.scenarios
+      .filter(
+        (scenario) =>
+          smokeScenarioPaths.has(scenario.sourcePath) &&
+          scenarioMatchesQaProviderLane({
+            scenario,
+            providerMode: "mock-openai",
+            primaryModel: defaultQaModelForMode("mock-openai"),
+            channelDriver: smokeProfile.channelDriver,
+          }),
+      )
+      .map((scenario) => scenario.id)
+      .toSorted();
+    expect(scenarioIds.toSorted()).toEqual(expectedScenarioIds);
     expect(new Set(scenarioIds).size).toBe(scenarioIds.length);
     const scenarioById = new Map(
-      readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario] as const),
+      scenarioPack.scenarios.map((scenario) => [scenario.id, scenario] as const),
     );
     expect(
       new Set(scenarioIds.map((scenarioId) => scenarioById.get(scenarioId)?.execution.kind)),


### PR DESCRIPTION
Closes #103655

## What Problem This Solves

Fixes an issue where the full release test suite failed whenever valid smoke scenarios were added, because the smoke-shard test hard-coded a catalog size of 98.

## Why This Change Was Made

The test now derives the exact expected scenario ID set from the current catalog, `smoke-ci` taxonomy profile, and mock-provider eligibility. It compares full set equality while retaining uniqueness, channel, execution-kind, and balanced-shard assertions.

## User Impact

Release CI no longer needs manual count bumps for legitimate QA catalog growth, and the test now detects actual missing or extra smoke scenarios instead of only count drift.

## Evidence

- Before on current main: `ci-smoke-plan.test.ts` expected 98 scenarios and received 100.
- Blacksmith Testbox through Crabbox `tbx_01kx5qan3y2kpr49rd9h4c5ajb`: focused test passed 1/1.
- Targeted formatting and `git diff --check` passed.
- Fresh autoreview: no accepted or actionable findings.
