### PR TITLE
fix(ui): avoid CSP eval violations during startup

### DIFF
--- a/ui/src/app/custom-theme-jitless.test.ts
+++ b/ui/src/app/custom-theme-jitless.test.ts
@@ -1,0 +1,41 @@
+// Control UI tests cover Zod initialization under the Gateway's strict CSP.
+import { describe, expect, it, vi } from "vitest";
+
+describe("custom theme Zod initialization", () => {
+  it("enables jitless mode before object schemas probe dynamic code", async () => {
+    vi.resetModules();
+    const { z } = await import("zod");
+    const config = z.config();
+    const previousJitless = config.jitless;
+    delete config.jitless;
+
+    const NativeFunction = globalThis.Function;
+    let evalProbeAttempted = false;
+    const FunctionProxy = new Proxy(NativeFunction, {
+      apply(target, thisArg, args) {
+        evalProbeAttempted ||= args.length === 1 && args[0] === "";
+        return Reflect.apply(target, thisArg, args);
+      },
+      construct(target, args, newTarget) {
+        evalProbeAttempted ||= args.length === 1 && args[0] === "";
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    vi.stubGlobal("Function", FunctionProxy);
+
+    try {
+      await import("./custom-theme.ts");
+
+      expect(z.config().jitless).toBe(true);
+      expect(evalProbeAttempted).toBe(false);
+    } finally {
+      vi.unstubAllGlobals();
+      if (previousJitless === undefined) {
+        delete config.jitless;
+      } else {
+        config.jitless = previousJitless;
+      }
+      vi.resetModules();
+    }
+  });
+});

--- a/ui/src/app/custom-theme.ts
+++ b/ui/src/app/custom-theme.ts
@@ -3,6 +3,10 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { z } from "zod";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
 
+// The Control UI CSP forbids dynamic code generation. Zod snapshots this flag
+// when z.object() is constructed, before its eval-backed fast path can probe.
+z.config({ jitless: true });
+
 const TWEAKCN_HOSTS = new Set(["tweakcn.com", "www.tweakcn.com"]);
 const THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const CUSTOM_THEME_STYLE_ID = "openclaw-custom-theme";

--- a/ui/src/e2e/csp-jitless.e2e.test.ts
+++ b/ui/src/e2e/csp-jitless.e2e.test.ts
@@ -1,0 +1,96 @@
+// Control UI tests cover startup under the Gateway's strict script policy.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  buildControlUiCspHeader,
+  computeInlineScriptHashes,
+} from "../../../src/gateway/control-ui-csp.ts";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI strict CSP E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("starts without probing eval under the Gateway script policy", async () => {
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    await context.addInitScript(() => {
+      const violations: Array<{ blockedUri: string; effectiveDirective: string }> = [];
+      Object.assign(globalThis, { __openclawCspViolations: violations });
+      document.addEventListener("securitypolicyviolation", (event) => {
+        violations.push({
+          blockedUri: event.blockedURI,
+          effectiveDirective: event.effectiveDirective,
+        });
+      });
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+    await page.route(server.baseUrl, async (route) => {
+      const response = await route.fetch();
+      const body = await response.text();
+      const csp = buildControlUiCspHeader({
+        inlineScriptHashes: computeInlineScriptHashes(body),
+      });
+      await route.fulfill({
+        body,
+        headers: { ...response.headers(), "content-security-policy": csp },
+        response,
+      });
+    });
+
+    try {
+      const response = await page.goto(server.baseUrl);
+      expect(response?.status()).toBe(200);
+      const csp = response?.headers()["content-security-policy"];
+      expect(csp).toBeDefined();
+      expect(csp).not.toContain("'unsafe-eval'");
+      await gateway.waitForRequest("connect");
+      await page
+        .locator(".agent-chat__composer-combobox textarea")
+        .waitFor({ state: "visible", timeout: 10_000 });
+
+      const evalViolations = await page.evaluate(() => {
+        const violations = (
+          globalThis as typeof globalThis & {
+            __openclawCspViolations?: Array<{
+              blockedUri: string;
+              effectiveDirective: string;
+            }>;
+          }
+        )["__openclawCspViolations"];
+        return (violations ?? []).filter(
+          (violation) =>
+            violation.blockedUri === "eval" &&
+            violation.effectiveDirective.startsWith("script-src"),
+        );
+      });
+      expect(evalViolations).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #78362

Related: #103124

## What Problem This Solves

Fixes an issue where opening the Control UI under the Gateway's strict Content Security Policy would trigger a blocked dynamic-code violation during startup. Zod caught the denial and fell back to its interpreter, so the verified impact is a CSP warning and lost validator fast path—not the fatal startup or 2026.6.11-only regression claimed by the duplicate report.

## Why This Change Was Made

Configure Zod's supported `jitless` mode before the Control UI constructs its custom-theme object schemas. This keeps `script-src 'self'` strict, avoids broad `unsafe-eval`, and leaves the separately reported bootstrap-config authentication flow unchanged because current `main` already skips unauthenticated fetches and refreshes after authenticated Gateway hello.

The regression tests prove both the dependency ordering contract and a real Chromium startup under the same CSP generated by the Gateway. AI-assisted; implementation and dependency contract reviewed before submission.

## User Impact

Control UI startup no longer probes blocked dynamic code. Operators retain the strict Gateway CSP without browser policy noise or Zod's CSP-triggered fallback.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kx5w0jaesvq913eq5vzfpj91` (`amber-krill`)
- Focused exact-head tests: 15 custom-theme/unit assertions plus 1 Chromium E2E assertion
- Changed-surface gate: production/test typecheck, 242-rule lint, database-first and sidecar guards, zero runtime import cycles
- Full `pnpm build`, including production Control UI bundle
- Built-UI Gateway proof: real `handleControlUiHttpRequest` served `dist/control-ui`; Chromium returned HTTP 200 with strict `script-src 'self'`, no `unsafe-eval`, zero eval policy violations, zero page errors, and a 44,557-byte rendered screenshot
- Fresh autoreview: no accepted or actionable findings

The root changelog is release-owned and is intentionally unchanged.
