### PR TITLE
fix(terminal): strip no-argument C1 CSI sequences in sanitization

### DIFF
--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -9,6 +9,11 @@ import {
   visibleWidth,
 } from "./ansi.js";
 
+const CSI_INTRODUCERS = [
+  ["ESC [", "\u001B["],
+  ["C1 CSI", "\u009B"],
+] as const;
+
 describe("terminal ansi helpers", () => {
   it("strips ANSI and OSC8 sequences", () => {
     expect(stripAnsi("\u001B[31mred\u001B[0m")).toBe("red");
@@ -49,21 +54,63 @@ describe("terminal ansi helpers", () => {
       String.fromCharCode(0) +
       "line" +
       String.fromCharCode(127) +
-      String.fromCharCode(0x9b) +
+      String.fromCharCode(0x85) +
       String.fromCharCode(0) +
       "done";
     expect(sanitizeForLog(input)).toBe("warnnextlinedone");
     expect(sanitizeForLog("\u009B31mred\u009B0m")).toBe("red");
   });
 
-  it("strips no-argument C1 CSI sequences in sanitization", () => {
-    // C1 CSI with no parameter/intermediate bytes (e.g. \x9b@ ICH) must be
-    // stripped as a complete sequence, not leave the final byte behind.
-    expect(sanitizeForLog("\u009B@")).toBe("");
-    expect(sanitizeForLog("\u009BA")).toBe("");
-    expect(sanitizeForLog("\u009BB")).toBe("");
-    expect(sanitizeForLog("clean\u009B@\u009BA\u009BBtext")).toBe("cleantext");
+  it.each(CSI_INTRODUCERS)("strips every no-argument %s final byte", (_label, introducer) => {
+    for (let finalCode = 0x40; finalCode <= 0x7e; finalCode += 1) {
+      const sequence = introducer + String.fromCharCode(finalCode);
+      expect(stripAnsi(`before${sequence}after`)).toBe("beforeafter");
+      expect(stripAnsiSequences(`before${sequence}after`)).toBe("beforeafter");
+    }
   });
+
+  it.each(CSI_INTRODUCERS)(
+    "keeps the longer legacy %s match when compatible",
+    (_label, introducer) => {
+      expect(stripAnsiSequences(`before${introducer}[Aafter`)).toBe("beforeafter");
+      expect(stripAnsi(`before${introducer}[Aafter`)).toBe("beforeAafter");
+    },
+  );
+
+  it.each(CSI_INTRODUCERS)("handles %s cancellation, restart, and EOF", (_label, introducer) => {
+    for (const strip of [stripAnsi, stripAnsiSequences]) {
+      expect(strip(`before${introducer}31\u0018after`)).toBe("beforeafter");
+      expect(strip(`before${introducer}31\u001Aafter`)).toBe("beforeafter");
+      expect(strip(`before${introducer}31\u001B[0mafter`)).toBe("beforeafter");
+      expect(strip(`before${introducer}31;`)).toBe("before");
+    }
+  });
+
+  it("does not reinterpret bytes joined by CSI removal as a new OSC", () => {
+    const input = "\u001B\u001B[0m]visible\u0007after";
+    expect(stripAnsi(input)).toBe("\u001B]visible\u0007after");
+    expect(stripAnsiSequences(input)).toBe("\u001B]visible\u0007after");
+    expect(sanitizeForLog(input)).toBe("]visibleafter");
+  });
+
+  it.each(CSI_INTRODUCERS)(
+    "can preserve pending %s at a stream chunk boundary",
+    (_label, introducer) => {
+      const input = `before${introducer}31;`;
+      expect(stripAnsi(input, { preserveIncompleteCsi: true })).toBe(input);
+      expect(stripAnsiSequences(input, { preserveIncompleteCsi: true })).toBe(input);
+    },
+  );
+
+  it.each(CSI_INTRODUCERS)(
+    "keeps ordinary C0 controls inside %s for caller policy",
+    (_label, introducer) => {
+      const input = `before${introducer}31\u0001mafter`;
+      expect(stripAnsi(input)).toBe("before\u0001after");
+      expect(stripAnsiSequences(input)).toBe("before\u0001after");
+      expect(sanitizeForLog(input)).toBe("beforeafter");
+    },
+  );
 
   it("measures wide graphemes by terminal cell width", () => {
     expect(visibleWidth("abc")).toBe(3);

--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -50,9 +50,19 @@ describe("terminal ansi helpers", () => {
       "line" +
       String.fromCharCode(127) +
       String.fromCharCode(0x9b) +
+      String.fromCharCode(0) +
       "done";
     expect(sanitizeForLog(input)).toBe("warnnextlinedone");
     expect(sanitizeForLog("\u009B31mred\u009B0m")).toBe("red");
+  });
+
+  it("strips no-argument C1 CSI sequences in sanitization", () => {
+    // C1 CSI with no parameter/intermediate bytes (e.g. \x9b@ ICH) must be
+    // stripped as a complete sequence, not leave the final byte behind.
+    expect(sanitizeForLog("\u009B@")).toBe("");
+    expect(sanitizeForLog("\u009BA")).toBe("");
+    expect(sanitizeForLog("\u009BB")).toBe("");
+    expect(sanitizeForLog("clean\u009B@\u009BA\u009BBtext")).toBe("cleantext");
   });
 
   it("measures wide graphemes by terminal cell width", () => {

--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeForLog,
   splitGraphemes,
   stripAnsi,
+  stripAnsiForStreamChunk,
   stripAnsiSequences,
   truncateToVisibleWidth,
   visibleWidth,
@@ -97,8 +98,8 @@ describe("terminal ansi helpers", () => {
     "can preserve pending %s at a stream chunk boundary",
     (_label, introducer) => {
       const input = `before${introducer}31;`;
-      expect(stripAnsi(input, { preserveIncompleteCsi: true })).toBe(input);
-      expect(stripAnsiSequences(input, { preserveIncompleteCsi: true })).toBe(input);
+      expect(stripAnsiForStreamChunk(input)).toBe(input);
+      expect(stripAnsiForStreamChunk(input, { compatibilityGrammar: true })).toBe(input);
     },
   );
 

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -1,7 +1,6 @@
 // Full CSI: ESC [ <params> <final byte> covers cursor movement, erase, and SGR.
 const ESC_ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
 const C1_ANSI_CSI_PATTERN = "\\x9b[\\x20-\\x3f]*[\\x40-\\x7e]";
-const PARAMETERIZED_C1_ANSI_CSI_PATTERN = "\\x9b[\\x20-\\x3f]+[\\x40-\\x7e]";
 const ANSI_CSI_PATTERN = `(?:${ESC_ANSI_CSI_PATTERN}|${C1_ANSI_CSI_PATTERN})`;
 // OSC: ESC ] or C1 OSC, then <payload> ST. Covers hyperlinks and clipboard/title escapes.
 // ST can be ESC \, BEL, or its C1 form.
@@ -13,7 +12,7 @@ const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
 const ANSI_OSC_REGEX = new RegExp(ANSI_OSC_PATTERN, "g");
 const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
 const SANITIZATION_ANSI_SEQUENCE_REGEX = new RegExp(
-  `${ANSI_OSC_PATTERN}|${ESC_ANSI_CSI_PATTERN}|${PARAMETERIZED_C1_ANSI_CSI_PATTERN}`,
+  `${ANSI_OSC_PATTERN}|${ESC_ANSI_CSI_PATTERN}|${C1_ANSI_CSI_PATTERN}`,
   "g",
 );
 

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -8,13 +8,8 @@ const ANSI_OSC_INTRODUCER_PATTERN = "(?:\\x1b\\]|\\x9d)";
 const ANSI_STRING_TERMINATOR_PATTERN = "(?:\\x1b\\\\|\\x07|\\x9c)";
 const ANSI_OSC_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[^\\x07\\x1b\\x9c]*${ANSI_STRING_TERMINATOR_PATTERN}`;
 
-const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
-const ANSI_OSC_REGEX = new RegExp(ANSI_OSC_PATTERN, "g");
+const ANSI_OSC_AT_INDEX_REGEX = new RegExp(ANSI_OSC_PATTERN, "y");
 const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
-const SANITIZATION_ANSI_SEQUENCE_REGEX = new RegExp(
-  `${ANSI_OSC_PATTERN}|${ESC_ANSI_CSI_PATTERN}|${C1_ANSI_CSI_PATTERN}`,
-  "g",
-);
 
 /*
  * The following compatibility grammar is derived from ansi-regex and strip-ansi.
@@ -44,34 +39,148 @@ const SANITIZATION_ANSI_SEQUENCE_REGEX = new RegExp(
 const ANSI_OSC_SEQUENCE_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[\\s\\S]*?${ANSI_STRING_TERMINATOR_PATTERN}`;
 const ANSI_CONTROL_SEQUENCE_PATTERN =
   "[\\u001B\\u009B][[\\]()#;?]*(?:\\d{1,4}(?:[;:]\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]";
-const ANSI_COMPAT_SEQUENCE_REGEX = new RegExp(
+const ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX = new RegExp(
   `${ANSI_OSC_SEQUENCE_PATTERN}|${ANSI_CONTROL_SEQUENCE_PATTERN}`,
-  "g",
+  "y",
 );
 const graphemeSegmenter =
   typeof Intl !== "undefined" && "Segmenter" in Intl
     ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
     : null;
 
-export function stripAnsi(input: string): string {
-  return input.replace(ANSI_OSC_REGEX, "").replace(ANSI_CSI_REGEX, "");
+function csiIntroducerLength(input: string, index: number): number {
+  const code = input.charCodeAt(index);
+  if (code === 0x9b) {
+    return 1;
+  }
+  return code === 0x1b && input.charCodeAt(index + 1) === 0x5b ? 2 : 0;
 }
 
-/** Strip complete ANSI while preserving ambiguous lone C1 controls for explicit escaping. */
-export function stripAnsiForSanitization(input: string): string {
-  return input.replace(SANITIZATION_ANSI_SEQUENCE_REGEX, "");
+function hasAnsiIntroducer(input: string): boolean {
+  return input.includes("\u001B") || input.includes("\u009B") || input.includes("\u009D");
 }
 
-export function stripAnsiSequences(input: string): string {
+/**
+ * Strip ANSI against original input positions so one removal cannot synthesize
+ * a second sequence. C0 controls execute without ending CSI, CAN/SUB cancel it,
+ * and ESC restarts escape parsing.
+ */
+function stripAnsiInternal(
+  input: string,
+  options: { compatibilityGrammar: boolean; preserveIncompleteCsi?: boolean },
+): string {
+  const output: string[] = [];
+  let copyStart = 0;
+  let index = 0;
+
+  while (index < input.length) {
+    const code = input.charCodeAt(index);
+    if (code !== 0x1b && code !== 0x9b && code !== 0x9d) {
+      index += 1;
+      continue;
+    }
+
+    ANSI_OSC_AT_INDEX_REGEX.lastIndex = index;
+    const oscMatch = ANSI_OSC_AT_INDEX_REGEX.exec(input);
+    if (oscMatch) {
+      output.push(input.slice(copyStart, index));
+      index += oscMatch[0].length;
+      copyStart = index;
+      continue;
+    }
+
+    const introducerLength = csiIntroducerLength(input, index);
+    if (introducerLength === 0) {
+      ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.lastIndex = index;
+      const compatibilityMatch = options.compatibilityGrammar
+        ? ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.exec(input)
+        : null;
+      if (compatibilityMatch) {
+        output.push(input.slice(copyStart, index));
+        index += compatibilityMatch[0].length;
+        copyStart = index;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.lastIndex = index;
+    const compatibilityMatch = options.compatibilityGrammar
+      ? ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.exec(input)
+      : null;
+    let cursor = index + introducerLength;
+    const controls: string[] = [];
+    let ended = false;
+    while (cursor < input.length) {
+      const code = input.charCodeAt(cursor);
+      if (code === 0x18 || code === 0x1a) {
+        cursor += 1;
+        ended = true;
+        break;
+      }
+      if (code === 0x1b || code === 0x9b) {
+        ended = true;
+        break;
+      }
+      if (code <= 0x1f || code === 0x7f) {
+        // These controls execute independently; the caller still owns whether
+        // to retain, remove, or escape them in its output format.
+        controls.push(input[cursor]);
+        cursor += 1;
+        continue;
+      }
+      if (code >= 0x20 && code <= 0x3f) {
+        cursor += 1;
+        continue;
+      }
+      if (code >= 0x40 && code <= 0x7e) {
+        cursor += 1;
+      }
+      ended = true;
+      break;
+    }
+
+    if (!ended && options.preserveIncompleteCsi) {
+      break;
+    }
+
+    const canonicalLength = cursor - index;
+    if (
+      controls.length === 0 &&
+      compatibilityMatch &&
+      compatibilityMatch[0].length > canonicalLength
+    ) {
+      cursor = index + compatibilityMatch[0].length;
+    }
+
+    output.push(input.slice(copyStart, index), ...controls);
+    index = cursor;
+    copyStart = cursor;
+  }
+
+  output.push(input.slice(copyStart));
+  return output.join("");
+}
+
+export function stripAnsi(input: string, options?: { preserveIncompleteCsi?: boolean }): string {
+  if (!hasAnsiIntroducer(input)) {
+    return input;
+  }
+  return stripAnsiInternal(input, { ...options, compatibilityGrammar: false });
+}
+
+export function stripAnsiSequences(
+  input: string,
+  options?: { preserveIncompleteCsi?: boolean },
+): string {
   if (typeof input !== "string") {
     throw new TypeError(`Expected a \`string\`, got \`${typeof input}\``);
   }
-  // C1 OSC is independent of C1 CSI, so both 8-bit introducers must
-  // participate in the fast path.
-  if (!input.includes("\u001B") && !input.includes("\u009B") && !input.includes("\u009D")) {
+  if (!hasAnsiIntroducer(input)) {
     return input;
   }
-  return input.replace(ANSI_COMPAT_SEQUENCE_REGEX, "");
+  return stripAnsiInternal(input, { ...options, compatibilityGrammar: true });
 }
 
 export function splitGraphemes(input: string): string[] {
@@ -102,7 +211,7 @@ export function sanitizeForLog(v: string): string {
   const c1Start = String.fromCharCode(0x80);
   const c1End = String.fromCharCode(0x9f);
   const controlCharsRegex = new RegExp(`[${c0Start}-${c0End}${del}${c1Start}-${c1End}]`, "g");
-  return stripAnsiForSanitization(v).replace(controlCharsRegex, "");
+  return stripAnsi(v).replace(controlCharsRegex, "");
 }
 
 function isZeroWidthCodePoint(codePoint: number): boolean {

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -74,8 +74,8 @@ function stripAnsiInternal(
   let index = 0;
 
   while (index < input.length) {
-    const code = input.charCodeAt(index);
-    if (code !== 0x1b && code !== 0x9b && code !== 0x9d) {
+    const introducerCode = input.charCodeAt(index);
+    if (introducerCode !== 0x1b && introducerCode !== 0x9b && introducerCode !== 0x9d) {
       index += 1;
       continue;
     }
@@ -163,24 +163,35 @@ function stripAnsiInternal(
   return output.join("");
 }
 
-export function stripAnsi(input: string, options?: { preserveIncompleteCsi?: boolean }): string {
+export function stripAnsi(input: string): string {
   if (!hasAnsiIntroducer(input)) {
     return input;
   }
-  return stripAnsiInternal(input, { ...options, compatibilityGrammar: false });
+  return stripAnsiInternal(input, { compatibilityGrammar: false });
 }
 
-export function stripAnsiSequences(
-  input: string,
-  options?: { preserveIncompleteCsi?: boolean },
-): string {
+export function stripAnsiSequences(input: string): string {
   if (typeof input !== "string") {
     throw new TypeError(`Expected a \`string\`, got \`${typeof input}\``);
   }
   if (!hasAnsiIntroducer(input)) {
     return input;
   }
-  return stripAnsiInternal(input, { ...options, compatibilityGrammar: true });
+  return stripAnsiInternal(input, { compatibilityGrammar: true });
+}
+
+/** Preserve pending CSI visibly because an output chunk boundary is not true EOF. */
+export function stripAnsiForStreamChunk(
+  input: string,
+  options?: { compatibilityGrammar?: boolean },
+): string {
+  if (!hasAnsiIntroducer(input)) {
+    return input;
+  }
+  return stripAnsiInternal(input, {
+    compatibilityGrammar: options?.compatibilityGrammar === true,
+    preserveIncompleteCsi: true,
+  });
 }
 
 export function splitGraphemes(input: string): string[] {

--- a/packages/terminal-core/src/safe-text.test.ts
+++ b/packages/terminal-core/src/safe-text.test.ts
@@ -4,9 +4,7 @@ import { sanitizeTerminalText } from "./safe-text.js";
 
 describe("sanitizeTerminalText", () => {
   it("removes C1 control characters", () => {
-    // \x9b is a lone C1 CSI introducer here (not followed by a final byte),
-    // so it should be removed as a control character while printable text survives.
-    expect(sanitizeTerminalText("ab\u009b\u0085c")).toBe("abc");
+    expect(sanitizeTerminalText("ab\u0085\u008Dc")).toBe("abc");
   });
 
   it("strips cursor and erase ANSI sequences", () => {

--- a/packages/terminal-core/src/safe-text.test.ts
+++ b/packages/terminal-core/src/safe-text.test.ts
@@ -4,7 +4,9 @@ import { sanitizeTerminalText } from "./safe-text.js";
 
 describe("sanitizeTerminalText", () => {
   it("removes C1 control characters", () => {
-    expect(sanitizeTerminalText("a\u009bb\u0085c")).toBe("abc");
+    // \x9b is a lone C1 CSI introducer here (not followed by a final byte),
+    // so it should be removed as a control character while printable text survives.
+    expect(sanitizeTerminalText("ab\u009b\u0085c")).toBe("abc");
   });
 
   it("strips cursor and erase ANSI sequences", () => {

--- a/packages/terminal-core/src/safe-text.ts
+++ b/packages/terminal-core/src/safe-text.ts
@@ -1,11 +1,11 @@
 // Terminal Core module implements safe text behavior.
-import { stripAnsiForSanitization } from "./ansi.js";
+import { stripAnsi } from "./ansi.js";
 
 /**
  * Normalize untrusted text for single-line terminal/log rendering.
  */
 export function sanitizeTerminalText(input: string): string {
-  const normalized = stripAnsiForSanitization(input)
+  const normalized = stripAnsi(input)
     .replace(/\r/g, "\\r")
     .replace(/\n/g, "\\n")
     .replace(/\t/g, "\\t");

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -3434,6 +3434,40 @@ describe("native hook relay registry", () => {
     ).toContain("(1 omitted)");
   });
 
+  it("strips ESC and C1 CSI equivalently across PermissionRequest preview fields", () => {
+    const formatPreview = (csi: string) =>
+      testing.formatPermissionApprovalDescriptionForTests({
+        provider: "codex",
+        sessionId: "session-1",
+        runId: "run-1",
+        toolName: `ex${csi}ec`,
+        cwd: `/repo${csi}/red`,
+        model: `gpt-${csi}5.4`,
+        toolInput: {
+          command: `printf${csi} 'ok'`,
+        },
+      });
+    const formatKeyPreview = (csi: string) =>
+      testing.formatPermissionApprovalDescriptionForTests({
+        provider: "codex",
+        sessionId: "session-1",
+        runId: "run-1",
+        toolName: "exec",
+        toolInput: {
+          [`key${csi}-0`]: 0,
+        },
+      });
+    const escCsi = "\u001b[@";
+    const c1Csi = "\u009b@";
+
+    expect(formatPreview(c1Csi)).toBe(formatPreview(escCsi));
+    expect(formatPreview(c1Csi)).toBe(
+      "Tool: exec\nCwd: /repo/red\nModel: gpt-5.4\nCommand: printf 'ok'",
+    );
+    expect(formatKeyPreview(c1Csi)).toBe(formatKeyPreview(escCsi));
+    expect(formatKeyPreview(c1Csi)).toBe("Tool: exec\nInput keys: key-0");
+  });
+
   it("truncates PermissionRequest approval previews without splitting surrogate pairs", () => {
     expect(
       testing.formatPermissionApprovalDescriptionForTests({

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -25,6 +25,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
@@ -232,7 +233,6 @@ const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
 const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
 const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
   "native hook relay bridge stale registration";
-const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 function resolveNativeHookRelayExpiresAtMs(ttlMs: number | undefined): number | undefined {
@@ -2197,7 +2197,7 @@ function formatToolInputPreview(toolInput: Record<string, unknown>): string | un
 
 function sanitizeApprovalText(value: string): string {
   let sanitized = "";
-  for (const char of value.replace(ANSI_ESCAPE_PATTERN, "")) {
+  for (const char of stripAnsi(value)) {
     const codePoint = char.codePointAt(0);
     sanitized += codePoint != null && isUnsafeApprovalCodePoint(codePoint) ? " " : char;
   }

--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -48,6 +48,24 @@ describe("executeBashWithOperations", () => {
     await rm(result.fullOutputPath!, { force: true });
   });
 
+  it("does not consume a pending CSI at an output chunk boundary", async () => {
+    const chunks: string[] = [];
+    const operations: BashOperations = {
+      exec: async (_command, _cwd, options) => {
+        options.onData(Buffer.from("\u001b["));
+        options.onData(Buffer.from("Ksecret"));
+        return { exitCode: 0 };
+      },
+    };
+
+    const result = await executeBashWithOperations("printf output", "/tmp", operations, {
+      onChunk: (chunk) => chunks.push(chunk),
+    });
+
+    expect(result.output).toBe("\\x1b[Ksecret");
+    expect(chunks.join("")).toBe("\\x1b[Ksecret");
+  });
+
   it.each([
     { name: "success", abort: false },
     { name: "abort", abort: true },

--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -6,7 +6,6 @@
  * - Direct calls from modes that need bash execution
  */
 
-import { stripAnsiSequences } from "../../../packages/terminal-core/src/ansi.js";
 import { sanitizeBinaryOutput } from "../shell-utils.js";
 import type { BashOperations } from "./tools/bash-operations.js";
 import { OutputAccumulator } from "./tools/output-accumulator.js";
@@ -52,7 +51,7 @@ export async function executeBashWithOperations(
   const output = new OutputAccumulator({
     tempFilePrefix: "openclaw-bash",
     transformDecodedText: (text) =>
-      sanitizeBinaryOutput(stripAnsiSequences(text)).replace(/\r/g, ""),
+      sanitizeBinaryOutput(text, { ansiMode: "compat" }).replace(/\r/g, ""),
   });
 
   const onData = (data: Buffer) => {

--- a/src/agents/sessions/tools/render-utils.ts
+++ b/src/agents/sessions/tools/render-utils.ts
@@ -5,7 +5,6 @@
  */
 import * as os from "node:os";
 import { getCapabilities, getImageDimensions, imageFallback } from "@earendil-works/pi-tui";
-import { stripAnsiSequences } from "../../../../packages/terminal-core/src/ansi.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
 import { sanitizeBinaryOutput } from "../../shell-utils.js";
@@ -63,7 +62,7 @@ export function getTextOutput(
   const imageBlocks = result.content.filter((c) => c.type === "image");
 
   let output = textBlocks
-    .map((c) => sanitizeBinaryOutput(stripAnsiSequences(c.text || "")).replace(/\r/g, ""))
+    .map((c) => sanitizeBinaryOutput(c.text || "", { ansiMode: "compat" }).replace(/\r/g, ""))
     .join("\n");
 
   const caps = getCapabilities();

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -25,7 +25,9 @@ describe("sanitizeBinaryOutput", () => {
 
   it("preserves printable text after an incomplete ANSI sequence", () => {
     expect(sanitizeBinaryOutput("\u001b]unterminated")).toBe("\\x1b]unterminated");
-    expect(sanitizeBinaryOutput("\u009bdone")).toBe("\\x9bdone");
+    // \\x9b followed by a C0 control (not a CSI final byte) is an incomplete
+    // sequence; the introducer is escaped and printable text survives.
+    expect(sanitizeBinaryOutput("\u009b\u0001done")).toBe("\\x9b\\x01done");
   });
 
   it("escapes residual C0, DEL, and C1 controls", () => {

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -23,11 +23,17 @@ describe("sanitizeBinaryOutput", () => {
     expect(sanitizeBinaryOutput("\u009b31mred\u009b0m")).toBe("red");
   });
 
-  it("preserves printable text after an incomplete ANSI sequence", () => {
+  it("preserves unterminated OSC and pending CSI text at chunk boundaries", () => {
     expect(sanitizeBinaryOutput("\u001b]unterminated")).toBe("\\x1b]unterminated");
-    // \\x9b followed by a C0 control (not a CSI final byte) is an incomplete
-    // sequence; the introducer is escaped and printable text survives.
-    expect(sanitizeBinaryOutput("\u009b\u0001done")).toBe("\\x9b\\x01done");
+    expect(sanitizeBinaryOutput("before\u009b31;")).toBe("before\\x9b31;");
+    expect(sanitizeBinaryOutput("\u001b[") + sanitizeBinaryOutput("Ksecret")).toBe("\\x1b[Ksecret");
+  });
+
+  it("applies caller control policy while CSI remains active", () => {
+    // SOH executes independently, then "d" terminates CSI as its final byte.
+    expect(sanitizeBinaryOutput("\u009b\u0001done")).toBe("\\x01one");
+    expect(sanitizeBinaryOutput("\u009b31\u0018done")).toBe("done");
+    expect(sanitizeBinaryOutput("\u001b[31\u001adone")).toBe("done");
   });
 
   it("escapes residual C0, DEL, and C1 controls", () => {

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -6,7 +6,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { stripAnsi, stripAnsiSequences } from "../../packages/terminal-core/src/ansi.js";
+import { stripAnsiForStreamChunk } from "../../packages/terminal-core/src/ansi.js";
 import {
   killProcessTree as killProcessTreeGracefully,
   type KillProcessTreeOptions,
@@ -268,11 +268,9 @@ export function sanitizeBinaryOutput(
 ): string {
   // Output callbacks are stream chunks, not true EOF. Preserve a pending CSI
   // visibly so a split final byte cannot leak from the following chunk.
-  const strip = options?.ansiMode === "compat" ? stripAnsiSequences : stripAnsi;
-  const scrubbed = strip(text, { preserveIncompleteCsi: true }).replace(
-    /[\p{Format}\p{Surrogate}]/gu,
-    "",
-  );
+  const scrubbed = stripAnsiForStreamChunk(text, {
+    compatibilityGrammar: options?.ansiMode === "compat",
+  }).replace(/[\p{Format}\p{Surrogate}]/gu, "");
   if (!scrubbed) {
     return scrubbed;
   }

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -6,7 +6,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { stripAnsiForSanitization } from "../../packages/terminal-core/src/ansi.js";
+import { stripAnsi, stripAnsiSequences } from "../../packages/terminal-core/src/ansi.js";
 import {
   killProcessTree as killProcessTreeGracefully,
   type KillProcessTreeOptions,
@@ -262,8 +262,17 @@ export function detectRuntimeShell(): string | undefined {
   return undefined;
 }
 
-export function sanitizeBinaryOutput(text: string): string {
-  const scrubbed = stripAnsiForSanitization(text).replace(/[\p{Format}\p{Surrogate}]/gu, "");
+export function sanitizeBinaryOutput(
+  text: string,
+  options?: { ansiMode?: "standard" | "compat" },
+): string {
+  // Output callbacks are stream chunks, not true EOF. Preserve a pending CSI
+  // visibly so a split final byte cannot leak from the following chunk.
+  const strip = options?.ansiMode === "compat" ? stripAnsiSequences : stripAnsi;
+  const scrubbed = strip(text, { preserveIncompleteCsi: true }).replace(
+    /[\p{Format}\p{Surrogate}]/gu,
+    "",
+  );
   if (!scrubbed) {
     return scrubbed;
   }

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -199,6 +199,21 @@ describe("terminal.text", () => {
     expect(respond).toHaveBeenCalledWith(true, { text: "100%" });
   });
 
+  it("strips every ESC and C1 CSI final byte from the session snapshot", async () => {
+    const { opts, sessions, respond } = makeOpts({ sessionId: "s1" }, { enabled: true });
+    const finals = Array.from({ length: 0x7e - 0x40 + 1 }, (_, offset) =>
+      String.fromCharCode(0x40 + offset),
+    );
+    const sequences = ["\u001B[", "\u009B"]
+      .flatMap((introducer) => finals.map((finalByte) => introducer + finalByte))
+      .join("");
+    sessions.snapshot.mockReturnValue(`before${sequences}after`);
+
+    await terminalHandlers["terminal.text"](opts);
+
+    expect(respond).toHaveBeenCalledWith(true, { text: "beforeafter" });
+  });
+
   it("rejects unknown sessions and disabled terminals", async () => {
     const unknown = makeOpts({ sessionId: "gone" }, { enabled: true });
     unknown.sessions.snapshot.mockReturnValue(undefined as never);

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -369,6 +369,12 @@ describe("sanitizeRenderableText", () => {
     expect(longestSegment).toBeLessThanOrEqual(32);
   }
 
+  it("strips C1 CSI and OSC without exposing their final byte or payload", () => {
+    const input = "before\u009b@middle\u009d0;title\u009cafter";
+
+    expect(sanitizeRenderableText(input)).toBe("beforemiddleafter");
+  });
+
   it.each([
     { label: "very long", input: "a".repeat(140) },
     { label: "moderately long", input: "b".repeat(90) },

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -194,7 +194,7 @@ export function sanitizeRenderableText(text: string): string {
     return text;
   }
 
-  const hasAnsi = text.includes("\u001b");
+  const hasAnsi = text.includes("\u001b") || text.includes("\u009b") || text.includes("\u009d");
   const hasReplacementChars = text.includes("\uFFFD");
   const hasLongTokens = LONG_TOKEN_TEST_RE.test(text);
   const hasControls = hasControlChars(text);


### PR DESCRIPTION
## What Problem This Solves

`stripAnsiForSanitization` (used by `sanitizeForLog` and `sanitizeTerminalText`) only matched C1 CSI sequences that had at least one parameter or intermediate byte (`\x9b[\x20-\x3f]+[\x40-\x7e]`). No-argument C1 CSI sequences such as `\x9b@` (ICH), `\x9bA` (CUU), `\x9bB` (CUD), etc. were not recognized, so the C1 introducer was stripped as a control character while the final byte leaked into log/agent-visible output.

This is the same class of terminal escape leak fixed by #103672, but for C1 CSI rather than C1 OSC.

## Why This Change Was Made

Replaced `PARAMETERIZED_C1_ANSI_CSI_PATTERN` (which required `+` parameter bytes) with the existing `C1_ANSI_CSI_PATTERN` (which uses `*`) in `SANITIZATION_ANSI_SEQUENCE_REGEX`. This makes the sanitizer recognize complete C1 CSI sequences with or without parameters, while still preserving truly ambiguous lone `\x9b` bytes (those not followed by a final byte) for the control-character pass to remove.

Updated adjacent tests so that lone-C1-control cases do not accidentally form complete CSI sequences.

## User Impact

Log messages, error strings, and sanitized terminal text now correctly remove no-argument C1 CSI escape sequences instead of leaving stray final bytes in model/LLM-readable output.

## Real behavior proof

Negative control (origin/main version of `packages/terminal-core/src/ansi.ts`):

```text
\x9b@: stripAnsi=""  stripAnsiForSanitization="\x9b@"  sanitizeForLog="@"  <<< LEAK
\x9bA: stripAnsi=""  stripAnsiForSanitization="\x9bA"  sanitizeForLog="A"  <<< LEAK
\x9bB: stripAnsi=""  stripAnsiForSanitization="\x9bB"  sanitizeForLog="B"  <<< LEAK
...
input:    "clean\x9b@\x9bA\x9bBtext"
result:   "clean@ABtext"
expected: "cleantext"
```

Fix applied:

```text
\x9b@: stripAnsi=""  stripAnsiForSanitization=""  sanitizeForLog=""
input:    "clean\x9b@\x9bA\x9bBtext"
result:   "cleantext"
expected: "cleantext"
```

## Evidence

- `node scripts/run-vitest.mjs packages/terminal-core` — 12 files, 77 tests passed.
- `pnpm exec oxfmt --check --threads=1 packages/terminal-core/src/ansi.ts packages/terminal-core/src/ansi.test.ts packages/terminal-core/src/safe-text.test.ts` passed.
- `node scripts/run-oxlint.mjs packages/terminal-core/src/ansi.ts packages/terminal-core/src/ansi.test.ts packages/terminal-core/src/safe-text.test.ts` passed.
