### PR TITLE
refactor(auth): harden CLI forwarding proposal boundary

### DIFF
--- a/src/plugin-sdk/cli-backend.ts
+++ b/src/plugin-sdk/cli-backend.ts
@@ -15,16 +15,6 @@ export type {
   CliBackendSideQuestionToolMode,
   CliBackendThinkingLevel,
 } from "../plugins/types.js";
-export type {
-  CliBackendAuthForwardingDecision,
-  CliBackendAuthProfileCredential,
-  CliBackendAuthProfileForwardingPolicy,
-  CliBackendForwardedCredential,
-  CliBackendForwardedCredentialKind,
-  CliBackendForwardedCredentialResolver,
-  CliBackendResolveForwardedCredentialContext,
-} from "../plugins/cli-backend-auth-forwarding.js";
-export { resolveCliBackendAuthForwarding } from "../plugins/cli-backend-auth-forwarding.js";
 export {
   CLI_FRESH_WATCHDOG_DEFAULTS,
   CLI_RESUME_WATCHDOG_DEFAULTS,

--- a/src/plugin-sdk/cli-backend.ts
+++ b/src/plugin-sdk/cli-backend.ts
@@ -15,6 +15,16 @@ export type {
   CliBackendSideQuestionToolMode,
   CliBackendThinkingLevel,
 } from "../plugins/types.js";
+export type {
+  CliBackendAuthForwardingDecision,
+  CliBackendAuthProfileCredential,
+  CliBackendAuthProfileForwardingPolicy,
+  CliBackendForwardedCredential,
+  CliBackendForwardedCredentialKind,
+  CliBackendForwardedCredentialResolver,
+  CliBackendResolveForwardedCredentialContext,
+} from "../plugins/cli-backend-auth-forwarding.js";
+export { resolveCliBackendAuthForwarding } from "../plugins/cli-backend-auth-forwarding.js";
 export {
   CLI_FRESH_WATCHDOG_DEFAULTS,
   CLI_RESUME_WATCHDOG_DEFAULTS,

--- a/src/plugins/cli-backend-auth-forwarding.test.ts
+++ b/src/plugins/cli-backend-auth-forwarding.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveCliBackendAuthForwarding } from "./cli-backend-auth-forwarding.js";
+
+const context = {
+  backendId: "example-cli",
+  provider: "example-provider",
+  modelId: "example-model",
+  profileId: "example-provider:user@example.com",
+  credential: {
+    type: "oauth" as const,
+    provider: "example-provider",
+    access: "raw-access-token",
+  },
+};
+
+const policy = {
+  supported: true as const,
+  providers: ["example-provider"],
+  credentialKinds: ["oauth" as const],
+};
+
+describe("CLI backend auth forwarding contract", () => {
+  it("requires explicit backend opt-in", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({
+        context,
+        resolver: vi.fn(),
+      }),
+    ).resolves.toEqual({ status: "not-supported" });
+  });
+
+  it("fails closed when the selected provider is not allowlisted", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy: { ...policy, providers: ["other-provider"] },
+        context,
+        resolver: vi.fn(),
+      }),
+    ).resolves.toEqual({
+      status: "provider-denied",
+      provider: "example-provider",
+    });
+  });
+
+  it("fails closed when the raw credential kind is not allowlisted", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy: { ...policy, credentialKinds: ["api_key"] },
+        context,
+        resolver: vi.fn(),
+      }),
+    ).resolves.toEqual({
+      status: "credential-kind-denied",
+      kind: "oauth",
+    });
+  });
+
+  it("distinguishes a missing resolver from an explicit decline", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({ policy, context }),
+    ).resolves.toEqual({ status: "resolver-missing" });
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: () => null,
+      }),
+    ).resolves.toEqual({ status: "resolver-declined" });
+  });
+
+  it("forwards only a resolver-owned minimal envelope", async () => {
+    const forwarded = {
+      kind: "oauth" as const,
+      providerId: "example-provider",
+      profileId: "example-provider:user@example.com",
+      userDataDir: "/tmp/example-profile",
+    };
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: () => forwarded,
+      }),
+    ).resolves.toEqual({ status: "forward", credential: forwarded });
+  });
+
+  it("rejects provider, profile, or kind substitution by the resolver", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: () => ({
+          kind: "oauth",
+          providerId: "other-provider",
+          profileId: context.profileId,
+        }),
+      }),
+    ).rejects.toThrow("returned provider other-provider");
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: () => ({
+          kind: "oauth",
+          providerId: context.provider,
+          profileId: "other-profile",
+        }),
+      }),
+    ).rejects.toThrow("returned profile other-profile");
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: () => ({
+          kind: "token",
+          providerId: context.provider,
+          profileId: context.profileId,
+        }),
+      }),
+    ).rejects.toThrow("returned kind token");
+  });
+});

--- a/src/plugins/cli-backend-auth-forwarding.test.ts
+++ b/src/plugins/cli-backend-auth-forwarding.test.ts
@@ -160,4 +160,63 @@ describe("CLI backend auth forwarding contract", () => {
       }),
     ).rejects.toThrow("returned kind token");
   });
+
+  it("validates resolver output against the pre-callback identity snapshot", async () => {
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: (resolverContext) => {
+          resolverContext.provider = "other-provider";
+          return {
+            kind: "oauth",
+            providerId: resolverContext.provider,
+            profileId: resolverContext.profileId,
+          };
+        },
+      }),
+    ).rejects.toThrow("returned provider other-provider");
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: (resolverContext) => {
+          resolverContext.profileId = "other-profile";
+          return {
+            kind: "oauth",
+            providerId: resolverContext.provider,
+            profileId: resolverContext.profileId,
+          };
+        },
+      }),
+    ).rejects.toThrow("returned profile other-profile");
+
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context,
+        resolver: (resolverContext) => {
+          resolverContext.credential.type = "token";
+          return {
+            kind: resolverContext.credential.type,
+            providerId: resolverContext.provider,
+            profileId: resolverContext.profileId,
+          };
+        },
+      }),
+    ).rejects.toThrow("returned kind token");
+
+    expect(context).toEqual({
+      backendId: "example-cli",
+      provider: "example-provider",
+      modelId: "example-model",
+      profileId: "example-provider:user@example.com",
+      credential: {
+        type: "oauth",
+        provider: "example-provider",
+        profileId: "example-provider:user@example.com",
+      },
+    });
+  });
 });

--- a/src/plugins/cli-backend-auth-forwarding.test.ts
+++ b/src/plugins/cli-backend-auth-forwarding.test.ts
@@ -9,7 +9,7 @@ const context = {
   credential: {
     type: "oauth" as const,
     provider: "example-provider",
-    access: "raw-access-token",
+    profileId: "example-provider:user@example.com",
   },
 };
 
@@ -29,6 +29,42 @@ describe("CLI backend auth forwarding contract", () => {
     ).resolves.toEqual({ status: "not-supported" });
   });
 
+  it("rejects mismatched input identity before invoking the resolver", async () => {
+    const providerResolver = vi.fn();
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context: {
+          ...context,
+          credential: { ...context.credential, provider: "other-provider" },
+        },
+        resolver: providerResolver,
+      }),
+    ).resolves.toEqual({
+      status: "credential-provider-mismatch",
+      selectedProvider: "example-provider",
+      credentialProvider: "other-provider",
+    });
+    expect(providerResolver).not.toHaveBeenCalled();
+
+    const profileResolver = vi.fn();
+    await expect(
+      resolveCliBackendAuthForwarding({
+        policy,
+        context: {
+          ...context,
+          credential: { ...context.credential, profileId: "other-profile" },
+        },
+        resolver: profileResolver,
+      }),
+    ).resolves.toEqual({
+      status: "credential-profile-mismatch",
+      selectedProfileId: "example-provider:user@example.com",
+      credentialProfileId: "other-profile",
+    });
+    expect(profileResolver).not.toHaveBeenCalled();
+  });
+
   it("fails closed when the selected provider is not allowlisted", async () => {
     await expect(
       resolveCliBackendAuthForwarding({
@@ -42,7 +78,7 @@ describe("CLI backend auth forwarding contract", () => {
     });
   });
 
-  it("fails closed when the raw credential kind is not allowlisted", async () => {
+  it("fails closed when the credential kind is not allowlisted", async () => {
     await expect(
       resolveCliBackendAuthForwarding({
         policy: { ...policy, credentialKinds: ["api_key"] },
@@ -56,9 +92,9 @@ describe("CLI backend auth forwarding contract", () => {
   });
 
   it("distinguishes a missing resolver from an explicit decline", async () => {
-    await expect(
-      resolveCliBackendAuthForwarding({ policy, context }),
-    ).resolves.toEqual({ status: "resolver-missing" });
+    await expect(resolveCliBackendAuthForwarding({ policy, context })).resolves.toEqual({
+      status: "resolver-missing",
+    });
 
     await expect(
       resolveCliBackendAuthForwarding({
@@ -69,12 +105,13 @@ describe("CLI backend auth forwarding contract", () => {
     ).resolves.toEqual({ status: "resolver-declined" });
   });
 
-  it("forwards only a resolver-owned minimal envelope", async () => {
+  it("forwards only a resolver-owned closed execution envelope", async () => {
     const forwarded = {
       kind: "oauth" as const,
       providerId: "example-provider",
       profileId: "example-provider:user@example.com",
-      userDataDir: "/tmp/example-profile",
+      env: { EXAMPLE_CLI_TOKEN_FILE: "/tmp/example-profile/token.json" },
+      clearEnv: ["EXAMPLE_API_KEY"],
     };
 
     await expect(

--- a/src/plugins/cli-backend-auth-forwarding.ts
+++ b/src/plugins/cli-backend-auth-forwarding.ts
@@ -1,0 +1,113 @@
+/**
+ * Proposed public contract for explicitly forwarding selected auth-profile
+ * material from a provider to a CLI backend.
+ *
+ * This module contains no runtime wiring. It defines and validates the boundary
+ * so maintainers can review the API independently before integrating it into the
+ * CLI runner.
+ */
+
+export type CliBackendForwardedCredentialKind = "api_key" | "oauth" | "token";
+
+export type CliBackendAuthProfileCredential = {
+  type: CliBackendForwardedCredentialKind;
+  provider: string;
+} & Record<string, unknown>;
+
+export type CliBackendAuthProfileForwardingPolicy = {
+  supported: true;
+  providers: readonly string[];
+  credentialKinds: readonly CliBackendForwardedCredentialKind[];
+};
+
+export type CliBackendForwardedCredential = {
+  kind: CliBackendForwardedCredentialKind;
+  providerId: string;
+  profileId: string;
+} & Record<string, unknown>;
+
+export type CliBackendResolveForwardedCredentialContext = {
+  backendId: string;
+  provider: string;
+  modelId: string;
+  profileId: string;
+  credential: CliBackendAuthProfileCredential;
+};
+
+export type CliBackendForwardedCredentialResolver = (
+  context: CliBackendResolveForwardedCredentialContext,
+) =>
+  | CliBackendForwardedCredential
+  | null
+  | undefined
+  | Promise<CliBackendForwardedCredential | null | undefined>;
+
+export type CliBackendAuthForwardingDecision =
+  | { status: "not-supported" }
+  | { status: "provider-denied"; provider: string }
+  | { status: "credential-kind-denied"; kind: CliBackendForwardedCredentialKind }
+  | { status: "resolver-missing" }
+  | { status: "resolver-declined" }
+  | { status: "forward"; credential: CliBackendForwardedCredential };
+
+function normalizeIds(values: readonly string[]): Set<string> {
+  return new Set(values.map((value) => value.trim()).filter(Boolean));
+}
+
+function assertResolvedCredentialMatchesSelection(params: {
+  selected: CliBackendResolveForwardedCredentialContext;
+  resolved: CliBackendForwardedCredential;
+}): void {
+  if (params.resolved.providerId !== params.selected.provider) {
+    throw new Error(
+      `CLI backend credential resolver returned provider ${params.resolved.providerId} for selected provider ${params.selected.provider}.`,
+    );
+  }
+  if (params.resolved.profileId !== params.selected.profileId) {
+    throw new Error(
+      `CLI backend credential resolver returned profile ${params.resolved.profileId} for selected profile ${params.selected.profileId}.`,
+    );
+  }
+  if (params.resolved.kind !== params.selected.credential.type) {
+    throw new Error(
+      `CLI backend credential resolver returned kind ${params.resolved.kind} for selected credential kind ${params.selected.credential.type}.`,
+    );
+  }
+}
+
+export async function resolveCliBackendAuthForwarding(params: {
+  policy?: CliBackendAuthProfileForwardingPolicy;
+  resolver?: CliBackendForwardedCredentialResolver;
+  context: CliBackendResolveForwardedCredentialContext;
+}): Promise<CliBackendAuthForwardingDecision> {
+  if (!params.policy?.supported) {
+    return { status: "not-supported" };
+  }
+
+  const providers = normalizeIds(params.policy.providers);
+  if (!providers.has(params.context.provider)) {
+    return { status: "provider-denied", provider: params.context.provider };
+  }
+
+  if (!params.policy.credentialKinds.includes(params.context.credential.type)) {
+    return {
+      status: "credential-kind-denied",
+      kind: params.context.credential.type,
+    };
+  }
+
+  if (!params.resolver) {
+    return { status: "resolver-missing" };
+  }
+
+  const resolved = await params.resolver(params.context);
+  if (!resolved) {
+    return { status: "resolver-declined" };
+  }
+
+  assertResolvedCredentialMatchesSelection({
+    selected: params.context,
+    resolved,
+  });
+  return { status: "forward", credential: resolved };
+}

--- a/src/plugins/cli-backend-auth-forwarding.ts
+++ b/src/plugins/cli-backend-auth-forwarding.ts
@@ -64,6 +64,12 @@ export type CliBackendAuthForwardingDecision =
   | { status: "resolver-declined" }
   | { status: "forward"; credential: CliBackendForwardedCredential };
 
+type CliBackendForwardingSelection = {
+  provider: string;
+  profileId: string;
+  kind: CliBackendForwardedCredentialKind;
+};
+
 function normalizeId(value: string): string {
   return value.trim();
 }
@@ -73,7 +79,7 @@ function normalizeIds(values: readonly string[]): Set<string> {
 }
 
 function assertResolvedCredentialMatchesSelection(params: {
-  selected: CliBackendResolveForwardedCredentialContext;
+  selected: CliBackendForwardingSelection;
   resolved: CliBackendForwardedCredential;
 }): void {
   if (params.resolved.providerId !== params.selected.provider) {
@@ -86,9 +92,9 @@ function assertResolvedCredentialMatchesSelection(params: {
       `CLI backend credential resolver returned profile ${params.resolved.profileId} for selected profile ${params.selected.profileId}.`,
     );
   }
-  if (params.resolved.kind !== params.selected.credential.type) {
+  if (params.resolved.kind !== params.selected.kind) {
     throw new Error(
-      `CLI backend credential resolver returned kind ${params.resolved.kind} for selected credential kind ${params.selected.credential.type}.`,
+      `CLI backend credential resolver returned kind ${params.resolved.kind} for selected credential kind ${params.selected.kind}.`,
     );
   }
 }
@@ -122,15 +128,16 @@ export async function resolveCliBackendAuthForwarding(params: {
     };
   }
 
+  const selectedKind = params.context.credential.type;
   const providers = normalizeIds(params.policy.providers);
   if (!providers.has(selectedProvider)) {
     return { status: "provider-denied", provider: selectedProvider };
   }
 
-  if (!params.policy.credentialKinds.includes(params.context.credential.type)) {
+  if (!params.policy.credentialKinds.includes(selectedKind)) {
     return {
       status: "credential-kind-denied",
-      kind: params.context.credential.type,
+      kind: selectedKind,
     };
   }
 
@@ -138,14 +145,28 @@ export async function resolveCliBackendAuthForwarding(params: {
     return { status: "resolver-missing" };
   }
 
-  const resolved = await params.resolver(params.context);
+  const selected: CliBackendForwardingSelection = {
+    provider: selectedProvider,
+    profileId: selectedProfileId,
+    kind: selectedKind,
+  };
+  const resolverContext: CliBackendResolveForwardedCredentialContext = {
+    backendId: params.context.backendId,
+    provider: selectedProvider,
+    modelId: params.context.modelId,
+    profileId: selectedProfileId,
+    credential: {
+      type: selectedKind,
+      provider: credentialProvider,
+      profileId: credentialProfileId,
+    },
+  };
+
+  const resolved = await params.resolver(resolverContext);
   if (!resolved) {
     return { status: "resolver-declined" };
   }
 
-  assertResolvedCredentialMatchesSelection({
-    selected: params.context,
-    resolved,
-  });
+  assertResolvedCredentialMatchesSelection({ selected, resolved });
   return { status: "forward", credential: resolved };
 }

--- a/src/plugins/cli-backend-auth-forwarding.ts
+++ b/src/plugins/cli-backend-auth-forwarding.ts
@@ -1,10 +1,11 @@
 /**
- * Proposed public contract for explicitly forwarding selected auth-profile
- * material from a provider to a CLI backend.
+ * Internal proposal for explicitly forwarding a provider-owned, minimized auth
+ * envelope to a CLI backend.
  *
- * This module contains no runtime wiring. It defines and validates the boundary
- * so maintainers can review the API independently before integrating it into the
- * CLI runner.
+ * Canonical auth-profile material does not cross this boundary. The resolver
+ * receives only validated selection metadata and returns a closed execution
+ * envelope. This module remains internal until a complete runtime consumer,
+ * documentation, and Plugin SDK compatibility baseline are reviewed together.
  */
 
 export type CliBackendForwardedCredentialKind = "api_key" | "oauth" | "token";
@@ -12,7 +13,8 @@ export type CliBackendForwardedCredentialKind = "api_key" | "oauth" | "token";
 export type CliBackendAuthProfileCredential = {
   type: CliBackendForwardedCredentialKind;
   provider: string;
-} & Record<string, unknown>;
+  profileId: string;
+};
 
 export type CliBackendAuthProfileForwardingPolicy = {
   supported: true;
@@ -24,7 +26,9 @@ export type CliBackendForwardedCredential = {
   kind: CliBackendForwardedCredentialKind;
   providerId: string;
   profileId: string;
-} & Record<string, unknown>;
+  env?: Readonly<Record<string, string>>;
+  clearEnv?: readonly string[];
+};
 
 export type CliBackendResolveForwardedCredentialContext = {
   backendId: string;
@@ -45,13 +49,27 @@ export type CliBackendForwardedCredentialResolver = (
 export type CliBackendAuthForwardingDecision =
   | { status: "not-supported" }
   | { status: "provider-denied"; provider: string }
+  | {
+      status: "credential-provider-mismatch";
+      selectedProvider: string;
+      credentialProvider: string;
+    }
+  | {
+      status: "credential-profile-mismatch";
+      selectedProfileId: string;
+      credentialProfileId: string;
+    }
   | { status: "credential-kind-denied"; kind: CliBackendForwardedCredentialKind }
   | { status: "resolver-missing" }
   | { status: "resolver-declined" }
   | { status: "forward"; credential: CliBackendForwardedCredential };
 
+function normalizeId(value: string): string {
+  return value.trim();
+}
+
 function normalizeIds(values: readonly string[]): Set<string> {
-  return new Set(values.map((value) => value.trim()).filter(Boolean));
+  return new Set(values.map(normalizeId).filter(Boolean));
 }
 
 function assertResolvedCredentialMatchesSelection(params: {
@@ -84,9 +102,29 @@ export async function resolveCliBackendAuthForwarding(params: {
     return { status: "not-supported" };
   }
 
+  const selectedProvider = normalizeId(params.context.provider);
+  const credentialProvider = normalizeId(params.context.credential.provider);
+  if (credentialProvider !== selectedProvider) {
+    return {
+      status: "credential-provider-mismatch",
+      selectedProvider,
+      credentialProvider,
+    };
+  }
+
+  const selectedProfileId = normalizeId(params.context.profileId);
+  const credentialProfileId = normalizeId(params.context.credential.profileId);
+  if (credentialProfileId !== selectedProfileId) {
+    return {
+      status: "credential-profile-mismatch",
+      selectedProfileId,
+      credentialProfileId,
+    };
+  }
+
   const providers = normalizeIds(params.policy.providers);
-  if (!providers.has(params.context.provider)) {
-    return { status: "provider-denied", provider: params.context.provider };
+  if (!providers.has(selectedProvider)) {
+    return { status: "provider-denied", provider: selectedProvider };
   }
 
   if (!params.policy.credentialKinds.includes(params.context.credential.type)) {


### PR DESCRIPTION
## Summary

Hardens the proposed CLI backend auth-forwarding boundary while keeping it internal and draft-only.

This remains separate from #99733 and the closed #103715. It does not alter current CLI execution behavior and does not publish an incomplete Plugin SDK contract.

## What changed

- Rejects credential-provider mismatches before any resolver is invoked.
- Rejects credential-profile mismatches before any resolver is invoked.
- Replaces the open-ended raw credential record with closed selection metadata.
- Replaces the open-ended returned record with a closed execution envelope containing only identity, environment additions, and environment removals.
- Snapshots provider, profile, and credential kind before invoking the resolver.
- Passes a separate resolver context so callback mutation cannot change the canonical identity used for output authorization.
- Keeps the helper internal by removing the premature `openclaw/plugin-sdk/cli-backend` export.
- Preserves fail-closed handling for unsupported backends, denied providers, denied credential kinds, missing resolvers, explicit declines, and resolver output substitution.

## Security boundary

Canonical auth-profile secrets do not cross into the resolver input. The resolver receives validated provider, profile, model, backend, and credential-kind metadata only.

The resolver output is validated against an immutable pre-callback identity snapshot. A resolver cannot authorize substituted output by mutating its input context. The original caller context is also not exposed for mutation.

## Current scope

This draft adds an internal validator and focused tests only.

It deliberately does not yet:

- add fields to `CliBackendPlugin`
- add a resolver hook to `ProviderPlugin`
- wire forwarding into CLI execution
- export a public Plugin SDK API
- claim live runtime behavior

A complete runtime consumer, documentation, SDK baseline, security-owner approval, and redacted live proof should be reviewed together before any public contract is introduced.

## Review findings addressed

- Input provider and profile identity are validated before resolver invocation.
- Resolver input no longer carries an open-ended raw credential record.
- Resolver output is a closed, identity-bound execution envelope.
- Resolver output provider, profile, and credential-kind substitution is rejected.
- Provider, profile, and credential-kind mutation inside the resolver is tested and rejected against the pre-callback snapshot.
- The incomplete proposal is not exported through the public Plugin SDK.

## Validation

Current head: `140e08149531bffe8cf22d4cfd100c5d2d2d2554`

Current-head GitHub Actions passed:

- CI
- Workflow Sanity
- iOS Periphery Dead Code

CodeQL and OpenGrep were skipped by repository policy for this draft head.

Focused coverage includes:

- explicit opt-in
- pre-resolver provider mismatch rejection
- pre-resolver profile mismatch rejection
- provider and credential-kind denial
- resolver absence and explicit decline
- closed-envelope forwarding
- resolver output provider, profile, and kind substitution rejection
- resolver input mutation for provider, profile, and kind
- preservation of the original caller context

## Remaining decision

The mechanical security defect is fixed. The remaining question is architectural: whether OpenClaw wants a generic provider-owned forwarding seam at all, and which concrete runtime consumer should justify it.

This PR remains draft until an auth/security owner sponsors the complete runtime migration and proof boundary.

## Tests

AI-assisted: yes.
