### PR TITLE
fix: allow gateway startup when SQLite migration target already exists

### DIFF
--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -425,6 +425,50 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
+  it("does NOT block gateway readiness for informational 'already existed' warnings", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    autoMigrateLegacyStateDir.mockResolvedValueOnce({
+      migrated: false,
+      skipped: false,
+      changes: [],
+      warnings: [
+        "Left task registry sidecar in place because 3 rows already existed in shared state: key1",
+        "Left plugin-state sidecar in place because 2 rows already existed in shared state: key2",
+      ],
+    });
+
+    const result = await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("still blocks gateway readiness for real migration failure warnings", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    autoMigrateLegacyStateDir.mockResolvedValueOnce({
+      migrated: false,
+      skipped: false,
+      changes: [],
+      warnings: ["Failed migrating task registry sidecar: permission denied"],
+    });
+
+    await expect(
+      runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        requireStartupMigrationCheckpoint: true,
+      }),
+    ).rejects.toThrow("refusing to report the gateway ready");
+
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
   it("blocks gateway readiness when plugin repair warnings remain", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     runPostCorePluginConvergence.mockResolvedValueOnce(

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -425,15 +425,16 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("does NOT block gateway readiness for informational 'already existed' warnings", async () => {
+  it("does NOT block gateway readiness when migrations produce only notices (no warnings)", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,
       skipped: false,
       changes: [],
-      warnings: [
-        "Left task registry sidecar in place because 3 rows already existed in shared state: key1",
-        "Left plugin-state sidecar in place because 2 rows already existed in shared state: key2",
+      warnings: [],
+      notices: [
+        "Skipped Memory Core session import because SQLite rows already exist",
+        "Skipped short-term recall import because SQLite rows already exist",
       ],
     });
 
@@ -448,13 +449,16 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("still blocks gateway readiness for real migration failure warnings", async () => {
+  it("still blocks gateway readiness for conflict warnings even when notices are present", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,
       skipped: false,
       changes: [],
-      warnings: ["Failed migrating task registry sidecar: permission denied"],
+      warnings: [
+        "Left task registry sidecar in place because 3 rows already existed in shared state: key1",
+      ],
+      notices: ["Skipped Memory Core session import because SQLite rows already exist"],
     });
 
     await expect(

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -159,39 +159,6 @@ function formatStartupMigrationFailure(params: { warnings: string[]; blockers: s
   ].join("\n");
 }
 
-/**
- * Informational migration warnings that indicate data already exists in SQLite
- * (i.e. the migration target was already reached on a previous run). These
- * should NOT block gateway startup — they are the expected state after a
- * successful prior migration.
- */
-const INFORMATIONAL_MIGRATION_WARNING_PATTERNS: RegExp[] = [
-  /already existed in shared state/i,
-  /already exists in shared state/i,
-  /already has/i,
-];
-
-/**
- * Separates migration warnings into informational (data already migrated) and
- * blocking (real migration failures). Only blocking warnings should prevent the
- * gateway from reporting ready.
- */
-function partitionMigrationWarnings(warnings: string[]): {
-  informational: string[];
-  blocking: string[];
-} {
-  const informational: string[] = [];
-  const blocking: string[] = [];
-  for (const warning of warnings) {
-    if (INFORMATIONAL_MIGRATION_WARNING_PATTERNS.some((p) => p.test(warning))) {
-      informational.push(warning);
-    } else {
-      blocking.push(warning);
-    }
-  }
-  return { informational, blocking };
-}
-
 function throwStartupMigrationGuardRejected(): never {
   throw new Error(
     "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
@@ -390,24 +357,16 @@ export async function runDoctorConfigPreflight(
           ? startupMigrationHeartbeatError
           : new Error("OpenClaw startup migration lease heartbeat failed.");
       }
-      const { informational: infoWarnings, blocking: blockingWarnings } =
-        partitionMigrationWarnings(startupMigrationWarnings);
-      if (infoWarnings.length > 0) {
-        note(
-          infoWarnings.map((w) => `- ${w}`).join("\n"),
-          "Doctor informational migration notices",
-        );
-      }
       const blockers =
-        blockingWarnings.length > 0
+        startupMigrationWarnings.length > 0
           ? []
           : snapshot.valid
             ? await runStartupUpgradeConvergence({ cfg: baseConfig, env: process.env })
             : ['OpenClaw config is invalid; run "openclaw doctor --fix" before startup.'];
-      if (blockingWarnings.length > 0 || blockers.length > 0) {
+      if (startupMigrationWarnings.length > 0 || blockers.length > 0) {
         throw new Error(
           formatStartupMigrationFailure({
-            warnings: blockingWarnings,
+            warnings: startupMigrationWarnings,
             blockers,
           }),
         );

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -159,6 +159,39 @@ function formatStartupMigrationFailure(params: { warnings: string[]; blockers: s
   ].join("\n");
 }
 
+/**
+ * Informational migration warnings that indicate data already exists in SQLite
+ * (i.e. the migration target was already reached on a previous run). These
+ * should NOT block gateway startup — they are the expected state after a
+ * successful prior migration.
+ */
+const INFORMATIONAL_MIGRATION_WARNING_PATTERNS: RegExp[] = [
+  /already existed in shared state/i,
+  /already exists in shared state/i,
+  /already has/i,
+];
+
+/**
+ * Separates migration warnings into informational (data already migrated) and
+ * blocking (real migration failures). Only blocking warnings should prevent the
+ * gateway from reporting ready.
+ */
+function partitionMigrationWarnings(warnings: string[]): {
+  informational: string[];
+  blocking: string[];
+} {
+  const informational: string[] = [];
+  const blocking: string[] = [];
+  for (const warning of warnings) {
+    if (INFORMATIONAL_MIGRATION_WARNING_PATTERNS.some((p) => p.test(warning))) {
+      informational.push(warning);
+    } else {
+      blocking.push(warning);
+    }
+  }
+  return { informational, blocking };
+}
+
 function throwStartupMigrationGuardRejected(): never {
   throw new Error(
     "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
@@ -357,16 +390,24 @@ export async function runDoctorConfigPreflight(
           ? startupMigrationHeartbeatError
           : new Error("OpenClaw startup migration lease heartbeat failed.");
       }
+      const { informational: infoWarnings, blocking: blockingWarnings } =
+        partitionMigrationWarnings(startupMigrationWarnings);
+      if (infoWarnings.length > 0) {
+        note(
+          infoWarnings.map((w) => `- ${w}`).join("\n"),
+          "Doctor informational migration notices",
+        );
+      }
       const blockers =
-        startupMigrationWarnings.length > 0
+        blockingWarnings.length > 0
           ? []
           : snapshot.valid
             ? await runStartupUpgradeConvergence({ cfg: baseConfig, env: process.env })
             : ['OpenClaw config is invalid; run "openclaw doctor --fix" before startup.'];
-      if (startupMigrationWarnings.length > 0 || blockers.length > 0) {
+      if (blockingWarnings.length > 0 || blockers.length > 0) {
         throw new Error(
           formatStartupMigrationFailure({
-            warnings: startupMigrationWarnings,
+            warnings: blockingWarnings,
             blockers,
           }),
         );


### PR DESCRIPTION
## What Problem This Solves

When the shared SQLite state store already contains data from previous migrations, the gateway startup preflight treats informational warnings like `"rows already existed in shared state"` as fatal errors. This causes the gateway to refuse startup with:

```
OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
```

These warnings are informational — they indicate the migration target already exists in SQLite, which is the expected state after a successful prior migration. They should not block gateway startup.

## Evidence

**Fix approach**: Added `partitionMigrationWarnings()` in `doctor-config-preflight.ts` that separates migration warnings into two categories:

- **Informational** (matching patterns like "already existed in shared state", "already has"): These indicate data was already migrated on a previous run and are logged as notices rather than blocking startup.
- **Blocking** (e.g., "Failed migrating...", "Left legacy config health state in place"): These represent real migration failures that should continue to block gateway readiness.

**Test coverage**: Added two new tests that verify:
1. "already existed" warnings allow startup to proceed without throwing
2. Real migration failure warnings (e.g., "Failed migrating...") still block startup

All existing tests continue to pass.

Fixes #103545