### PR TITLE
fix(ui): guard cron page registration

### DIFF
--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -130,6 +130,16 @@ afterEach(() => {
 });
 
 describe("CronPage lifecycle", () => {
+  it("registers idempotently after a module reset with the shared custom element registry", async () => {
+    const registered = customElements.get("openclaw-cron-page");
+    expect(registered).toBeDefined();
+
+    vi.resetModules();
+    await expect(import("./cron-page.ts")).resolves.toBeDefined();
+
+    expect(customElements.get("openclaw-cron-page")).toBe(registered);
+  });
+
   it("replaces all mutable page state on each connection epoch", async () => {
     const request = createRequest();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -460,4 +460,7 @@ class CronPage extends OpenClawLightDomElement {
   }
 }
 
-customElements.define("openclaw-cron-page", CronPage);
+// Module re-evaluation can retain the shared registry (for example, in Vitest).
+if (!customElements.get("openclaw-cron-page")) {
+  customElements.define("openclaw-cron-page", CronPage);
+}


### PR DESCRIPTION
Closes #103662

## What Problem This Solves

Fixes an issue where the Control UI unit suite could fail during test collection when the cron page module was evaluated again while the shared custom-element registry was retained.

## Why This Change Was Made

The cron page now registers its custom element only when that tag is not already present. A deterministic module-reset regression test verifies that re-evaluation preserves the original registered constructor instead of throwing; other page registrations are intentionally unchanged.

## User Impact

Control UI tests no longer depend on whether the cron page or gateway source-replacement suite runs first. Runtime cron-page behavior is unchanged.

## Evidence

- Before: the new regression failed on `9330ad86ffdaae640ff778572028644afe29d92a` with `NotSupportedError: This name has already been registered in the registry` (1 failed, 3 passed).
- After: focused cron-page unit test: 4/4 passed.
- Importer pair, single worker/no file parallelism: 19/19 passed in both gateway-to-cron and cron-to-gateway (seed 3) orders.
- Full UI unit lane, single worker/no file parallelism: 194/194 files, 2,810/2,810 tests passed.
- Focused Chromium cron E2E: 1/1 file, 2/2 tests passed.
- `pnpm format:check` for both files and scoped `pnpm check:changed`: passed.
- Fresh autoreview: clean, no accepted or actionable findings.
- Final PR head `198ce09694449f2651a82f7fabc5402859628fd0`: cron-to-gateway importer order passed 19/19 on Testbox `tbx_01kx5vs4jr6ppbjph5004vt5gt`.
