### PR TITLE
fix(canvas): reject invalid A2UI tool JSONL

### DIFF
--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -1,9 +1,28 @@
 // Canvas tests cover index plugin behavior.
-import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginNodeInvokePolicyContext,
+} from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import canvasPlugin from "./index.js";
 import { SHOW_WIDGET_REQUIRED_CLIENT_CAPS } from "./src/tool-schema.js";
+
+const VALID_A2UI_V08_JSONL = [
+  JSON.stringify({
+    surfaceUpdate: {
+      surfaceId: "main",
+      components: [
+        {
+          id: "root",
+          component: { Text: { text: { literalString: "Canvas proof" }, usageHint: "body" } },
+        },
+      ],
+    },
+  }),
+  JSON.stringify({ beginRendering: { surfaceId: "main", root: "root" } }),
+].join("\n");
 
 const mocks = vi.hoisted(() => {
   const httpHandler = {
@@ -71,6 +90,8 @@ function registerCanvas() {
     registrar: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[0];
     opts: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[1];
   }> = [];
+  const nodeInvokePolicies: Array<Parameters<OpenClawPluginApi["registerNodeInvokePolicy"]>[0]> =
+    [];
   canvasPlugin.register?.(
     createTestPluginApi({
       id: "canvas",
@@ -81,10 +102,23 @@ function registerCanvas() {
       registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
       registerTool: (tool, opts) => tools.push({ tool, opts }),
       registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
-      registerNodeInvokePolicy: vi.fn(),
+      registerNodeInvokePolicy: (policy) => nodeInvokePolicies.push(policy),
     }),
   );
-  return { routes, services, resolvers, tools, cliFeatures };
+  return { routes, services, resolvers, tools, cliFeatures, nodeInvokePolicies };
+}
+
+function createNodeInvokeContext(
+  params: Partial<OpenClawPluginNodeInvokePolicyContext>,
+): OpenClawPluginNodeInvokePolicyContext {
+  return {
+    nodeId: "node-1",
+    command: "canvas.a2ui.pushJSONL",
+    params: {},
+    config: {},
+    invokeNode: vi.fn(async () => ({ ok: true as const })),
+    ...params,
+  };
 }
 
 describe("Canvas plugin entry", () => {
@@ -174,5 +208,73 @@ describe("Canvas plugin entry", () => {
       title: "Status",
       widget_code: "<p>ready</p>",
     });
+  });
+
+  it.each([
+    ["malformed pushJSONL", "canvas.a2ui.pushJSONL", { jsonl: "{not-json}" }],
+    [
+      "versioned A2UI v0.9 pushJSONL",
+      "canvas.a2ui.pushJSONL",
+      {
+        jsonl: JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "main" } }),
+      },
+    ],
+    ["malformed legacy push JSONL fallback", "canvas.a2ui.push", { jsonl: "{not-json}" }],
+  ])("rejects %s at the final Canvas node policy", async (_label, command, params) => {
+    const { nodeInvokePolicies } = registerCanvas();
+    const policy = nodeInvokePolicies[0];
+    if (!policy) {
+      throw new Error("Canvas node invoke policy was not registered");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await policy.handle(createNodeInvokeContext({ command, params, invokeNode }));
+
+    expect(result).toMatchObject({ ok: false, code: "INVALID_A2UI_JSONL" });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("dispatches A2UI v0.8 JSONL unchanged through the final Canvas node policy", async () => {
+    const { nodeInvokePolicies } = registerCanvas();
+    const policy = nodeInvokePolicies[0];
+    if (!policy) {
+      throw new Error("Canvas node invoke policy was not registered");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await policy.handle(
+      createNodeInvokeContext({
+        params: { jsonl: VALID_A2UI_V08_JSONL },
+        invokeNode,
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(invokeNode).toHaveBeenCalledTimes(1);
+    expect(invokeNode).toHaveBeenCalledWith();
+  });
+
+  it("leaves canonical A2UI message arrays to the native node", async () => {
+    const { nodeInvokePolicies } = registerCanvas();
+    const policy = nodeInvokePolicies[0];
+    if (!policy) {
+      throw new Error("Canvas node invoke policy was not registered");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await policy.handle(
+      createNodeInvokeContext({
+        command: "canvas.a2ui.push",
+        params: {
+          messages: [{ deleteSurface: { surfaceId: "main" } }],
+          jsonl: "{not-used-by-native-node}",
+        },
+        invokeNode,
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(invokeNode).toHaveBeenCalledTimes(1);
+    expect(invokeNode).toHaveBeenCalledWith();
   });
 });

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -5,8 +5,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { validateSupportedA2UIJsonl } from "./src/a2ui-jsonl.js";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
 import {
@@ -143,7 +145,32 @@ export default definePluginEntry({
       commands: CANVAS_NODE_COMMANDS,
       defaultPlatforms: ["ios", "android", "macos", "windows", "unknown"],
       foregroundRestrictedOnIos: true,
-      handle: (ctx) => ctx.invokeNode(),
+      handle: async (ctx) => {
+        const params =
+          ctx.params && typeof ctx.params === "object" && !Array.isArray(ctx.params)
+            ? (ctx.params as Record<string, unknown>)
+            : {};
+        // Native nodes also accept JSONL under `push` when messages[] is absent.
+        // Validate that fallback here so callers cannot bypass the JSONL policy.
+        const usesJsonl =
+          ctx.command === "canvas.a2ui.pushJSONL" ||
+          (ctx.command === "canvas.a2ui.push" &&
+            !Array.isArray(params.messages) &&
+            Object.hasOwn(params, "jsonl"));
+        if (usesJsonl) {
+          const jsonl = typeof params.jsonl === "string" ? params.jsonl : "";
+          try {
+            validateSupportedA2UIJsonl(jsonl);
+          } catch (error) {
+            return {
+              ok: false,
+              code: "INVALID_A2UI_JSONL",
+              message: formatErrorMessage(error),
+            };
+          }
+        }
+        return await ctx.invokeNode();
+      },
     });
     api.registerTool((ctx) =>
       createLazyCanvasTool({

--- a/extensions/canvas/src/a2ui-jsonl.ts
+++ b/extensions/canvas/src/a2ui-jsonl.ts
@@ -9,7 +9,7 @@ const A2UI_ACTION_KEYS = [
   "createSurface",
 ] as const;
 
-/** Supported A2UI message dialects accepted by the Canvas host. */
+/** A2UI message dialects recognized by the Canvas validator. */
 type A2UIVersion = "v0.8" | "v0.9";
 
 /** Builds a minimal A2UI JSONL payload that renders text in a single surface. */
@@ -41,7 +41,7 @@ export function buildA2UITextJsonl(text: string) {
 }
 
 /** Validates A2UI JSONL and returns the detected dialect/version metadata. */
-export function validateA2UIJsonl(jsonl: string) {
+function validateA2UIJsonl(jsonl: string) {
   const lines = jsonl.split(/\r?\n/);
   const errors: string[] = [];
   let sawV08 = false;
@@ -66,6 +66,16 @@ export function validateA2UIJsonl(jsonl: string) {
       return;
     }
     const record = obj as Record<string, unknown>;
+    const explicitVersion = record.version;
+    // Bundled v0.8 is strict and unversioned; v0.9 identifies every message.
+    if (explicitVersion === "v0.8") {
+      errors.push(`line ${idx + 1}: A2UI v0.8 messages must not include a version field`);
+      return;
+    }
+    if (explicitVersion !== undefined && explicitVersion !== "v0.9") {
+      errors.push(`line ${idx + 1}: unsupported A2UI version: ${JSON.stringify(explicitVersion)}`);
+      return;
+    }
     const actionKeys = A2UI_ACTION_KEYS.filter((key) => key in record);
     if (actionKeys.length !== 1) {
       errors.push(
@@ -73,7 +83,9 @@ export function validateA2UIJsonl(jsonl: string) {
       );
       return;
     }
-    if (actionKeys[0] === "createSurface") {
+    // v0.9 requires an explicit version, but keep recognizing legacy
+    // createSurface payloads so older generators still fail closed.
+    if (explicitVersion === "v0.9" || actionKeys[0] === "createSurface") {
       sawV09 = true;
     } else {
       sawV08 = true;
@@ -92,4 +104,13 @@ export function validateA2UIJsonl(jsonl: string) {
 
   const version: A2UIVersion = sawV09 ? "v0.9" : "v0.8";
   return { version, messageCount };
+}
+
+/** Validates A2UI JSONL against the Canvas runtime's currently supported dialect. */
+export function validateSupportedA2UIJsonl(jsonl: string) {
+  const result = validateA2UIJsonl(jsonl);
+  if (result.version !== "v0.8") {
+    throw new Error("Detected unsupported A2UI v0.9 JSONL. OpenClaw currently supports v0.8 only.");
+  }
+  return result;
 }

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -21,7 +21,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { shortenHomePath } from "openclaw/plugin-sdk/text-utility-runtime";
-import { buildA2UITextJsonl, validateA2UIJsonl } from "./a2ui-jsonl.js";
+import { buildA2UITextJsonl, validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
 import { canvasSnapshotTempPath, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 
 /** Runtime output surface used by Canvas CLI commands. */
@@ -444,12 +444,7 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
           const jsonl = hasText
             ? buildA2UITextJsonl(opts.text ?? "")
             : await fs.readFile(String(opts.jsonl), "utf8");
-          const { version, messageCount } = validateA2UIJsonl(jsonl);
-          if (version === "v0.9") {
-            throw new Error(
-              "Detected A2UI v0.9 JSONL (createSurface). OpenClaw currently supports v0.8 only.",
-            );
-          }
+          const { messageCount } = validateSupportedA2UIJsonl(jsonl);
           await invokeCanvas(deps, opts, "canvas.a2ui.pushJSONL", { jsonl });
           if (!opts.json) {
             const { ok } = deps.getNodesTheme();

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -5,6 +5,21 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCanvasTool } from "./tool.js";
 
+const VALID_A2UI_V08_JSONL = [
+  JSON.stringify({
+    surfaceUpdate: {
+      surfaceId: "main",
+      components: [
+        {
+          id: "root",
+          component: { Text: { text: { literalString: "Canvas proof" }, usageHint: "body" } },
+        },
+      ],
+    },
+  }),
+  JSON.stringify({ beginRendering: { surfaceId: "main", root: "root" } }),
+].join("\n");
+
 const mocks = vi.hoisted(() => ({
   callGatewayTool: vi.fn(),
   imageResultFromFile: vi.fn(async (params) => ({ content: [], details: params })),
@@ -60,6 +75,7 @@ describe("Canvas tool", () => {
           jsonlPath: "events.jsonl",
         }),
       ).rejects.toThrow("jsonlPath outside workspace");
+      expect(mocks.listNodes).not.toHaveBeenCalled();
       expect(mocks.callGatewayTool).not.toHaveBeenCalled();
     },
   );
@@ -152,6 +168,73 @@ describe("Canvas tool", () => {
     );
   });
 
+  it("dispatches valid A2UI v0.8 JSONL unchanged", async () => {
+    const tool = createCanvasTool();
+
+    await tool.execute("tool-call-1", {
+      action: "a2ui_push",
+      jsonl: VALID_A2UI_V08_JSONL,
+    });
+
+    expect(mocks.callGatewayTool).toHaveBeenCalledTimes(1);
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "canvas.a2ui.pushJSONL",
+        params: { jsonl: VALID_A2UI_V08_JSONL },
+        idempotencyKey: expect.any(String),
+      },
+    );
+  });
+
+  it.each([
+    ["malformed JSONL", "{not-json}", /Invalid A2UI JSONL/],
+    [
+      "A2UI v0.9 createSurface JSONL",
+      JSON.stringify({
+        version: "v0.9",
+        createSurface: {
+          surfaceId: "main",
+          catalogId: "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+        },
+      }),
+      /OpenClaw currently supports v0\.8 only/,
+    ],
+    [
+      "legacy createSurface JSONL",
+      JSON.stringify({ createSurface: { surfaceId: "main", root: "root" } }),
+      /OpenClaw currently supports v0\.8 only/,
+    ],
+    [
+      "A2UI v0.9 deleteSurface JSONL",
+      JSON.stringify({ version: "v0.9", deleteSurface: { surfaceId: "main" } }),
+      /OpenClaw currently supports v0\.8 only/,
+    ],
+    [
+      "an unsupported explicit A2UI version",
+      JSON.stringify({ version: "v1.0", deleteSurface: { surfaceId: "main" } }),
+      /unsupported A2UI version: "v1\.0"/,
+    ],
+    [
+      "an explicit version on an A2UI v0.8 message",
+      JSON.stringify({ version: "v0.8", deleteSurface: { surfaceId: "main" } }),
+      /A2UI v0\.8 messages must not include a version field/,
+    ],
+  ])("rejects %s before resolving or invoking a node", async (_label, jsonl, message) => {
+    const tool = createCanvasTool();
+
+    await expect(
+      tool.execute("tool-call-1", {
+        action: "a2ui_push",
+        jsonl,
+      }),
+    ).rejects.toThrow(message);
+    expect(mocks.listNodes).not.toHaveBeenCalled();
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed numeric canvas params before invoking node commands", async () => {
     const tool = createCanvasTool();
 
@@ -161,6 +244,7 @@ describe("Canvas tool", () => {
         maxWidth: "800px",
       }),
     ).rejects.toThrow("maxWidth must be a positive integer");
+    expect(mocks.listNodes).not.toHaveBeenCalled();
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -18,6 +18,7 @@ import {
 import { readFiniteNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { AnyAgentTool, OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
 import { normalizeCanvasSnapshotFileExtension, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 import { CanvasToolSchema } from "./tool-schema.js";
 
@@ -102,20 +103,17 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
       const params = args as Record<string, unknown>;
       const action = readStringParam(params, "action", { required: true });
       const gatewayOpts = readGatewayCallOptions(params);
+      const nodeQuery = readStringParam(params, "node", { trim: true });
 
-      const nodeId = await resolveNodeId(
-        gatewayOpts,
-        readStringParam(params, "node", { trim: true }),
-        true,
-      );
-
-      const invoke = async (command: string, invokeParams?: Record<string, unknown>) =>
-        await callGatewayTool("node.invoke", gatewayOpts, {
+      const invoke = async (command: string, invokeParams?: Record<string, unknown>) => {
+        const nodeId = await resolveNodeId(gatewayOpts, nodeQuery, true);
+        return await callGatewayTool("node.invoke", gatewayOpts, {
           nodeId,
           command,
           params: invokeParams,
           idempotencyKey: randomUUID(),
         });
+      };
 
       switch (action) {
         case "present": {
@@ -207,6 +205,7 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
           if (!jsonl.trim()) {
             throw new Error("jsonl or jsonlPath required");
           }
+          validateSupportedA2UIJsonl(jsonl);
           await invoke("canvas.a2ui.pushJSONL", { jsonl });
           return jsonResult({ ok: true });
         }


### PR DESCRIPTION
## What Problem This Solves

Malformed or unsupported Canvas A2UI JSONL could reach a paired node through agent-tool or direct node-invoke paths even though the Canvas CLI rejected it.

## Why This Change Was Made

Canvas now owns one supported-dialect validator and applies it at every JSONL boundary:

- Canvas CLI
- agent-facing Canvas tool
- final Canvas node-invoke policy, including the legacy `canvas.a2ui.push` JSONL fallback

Canonical `messages[]` dispatch remains native. Supported unversioned A2UI v0.8 JSONL is forwarded byte-for-byte; explicit v0.9 and malformed/unknown envelopes fail before node dispatch.

The version rules match upstream A2UI: v0.8 is strict and unversioned, while v0.9 requires `version: "v0.9"` on its message envelopes.

## User Impact

All OpenClaw Canvas entry points now reject the same invalid or unsupported JSONL before it reaches a device, while existing v0.8 Canvas rendering continues unchanged.

## Evidence

- Exact-head CI run `29132992111`: green.
- Final Codex autoreview: clean, no accepted or actionable findings.
- Native review artifacts: READY, zero findings; hosted `prepare-run` passed.
- Real candidate-plugin Gateway proof with paired `megaclaw`:
  - malformed JSONL rejected with `Invalid A2UI JSONL`
  - conformant v0.9 `deleteSurface` rejected as unsupported
  - unchanged v0.8 JSONL dispatched successfully with surface `pr-103713-candidate`
  - PNG snapshot visibly rendered `OpenClaw Canvas v0.8 candidate proof — PR #103713`
- Focused policy/tool tests cover rejection without node listing/invocation, legacy fallback validation, canonical `messages[]` bypass, and exact v0.8 dispatch.

The live screenshot was inspected locally; the configured Crabbox artifact broker was unavailable, so it was not attached to the PR.

AI-assisted.
