### PR TITLE
fix(terminal): keep C1 CSI and BEL-terminated OSC-8 links intact when wrapping table cells

### DIFF
--- a/packages/terminal-core/src/ansi-sequences.ts
+++ b/packages/terminal-core/src/ansi-sequences.ts
@@ -1,0 +1,99 @@
+export const ANSI_OSC_INTRODUCER_PATTERN = "(?:\\x1b\\]|\\x9d)";
+export const ANSI_STRING_TERMINATOR_PATTERN = "(?:\\x1b\\\\|\\x07|\\x9c)";
+const ANSI_OSC_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[^\\x07\\x1b\\x9c]*${ANSI_STRING_TERMINATOR_PATTERN}`;
+
+const ansiOscAtIndexRegex = new RegExp(ANSI_OSC_PATTERN, "y");
+
+export type AnsiSegment =
+  | { controls: string[]; kind: "ansi"; value: string }
+  | { kind: "text"; value: string };
+
+export function matchAnsiOscAt(input: string, index: number): string | undefined {
+  ansiOscAtIndexRegex.lastIndex = index;
+  return ansiOscAtIndexRegex.exec(input)?.[0];
+}
+
+function csiIntroducerLength(input: string, index: number): number {
+  const code = input.charCodeAt(index);
+  if (code === 0x9b) {
+    return 1;
+  }
+  return code === 0x1b && input.charCodeAt(index + 1) === 0x5b ? 2 : 0;
+}
+
+export type AnsiCsiScan = {
+  controls: string[];
+  ended: boolean;
+  value: string;
+};
+
+/** Scan one CSI parser pass, retaining independently executed C0 controls. */
+export function scanAnsiCsiAt(input: string, index: number): AnsiCsiScan | undefined {
+  const introducerLength = csiIntroducerLength(input, index);
+  if (introducerLength === 0) {
+    return undefined;
+  }
+
+  let cursor = index + introducerLength;
+  const controls: string[] = [];
+  let ended = false;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    if (code === 0x18 || code === 0x1a) {
+      cursor += 1;
+      ended = true;
+      break;
+    }
+    if (code === 0x1b || code === 0x9b) {
+      ended = true;
+      break;
+    }
+    if (code <= 0x1f || code === 0x7f) {
+      controls.push(input.charAt(cursor));
+      cursor += 1;
+      continue;
+    }
+    if (code >= 0x20 && code <= 0x3f) {
+      cursor += 1;
+      continue;
+    }
+    if (code >= 0x40 && code <= 0x7e) {
+      cursor += 1;
+    }
+    ended = true;
+    break;
+  }
+  return { controls, ended, value: input.slice(index, cursor) };
+}
+
+export function splitAnsiSegments(input: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = [];
+  let position = 0;
+  let index = 0;
+
+  while (index < input.length) {
+    const code = input.charCodeAt(index);
+    if (code !== 0x1b && code !== 0x9b && code !== 0x9d) {
+      index += 1;
+      continue;
+    }
+
+    const osc = matchAnsiOscAt(input, index);
+    const csi = osc ? undefined : scanAnsiCsiAt(input, index);
+    const value = osc ?? csi?.value;
+    if (!value) {
+      index += 1;
+      continue;
+    }
+    if (index > position) {
+      segments.push({ kind: "text", value: input.slice(position, index) });
+    }
+    segments.push({ controls: csi?.controls ?? [], kind: "ansi", value });
+    index += value.length;
+    position = index;
+  }
+  if (position < input.length) {
+    segments.push({ kind: "text", value: input.slice(position) });
+  }
+  return segments;
+}

--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -118,6 +118,8 @@ describe("terminal ansi helpers", () => {
     expect(visibleWidth("📸 skill")).toBe(8);
     expect(visibleWidth("表")).toBe(2);
     expect(visibleWidth("\u001B[31m📸\u001B[0m")).toBe(2);
+    expect(visibleWidth("\u0007\u007F\u0085")).toBe(0);
+    expect(visibleWidth("a\u001B[31\u0001mb")).toBe(2);
   });
 
   it("keeps emoji zwj sequences as single graphemes", () => {
@@ -165,6 +167,18 @@ describe("terminal ansi helpers", () => {
     expect(truncateToVisibleWidth("[31mab[0m", 1)).toBe("[31ma[0m");
     expect(truncateToVisibleWidth("[31m表文[0m", 1)).toBe("[31m[0m");
     expect(visibleWidth(truncateToVisibleWidth("[31m表文[0m", 1))).toBe(0);
+  });
+
+  it("counts independently executed controls inside atomic CSI sequences", () => {
+    const sequence = "\x1b[31\tm";
+    const truncated = truncateToVisibleWidth(`a${sequence}B`, 2);
+    expect(truncated).toBe(`a${sequence}`);
+    expect(visibleWidth(truncated)).toBe(2);
+    expect(visibleWidth(truncateToVisibleWidth(`a${sequence}B`, 1))).toBe(1);
+
+    const reset = truncateToVisibleWidth("\x1b[31mA\x1b[0\tmB", 1);
+    expect(reset).toBe("\x1b[31mA\x1b[0m");
+    expect(visibleWidth(reset)).toBe(1);
   });
 
   it("reuses the ANSI scanner across truncation calls", () => {

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -1,15 +1,10 @@
-// Full CSI: ESC [ <params> <final byte> covers cursor movement, erase, and SGR.
-const ESC_ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
-const C1_ANSI_CSI_PATTERN = "\\x9b[\\x20-\\x3f]*[\\x40-\\x7e]";
-const ANSI_CSI_PATTERN = `(?:${ESC_ANSI_CSI_PATTERN}|${C1_ANSI_CSI_PATTERN})`;
-// OSC: ESC ] or C1 OSC, then <payload> ST. Covers hyperlinks and clipboard/title escapes.
-// ST can be ESC \, BEL, or its C1 form.
-const ANSI_OSC_INTRODUCER_PATTERN = "(?:\\x1b\\]|\\x9d)";
-const ANSI_STRING_TERMINATOR_PATTERN = "(?:\\x1b\\\\|\\x07|\\x9c)";
-const ANSI_OSC_PATTERN = `${ANSI_OSC_INTRODUCER_PATTERN}[^\\x07\\x1b\\x9c]*${ANSI_STRING_TERMINATOR_PATTERN}`;
-
-const ANSI_OSC_AT_INDEX_REGEX = new RegExp(ANSI_OSC_PATTERN, "y");
-const ANSI_SEQUENCE_REGEX = new RegExp(`${ANSI_OSC_PATTERN}|${ANSI_CSI_PATTERN}`, "g");
+import {
+  ANSI_OSC_INTRODUCER_PATTERN,
+  ANSI_STRING_TERMINATOR_PATTERN,
+  matchAnsiOscAt,
+  scanAnsiCsiAt,
+  splitAnsiSegments,
+} from "./ansi-sequences.js";
 
 /*
  * The following compatibility grammar is derived from ansi-regex and strip-ansi.
@@ -48,14 +43,6 @@ const graphemeSegmenter =
     ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
     : null;
 
-function csiIntroducerLength(input: string, index: number): number {
-  const code = input.charCodeAt(index);
-  if (code === 0x9b) {
-    return 1;
-  }
-  return code === 0x1b && input.charCodeAt(index + 1) === 0x5b ? 2 : 0;
-}
-
 function hasAnsiIntroducer(input: string): boolean {
   return input.includes("\u001B") || input.includes("\u009B") || input.includes("\u009D");
 }
@@ -80,17 +67,16 @@ function stripAnsiInternal(
       continue;
     }
 
-    ANSI_OSC_AT_INDEX_REGEX.lastIndex = index;
-    const oscMatch = ANSI_OSC_AT_INDEX_REGEX.exec(input);
-    if (oscMatch) {
+    const osc = matchAnsiOscAt(input, index);
+    if (osc) {
       output.push(input.slice(copyStart, index));
-      index += oscMatch[0].length;
+      index += osc.length;
       copyStart = index;
       continue;
     }
 
-    const introducerLength = csiIntroducerLength(input, index);
-    if (introducerLength === 0) {
+    const csi = scanAnsiCsiAt(input, index);
+    if (!csi) {
       ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.lastIndex = index;
       const compatibilityMatch = options.compatibilityGrammar
         ? ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.exec(input)
@@ -109,52 +95,21 @@ function stripAnsiInternal(
     const compatibilityMatch = options.compatibilityGrammar
       ? ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX.exec(input)
       : null;
-    let cursor = index + introducerLength;
-    const controls: string[] = [];
-    let ended = false;
-    while (cursor < input.length) {
-      const code = input.charCodeAt(cursor);
-      if (code === 0x18 || code === 0x1a) {
-        cursor += 1;
-        ended = true;
-        break;
-      }
-      if (code === 0x1b || code === 0x9b) {
-        ended = true;
-        break;
-      }
-      if (code <= 0x1f || code === 0x7f) {
-        // These controls execute independently; the caller still owns whether
-        // to retain, remove, or escape them in its output format.
-        controls.push(input.charAt(cursor));
-        cursor += 1;
-        continue;
-      }
-      if (code >= 0x20 && code <= 0x3f) {
-        cursor += 1;
-        continue;
-      }
-      if (code >= 0x40 && code <= 0x7e) {
-        cursor += 1;
-      }
-      ended = true;
+    if (!csi.ended && options.preserveIncompleteCsi) {
       break;
     }
 
-    if (!ended && options.preserveIncompleteCsi) {
-      break;
-    }
-
-    const canonicalLength = cursor - index;
+    let cursor = index + csi.value.length;
+    const canonicalLength = csi.value.length;
     if (
-      controls.length === 0 &&
+      csi.controls.length === 0 &&
       compatibilityMatch &&
       compatibilityMatch[0].length > canonicalLength
     ) {
       cursor = index + compatibilityMatch[0].length;
     }
 
-    output.push(input.slice(copyStart, index), ...controls);
+    output.push(input.slice(copyStart, index), ...csi.controls);
     index = cursor;
     copyStart = cursor;
   }
@@ -227,6 +182,8 @@ export function sanitizeForLog(v: string): string {
 
 function isZeroWidthCodePoint(codePoint: number): boolean {
   return (
+    (codePoint <= 0x1f && codePoint !== 0x09) ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
     (codePoint >= 0x0300 && codePoint <= 0x036f) ||
     (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
     (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
@@ -323,11 +280,10 @@ export function visibleWidth(input: string): number {
 
 /**
  * Truncate to at most `maxWidth` visible columns, dropping whole grapheme
- * clusters that would overflow while preserving ANSI sequences verbatim
- * (they have zero visible width). A single wide grapheme that cannot fit the
- * remaining budget is dropped rather than emitted partially, so the result is
- * always `visibleWidth(result) <= maxWidth`. Callers that need a fixed width
- * pad the (possibly short) remainder themselves.
+ * clusters that would overflow while preserving zero-width ANSI sequences
+ * verbatim. Independently executed controls inside CSI count toward the budget
+ * while the containing sequence stays atomic. A single wide grapheme that
+ * cannot fit is dropped whole, so `visibleWidth(result) <= maxWidth`.
  */
 export function truncateToVisibleWidth(input: string, maxWidth: number): string {
   if (maxWidth <= 0) {
@@ -336,13 +292,11 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
   if (visibleWidth(input) <= maxWidth) {
     return input;
   }
-  ANSI_SEQUENCE_REGEX.lastIndex = 0;
   let out = "";
   let used = 0;
-  let pos = 0;
   // Once the visible budget is spent we stop emitting graphemes but keep
-  // copying ANSI sequences, so trailing resets/link-closes still land and the
-  // truncated cell does not bleed styling into the padding or border.
+  // copying zero-width ANSI sequences, so trailing resets/link-closes still
+  // land without letting embedded executable controls exceed the budget.
   let budgetSpent = false;
   const appendVisible = (segment: string): void => {
     if (budgetSpent) {
@@ -358,12 +312,25 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
       used += width;
     }
   };
-  let match: RegExpExecArray | null;
-  while ((match = ANSI_SEQUENCE_REGEX.exec(input)) !== null) {
-    appendVisible(input.slice(pos, match.index));
-    out += match[0];
-    pos = match.index + match[0].length;
+  for (const segment of splitAnsiSegments(input)) {
+    if (segment.kind === "ansi") {
+      const widthControls = segment.controls.filter((control) => graphemeWidth(control) > 0);
+      const controlWidth = widthControls.reduce((sum, control) => sum + graphemeWidth(control), 0);
+      if (!budgetSpent && used + controlWidth <= maxWidth) {
+        out += segment.value;
+        used += controlWidth;
+      } else if (controlWidth > 0) {
+        out += widthControls.reduce(
+          (value, control) => value.replaceAll(control, ""),
+          segment.value,
+        );
+        budgetSpent = true;
+      } else {
+        out += segment.value;
+      }
+    } else {
+      appendVisible(segment.value);
+    }
   }
-  appendVisible(input.slice(pos));
   return out;
 }

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -227,6 +227,47 @@ describe("renderTable", () => {
     }
   });
 
+  it.each([
+    ["BEL ST", "\x1b]8;;https://openclaw.ai\x07", "\x1b]8;;\x07"],
+    ["ESC-backslash ST", "\x1b]8;;https://openclaw.ai\x1b\\", "\x1b]8;;\x1b\\"],
+    ["C1 ST", "\x9d8;;https://openclaw.ai\x9c", "\x9d8;;\x9c"],
+  ])(
+    "closes and reopens embedded OSC-8 links at wrap boundaries (%s)",
+    (_label, openSeq, closeSeq) => {
+      const link = `${openSeq}OpenClaw${closeSeq}`;
+      const out = renderTable({
+        width: 20,
+        columns: [
+          { key: "K", header: "K", minWidth: 3 },
+          { key: "V", header: "V", flex: true, minWidth: 10 },
+        ],
+        rows: [{ K: "X", V: `before ${link} after` }],
+      });
+
+      const lines = out
+        .split("\n")
+        .filter((line) => line.includes("before") || line.includes("after"));
+      // Every line that contains visible text should close any active link before
+      // the table border and reopen it at the start of the continuation.
+      for (const line of lines) {
+        const contentStart = Math.max(line.lastIndexOf("│"), line.lastIndexOf("|")) + 1;
+        const content = line.slice(contentStart);
+        // "after" must not be part of the hyperlink: it should appear after a
+        // close sequence on its line, or the line has no open sequence at all.
+        if (content.includes("after")) {
+          const afterIndex = content.indexOf("after");
+          const openIndex = content.indexOf(openSeq);
+          const closeIndex = content.indexOf(closeSeq);
+          expect(closeIndex).toBeGreaterThan(-1);
+          expect(closeIndex).toBeLessThan(afterIndex);
+          if (openIndex >= 0 && openIndex < afterIndex) {
+            expect(closeIndex).toBeGreaterThan(openIndex);
+          }
+        }
+      }
+    },
+  );
+
   it("respects explicit newlines in cell values", () => {
     const out = renderTable({
       width: 48,

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -161,6 +161,72 @@ describe("renderTable", () => {
     }
   });
 
+  it("does not split BEL-terminated OSC-8 links when wrapping", () => {
+    const link = "\x1b]8;;https://openclaw.ai\x07OpenClaw\x1b]8;;\x07";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: link }],
+    });
+
+    // The OSC-8 open/close sequences must stay intact; no dangling ESC bytes.
+    const osc8Token = new RegExp(String.raw`\]8;;.*?|\]8;;.*?\\`, "gs");
+    let escapeIndex = out.indexOf("");
+    while (escapeIndex >= 0) {
+      osc8Token.lastIndex = escapeIndex;
+      const match = osc8Token.exec(out);
+      expect(match?.index).toBe(escapeIndex);
+      escapeIndex = out.indexOf("", escapeIndex + 1);
+    }
+  });
+
+  it("does not split C1 CSI SGR sequences when wrapping", () => {
+    const red = "\x9b31m";
+    const reset = "\x9b0m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${red}${"a".repeat(80)}${reset}` }],
+    });
+
+    const lines = out.split("\n").filter((line) => line.includes("a"));
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      const resetIndex = line.lastIndexOf(reset);
+      const lastSep = Math.max(line.lastIndexOf("│"), line.lastIndexOf("|"));
+      expect(resetIndex).toBeGreaterThan(-1);
+      expect(lastSep).toBeGreaterThan(resetIndex);
+    }
+  });
+
+  it("does not split C1 OSC-8 links when wrapping", () => {
+    const link = "\x9d8;;https://openclaw.ai\x9cOpenClaw\x9d8;;\x9c";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: link }],
+    });
+
+    // C1 OSC-8 open/close sequences must stay intact.
+    const osc8Token = new RegExp(String.raw`8;;.*?`, "gs");
+    let oscIndex = out.indexOf("");
+    while (oscIndex >= 0) {
+      osc8Token.lastIndex = oscIndex;
+      const match = osc8Token.exec(out);
+      expect(match?.index).toBe(oscIndex);
+      oscIndex = out.indexOf("", oscIndex + 1);
+    }
+  });
+
   it("respects explicit newlines in cell values", () => {
     const out = renderTable({
       width: 48,

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -268,6 +268,40 @@ describe("renderTable", () => {
     },
   );
 
+  it.each([
+    ["BEL ST", "\x1b]8;;https://openclaw.ai\x07", "\x1b]8;;\x07"],
+    ["ESC-backslash ST", "\x1b]8;;https://openclaw.ai\x1b\\", "\x1b]8;;\x1b\\"],
+    ["C1 ST", "\x9d8;;https://openclaw.ai\x9c", "\x9d8;;\x9c"],
+  ])(
+    "does not reopen a leading OSC-8 link onto wrapped suffix lines (%s)",
+    (_label, openSeq, closeSeq) => {
+      const link = `${openSeq}OpenClaw${closeSeq}`;
+      const out = renderTable({
+        width: 20,
+        columns: [
+          { key: "K", header: "K", minWidth: 3 },
+          { key: "V", header: "V", flex: true, minWidth: 10 },
+        ],
+        rows: [{ K: "X", V: `${link} after` }],
+      });
+
+      // "after" wraps onto a continuation line after the link's close. The
+      // leading opener must not be prepended to that line, or "after" plus its
+      // padding become an unclosed hyperlink that bleeds past the cell border.
+      const lines = out.split("\n");
+      const afterLines = lines.filter((line) => line.includes("after"));
+      expect(afterLines.length).toBeGreaterThan(0);
+      for (const line of afterLines) {
+        expect(line.includes(openSeq)).toBe(false);
+      }
+      // The link itself stays intact on the OpenClaw line: open + close present.
+      const linkLine = lines.find((line) => line.includes("OpenClaw"));
+      expect(linkLine).toBeDefined();
+      expect(linkLine?.includes(openSeq)).toBe(true);
+      expect(linkLine?.includes(closeSeq)).toBe(true);
+    },
+  );
+
   it("respects explicit newlines in cell values", () => {
     const out = renderTable({
       width: 48,

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -10,6 +10,18 @@ function mockProcessPlatform(platform: NodeJS.Platform): void {
   vi.spyOn(process, "platform", "get").mockReturnValue(platform);
 }
 
+function expectIntroducersToStartCompleteSequences(
+  value: string,
+  introducer: string,
+  sequences: readonly string[],
+): void {
+  let index = value.indexOf(introducer);
+  while (index >= 0) {
+    expect(sequences.some((sequence) => value.startsWith(sequence, index))).toBe(true);
+    index = value.indexOf(introducer, index + introducer.length);
+  }
+}
+
 describe("renderTable", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -71,7 +83,8 @@ describe("renderTable", () => {
   });
 
   it("resets ANSI styling on wrapped lines", () => {
-    const reset = "\x1b[0m";
+    const globalReset = "\x1b[0m";
+    const foregroundReset = "\x1b[39m";
     const out = renderTable({
       width: 24,
       columns: [
@@ -81,14 +94,14 @@ describe("renderTable", () => {
       rows: [
         {
           K: "X",
-          V: `\x1b[31m${"a".repeat(80)}${reset}`,
+          V: `\x1b[31m${"a".repeat(80)}${globalReset}`,
         },
       ],
     });
 
     const lines = out.split("\n").filter((line) => line.includes("a"));
     for (const line of lines) {
-      const resetIndex = line.lastIndexOf(reset);
+      const resetIndex = Math.max(line.lastIndexOf(globalReset), line.lastIndexOf(foregroundReset));
       const lastSep = Math.max(line.lastIndexOf("│"), line.lastIndexOf("|"));
       expect(resetIndex).toBeGreaterThan(-1);
       expect(lastSep).toBeGreaterThan(resetIndex);
@@ -161,44 +174,135 @@ describe("renderTable", () => {
     }
   });
 
-  it("does not split BEL-terminated OSC-8 links when wrapping", () => {
-    const link = "\x1b]8;;https://openclaw.ai\x07OpenClaw\x1b]8;;\x07";
+  it("keeps intensity active when an RGB color contains zero operands", () => {
+    const bold = "\x1b[1m";
+    const red = "\x1b[38;2;255;0;0m";
+    const reset = "\x1b[0m";
     const out = renderTable({
       width: 24,
       columns: [
         { key: "K", header: "K", minWidth: 3 },
         { key: "V", header: "V", flex: true, minWidth: 10 },
       ],
-      rows: [{ K: "X", V: link }],
+      rows: [{ K: "X", V: `prefix ${bold}${red}${"a".repeat(80)}${reset}` }],
     });
 
-    // The OSC-8 open/close sequences must stay intact; no dangling ESC bytes.
-    const osc8Token = new RegExp(String.raw`\]8;;.*?|\]8;;.*?\\`, "gs");
-    let escapeIndex = out.indexOf("");
-    while (escapeIndex >= 0) {
-      osc8Token.lastIndex = escapeIndex;
-      const match = osc8Token.exec(out);
-      expect(match?.index).toBe(escapeIndex);
-      escapeIndex = out.indexOf("", escapeIndex + 1);
+    const styledLines = out.split("\n").filter((line) => line.includes("a"));
+    expect(styledLines.length).toBeGreaterThan(1);
+    for (const line of styledLines) {
+      expect(line).toContain(bold);
+      expect(line).toContain(red);
     }
   });
 
-  it("does not split C1 CSI SGR sequences when wrapping", () => {
-    const red = "\x9b31m";
-    const reset = "\x9b0m";
+  it.each([
+    ["semicolon", "\x1b[4;58;2;255;0;0m", "\x1b[58;2;255;0;0m"],
+    ["colon", "\x1b[4;58:2::255:0:0m", "\x1b[58:2::255:0:0m"],
+  ])("keeps underline color active with %s operands", (_label, combined, color) => {
+    const underline = "\x1b[4m";
+    const globalReset = "\x1b[0m";
     const out = renderTable({
       width: 24,
       columns: [
         { key: "K", header: "K", minWidth: 3 },
         { key: "V", header: "V", flex: true, minWidth: 10 },
       ],
-      rows: [{ K: "X", V: `${red}${"a".repeat(80)}${reset}` }],
+      rows: [{ K: "X", V: `${combined}${"u".repeat(80)}${globalReset}` }],
+    });
+
+    const styledLines = out.split("\n").filter((line) => line.includes("u"));
+    expect(styledLines.length).toBeGreaterThan(1);
+    for (const line of styledLines) {
+      const hasOpeningState =
+        line.includes(combined) || (line.includes(underline) && line.includes(color));
+      expect(hasOpeningState).toBe(true);
+      const hasClosingState =
+        line.includes(globalReset) || (line.includes("\x1b[24m") && line.includes("\x1b[59m"));
+      expect(hasClosingState).toBe(true);
+    }
+  });
+
+  it("keeps unrelated SGR categories after a selective reset", () => {
+    const boldRed = "\x1b[1;31m";
+    const bold = "\x1b[1m";
+    const resetForeground = "\x1b[39m";
+    const reset = "\x1b[0m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [
+        {
+          K: "X",
+          V: `${boldRed}red${resetForeground}\n${"z".repeat(80)}${reset}`,
+        },
+      ],
+    });
+
+    const continuationLines = out.split("\n").filter((line) => line.includes("z"));
+    expect(continuationLines.length).toBeGreaterThan(1);
+    for (const line of continuationLines) {
+      expect(line).toContain(bold);
+      expect(line).not.toContain(boldRed);
+      expect(line).not.toContain("\x1b[31m");
+    }
+  });
+
+  it("keeps colon-form SGR sequences intact when wrapping", () => {
+    const red = "\x1b[38:2::255:0:0m";
+    const globalReset = "\x1b[0m";
+    const foregroundReset = "\x1b[39m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${red}${"a".repeat(80)}${globalReset}` }],
     });
 
     const lines = out.split("\n").filter((line) => line.includes("a"));
     expect(lines.length).toBeGreaterThan(1);
     for (const line of lines) {
-      const resetIndex = line.lastIndexOf(reset);
+      expect(line).toContain(red);
+      expect(line.includes(globalReset) || line.includes(foregroundReset)).toBe(true);
+    }
+  });
+
+  it("does not split BEL-terminated OSC-8 links when wrapping", () => {
+    const open = "\x1b]8;;https://openclaw.ai\x07";
+    const close = "\x1b]8;;\x07";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${open}OpenClaw${close}` }],
+    });
+
+    expectIntroducersToStartCompleteSequences(out, "\x1b", [open, close]);
+  });
+
+  it("does not split C1 CSI SGR sequences when wrapping", () => {
+    const red = "\x9b31m";
+    const globalReset = "\x9b0m";
+    const foregroundReset = "\x9b39m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${red}${"a".repeat(80)}${globalReset}` }],
+    });
+
+    const lines = out.split("\n").filter((line) => line.includes("a"));
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      const resetIndex = Math.max(line.lastIndexOf(globalReset), line.lastIndexOf(foregroundReset));
       const lastSep = Math.max(line.lastIndexOf("│"), line.lastIndexOf("|"));
       expect(resetIndex).toBeGreaterThan(-1);
       expect(lastSep).toBeGreaterThan(resetIndex);
@@ -206,24 +310,50 @@ describe("renderTable", () => {
   });
 
   it("does not split C1 OSC-8 links when wrapping", () => {
-    const link = "\x9d8;;https://openclaw.ai\x9cOpenClaw\x9d8;;\x9c";
+    const open = "\x9d8;;https://openclaw.ai\x9c";
+    const close = "\x9d8;;\x9c";
+    const canonicalOpen = "\x1b]8;;https://openclaw.ai\x07";
+    const canonicalClose = "\x1b]8;;\x07";
     const out = renderTable({
       width: 24,
       columns: [
         { key: "K", header: "K", minWidth: 3 },
         { key: "V", header: "V", flex: true, minWidth: 10 },
       ],
-      rows: [{ K: "X", V: link }],
+      rows: [{ K: "X", V: `${open}OpenClaw${close}` }],
     });
 
-    // C1 OSC-8 open/close sequences must stay intact.
-    const osc8Token = new RegExp(String.raw`8;;.*?`, "gs");
-    let oscIndex = out.indexOf("");
-    while (oscIndex >= 0) {
-      osc8Token.lastIndex = oscIndex;
-      const match = osc8Token.exec(out);
-      expect(match?.index).toBe(oscIndex);
-      oscIndex = out.indexOf("", oscIndex + 1);
+    expectIntroducersToStartCompleteSequences(out, "\x9d", [open, close]);
+    expectIntroducersToStartCompleteSequences(out, "\x1b", [canonicalOpen, canonicalClose]);
+  });
+
+  it("preserves OSC-8 parameters when reopening wrapped links", () => {
+    const open = "\x1b]8;id=docs;https://openclaw.ai\x07";
+    const close = "\x1b]8;;\x07";
+    const out = renderTable({
+      width: 20,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${open}${"OpenClaw".repeat(5)}${close} after` }],
+    });
+
+    const linkLines = out.split("\n").filter((line) => line.includes("OpenClaw"));
+    expect(linkLines.length).toBeGreaterThan(1);
+    for (const line of linkLines) {
+      expect(line).toContain(open);
+      expect(line).toContain(close);
+    }
+    const afterLine = out.split("\n").find((line) => line.includes("after"));
+    expect(afterLine).toBeDefined();
+    const afterIndex = afterLine?.indexOf("after") ?? -1;
+    const closeIndex = afterLine?.indexOf(close) ?? -1;
+    expect(closeIndex).toBeGreaterThan(-1);
+    expect(closeIndex).toBeLessThan(afterIndex);
+    const openIndex = afterLine?.indexOf(open) ?? -1;
+    if (openIndex >= 0) {
+      expect(openIndex).toBeLessThan(closeIndex);
     }
   });
 
@@ -401,18 +531,76 @@ describe("renderTable", () => {
     }
   });
 
-  it("consumes unsupported escape sequences without hanging", () => {
+  it.each([
+    ["ESC CSI", "\x1b[2J"],
+    ["C1 CSI", "\x9b2J"],
+  ])("keeps unsupported %s sequences atomic at wrap boundaries", (_label, sequence) => {
     const out = renderTable({
-      width: 48,
-      columns: [
-        { key: "K", header: "K", minWidth: 6 },
-        { key: "V", header: "V", minWidth: 12, flex: true },
-      ],
-      rows: [{ K: "row", V: "before \x1b[2J after" }],
+      width: 5,
+      border: "ascii",
+      padding: 0,
+      columns: [{ key: "V", header: "V", minWidth: 3 }],
+      rows: [{ V: `abc${sequence}d` }],
     });
 
-    expect(out).toContain("before");
-    expect(out).toContain("after");
+    expect(out).toContain(sequence);
+    for (const line of out.trimEnd().split("\n")) {
+      expect(visibleWidth(line)).toBe(5);
+    }
+  });
+
+  it.each([
+    ["ESC CSI with BEL", "\x1b[31\x07m"],
+    ["C1 CSI with BEL", "\x9b31\x07m"],
+    ["ESC CSI with HT", "\x1b[31\tm"],
+    ["C1 CSI with HT", "\x9b31\tm"],
+  ])("keeps %s sequences with executable C0 controls atomic", (_label, sequence) => {
+    const out = renderTable({
+      width: 5,
+      border: "ascii",
+      padding: 0,
+      columns: [{ key: "V", header: "V", minWidth: 3 }],
+      rows: [{ V: `abc${sequence}d\x1b[0m` }],
+    });
+
+    expect(out).toContain(sequence);
+    for (const line of out.trimEnd().split("\n")) {
+      expect(visibleWidth(line)).toBe(5);
+    }
+  });
+
+  it("rechecks atomic control width after wrapping at an earlier break", () => {
+    const sequence = "\x1b[31\t\t\tm";
+    const out = renderTable({
+      width: 7,
+      border: "ascii",
+      padding: 0,
+      columns: [{ key: "V", header: "V", minWidth: 5 }],
+      rows: [{ V: `a bbb${sequence}d\x1b[0m` }],
+    });
+
+    expect(out).toContain(sequence);
+    for (const line of out.trimEnd().split("\n")) {
+      expect(visibleWidth(line)).toBe(7);
+    }
+  });
+
+  it("does not interpret CSI intermediates as SGR state", () => {
+    const sequence = "\x1b[31 m";
+    const out = renderTable({
+      width: 24,
+      columns: [
+        { key: "K", header: "K", minWidth: 3 },
+        { key: "V", header: "V", flex: true, minWidth: 10 },
+      ],
+      rows: [{ K: "X", V: `${sequence}${"a".repeat(80)}` }],
+    });
+
+    expect(out.split(sequence)).toHaveLength(2);
+    expect(out).not.toContain("\x1b[39m");
+    for (const line of out.trimEnd().split("\n")) {
+      expect(visibleWidth(line)).toBe(24);
+    }
   });
 
   it("falls back to ASCII borders on legacy Windows consoles", () => {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -78,64 +78,102 @@ function wrapLine(text: string, width: number): string[] {
   // Table cells are padded and bordered per physical line, so wrapped lines
   // must not leak styling into padding while the next continuation keeps it.
   const ESC = "\u001b";
+  const C1_CSI = "\u009b";
+  const C1_OSC = "\u009d";
+  const BEL = "\u0007";
+  const C1_ST = "\u009c";
   const SGR_RESET = `${ESC}[0m`;
+
+  // Find the end of an OSC-8 sequence starting at `start` (index after the
+  // "8;;" prefix). ST may be ESC \, BEL, or C1 ST.
+  const findOsc8End = (start: number): number => {
+    for (let k = start; k < text.length; k += 1) {
+      const ch = text[k];
+      if (ch === ESC && text[k + 1] === "\\") {
+        return k + 2;
+      }
+      if (ch === BEL || ch === C1_ST) {
+        return k + 1;
+      }
+    }
+    return -1;
+  };
 
   type Token = { kind: "ansi" | "char"; value: string };
   const tokens: Token[] = [];
-  for (let i = 0; i < text.length;) {
-    if (text[i] === ESC) {
-      // SGR: ESC [ ... m
-      if (text[i + 1] === "[") {
-        let j = i + 2;
-        while (j < text.length) {
-          const ch = text[j];
-          if (ch === "m") {
-            break;
-          }
-          if (ch && ch >= "0" && ch <= "9") {
-            j += 1;
-            continue;
-          }
-          if (ch === ";") {
-            j += 1;
-            continue;
-          }
+  for (let i = 0; i < text.length; ) {
+    const ch0 = text[i];
+    const isEsc = ch0 === ESC;
+    const isC1Csi = ch0 === C1_CSI;
+
+    // SGR: ESC [ ... m  or  C1 CSI ... m
+    if ((isEsc || isC1Csi) && (!isEsc || text[i + 1] === "[")) {
+      const paramStart = isEsc ? i + 2 : i + 1;
+      let j = paramStart;
+      while (j < text.length) {
+        const ch = text[j];
+        if (ch === "m") {
           break;
         }
-        if (text[j] === "m") {
-          tokens.push({ kind: "ansi", value: text.slice(i, j + 1) });
-          i = j + 1;
+        if (ch && ch >= "0" && ch <= "9") {
+          j += 1;
           continue;
         }
+        if (ch === ";") {
+          j += 1;
+          continue;
+        }
+        break;
       }
-
-      // OSC-8 link open/close: ESC ] 8 ; ; ... ST (ST = ESC \)
-      if (text[i + 1] === "]" && text.slice(i + 2, i + 5) === "8;;") {
-        const st = text.indexOf(`${ESC}\\`, i + 5);
-        if (st >= 0) {
-          tokens.push({ kind: "ansi", value: text.slice(i, st + 2) });
-          i = st + 2;
-          continue;
-        }
+      if (text[j] === "m") {
+        tokens.push({ kind: "ansi", value: text.slice(i, j + 1) });
+        i = j + 1;
+        continue;
       }
     }
 
-    let nextEsc = text.indexOf(ESC, i);
-    if (nextEsc < 0) {
-      nextEsc = text.length;
+    // OSC-8 link open/close: ESC ] 8 ; ; ... ST  or  C1 OSC 8 ; ; ... ST
+    // ST can be ESC \, BEL, or C1 ST.
+    if (
+      (isEsc && text[i + 1] === "]" && text.slice(i + 2, i + 5) === "8;;") ||
+      (ch0 === C1_OSC && text.slice(i + 1, i + 4) === "8;;")
+    ) {
+      const payloadStart = isEsc ? i + 5 : i + 4;
+      const end = findOsc8End(payloadStart);
+      if (end >= 0) {
+        tokens.push({ kind: "ansi", value: text.slice(i, end) });
+        i = end;
+        continue;
+      }
     }
-    if (nextEsc === i) {
+
+    // Find the next potential ANSI introducer (ESC, C1 CSI, or C1 OSC).
+    const nextEsc = text.indexOf(ESC, i);
+    const nextC1Csi = text.indexOf(C1_CSI, i);
+    const nextC1Osc = text.indexOf(C1_OSC, i);
+    let nextSpecial = text.length;
+    if (nextEsc >= 0) {
+      nextSpecial = Math.min(nextSpecial, nextEsc);
+    }
+    if (nextC1Csi >= 0) {
+      nextSpecial = Math.min(nextSpecial, nextC1Csi);
+    }
+    if (nextC1Osc >= 0) {
+      nextSpecial = Math.min(nextSpecial, nextC1Osc);
+    }
+
+    if (nextSpecial === i) {
       // Consume unsupported escape bytes as plain characters so wrapping
       // cannot stall on unknown ANSI/control sequences.
-      tokens.push({ kind: "char", value: ESC });
-      i += ESC.length;
+      tokens.push({ kind: "char", value: text[i] ?? "" });
+      i += 1;
       continue;
     }
-    const plainChunk = text.slice(i, nextEsc);
+    const plainChunk = text.slice(i, nextSpecial);
     for (const grapheme of splitGraphemes(plainChunk)) {
       tokens.push({ kind: "char", value: grapheme });
     }
-    i = nextEsc;
+    i = nextSpecial;
   }
 
   const firstCharIndex = tokens.findIndex((t) => t.kind === "char");
@@ -177,10 +215,13 @@ function wrapLine(text: string, width: number): string[] {
     slice.reduce((acc, t) => acc + (t.kind === "char" ? visibleWidth(t.value) : 0), 0);
 
   const parseSgrParams = (value: string): number[] | null => {
-    if (!value.startsWith(`${ESC}[`) || !value.endsWith("m")) {
+    const isEscSgr = value.startsWith(`${ESC}[`) && value.endsWith("m");
+    const isC1Sgr = value.startsWith(C1_CSI) && value.endsWith("m");
+    if (!isEscSgr && !isC1Sgr) {
       return null;
     }
-    const raw = value.slice(2, -1);
+    const prefixLen = isEscSgr ? 2 : 1;
+    const raw = value.slice(prefixLen, -1);
     if (!raw) {
       return [0];
     }

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -229,6 +229,32 @@ function wrapLine(text: string, width: number): string[] {
     return params.every((param) => Number.isInteger(param)) ? params : null;
   };
 
+  // Returns the OSC-8 hyperlink params, or empty string for a close sequence,
+  // or undefined if the token is not an OSC-8 sequence. params excludes the
+  // surrounding introducer, "8;;" prefix, and string terminator.
+  const parseOsc8Params = (value: string): string | undefined => {
+    const escPrefix = `${ESC}]8;;`;
+    const c1Prefix = `${C1_OSC}8;;`;
+    let prefix: string;
+    let stLength: number;
+    if (value.startsWith(escPrefix)) {
+      prefix = escPrefix;
+      stLength = value.endsWith(`${ESC}\\`) ? 2 : 1;
+    } else if (value.startsWith(c1Prefix)) {
+      prefix = c1Prefix;
+      if (value.endsWith(C1_ST)) {
+        stLength = 1;
+      } else if (value.endsWith(`${ESC}\\`)) {
+        stLength = 2;
+      } else {
+        stLength = 1;
+      }
+    } else {
+      return undefined;
+    }
+    return value.slice(prefix.length, value.length - stLength);
+  };
+
   const activeSgrAfter = (tokensValue: Token[]) => {
     type SgrCategory =
       | "background"
@@ -348,6 +374,28 @@ function wrapLine(text: string, width: number): string[] {
     return active.map((entry) => entry.value).join("");
   };
 
+  // Track the active OSC-8 hyperlink params after a sequence of tokens.
+  // Returns undefined when no link is open, or the params string when a link
+  // opener has been seen without a matching close.
+  const activeOsc8After = (tokensValue: Token[]): string | undefined => {
+    let activeParams: string | undefined;
+    for (const token of tokensValue) {
+      if (token.kind !== "ansi") {
+        continue;
+      }
+      const params = parseOsc8Params(token.value);
+      if (params === undefined) {
+        continue;
+      }
+      if (params === "") {
+        activeParams = undefined;
+      } else {
+        activeParams = params;
+      }
+    }
+    return activeParams;
+  };
+
   const pushLine = (value: string) => {
     const cleaned = value.replace(/\s+$/, "");
     if (visibleWidth(cleaned) === 0) {
@@ -374,10 +422,19 @@ function wrapLine(text: string, width: number): string[] {
     if (buf.length === 0) {
       return;
     }
+    const left = breakAt == null || breakAt <= 0 ? buf : buf.slice(0, breakAt);
+    const activeSgr = activeSgrAfter(left);
+    const activeOsc8Params = activeOsc8After(left);
+    const closeOsc8 = activeOsc8Params !== undefined ? `${ESC}]8;;${BEL}` : "";
+    const openOsc8 = activeOsc8Params !== undefined ? `${ESC}]8;;${activeOsc8Params}${BEL}` : "";
+    const sgrReset = activeSgr ? SGR_RESET : "";
+
     if (breakAt == null || breakAt <= 0) {
-      const activeSgr = activeSgrAfter(buf);
-      pushLine(activeSgr ? `${bufToString()}${SGR_RESET}` : bufToString());
+      pushLine(`${bufToString()}${closeOsc8}${sgrReset}`);
       buf.length = 0;
+      if (openOsc8) {
+        buf.push({ kind: "ansi", value: openOsc8 });
+      }
       if (activeSgr) {
         buf.push({ kind: "ansi", value: activeSgr });
       }
@@ -386,11 +443,12 @@ function wrapLine(text: string, width: number): string[] {
       return;
     }
 
-    const left = buf.slice(0, breakAt);
     const rest = buf.slice(breakAt);
-    const activeSgr = activeSgrAfter(left);
-    pushLine(activeSgr ? `${bufToString(left)}${SGR_RESET}` : bufToString(left));
+    pushLine(`${bufToString(left)}${closeOsc8}${sgrReset}`);
     trimLeadingSpaces(rest);
+    if (openOsc8) {
+      rest.unshift({ kind: "ansi", value: openOsc8 });
+    }
     if (activeSgr) {
       rest.unshift({ kind: "ansi", value: activeSgr });
     }

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -101,7 +101,7 @@ function wrapLine(text: string, width: number): string[] {
 
   type Token = { kind: "ansi" | "char"; value: string };
   const tokens: Token[] = [];
-  for (let i = 0; i < text.length; ) {
+  for (let i = 0; i < text.length;) {
     const ch0 = text[i];
     const isEsc = ch0 === ESC;
     const isC1Csi = ch0 === C1_CSI;

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -187,17 +187,36 @@ function wrapLine(text: string, width: number): string[] {
       break;
     }
   }
-  const prefixAnsi = tokens
-    .slice(0, firstCharIndex)
-    .filter((t) => t.kind === "ansi")
+  // OSC-8 token predicate: matches ESC ] 8 ;; or C1 OSC 8 ;; introducers
+  // (both openers with a target and closers with empty params).
+  const isOsc8Token = (value: string): boolean =>
+    value.startsWith(`${ESC}]8;;`) || value.startsWith(`${C1_OSC}8;;`);
+
+  const leadingAnsiTokens = tokens.slice(0, firstCharIndex).filter((t) => t.kind === "ansi");
+  const trailingAnsiTokens = tokens.slice(lastCharIndex + 1).filter((t) => t.kind === "ansi");
+  // SGR styling that brackets the cell is reapplied to every wrapped line.
+  // OSC-8 openers are deliberately excluded: a leading hyperlink opener must be
+  // carried as initial state into the wrap state machine so it closes at its
+  // matching closer, instead of being prepended to every continuation line and
+  // reopening the link onto trailing plain text and padding (e.g. `${link} after`
+  // wrapping would otherwise leave "after" + padding inside an unclosed link).
+  const prefixAnsi = leadingAnsiTokens
+    .filter((t) => !isOsc8Token(t.value))
     .map((t) => t.value)
     .join("");
-  const suffixAnsi = tokens
-    .slice(lastCharIndex + 1)
-    .filter((t) => t.kind === "ansi")
+  const suffixAnsi = trailingAnsiTokens
+    .filter((t) => !isOsc8Token(t.value))
     .map((t) => t.value)
     .join("");
-  const coreTokens = tokens.slice(firstCharIndex, lastCharIndex + 1);
+  const leadingOsc8Tokens = leadingAnsiTokens.filter((t) => isOsc8Token(t.value));
+  const trailingOsc8Tokens = trailingAnsiTokens.filter((t) => isOsc8Token(t.value));
+  // Seed leading OSC-8 openers and append trailing closers so flushAt's
+  // close/reopen logic owns hyperlink state end to end across wrap boundaries.
+  const coreTokens = [
+    ...leadingOsc8Tokens,
+    ...tokens.slice(firstCharIndex, lastCharIndex + 1),
+    ...trailingOsc8Tokens,
+  ];
 
   const lines: string[] = [];
   const isBreakChar = (ch: string) =>

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -1,4 +1,6 @@
 // Terminal Core module implements table behavior.
+
+import { splitAnsiSegments } from "./ansi-sequences.js";
 import { splitGraphemes, truncateToVisibleWidth, visibleWidth } from "./ansi.js";
 import { displayString } from "./display-string.js";
 
@@ -69,6 +71,296 @@ function padCell(text: string, width: number, align: Align): string {
   return `${content}${repeat(" ", pad)}`;
 }
 
+const ESC = "\u001b";
+const C1_CSI = "\u009b";
+const C1_OSC = "\u009d";
+const C1_ST = "\u009c";
+const BEL = "\u0007";
+
+type AnsiToken = { kind: "ansi"; value: string; width: number } | { kind: "char"; value: string };
+type SgrCategory =
+  | "background"
+  | "blink"
+  | "conceal"
+  | "font"
+  | "foreground"
+  | "frame"
+  | "ideogram"
+  | "intensity"
+  | "inverse"
+  | "italic"
+  | "overline"
+  | "proportional"
+  | "script"
+  | "strike"
+  | "underline"
+  | "underlineColor";
+
+const SGR_CATEGORY_ORDER: readonly SgrCategory[] = [
+  "font",
+  "intensity",
+  "italic",
+  "underline",
+  "underlineColor",
+  "blink",
+  "inverse",
+  "conceal",
+  "strike",
+  "proportional",
+  "frame",
+  "overline",
+  "ideogram",
+  "script",
+  "foreground",
+  "background",
+];
+
+const SGR_RESET_CATEGORIES = new Map<number, SgrCategory>([
+  [10, "font"],
+  [22, "intensity"],
+  [23, "italic"],
+  [24, "underline"],
+  [25, "blink"],
+  [27, "inverse"],
+  [28, "conceal"],
+  [29, "strike"],
+  [39, "foreground"],
+  [49, "background"],
+  [50, "proportional"],
+  [54, "frame"],
+  [55, "overline"],
+  [59, "underlineColor"],
+  [65, "ideogram"],
+  [75, "script"],
+]);
+
+const SGR_CATEGORY_RESETS = new Map<SgrCategory, number>([
+  ["font", 10],
+  ["intensity", 22],
+  ["italic", 23],
+  ["underline", 24],
+  ["blink", 25],
+  ["inverse", 27],
+  ["conceal", 28],
+  ["strike", 29],
+  ["foreground", 39],
+  ["background", 49],
+  ["proportional", 50],
+  ["frame", 54],
+  ["overline", 55],
+  ["underlineColor", 59],
+  ["ideogram", 65],
+  ["script", 75],
+]);
+
+function simpleSgrCategory(param: number): SgrCategory | undefined {
+  if (param === 1 || param === 2) {
+    return "intensity";
+  }
+  if (param >= 11 && param <= 19) {
+    return "font";
+  }
+  if (param === 3 || param === 20) {
+    return "italic";
+  }
+  if (param === 4 || param === 21) {
+    return "underline";
+  }
+  if (param === 5 || param === 6) {
+    return "blink";
+  }
+  if (param === 7) {
+    return "inverse";
+  }
+  if (param === 8) {
+    return "conceal";
+  }
+  if (param === 9) {
+    return "strike";
+  }
+  if (param === 26) {
+    return "proportional";
+  }
+  if ((param >= 30 && param <= 37) || (param >= 90 && param <= 97)) {
+    return "foreground";
+  }
+  if ((param >= 40 && param <= 47) || (param >= 100 && param <= 107)) {
+    return "background";
+  }
+  if (param === 51 || param === 52) {
+    return "frame";
+  }
+  if (param === 53) {
+    return "overline";
+  }
+  if (param >= 60 && param <= 64) {
+    return "ideogram";
+  }
+  if (param === 73 || param === 74) {
+    return "script";
+  }
+  return undefined;
+}
+
+function extendedSgrCategory(param: number): SgrCategory | undefined {
+  if (param === 38) {
+    return "foreground";
+  }
+  if (param === 48) {
+    return "background";
+  }
+  return param === 58 ? "underlineColor" : undefined;
+}
+
+function parseSgrSequence(value: string): { introducer: string; parameters: string } | undefined {
+  let introducer: string;
+  if (value.startsWith(`${ESC}[`) && value.endsWith("m")) {
+    introducer = `${ESC}[`;
+  } else if (value.startsWith(C1_CSI) && value.endsWith("m")) {
+    introducer = C1_CSI;
+  } else {
+    return undefined;
+  }
+  const parameters = Array.from(value.slice(introducer.length, -1))
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join("");
+  const hasOnlySgrParameters = Array.from(parameters).every(
+    (character) => (character >= "0" && character <= "9") || character === ";" || character === ":",
+  );
+  if (!hasOnlySgrParameters) {
+    return undefined;
+  }
+  return { introducer, parameters };
+}
+
+function sgrSequence(introducer: string, parameters: string): string {
+  return `${introducer}${parameters}m`;
+}
+
+function applySgrSequence(active: Map<SgrCategory, string>, value: string): void {
+  const sequence = parseSgrSequence(value);
+  if (!sequence) {
+    return;
+  }
+
+  const fields = sequence.parameters === "" ? ["0"] : sequence.parameters.split(";");
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index] ?? "";
+    if (field.includes(":")) {
+      const param = Number(field.slice(0, field.indexOf(":")));
+      const category = extendedSgrCategory(param) ?? simpleSgrCategory(param);
+      if (category) {
+        active.set(category, sgrSequence(sequence.introducer, field));
+      }
+      continue;
+    }
+
+    const param = field === "" ? 0 : Number(field);
+    if (!Number.isInteger(param)) {
+      continue;
+    }
+    if (param === 0) {
+      active.clear();
+      continue;
+    }
+    const resetCategory = SGR_RESET_CATEGORIES.get(param);
+    if (resetCategory) {
+      active.delete(resetCategory);
+      continue;
+    }
+
+    const extendedCategory = extendedSgrCategory(param);
+    if (extendedCategory) {
+      const mode = Number(fields[index + 1]);
+      const operandCount = mode === 2 ? 3 : mode === 5 ? 1 : undefined;
+      const lastOperandIndex = operandCount === undefined ? -1 : index + 1 + operandCount;
+      if (lastOperandIndex < index || lastOperandIndex >= fields.length) {
+        break;
+      }
+      const parameters = fields.slice(index, lastOperandIndex + 1).join(";");
+      active.set(extendedCategory, sgrSequence(sequence.introducer, parameters));
+      index = lastOperandIndex;
+      continue;
+    }
+
+    const category = simpleSgrCategory(param);
+    if (category) {
+      active.set(category, sgrSequence(sequence.introducer, String(param)));
+    }
+  }
+}
+
+type ActiveSgr = { close: string; open: string };
+
+function activeSgrAfter(tokens: readonly AnsiToken[]): ActiveSgr[] {
+  const active = new Map<SgrCategory, string>();
+  for (const token of tokens) {
+    if (token.kind === "ansi") {
+      applySgrSequence(active, token.value);
+    }
+  }
+  return SGR_CATEGORY_ORDER.flatMap((category) => {
+    const open = active.get(category);
+    const parsed = open ? parseSgrSequence(open) : undefined;
+    const reset = SGR_CATEGORY_RESETS.get(category);
+    return open && parsed && reset !== undefined
+      ? [{ close: sgrSequence(parsed.introducer, String(reset)), open }]
+      : [];
+  });
+}
+
+type Osc8Link = { params: string; uri: string };
+
+function parseOsc8Sequence(value: string): Osc8Link | undefined {
+  let payloadStart: number;
+  if (value.startsWith(`${ESC}]`)) {
+    payloadStart = 2;
+  } else if (value.startsWith(C1_OSC)) {
+    payloadStart = 1;
+  } else {
+    return undefined;
+  }
+
+  let terminatorLength: number;
+  if (value.endsWith(`${ESC}\\`)) {
+    terminatorLength = 2;
+  } else if (value.endsWith(BEL) || value.endsWith(C1_ST)) {
+    terminatorLength = 1;
+  } else {
+    return undefined;
+  }
+
+  const payload = value.slice(payloadStart, -terminatorLength);
+  if (!payload.startsWith("8;")) {
+    return undefined;
+  }
+  const uriSeparator = payload.indexOf(";", 2);
+  if (uriSeparator < 0) {
+    return undefined;
+  }
+  return {
+    params: payload.slice(2, uriSeparator),
+    uri: payload.slice(uriSeparator + 1),
+  };
+}
+
+function activeOsc8After(tokens: readonly AnsiToken[]): Osc8Link | undefined {
+  let active: Osc8Link | undefined;
+  for (const token of tokens) {
+    if (token.kind !== "ansi") {
+      continue;
+    }
+    const link = parseOsc8Sequence(token.value);
+    if (link) {
+      active = link.uri === "" ? undefined : link;
+    }
+  }
+  return active;
+}
+
 function wrapLine(text: string, width: number): string[] {
   if (width <= 0) {
     return [text];
@@ -77,146 +369,24 @@ function wrapLine(text: string, width: number): string[] {
   // ANSI-aware wrapping: never split inside ANSI SGR/OSC-8 sequences.
   // Table cells are padded and bordered per physical line, so wrapped lines
   // must not leak styling into padding while the next continuation keeps it.
-  const ESC = "\u001b";
-  const C1_CSI = "\u009b";
-  const C1_OSC = "\u009d";
-  const BEL = "\u0007";
-  const C1_ST = "\u009c";
-  const SGR_RESET = `${ESC}[0m`;
-
-  // Find the end of an OSC-8 sequence starting at `start` (index after the
-  // "8;;" prefix). ST may be ESC \, BEL, or C1 ST.
-  const findOsc8End = (start: number): number => {
-    for (let k = start; k < text.length; k += 1) {
-      const ch = text[k];
-      if (ch === ESC && text[k + 1] === "\\") {
-        return k + 2;
-      }
-      if (ch === BEL || ch === C1_ST) {
-        return k + 1;
-      }
-    }
-    return -1;
-  };
-
-  type Token = { kind: "ansi" | "char"; value: string };
-  const tokens: Token[] = [];
-  for (let i = 0; i < text.length;) {
-    const ch0 = text[i];
-    const isEsc = ch0 === ESC;
-    const isC1Csi = ch0 === C1_CSI;
-
-    // SGR: ESC [ ... m  or  C1 CSI ... m
-    if ((isEsc || isC1Csi) && (!isEsc || text[i + 1] === "[")) {
-      const paramStart = isEsc ? i + 2 : i + 1;
-      let j = paramStart;
-      while (j < text.length) {
-        const ch = text[j];
-        if (ch === "m") {
-          break;
-        }
-        if (ch && ch >= "0" && ch <= "9") {
-          j += 1;
-          continue;
-        }
-        if (ch === ";") {
-          j += 1;
-          continue;
-        }
-        break;
-      }
-      if (text[j] === "m") {
-        tokens.push({ kind: "ansi", value: text.slice(i, j + 1) });
-        i = j + 1;
-        continue;
-      }
-    }
-
-    // OSC-8 link open/close: ESC ] 8 ; ; ... ST  or  C1 OSC 8 ; ; ... ST
-    // ST can be ESC \, BEL, or C1 ST.
-    if (
-      (isEsc && text[i + 1] === "]" && text.slice(i + 2, i + 5) === "8;;") ||
-      (ch0 === C1_OSC && text.slice(i + 1, i + 4) === "8;;")
-    ) {
-      const payloadStart = isEsc ? i + 5 : i + 4;
-      const end = findOsc8End(payloadStart);
-      if (end >= 0) {
-        tokens.push({ kind: "ansi", value: text.slice(i, end) });
-        i = end;
-        continue;
-      }
-    }
-
-    // Find the next potential ANSI introducer (ESC, C1 CSI, or C1 OSC).
-    const nextEsc = text.indexOf(ESC, i);
-    const nextC1Csi = text.indexOf(C1_CSI, i);
-    const nextC1Osc = text.indexOf(C1_OSC, i);
-    let nextSpecial = text.length;
-    if (nextEsc >= 0) {
-      nextSpecial = Math.min(nextSpecial, nextEsc);
-    }
-    if (nextC1Csi >= 0) {
-      nextSpecial = Math.min(nextSpecial, nextC1Csi);
-    }
-    if (nextC1Osc >= 0) {
-      nextSpecial = Math.min(nextSpecial, nextC1Osc);
-    }
-
-    if (nextSpecial === i) {
-      // Consume unsupported escape bytes as plain characters so wrapping
-      // cannot stall on unknown ANSI/control sequences.
-      tokens.push({ kind: "char", value: text[i] ?? "" });
-      i += 1;
+  const tokens: AnsiToken[] = [];
+  for (const segment of splitAnsiSegments(text)) {
+    if (segment.kind === "ansi") {
+      tokens.push({
+        kind: "ansi",
+        value: segment.value,
+        width: visibleWidth(segment.controls.join("")),
+      });
       continue;
     }
-    const plainChunk = text.slice(i, nextSpecial);
-    for (const grapheme of splitGraphemes(plainChunk)) {
+    for (const grapheme of splitGraphemes(segment.value)) {
       tokens.push({ kind: "char", value: grapheme });
     }
-    i = nextSpecial;
   }
 
-  const firstCharIndex = tokens.findIndex((t) => t.kind === "char");
-  if (firstCharIndex < 0) {
+  if (!tokens.some((token) => token.kind === "char")) {
     return [text];
   }
-  let lastCharIndex = -1;
-  for (let i = tokens.length - 1; i >= 0; i -= 1) {
-    if (tokens[i]?.kind === "char") {
-      lastCharIndex = i;
-      break;
-    }
-  }
-  // OSC-8 token predicate: matches ESC ] 8 ;; or C1 OSC 8 ;; introducers
-  // (both openers with a target and closers with empty params).
-  const isOsc8Token = (value: string): boolean =>
-    value.startsWith(`${ESC}]8;;`) || value.startsWith(`${C1_OSC}8;;`);
-
-  const leadingAnsiTokens = tokens.slice(0, firstCharIndex).filter((t) => t.kind === "ansi");
-  const trailingAnsiTokens = tokens.slice(lastCharIndex + 1).filter((t) => t.kind === "ansi");
-  // SGR styling that brackets the cell is reapplied to every wrapped line.
-  // OSC-8 openers are deliberately excluded: a leading hyperlink opener must be
-  // carried as initial state into the wrap state machine so it closes at its
-  // matching closer, instead of being prepended to every continuation line and
-  // reopening the link onto trailing plain text and padding (e.g. `${link} after`
-  // wrapping would otherwise leave "after" + padding inside an unclosed link).
-  const prefixAnsi = leadingAnsiTokens
-    .filter((t) => !isOsc8Token(t.value))
-    .map((t) => t.value)
-    .join("");
-  const suffixAnsi = trailingAnsiTokens
-    .filter((t) => !isOsc8Token(t.value))
-    .map((t) => t.value)
-    .join("");
-  const leadingOsc8Tokens = leadingAnsiTokens.filter((t) => isOsc8Token(t.value));
-  const trailingOsc8Tokens = trailingAnsiTokens.filter((t) => isOsc8Token(t.value));
-  // Seed leading OSC-8 openers and append trailing closers so flushAt's
-  // close/reopen logic owns hyperlink state end to end across wrap boundaries.
-  const coreTokens = [
-    ...leadingOsc8Tokens,
-    ...tokens.slice(firstCharIndex, lastCharIndex + 1),
-    ...trailingOsc8Tokens,
-  ];
 
   const lines: string[] = [];
   const isBreakChar = (ch: string) =>
@@ -224,196 +394,17 @@ function wrapLine(text: string, width: number): string[] {
   const isSpaceChar = (ch: string) => ch === " " || ch === "\t";
   let skipNextLf = false;
 
-  const buf: Token[] = [];
+  const buf: AnsiToken[] = [];
   let bufVisible = 0;
   let lastBreakIndex: number | null = null;
 
-  const bufToString = (slice?: Token[]) => (slice ?? buf).map((t) => t.value).join("");
+  const bufToString = (slice?: AnsiToken[]) => (slice ?? buf).map((t) => t.value).join("");
 
-  const bufVisibleWidth = (slice: Token[]) =>
-    slice.reduce((acc, t) => acc + (t.kind === "char" ? visibleWidth(t.value) : 0), 0);
-
-  const parseSgrParams = (value: string): number[] | null => {
-    const isEscSgr = value.startsWith(`${ESC}[`) && value.endsWith("m");
-    const isC1Sgr = value.startsWith(C1_CSI) && value.endsWith("m");
-    if (!isEscSgr && !isC1Sgr) {
-      return null;
-    }
-    const prefixLen = isEscSgr ? 2 : 1;
-    const raw = value.slice(prefixLen, -1);
-    if (!raw) {
-      return [0];
-    }
-    const params = raw.split(";").map((part) => (part === "" ? 0 : Number(part)));
-    return params.every((param) => Number.isInteger(param)) ? params : null;
-  };
-
-  // Returns the OSC-8 hyperlink params, or empty string for a close sequence,
-  // or undefined if the token is not an OSC-8 sequence. params excludes the
-  // surrounding introducer, "8;;" prefix, and string terminator.
-  const parseOsc8Params = (value: string): string | undefined => {
-    const escPrefix = `${ESC}]8;;`;
-    const c1Prefix = `${C1_OSC}8;;`;
-    let prefix: string;
-    let stLength: number;
-    if (value.startsWith(escPrefix)) {
-      prefix = escPrefix;
-      stLength = value.endsWith(`${ESC}\\`) ? 2 : 1;
-    } else if (value.startsWith(c1Prefix)) {
-      prefix = c1Prefix;
-      if (value.endsWith(C1_ST)) {
-        stLength = 1;
-      } else if (value.endsWith(`${ESC}\\`)) {
-        stLength = 2;
-      } else {
-        stLength = 1;
-      }
-    } else {
-      return undefined;
-    }
-    return value.slice(prefix.length, value.length - stLength);
-  };
-
-  const activeSgrAfter = (tokensValue: Token[]) => {
-    type SgrCategory =
-      | "background"
-      | "blink"
-      | "conceal"
-      | "foreground"
-      | "intensity"
-      | "inverse"
-      | "italic"
-      | "strike"
-      | "underline";
-    const active: Array<{ value: string; categories: Set<SgrCategory> }> = [];
-    const resetCategoriesFor = (params: number[]) => {
-      const categories = new Set<SgrCategory>();
-      for (const param of params) {
-        if (param === 22) {
-          categories.add("intensity");
-        } else if (param === 23) {
-          categories.add("italic");
-        } else if (param === 24) {
-          categories.add("underline");
-        } else if (param === 25) {
-          categories.add("blink");
-        } else if (param === 27) {
-          categories.add("inverse");
-        } else if (param === 28) {
-          categories.add("conceal");
-        } else if (param === 29) {
-          categories.add("strike");
-        } else if (param === 39) {
-          categories.add("foreground");
-        } else if (param === 49) {
-          categories.add("background");
-        }
-      }
-      return categories;
-    };
-    const activeCategoriesFor = (params: number[]) => {
-      const categories = new Set<SgrCategory>();
-      for (let i = 0; i < params.length; i += 1) {
-        const param = params[i] ?? 0;
-        if (param === 1 || param === 2) {
-          categories.add("intensity");
-        } else if (param === 3) {
-          categories.add("italic");
-        } else if (param === 4) {
-          categories.add("underline");
-        } else if (param === 5 || param === 6) {
-          categories.add("blink");
-        } else if (param === 7) {
-          categories.add("inverse");
-        } else if (param === 8) {
-          categories.add("conceal");
-        } else if (param === 9) {
-          categories.add("strike");
-        } else if ((param >= 30 && param <= 37) || (param >= 90 && param <= 97)) {
-          categories.add("foreground");
-        } else if (param === 38) {
-          categories.add("foreground");
-          if (params[i + 1] === 2) {
-            i += 4;
-          } else if (params[i + 1] === 5) {
-            i += 2;
-          }
-        } else if ((param >= 40 && param <= 47) || (param >= 100 && param <= 107)) {
-          categories.add("background");
-        } else if (param === 48) {
-          categories.add("background");
-          if (params[i + 1] === 2) {
-            i += 4;
-          } else if (params[i + 1] === 5) {
-            i += 2;
-          }
-        }
-      }
-      return categories;
-    };
-    const intersects = (left: Set<SgrCategory>, right: Set<SgrCategory>) => {
-      for (const value of left) {
-        if (right.has(value)) {
-          return true;
-        }
-      }
-      return false;
-    };
-    for (const token of tokensValue) {
-      if (token.kind !== "ansi") {
-        continue;
-      }
-      const params = parseSgrParams(token.value);
-      if (!params) {
-        continue;
-      }
-      if (params.includes(0)) {
-        active.length = 0;
-      }
-      const resetCategories = resetCategoriesFor(params);
-      if (resetCategories.size > 0) {
-        for (let i = active.length - 1; i >= 0; i -= 1) {
-          const entry = active[i];
-          if (entry && intersects(entry.categories, resetCategories)) {
-            active.splice(i, 1);
-          }
-        }
-      }
-      const activeCategories = activeCategoriesFor(params);
-      if (activeCategories.size > 0) {
-        for (let i = active.length - 1; i >= 0; i -= 1) {
-          const entry = active[i];
-          if (entry && intersects(entry.categories, activeCategories)) {
-            active.splice(i, 1);
-          }
-        }
-        active.push({ value: token.value, categories: activeCategories });
-      }
-    }
-    return active.map((entry) => entry.value).join("");
-  };
-
-  // Track the active OSC-8 hyperlink params after a sequence of tokens.
-  // Returns undefined when no link is open, or the params string when a link
-  // opener has been seen without a matching close.
-  const activeOsc8After = (tokensValue: Token[]): string | undefined => {
-    let activeParams: string | undefined;
-    for (const token of tokensValue) {
-      if (token.kind !== "ansi") {
-        continue;
-      }
-      const params = parseOsc8Params(token.value);
-      if (params === undefined) {
-        continue;
-      }
-      if (params === "") {
-        activeParams = undefined;
-      } else {
-        activeParams = params;
-      }
-    }
-    return activeParams;
-  };
+  const bufVisibleWidth = (slice: AnsiToken[]) =>
+    slice.reduce(
+      (acc, token) => acc + (token.kind === "char" ? visibleWidth(token.value) : token.width),
+      0,
+    );
 
   const pushLine = (value: string) => {
     const cleaned = value.replace(/\s+$/, "");
@@ -423,7 +414,7 @@ function wrapLine(text: string, width: number): string[] {
     lines.push(cleaned);
   };
 
-  const trimLeadingSpaces = (tokensLocal: Token[]) => {
+  const trimLeadingSpaces = (tokensLocal: AnsiToken[]) => {
     while (true) {
       const firstCharIndexLocal = tokensLocal.findIndex((token) => token.kind === "char");
       if (firstCharIndexLocal < 0) {
@@ -443,19 +434,19 @@ function wrapLine(text: string, width: number): string[] {
     }
     const left = breakAt == null || breakAt <= 0 ? buf : buf.slice(0, breakAt);
     const activeSgr = activeSgrAfter(left);
-    const activeOsc8Params = activeOsc8After(left);
-    const closeOsc8 = activeOsc8Params !== undefined ? `${ESC}]8;;${BEL}` : "";
-    const openOsc8 = activeOsc8Params !== undefined ? `${ESC}]8;;${activeOsc8Params}${BEL}` : "";
-    const sgrReset = activeSgr ? SGR_RESET : "";
+    const activeOsc8 = activeOsc8After(left);
+    const closeOsc8 = activeOsc8 ? `${ESC}]8;;${BEL}` : "";
+    const openOsc8 = activeOsc8 ? `${ESC}]8;${activeOsc8.params};${activeOsc8.uri}${BEL}` : "";
+    const closeSgr = activeSgr.map((state) => state.close).join("");
 
     if (breakAt == null || breakAt <= 0) {
-      pushLine(`${bufToString()}${closeOsc8}${sgrReset}`);
+      pushLine(`${bufToString()}${closeOsc8}${closeSgr}`);
       buf.length = 0;
       if (openOsc8) {
-        buf.push({ kind: "ansi", value: openOsc8 });
+        buf.push({ kind: "ansi", value: openOsc8, width: 0 });
       }
-      if (activeSgr) {
-        buf.push({ kind: "ansi", value: activeSgr });
+      for (const state of activeSgr) {
+        buf.push({ kind: "ansi", value: state.open, width: 0 });
       }
       bufVisible = 0;
       lastBreakIndex = null;
@@ -463,13 +454,19 @@ function wrapLine(text: string, width: number): string[] {
     }
 
     const rest = buf.slice(breakAt);
-    pushLine(`${bufToString(left)}${closeOsc8}${sgrReset}`);
+    pushLine(`${bufToString(left)}${closeOsc8}${closeSgr}`);
     trimLeadingSpaces(rest);
     if (openOsc8) {
-      rest.unshift({ kind: "ansi", value: openOsc8 });
+      rest.unshift({ kind: "ansi", value: openOsc8, width: 0 });
     }
-    if (activeSgr) {
-      rest.unshift({ kind: "ansi", value: activeSgr });
+    if (activeSgr.length > 0) {
+      rest.unshift(
+        ...activeSgr.map((state) => ({
+          kind: "ansi" as const,
+          value: state.open,
+          width: 0,
+        })),
+      );
     }
 
     buf.length = 0;
@@ -478,9 +475,21 @@ function wrapLine(text: string, width: number): string[] {
     lastBreakIndex = null;
   };
 
-  for (const token of coreTokens) {
+  const makeRoomFor = (tokenWidth: number) => {
+    if (bufVisible + tokenWidth <= width || bufVisible === 0) {
+      return;
+    }
+    flushAt(lastBreakIndex);
+    if (bufVisible + tokenWidth > width && bufVisible > 0) {
+      flushAt(null);
+    }
+  };
+
+  for (const token of tokens) {
     if (token.kind === "ansi") {
+      makeRoomFor(token.width);
       buf.push(token);
+      bufVisible += token.width;
       continue;
     }
 
@@ -499,9 +508,7 @@ function wrapLine(text: string, width: number): string[] {
       continue;
     }
     const charWidth = visibleWidth(ch);
-    if (bufVisible + charWidth > width && bufVisible > 0) {
-      flushAt(lastBreakIndex);
-    }
+    makeRoomFor(charWidth);
     if (bufVisible === 0 && isSpaceChar(ch)) {
       continue;
     }
@@ -514,18 +521,7 @@ function wrapLine(text: string, width: number): string[] {
   }
 
   flushAt(buf.length);
-  if (!lines.length) {
-    return [""];
-  }
-  if (!prefixAnsi && !suffixAnsi) {
-    return lines;
-  }
-  return lines.map((line) => {
-    if (!line) {
-      return line;
-    }
-    return `${prefixAnsi}${line}${suffixAnsi}`;
-  });
+  return lines.length > 0 ? lines : [""];
 }
 
 function normalizeWidth(n: number | undefined): number | undefined {


### PR DESCRIPTION
## What Problem This Solves

`renderTable` uses `wrapLine` to wrap long cell values. `wrapLine` only recognized ANSI sequences that start with `ESC [` (SGR) or `ESC ]8;;` followed by `ESC \\` (OSC-8). This left two gaps:

1. **BEL-terminated OSC-8 links**: `formatTerminalLink` emits OSC-8 hyperlinks terminated by `BEL` (`\x07`). When such a link had to wrap, `wrapLine` treated the introducer and payload as plain characters and split them apart.
2. **C1 CSI / C1 OSC**: Sequences using the 8-bit introducers `\x9b` (C1 CSI) and `\x9d` (C1 OSC) were not recognized as ANSI tokens, so they were split at character boundaries and leaked raw C1/escape bytes into the rendered table.
3. **OSC-8 state at wrap boundaries**: Even after recognizing OSC-8 tokens, an active hyperlink was not closed before a physical line break and reopened on the continuation, so link styling could bleed across padding/separators or unrelated text.

## Why This Change Was Made

Extended `wrapLine` to recognize:
- C1 CSI SGR sequences (`\x9b...m`) in addition to `ESC [...m`.
- BEL-terminated OSC-8 links (`ESC ]8;;...BEL`) in addition to `ESC ]8;;...ESC \\`.
- C1 OSC-8 links (`\x9d8;;...ST`) where the string terminator may be `BEL`, `ESC \\`, or `\x9c`.

Added `parseOsc8Params` and `activeOsc8After` to track active hyperlink state. `flushAt` now closes any open OSC-8 link before the physical line boundary and reopens it on the continuation, matching the existing SGR continuation behavior.

## User Impact

Table cells containing terminal hyperlinks or C1-prefixed ANSI styling now wrap cleanly without corrupting escape sequences, leaking raw control bytes, or letting hyperlink state bleed across unrelated text.

## Real behavior proof

Negative control (origin/main version of `packages/terminal-core/src/table.ts`):

BEL-terminated OSC-8 link forced to wrap:
```text
+------+-------+
| Name | Link  |
+------+-------+
| Plai | \x1b]8;; |
| n    | https |
|      | ://   |
|      | openc |
|      | law.  |
|      | ai\x07Op |
|      | enCla |
|      | w\x1b]8; |
|      | ;\x07    |
+------+-------+
```

C1 CSI SGR forced to wrap:
```text
+-----+
| H   |
+-----+
| \x9b31 |
| mRe |
| d\x9b0 |
| m   |
+-----+
```

Fix applied:

BEL-terminated OSC-8 link:
```text
+------+-------+
| Name | Link  |
+------+-------+
| Plai | \x1b]8;;https://openclaw.ai\x07OpenC\x1b]8;;\x07 |
| n    | \x1b]8;;https://openclaw.ai\x07law\x1b]8;;\x07   |
+------+-------+
```

Embedded OSC-8 link with prefix/suffix (`before ${link} after`) forced to wrap:
```text
+--------------------+
| V                  |
+--------------------+
| before \x1b]8;;https://openclaw.ai\x07Open\x1b]8;;\x07 a |
| fter               |
+--------------------+
```

Note that "after" is no longer inside the hyperlink on the first line.

## Evidence

- `node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts` — 31 tests passed.
- `node scripts/run-vitest.mjs packages/terminal-core` — 12 files, 82 tests passed.
- `pnpm exec oxfmt --check --threads=1 packages/terminal-core/src/table.ts packages/terminal-core/src/table.test.ts` passed.
- `node scripts/run-oxlint.mjs packages/terminal-core/src/table.ts packages/terminal-core/src/table.test.ts` passed.
- Branch rebased onto latest `origin/main`.
