### PR TITLE
fix(mcp): bound short-lived OAuth requests

### DIFF
--- a/src/agents/mcp-auth-profile.test.ts
+++ b/src/agents/mcp-auth-profile.test.ts
@@ -1,6 +1,7 @@
 /** Tests auth-profile backed MCP bearer projection. */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMcpBearerBundleConfig, withMcpAuthProfileBearer } from "./mcp-auth-profile.js";
+import * as mcpHttpFetch from "./mcp-http-fetch.js";
 
 const authMocks = vi.hoisted(() => ({
   loadAuthProfileStoreForSecretsRuntime: vi.fn(),
@@ -27,7 +28,12 @@ describe("mcp auth profile bearer projection", () => {
     authMocks.resolveMcpOAuthAccessToken.mockReset();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("projects existing MCP-native OAuth credentials without an auth profile", async () => {
+    const buildMcpHttpFetch = vi.spyOn(mcpHttpFetch, "buildMcpHttpFetch");
     authMocks.resolveMcpOAuthAccessToken.mockResolvedValueOnce("native-access-token");
 
     const resolved = await resolveMcpBearerBundleConfig({
@@ -38,6 +44,7 @@ describe("mcp auth profile bearer projection", () => {
             type: "http",
             auth: "oauth",
             oauth: { scope: "docs.read" },
+            requestTimeoutMs: 25,
           },
         },
       },
@@ -52,6 +59,12 @@ describe("mcp auth profile bearer projection", () => {
     expect(resolved.config.mcpServers.docs?.auth).toBeUndefined();
     expect(resolved.config.mcpServers.docs?.oauth).toBeUndefined();
     expect(Object.values(resolved.env ?? {})).toEqual(["native-access-token"]);
+    expect(buildMcpHttpFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceUrl: "https://mcp.example.com/mcp",
+        timeoutMs: 25,
+      }),
+    );
     expect(authMocks.resolveMcpOAuthAccessToken).toHaveBeenCalledWith(
       expect.objectContaining({
         serverName: "docs",

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -24,16 +24,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function withoutAuthorizationHeader(
-  headers: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!headers) {
-    return undefined;
-  }
-  const entries = Object.entries(headers).filter(([key]) => key.toLowerCase() !== "authorization");
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
 function normalizeStringHeaders(value: unknown): Record<string, string> | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -136,6 +126,9 @@ async function resolveMcpBearerToken(params: {
       clientCert: resolved.clientCert,
       clientKey: resolved.clientKey,
       resourceUrl: resolved.url,
+      // OAuth discovery and token refresh must be bounded. Runtime transports
+      // stay unbounded because they own long-lived SSE and streamable bodies.
+      timeoutMs: resolved.requestTimeoutMs,
     }),
     headers: withoutMcpAuthorizationHeader(resolved.headers),
     resourceUrl: resolved.url,
@@ -159,7 +152,7 @@ export function withMcpAuthProfileBearer(
   } & McpAuthProfileOptions,
 ): FetchLike {
   const resourceOrigin = new URL(params.resourceUrl).origin;
-  const configuredHeaders = withoutAuthorizationHeader(params.headers);
+  const configuredHeaders = withoutMcpAuthorizationHeader(params.headers);
   return async (url, init) => {
     if (new URL(url).origin !== resourceOrigin) {
       return params.fetchFn(url, init);
@@ -239,7 +232,7 @@ export async function resolveMcpBearerBundleConfig(
       nextEnv[envVar] = token;
       authorization = `Bearer \${${envVar}}`;
     }
-    const headers = withoutAuthorizationHeader(normalizeStringHeaders(server.headers));
+    const headers = withoutMcpAuthorizationHeader(normalizeStringHeaders(server.headers));
     nextServers ??= { ...params.config.mcpServers };
     nextServers[serverName] = stripOpenClawOnlyOAuthConfig({
       ...server,

--- a/src/agents/mcp-auth-profile.ts
+++ b/src/agents/mcp-auth-profile.ts
@@ -126,8 +126,8 @@ async function resolveMcpBearerToken(params: {
       clientCert: resolved.clientCert,
       clientKey: resolved.clientKey,
       resourceUrl: resolved.url,
-      // OAuth discovery and token refresh must be bounded. Runtime transports
-      // stay unbounded because they own long-lived SSE and streamable bodies.
+      // External bearer projection performs only OAuth discovery/token work,
+      // so the configured deadline can own the full short-lived response.
       timeoutMs: resolved.requestTimeoutMs,
     }),
     headers: withoutMcpAuthorizationHeader(resolved.headers),

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -272,4 +272,49 @@ describe("MCP HTTP fetch helpers", () => {
     expect(response.body).toBeNull();
     expect(text).not.toHaveBeenCalled();
   });
+
+  it("aborts hung OAuth requests when requestTimeoutMs is configured", async () => {
+    vi.useFakeTimers();
+    try {
+      testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+        Agent: TestAgent,
+        EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+        ProxyAgent: TestProxyAgent,
+        fetch: async (_url: string | URL | Request, init?: unknown) =>
+          await new Promise<Response>((_resolve, reject) => {
+            const signal =
+              typeof init === "object" && init !== null && "signal" in init
+                ? (init as { signal?: AbortSignal }).signal
+                : undefined;
+            if (!signal) {
+              reject(new Error("expected signal"));
+              return;
+            }
+            const rejectForAbort = () => {
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new Error("MCP OAuth request aborted"),
+              );
+            };
+            if (signal.aborted) {
+              rejectForAbort();
+              return;
+            }
+            signal.addEventListener("abort", rejectForAbort, { once: true });
+          }),
+      };
+      const fetch = buildMcpHttpFetch({
+        resourceUrl: "https://mcp.example.com/mcp",
+        requestTimeoutMs: 25,
+      });
+
+      const pending = fetch("https://mcp.example.com/token", { method: "POST" });
+      const expectation = expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+      await vi.advanceTimersByTimeAsync(30);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -116,6 +116,13 @@ function expectBoundedTimeout(error: unknown, undiciCode: string): void {
   });
 }
 
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  return await promise.then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+}
+
 describe("MCP HTTP fetch helpers", () => {
   const fetchCalls: Array<{
     url: string | URL | Request;
@@ -321,19 +328,13 @@ describe("MCP HTTP fetch helpers", () => {
       try {
         const pending = fetch(`${baseUrl}/token`, { method: "POST" });
         if (stage === "headers") {
-          const error = await pending.then(
-            () => undefined,
-            (error: unknown) => error,
-          );
+          const error = await captureRejection(pending);
           expect(error).toBeDefined();
           expectBoundedTimeout(error, "UND_ERR_HEADERS_TIMEOUT");
           return;
         }
         const response = await pending;
-        const error = await response.json().then(
-          () => undefined,
-          (error: unknown) => error,
-        );
+        const error = await captureRejection(response.json());
         expect(error).toBeDefined();
         expectBoundedTimeout(error, "UND_ERR_BODY_TIMEOUT");
       } finally {

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -106,6 +106,16 @@ async function closeLoopbackServer(server: Server): Promise<void> {
   await closed;
 }
 
+function expectBoundedTimeout(error: unknown, undiciCode: string): void {
+  if (error instanceof Error && error.name === "TimeoutError") {
+    return;
+  }
+  expect(error).toMatchObject({
+    name: "TypeError",
+    cause: expect.objectContaining({ code: undiciCode }),
+  });
+}
+
 describe("MCP HTTP fetch helpers", () => {
   const fetchCalls: Array<{
     url: string | URL | Request;
@@ -306,19 +316,53 @@ describe("MCP HTTP fetch helpers", () => {
         }
       });
       const baseUrl = await listenOnLoopback(server);
-      const fetch = buildMcpHttpFetch({ resourceUrl: `${baseUrl}/mcp`, timeoutMs: 100 });
+      const fetch = buildMcpHttpFetch({ resourceUrl: `${baseUrl}/mcp`, timeoutMs: 500 });
 
       try {
         const pending = fetch(`${baseUrl}/token`, { method: "POST" });
         if (stage === "headers") {
-          await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+          const error = await pending.then(
+            () => undefined,
+            (error: unknown) => error,
+          );
+          expect(error).toBeDefined();
+          expectBoundedTimeout(error, "UND_ERR_HEADERS_TIMEOUT");
           return;
         }
         const response = await pending;
-        await expect(response.json()).rejects.toMatchObject({ name: "TimeoutError" });
+        const error = await response.json().then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+        expect(error).toBeDefined();
+        expectBoundedTimeout(error, "UND_ERR_BODY_TIMEOUT");
       } finally {
         await closeLoopbackServer(server);
       }
     },
   );
+
+  it("composes caller cancellation with the configured timeout", async () => {
+    const controller = new AbortController();
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async (_url: string | URL | Request, init?: unknown) => {
+        const signal =
+          typeof init === "object" && init !== null && "signal" in init
+            ? (init as { signal?: AbortSignal }).signal
+            : undefined;
+        controller.abort();
+        expect(signal?.aborted).toBe(true);
+        return new Response(null, { status: 204 });
+      },
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+      timeoutMs: 60_000,
+    });
+
+    await fetch("https://mcp.example.com/token", { signal: controller.signal });
+  });
 });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -1,3 +1,5 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { parseErrorResponse } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 /**
@@ -82,6 +84,26 @@ function getDispatcherConnectOptions(init: unknown): Record<string, unknown> | u
   }
   const options = dispatcher.options as { connect?: Record<string, unknown> };
   return options.connect;
+}
+
+async function listenOnLoopback(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeLoopbackServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  server.closeAllConnections();
+  await closed;
 }
 
 describe("MCP HTTP fetch helpers", () => {
@@ -273,48 +295,30 @@ describe("MCP HTTP fetch helpers", () => {
     expect(text).not.toHaveBeenCalled();
   });
 
-  it("aborts hung OAuth requests when requestTimeoutMs is configured", async () => {
-    vi.useFakeTimers();
-    try {
-      testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-        Agent: TestAgent,
-        EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-        ProxyAgent: TestProxyAgent,
-        fetch: async (_url: string | URL | Request, init?: unknown) =>
-          await new Promise<Response>((_resolve, reject) => {
-            const signal =
-              typeof init === "object" && init !== null && "signal" in init
-                ? (init as { signal?: AbortSignal }).signal
-                : undefined;
-            if (!signal) {
-              reject(new Error("expected signal"));
-              return;
-            }
-            const rejectForAbort = () => {
-              reject(
-                signal.reason instanceof Error
-                  ? signal.reason
-                  : new Error("MCP OAuth request aborted"),
-              );
-            };
-            if (signal.aborted) {
-              rejectForAbort();
-              return;
-            }
-            signal.addEventListener("abort", rejectForAbort, { once: true });
-          }),
-      };
-      const fetch = buildMcpHttpFetch({
-        resourceUrl: "https://mcp.example.com/mcp",
-        requestTimeoutMs: 25,
+  it.each(["headers", "body"] as const)(
+    "aborts a hung OAuth request while awaiting %s",
+    async (stage) => {
+      delete testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY];
+      const server = createServer((_request, response) => {
+        if (stage === "body") {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.write('{"access_token":');
+        }
       });
+      const baseUrl = await listenOnLoopback(server);
+      const fetch = buildMcpHttpFetch({ resourceUrl: `${baseUrl}/mcp`, timeoutMs: 100 });
 
-      const pending = fetch("https://mcp.example.com/token", { method: "POST" });
-      const expectation = expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
-      await vi.advanceTimersByTimeAsync(30);
-      await expectation;
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+      try {
+        const pending = fetch(`${baseUrl}/token`, { method: "POST" });
+        if (stage === "headers") {
+          await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+          return;
+        }
+        const response = await pending;
+        await expect(response.json()).rejects.toMatchObject({ name: "TimeoutError" });
+      } finally {
+        await closeLoopbackServer(server);
+      }
+    },
+  );
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -96,6 +96,7 @@ export function buildMcpHttpFetch(params: {
   clientCert?: string;
   clientKey?: string;
   resourceUrl?: string;
+  requestTimeoutMs?: number;
 }): FetchLike {
   const needsCustomDispatcher =
     params.sslVerify === false || Boolean(params.clientCert || params.clientKey);
@@ -127,6 +128,7 @@ export function buildMcpHttpFetch(params: {
       allowCrossOriginUnsafeRedirectReplay: true,
       auditContext: "mcp-http",
       useEnvProxyForEligibleUrls: true,
+      ...(params.requestTimeoutMs !== undefined ? { timeoutMs: params.requestTimeoutMs } : {}),
       ...(policy ? { policy } : {}),
       ...(needsCustomDispatcher ? { resolveDispatcherPolicy: resolveCustomDispatcherPolicy } : {}),
     };

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -96,7 +96,7 @@ export function buildMcpHttpFetch(params: {
   clientCert?: string;
   clientKey?: string;
   resourceUrl?: string;
-  requestTimeoutMs?: number;
+  timeoutMs?: number;
 }): FetchLike {
   const needsCustomDispatcher =
     params.sslVerify === false || Boolean(params.clientCert || params.clientKey);
@@ -128,7 +128,7 @@ export function buildMcpHttpFetch(params: {
       allowCrossOriginUnsafeRedirectReplay: true,
       auditContext: "mcp-http",
       useEnvProxyForEligibleUrls: true,
-      ...(params.requestTimeoutMs !== undefined ? { timeoutMs: params.requestTimeoutMs } : {}),
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
       ...(policy ? { policy } : {}),
       ...(needsCustomDispatcher ? { resolveDispatcherPolicy: resolveCustomDispatcherPolicy } : {}),
     };

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -33,19 +33,21 @@ function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
     const body = request.body ?? undefined;
     return {
       url: request.url,
+      signal: request.signal,
       init: {
         method: request.method,
         headers: request.headers,
         body,
         redirect: request.redirect,
-        signal: request.signal,
         ...(body ? ({ duplex: "half" } as const) : {}),
       } satisfies RequestInit & { duplex?: "half" },
     };
   }
+  const { signal, ...requestInit } = init ?? {};
   return {
     url: input instanceof URL ? input.toString() : input,
-    init,
+    signal: signal ?? undefined,
+    init: init ? requestInit : undefined,
   };
 }
 
@@ -128,6 +130,7 @@ export function buildMcpHttpFetch(params: {
       allowCrossOriginUnsafeRedirectReplay: true,
       auditContext: "mcp-http",
       useEnvProxyForEligibleUrls: true,
+      ...(request.signal ? { signal: request.signal } : {}),
       ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
       ...(policy ? { policy } : {}),
       ...(needsCustomDispatcher ? { resolveDispatcherPolicy: resolveCustomDispatcherPolicy } : {}),

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -124,6 +124,8 @@ export function resolveMcpTransport(
           config: resolved.oauth,
         })
       : undefined;
+  // The SDK reuses one fetch for OAuth and long-lived SSE/streamable bodies.
+  // Per-RPC deadlines belong to client calls, not this transport fetch.
   const baseFetch = buildMcpHttpFetch({
     sslVerify: resolved.sslVerify,
     clientCert: resolved.clientCert,

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { registerMcpCli } from "./mcp-cli.js";
 
@@ -305,6 +306,7 @@ describe("mcp cli", () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      const buildMcpHttpFetch = vi.spyOn(mcpHttpFetch, "buildMcpHttpFetch");
       runMcpOAuthLogin.mockResolvedValueOnce("authorized");
 
       await runMcpCommand([
@@ -325,6 +327,12 @@ describe("mcp cli", () => {
       ]);
       await runMcpCommand(["mcp", "login", "docs", "--code", "abc123"]);
 
+      expect(buildMcpHttpFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceUrl: "https://mcp.example.com",
+          requestTimeoutMs: 9_000,
+        }),
+      );
       expect(runMcpOAuthLogin).toHaveBeenCalledWith({
         serverName: "docs",
         serverUrl: "https://mcp.example.com",

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -330,7 +330,7 @@ describe("mcp cli", () => {
       expect(buildMcpHttpFetch).toHaveBeenCalledWith(
         expect.objectContaining({
           resourceUrl: "https://mcp.example.com",
-          requestTimeoutMs: 9_000,
+          timeoutMs: 9_000,
         }),
       );
       expect(runMcpOAuthLogin).toHaveBeenCalledWith({

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1260,6 +1260,7 @@ export function registerMcpCli(program: Command) {
             clientCert: resolved.clientCert,
             clientKey: resolved.clientKey,
             resourceUrl: resolved.url,
+            requestTimeoutMs: resolved.requestTimeoutMs,
           }),
           headers: withoutMcpAuthorizationHeader(resolved.headers),
           resourceUrl: resolved.url,

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1260,7 +1260,7 @@ export function registerMcpCli(program: Command) {
             clientCert: resolved.clientCert,
             clientKey: resolved.clientKey,
             resourceUrl: resolved.url,
-            requestTimeoutMs: resolved.requestTimeoutMs,
+            timeoutMs: resolved.requestTimeoutMs,
           }),
           headers: withoutMcpAuthorizationHeader(resolved.headers),
           resourceUrl: resolved.url,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Short-lived MCP OAuth HTTP work could hang indefinitely even when the server had `requestTimeoutMs` configured. This affected `openclaw mcp login <name>` and MCP-native OAuth bearer projection for external runtimes when discovery, token exchange, an upstream proxy, or response-body delivery stalled.

The pre-header case was only half of the bug: a peer could send headers and then stop during JSON body delivery, leaving OAuth consumers blocked after `fetch()` had resolved.

## Why This Change Was Made

Apply the configured deadline at the shared guarded-fetch boundary and keep it active through managed response-body consumption. CLI login and external bearer projection now map `requestTimeoutMs` into the short-lived OAuth fetch lifecycle.

Maintainer follow-up also:

- composed caller cancellation with the deadline instead of overwriting `RequestInit.signal`;
- carried that composed signal across redirects;
- reused the shared case-insensitive Authorization-header filter;
- covered both OpenClaw timer aborts and the matching Undici header/body timeout causes;
- intentionally kept runtime transport fetches unbounded because MCP SDK 1.29.0 reuses them for long-lived SSE and Streamable HTTP bodies. Per-RPC runtime deadlines remain unchanged.

## User Impact

**Before:** MCP OAuth login or external bearer projection could wait forever before headers or during a stalled response body.

**After:** Existing `requestTimeoutMs` configuration bounds the complete short-lived OAuth response lifecycle while preserving caller cancellation and valid long-lived MCP transports.

## Evidence

- Exact reviewed head: `e8e1905469a29321b018dcb921baabc7cbabc0a4`
- Fresh autoreview after each accepted refactor: clean
- Sanitized AWS Crabbox `run_37614b899e44`, Linux Node 24.15.0:
  - 46 focused CLI, auth-profile, and guarded-fetch assertions passed
  - `pnpm check:changed` passed core/core-test typechecks, lint, dependency, architecture, database, media, runtime-loader, import-cycle, webhook, and pairing guards
  - real `openclaw mcp login docs` failed safely 1200 ms after a loopback peer accepted a pre-header stall
  - real `openclaw mcp login docs` failed safely 1184 ms after a loopback peer sent a partial JSON body and stalled
- Exact-head hosted CI `29173234612`: 71 successful checks, zero failures or running checks
- Direct dependency inspection: MCP SDK 1.29.0 OAuth discovery/token consumers and its Streamable HTTP/SSE fetch ownership were reviewed before choosing the boundary.

## Real behavior proof

- **Canonical path:** `openclaw mcp login` → configured server resolution → guarded MCP fetch → MCP SDK OAuth discovery/token consumer.
- **Boundary crossed:** production CLI process, real loopback TCP/HTTP server, real fetch and response-body stream; no Vitest or fetch mock in the live proof.
- **Failure controls:** server accepted a request but sent no headers; server sent JSON headers plus a partial body and never completed it.
- **Observed result:** both commands exited nonzero with a bounded-fetch diagnostic roughly 1.2 seconds after request acceptance; neither hung.
- **Positive controls:** focused CLI/auth tests verify configured timeout wiring and external bearer projection; caller-abort regression verifies cancellation composition.
- **What was not tested:** a public internet OAuth provider. The controlled server exercised the two exact network failure phases this change owns.
- **Fix classification:** root-cause fix.

## Release note

MCP: bound short-lived OAuth discovery and token responses with the configured request timeout, including stalled response bodies. Thanks @hugenshen.

- [x] AI-assisted
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
