### PR TITLE
fix(browser): closing a tab could destroy an unrelated live page when the target was an OOPIF iframe

### DIFF
--- a/extensions/browser/src/browser/cdp-target-filter.test.ts
+++ b/extensions/browser/src/browser/cdp-target-filter.test.ts
@@ -1,0 +1,30 @@
+// Browser tests cover CDP target selectability filtering.
+import { describe, expect, it } from "vitest";
+import { isSelectableCdpBrowserTarget } from "./cdp-target-filter.js";
+
+describe("isSelectableCdpBrowserTarget", () => {
+  it("keeps page targets", () => {
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type: "page" })).toBe(true);
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type: " Page " })).toBe(true);
+  });
+
+  it("keeps targets without a type for url-only discovery paths", () => {
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com" })).toBe(true);
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type: undefined })).toBe(
+      true,
+    );
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type: null })).toBe(true);
+    expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type: "" })).toBe(true);
+  });
+
+  it("excludes non-page targets such as OOPIF iframes and workers", () => {
+    for (const type of ["iframe", "worker", "service_worker", "shared_worker", "other"]) {
+      expect(isSelectableCdpBrowserTarget({ url: "https://example.com", type })).toBe(false);
+    }
+  });
+
+  it("excludes browser-internal URLs regardless of type", () => {
+    expect(isSelectableCdpBrowserTarget({ url: "chrome://newtab/", type: "page" })).toBe(false);
+    expect(isSelectableCdpBrowserTarget({ url: "devtools://devtools/inspector.html" })).toBe(false);
+  });
+});

--- a/extensions/browser/src/browser/cdp-target-filter.ts
+++ b/extensions/browser/src/browser/cdp-target-filter.ts
@@ -1,8 +1,10 @@
 /**
  * CDP target filtering helpers.
  *
- * Browser-internal pages cannot be reliably automated as user content, so tab
- * selection filters them before exposing targets to browser actions.
+ * Browser-internal pages cannot be reliably automated as user content, and
+ * non-page targets (OOPIFs, workers) must never be exposed as tabs: closing an
+ * iframe target via /json/close destroys the page hosting it. Tab selection
+ * filters both classes before exposing targets to browser actions.
  */
 const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
   "chrome://",
@@ -14,8 +16,9 @@ const BROWSER_INTERNAL_TARGET_URL_PREFIXES = [
   "opera://",
 ];
 
-type BrowserTargetUrlLike = {
+type BrowserTargetLike = {
   url?: string | null;
+  type?: string | null;
 };
 
 /** Return true for browser-owned chrome/devtools/internal URLs. */
@@ -24,7 +27,18 @@ function isBrowserInternalTargetUrl(url: string | null | undefined): boolean {
   return BROWSER_INTERNAL_TARGET_URL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
+/**
+ * Return true for CDP target types that are not top-level pages (iframe,
+ * worker, service_worker, ...). Missing/empty type stays selectable because
+ * some callers (e.g. Playwright page listings) filter url-only shapes for
+ * targets already known to be pages.
+ */
+function isNonPageTargetType(type: string | null | undefined): boolean {
+  const normalized = type?.trim().toLowerCase() ?? "";
+  return normalized !== "" && normalized !== "page";
+}
+
 /** Return true when a CDP target should be selectable by user-facing actions. */
-export function isSelectableCdpBrowserTarget(target: BrowserTargetUrlLike): boolean {
-  return !isBrowserInternalTargetUrl(target.url);
+export function isSelectableCdpBrowserTarget(target: BrowserTargetLike): boolean {
+  return !isNonPageTargetType(target.type) && !isBrowserInternalTargetUrl(target.url);
 }

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
@@ -113,6 +113,43 @@ describe("browser remote profile fallback and attachOnly behavior", () => {
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
   });
 
+  it("filters non-page CDP targets so OOPIF iframes cannot be closed as tabs", async () => {
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue(null);
+    const { remote } = deps.createRemoteRouteHarness(
+      vi.fn(
+        deps.createJsonListFetchMock([
+          {
+            id: "IFRAME",
+            title: "Third-party tracker",
+            url: "https://tracker.example/frame",
+            webSocketDebuggerUrl: "wss://1.1.1.1:9222/devtools/page/IFRAME",
+            type: "iframe",
+          },
+          {
+            id: "SW",
+            title: "Service worker",
+            url: "https://example.com/sw.js",
+            webSocketDebuggerUrl: "wss://1.1.1.1:9222/devtools/page/SW",
+            type: "service_worker",
+          },
+          {
+            id: "T1",
+            title: "Tab 1",
+            url: "https://example.com",
+            webSocketDebuggerUrl: "wss://1.1.1.1:9222/devtools/page/T1",
+            type: "page",
+          },
+        ]),
+      ),
+    );
+
+    const tabs = await remote.listTabs();
+    expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
+    // Closing an OOPIF target via /json/close destroys its host page, so
+    // targetId resolution must reject iframe targets instead of passing them on.
+    await expect(remote.closeTab("IFRAME")).rejects.toThrow(/tab not found/i);
+  });
+
   it("rejects policy-blocked discovered CDP websocket URLs from raw tab listings", async () => {
     vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue(null);
     const { state, remote } = deps.createRemoteRouteHarness(

--- a/extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts
+++ b/extensions/browser/src/browser/server-context.remote-tab-ops.harness.ts
@@ -158,7 +158,8 @@ type JsonListEntry = {
   title: string;
   url: string;
   webSocketDebuggerUrl: string;
-  type: "page";
+  // Real /json/list payloads mix page targets with iframe/worker targets.
+  type: string;
 };
 
 /** Creates a /json/list fetch mock with static entries. */


### PR DESCRIPTION
Closes #103712

## What Problem This Solves

`openclaw browser tabs` listed site-isolation OOPIF iframe and worker CDP targets (e.g. third-party tracker iframes embedded in a page) as if they were tabs, and `openclaw browser close <targetId>` on such a target made Chrome destroy the page hosting that iframe together with all its sibling iframe targets, while still reporting `{"ok":true}`. An agent doing routine tab cleanup could silently kill a live page it never asked to touch, losing its state (cart contents, form input, session flows).

## Why This Change Was Made

`isSelectableCdpBrowserTarget` only filtered browser-internal URL prefixes (`chrome://` etc.) and ignored the CDP target `type`, so every `/json/list` entry (iframe, worker, service_worker, ...) surfaced as a tab in listing, alias assignment, and close-target resolution. The filter now also rejects targets whose `type` is present and not `page`; targets without a `type` remain selectable so url-only discovery paths (which only ever see real pages) keep working. Since close/focus resolve target ids through `listTabs`, non-page target ids now fail with a tab-not-found error instead of reaching `/json/close`.

## User Impact

`browser tabs` now lists only real page tabs, and `browser close` can no longer cascade-close a host page via one of its iframe/worker targets. Passing an iframe target id now returns a clear "tab not found" error instead of a false `{"ok":true}` plus a destroyed page.

## Evidence

Reproduced with raw CDP against a real managed Chrome session (full transcript in #103712): a page with cross-origin tracker iframes shows `type:"iframe"` entries in `/json/list`; issuing `/json/close/<iframe-id>` closes the host page plus all sibling iframe targets, leaving only unrelated tabs. With this fix the iframe target is filtered from tab listing and close resolution rejects it before any `/json/close` request (proven by a test mock that throws on any unexpected fetch).

Validation:
- New unit coverage in `extensions/browser/src/browser/cdp-target-filter.test.ts`: non-page types (iframe, worker, service_worker, shared_worker, other) excluded; missing/empty `type` kept; browser-internal URLs still excluded regardless of type.
- New integration case in `server-context.remote-profile-tab-ops.fallback.test.ts`: iframe/service_worker entries from a raw `/json/list` payload are hidden from `listTabs`, and `closeTab("IFRAME")` rejects with tab-not-found without issuing `/json/close`.
- `tsgo:extensions`, `tsgo:extensions:test`, oxlint, and oxfmt are clean. One pre-existing failure in the fallback test file ("passes configured remote CDP timeouts...") also fails on pristine `origin/main` and is unrelated.
- `codex review --base origin/main` run locally per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
