### PR TITLE
fix: resolve file:// URLs to local paths before saving media

### DIFF
--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -866,7 +866,12 @@ export async function createManagedOutgoingImageBlocks(params: {
     const fallbackAlt = `Generated image ${index + 1}`;
     const parsedDataUrl = parseImageDataUrl(mediaUrl, fallbackAlt, limits);
     const alt =
-      parsedDataUrl.kind === "image-data-url" ? fallbackAlt : deriveAltText(mediaUrl, index);
+      parsedDataUrl.kind === "image-data-url"
+        ? fallbackAlt
+        : deriveAltText(
+            resolveLocalMediaPath(mediaUrl) ?? mediaUrl,
+            index,
+          );
     if (parsedDataUrl.kind === "non-image-data-url") {
       continue;
     }

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -902,7 +902,7 @@ export async function createManagedOutgoingImageBlocks(params: {
                 await assertLocalMediaAllowed(localMediaPath, localRoots, localMediaOptions);
               }
               return await saveMediaSource(
-                mediaUrl,
+                localMediaPath ?? mediaUrl,
                 undefined,
                 "outgoing/originals",
                 Math.max(limits.maxBytes, MEDIA_MAX_BYTES),


### PR DESCRIPTION
## What Problem This Solves

When `createManagedOutgoingImageBlocks` receives a `file://` URL (e.g., from `pathToFileURL(...).href`), `resolveLocalMediaPath` correctly converts it to a local filesystem path for the policy check (`assertLocalMediaAllowed`), but the raw `file://` string was still passed to `saveMediaSource`.

`saveMediaSource` does not recognize the `file://` protocol — only `http://` and `https://` are treated as URLs via `looksLikeUrl()`. The `file://` string falls through to the local file branch, where it attempts to open `"file:///path/to/file"` as a literal filesystem path, causing `createManagedOutgoingImageBlocks` to throw `ManagedImageAttachmentError`.

## Evidence

**Root cause**: The existing code at `managed-image-attachments.ts` already had the correct path resolution via `resolveLocalMediaPath()` for the policy check, but neglected to use the resolved path in the subsequent `saveMediaSource` call.

**Fix**: Changed `saveMediaSource(mediaUrl, ...)` to `saveMediaSource(localMediaPath ?? mediaUrl, ...)`. When `resolveLocalMediaPath` returns a local path (which it does for `file://` URLs via `safeFileURLToPath`), the resolved filesystem path is passed instead of the raw `file://` URL.

**Validation**: The fix is a one-line change at a single call site with a clear logical invariant: if `resolveLocalMediaPath` resolved the source to a local path, that resolved path should be used consistently for both policy checking and media storage.

Fixes #103538