### PR TITLE
fix(providers): align Meta Model API contract

### DIFF
--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -18,7 +18,7 @@ plugin.
 | Onboarding flag   | `--auth-choice meta-api-key`       |
 | Direct CLI flag   | `--meta-api-key <key>`             |
 | API               | Responses API (`openai-responses`) |
-| Base URL          | `https://api.ai.meta.com/v1`       |
+| Base URL          | `https://api.meta.ai/v1`           |
 | Default model     | `meta/muse-spark-1.1`              |
 | Default reasoning | `high` (`reasoning.effort`)        |
 
@@ -70,7 +70,7 @@ openclaw onboard --non-interactive --accept-risk \
 
 | Model ref             | Name           | Reasoning | Context window | Max output |
 | --------------------- | -------------- | --------- | -------------- | ---------- |
-| `meta/muse-spark-1.1` | Muse Spark 1.1 | yes       | 1,048,576      | 128,000    |
+| `meta/muse-spark-1.1` | Muse Spark 1.1 | yes       | 1,048,576      | 131,072    |
 
 Capabilities:
 

--- a/extensions/meta/README.md
+++ b/extensions/meta/README.md
@@ -3,10 +3,11 @@
 Bundled OpenClaw provider plugin for the **Meta API** — an OpenAI-compatible
 **Responses API** endpoint (`POST /v1/responses`).
 
-- **Base URL:** `https://api.ai.meta.com/v1`
+- **Base URL:** `https://api.meta.ai/v1`
 - **Auth:** `Authorization: Bearer $MODEL_API_KEY`
 - **Model:** `muse-spark-1.1` (reasoning model)
   - Context window: 1,048,576 tokens (input + output share the budget)
+  - Maximum output: 131,072 tokens
   - Reasoning effort: `minimal | low | medium | high | xhigh` (default: `high`)
   - Vision: image input in `user` messages
   - Tool calling + streaming

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -35,13 +35,14 @@ describe("meta provider", () => {
 
   it("builds the muse-spark-1.1 catalog entry over openai-responses", () => {
     const providerConfig = buildMetaProvider();
-    expect(providerConfig.baseUrl).toBe("https://api.ai.meta.com/v1");
+    expect(providerConfig.baseUrl).toBe("https://api.meta.ai/v1");
     expect(providerConfig.api).toBe("openai-responses");
     const model = providerConfig.models.find((m) => m.id === "muse-spark-1.1");
     if (!model) {
       throw new Error("Expected muse-spark-1.1 model");
     }
     expect(model.contextWindow).toBe(1048576);
+    expect(model.maxTokens).toBe(131072);
     expect(model.reasoning).toBe(true);
     expect(model.input).toContain("image");
   });

--- a/extensions/meta/meta.live.test.ts
+++ b/extensions/meta/meta.live.test.ts
@@ -8,8 +8,7 @@ import { wrapMetaProviderStream } from "./stream.js";
 const MODEL_API_KEY = process.env.MODEL_API_KEY?.trim() ?? "";
 const LIVE_MODEL_ID = "muse-spark-1.1";
 const LIVE =
-  isLiveTestEnabled(["META_LIVE_TEST", "MODEL_API_LIVE_TEST"]) &&
-  MODEL_API_KEY.length > 0;
+  isLiveTestEnabled(["META_LIVE_TEST", "MODEL_API_LIVE_TEST"]) && MODEL_API_KEY.length > 0;
 const describeLive = LIVE ? describe : describe.skip;
 
 function resolveLiveModel(): Model<"openai-responses"> {
@@ -40,7 +39,8 @@ function resolveLiveStreamFn() {
 
 describeLive("meta plugin live", () => {
   it("lists muse-spark-1.1 via the /models endpoint", async () => {
-    const response = await fetch("https://api.ai.meta.com/v1/models", {
+    const provider = buildMetaProvider();
+    const response = await fetch(`${provider.baseUrl}/models`, {
       headers: { Authorization: `Bearer ${MODEL_API_KEY}` },
     });
     expect(response.ok).toBe(true);

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -8,7 +8,7 @@
   "providerEndpoints": [
     {
       "endpointClass": "meta-native",
-      "hosts": ["api.ai.meta.com"]
+      "hosts": ["api.meta.ai"]
     }
   ],
   "providerRequest": {
@@ -21,7 +21,7 @@
   "modelCatalog": {
     "providers": {
       "meta": {
-        "baseUrl": "https://api.ai.meta.com/v1",
+        "baseUrl": "https://api.meta.ai/v1",
         "api": "openai-responses",
         "models": [
           {
@@ -30,7 +30,7 @@
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 1048576,
-            "maxTokens": 128000,
+            "maxTokens": 131072,
             "thinkingLevelMap": {
               "off": "minimal",
               "minimal": "minimal",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -695,7 +695,7 @@
         "providerEndpoints": [
           {
             "endpointClass": "meta-native",
-            "hosts": ["api.ai.meta.com"]
+            "hosts": ["api.meta.ai"]
           }
         ],
         "providers": [

--- a/src/agents/provider-attribution.catalog-endpoints.test.ts
+++ b/src/agents/provider-attribution.catalog-endpoints.test.ts
@@ -42,6 +42,7 @@ describe("catalog-backed provider endpoint classification", () => {
     ["https://api.groq.com/openai/v1", "groq-native"],
     ["https://api.cerebras.ai/v1", "cerebras-native"],
     ["https://llm.chutes.ai/v1", "chutes-native"],
+    ["https://api.meta.ai/v1", "meta-native"],
   ])("classifies %s as %s without an installed plugin manifest", (baseUrl, endpointClass) => {
     expect(resolveProviderEndpoint(baseUrl).endpointClass).toBe(endpointClass);
   });
@@ -59,6 +60,18 @@ describe("catalog-backed provider endpoint classification", () => {
     });
     expect(capabilities.endpointClass).toBe("modelstudio-native");
     expect(capabilities.supportsNativeStreamingUsageCompat).toBe(true);
+    expect(capabilities.isKnownNativeEndpoint).toBe(true);
+  });
+
+  it("resolves Meta request capabilities from catalog metadata", () => {
+    const capabilities = resolveProviderRequestCapabilities({
+      provider: "meta",
+      api: "openai-responses",
+      baseUrl: "https://api.meta.ai/v1",
+      capability: "llm",
+      transport: "stream",
+    });
+    expect(capabilities.endpointClass).toBe("meta-native");
     expect(capabilities.isKnownNativeEndpoint).toBe(true);
   });
 

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -58,6 +58,7 @@ export type ProviderEndpointClass =
   | "deepseek-native"
   | "github-copilot-native"
   | "groq-native"
+  | "meta-native"
   | "mistral-public"
   | "moonshot-native"
   | "modelstudio-native"
@@ -160,6 +161,7 @@ const MANIFEST_PROVIDER_ENDPOINT_CLASSES = new Set<ProviderEndpointClass>([
   "deepseek-native",
   "github-copilot-native",
   "groq-native",
+  "meta-native",
   "mistral-public",
   "moonshot-native",
   "modelstudio-native",
@@ -724,6 +726,7 @@ export function resolveProviderRequestCapabilities(
     endpointClass === "deepseek-native" ||
     endpointClass === "github-copilot-native" ||
     endpointClass === "groq-native" ||
+    endpointClass === "meta-native" ||
     endpointClass === "mistral-public" ||
     endpointClass === "moonshot-native" ||
     endpointClass === "modelstudio-native" ||

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -914,6 +914,31 @@ describe("buildGuardedModelFetch", () => {
     expect(policy).toBeUndefined();
   });
 
+  it("keeps Meta's native endpoint under DNS rebinding checks", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValueOnce({
+      allowPrivateNetwork: false,
+      policy: { endpointClass: "meta-native" },
+    });
+    const model = {
+      id: "muse-spark-1.1",
+      provider: "meta",
+      api: "openai-responses",
+      baseUrl: "https://api.meta.ai/v1",
+    } as unknown as Model<"openai-responses">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.meta.ai/v1/responses", { method: "POST" });
+
+    const policy = latestGuardedFetchParams().policy as Record<string, unknown> | undefined;
+    expect(policy).toEqual({
+      allowRfc2544BenchmarkRange: true,
+      allowIpv6UniqueLocalRange: true,
+      hostnameAllowlist: ["api.meta.ai"],
+    });
+    expect(policy?.allowedOrigins).toBeUndefined();
+    expect(policy?.allowPrivateNetwork).toBeUndefined();
+  });
+
   it.each([
     {
       label: "link-local metadata IP",

--- a/src/plugins/official-external-provider-endpoints.test.ts
+++ b/src/plugins/official-external-provider-endpoints.test.ts
@@ -132,6 +132,7 @@ describe("official external provider endpoint catalog mirror", () => {
     );
     expect(endpointClasses).toContain("modelstudio-native");
     expect(endpointClasses).toContain("moonshot-native");
+    expect(endpointClasses).toContain("meta-native");
     expect(endpointClasses).toContain("zai-native");
   });
 });


### PR DESCRIPTION
Fixes #103667

## What Problem This Solves

The Meta provider used the pre-launch `api.ai.meta.com` endpoint and a stale
128,000-token output limit for `muse-spark-1.1`. Its declared `meta-native`
endpoint class was also ignored by core, causing the official Meta host to be
treated as a custom endpoint with exact-origin private-DNS trust.

## Why This Change Was Made

Meta's public Model API contract defines `https://api.meta.ai/v1`, a
131,072-token maximum output, and a 1,048,576-token context window. This change
aligns the plugin manifest, catalog mirror, docs, and live preflight with that
contract. It also registers `meta-native` in the core endpoint classifier so
Meta requests retain native-provider DNS rebinding protections.

## User Impact

Meta users connect to the canonical Model API endpoint with accurate
`muse-spark-1.1` limits. Guarded requests to `api.meta.ai` no longer receive
custom-provider exact-origin private-network trust.

## Evidence

- Official contract: https://dev.meta.ai/docs/getting-started/overview/
- Focused Testbox: 216/216 tests passed across Meta catalog, provider
  attribution, transport policy, and external catalog mirrors.
- Exact-tree Testbox `tbx_01kx5ye99asq3j59r2r988ws7j`: `check:changed`
  passed all core, core-test, extension, extension-test, docs, and tooling lanes.
- Exact runtime probe: `api.meta.ai` resolves to `meta-native` with
  `isKnownNativeEndpoint: true`.
- Transport regression: Meta receives hostname-scoped fake-IP policy and no
  `allowedOrigins` private-origin trust.
- Formatting and docs formatting passed.
- Structured autoreview: no findings; patch correct; confidence 0.82.
- Live endpoint reachability returned the expected unauthenticated HTTP 401.
  A completion probe was skipped because `MODEL_API_KEY` was unavailable and
  1Password was locked, per the beta3 operator waiver.
