### PR TITLE
fix(install-cli): track mktemp paths and clean up on EXIT

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -29,6 +29,18 @@ ensure_home_env() {
 
 ensure_home_env
 
+# Track temp paths so fail/exit paths do not leak mktemp dirs/files.
+# Register paths in the caller: command substitutions run in a subshell, so
+# array mutations inside a helper would not reach this shell.
+TMPFILES=()
+cleanup_tmpfiles() {
+  local f
+  for f in "${TMPFILES[@]:-}"; do
+    rm -rf "$f" 2>/dev/null || true
+  done
+}
+trap cleanup_tmpfiles EXIT
+
 resolve_openclaw_effective_home() {
   local openclaw_home="${OPENCLAW_HOME:-}"
   if [[ -z "$openclaw_home" ]]; then
@@ -819,6 +831,7 @@ install_node() {
 
   mkdir -p "${PREFIX}/tools"
   tmp="$(mktemp -d)"
+  TMPFILES+=("$tmp")
   base_url="https://nodejs.org/dist/v${NODE_VERSION}"
   tarball="node-v${NODE_VERSION}-${os}-${arch}.tar.gz"
   url="${base_url}/${tarball}"
@@ -1055,6 +1068,7 @@ ensure_pnpm_git_prepare_allowlist() {
 
   if [[ -f "$workspace_file" ]] && ! grep -Fq "\"${dep}\"" "$workspace_file" && ! grep -Fq "${dep}:" "$workspace_file" && ! grep -Fq -- "- ${dep}" "$workspace_file"; then
     tmp="$(mktemp)"
+    TMPFILES+=("$tmp")
     if grep -q '^allowBuilds:[[:space:]]*$' "$workspace_file"; then
       awk -v dep="$dep" '
         BEGIN { inserted = 0 }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -757,6 +757,67 @@ describe("install-cli.sh", () => {
     }
   });
 
+  it("removes the Node staging directory when download fails", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-node-cleanup-"));
+    const prefix = join(tmp, "prefix");
+    const stagingDir = join(tmp, "node-staging");
+
+    try {
+      const result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(process.cwd())}`,
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          "os_detect() { printf 'linux\\n'; }",
+          "arch_detect() { printf 'x64\\n'; }",
+          "is_musl_linux() { return 1; }",
+          "linked_node_is_usable() { return 1; }",
+          "detect_downloader() { :; }",
+          "require_bin() { :; }",
+          `mktemp() { mkdir -p ${JSON.stringify(stagingDir)}; printf '%s\\n' ${JSON.stringify(stagingDir)}; }`,
+          "download_file() { return 42; }",
+          `PREFIX=${JSON.stringify(prefix)}`,
+          "NODE_VERSION=22.22.0",
+          "install_node",
+        ].join("\n"),
+      );
+
+      expect(result.status).toBe(42);
+      expect(() => lstatSync(stagingDir)).toThrow();
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+  });
+
+  it("removes the workspace rewrite temp file when rewriting fails", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-workspace-cleanup-"));
+    const repo = join(tmp, "repo");
+    const workspaceFile = join(repo, "pnpm-workspace.yaml");
+    const rewriteTemp = join(tmp, "workspace-rewrite");
+    const workspace = 'packages:\n  - "packages/*"\n\nallowBuilds:\n';
+    mkdirSync(repo, { recursive: true });
+    writeFileSync(workspaceFile, workspace);
+
+    try {
+      const result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(process.cwd())}`,
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          `mktemp() { : > ${JSON.stringify(rewriteTemp)}; printf '%s\\n' ${JSON.stringify(rewriteTemp)}; }`,
+          "awk() { return 43; }",
+          `ensure_pnpm_git_prepare_allowlist ${JSON.stringify(repo)}`,
+        ].join("\n"),
+      );
+
+      expect(result.status).toBe(43);
+      expect(() => lstatSync(rewriteTemp)).toThrow();
+      expect(readFileSync(workspaceFile, "utf8")).toBe(workspace);
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+  });
+
   it("clears npm freshness filters for package installs", () => {
     expect(script).toContain('freshness_flag="--min-release-age=0"');
     expect(script).toContain('npm_config_has_raw_key "$(npm_bin)" "min-release-age"');


### PR DESCRIPTION
## What Problem This Solves

`scripts/install-cli.sh` creates temporary paths for user-space Node staging and pnpm workspace rewrites. Failure after `mktemp` could exit without removing those paths, leaving installer debris under the system temporary directory.

## Why This Change Was Made

The installer now owns one EXIT cleanup list. Each direct caller registers its temporary path in the parent shell immediately after creation, avoiding command-substitution subshell state and giving every later failure path the same cleanup behavior.

## User Impact

Failed CLI installs no longer leak Node staging directories or pnpm workspace rewrite files. Successful installs retain their existing behavior.

## Evidence

- Regression: forced Node download failure after staging registration removes the temporary directory.
- Regression: forced pnpm workspace rewrite failure removes the temporary file.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29133125457 — success on attempt 2.
- Cross-platform Website Installer Sync: https://github.com/openclaw/openclaw/actions/runs/29133125444
- Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/29133124377
- Fresh Codex autoreview: no accepted or actionable findings.
- Native review artifacts: READY, zero findings; hosted `prepare-run` passed.

No live Node tarball checksum failure was induced; the regressions cover both temporary-path owners at their production failure boundaries.

CI attempt 1 hit an unrelated `apply-patch.test.ts` fs-safe unhandled-rejection flake; the isolated rerun passed without code changes.

AI-assisted.
