### PR TITLE
test(shared): add unit tests for safe import path conversion

### DIFF
--- a/src/shared/import-specifier.test.ts
+++ b/src/shared/import-specifier.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: string) {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", {
+    value: originalPlatform,
+    configurable: true,
+  });
+});
+
+import { toSafeImportPath } from "./import-specifier.js";
+
+describe("toSafeImportPath", () => {
+  describe("on non-Windows platforms", () => {
+    it("returns the specifier unchanged", () => {
+      setPlatform("darwin");
+      expect(toSafeImportPath("/absolute/path.js")).toBe("/absolute/path.js");
+      expect(toSafeImportPath("./relative/path.js")).toBe("./relative/path.js");
+      expect(toSafeImportPath("C:\\windows\\path.js")).toBe("C:\\windows\\path.js");
+    });
+  });
+
+  describe("on Windows", () => {
+    it("returns already-file:// URLs unchanged", () => {
+      setPlatform("win32");
+      expect(toSafeImportPath("file:///C:/foo/bar.js")).toBe("file:///C:/foo/bar.js");
+    });
+
+    it("converts absolute Windows paths to file:// URLs", () => {
+      setPlatform("win32");
+      const result = toSafeImportPath("C:\\Users\\test\\module.js");
+      expect(result).toMatch(/^file:\/\/\/[A-Z]:/i);
+    });
+
+    it("returns relative paths unchanged", () => {
+      setPlatform("win32");
+      expect(toSafeImportPath("./relative/module.js")).toBe("./relative/module.js");
+      expect(toSafeImportPath("../parent/module.js")).toBe("../parent/module.js");
+    });
+  });
+});

--- a/src/shared/import-specifier.test.ts
+++ b/src/shared/import-specifier.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const originalPlatform = process.platform;
 
@@ -36,8 +36,9 @@ describe("toSafeImportPath", () => {
 
     it("converts absolute Windows paths to file:// URLs", () => {
       setPlatform("win32");
-      const result = toSafeImportPath("C:\\Users\\test\\module.js");
-      expect(result).toMatch(/^file:\/\/\/[A-Z]:/i);
+      expect(toSafeImportPath("C:\\Users\\test\\module.js")).toBe(
+        "file:///C:/Users/test/module.js",
+      );
     });
 
     it("returns relative paths unchanged", () => {


### PR DESCRIPTION
## What Problem This Solves

The `toSafeImportPath` utility in `src/shared/import-specifier.ts` has no dedicated unit tests, leaving the cross-platform ESM import path conversion unverified against regressions.

## Why This Change Was Made

Adds unit test coverage for the `toSafeImportPath` helper, covering:
- Non-Windows platforms return the specifier unchanged
- Windows: already-file:// URLs pass through unchanged
- Windows: absolute paths converted to exact file:// URLs
- Windows: relative paths returned unchanged

## User Impact

- Purely additive: one new test file, no production code changes
- No risk of breaking existing behavior

## Evidence

```
$ npx vitest run src/shared/import-specifier.test.ts --reporter=verbose

 ✓  unit-fast  src/shared/import-specifier.test.ts > toSafeImportPath > on non-Windows platforms > returns the specifier unchanged
 ✓  unit-fast  src/shared/import-specifier.test.ts > toSafeImportPath > on Windows > returns already-file:// URLs unchanged
 ✓  unit-fast  src/shared/import-specifier.test.ts > toSafeImportPath > on Windows > converts absolute Windows paths to file:// URLs
 ✓  unit-fast  src/shared/import-specifier.test.ts > toSafeImportPath > on Windows > returns relative paths unchanged

 Test Files  1 passed (1)
      Tests  4 passed (4)
```