### PR TITLE
fix(telegram): scope reply-fence abort authority to pre-adoption dispatch

### DIFF
--- a/extensions/telegram/AGENTS.md
+++ b/extensions/telegram/AGENTS.md
@@ -34,6 +34,11 @@ Verified against Telegram Bot API 10.1, July 1 2026.
   `OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS`) is the only ingress
   guillotine; it dead-letters with `handler-timeout` when claim→adoption
   stalls. Healthy long turns must not be killed by the spool watchdog.
+- Reply fence abort authority is pre-adoption only. At turn adoption the fence
+  releases its abort controller; core owns all further interruption (queue
+  interrupt mode, reply-run registry aborts). Normal messages never supersede
+  in any chat type; only authorized abort text and authorized explicit
+  commands do.
 - No per-message full-store writes. Hot-path SQLite writes are per-entry.
   Rewriting a cache on every send or read stalls the event loop, and that
   stall masquerades as a polling stall (the sent-message-cache regression).

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -5590,7 +5590,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredTexts).not.toContain("stale ambient answer");
   });
 
-  it("lets newer user requests abort active same-session dispatch", async () => {
+  it("keeps newer group requests from aborting active same-session dispatch", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);
     let firstStarted: (() => void) | undefined;
@@ -5607,18 +5607,19 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
     let firstAbortSignal: AbortSignal | undefined;
     dispatchReplyWithBufferedBlockDispatcher
-      .mockImplementationOnce(async ({ replyOptions }) => {
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
         firstAbortSignal = replyOptions?.abortSignal;
         firstStarted?.();
         await firstGate;
+        await dispatcherOptions.deliver({ text: "earlier group answer" }, { kind: "final" });
         return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
         };
       })
       .mockImplementationOnce(async ({ dispatcherOptions }) => {
         secondStarted?.();
-        await dispatcherOptions.deliver({ text: "fresh request answer" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "fresh group answer" }, { kind: "final" });
         return {
           queuedFinal: true,
           counts: { block: 0, final: 1, tool: 0 },
@@ -5660,7 +5661,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
     await secondStartGate;
 
-    expect(firstAbortSignal?.aborted).toBe(true);
+    expect(firstAbortSignal?.aborted).toBe(false);
     releaseFirst?.();
     await Promise.all([firstPromise, secondPromise]);
 
@@ -5669,7 +5670,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
         (reply) => reply.text,
       ),
     );
-    expect(deliveredTexts).toContain("fresh request answer");
+    expect(deliveredTexts).toContain("fresh group answer");
+    expect(deliveredTexts).toContain("earlier group answer");
   });
 
   it("keeps newer DM requests from aborting active same-session dispatch", async () => {
@@ -5908,6 +5910,264 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(sideAbortSignal?.aborted).toBe(true);
     releaseSide?.();
     await sidePromise;
+  });
+
+  it("releases fence abort authority at turn adoption", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstAbortSignal: AbortSignal | undefined;
+    let adoptTurn: (() => void | Promise<void>) | undefined;
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ replyOptions }) => {
+        firstAbortSignal = replyOptions?.abortSignal;
+        adoptTurn = replyOptions?.onTurnAdopted;
+        firstStarted?.();
+        await firstGate;
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async () => ({
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      }));
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+          text: body,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createGroupContext(99, "@bot long turn"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    expect(firstAbortSignal?.aborted).toBe(false);
+    expect(adoptTurn).toEqual(expect.any(Function));
+
+    // Before adoption, fence supersede still aborts the live controller.
+    const { beginTelegramReplyFence, endTelegramReplyFence, supersedeTelegramReplyFence } =
+      await import("./telegram-reply-fence.js");
+    const preAdoptController = new AbortController();
+    beginTelegramReplyFence({
+      key: "agent:main:telegram:group:pre-adopt",
+      supersede: false,
+      abortController: preAdoptController,
+    });
+    expect(supersedeTelegramReplyFence("agent:main:telegram:group:pre-adopt")).toBe(true);
+    expect(preAdoptController.signal.aborted).toBe(true);
+    endTelegramReplyFence("agent:main:telegram:group:pre-adopt");
+
+    // After adoption, the dispatch controller is released from the fence set so
+    // a later superseding peer (authorized explicit command) cannot abort it.
+    await adoptTurn?.();
+    expect(firstAbortSignal?.aborted).toBe(false);
+
+    await dispatchWithContext({
+      context: createGroupContext(100, "/export-trajectory bundle"),
+      streamMode: "off",
+    });
+    expect(firstAbortSignal?.aborted).toBe(false);
+    releaseFirst?.();
+    await firstPromise;
+  });
+
+  it("lets authorized /stop kill an adopted run without the released fence controller", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    // Core owns post-adoption abort via reply-run registry / handleStopCommand.
+    // Pin: after fence release, a core-owned abort still ends the run while the
+    // fence controller stays non-aborted.
+    const coreRunController = new AbortController();
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let firstAbortSignal: AbortSignal | undefined;
+    let adoptTurn: (() => void | Promise<void>) | undefined;
+    let runSettled = false;
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ replyOptions }) => {
+        firstAbortSignal = replyOptions?.abortSignal;
+        adoptTurn = replyOptions?.onTurnAdopted;
+        firstStarted?.();
+        await new Promise<void>((resolve) => {
+          const finish = () => {
+            if (runSettled) {
+              return;
+            }
+            runSettled = true;
+            resolve();
+          };
+          firstAbortSignal?.addEventListener("abort", finish, { once: true });
+          coreRunController.signal.addEventListener("abort", finish, { once: true });
+        });
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async () => {
+        // Simulate core handleStopCommand / abortReplyRunBySessionId effect on the
+        // adopted registry-owned run (independent of the released fence controller).
+        coreRunController.abort();
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      });
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+          text: body,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createGroupContext(99, "@bot long adopted turn"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    await adoptTurn?.();
+    expect(firstAbortSignal?.aborted).toBe(false);
+    expect(coreRunController.signal.aborted).toBe(false);
+
+    await dispatchWithContext({
+      context: createGroupContext(100, "/stop"),
+      streamMode: "off",
+    });
+
+    await firstPromise;
+    expect(firstAbortSignal?.aborted).toBe(false);
+    expect(coreRunController.signal.aborted).toBe(true);
+  });
+
+  it("keeps overlapping group deliveries non-superseded", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let secondStarted: (() => void) | undefined;
+    const secondStartGate = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onTurnAdopted?.();
+        firstStarted?.();
+        await firstGate;
+        await dispatcherOptions.deliver({ text: "earlier group answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onTurnAdopted?.();
+        secondStarted?.();
+        await dispatcherOptions.deliver({ text: "fresh group answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createGroupContext(99, "@bot first request"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    const secondPromise = dispatchWithContext({
+      context: createGroupContext(100, "@bot second request"),
+      streamMode: "off",
+    });
+    await secondStartGate;
+    releaseFirst?.();
+    await Promise.all([firstPromise, secondPromise]);
+
+    const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text,
+      ),
+    );
+    expect(deliveredTexts).toContain("earlier group answer");
+    expect(deliveredTexts).toContain("fresh group answer");
   });
 
   it("does not drop the first chunk of a long final after a generic lane rotation", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1510,7 +1510,9 @@ export const dispatchTelegramMessage = async ({
         activeKey: replyFenceKey.activeKey,
         laneKey: scopedReplyFenceLaneKey,
       });
-  if (!isRoomEvent && supersedeReplyFence) {
+  // Ambient room-event work uses a separate fence key. Any non-room-event
+  // inbound may cancel it without owning abort authority over adopted user turns.
+  if (!isRoomEvent) {
     supersedeTelegramReplyFence(replyFenceKey.roomEventKey);
   }
   replyFenceGeneration = beginTelegramReplyFence({
@@ -2622,7 +2624,17 @@ export const dispatchTelegramMessage = async ({
                   skillFilter,
                   disableBlockStreaming,
                   abortSignal: replyAbortController.signal,
-                  ...(onTurnAdopted ? { onTurnAdopted } : {}),
+                  onTurnAdopted: async () => {
+                    // Fence abort authority ends at adoption. Core (queue interrupt
+                    // mode / reply-run registry abort) is the sole owner of killing
+                    // adopted runs; without this release a channel supersede could
+                    // kill an owned turn (#85361 sibling, group incident 2026-07-10).
+                    releaseTelegramReplyFenceAbortController(
+                      activeReplyFenceKey,
+                      replyAbortController,
+                    );
+                    await onTurnAdopted?.();
+                  },
                   sourceReplyDeliveryMode: isRoomEvent ? "message_tool_only" : undefined,
                   queuedDeliveryCorrelations: isRoomEvent
                     ? [{ begin: beginDeliveryCorrelation }]

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   beginTelegramReplyFence,
   buildTelegramNonInterruptingReplyFenceKey,
+  isTelegramReplyFenceSuperseded,
+  releaseTelegramReplyFenceAbortController,
   resetTelegramReplyFenceForTests,
   shouldSupersedeTelegramReplyFence,
   supersedeTelegramReplyFence,
@@ -24,15 +26,17 @@ describe("shouldSupersedeTelegramReplyFence", () => {
     ).toBe(false);
   });
 
-  it("keeps normal turns and authorized aborts interrupting active runs", () => {
+  it("keeps normal turns from superseding while preserving authorized aborts and commands", () => {
     expect(
       shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
         CommandBody: "@bot answer this",
         CommandAuthorized: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
         CommandBody: "/stop",
         CommandAuthorized: true,
       }),
@@ -108,6 +112,44 @@ describe("shouldSupersedeTelegramReplyFence", () => {
       }),
     ).toBe(true);
   });
+
+  it("applies the same supersede rule in groups as in direct chats", () => {
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
+        CommandBody: "answer this",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
+        CommandBody: "/stop",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
+        CommandBody: "/diagnostics confirm abc123def456",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        ChatType: "group",
+        CommandBody: "/plugin_command",
+        CommandAuthorized: true,
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          commandName: "plugin_command",
+          body: "/plugin_command",
+        },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("telegram reply fence supersede", () => {
@@ -133,6 +175,30 @@ describe("telegram reply fence supersede", () => {
     expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
     expect(mainController.signal.aborted).toBe(true);
     expect(sideController.signal.aborted).toBe(true);
+    resetTelegramReplyFenceForTests();
+  });
+
+  it("keeps released controllers from being aborted by later fence supersedes", () => {
+    resetTelegramReplyFenceForTests();
+    const activeKey = "agent:main:telegram:group:-100123";
+    const adoptedController = new AbortController();
+    const generation = beginTelegramReplyFence({
+      key: activeKey,
+      supersede: true,
+      abortController: adoptedController,
+    });
+    releaseTelegramReplyFenceAbortController(activeKey, adoptedController);
+
+    // Supersede still bumps generation for delivery staleness, but the released
+    // controller is no longer in the fence set so it is not aborted.
+    expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
+    expect(adoptedController.signal.aborted).toBe(false);
+    expect(
+      isTelegramReplyFenceSuperseded({
+        key: activeKey,
+        generation,
+      }),
+    ).toBe(true);
     resetTelegramReplyFenceForTests();
   });
 });

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -221,17 +221,13 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   ) {
     return false;
   }
-  if (ctxPayload.ChatType === "direct") {
-    if (
-      ctxPayload.CommandAuthorized &&
-      (isExplicitCommandTurn(ctxPayload.CommandTurn) ||
-        isRecognizedTelegramTextCommand(dispatchText))
-    ) {
-      return true;
-    }
-    return false;
-  }
-  return true;
+  // One rule for all chat types: only authorized explicit/native commands
+  // supersede. Normal messages never abort an active turn at the transport
+  // fence; core queue policy owns steer/followup/interrupt after adoption.
+  return (
+    ctxPayload.CommandAuthorized &&
+    (isExplicitCommandTurn(ctxPayload.CommandTurn) || isRecognizedTelegramTextCommand(dispatchText))
+  );
 }
 
 export function resetTelegramReplyFenceForTests(): void {


### PR DESCRIPTION
## What Problem This Solves

Production incident 2026-07-10 (main @ f74e0184a60): a user @-tagged the bot during a long-running group turn and the turn was killed ~30ms later — the in-flight job (a remote generation task) was orphaned. Cause: `shouldSupersedeTelegramReplyFence` returned `true` for EVERY normal group message, so the transport fence aborted the previous dispatch's controller before core queue policy (steer/followup) ever ran. DMs were fixed in #85361; groups kept the kill switch, unreachable mid-run until #103549 freed the ingress lane. Telegram was the only channel holding a transport-level kill switch over agent turns.

Root cause: two owners of turn-interruption authority — core (queue `interrupt` mode, reply-run registry aborts) and the Telegram fence.

## Why This Change Was Made

Core becomes the sole owner of aborting adopted turns; the fence is scoped to pre-adoption dispatch work:

1. **One supersede rule for all chat types** (`telegram-reply-fence.ts`, net −4 LOC): only authorized abort text and authorized explicit/native commands supersede. Normal messages never abort at the transport fence and never bump the delivery generation (avoids silent-zombie turns whose sends would be marked stale). This is the DM rule from #85361 applied everywhere — the chat-type branch is deleted.
2. **Fence releases its abort controller at turn adoption** (`bot-message-dispatch.ts`, composed with the #103549 `onTurnAdopted` hook): pre-adoption, an authorized supersede still cancels moot dispatch work (legitimately transport-scoped); post-adoption, the fence structurally cannot kill the run.
3. **`/stop` verified independent of the fence**: core path already existed (`handleStopCommand` → `abortSessionRunTargetWithOutcome` → registry/embedded abort) — pinned by a new test that kills an adopted run after the fence controller was released. No wiring needed.
4. Ambient room-event fences (separate key) now cancel on any user inbound — preserves the "current context outranks stale ambient work" contract under the collapsed rule.

## User Impact

Tagging the bot while it works no longer kills the job on any chat type: the message steers into the live turn (or queues as a followup) per core queue policy, the turn finishes, and both answers deliver. `/stop`, `/btw` lanes, DM overlap deliverability, and room-event contracts are unchanged.

## Evidence

- Tests: replaced the two pins of the group-kill behavior (fence "keeps normal turns…interrupting", dispatch "lets newer user requests abort active same-session dispatch") with survives-and-delivers-both equivalents; added adoption-release, /stop-kills-adopted-run-via-core, and group-overlap-deliverability pins; DM/#85361, /btw, room-event, and child-cascade contracts kept passing unchanged. Full `extensions/telegram` suite: 2495 tests green; tsgo core+extensions, oxlint, oxfmt, `git diff --check` all clean. +8 net prod LOC.
- **Live gateway reproduction** (ephemeral gateway from this branch, isolated state dir, mock Bot API via `channels.telegram.apiRoot`, mock OpenAI provider streaming a 20s "long task" turn; mid-turn @-mention injected 2s in): long turn's provider stream ran to completion through the tag (`turn1_finished: true, turn1_aborted: false`), final answer delivered via the streaming edit, second message answered — where production on current main shows the turn dying ~30ms after the tag (lane task `AbortError` 5s/36s into turns, 2026-07-10 10:09–10:15 UTC logs).
