### PR TITLE
fix(ci): preflight locale publisher permissions

### DIFF
--- a/.github/actions/create-generated-pr-tokens/action.yml
+++ b/.github/actions/create-generated-pr-tokens/action.yml
@@ -1,0 +1,47 @@
+name: Create generated PR tokens
+description: Mint repo-scoped GitHub App tokens for generated branch and pull request publication.
+
+inputs:
+  contents-client-id:
+    description: GitHub App client id with contents write access.
+    required: true
+  contents-private-key:
+    description: GitHub App private key with contents write access.
+    required: true
+  pull-request-app-id:
+    description: GitHub App id with pull-request write access.
+    required: true
+  pull-request-private-key:
+    description: GitHub App private key with pull-request write access.
+    required: true
+
+outputs:
+  contents-token:
+    description: Repository-scoped contents-write installation token.
+    value: ${{ steps.contents-token.outputs.token }}
+  pull-request-token:
+    description: Repository-scoped pull-request-write installation token.
+    value: ${{ steps.pull-request-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create generated branch app token
+      id: contents-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        client-id: ${{ inputs.contents-client-id }}
+        private-key: ${{ inputs.contents-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-contents: write
+
+    - name: Create generated PR app token
+      id: pull-request-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      with:
+        app-id: ${{ inputs.pull-request-app-id }}
+        private-key: ${{ inputs.pull-request-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-pull-requests: write

--- a/.github/actions/publish-generated-pr/action.yml
+++ b/.github/actions/publish-generated-pr/action.yml
@@ -2,11 +2,11 @@ name: Publish generated pull request
 description: Commit generated files to an automation branch and open or update its pull request.
 
 inputs:
-  primary-private-key:
-    description: Primary OpenClaw GitHub App private key.
+  contents-client-id:
+    description: GitHub App client id with contents write access.
     required: true
-  fallback-private-key:
-    description: Fallback OpenClaw GitHub App private key.
+  contents-private-key:
+    description: GitHub App private key with contents write access.
     required: true
   pull-request-app-id:
     description: GitHub App id with pull-request write access.
@@ -39,39 +39,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create generated branch app token
-      id: contents-token
-      continue-on-error: true
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+    - name: Create generated PR tokens
+      id: tokens
+      uses: ./.github/actions/create-generated-pr-tokens
       with:
-        app-id: "2729701"
-        private-key: ${{ inputs.primary-private-key }}
-        permission-contents: write
-
-    - name: Create generated branch fallback app token
-      id: contents-token-fallback
-      if: steps.contents-token.outcome == 'failure'
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-      with:
-        app-id: "2971289"
-        private-key: ${{ inputs.fallback-private-key }}
-        permission-contents: write
-
-    - name: Create generated PR app token
-      id: pull-request-token
-      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-      with:
-        app-id: ${{ inputs.pull-request-app-id }}
-        private-key: ${{ inputs.pull-request-private-key }}
-        owner: ${{ github.repository_owner }}
-        repositories: ${{ github.event.repository.name }}
-        permission-pull-requests: write
+        contents-client-id: ${{ inputs.contents-client-id }}
+        contents-private-key: ${{ inputs.contents-private-key }}
+        pull-request-app-id: ${{ inputs.pull-request-app-id }}
+        pull-request-private-key: ${{ inputs.pull-request-private-key }}
 
     - name: Publish generated pull request
       shell: bash
       env:
-        CONTENTS_TOKEN: ${{ steps.contents-token.outputs.token || steps.contents-token-fallback.outputs.token }}
-        GH_TOKEN: ${{ steps.pull-request-token.outputs.token }}
+        CONTENTS_TOKEN: ${{ steps.tokens.outputs.contents-token }}
+        GH_TOKEN: ${{ steps.tokens.outputs.pull-request-token }}
         BASE_BRANCH: ${{ inputs.base-branch }}
         HEAD_BRANCH: ${{ inputs.head-branch }}
         COMMIT_MESSAGE: ${{ inputs.commit-message }}
@@ -88,7 +69,7 @@ runs:
         export GIT_TERMINAL_PROMPT=0
 
         if [[ -z "${CONTENTS_TOKEN:-}" ]]; then
-          echo "Generated branch publication requires an OpenClaw contents-write App token." >&2
+          echo "Generated branch publication requires a contents-write App token." >&2
           exit 1
         fi
         if [[ -z "${GH_TOKEN:-}" ]]; then

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -11,6 +11,7 @@ on:
       - ui/src/i18n/lib/types.ts
       - ui/src/i18n/lib/registry.ts
       - scripts/control-ui-i18n.ts
+      - .github/actions/create-generated-pr-tokens/action.yml
       - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/control-ui-locale-refresh.yml
   release:
@@ -19,14 +20,23 @@ on:
   schedule:
     - cron: "23 4 * * *"
   workflow_dispatch:
+    inputs:
+      token_preflight_only:
+        description: Verify generated PR App permissions without running locale generation.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: control-ui-locale-refresh
-  # Finish the active full refresh; GitHub retains only the newest pending run for this group.
-  # Publisher overlap checks defer stale generated paths to that queued reconciliation run.
+  group: >-
+    ${{ github.event_name == 'workflow_dispatch' && inputs.token_preflight_only &&
+      format('control-ui-locale-token-preflight-{0}', github.ref) ||
+      'control-ui-locale-refresh' }}
+  # Full refreshes stay serialized; cheap App-permission probes get a ref-scoped group.
+  # Publisher overlap checks defer stale generated paths to the queued full reconciliation run.
   cancel-in-progress: false
 
 jobs:
@@ -38,27 +48,57 @@ jobs:
     outputs:
       sha: ${{ steps.base.outputs.sha }}
     steps:
-      - name: Resolve default branch head
+      - name: Resolve source commit
         id: base
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
+          TOKEN_PREFLIGHT_ONLY: ${{ inputs.token_preflight_only || false }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          sha="$(
-            timeout --signal=TERM --kill-after=10s 60s \
-              gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha
-          )"
+          if [[ "${TOKEN_PREFLIGHT_ONLY}" == "true" ]]; then
+            sha="${WORKFLOW_SHA}"
+          else
+            sha="$(
+              timeout --signal=TERM --kill-after=10s 60s \
+                gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha
+            )"
+          fi
           if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Unable to resolve ${DEFAULT_BRANCH} to an exact commit." >&2
+            echo "Unable to resolve the locale refresh source to an exact commit." >&2
             exit 1
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 
-  refresh:
+  publisher-preflight:
+    name: Verify generated PR App permissions
     needs: resolve-base
     if: needs.resolve-base.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.resolve-base.outputs.sha }}
+          persist-credentials: false
+          submodules: false
+
+      - name: Create generated PR tokens
+        uses: ./.github/actions/create-generated-pr-tokens
+        with:
+          contents-client-id: Iv23liOECG0slfuhz093
+          contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
+
+  refresh:
+    needs: [resolve-base, publisher-preflight]
+    if: >-
+      needs.resolve-base.result == 'success' &&
+      needs.publisher-preflight.result == 'success' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.token_preflight_only)
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -199,8 +239,12 @@ jobs:
 
   finalize:
     name: Commit control UI locale refresh
-    needs: [resolve-base, refresh]
-    if: needs.resolve-base.result == 'success' && needs.refresh.result == 'success'
+    needs: [resolve-base, publisher-preflight, refresh]
+    if: >-
+      needs.resolve-base.result == 'success' &&
+      needs.publisher-preflight.result == 'success' &&
+      needs.refresh.result == 'success' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.token_preflight_only)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -238,8 +282,8 @@ jobs:
       - name: Open or update generated locale PR
         uses: ./.github/actions/publish-generated-pr
         with:
-          primary-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          fallback-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          contents-client-id: Iv23liOECG0slfuhz093
+          contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
@@ -254,6 +298,7 @@ jobs:
             ui/src/i18n/lib/types.ts
             ui/src/i18n/lib/registry.ts
             scripts/control-ui-i18n.ts
+            .github/actions/create-generated-pr-tokens/action.yml
             .github/actions/publish-generated-pr/action.yml
             .github/workflows/control-ui-locale-refresh.yml
           pr-body: |

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -15,6 +15,7 @@ on:
       - scripts/control-ui-i18n.ts
       - scripts/native-app-i18n.ts
       - ui/src/i18n/.i18n/glossary.*.json
+      - .github/actions/create-generated-pr-tokens/action.yml
       - .github/actions/publish-generated-pr/action.yml
       - .github/workflows/native-app-locale-refresh.yml
   workflow_dispatch:
@@ -55,9 +56,32 @@ jobs:
           fi
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 
-  refresh:
+  publisher-preflight:
+    name: Verify generated PR App permissions
     needs: resolve-base
     if: needs.resolve-base.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.resolve-base.outputs.sha }}
+          persist-credentials: false
+          submodules: false
+
+      - name: Create generated PR tokens
+        uses: ./.github/actions/create-generated-pr-tokens
+        with:
+          contents-client-id: Iv23liOECG0slfuhz093
+          contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
+          pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
+
+  refresh:
+    needs: [resolve-base, publisher-preflight]
+    if: >-
+      needs.resolve-base.result == 'success' &&
+      needs.publisher-preflight.result == 'success'
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -199,8 +223,11 @@ jobs:
 
   finalize:
     name: Commit native locale refresh
-    needs: [resolve-base, refresh]
-    if: needs.resolve-base.result == 'success' && needs.refresh.result == 'success'
+    needs: [resolve-base, publisher-preflight, refresh]
+    if: >-
+      needs.resolve-base.result == 'success' &&
+      needs.publisher-preflight.result == 'success' &&
+      needs.refresh.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -243,8 +270,8 @@ jobs:
       - name: Open or update generated locale PR
         uses: ./.github/actions/publish-generated-pr
         with:
-          primary-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          fallback-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          contents-client-id: Iv23liOECG0slfuhz093
+          contents-private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           pull-request-app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
           pull-request-private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
           base-branch: ${{ github.event.repository.default_branch }}
@@ -263,6 +290,7 @@ jobs:
             scripts/control-ui-i18n.ts
             scripts/native-app-i18n.ts
             ui/src/i18n/.i18n/glossary.*.json
+            .github/actions/create-generated-pr-tokens/action.yml
             .github/actions/publish-generated-pr/action.yml
             .github/workflows/native-app-locale-refresh.yml
           pr-body: |

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -632,6 +632,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ],
   [".crabbox.yaml", ["test/scripts/package-acceptance-workflow.test.ts"]],
   [".github/actions/detect-docs-changes/action.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
+  [
+    ".github/actions/create-generated-pr-tokens/action.yml",
+    ["test/scripts/ci-workflow-guards.test.ts"],
+  ],
   [".github/actions/publish-generated-pr/action.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
   [
     ".github/actions/docker-e2e-plan/action.yml",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -28,6 +28,7 @@ const OPENGREP_PR_DIFF_WORKFLOW = ".github/workflows/opengrep-precise.yml";
 const OPENGREP_FULL_WORKFLOW = ".github/workflows/opengrep-precise-full.yml";
 const CONTROL_UI_LOCALE_REFRESH_WORKFLOW = ".github/workflows/control-ui-locale-refresh.yml";
 const NATIVE_APP_LOCALE_REFRESH_WORKFLOW = ".github/workflows/native-app-locale-refresh.yml";
+const CREATE_GENERATED_PR_TOKENS_ACTION = ".github/actions/create-generated-pr-tokens/action.yml";
 const PUBLISH_GENERATED_PR_ACTION = ".github/actions/publish-generated-pr/action.yml";
 
 function readCiWorkflow() {
@@ -201,7 +202,7 @@ function runGeneratedPublisherScenario(
       'while [[ "$#" -gt 0 ]]; do',
       '  case "$1" in',
       "    --signal=*|--kill-after=*) shift ;;",
-      '    [0-9]*s) shift; break ;;',
+      "    [0-9]*s) shift; break ;;",
       "    *) break ;;",
       "  esac",
       "done",
@@ -369,6 +370,8 @@ describe("ci workflow guards", () => {
     const workflow = parse(readFileSync(NATIVE_APP_LOCALE_REFRESH_WORKFLOW, "utf8"));
     const controlUiResolveBase = controlUiWorkflow.jobs["resolve-base"];
     const nativeResolveBase = workflow.jobs["resolve-base"];
+    const controlUiPreflight = controlUiWorkflow.jobs["publisher-preflight"];
+    const nativePreflight = workflow.jobs["publisher-preflight"];
     const refresh = workflow.jobs.refresh;
     const nativeFinalize = workflow.jobs.finalize;
     const controlUiFinalize = controlUiWorkflow.jobs.finalize;
@@ -385,12 +388,18 @@ describe("ci workflow guards", () => {
       (step: { name?: string }) => step.name === "Refresh control UI locale files",
     );
 
-    expect(refresh.if).toBe("needs.resolve-base.result == 'success'");
+    expect(refresh.if).toBe(
+      "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success'",
+    );
     expect(refresh.strategy.matrix.locale).toEqual(NATIVE_I18N_LOCALES);
     expect(controlUiWorkflow.concurrency["cancel-in-progress"]).toBe(false);
-    expect(controlUiWorkflow.concurrency.group).toBe("control-ui-locale-refresh");
+    expect(controlUiWorkflow.concurrency.group.replace(/\s+/gu, " ")).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.token_preflight_only && format('control-ui-locale-token-preflight-{0}', github.ref) || 'control-ui-locale-refresh' }}",
+    );
     expect(controlUiWorkflow.jobs.plan).toBeUndefined();
-    expect(controlUiWorkflow.jobs.refresh.if).toBe("needs.resolve-base.result == 'success'");
+    expect(controlUiWorkflow.jobs.refresh.if).toBe(
+      "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.token_preflight_only)",
+    );
     expect(controlUiWorkflow.jobs.refresh.strategy.matrix.locale).toEqual(
       SUPPORTED_LOCALES.filter((locale) => locale !== "en"),
     );
@@ -398,6 +407,22 @@ describe("ci workflow guards", () => {
     expect(workflow.concurrency.group).toBe("native-app-locale-refresh");
     expect(controlUiResolveBase.if).not.toContain("chore(ui): refresh control ui locales");
     expect(nativeResolveBase.if).not.toContain("chore(i18n): refresh native locales");
+    const controlResolveCondition = controlUiResolveBase.if.replace(/\s+/gu, " ");
+    expect(controlResolveCondition).toBe(
+      "github.repository == 'openclaw/openclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')",
+    );
+    expect(controlResolveCondition).not.toContain("inputs.token_preflight_only");
+    expect(controlResolveCondition).not.toContain("github.ref_type");
+    expect(nativeResolveBase.if).toBe(
+      "github.repository == 'openclaw/openclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')",
+    );
+    expect(controlUiWorkflow.on.workflow_dispatch.inputs.token_preflight_only).toEqual({
+      description: "Verify generated PR App permissions without running locale generation.",
+      required: false,
+      default: false,
+      type: "boolean",
+    });
+    expect(workflow.on.workflow_dispatch?.inputs).toBeUndefined();
     expect(workflow.on.push.paths).toContain("ui/src/i18n/.i18n/glossary.*.json");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native/**");
     expect(workflow.on.push.paths).toContain("apps/.i18n/native-source.json");
@@ -425,10 +450,15 @@ describe("ci workflow guards", () => {
     expect(controlUiRefreshStep.env.OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL).toBe("0");
 
     for (const ownerWorkflow of [controlUiWorkflow, workflow]) {
+      expect(ownerWorkflow.on.push.paths).toContain(CREATE_GENERATED_PR_TOKENS_ACTION);
       expect(ownerWorkflow.on.push.paths).toContain(PUBLISH_GENERATED_PR_ACTION);
       const resolveBase = ownerWorkflow.jobs["resolve-base"];
       const resolveStep = resolveBase.steps.find(
-        (step: { name?: string }) => step.name === "Resolve default branch head",
+        (step: { name?: string }) =>
+          step.name ===
+          (ownerWorkflow === controlUiWorkflow
+            ? "Resolve source commit"
+            : "Resolve default branch head"),
       );
       expect(resolveBase.outputs.sha).toBe("${{ steps.base.outputs.sha }}");
       expect(resolveStep.env.GH_TOKEN).toBe("${{ github.token }}");
@@ -448,41 +478,84 @@ describe("ci workflow guards", () => {
       }
     }
 
-    const publishAction = parse(readFileSync(PUBLISH_GENERATED_PR_ACTION, "utf8"));
-    const primaryTokenStep = publishAction.runs.steps.find(
+    const controlUiResolveStep = controlUiResolveBase.steps.find(
+      (step: { name?: string }) => step.name === "Resolve source commit",
+    );
+    expect(controlUiResolveStep.env.TOKEN_PREFLIGHT_ONLY).toContain("inputs.token_preflight_only");
+    expect(controlUiResolveStep.env.WORKFLOW_SHA).toBe("${{ github.workflow_sha }}");
+    expect(controlUiResolveStep.run).toContain(
+      'if [[ "${TOKEN_PREFLIGHT_ONLY}" == "true" ]]; then',
+    );
+    expect(controlUiResolveStep.run).toContain('sha="${WORKFLOW_SHA}"');
+
+    for (const preflight of [controlUiPreflight, nativePreflight]) {
+      expect(preflight.needs).toBe("resolve-base");
+      expect(preflight.if).toBe("needs.resolve-base.result == 'success'");
+      expect(preflight.strategy).toBeUndefined();
+      expect(preflight.steps).toHaveLength(2);
+      const checkoutStep = preflight.steps.find(
+        (step: { uses?: string }) => step.uses === CHECKOUT_V6,
+      );
+      const tokensStep = preflight.steps.find(
+        (step: { name?: string }) => step.name === "Create generated PR tokens",
+      );
+      expect(checkoutStep.with).toMatchObject({
+        ref: "${{ needs.resolve-base.outputs.sha }}",
+        "persist-credentials": false,
+      });
+      expect(tokensStep.uses).toBe("./.github/actions/create-generated-pr-tokens");
+      expect(tokensStep.with).toEqual({
+        "contents-client-id": "Iv23liOECG0slfuhz093",
+        "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
+        "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
+        "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
+      });
+    }
+
+    const tokenAction = parse(readFileSync(CREATE_GENERATED_PR_TOKENS_ACTION, "utf8"));
+    const tokenActionSource = readFileSync(CREATE_GENERATED_PR_TOKENS_ACTION, "utf8");
+    const contentsTokenStep = tokenAction.runs.steps.find(
       (step: { name?: string }) => step.name === "Create generated branch app token",
     );
-    const fallbackTokenStep = publishAction.runs.steps.find(
-      (step: { name?: string }) => step.name === "Create generated branch fallback app token",
-    );
-    const pullRequestTokenStep = publishAction.runs.steps.find(
+    const pullRequestTokenStep = tokenAction.runs.steps.find(
       (step: { name?: string }) => step.name === "Create generated PR app token",
+    );
+    const publishAction = parse(readFileSync(PUBLISH_GENERATED_PR_ACTION, "utf8"));
+    const publishActionSource = readFileSync(PUBLISH_GENERATED_PR_ACTION, "utf8");
+    const createTokensStep = publishAction.runs.steps.find(
+      (step: { name?: string }) => step.name === "Create generated PR tokens",
     );
     const actionPublishStep = publishAction.runs.steps.find(
       (step: { name?: string }) => step.name === "Publish generated pull request",
     );
 
-    expect(primaryTokenStep).toMatchObject({
+    expect(tokenAction.runs.steps).toHaveLength(2);
+    for (const input of [
+      "contents-client-id",
+      "contents-private-key",
+      "pull-request-app-id",
+      "pull-request-private-key",
+    ]) {
+      expect(tokenAction.inputs[input].required).toBe(true);
+      expect(publishAction.inputs[input].required).toBe(true);
+    }
+    expect(`${tokenActionSource}\n${publishActionSource}`).not.toMatch(
+      /2729701|2971289|primary-private-key|fallback-private-key/u,
+    );
+    expect(contentsTokenStep).toEqual({
+      name: "Create generated branch app token",
       id: "contents-token",
-      "continue-on-error": true,
       uses: CREATE_GITHUB_APP_TOKEN_V3,
       with: {
-        "app-id": "2729701",
-        "private-key": "${{ inputs.primary-private-key }}",
+        "client-id": "${{ inputs.contents-client-id }}",
+        "private-key": "${{ inputs.contents-private-key }}",
+        owner: "${{ github.repository_owner }}",
+        repositories: "${{ github.event.repository.name }}",
         "permission-contents": "write",
       },
     });
-    expect(fallbackTokenStep).toMatchObject({
-      id: "contents-token-fallback",
-      if: "steps.contents-token.outcome == 'failure'",
-      uses: CREATE_GITHUB_APP_TOKEN_V3,
-      with: {
-        "app-id": "2971289",
-        "private-key": "${{ inputs.fallback-private-key }}",
-        "permission-contents": "write",
-      },
-    });
-    expect(pullRequestTokenStep).toMatchObject({
+    expect(pullRequestTokenStep).toEqual({
+      name: "Create generated PR app token",
       id: "pull-request-token",
       uses: CREATE_GITHUB_APP_TOKEN_V3,
       with: {
@@ -493,13 +566,30 @@ describe("ci workflow guards", () => {
         "permission-pull-requests": "write",
       },
     });
-    expect(actionPublishStep.env.CONTENTS_TOKEN).toBe(
-      "${{ steps.contents-token.outputs.token || steps.contents-token-fallback.outputs.token }}",
+    expect(tokenAction.outputs["contents-token"].value).toBe(
+      "${{ steps.contents-token.outputs.token }}",
     );
-    expect(actionPublishStep.env.GH_TOKEN).toBe("${{ steps.pull-request-token.outputs.token }}");
-    expect(actionPublishStep.env.INVALIDATION_PATHS).toBe(
-      "${{ inputs.invalidation-paths }}",
+    expect(tokenAction.outputs["pull-request-token"].value).toBe(
+      "${{ steps.pull-request-token.outputs.token }}",
     );
+    expect(createTokensStep).toMatchObject({
+      id: "tokens",
+      uses: "./.github/actions/create-generated-pr-tokens",
+      with: {
+        "contents-client-id": "${{ inputs.contents-client-id }}",
+        "contents-private-key": "${{ inputs.contents-private-key }}",
+        "pull-request-app-id": "${{ inputs.pull-request-app-id }}",
+        "pull-request-private-key": "${{ inputs.pull-request-private-key }}",
+      },
+    });
+    expect(
+      publishAction.runs.steps.filter(
+        (step: { uses?: string }) => step.uses === CREATE_GITHUB_APP_TOKEN_V3,
+      ),
+    ).toEqual([]);
+    expect(actionPublishStep.env.CONTENTS_TOKEN).toBe("${{ steps.tokens.outputs.contents-token }}");
+    expect(actionPublishStep.env.GH_TOKEN).toBe("${{ steps.tokens.outputs.pull-request-token }}");
+    expect(actionPublishStep.env.INVALIDATION_PATHS).toBe("${{ inputs.invalidation-paths }}");
     expect(actionPublishStep.run).toContain("GIT_TERMINAL_PROMPT=0");
     expect(actionPublishStep.run).toContain(
       'git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${git_auth}"',
@@ -527,12 +617,8 @@ describe("ci workflow guards", () => {
     expect(actionPublishStep.run).toContain(
       'gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls"',
     );
-    expect(actionPublishStep.run).toContain(
-      '-f "head=${GITHUB_REPOSITORY_OWNER}:${HEAD_BRANCH}"',
-    );
-    expect(actionPublishStep.run).toContain(
-      ".head.repo.full_name == env.GITHUB_REPOSITORY",
-    );
+    expect(actionPublishStep.run).toContain('-f "head=${GITHUB_REPOSITORY_OWNER}:${HEAD_BRANCH}"');
+    expect(actionPublishStep.run).toContain(".head.repo.full_name == env.GITHUB_REPOSITORY");
     expect(actionPublishStep.run).toContain(".head.ref == env.HEAD_BRANCH");
     expect(actionPublishStep.run).toContain(".head.sha");
     expect(actionPublishStep.run).not.toContain("gh pr list");
@@ -564,9 +650,7 @@ describe("ci workflow guards", () => {
     expect(actionPublishStep.run).toContain(
       '[[ "${current_remote_head}" != "${published_commit}" ]]',
     );
-    expect(actionPublishStep.run).toContain(
-      '[[ "${final_pr_head}" != "${published_commit}" ]]',
-    );
+    expect(actionPublishStep.run).toContain('[[ "${final_pr_head}" != "${published_commit}" ]]');
     expect(actionPublishStep.run).toContain("gh pr edit");
     expect(actionPublishStep.run).toContain("gh pr create");
     expect(actionPublishStep.run).toContain('--base "${BASE_BRANCH}"');
@@ -613,10 +697,13 @@ describe("ci workflow guards", () => {
       );
 
       expect(ownerWorkflow.permissions.contents).toBe("read");
-      expect(refreshJob.needs).toBe("resolve-base");
-      expect(finalizeJob.needs).toEqual(["resolve-base", "refresh"]);
+      expect(refreshJob.needs).toEqual(["resolve-base", "publisher-preflight"]);
+      expect(finalizeJob.needs).toEqual(["resolve-base", "publisher-preflight", "refresh"]);
+      const isNative = automationBranch.includes("native");
       expect(finalizeJob.if).toBe(
-        "needs.resolve-base.result == 'success' && needs.refresh.result == 'success'",
+        isNative
+          ? "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success' && needs.refresh.result == 'success'"
+          : "needs.resolve-base.result == 'success' && needs.publisher-preflight.result == 'success' && needs.refresh.result == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.token_preflight_only)",
       );
       expect(uploadStep.uses).toBe(UPLOAD_ARTIFACT_V7);
       expect(downloadStep.uses).toBe(DOWNLOAD_ARTIFACT_V8);
@@ -626,8 +713,8 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.with["fetch-depth"]).toBe(0);
       expect(publishStep.uses).toBe("./.github/actions/publish-generated-pr");
       expect(publishStep.with).toMatchObject({
-        "primary-private-key": "${{ secrets.GH_APP_PRIVATE_KEY }}",
-        "fallback-private-key": "${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}",
+        "contents-client-id": "Iv23liOECG0slfuhz093",
+        "contents-private-key": "${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}",
         "pull-request-app-id": "${{ secrets.MANTIS_GITHUB_APP_ID }}",
         "pull-request-private-key": "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
         "base-branch": "${{ github.event.repository.default_branch }}",
@@ -642,6 +729,9 @@ describe("ci workflow guards", () => {
         automationBranch.includes("native")
           ? "apps/android/app/src/main"
           : "ui/src/i18n/locales/en.ts",
+      );
+      expect(publishStep.with["invalidation-paths"]).toContain(
+        ".github/actions/create-generated-pr-tokens/action.yml",
       );
       expect(publishStep.with["invalidation-paths"]).toContain(
         ".github/actions/publish-generated-pr/action.yml",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1267,18 +1267,18 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps generated locale publisher and inventory edits on workflow guards", () => {
-    expect(
-      resolveChangedTestTargetPlan([".github/actions/publish-generated-pr/action.yml"]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/ci-workflow-guards.test.ts"],
-    });
+    for (const actionPath of [
+      ".github/actions/create-generated-pr-tokens/action.yml",
+      ".github/actions/publish-generated-pr/action.yml",
+    ]) {
+      expect(resolveChangedTestTargetPlan([actionPath])).toEqual({
+        mode: "targets",
+        targets: ["test/scripts/ci-workflow-guards.test.ts"],
+      });
+    }
     expect(resolveChangedTestTargetPlan(["scripts/native-app-i18n.ts"])).toEqual({
       mode: "targets",
-      targets: [
-        "test/scripts/native-app-i18n.test.ts",
-        "test/scripts/ci-workflow-guards.test.ts",
-      ],
+      targets: ["test/scripts/native-app-i18n.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
     });
   });
 


### PR DESCRIPTION
Related: #103570

## What Problem This Solves

Fixes an issue where the Control UI and native locale refresh workflows completed their translation matrices but could not publish the generated branch because the available GitHub App tokens did not have repository contents-write permission.

## Why This Change Was Made

The workflows now mint two exact-repository, least-privilege tokens: a ClawSweeper token for generated branch contents and a Mantis token for pull-request mutation. A mandatory token preflight runs before either provider-backed locale matrix, and a main-only preflight mode gives maintainers a cheap permission-drift diagnostic without exposing App secrets to branch-controlled workflow code.

The shared publisher delegates token creation to one composite action, and both workflows include that action in their trigger and stale-input paths. Guard tests lock the token scopes, dispatch boundary, preflight dependency, publisher wiring, and changed-test routing.

## User Impact

Automated locale refreshes fail before spending translation-provider capacity when App installation permissions drift, and successful runs can publish reviewable generated pull requests again. There is no direct product behavior change.

## Evidence

- Before: [Control UI locale run 29088903227](https://github.com/openclaw/openclaw/actions/runs/29088903227) passed all 20 locale jobs and validation, then failed while requesting contents-write App tokens.
- Testbox-through-Crabbox `tbx_01kx5x3a4nqphdnex9yte298jj`: 229/229 focused workflow and changed-target tests passed.
- `pnpm check:workflows`
- Exact-path `pnpm check:changed -- <7 touched files>`
- Targeted `oxfmt --check` and local `actionlint`
- Fresh structured autoreview: no accepted or actionable findings.
