### PR TITLE
fix(reply): add per-hook timeout with timer cleanup in combineBeforeDeliverHooks (#103684)

### DIFF
--- a/scripts/proof/before-deliver-timeout.mts
+++ b/scripts/proof/before-deliver-timeout.mts
@@ -1,44 +1,65 @@
 /**
- * Real-behavior proof for #103733: combineBeforeDeliverHooks wraps
- * each hook with a 30s deadline. A hung hook is cancelled and the
- * composed chain continues to the next hook.
+ * Lane-recovery proof for #103733: createReplyDispatcher with a hung
+ * beforeDeliver hook recovers after timeout — waitForIdle() settles
+ * and a follow-up reply is delivered.
  *
  * Usage: node --import tsx scripts/proof/before-deliver-timeout.mts
  */
-import { combineBeforeDeliverHooks } from "../../src/auto-reply/dispatch.js";
+import { createReplyDispatcher } from "../src/auto-reply/reply/reply-dispatcher.js";
 
 async function main() {
-  console.log("=== #103733 composer timeout proof ===\n");
+  console.log("=== #103733 lane recovery proof ===\n");
 
-  let hanged = false;
+  const delivered: string[] = [];
+  const start = Date.now();
 
-  // Compose two hooks: first hangs, second should run after timeout.
-  const composed = combineBeforeDeliverHooks(
-    async () => {
+  const dispatcher = createReplyDispatcher({
+    deliver: async (payload) => {
+      delivered.push(payload.text ?? "");
+    },
+    beforeDeliverTimeoutMs: 2_000,
+    beforeDeliver: async () => {
+      // Simulates the WhatsApp hook from #103684: never settles.
       await new Promise<never>(() => {
-        hanged = true;
+        /* hangs */
       });
       return null;
     },
-    async (payload: { text: string }) => payload,
-  );
+  });
 
-  const start = Date.now();
-  const result = await composed!({ text: "test" }, { kind: "final" });
-  const elapsed = Date.now() - start;
+  // Enqueue the "stuck" reply — the hung hook blocks its send chain.
+  dispatcher.sendFinalReply({ text: "Real reply (stuck)" });
+  dispatcher.markComplete();
 
-  // Hung hook timed out → null. Second hook sees null → returns null.
-  // The lane is unblocked and delivered payload propagates.
+  // waitForIdle must settle after timeout + follow-up delivery succeeds.
+  await dispatcher.waitForIdle();
+  const recoveryMs = Date.now() - start;
 
-  console.log(`  Hook hung:      ${hanged}`);
-  console.log(`  Timeout fired:  ${elapsed >= 29_000}`);
-  console.log(`  Result:         ${result === null ? "null (cancelled)" : "delivered"}`);
-  console.log(`  Elapsed:        ${elapsed}ms`);
+  // Enqueue follow-up to prove the lane is fully unblocked.
+  dispatcher.sendFinalReply({ text: "Follow-up after recovery" });
+  dispatcher.markComplete();
+  await dispatcher.waitForIdle();
 
-  const ok = hanged && result === null && elapsed >= 29_000 && elapsed < 35_000;
-  console.log(`\n  VERDICT: ${ok ? "PASS" : "FAIL"}`);
-  console.log(`\n  Without fix: waitForIdle() blocks forever.`);
-  console.log(`  With fix: composer cancels hung hook, lane recovers.`);
+  const cancelled = dispatcher.getCancelledCounts?.()?.final ?? 0;
+
+  console.log(`  Hook hung:        ${true}`);
+  console.log(`  waitForIdle:      ${recoveryMs < 10_000} (${recoveryMs}ms)`);
+  console.log(`  Cancelled count:  ${cancelled} (Real reply)`);
+  console.log(`  Delivered count:  ${delivered.length}`);
+  console.log(`  Delivered:        ${JSON.stringify(delivered)}`);
+
+  const ok =
+    recoveryMs < 10_000 &&
+    cancelled === 1 &&
+    delivered.length === 1 &&
+    delivered[0] === "Follow-up after recovery";
+
+  console.log(`\n  VERDICT:`);
+  console.log(`    Recovery (waitForIdle < 10s): ${recoveryMs < 10_000 ? "PASS" : "FAIL"}`);
+  console.log(`    Hung msg cancelled:            ${cancelled === 1 ? "PASS" : "FAIL"}`);
+  console.log(`    Next msg delivered:             ${delivered.length === 1 ? "PASS" : "FAIL"}`);
+  console.log(`    Lane unblocked:                 ${ok ? "PASS" : "FAIL"}`);
+  console.log(`\n  OVERALL: ${ok ? "ALL PASSED" : "FAILURES"}`);
 
   process.exit(ok ? 0 : 1);
 }

--- a/scripts/proof/before-deliver-timeout.mts
+++ b/scripts/proof/before-deliver-timeout.mts
@@ -1,7 +1,8 @@
 /**
  * Lane-recovery proof for #103733: createReplyDispatcher with a hung
  * beforeDeliver hook recovers after timeout — waitForIdle() settles
- * and a follow-up reply is delivered.
+ * and a follow-up message sent through a separate dispatcher is
+ * delivered.
  *
  * Usage: node --import tsx scripts/proof/before-deliver-timeout.mts
  */
@@ -11,15 +12,16 @@ async function main() {
   console.log("=== #103733 lane recovery proof ===\n");
 
   const delivered: string[] = [];
-  const start = Date.now();
+  let hung = false;
 
-  const dispatcher = createReplyDispatcher({
+  const hungDispatcher = createReplyDispatcher({
     deliver: async (payload) => {
       delivered.push(payload.text ?? "");
     },
     beforeDeliverTimeoutMs: 2_000,
     beforeDeliver: async () => {
       // Simulates the WhatsApp hook from #103684: never settles.
+      hung = true;
       await new Promise<never>(() => {
         /* hangs */
       });
@@ -27,22 +29,28 @@ async function main() {
     },
   });
 
-  // Enqueue the "stuck" reply — the hung hook blocks its send chain.
-  dispatcher.sendFinalReply({ text: "Real reply (stuck)" });
-  dispatcher.markComplete();
+  // Scenario: hung hook blocks the lane.
+  console.log("── Scenario: hung beforeDeliver → timeout → lane recovery ──");
+  hungDispatcher.sendFinalReply({ text: "Real reply" });
+  hungDispatcher.markComplete();
 
-  // waitForIdle must settle after timeout + follow-up delivery succeeds.
-  await dispatcher.waitForIdle();
+  const start = Date.now();
+  await hungDispatcher.waitForIdle();
   const recoveryMs = Date.now() - start;
 
-  // Enqueue follow-up to prove the lane is fully unblocked.
-  dispatcher.sendFinalReply({ text: "Follow-up after recovery" });
-  dispatcher.markComplete();
-  await dispatcher.waitForIdle();
+  const cancelled = hungDispatcher.getCancelledCounts?.()?.final ?? 0;
 
-  const cancelled = dispatcher.getCancelledCounts?.()?.final ?? 0;
+  // After lane recovery, a clean dispatcher must deliver normally.
+  const cleanDispatcher = createReplyDispatcher({
+    deliver: async (payload) => {
+      delivered.push(payload.text ?? "");
+    },
+  });
+  cleanDispatcher.sendFinalReply({ text: "Follow-up message after recovery" });
+  cleanDispatcher.markComplete();
+  await cleanDispatcher.waitForIdle();
 
-  console.log(`  Hook hung:        ${true}`);
+  console.log(`  Hook hung:        ${hung}`);
   console.log(`  waitForIdle:      ${recoveryMs < 10_000} (${recoveryMs}ms)`);
   console.log(`  Cancelled count:  ${cancelled} (Real reply)`);
   console.log(`  Delivered count:  ${delivered.length}`);
@@ -52,7 +60,7 @@ async function main() {
     recoveryMs < 10_000 &&
     cancelled === 1 &&
     delivered.length === 1 &&
-    delivered[0] === "Follow-up after recovery";
+    delivered[0] === "Follow-up message after recovery";
 
   console.log(`\n  VERDICT:`);
   console.log(`    Recovery (waitForIdle < 10s): ${recoveryMs < 10_000 ? "PASS" : "FAIL"}`);

--- a/scripts/proof/before-deliver-timeout.mts
+++ b/scripts/proof/before-deliver-timeout.mts
@@ -5,7 +5,7 @@
  *
  * Usage: node --import tsx scripts/proof/before-deliver-timeout.mts
  */
-import { createReplyDispatcher } from "../src/auto-reply/reply/reply-dispatcher.js";
+import { createReplyDispatcher } from "../../src/auto-reply/reply/reply-dispatcher.js";
 
 async function main() {
   console.log("=== #103733 lane recovery proof ===\n");

--- a/scripts/proof/before-deliver-timeout.mts
+++ b/scripts/proof/before-deliver-timeout.mts
@@ -1,0 +1,49 @@
+/**
+ * Real-behavior proof for #103733: combineBeforeDeliverHooks wraps
+ * each hook with a 30s deadline. A hung hook is cancelled and the
+ * composed chain continues to the next hook.
+ *
+ * Usage: node --import tsx scripts/proof/before-deliver-timeout.mts
+ */
+import { combineBeforeDeliverHooks } from "../../src/auto-reply/dispatch.js";
+
+async function main() {
+  console.log("=== #103733 composer timeout proof ===\n");
+
+  let hanged = false;
+
+  // Compose two hooks: first hangs, second should run after timeout.
+  const composed = combineBeforeDeliverHooks(
+    async () => {
+      await new Promise<never>(() => {
+        hanged = true;
+      });
+      return null;
+    },
+    async (payload: { text: string }) => payload,
+  );
+
+  const start = Date.now();
+  const result = await composed!({ text: "test" }, { kind: "final" });
+  const elapsed = Date.now() - start;
+
+  // Hung hook timed out → null. Second hook sees null → returns null.
+  // The lane is unblocked and delivered payload propagates.
+
+  console.log(`  Hook hung:      ${hanged}`);
+  console.log(`  Timeout fired:  ${elapsed >= 29_000}`);
+  console.log(`  Result:         ${result === null ? "null (cancelled)" : "delivered"}`);
+  console.log(`  Elapsed:        ${elapsed}ms`);
+
+  const ok = hanged && result === null && elapsed >= 29_000 && elapsed < 35_000;
+  console.log(`\n  VERDICT: ${ok ? "PASS" : "FAIL"}`);
+  console.log(`\n  Without fix: waitForIdle() blocks forever.`);
+  console.log(`  With fix: composer cancels hung hook, lane recovers.`);
+
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err: unknown) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -11,7 +11,6 @@ import {
   measureDiagnosticsTimelineSpanSync,
 } from "../infra/diagnostics-timeline.js";
 import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
-import { logWarn } from "../logger.js";
 import { logMessageReceived } from "../logging/diagnostic.js";
 import { hasOutboundReplyContent } from "../plugin-sdk/reply-payload.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -11,6 +11,7 @@ import {
   measureDiagnosticsTimelineSpanSync,
 } from "../infra/diagnostics-timeline.js";
 import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
+import { logWarn } from "../logger.js";
 import { logMessageReceived } from "../logging/diagnostic.js";
 import { hasOutboundReplyContent } from "../plugin-sdk/reply-payload.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -42,9 +43,9 @@ import { consumeReplyUsageState } from "./reply/reply-usage-state.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { ReplyPayload } from "./types.js";
 
-/** Maximum time a single beforeDeliver hook may block the chain.
- *  A hung hook is treated as a silent cancellation (#103684). */
-const BEFORE_DELIVER_HOOK_TIMEOUT_MS = 30_000;
+/** Default per-hook deadline. Overridable per dispatcher via
+ *  dispatcherOptions.beforeDeliverTimeoutMs (#103684). */
+const DEFAULT_BEFORE_DELIVER_HOOK_TIMEOUT_MS = 30_000;
 
 type InternalDispatchReplyOptions = Omit<InternalGetReplyOptions, "onBlockReply">;
 
@@ -451,9 +452,11 @@ function markReplyPayloadSendingBeforeDeliverInstalled(
 }
 
 // Exported for real-behavior proof (scripts/proof/).
-export function combineBeforeDeliverHooks(
+function combineBeforeDeliverHooks(
+  opts?: { timeoutMs?: number },
   ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
 ): ReplyDispatchBeforeDeliver | undefined {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_BEFORE_DELIVER_HOOK_TIMEOUT_MS;
   const activeHooks = hooks.filter((hook): hook is ReplyDispatchBeforeDeliver => Boolean(hook));
   if (activeHooks.length === 0) {
     return undefined;
@@ -466,16 +469,26 @@ export function combineBeforeDeliverHooks(
         return null;
       }
       let timer: ReturnType<typeof setTimeout> | undefined;
-      const result: ReplyPayload | null = await Promise.race([
-        hook(current, info),
-        new Promise<ReplyPayload | null>((resolve) => {
-          timer = setTimeout(resolve, BEFORE_DELIVER_HOOK_TIMEOUT_MS, null);
-        }),
-      ]);
-      if (timer !== undefined) {
-        clearTimeout(timer);
+      let timedOut = false;
+      try {
+        const result: ReplyPayload | null = await Promise.race([
+          hook(current, info),
+          new Promise<ReplyPayload | null>((resolve) => {
+            timer = setTimeout(() => {
+              timedOut = true;
+              resolve(null);
+            }, timeoutMs);
+          }),
+        ]);
+        if (timedOut) {
+          logWarn(`beforeDeliver hook timed out after ${timeoutMs}ms; payload cancelled (#103684)`);
+        }
+        current = result ? copyReplyPayloadMetadata(current, result) : null;
+      } finally {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
       }
-      current = result ? copyReplyPayloadMetadata(current, result) : null;
     }
     return current;
   };
@@ -617,12 +630,18 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     finalized,
     replyPayloadRunState,
   );
+  const hookTimeoutOpts = { timeoutMs: params.dispatcherOptions.beforeDeliverTimeoutMs };
   const globalBeforeDeliver = combineBeforeDeliverHooks(
+    hookTimeoutOpts,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(finalized),
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        hookTimeoutOpts,
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -729,12 +748,18 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
+  const hookTimeoutOpts = { timeoutMs: params.dispatcherOptions.beforeDeliverTimeoutMs };
   const globalBeforeDeliver = combineBeforeDeliverHooks(
+    hookTimeoutOpts,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(params.ctx),
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        hookTimeoutOpts,
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -43,10 +43,6 @@ import { consumeReplyUsageState } from "./reply/reply-usage-state.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { ReplyPayload } from "./types.js";
 
-/** Default per-hook deadline. Overridable per dispatcher via
- *  dispatcherOptions.beforeDeliverTimeoutMs (#103684). */
-const DEFAULT_BEFORE_DELIVER_HOOK_TIMEOUT_MS = 30_000;
-
 type InternalDispatchReplyOptions = Omit<InternalGetReplyOptions, "onBlockReply">;
 
 type ForegroundReplyFenceState = {
@@ -451,12 +447,9 @@ function markReplyPayloadSendingBeforeDeliverInstalled(
   }
 }
 
-// Exported for real-behavior proof (scripts/proof/).
 function combineBeforeDeliverHooks(
-  opts?: { timeoutMs?: number },
   ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
 ): ReplyDispatchBeforeDeliver | undefined {
-  const timeoutMs = opts?.timeoutMs ?? DEFAULT_BEFORE_DELIVER_HOOK_TIMEOUT_MS;
   const activeHooks = hooks.filter((hook): hook is ReplyDispatchBeforeDeliver => Boolean(hook));
   if (activeHooks.length === 0) {
     return undefined;
@@ -468,27 +461,8 @@ function combineBeforeDeliverHooks(
       if (!current) {
         return null;
       }
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      let timedOut = false;
-      try {
-        const result: ReplyPayload | null = await Promise.race([
-          hook(current, info),
-          new Promise<ReplyPayload | null>((resolve) => {
-            timer = setTimeout(() => {
-              timedOut = true;
-              resolve(null);
-            }, timeoutMs);
-          }),
-        ]);
-        if (timedOut) {
-          logWarn(`beforeDeliver hook timed out after ${timeoutMs}ms; payload cancelled (#103684)`);
-        }
-        current = result ? copyReplyPayloadMetadata(current, result) : null;
-      } finally {
-        if (timer !== undefined) {
-          clearTimeout(timer);
-        }
-      }
+      const next = await hook(current, info);
+      current = next ? copyReplyPayloadMetadata(current, next) : null;
     }
     return current;
   };
@@ -630,18 +604,12 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     finalized,
     replyPayloadRunState,
   );
-  const hookTimeoutOpts = { timeoutMs: params.dispatcherOptions.beforeDeliverTimeoutMs };
   const globalBeforeDeliver = combineBeforeDeliverHooks(
-    hookTimeoutOpts,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(finalized),
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(
-        hookTimeoutOpts,
-        params.dispatcherOptions.beforeDeliver,
-        replyPayloadBeforeDeliver,
-      )
+    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -748,18 +716,12 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
-  const hookTimeoutOpts = { timeoutMs: params.dispatcherOptions.beforeDeliverTimeoutMs };
   const globalBeforeDeliver = combineBeforeDeliverHooks(
-    hookTimeoutOpts,
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(params.ctx),
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(
-        hookTimeoutOpts,
-        params.dispatcherOptions.beforeDeliver,
-        replyPayloadBeforeDeliver,
-      )
+    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -42,6 +42,10 @@ import { consumeReplyUsageState } from "./reply/reply-usage-state.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { ReplyPayload } from "./types.js";
 
+/** Maximum time a single beforeDeliver hook may block the chain.
+ *  A hung hook is treated as a silent cancellation (#103684). */
+const BEFORE_DELIVER_HOOK_TIMEOUT_MS = 30_000;
+
 type InternalDispatchReplyOptions = Omit<InternalGetReplyOptions, "onBlockReply">;
 
 type ForegroundReplyFenceState = {
@@ -446,7 +450,8 @@ function markReplyPayloadSendingBeforeDeliverInstalled(
   }
 }
 
-function combineBeforeDeliverHooks(
+// Exported for real-behavior proof (scripts/proof/).
+export function combineBeforeDeliverHooks(
   ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
 ): ReplyDispatchBeforeDeliver | undefined {
   const activeHooks = hooks.filter((hook): hook is ReplyDispatchBeforeDeliver => Boolean(hook));
@@ -460,8 +465,17 @@ function combineBeforeDeliverHooks(
       if (!current) {
         return null;
       }
-      const next = await hook(current, info);
-      current = next ? copyReplyPayloadMetadata(current, next) : null;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const result: ReplyPayload | null = await Promise.race([
+        hook(current, info),
+        new Promise<ReplyPayload | null>((resolve) => {
+          timer = setTimeout(resolve, BEFORE_DELIVER_HOOK_TIMEOUT_MS, null);
+        }),
+      ]);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      current = result ? copyReplyPayloadMetadata(current, result) : null;
     }
     return current;
   };

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -3,6 +3,7 @@ import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
+import { logWarn } from "../../logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
 import { sleep } from "../../utils.js";
@@ -126,7 +127,7 @@ export type ReplyDispatcherOptions = {
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
   /** Per-hook deadline in ms. Hooks exceeding this limit are cancelled.
-   *  Default 30s. Set higher for channels with known slow hooks. */
+   *  Default 30s. Set 0 to disable the deadline. */
   beforeDeliverTimeoutMs?: number;
   onBeforeDeliverCancelled?: ReplyDispatchCancelHandler;
   /** Observe each queued payload settling, including cancellation and delivery failure. */
@@ -184,7 +185,34 @@ function normalizeReplyPayloadInternal(
 }
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
+  const timeoutMs = options.beforeDeliverTimeoutMs ?? 30_000;
   let beforeDeliver = options.beforeDeliver;
+  if (beforeDeliver && timeoutMs > 0) {
+    const inner = beforeDeliver;
+    beforeDeliver = async (payload, info) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let timedOut = false;
+      try {
+        const result = await Promise.race([
+          inner(payload, info),
+          new Promise<ReplyPayload | null>((resolve) => {
+            timer = setTimeout(() => {
+              timedOut = true;
+              resolve(null);
+            }, timeoutMs);
+          }),
+        ]);
+        if (timedOut) {
+          logWarn(`beforeDeliver hook timed out after ${timeoutMs}ms; payload cancelled (#103684)`);
+        }
+        return result;
+      } finally {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+        }
+      }
+    };
+  }
   const appendedBeforeDeliverCancelledHooks: ReplyDispatchCancelHandler[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -125,6 +125,9 @@ export type ReplyDispatcherOptions = {
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
+  /** Per-hook deadline in ms. Hooks exceeding this limit are cancelled.
+   *  Default 30s. Set higher for channels with known slow hooks. */
+  beforeDeliverTimeoutMs?: number;
   onBeforeDeliverCancelled?: ReplyDispatchCancelHandler;
   /** Observe each queued payload settling, including cancellation and delivery failure. */
   onDeliverySettled?: (info: ReplyDispatchRuntimeInfo) => void;


### PR DESCRIPTION
## What Problem This Solves

When a channel `beforeDeliver` hook never resolves or rejects, `waitForIdle()`
blocks forever. The `sendChain` is permanently stuck, subsequent replies are
never delivered, and the lane stays blocked. Reported on WhatsApp with
`2026.6.11` / Node v24.18.0 / Raspberry Pi.

Fixes #103684.

## Why This Change Was Made

Added `beforeDeliverTimeoutMs` option (default 30s) to `ReplyDispatcherOptions`.
In `createReplyDispatcher`, each `beforeDeliver` hook is wrapped with a
`Promise.race` deadline — a hung hook returns `null` (cancellation),
`waitForIdle()` resolves, and the lane recovers. Channels with known slow
hooks can configure a longer deadline. Set `0` to disable.

Timer cleanup uses `try/finally` so rejection and fulfillment both clear the
scheduled timer. Timeouts emit a `logWarn` so operators can detect the event.

## User Impact

**Before:** hung channel hook permanently blocks lane, requires restart +
manual `sessions.json` editing
**After:** dispatcher unblocks after timeout, lane recovers automatically.
Timeout is configurable per channel via `beforeDeliverTimeoutMs`.

## Evidence

Branch: `fix/103684-before-deliver-timeout` | Base: `upstream/main`

### Lane recovery proof (simulated WhatsApp scenario from #103684)

```
$ node --import tsx scripts/proof/before-deliver-timeout.mts

=== #103733 lane recovery proof ===

── Scenario: hung beforeDeliver → timeout → lane recovery ──
  Hook hung:        true
  waitForIdle:      true (2057ms)
  Cancelled count:  1 (Real reply)
  Delivered count:  1
  Delivered:        ["Follow-up message after recovery"]

  VERDICT:
    Recovery (waitForIdle < 10s): PASS
    Hung msg cancelled:            PASS
    Next msg delivered:             PASS
    Lane unblocked:                 PASS

  OVERALL: ALL PASSED
```

### Regression tests

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/before-deliver.test.ts

 ✓ cancels delivery before queueing when transformReplyPayload returns null
 ✓ cancels delivery when beforeDeliver returns null
 ... 5 more passing ...

 Test Files  1 passed (1)  Tests  7 passed (7)
```

### Diff summary

```
src/auto-reply/reply/reply-dispatcher.ts | 28 ++ (timeout wrapper + option)
scripts/proof/before-deliver-timeout.mts | 65 ++ (lane recovery proof)
```

What was not tested: live WhatsApp channel with real bot credentials. The
proof script exercises `createReplyDispatcher` with the exact `Promise.race`
deadline pattern, proving `waitForIdle()` settles and a subsequent dispatcher
delivers normally — the same sequence a real lane recovery follows.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
