### PR TITLE
fix(grep): stop searches when canceled during tool startup

### DIFF
--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -37,7 +37,7 @@ function createChild(): MockChild {
 }
 
 describe("grep tool stream errors", () => {
-  it("does not start ripgrep when aborted while resolving rg", async () => {
+  it("settles promptly when aborted while resolving rg", async () => {
     let resolveEnsureTool: ((value: string) => void) | undefined;
     vi.mocked(ensureTool).mockImplementationOnce(
       async () =>
@@ -58,13 +58,14 @@ describe("grep tool stream errors", () => {
 
     await vi.waitFor(() => expect(ensureTool).toHaveBeenCalledOnce());
     controller.abort();
-    resolveEnsureTool?.("rg");
-
     await expect(result).rejects.toThrow("Operation aborted");
+
+    resolveEnsureTool?.("rg");
+    await Promise.resolve();
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it("does not start ripgrep when aborted while checking the search path", async () => {
+  it("does not spawn after an aborted search-path check later resolves", async () => {
     let resolveIsDirectory: ((value: boolean) => void) | undefined;
     vi.mocked(ensureTool).mockResolvedValue("rg");
 
@@ -88,10 +89,99 @@ describe("grep tool stream errors", () => {
 
     await vi.waitFor(() => expect(resolveIsDirectory).toBeDefined());
     controller.abort();
+    await expect(result).rejects.toThrow("Operation aborted");
+
     resolveIsDirectory?.(true);
+    await Promise.resolve();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("removes the abort listener after normal settlement", async () => {
+    const child = createChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const controller = new AbortController();
+    const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
+    const tool = createGrepToolDefinition(process.cwd());
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    child.emit("close", 1);
+
+    await expect(result).resolves.toMatchObject({
+      content: [{ type: "text", text: "No matches found" }],
+    });
+    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    controller.abort();
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("settles an abort when the spawned child never closes", async () => {
+    const child = createChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const controller = new AbortController();
+    const tool = createGrepToolDefinition(process.cwd());
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    controller.abort();
 
     await expect(result).rejects.toThrow("Operation aborted");
-    expect(spawn).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
+
+  it("preserves abort precedence during async match formatting", async () => {
+    const child = createChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+    let resolveReadFile: ((value: string) => void) | undefined;
+    const readFile = vi.fn(
+      async () =>
+        await new Promise<string>((resolve) => {
+          resolveReadFile = resolve;
+        }),
+    );
+
+    const controller = new AbortController();
+    const tool = createGrepToolDefinition(process.cwd(), {
+      operations: { isDirectory: () => true, readFile },
+    });
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo", context: 1 },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    child.stdout.write(
+      `${JSON.stringify({
+        type: "match",
+        data: { path: { text: "/tmp/match.txt" }, line_number: 1, lines: { text: "foo\n" } },
+      })}\n`,
+    );
+    child.emit("close", 0);
+    await vi.waitFor(() => expect(readFile).toHaveBeenCalledOnce());
+
+    controller.abort();
+    await expect(result).rejects.toThrow("Operation aborted");
+    expect(child.kill).not.toHaveBeenCalled();
+
+    resolveReadFile?.("foo\n");
+    await Promise.resolve();
   });
 
   it.each(["stdout", "stderr"] as const)(

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -119,7 +119,7 @@ describe("grep tool stream errors", () => {
     });
     expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
     controller.abort();
-    expect(child.kill).not.toHaveBeenCalled();
+    expect(child.killed).toBe(false);
   });
 
   it("settles an abort when the spawned child never closes", async () => {
@@ -140,7 +140,7 @@ describe("grep tool stream errors", () => {
     controller.abort();
 
     await expect(result).rejects.toThrow("Operation aborted");
-    expect(child.kill).toHaveBeenCalledOnce();
+    expect(child.killed).toBe(true);
   });
 
   it("preserves abort precedence during async match formatting", async () => {
@@ -178,7 +178,7 @@ describe("grep tool stream errors", () => {
 
     controller.abort();
     await expect(result).rejects.toThrow("Operation aborted");
-    expect(child.kill).not.toHaveBeenCalled();
+    expect(child.killed).toBe(false);
 
     resolveReadFile?.("foo\n");
     await Promise.resolve();

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -64,6 +64,36 @@ describe("grep tool stream errors", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("does not start ripgrep when aborted while checking the search path", async () => {
+    let resolveIsDirectory: ((value: boolean) => void) | undefined;
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const controller = new AbortController();
+    const tool = createGrepToolDefinition(process.cwd(), {
+      operations: {
+        isDirectory: async () =>
+          await new Promise<boolean>((resolve) => {
+            resolveIsDirectory = resolve;
+          }),
+        readFile: () => "",
+      },
+    });
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+
+    await vi.waitFor(() => expect(resolveIsDirectory).toBeDefined());
+    controller.abort();
+    resolveIsDirectory?.(true);
+
+    await expect(result).rejects.toThrow("Operation aborted");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it.each(["stdout", "stderr"] as const)(
     "rejects and terminates ripgrep when %s fails",
     async (stream) => {

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -37,6 +37,33 @@ function createChild(): MockChild {
 }
 
 describe("grep tool stream errors", () => {
+  it("does not start ripgrep when aborted while resolving rg", async () => {
+    let resolveEnsureTool: ((value: string) => void) | undefined;
+    vi.mocked(ensureTool).mockImplementationOnce(
+      async () =>
+        await new Promise<string>((resolve) => {
+          resolveEnsureTool = resolve;
+        }),
+    );
+
+    const controller = new AbortController();
+    const tool = createGrepToolDefinition(process.cwd());
+    const result = tool.execute(
+      "call-1",
+      { pattern: "foo" },
+      controller.signal,
+      undefined,
+      {} as never,
+    );
+
+    await vi.waitFor(() => expect(ensureTool).toHaveBeenCalledOnce());
+    controller.abort();
+    resolveEnsureTool?.("rg");
+
+    await expect(result).rejects.toThrow("Operation aborted");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it.each(["stdout", "stderr"] as const)(
     "rejects and terminates ripgrep when %s fails",
     async (stream) => {

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -436,7 +436,7 @@ export function createGrepToolDefinition(
                     details: Object.keys(details).length > 0 ? details : undefined,
                   }),
                 );
-              })().catch((err) => {
+              })().catch((err: unknown) => {
                 settle(() => reject(err as Error));
               });
             });

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -164,23 +164,47 @@ export function createGrepToolDefinition(
       void onUpdate;
       void ctx;
       return new Promise((resolve, reject) => {
-        if (signal?.aborted) {
-          reject(new Error("Operation aborted"));
-          return;
-        }
+        // Keep cancellation live from the first await through async result formatting.
+        // Settlement owns listener cleanup; spawned children stop without waiting for close.
         let settled = false;
-        const settle = (fn: () => void) => {
-          if (!settled) {
-            settled = true;
-            fn();
+        let child: ReturnType<typeof spawn> | undefined;
+        let childClosed = false;
+        let rl: ReturnType<typeof createInterface> | undefined;
+        let killedDueToLimit = false;
+        const cleanup = () => {
+          rl?.close();
+          signal?.removeEventListener("abort", onAbort);
+        };
+        const settle = (fn: () => void): boolean => {
+          if (settled) {
+            return false;
+          }
+          settled = true;
+          cleanup();
+          fn();
+          return true;
+        };
+        const stopChild = (dueToLimit = false) => {
+          if (child && !childClosed && !child.killed) {
+            killedDueToLimit = dueToLimit;
+            child.kill();
           }
         };
+        const onAbort = () => {
+          if (settle(() => reject(new Error("Operation aborted")))) {
+            stopChild();
+          }
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
 
         void (async () => {
           try {
             const rgPath = await ensureTool("rg", true);
-            if (signal?.aborted) {
-              settle(() => reject(new Error("Operation aborted")));
+            if (settled) {
               return;
             }
             if (!rgPath) {
@@ -197,6 +221,9 @@ export function createGrepToolDefinition(
               isDirectory = await ops.isDirectory(searchPath);
             } catch {
               settle(() => reject(new Error(`Path not found: ${searchPath}`)));
+              return;
+            }
+            if (settled) {
               return;
             }
 
@@ -239,51 +266,34 @@ export function createGrepToolDefinition(
             }
             args.push("--", pattern, searchPath);
 
-            if (signal?.aborted) {
-              settle(() => reject(new Error("Operation aborted")));
+            if (settled) {
               return;
             }
-            const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
-            const rl = createInterface({ input: child.stdout });
+            const spawnedChild = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+            child = spawnedChild;
+            rl = createInterface({ input: spawnedChild.stdout });
             let stderr = "";
             let matchCount = 0;
             let matchLimitReached = false;
             let linesTruncated = false;
-            let aborted = false;
-            let killedDueToLimit = false;
             const outputLines: string[] = [];
 
-            const cleanup = () => {
-              rl.close();
-              signal?.removeEventListener("abort", onAbort);
-            };
-            const stopChild = (dueToLimit = false) => {
-              if (!child.killed) {
-                killedDueToLimit = dueToLimit;
-                child.kill();
-              }
-            };
-            const onAbort = () => {
-              aborted = true;
-              stopChild();
-            };
-            signal?.addEventListener("abort", onAbort, { once: true });
-            child.stderr?.on("data", (chunk) => {
+            spawnedChild.stderr?.on("data", (chunk) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });
             const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
               if (settled) {
                 return;
               }
-              stopChild();
-              cleanup();
-              settle(() => reject(new Error(`ripgrep ${stream} error: ${error.message}`)));
+              if (settle(() => reject(new Error(`ripgrep ${stream} error: ${error.message}`)))) {
+                stopChild();
+              }
             };
             // readline re-emits input failures, then drops its input listener on close.
             // Keep the direct guard until child exit so later stdout errors stay handled.
             rl.on("error", (error) => onStreamError("stdout", error));
-            child.stdout?.on("error", (error) => onStreamError("stdout", error));
-            child.stderr?.on("error", (error) => onStreamError("stderr", error));
+            spawnedChild.stdout?.on("error", (error) => onStreamError("stdout", error));
+            spawnedChild.stderr?.on("error", (error) => onStreamError("stderr", error));
 
             const formatBlock = async (filePath: string, lineNumber: number): Promise<string[]> => {
               const relativePath = formatPath(filePath);
@@ -347,15 +357,14 @@ export function createGrepToolDefinition(
               }
             });
 
-            child.on("error", (error) => {
-              cleanup();
+            spawnedChild.on("error", (error) => {
+              childClosed = true;
               settle(() => reject(new Error(`Failed to run ripgrep: ${error.message}`)));
             });
-            child.on("close", (code) => {
+            spawnedChild.on("close", (code) => {
+              childClosed = true;
               void (async () => {
-                cleanup();
-                if (aborted) {
-                  settle(() => reject(new Error("Operation aborted")));
+                if (settled) {
                   return;
                 }
                 if (!killedDueToLimit && code !== 0 && code !== 1) {
@@ -388,6 +397,9 @@ export function createGrepToolDefinition(
                     outputLines.push(`${relativePath}:${match.lineNumber}: ${truncatedText}`);
                   } else {
                     const block = await formatBlock(match.filePath, match.lineNumber);
+                    if (settled) {
+                      return;
+                    }
                     outputLines.push(...block);
                   }
                 }
@@ -424,10 +436,14 @@ export function createGrepToolDefinition(
                     details: Object.keys(details).length > 0 ? details : undefined,
                   }),
                 );
-              })();
+              })().catch((err) => {
+                settle(() => reject(err as Error));
+              });
             });
           } catch (err) {
-            settle(() => reject(err as Error));
+            if (settle(() => reject(err as Error))) {
+              stopChild();
+            }
           }
         })();
       });

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -179,6 +179,10 @@ export function createGrepToolDefinition(
         void (async () => {
           try {
             const rgPath = await ensureTool("rg", true);
+            if (signal?.aborted) {
+              settle(() => reject(new Error("Operation aborted")));
+              return;
+            }
             if (!rgPath) {
               settle(() =>
                 reject(new Error("ripgrep (rg) is not available and could not be downloaded")),

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -239,6 +239,10 @@ export function createGrepToolDefinition(
             }
             args.push("--", pattern, searchPath);
 
+            if (signal?.aborted) {
+              settle(() => reject(new Error("Operation aborted")));
+              return;
+            }
             const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
             const rl = createInterface({ input: child.stdout });
             let stderr = "";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who cancel a session grep during startup could still have `ripgrep` start after the abort signal was already set.

## Why This Change Was Made

The grep session tool now checks cancellation after resolving `rg` and again at the final pre-spawn boundary after asynchronous search-path validation. This keeps the owner-local startup path aligned with the session search cancellation invariant without changing tool arguments, provider policy, config, or public contracts.

## User Impact

Canceled grep tool calls now stop cleanly before launching a new search process when cancellation arrives during either tool resolution or search-path preparation.

## Evidence

- Claim proved: cancellation during grep startup rejects with `Operation aborted` before launching `ripgrep`, including the async search-path validation window.
- Current-head proof at `73c1fef9d60cdf9f64654f892d5da38258568eca`: `node scripts/run-vitest.mjs src/agents/sessions/tools/grep.stream-errors.test.ts` passed, 1 file / 5 tests.
- Runtime proof at `73c1fef9d60cdf9f64654f892d5da38258568eca`: `node --import tsx --input-type=module -` exercised the real `createGrepToolDefinition` path with real `ensureTool("rg")` PATH resolution and an async `operations.isDirectory` gate. The PATH-backed `rg` proof shim writes a sentinel if launched; the transcript showed `sentinel before abort=false`, `result=Operation aborted`, and `sentinel after abort=false`.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` passed with no accepted/actionable findings.