### PR TITLE
fix(browser): normalize local dispatch request paths

### DIFF
--- a/extensions/browser/src/browser/routes/dispatcher.path-normalization.test.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.path-normalization.test.ts
@@ -18,7 +18,7 @@ describe("browser route dispatcher path normalization", () => {
     ({ createBrowserRouteDispatcher } = await import("./dispatcher.js"));
   });
 
-  it.each(["snapshot", "/snapshot/", "  snapshot/  "])(
+  it.each(["snapshot", "/snapshot/", "/snapshot///", "  snapshot///  "])(
     "normalizes dispatch path %j like browser proxy requests",
     async (path) => {
       const dispatcher = createBrowserRouteDispatcher({} as BrowserRouteContext);

--- a/extensions/browser/src/browser/routes/dispatcher.path-normalization.test.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.path-normalization.test.ts
@@ -1,0 +1,34 @@
+// Browser tests cover dispatcher path normalization.
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { BrowserRouteContext } from "../server-context.js";
+
+let createBrowserRouteDispatcher: typeof import("./dispatcher.js").createBrowserRouteDispatcher;
+
+describe("browser route dispatcher path normalization", () => {
+  beforeAll(async () => {
+    vi.doMock("./index.js", () => {
+      return {
+        registerBrowserRoutes(app: { get: (path: string, handler: unknown) => void }) {
+          app.get("/snapshot", (_: unknown, res: { json: (body: unknown) => void }) => {
+            res.json({ route: "snapshot" });
+          });
+        },
+      };
+    });
+    ({ createBrowserRouteDispatcher } = await import("./dispatcher.js"));
+  });
+
+  it.each(["snapshot", "/snapshot/", "  snapshot/  "])(
+    "normalizes dispatch path %j like browser proxy requests",
+    async (path) => {
+      const dispatcher = createBrowserRouteDispatcher({} as BrowserRouteContext);
+
+      const result = await dispatcher.dispatch({
+        method: "GET",
+        path,
+      });
+
+      expect(result).toEqual({ status: 200, body: { route: "snapshot" } });
+    },
+  );
+});

--- a/extensions/browser/src/browser/routes/dispatcher.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.ts
@@ -5,6 +5,7 @@
  * the same route handlers without opening an HTTP socket.
  */
 import { escapeRegExp } from "../../utils.js";
+import { normalizeBrowserRequestPath } from "../request-policy.js";
 import type { BrowserRouteContext } from "../server-context.js";
 import { registerBrowserRoutes } from "./index.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
@@ -59,10 +60,7 @@ function createRegistry() {
 }
 
 function normalizePath(path: string) {
-  if (!path) {
-    return "/";
-  }
-  return path.startsWith("/") ? path : `/${path}`;
+  return normalizeBrowserRequestPath(path) || "/";
 }
 
 /** Create an in-process dispatcher for registered browser routes. */

--- a/extensions/browser/src/browser/routes/dispatcher.ts
+++ b/extensions/browser/src/browser/routes/dispatcher.ts
@@ -59,10 +59,6 @@ function createRegistry() {
   return { routes, router };
 }
 
-function normalizePath(path: string) {
-  return normalizeBrowserRequestPath(path) || "/";
-}
-
 /** Create an in-process dispatcher for registered browser routes. */
 export function createBrowserRouteDispatcher(ctx: BrowserRouteContext) {
   const registry = createRegistry();
@@ -71,7 +67,7 @@ export function createBrowserRouteDispatcher(ctx: BrowserRouteContext) {
   return {
     dispatch: async (req: BrowserDispatchRequest): Promise<BrowserDispatchResponse> => {
       const method = req.method;
-      const path = normalizePath(req.path);
+      const path = normalizeBrowserRequestPath(req.path) || "/";
       const query = req.query ?? {};
       const body = req.body;
       const signal = req.signal;


### PR DESCRIPTION
## What Problem This Solves

The in-process browser route dispatcher normalized request paths differently from the node/browser proxy path. Local dispatch accepted missing leading slashes but failed exact route matching when callers supplied repeated trailing slashes, including `/snapshot///`.

## Why This Change Was Made

All browser request entry points should route and guard the same canonical path. The dispatcher now reuses `normalizeBrowserRequestPath` directly, matching the established request-policy and node-host contract without maintaining a second local normalizer.

## User Impact

Local `browser.request` dispatch now treats `snapshot`, `/snapshot/`, `/snapshot///`, and whitespace-wrapped equivalents as `/snapshot`. Unknown routes, abort propagation, mutation guards, and node-host routing remain unchanged.

## Evidence

- Rebased onto `openclaw/main` at `6b460e50a4a`; exact PR head `a48e0f54a4f12434e46c6cb22e86ddf9b896ca8c`.
- Sanitized AWS Crabbox run `run_9b59da1ed3ed`: 7 focused files, 56 tests passed on Linux/Node 24. Coverage included dispatcher normalization and aborts, shared request policy, Gateway profile/shared-state/timeout paths, and node-host dispatch.
- Exact-head GitHub CI [run 29133330820](https://github.com/openclaw/openclaw/actions/runs/29133330820): successful; no failed or pending relevant checks.
- `git diff --check 6b460e50a4a...a48e0f54a4f`
- Fresh autoreview: no actionable findings.

## Real Gateway Proof

Sanitized AWS Crabbox run `run_ef31f430eb3e` used the exact PR head, an isolated real loopback Gateway, the bundled browser plugin, and Playwright Chromium. It started the managed `openclaw` profile through the actual `browser.request` Gateway method, opened `https://example.com`, then called canonical `/snapshot` and raw `/snapshot///` through that same method.

Redacted result:

```text
gateway=real browser=chromium
start_ok=true profile=openclaw
opened_url=https://example.com/
canonical_path=/snapshot canonical_ok=true canonical_nodes=15
triple_path=/snapshot/// triple_ok=true triple_nodes=15 format=aria
```

This exercises the production path from Gateway RPC through local browser dispatch and the real snapshot route. It does not use `openclaw browser snapshot`, which hardcodes `/snapshot` and therefore cannot prove raw repeated-trailing-slash routing.
