### PR TITLE
fix(qa): require web fetch after tool discovery

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4008,6 +4008,26 @@ describe("qa mock openai server", () => {
     expect(String(toolPlanOutput.arguments)).toContain("current");
   });
 
+  it("plans the explicit web_fetch fixture prompt as the canonical direct call", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Call web_fetch exactly once with URL https://example.com/ and maxChars 500, wait for its result, then summarize. If web_fetch is already callable, call it directly without tool_search. Otherwise use tool_search to locate it first, then call web_fetch. A tool_search result alone does not complete the task; do not finish before web_fetch returns. QA routing marker: tool search qa check target=web_fetch.";
+
+    const response = await postResponses(server, {
+      stream: false,
+      input: [makeUserInput(prompt)],
+    });
+
+    expect(response.status).toBe(200);
+    const toolPlanOutput = outputItem(await response.json());
+    expect(toolPlanOutput.type).toBe("function_call");
+    expect(toolPlanOutput.name).toBe("web_fetch");
+    expect(JSON.parse(String(toolPlanOutput.arguments))).toEqual({
+      url: "https://example.com/",
+      maxChars: 500,
+    });
+  });
+
   it("summarizes QA tool-search bridge outputs with the nested plugin result marker", async () => {
     const server = await startMockServer();
     const targetTool = "fake_plugin_tool_17";

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -340,6 +340,7 @@ describe("qa scenario catalog", () => {
     const applyPatch = readQaScenarioById("runtime-tool-apply-patch");
     const messageTool = readQaScenarioById("runtime-tool-message-tool");
     const tavilySearch = readQaScenarioById("runtime-tool-tavily-search");
+    const webFetch = readQaScenarioById("runtime-tool-web-fetch");
     const webSearch = readQaScenarioById("runtime-tool-web-search");
     const imageGenerate = readQaScenarioById("runtime-tool-image-generate");
 
@@ -372,6 +373,16 @@ describe("qa scenario catalog", () => {
         required: true,
       },
     });
+    const webFetchConfig = readQaScenarioExecutionConfig(webFetch.id);
+    expect(webFetchConfig?.happyPrompt).toContain("Call web_fetch exactly once");
+    expect(webFetchConfig?.happyPrompt).toContain("call it directly without tool_search");
+    expect(webFetchConfig?.happyPrompt).toContain("Otherwise use tool_search to locate it first");
+    expect(webFetchConfig?.happyPrompt).toContain(
+      "A tool_search result alone does not complete the task",
+    );
+    expect(webFetchConfig?.happyPrompt).toContain("https://example.com/");
+    expect(webFetchConfig?.happyPrompt).toContain("maxChars 500");
+    expect(webFetchConfig?.happyPrompt).toContain("tool search qa check target=web_fetch");
     expect(webSearch.plugins).toEqual(["qa-lab"]);
     expect(webSearch.gatewayConfigPatch?.tools).toEqual({
       web: {

--- a/qa/scenarios/runtime/tools/web-fetch.yaml
+++ b/qa/scenarios/runtime/tools/web-fetch.yaml
@@ -23,6 +23,7 @@ scenario:
     summary: Exercise the web_fetch runtime tool family.
     config:
       toolName: web_fetch
+      happyPrompt: "Call web_fetch exactly once with URL https://example.com/ and maxChars 500, wait for its result, then summarize. If web_fetch is already callable, call it directly without tool_search. Otherwise use tool_search to locate it first, then call web_fetch. A tool_search result alone does not complete the task; do not finish before web_fetch returns. QA routing marker: tool search qa check target=web_fetch."
       toolCoverage:
         family: web_fetch
         actualTool: web_fetch


### PR DESCRIPTION
Closes #103678

## What Problem This Solves

Fixes an issue where the live Codex runtime could stop after discovering `web_fetch` through `tool_search`, causing the required runtime-tool release gate to fail without ever invoking `web_fetch`.

## Why This Change Was Made

The `web_fetch` scenario now gives an explicit scenario-local instruction: call `web_fetch` directly when available, otherwise use `tool_search` only to locate it and then invoke it. The prompt retains the deterministic QA routing marker and canonical safe URL/argument contract. The shared prompt used by the other runtime-tool fixtures and the denied-input failure path are unchanged.

## User Impact

Release validation now measures the intended `web_fetch` call instead of accepting discovery as task completion. Product runtime behavior is unchanged.

## Evidence

- Reproduced on exact release-proof SHA `7b03a2ae201ab9c27dc3bc39569e97c9f9582360`: Codex returned after `tool_search`; the fixture reported no happy-path `web_fetch` call.
- `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/runtime-tool-fixture.test.ts`: 185/185 passed on Blacksmith Testbox `tbx_01kx5z1230vnm2jfxkygm9hbtd` through the repository Crabbox wrapper.
- The mock-provider regression proves the exact prompt plans one `web_fetch` call with `{ url: "https://example.com/", maxChars: 500 }`.
- `pnpm check:changed`: typecheck, lint, guards, and runtime import-cycle checks passed on the same Testbox.
- Targeted `oxfmt` and `git diff --check` passed.
- Fresh autoreview: clean, no accepted/actionable findings (`overall: patch is correct`, confidence 0.89).
- Authenticated exact-head live runtime pair passed 1/1 on OpenClaw and Codex at `744c218a45b509e297ab63856359e6934017a19e` using Blacksmith Testbox `tbx_01kx5xy78gj59snb0ny0tqh2cx`; both cells invoked `web_fetch` exactly once.
- Hosted PR CI completed successfully with 43 successful jobs and no failures: https://github.com/openclaw/openclaw/actions/runs/29092125686

AI-assisted change; implementation and tool-discovery contracts were source-audited, including the direct Codex tool-search handler and tests.
