### PR TITLE
fix(mcp): silence unknown schema format warnings

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -353,22 +353,60 @@ describe("session MCP runtime", () => {
       const validator = createBundleMcpJsonSchemaValidator().getValidator<{
         duration: string;
         email: string;
+        idnEmail: string;
+        isoTime: string;
+        jsonPointerFragment: string;
       }>({
         type: "object",
         properties: {
           duration: { type: "string", format: "google-duration" },
           email: { type: "string", format: "email" },
+          idnEmail: { type: "string", format: "idn-email" },
+          isoTime: { type: "string", format: "iso-time" },
+          jsonPointerFragment: {
+            type: "string",
+            format: "json-pointer-uri-fragment",
+          },
         },
-        required: ["duration", "email"],
+        required: ["duration", "email", "idnEmail", "isoTime", "jsonPointerFragment"],
         additionalProperties: false,
       });
 
       expect(warnSpy).not.toHaveBeenCalled();
-      expect(validator({ duration: "not parsed by OpenClaw", email: "bad" }).valid).toBe(false);
+      expect(
+        validator({
+          duration: "not parsed by OpenClaw",
+          email: "bad",
+          idnEmail: "not checked by ajv-formats",
+          isoTime: "09:30:15Z",
+          jsonPointerFragment: "#/valid/path",
+        }).valid,
+      ).toBe(false);
       expect(
         validator({
           duration: "not parsed by OpenClaw",
           email: "ops@example.com",
+          idnEmail: "not checked by ajv-formats",
+          isoTime: "not an iso time",
+          jsonPointerFragment: "#/valid/path",
+        }).valid,
+      ).toBe(false);
+      expect(
+        validator({
+          duration: "not parsed by OpenClaw",
+          email: "ops@example.com",
+          idnEmail: "not checked by ajv-formats",
+          isoTime: "09:30:15Z",
+          jsonPointerFragment: "not a uri fragment",
+        }).valid,
+      ).toBe(false);
+      expect(
+        validator({
+          duration: "not parsed by OpenClaw",
+          email: "ops@example.com",
+          idnEmail: "not checked by ajv-formats",
+          isoTime: "09:30:15Z",
+          jsonPointerFragment: "#/valid/path",
         }).valid,
       ).toBe(true);
     } finally {
@@ -905,6 +943,64 @@ describe("session MCP runtime", () => {
       expect(catalog.diagnostics?.[0]?.message).toContain("object");
     } finally {
       await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lists MCP tools whose schemas mix unknown formats with ajv-formats registry formats", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-schema-formats-"));
+    const serverPath = path.join(tempDir, "schema-formats.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      tools: [
+        {
+          name: "format_probe",
+          inputSchema: {
+            type: "object",
+            properties: {
+              duration: { type: "string", format: "google-duration" },
+              idnEmail: { type: "string", format: "idn-email" },
+              isoTime: { type: "string", format: "iso-time" },
+              jsonPointerFragment: {
+                type: "string",
+                format: "json-pointer-uri-fragment",
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-schema-formats",
+      sessionKey: "agent:test:session-schema-formats",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            schemaFormats: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(catalog.diagnostics ?? []).toEqual([]);
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["format_probe"]);
+      expect(catalog.servers.schemaFormats?.toolCount).toBe(1);
+      await waitForFileText(logPath, "recv tools/list", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+      warnSpy.mockRestore();
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -346,6 +346,36 @@ afterEach(async () => {
 });
 
 describe("session MCP runtime", () => {
+  it("ignores unknown non-draft schema formats without suppressing known format validation", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const validator = createBundleMcpJsonSchemaValidator().getValidator<{
+        duration: string;
+        email: string;
+      }>({
+        type: "object",
+        properties: {
+          duration: { type: "string", format: "google-duration" },
+          email: { type: "string", format: "email" },
+        },
+        required: ["duration", "email"],
+        additionalProperties: false,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(validator({ duration: "not parsed by OpenClaw", email: "bad" }).valid).toBe(false);
+      expect(
+        validator({
+          duration: "not parsed by OpenClaw",
+          email: "ops@example.com",
+        }).valid,
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("accepts draft-2020-12 tool output schemas from external MCP catalogs", () => {
     const validator = createBundleMcpJsonSchemaValidator().getValidator<{
       format: string;

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -133,6 +133,8 @@ const schemaValueKeywords = new Set([
   "unevaluatedProperties",
 ]);
 const schemaArrayKeywords = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+// Keep in sync with ajv-formats 3.x formatNames; MCP schemas may use draft
+// vocabularies, but Ajv only validates the formats registered by this package.
 const ajvKnownFormats = new Set([
   "binary",
   "byte",
@@ -143,15 +145,14 @@ const ajvKnownFormats = new Set([
   "email",
   "float",
   "hostname",
-  "idn-email",
-  "idn-hostname",
   "int32",
   "int64",
   "ipv4",
   "ipv6",
-  "iri",
-  "iri-reference",
+  "iso-date-time",
+  "iso-time",
   "json-pointer",
+  "json-pointer-uri-fragment",
   "password",
   "regex",
   "relative-json-pointer",

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -133,13 +133,48 @@ const schemaValueKeywords = new Set([
   "unevaluatedProperties",
 ]);
 const schemaArrayKeywords = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+const ajvKnownFormats = new Set([
+  "binary",
+  "byte",
+  "date",
+  "date-time",
+  "double",
+  "duration",
+  "email",
+  "float",
+  "hostname",
+  "idn-email",
+  "idn-hostname",
+  "int32",
+  "int64",
+  "ipv4",
+  "ipv6",
+  "iri",
+  "iri-reference",
+  "json-pointer",
+  "password",
+  "regex",
+  "relative-json-pointer",
+  "time",
+  "uri",
+  "uri-reference",
+  "uri-template",
+  "url",
+  "uuid",
+]);
 
-function stripSchemaMapFormats(value: unknown): unknown {
+function stripSchemaMapFormats(
+  value: unknown,
+  shouldStripFormat: (format: string) => boolean,
+): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return value;
   }
   return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [key, stripJsonSchemaFormats(entry)]),
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      stripJsonSchemaFormats(entry, shouldStripFormat),
+    ]),
   );
 }
 
@@ -153,9 +188,12 @@ function expandJsonSchemaTypeArray(schema: Record<string, unknown>): Record<stri
   };
 }
 
-function stripJsonSchemaFormats(schema: unknown): unknown {
+function stripJsonSchemaFormats(
+  schema: unknown,
+  shouldStripFormat: (format: string) => boolean = () => true,
+): unknown {
   if (Array.isArray(schema)) {
-    return schema.map((entry) => stripJsonSchemaFormats(entry));
+    return schema.map((entry) => stripJsonSchemaFormats(entry, shouldStripFormat));
   }
   if (!schema || typeof schema !== "object") {
     return schema;
@@ -163,20 +201,27 @@ function stripJsonSchemaFormats(schema: unknown): unknown {
   const normalizedSchema = expandJsonSchemaTypeArray(schema as Record<string, unknown>);
   return Object.fromEntries(
     Object.entries(normalizedSchema)
-      .filter(([key]) => key !== "format")
+      .filter(
+        ([key, value]) =>
+          key !== "format" || typeof value !== "string" || !shouldStripFormat(value),
+      )
       .map(([key, value]) => {
         if (schemaMapKeywords.has(key)) {
-          return [key, stripSchemaMapFormats(value)];
+          return [key, stripSchemaMapFormats(value, shouldStripFormat)];
         }
         if (key === "dependencies") {
-          return [key, stripSchemaMapFormats(value)];
+          return [key, stripSchemaMapFormats(value, shouldStripFormat)];
         }
         if (schemaValueKeywords.has(key) || schemaArrayKeywords.has(key)) {
-          return [key, stripJsonSchemaFormats(value)];
+          return [key, stripJsonSchemaFormats(value, shouldStripFormat)];
         }
         return [key, value];
       }),
   );
+}
+
+function stripUnknownJsonSchemaFormats(schema: unknown): unknown {
+  return stripJsonSchemaFormats(schema, (format) => !ajvKnownFormats.has(format));
 }
 
 export function createBundleMcpJsonSchemaValidator(): jsonSchemaValidator {
@@ -185,7 +230,9 @@ export function createBundleMcpJsonSchemaValidator(): jsonSchemaValidator {
   return {
     getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
       if (!isDraft202012Schema(schema)) {
-        return defaultValidator.getValidator<T>(schema);
+        return defaultValidator.getValidator<T>(
+          stripUnknownJsonSchemaFormats(schema) as JsonSchemaType,
+        );
       }
       let validator: ReturnType<typeof Compile>;
       try {


### PR DESCRIPTION
Closes #103694

AI-assisted contribution.

## What Problem This Solves

Fixes an issue where operators using remote MCP servers would see repeated WARN-level startup noise when a tool schema used an informational, non-standard JSON Schema `format` such as `google-duration`.

## Why This Change Was Made

OpenClaw now strips only unknown schema `format` values before non-draft MCP schemas reach the SDK AJV validator. Known AJV formats such as `email`, `uri`, and date/time formats remain in place, so this removes the noisy warning without disabling standard format validation. Existing draft-2020-12 handling keeps its current format-stripping behavior.

## User Impact

Remote MCP servers with vendor-specific schema formats can load without polluting boot logs with duplicate warnings, while normal schema validation still catches invalid values for supported standard formats.

## Evidence

- Reproduced the underlying AJV behavior locally: compiling a schema with `format: "google-duration"` emits duplicate `unknown format` warnings while still validating successfully.
- Added a regression test proving `google-duration` no longer calls `console.warn` and that a known `email` format still rejects invalid input.
- Validation run:
  - `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts`
  - Passed: 1 file, 43 tests.
  - `node scripts/run-oxlint.mjs src/agents/agent-bundle-mcp-runtime.ts src/agents/agent-bundle-mcp-runtime.test.ts`
  - `git diff --check`
  - Both passed.
