### PR TITLE
fix(gateway): reload plugin code across in-process restarts (#103571)

### DIFF
--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -54,3 +54,4 @@ export { waitForActiveGatewayRootWork } from "../../process/gateway-work-admissi
 export { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 export { reloadTaskRuntimeStateFromStore } from "../../tasks/runtime-internal.js";
 export { abortPendingChannelReloads } from "../../gateway/server-reload-handlers.js";
+export { clearPluginCachesForInProcessRestart } from "../../plugins/loader.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -76,6 +76,7 @@ const waitForActiveCronJobs = vi.fn(async (_timeoutMs?: number) => ({
 const reloadTaskRuntimeStateFromStore = vi.fn();
 const rotateAgentEventLifecycleGeneration = vi.fn();
 const clearRuntimeConfigSnapshot = vi.fn();
+const clearPluginCachesForInProcessRestart = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   (_opts?: { env?: NodeJS.ProcessEnv }) => {
     mode: "spawned" | "supervised" | "disabled" | "failed";
@@ -208,6 +209,10 @@ vi.mock("../../infra/agent-events.js", () => ({
 
 vi.mock("../../config/runtime-snapshot.js", () => ({
   clearRuntimeConfigSnapshot: () => clearRuntimeConfigSnapshot(),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  clearPluginCachesForInProcessRestart: () => clearPluginCachesForInProcessRestart(),
 }));
 
 vi.mock("../../tasks/task-registry.maintenance.js", () => ({
@@ -979,6 +984,7 @@ describe("runGatewayLoop", () => {
       expect(
         resetGatewaySuspendCoordinatorForLifecycleRestart.mock.invocationCallOrder[0],
       ).toBeLessThan(resetAllLanes.mock.invocationCallOrder[0] ?? 0);
+      expect(clearPluginCachesForInProcessRestart).toHaveBeenCalledTimes(1);
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
       expect(rotateAgentEventLifecycleGeneration).toHaveBeenCalledTimes(1);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(1);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -901,6 +901,7 @@ export async function runGatewayLoop(params: {
       // cancelled/completed work is not kept alive by old in-memory maps.
       const {
         abortActiveCronTaskRuns,
+        clearPluginCachesForInProcessRestart,
         advanceCronActiveJobGeneration,
         reloadTaskRuntimeStateFromStore,
         retireActiveCronTaskRunTracking,
@@ -930,6 +931,10 @@ export async function runGatewayLoop(params: {
       resetGatewaySuspendCoordinatorForLifecycleRestart();
       resetAllLanes();
       clearRuntimeConfigSnapshot();
+      // Plugin registries/manifests are process-stable; an explicit in-process restart
+      // is the reload boundary, so drop them or updated workspace plugin code on disk
+      // never loads while the restart still logs "registered" (#103571).
+      clearPluginCachesForInProcessRestart();
       resetGatewayRestartStateForInProcessRestart();
       reloadTaskRuntimeStateFromStore();
       markGatewayRestartTrace("restart.next-start");

--- a/src/plugins/loader.restart-reload.test.ts
+++ b/src/plugins/loader.restart-reload.test.ts
@@ -198,6 +198,56 @@ describe("plugin loader in-process restart reload", () => {
     expect(loadedToolNames(reloaded)).not.toContain("nested_tool_v1");
   });
 
+  it("reloads edited TypeScript plugin source after the restart-boundary clear (#103688 review)", () => {
+    useNoBundledPlugins();
+    // TypeScript entrypoints load through jiti, which registers transformed
+    // modules in Node's CJS cache under their .ts source paths — the native-JS
+    // eviction never matches them by extension.
+    const root = path.join(makeTempDir(), "ts-restart-probe");
+    fs.mkdirSync(root, { recursive: true });
+    const tsBody = (toolName: string) => `const plugin = {
+  id: "ts-restart-probe",
+  register(api: { registerTool: (tool: object) => void }) {
+    const toolName: string = ${JSON.stringify(toolName)};
+    api.registerTool({
+      name: toolName,
+      description: "ts restart probe tool",
+      parameters: {},
+      execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+  },
+};
+export default plugin;
+`;
+    const entryPath = path.join(root, "index.ts");
+    fs.writeFileSync(entryPath, tsBody("ts_tool_v1"), "utf-8");
+    const writeTsManifest = (toolName: string) => {
+      fs.writeFileSync(
+        path.join(root, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "ts-restart-probe",
+          configSchema: { type: "object", additionalProperties: false },
+          contracts: { tools: [toolName] },
+        }),
+        "utf-8",
+      );
+    };
+    writeTsManifest("ts_tool_v1");
+    const config = {
+      plugins: { load: { paths: [entryPath] }, allow: ["ts-restart-probe"] },
+    };
+
+    expect(loadedToolNames(loadOpenClawPlugins({ config }))).toContain("ts_tool_v1");
+
+    fs.writeFileSync(entryPath, tsBody("ts_tool_v2"), "utf-8");
+    writeTsManifest("ts_tool_v2");
+
+    clearPluginCachesForInProcessRestart();
+    const reloaded = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(reloaded)).toContain("ts_tool_v2");
+    expect(loadedToolNames(reloaded)).not.toContain("ts_tool_v1");
+  });
+
   it("tracks only plugin-owned modules for restart eviction, never shared runtime (#103688 review)", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.restart-reload.test.ts
+++ b/src/plugins/loader.restart-reload.test.ts
@@ -1,0 +1,93 @@
+// Covers the in-process restart boundary: cached plugin registries must drop so
+// updated workspace plugin source on disk loads on the next startup (#103571).
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { clearPluginCachesForInProcessRestart, loadOpenClawPlugins } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+function pluginBody(toolName: string): string {
+  return `module.exports = {
+  id: "restart-reload-probe",
+  register(api) {
+    api.registerTool({
+      name: ${JSON.stringify(toolName)},
+      description: "restart reload probe tool",
+      parameters: {},
+      execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+  },
+};`;
+}
+
+function writeManifest(dir: string, toolName: string): void {
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: "restart-reload-probe",
+        configSchema: { type: "object", additionalProperties: false },
+        contracts: { tools: [toolName] },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
+function loadedToolNames(registry: ReturnType<typeof loadOpenClawPlugins>): string[] {
+  return registry.tools.flatMap((entry) => entry.names);
+}
+
+describe("plugin loader in-process restart reload", () => {
+  it("loads updated workspace plugin code after the restart-boundary cache clear (#103571)", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "restart-reload-probe",
+      filename: "restart-reload-probe.cjs",
+      body: pluginBody("probe_tool_v1"),
+    });
+    writeManifest(plugin.dir, "probe_tool_v1");
+    const config = {
+      plugins: {
+        load: { paths: [plugin.dir] },
+        allow: ["restart-reload-probe"],
+      },
+    };
+
+    const first = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(first)).toContain("probe_tool_v1");
+
+    // Update the plugin source (and its declared tool contract) on disk — the
+    // issue's repro step 3: add a tool, expect it after an in-process restart.
+    fs.writeFileSync(plugin.file, pluginBody("probe_tool_v2"), "utf-8");
+    writeManifest(plugin.dir, "probe_tool_v2");
+
+    // Without the restart-boundary clear the cached registry re-serves the old
+    // module graph — the stale behavior reported for in-process restarts.
+    const stale = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(stale)).toContain("probe_tool_v1");
+    expect(loadedToolNames(stale)).not.toContain("probe_tool_v2");
+
+    // The in-process restart boundary drops plugin caches, so the next startup
+    // loads the updated source from disk.
+    clearPluginCachesForInProcessRestart();
+    const reloaded = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(reloaded)).toContain("probe_tool_v2");
+    expect(loadedToolNames(reloaded)).not.toContain("probe_tool_v1");
+  });
+});

--- a/src/plugins/loader.restart-reload.test.ts
+++ b/src/plugins/loader.restart-reload.test.ts
@@ -3,7 +3,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
-import { clearPluginCachesForInProcessRestart, loadOpenClawPlugins } from "./loader.js";
+import {
+  clearPluginCachesForInProcessRestart,
+  getTrackedPluginModuleImportsForRestartForTests,
+  loadOpenClawPluginCliRegistry,
+  loadOpenClawPlugins,
+} from "./loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makeTempDir,
@@ -20,9 +25,9 @@ afterAll(() => {
   cleanupPluginLoaderFixturesForTest();
 });
 
-function pluginBody(toolName: string): string {
+function pluginBody(toolName: string, id = "restart-reload-probe"): string {
   return `module.exports = {
-  id: "restart-reload-probe",
+  id: ${JSON.stringify(id)},
   register(api) {
     api.registerTool({
       name: ${JSON.stringify(toolName)},
@@ -191,5 +196,64 @@ describe("plugin loader in-process restart reload", () => {
     const reloaded = loadOpenClawPlugins({ config });
     expect(loadedToolNames(reloaded)).toContain("nested_tool_v2");
     expect(loadedToolNames(reloaded)).not.toContain("nested_tool_v1");
+  });
+
+  it("tracks only plugin-owned modules for restart eviction, never shared runtime (#103688 review)", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "restart-owner-probe",
+      filename: "restart-owner-probe.cjs",
+      body: pluginBody("owner_probe_tool", "restart-owner-probe"),
+    });
+    writeManifest(plugin.dir, "owner_probe_tool", "restart-owner-probe");
+    const config = {
+      plugins: { load: { paths: [plugin.dir] }, allow: ["restart-owner-probe"] },
+    };
+
+    const registry = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(registry)).toContain("owner_probe_tool");
+
+    const tracked = getTrackedPluginModuleImportsForRestartForTests();
+    const pluginRoot = fs.realpathSync(plugin.dir);
+    const repoRoot = fs.realpathSync(process.cwd());
+    const ownEntries = [...tracked].filter(([modulePath]) =>
+      fs.realpathSync(modulePath).startsWith(pluginRoot),
+    );
+    // The plugin's own entry is tracked with its package root…
+    expect(ownEntries.length).toBeGreaterThan(0);
+    for (const [, rootDir] of ownEntries) {
+      expect(rootDir && fs.realpathSync(rootDir)).toBe(pluginRoot);
+    }
+    // …and the shared plugin runtime module (an OpenClaw core module graph that
+    // resolves inside the repo) never enters the restart-eviction set.
+    for (const [modulePath] of tracked) {
+      expect(fs.realpathSync(modulePath).startsWith(repoRoot)).toBe(false);
+    }
+  });
+
+  it("tracks CLI metadata entrypoints with their plugin package root (#103688 review)", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "restart-cli-probe",
+      filename: "restart-cli-probe.cjs",
+      body: pluginBody("cli_probe_tool", "restart-cli-probe"),
+    });
+    writeManifest(plugin.dir, "cli_probe_tool", "restart-cli-probe");
+    const config = {
+      plugins: { load: { paths: [plugin.dir] }, allow: ["restart-cli-probe"] },
+    };
+
+    await loadOpenClawPluginCliRegistry({ config });
+
+    const pluginRoot = fs.realpathSync(plugin.dir);
+    const tracked = [...getTrackedPluginModuleImportsForRestartForTests()].filter(([modulePath]) =>
+      fs.realpathSync(modulePath).startsWith(pluginRoot),
+    );
+    // The CLI metadata load registers the entry under the plugin package root so
+    // restart eviction covers plugin-owned dependencies outside the entry dir.
+    expect(tracked.length).toBeGreaterThan(0);
+    for (const [, rootDir] of tracked) {
+      expect(rootDir && fs.realpathSync(rootDir)).toBe(pluginRoot);
+    }
   });
 });

--- a/src/plugins/loader.restart-reload.test.ts
+++ b/src/plugins/loader.restart-reload.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { clearPluginCachesForInProcessRestart, loadOpenClawPlugins } from "./loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
+  makeTempDir,
   resetPluginLoaderTestStateForTest,
   useNoBundledPlugins,
   writePlugin,
@@ -127,5 +128,68 @@ describe("plugin loader in-process restart reload", () => {
     const reloaded = loadOpenClawPlugins({ config });
     expect(loadedToolNames(reloaded)).toContain("helper_tool_v2");
     expect(loadedToolNames(reloaded)).not.toContain("helper_tool_v1");
+  });
+
+  it("evicts package-root modules for nested entrypoints on restart (#103688 review)", () => {
+    useNoBundledPlugins();
+    // Layout: <root>/openclaw.plugin.json + package.json(main: dist/entry.cjs)
+    //         <root>/dist/entry.cjs  → requires ../lib/helper.cjs (OUTSIDE dist/)
+    const root = path.join(makeTempDir(), "nested-root-probe");
+    fs.mkdirSync(path.join(root, "dist"), { recursive: true });
+    fs.mkdirSync(path.join(root, "lib"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "nested-root-probe",
+        main: "dist/entry.cjs",
+        openclaw: { extensions: ["dist/entry.cjs"] },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(root, "dist", "entry.cjs"),
+      `module.exports = {
+  id: "nested-root-probe",
+  register(api) {
+    const helper = require("../lib/helper.cjs");
+    api.registerTool({
+      name: helper.toolName,
+      description: "nested probe tool",
+      parameters: {},
+      execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+  },
+};`,
+      "utf-8",
+    );
+    const helperPath = path.join(root, "lib", "helper.cjs");
+    fs.writeFileSync(helperPath, 'module.exports = { toolName: "nested_tool_v1" };', "utf-8");
+    const writeNestedManifest = (toolName: string) => {
+      fs.writeFileSync(
+        path.join(root, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "nested-root-probe",
+          configSchema: { type: "object", additionalProperties: false },
+          contracts: { tools: [toolName] },
+        }),
+        "utf-8",
+      );
+    };
+    writeNestedManifest("nested_tool_v1");
+    const config = {
+      plugins: { load: { paths: [root] }, allow: ["nested-root-probe"] },
+    };
+
+    expect(loadedToolNames(loadOpenClawPlugins({ config }))).toContain("nested_tool_v1");
+
+    // Edit only the module OUTSIDE the entrypoint directory: entry-dir-scoped
+    // eviction misses it, so the fresh entry pairs with a stale helper.
+    fs.writeFileSync(helperPath, 'module.exports = { toolName: "nested_tool_v2" };', "utf-8");
+    writeNestedManifest("nested_tool_v2");
+
+    clearPluginCachesForInProcessRestart();
+    const reloaded = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(reloaded)).toContain("nested_tool_v2");
+    expect(loadedToolNames(reloaded)).not.toContain("nested_tool_v1");
   });
 });

--- a/src/plugins/loader.restart-reload.test.ts
+++ b/src/plugins/loader.restart-reload.test.ts
@@ -33,12 +33,12 @@ function pluginBody(toolName: string): string {
 };`;
 }
 
-function writeManifest(dir: string, toolName: string): void {
+function writeManifest(dir: string, toolName: string, id = "restart-reload-probe"): void {
   fs.writeFileSync(
     path.join(dir, "openclaw.plugin.json"),
     JSON.stringify(
       {
-        id: "restart-reload-probe",
+        id,
         configSchema: { type: "object", additionalProperties: false },
         contracts: { tools: [toolName] },
       },
@@ -89,5 +89,43 @@ describe("plugin loader in-process restart reload", () => {
     const reloaded = loadOpenClawPlugins({ config });
     expect(loadedToolNames(reloaded)).toContain("probe_tool_v2");
     expect(loadedToolNames(reloaded)).not.toContain("probe_tool_v1");
+  });
+
+  it("reloads plugin-local imported modules, not just the entrypoint (#103688 review)", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "restart-local-dep-probe",
+      filename: "restart-local-dep-probe.cjs",
+      body: `module.exports = {
+  id: "restart-local-dep-probe",
+  register(api) {
+    const helper = require("./helper.cjs");
+    api.registerTool({
+      name: helper.toolName,
+      description: "restart reload probe tool",
+      parameters: {},
+      execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+  },
+};`,
+    });
+    const helperPath = path.join(plugin.dir, "helper.cjs");
+    fs.writeFileSync(helperPath, 'module.exports = { toolName: "helper_tool_v1" };', "utf-8");
+    writeManifest(plugin.dir, "helper_tool_v1", "restart-local-dep-probe");
+    const config = {
+      plugins: { load: { paths: [plugin.file] }, allow: ["restart-local-dep-probe"] },
+    };
+
+    expect(loadedToolNames(loadOpenClawPlugins({ config }))).toContain("helper_tool_v1");
+
+    // Edit only the plugin-LOCAL dependency; a fresh entrypoint must not be paired
+    // with this stale cached helper (the mixed-runtime hazard).
+    fs.writeFileSync(helperPath, 'module.exports = { toolName: "helper_tool_v2" };', "utf-8");
+    writeManifest(plugin.dir, "helper_tool_v2", "restart-local-dep-probe");
+
+    clearPluginCachesForInProcessRestart();
+    const reloaded = loadOpenClawPlugins({ config });
+    expect(loadedToolNames(reloaded)).toContain("helper_tool_v2");
+    expect(loadedToolNames(reloaded)).not.toContain("helper_tool_v1");
   });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -99,7 +99,10 @@ import {
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
-import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
+import {
+  clearNativeRequireJavaScriptModuleCache,
+  clearRequireModuleCacheUnderPluginRoot,
+} from "./native-module-require.js";
 import {
   fingerprintPluginDiscoveryContext,
   resolvePluginDiscoveryContext,
@@ -412,12 +415,18 @@ export function clearPluginLoaderCache(): void {
 export function clearPluginCachesForInProcessRestart(): void {
   clearPluginLoaderCache();
   clearPluginManifestLoadCache();
-  // Evict each tracked entrypoint plus its plugin-LOCAL dependency subtree (e.g. a
-  // helper.cjs beside the entry) through the existing native cache-clear owner, so a
-  // fresh entrypoint is never paired with stale local exports while shared OpenClaw
-  // and third-party singleton modules stay untouched.
+  // Evict each tracked entrypoint plus its plugin-LOCAL dependency subtree so a
+  // fresh entrypoint is never paired with stale local exports while shared
+  // OpenClaw and third-party singleton modules stay untouched. Root-scoped
+  // purge covers jiti-transformed TypeScript entries too (jiti registers them
+  // in Node's CJS cache under their source paths, which the native-JS eviction
+  // cannot match by extension).
   for (const [modulePath, rootDir] of importedPluginModulePathsForRestart) {
-    clearNativeRequireJavaScriptModuleCache(modulePath, rootDir ? { dependencyRoot: rootDir } : {});
+    if (rootDir) {
+      clearRequireModuleCacheUnderPluginRoot(rootDir);
+    } else {
+      clearNativeRequireJavaScriptModuleCache(modulePath, {});
+    }
   }
   importedPluginModulePathsForRestart.clear();
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -398,14 +398,29 @@ export function clearPluginLoaderCache(): void {
 export function clearPluginCachesForInProcessRestart(): void {
   clearPluginLoaderCache();
   clearPluginManifestLoadCache();
+  const pluginModuleRoots = new Set<string>();
   for (const modulePath of importedPluginModulePathsForRestart) {
     try {
-      delete requireForPluginRestartCacheBust.cache[
-        requireForPluginRestartCacheBust.resolve(modulePath)
-      ];
+      const resolved = requireForPluginRestartCacheBust.resolve(modulePath);
+      delete requireForPluginRestartCacheBust.cache[resolved];
+      pluginModuleRoots.add(path.dirname(resolved) + path.sep);
     } catch {
       // Best-effort: TS entrypoints resolve through jiti (per-load instances), and
       // removed files simply have nothing to purge.
+    }
+  }
+  // Also evict plugin-LOCAL modules the entrypoints pulled in (e.g. a helper.cjs
+  // beside the entry): a fresh entrypoint must not receive stale exports from its
+  // previously cached local dependency graph. Bounding eviction to the plugin
+  // directories keeps shared OpenClaw and third-party singletons untouched.
+  if (pluginModuleRoots.size > 0) {
+    for (const cachedPath of Object.keys(requireForPluginRestartCacheBust.cache)) {
+      for (const root of pluginModuleRoots) {
+        if (cachedPath.startsWith(root)) {
+          delete requireForPluginRestartCacheBust.cache[cachedPath];
+          break;
+        }
+      }
     }
   }
   importedPluginModulePathsForRestart.clear();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -352,6 +352,13 @@ function recordPluginModuleImportForRestart(modulePath: string, rootDir?: string
   const existing = importedPluginModulePathsForRestart.get(modulePath);
   importedPluginModulePathsForRestart.set(modulePath, rootDir ?? existing);
 }
+
+export function getTrackedPluginModuleImportsForRestartForTests(): ReadonlyMap<
+  string,
+  string | undefined
+> {
+  return new Map(importedPluginModulePathsForRestart);
+}
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "gateway",
@@ -520,10 +527,12 @@ function createPluginModuleLoader(options: {
       pluginSdkResolution: options.pluginSdkResolution,
     });
   };
-  return (modulePath: string): unknown => {
-    recordPluginModuleImportForRestart(modulePath);
-    return createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
-  };
+  // Restart tracking happens at the plugin-owned call sites (main, setup/runtime,
+  // CLI entrypoints) with each plugin's discovered root — never here: this loader
+  // also imports the shared plugin runtime module, and evicting that on restart
+  // would tear down a module graph core still holds.
+  return (modulePath: string): unknown =>
+    createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
 }
 
 function formatPluginRuntimeModuleResolutionError(params: {
@@ -2253,7 +2262,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               runtimeMod = withProfile(
                 { pluginId: record.id, source: safeRuntimeSource },
                 "load-setup-runtime-entry",
-                () => loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
+                () => {
+                  recordPluginModuleImportForRestart(safeRuntimeSource, runtimeModuleRoot);
+                  return loadPluginModule(safeRuntimeSource) as OpenClawPluginModule;
+                },
               );
             } catch (err) {
               recordPluginError({
@@ -2900,11 +2912,10 @@ export async function loadOpenClawPluginCliRegistry(
 
     let mod: OpenClawPluginModule | null;
     try {
-      mod = withProfile(
-        { pluginId: record.id, source: safeSource },
-        "cli-metadata",
-        () => loadPluginModule(safeSource) as OpenClawPluginModule,
-      );
+      mod = withProfile({ pluginId: record.id, source: safeSource }, "cli-metadata", () => {
+        recordPluginModuleImportForRestart(safeSource, pluginRoot);
+        return loadPluginModule(safeSource) as OpenClawPluginModule;
+      });
     } catch (err) {
       recordPluginError({
         logger,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,7 +1,6 @@
 // Discovers, validates, and loads plugin metadata and runtime entrypoints.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -100,6 +99,7 @@ import {
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
+import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
 import {
   fingerprintPluginDiscoveryContext,
   resolvePluginDiscoveryContext,
@@ -344,7 +344,6 @@ const { scoped: pluginLoaderCacheState, fullWorkspace: fullWorkspacePluginLoader
 // Node's shared require.cache, which must be purged at the in-process restart
 // boundary or reloads re-serve stale module exports (#103571).
 const importedPluginModulePathsForRestart = new Set<string>();
-const requireForPluginRestartCacheBust = createRequire(import.meta.url);
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "gateway",
@@ -398,30 +397,12 @@ export function clearPluginLoaderCache(): void {
 export function clearPluginCachesForInProcessRestart(): void {
   clearPluginLoaderCache();
   clearPluginManifestLoadCache();
-  const pluginModuleRoots = new Set<string>();
+  // Evict each tracked entrypoint plus its plugin-LOCAL dependency subtree (e.g. a
+  // helper.cjs beside the entry) through the existing native cache-clear owner, so a
+  // fresh entrypoint is never paired with stale local exports while shared OpenClaw
+  // and third-party singleton modules stay untouched.
   for (const modulePath of importedPluginModulePathsForRestart) {
-    try {
-      const resolved = requireForPluginRestartCacheBust.resolve(modulePath);
-      delete requireForPluginRestartCacheBust.cache[resolved];
-      pluginModuleRoots.add(path.dirname(resolved) + path.sep);
-    } catch {
-      // Best-effort: TS entrypoints resolve through jiti (per-load instances), and
-      // removed files simply have nothing to purge.
-    }
-  }
-  // Also evict plugin-LOCAL modules the entrypoints pulled in (e.g. a helper.cjs
-  // beside the entry): a fresh entrypoint must not receive stale exports from its
-  // previously cached local dependency graph. Bounding eviction to the plugin
-  // directories keeps shared OpenClaw and third-party singletons untouched.
-  if (pluginModuleRoots.size > 0) {
-    for (const cachedPath of Object.keys(requireForPluginRestartCacheBust.cache)) {
-      for (const root of pluginModuleRoots) {
-        if (cachedPath.startsWith(root)) {
-          delete requireForPluginRestartCacheBust.cache[cachedPath];
-          break;
-        }
-      }
-    }
+    clearNativeRequireJavaScriptModuleCache(modulePath);
   }
   importedPluginModulePathsForRestart.clear();
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -86,18 +86,8 @@ import {
 } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { clearPluginManifestLoadCache } from "./manifest.js";
-import {
-  clearMemoryEmbeddingProviders,
-  listRegisteredMemoryEmbeddingProviders,
-  restoreRegisteredMemoryEmbeddingProviders,
-} from "./memory-embedding-providers.js";
-import {
-  clearMemoryPluginState,
-  getMemoryCapabilityRegistration,
-  listMemoryCorpusSupplements,
-  listMemoryPromptSupplements,
-  restoreMemoryPluginState,
-} from "./memory-state.js";
+import { clearMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
+import { clearMemoryPluginState } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import {
   clearNativeRequireJavaScriptModuleCache,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -343,7 +343,15 @@ const { scoped: pluginLoaderCacheState, fullWorkspace: fullWorkspacePluginLoader
 // Plugin entrypoints imported this process-lifetime; native-required JS lands in
 // Node's shared require.cache, which must be purged at the in-process restart
 // boundary or reloads re-serve stale module exports (#103571).
-const importedPluginModulePathsForRestart = new Set<string>();
+const importedPluginModulePathsForRestart = new Map<string, string | undefined>();
+
+// Records a plugin module import for restart-boundary eviction. rootDir, when known,
+// becomes the eviction dependencyRoot so nested entrypoints (e.g. dist/index.js)
+// still evict plugin-owned modules elsewhere under the package root.
+function recordPluginModuleImportForRestart(modulePath: string, rootDir?: string): void {
+  const existing = importedPluginModulePathsForRestart.get(modulePath);
+  importedPluginModulePathsForRestart.set(modulePath, rootDir ?? existing);
+}
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "gateway",
@@ -401,8 +409,8 @@ export function clearPluginCachesForInProcessRestart(): void {
   // helper.cjs beside the entry) through the existing native cache-clear owner, so a
   // fresh entrypoint is never paired with stale local exports while shared OpenClaw
   // and third-party singleton modules stay untouched.
-  for (const modulePath of importedPluginModulePathsForRestart) {
-    clearNativeRequireJavaScriptModuleCache(modulePath);
+  for (const [modulePath, rootDir] of importedPluginModulePathsForRestart) {
+    clearNativeRequireJavaScriptModuleCache(modulePath, rootDir ? { dependencyRoot: rootDir } : {});
   }
   importedPluginModulePathsForRestart.clear();
 }
@@ -513,7 +521,7 @@ function createPluginModuleLoader(options: {
     });
   };
   return (modulePath: string): unknown => {
-    importedPluginModulePathsForRestart.add(modulePath);
+    recordPluginModuleImportForRestart(modulePath);
     return createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
   };
 }
@@ -2142,11 +2150,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         recordImportedPluginId(record.id);
         pluginLoadAttemptCount++;
         logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
-        mod = withProfile(
-          { pluginId: record.id, source: safeSource },
-          registrationMode,
-          () => loadPluginModule(safeSource) as OpenClawPluginModule,
-        );
+        mod = withProfile({ pluginId: record.id, source: safeSource }, registrationMode, () => {
+          recordPluginModuleImportForRestart(safeSource, record.rootDir);
+          return loadPluginModule(safeSource) as OpenClawPluginModule;
+        });
       } catch (err) {
         recordPluginError({
           logger,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,6 +1,7 @@
 // Discovers, validates, and loads plugin metadata and runtime entrypoints.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -85,8 +86,19 @@ import {
   type PluginManifestRegistry,
 } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
-import { clearMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
-import { clearMemoryPluginState } from "./memory-state.js";
+import { clearPluginManifestLoadCache } from "./manifest.js";
+import {
+  clearMemoryEmbeddingProviders,
+  listRegisteredMemoryEmbeddingProviders,
+  restoreRegisteredMemoryEmbeddingProviders,
+} from "./memory-embedding-providers.js";
+import {
+  clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
+  listMemoryCorpusSupplements,
+  listMemoryPromptSupplements,
+  restoreMemoryPluginState,
+} from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import {
   fingerprintPluginDiscoveryContext,
@@ -328,6 +340,11 @@ class PluginLoadFailureError extends Error {
 
 const { scoped: pluginLoaderCacheState, fullWorkspace: fullWorkspacePluginLoaderCacheState } =
   pluginLoaderCacheInstances;
+// Plugin entrypoints imported this process-lifetime; native-required JS lands in
+// Node's shared require.cache, which must be purged at the in-process restart
+// boundary or reloads re-serve stale module exports (#103571).
+const importedPluginModulePathsForRestart = new Set<string>();
+const requireForPluginRestartCacheBust = createRequire(import.meta.url);
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "gateway",
@@ -365,6 +382,35 @@ function createPluginCandidatesFromManifestRegistry(
     ...(record.packageManifest !== undefined ? { packageManifest: record.packageManifest } : {}),
   }));
 }
+export function clearPluginLoaderCache(): void {
+  pluginLoaderCacheState.clear();
+  fullWorkspacePluginLoaderCacheState.clear();
+  clearActivatedPluginRuntimeState();
+}
+
+/**
+ * Drops cached plugin registries, activated runtime state, and manifest reads at the
+ * in-process gateway restart boundary (SIGUSR1 / `gateway restart --safe`). Restart is
+ * the explicit reload moment for process-stable plugin state: without this, the next
+ * startup re-runs `register()` from the cached module graph and logs "registered"
+ * while updated workspace plugin source on disk never loads (#103571).
+ */
+export function clearPluginCachesForInProcessRestart(): void {
+  clearPluginLoaderCache();
+  clearPluginManifestLoadCache();
+  for (const modulePath of importedPluginModulePathsForRestart) {
+    try {
+      delete requireForPluginRestartCacheBust.cache[
+        requireForPluginRestartCacheBust.resolve(modulePath)
+      ];
+    } catch {
+      // Best-effort: TS entrypoints resolve through jiti (per-load instances), and
+      // removed files simply have nothing to purge.
+    }
+  }
+  importedPluginModulePathsForRestart.clear();
+}
+
 export function clearActivatedPluginRuntimeState(): void {
   clearAgentHarnesses();
   clearPluginCommands();
@@ -470,8 +516,10 @@ function createPluginModuleLoader(options: {
       pluginSdkResolution: options.pluginSdkResolution,
     });
   };
-  return (modulePath: string): unknown =>
-    createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
+  return (modulePath: string): unknown => {
+    importedPluginModulePathsForRestart.add(modulePath);
+    return createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
+  };
 }
 
 function formatPluginRuntimeModuleResolutionError(params: {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -45,6 +45,14 @@ type PluginManifestLoadCacheEntry = {
 const pluginManifestLoadCache = new PluginLruCache<PluginManifestLoadCacheEntry>(
   MAX_PLUGIN_MANIFEST_LOAD_CACHE_ENTRIES,
 );
+
+// The manifest load cache is process-stable and keyed by file identity, so an in-process
+// restart that reloads updated workspace plugin code must also drop cached manifests or the
+// next load re-serves stale metadata for changed plugins (#103571).
+export function clearPluginManifestLoadCache(): void {
+  pluginManifestLoadCache.clear();
+}
+
 export type PluginManifestChannelConfig = {
   schema: JsonSchemaObject;
   uiHints?: Record<string, PluginConfigUiHint>;

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -110,6 +110,22 @@ export function clearNativeRequireJavaScriptModuleCache(
   }
 }
 
+/**
+ * Clears every CJS-cached module under a plugin's package root, regardless of
+ * extension. TypeScript plugin entrypoints load through jiti, which registers
+ * transformed modules in Node's native require cache (moduleCache: true) keyed
+ * by their source path — the native-JS eviction above never matches ".ts", so
+ * restart eviction for a plugin with a known root purges by root containment.
+ */
+export function clearRequireModuleCacheUnderPluginRoot(rootDir: string): void {
+  const root = resolveRequireCachePath(rootDir);
+  for (const cachedPath of Object.keys(nodeRequire.cache)) {
+    if (isPathInsideOrSame(root, cachedPath)) {
+      delete nodeRequire.cache[cachedPath];
+    }
+  }
+}
+
 function resolveRequireCachePath(targetPath: string): string {
   try {
     return fs.realpathSync.native(targetPath);


### PR DESCRIPTION
## What Problem This Solves

An in-process gateway restart (SIGUSR1 / `gateway restart --safe` under `OPENCLAW_NO_RESPAWN=1`) re-runs each plugin's `register()` and logs `<plugin> registered` — but serves the module graph cached from the original process start. Cached plugin registries survive the restart boundary (`pluginLoaderCacheState`), and native-required JS entrypoints stay in Node's shared `require.cache`, so updated **workspace plugin code** on disk (e.g. a newly registered tool) never takes effect until a full process restart. Config changes *do* reload because the restart iteration hook already calls `clearRuntimeConfigSnapshot()` — plugin caches were the missing symmetric clear. Fixes #103571.

## Why This Change Was Made

Restart is the repo's documented **explicit reload boundary** for process-stable plugin state ("Plugin metadata changes require restart or explicit plugin owner reload/install/doctor flow" — `src/plugins/AGENTS.md`). Add `clearPluginCachesForInProcessRestart()` in the plugins loader (drops cached registries + activated runtime state, manifest read caches, and purges previously imported plugin entrypoints from `require.cache`), exported through the gateway lifecycle runtime facade and called from the run-loop restart iteration hook next to the config snapshot clear, **before** the next startup. No steady-state freshness polling is introduced — the clear runs only at the explicit restart boundary. No new options or public API surface.

## User Impact

Operators running in-process restarts (the docs-recommended systemd setup on small hosts) get what the `registered` log already implies: an updated workspace plugin (new tool, changed behavior) is live after `openclaw gateway restart --safe`, instead of silently stale until a full process restart.

## Evidence

Two tests, both discriminating:
- `run-loop.test.ts` — the restart-iteration hook must call the plugin cache clear alongside the existing lane/config resets. **Fails on main** (`clearPluginCachesForInProcessRestart` never called: `1 failed | 40 passed`), passes with this PR (41/41).
- `loader.restart-reload.test.ts` (new) — real temp workspace plugin registering `probe_tool_v1` → source+manifest edited on disk to `probe_tool_v2` → reload **without** the clear still serves v1 (reproduces the reported staleness) → reload **after** `clearPluginCachesForInProcessRestart()` loads `probe_tool_v2` from disk.

`tsgo:core` 0 errors; `oxfmt`/`oxlint` clean.
