### PR TITLE
fix(terminal): strip C1 OSC payloads from output

### DIFF
--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -24,11 +24,21 @@ describe("terminal ansi helpers", () => {
   it("strips the agent output escape grammar without changing text policy", () => {
     expect(stripAnsiSequences("\u001B[38:5:196mred\u001B[0m")).toBe("red");
     expect(stripAnsiSequences("\u009B31mred\u009B0m")).toBe("red");
-    expect(stripAnsiSequences("\u001B]8;;https://openclaw.ai\u009Clink\u001B]8;;\u0007")).toBe(
-      "link",
-    );
     expect(stripAnsiSequences("line\n\t🙂\u001B]unterminated")).toBe("line\n\t🙂nterminated");
     expect(() => stripAnsiSequences(null as never)).toThrow("Expected a `string`, got `object`");
+  });
+
+  it.each([
+    ["ESC OSC with BEL", "\u001B]", "\u0007"],
+    ["ESC OSC with ESC ST", "\u001B]", "\u001B\\"],
+    ["ESC OSC with C1 ST", "\u001B]", "\u009C"],
+    ["C1 OSC with BEL", "\u009D", "\u0007"],
+    ["C1 OSC with ESC ST", "\u009D", "\u001B\\"],
+    ["C1 OSC with C1 ST", "\u009D", "\u009C"],
+  ])("strips %s without clipping adjacent text", (_label, introducer, terminator) => {
+    expect(stripAnsiSequences(`before🙂${introducer}0;title${terminator}after界`)).toBe(
+      "before🙂after界",
+    );
   });
 
   it("sanitizes control characters for log-safe interpolation", () => {

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -3,9 +3,11 @@ const ESC_ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
 const C1_ANSI_CSI_PATTERN = "\\x9b[\\x20-\\x3f]*[\\x40-\\x7e]";
 const PARAMETERIZED_C1_ANSI_CSI_PATTERN = "\\x9b[\\x20-\\x3f]+[\\x40-\\x7e]";
 const ANSI_CSI_PATTERN = `(?:${ESC_ANSI_CSI_PATTERN}|${C1_ANSI_CSI_PATTERN})`;
-// OSC: ESC ] <payload> ST. Covers OSC-8 hyperlinks and clipboard/title escapes.
+// OSC: ESC ] or C1 OSC, then <payload> ST. Covers hyperlinks and clipboard/title escapes.
 // ST can be ESC \, BEL, or its C1 form.
-const ANSI_OSC_PATTERN = "(?:\\x1b\\]|\\x9d)[^\\x07\\x1b\\x9c]*(?:\\x1b\\\\|\\x07|\\x9c)";
+const ANSI_OSC_INTRODUCER_PATTERN = "(?:\\x1b\\]|\\x9d)";
+const ANSI_STRING_TERMINATOR_PATTERN = "(?:\\x1b\\\\|\\x07|\\x9c)";
+const ANSI_OSC_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[^\\x07\\x1b\\x9c]*${ANSI_STRING_TERMINATOR_PATTERN}`;
 
 const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
 const ANSI_OSC_REGEX = new RegExp(ANSI_OSC_PATTERN, "g");
@@ -40,8 +42,7 @@ const SANITIZATION_ANSI_SEQUENCE_REGEX = new RegExp(
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-const ANSI_STRING_TERMINATOR_PATTERN = "(?:\\u0007|\\u001B\\u005C|\\u009C)";
-const ANSI_OSC_SEQUENCE_PATTERN = `(?:\\u001B\\][\\s\\S]*?${ANSI_STRING_TERMINATOR_PATTERN})`;
+const ANSI_OSC_SEQUENCE_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[\\s\\S]*?${ANSI_STRING_TERMINATOR_PATTERN}`;
 const ANSI_CONTROL_SEQUENCE_PATTERN =
   "[\\u001B\\u009B][[\\]()#;?]*(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]";
 const ANSI_COMPAT_SEQUENCE_REGEX = new RegExp(
@@ -66,7 +67,9 @@ export function stripAnsiSequences(input: string): string {
   if (typeof input !== "string") {
     throw new TypeError(`Expected a \`string\`, got \`${typeof input}\``);
   }
-  if (!input.includes("\u001B") && !input.includes("\u009B")) {
+  // C1 OSC is independent of C1 CSI, so both 8-bit introducers must
+  // participate in the fast path.
+  if (!input.includes("\u001B") && !input.includes("\u009B") && !input.includes("\u009D")) {
     return input;
   }
   return input.replace(ANSI_COMPAT_SEQUENCE_REGEX, "");
@@ -163,8 +166,7 @@ function isWideEmojiGrapheme(grapheme: string): boolean {
   }
   // Minimally qualified ZWJ sequences still shape as one wide emoji in terminals.
   return (
-    grapheme.includes("\u200D") &&
-    (grapheme.match(extendedPictographicPattern)?.length ?? 0) >= 2
+    grapheme.includes("\u200D") && (grapheme.match(extendedPictographicPattern)?.length ?? 0) >= 2
   );
 }
 

--- a/src/gateway/terminal/buffer-text.test.ts
+++ b/src/gateway/terminal/buffer-text.test.ts
@@ -20,13 +20,14 @@ describe("renderTerminalBufferText", () => {
   });
 
   it("drops the full residual C1 range without clipping adjacent Unicode text", () => {
-    const c1 = Array.from({ length: 0x20 }, (_, offset) =>
-      String.fromCharCode(0x80 + offset),
-    ).join("");
+    const c1 = Array.from({ length: 0x20 }, (_, offset) => String.fromCharCode(0x80 + offset)).join(
+      "",
+    );
     expect(renderTerminalBufferText(`a\u007f${c1}\u00a0b\tc`)).toBe("a\u00a0b\tc");
   });
 
-  it("strips OSC title sequences", () => {
+  it("strips OSC title sequences in ESC and C1 forms", () => {
     expect(renderTerminalBufferText("\u001b]0;title\u0007prompt$ ")).toBe("prompt$ ");
+    expect(renderTerminalBufferText("\u009d0;title\u009cprompt$ ")).toBe("prompt$ ");
   });
 });


### PR DESCRIPTION
Closes #103661

## What Problem This Solves

Fixes an issue where terminal snapshots and sanitized agent output exposed OSC title, hyperlink, or clipboard payload text when a producer used the 8-bit C1 OSC introducer (`U+009D`). The delimiters were removed later, but the metadata payload remained visible as ordinary terminal text.

## Why This Change Was Made

The shared terminal scanner now recognizes both ECMA-48 OSC introducers and all three supported string terminators through common pattern constants. The compatibility scanner keeps its historical broad payload behavior, while the sanitizing scanner keeps its stricter payload rules; only C1 OSC handling changes. The fast path also recognizes `U+009D` so these sequences reach the scanner.

## User Impact

Terminal snapshot text and downstream sanitized output no longer display metadata carried in C1 OSC sequences. Adjacent emoji, CJK text, and prompts remain unchanged.

## Evidence

- Current-`main` Testbox repro (`4cc5304178`): `\u009D0;title\u009Cprompt$` rendered as `0;titleprompt$`; expected `prompt$`.
- Regression matrix: ESC and C1 OSC introducers crossed with BEL, ESC-ST, and C1-ST terminators, with adjacent emoji/CJK preservation.
- Focused Testbox proof: terminal-core, gateway terminal, terminal server-method, and bash executor suites; 67 tests passed.
- Post-mutation Testbox proof: terminal-core and gateway terminal suites; 39 tests passed.
- Mutation proof: removing C1 OSC recognition failed exactly the existing C1 sanitizer case plus the three new C1 matrix rows; ESC rows remained green.
- `corepack pnpm check:changed` passed on Testbox (guards, tsgo core/core-test, lint, and scoped repository checks).
- `corepack pnpm format:check packages/terminal-core/src/ansi.ts packages/terminal-core/src/ansi.test.ts src/gateway/terminal/buffer-text.test.ts` passed.
- Fresh autoreview: no accepted or actionable findings.

AI-assisted implementation and review.
