### PR TITLE
fix(qa): accept structured gateway restart outcomes

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -435,18 +435,20 @@ describe("qa scenario catalog", () => {
     expect(readQaScenarioById("long-context-progress-watchdog").sourcePath).toBe(
       "qa/scenarios/runtime/long-context-progress-watchdog.yaml",
     );
-    expect(
-      JSON.stringify(readQaScenarioById("gateway-restart-inflight-run").execution.flow),
-    ).toContain("EmbeddedAttemptSessionTakeoverError");
-    expect(
-      JSON.stringify(readQaScenarioById("gateway-restart-inflight-run").execution.flow),
-    ).toContain("AbortError");
-    expect(
-      JSON.stringify(readQaScenarioById("gateway-restart-inflight-run").execution.flow),
-    ).toContain("This operation was aborted");
-    expect(
-      JSON.stringify(readQaScenarioById("gateway-restart-inflight-run").execution.flow),
-    ).toContain("liveTurnTimeoutMs(env, 180000)");
+    const gatewayRestartFlow = readQaScenarioById("gateway-restart-inflight-run").execution.flow;
+    const interruptedStatusAssertion = gatewayRestartFlow?.steps
+      .flatMap((step) => step.actions)
+      .find((action) =>
+        JSON.stringify(action).includes("interrupted agent run ended with unexpected status"),
+      );
+    expect(interruptedStatusAssertion).toBeDefined();
+    const interruptedStatusContract = JSON.stringify(interruptedStatusAssertion);
+    expect(interruptedStatusContract).toContain("waited.stopReason === 'restart'");
+    expect(interruptedStatusContract).toContain("waited.stopReason === 'aborted'");
+    expect(interruptedStatusContract).toContain("EmbeddedAttemptSessionTakeoverError");
+    expect(interruptedStatusContract).toContain("AbortError");
+    expect(interruptedStatusContract).toContain("This operation was aborted");
+    expect(JSON.stringify(gatewayRestartFlow)).toContain("liveTurnTimeoutMs(env, 180000)");
     const longContextFlow = JSON.stringify(
       readQaScenarioById("long-context-progress-watchdog").execution.flow,
     );

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -779,6 +779,18 @@ describe("qa suite runtime agent process helpers", () => {
     );
   });
 
+  it.each(["restart", "aborted"])(
+    "preserves the %s stop reason from agent.wait",
+    async (stopReason) => {
+      const result = { status: "error", stopReason };
+      const gatewayCall = vi.fn(async () => result);
+
+      await expect(
+        waitForAgentRun({ gateway: { call: gatewayCall } } as never, "run-interrupted"),
+      ).resolves.toEqual(result);
+    },
+  );
+
   it("caps the gateway client timeout when waiting for oversized agent runs", async () => {
     const gatewayCall = vi.fn(async () => ({ status: "ok" }));
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -46,6 +46,7 @@ type QaChatHistoryResponse = {
 type QaAgentWaitResult = {
   status?: string;
   error?: string;
+  stopReason?: string;
 };
 
 const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g");

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -96,7 +96,7 @@ flow:
             - expr: started.runId
             - expr: liveTurnTimeoutMs(env, 180000)
         - assert:
-            expr: "waited.status === 'ok' || waited.status === 'timeout' || (waited.status === 'error' && (String(waited.error ?? '').includes('EmbeddedAttemptSessionTakeoverError') || String(waited.error ?? '').includes('AbortError') || String(waited.error ?? '').includes('This operation was aborted')))"
+            expr: "waited.status === 'ok' || waited.status === 'timeout' || (waited.status === 'error' && (waited.stopReason === 'restart' || waited.stopReason === 'aborted' || String(waited.error ?? '').includes('EmbeddedAttemptSessionTakeoverError') || String(waited.error ?? '').includes('AbortError') || String(waited.error ?? '').includes('This operation was aborted')))"
             message:
               expr: "`interrupted agent run ended with unexpected status: ${JSON.stringify(waited)}`"
         - set: interruptedMatches


### PR DESCRIPTION
Closes #103676

## What Problem This Solves

Fixes an issue where the live runtime-parity release gate reported gateway restart recovery as failed when `agent.wait` returned the current structured `restart` or `aborted` terminal reason.

## Why This Change Was Made

The scenario now accepts only those two canonical restart-owned stop reasons in addition to its existing `ok`, `timeout`, and legacy upgrade-path error forms. Recovery health, interrupted-marker deduplication, and exactly-once recovery delivery remain mandatory. The QA wait-result boundary now types and tests `stopReason` preservation.

## User Impact

Release validation no longer false-fails a healthy gateway restart solely because current runtimes use structured terminal metadata. Runtime product behavior is unchanged.

## Evidence

- Reproduced on exact release-proof SHA `7b03a2ae201ab9c27dc3bc39569e97c9f9582360`: OpenClaw returned `status=error, stopReason=restart`; Codex returned `status=error, stopReason=aborted`.
- `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/suite-runtime-agent-process.test.ts`: 65/65 passed on Blacksmith Testbox `tbx_01kx5y7vzbyq4s1pb1nc2kdakj` through the repository Crabbox wrapper.
- `pnpm check:changed`: typecheck, lint, guards, and runtime import-cycle checks passed on the same Testbox.
- Targeted `oxfmt` and `git diff --check` passed.
- Fresh autoreview: clean, no accepted/actionable findings (`overall: patch is correct`, confidence 0.97).
- Authenticated exact-head live runtime pair passed 1/1 on both OpenClaw and Codex at `29f0cb6b9872a88149aac9e882477f2609225392` using Blacksmith Testbox `tbx_01kx5xy78gj59snb0ny0tqh2cx`.
- Hosted PR CI passed 43/43: https://github.com/openclaw/openclaw/actions/runs/29091415411

AI-assisted change; implementation and contracts were source-audited, including the direct Codex app-server interrupt contract.
