### PR TITLE
fix(release): make validation proof no-write

### DIFF
--- a/.agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs
+++ b/.agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs
@@ -4,21 +4,90 @@
  * full release run.
  */
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { plainGhEnv, resolvePlainGhBin } from "../../../../scripts/lib/plain-gh.mjs";
 
-const runId = process.argv[2];
-const repo = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
+const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
+const RELEASE_EVIDENCE_SCHEMA = "openclaw.release-validation-evidence/v3";
+const RELEASE_EVIDENCE_SCRIPT = ".agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs";
+const RELEASE_EVIDENCE_FILE = fileURLToPath(import.meta.url);
+const RELEASE_EVIDENCE_REPO_ROOT = resolve(dirname(RELEASE_EVIDENCE_FILE), "../../../..");
+const MANIFEST_ARTIFACT_ENTRY = "full-release-validation-manifest.json";
+const MAX_MANIFEST_ARTIFACT_ZIP_BYTES = 256 * 1024;
+const MAX_MANIFEST_JSON_BYTES = 128 * 1024;
+const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
 
-if (!runId) {
-  console.error("usage: release-ci-summary.mjs <full-release-run-id>");
-  process.exit(2);
-}
+const CHILD_DISPATCHES = [
+  {
+    manifestKey: "normalCi",
+    name: "CI",
+    parentJobName: "Run normal full CI",
+    suffix: "-ci",
+    trustedRef: "parent",
+    workflow: "ci.yml",
+  },
+  {
+    manifestKey: "releaseChecks",
+    name: "OpenClaw Release Checks",
+    parentJobName: "Run release/live/Docker/QA validation",
+    suffix: "-release-checks",
+    trustedRef: "parent",
+    workflow: "openclaw-release-checks.yml",
+  },
+  {
+    manifestKey: "pluginPrerelease",
+    name: "Plugin Prerelease",
+    parentJobName: "Run plugin prerelease validation",
+    suffix: "-plugin-prerelease",
+    trustedRef: "parent",
+    workflow: "plugin-prerelease.yml",
+  },
+  {
+    manifestKey: "npmTelegram",
+    name: "NPM Telegram Beta E2E",
+    parentJobName: "Run package Telegram E2E",
+    suffix: "-npm-telegram",
+    trustedRef: "parent",
+    workflow: "npm-telegram-beta-e2e.yml",
+  },
+  {
+    manifestKey: "productPerformance",
+    name: "OpenClaw Performance",
+    parentJobName: "Run product performance evidence",
+    suffix: "",
+    trustedRef: "parent",
+    workflow: "openclaw-performance.yml",
+  },
+];
+
+const EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
+
+const RERUN_GROUP_CHILD_KEYS = new Map([
+  ["all", ["normalCi", "releaseChecks", "pluginPrerelease", "productPerformance"]],
+  ["ci", ["normalCi"]],
+  ["plugin-prerelease", ["pluginPrerelease"]],
+  ["release-checks", ["releaseChecks"]],
+  ["install-smoke", ["releaseChecks"]],
+  ["cross-os", ["releaseChecks"]],
+  ["live-e2e", ["releaseChecks"]],
+  ["package", ["releaseChecks"]],
+  ["qa", ["releaseChecks"]],
+  ["qa-parity", ["releaseChecks"]],
+  ["qa-live", ["releaseChecks"]],
+  ["npm-telegram", ["npmTelegram"]],
+  ["performance", ["productPerformance"]],
+]);
 
 function gh(args) {
   return execFileSync(resolvePlainGhBin(), args, {
     encoding: "utf8",
     env: plainGhEnv(),
+    maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }
@@ -27,7 +96,7 @@ function jsonGh(args) {
   return JSON.parse(gh(args));
 }
 
-function githubRestJson(pathSuffix) {
+function githubRestJson(pathSuffix, repository = DEFAULT_REPO) {
   const result = execFileSync(
     "bash",
     [
@@ -43,13 +112,36 @@ function githubRestJson(pathSuffix) {
       env: {
         ...plainGhEnv(),
         OPENCLAW_PLAIN_GH_BIN: resolvePlainGhBin(),
-        OPENCLAW_GITHUB_REST_URL: `https://api.github.com/repos/${repo}/${pathSuffix}`,
+        OPENCLAW_GITHUB_REST_URL: `https://api.github.com/repos/${repository}/${pathSuffix}`,
       },
       maxBuffer: 16 * 1024 * 1024,
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
   return JSON.parse(result);
+}
+
+function downloadArtifactZip(artifactId, destination, repository = DEFAULT_REPO) {
+  execFileSync(
+    "bash",
+    [
+      "-lc",
+      [
+        "set -euo pipefail",
+        'token="$("$OPENCLAW_PLAIN_GH_BIN" auth token)"',
+        'curl -fsSL -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" --output "$OPENCLAW_GITHUB_ARTIFACT_DESTINATION" "$OPENCLAW_GITHUB_ARTIFACT_URL"',
+      ].join("\n"),
+    ],
+    {
+      env: {
+        ...plainGhEnv(),
+        OPENCLAW_GITHUB_ARTIFACT_DESTINATION: destination,
+        OPENCLAW_GITHUB_ARTIFACT_URL: `https://api.github.com/repos/${repository}/actions/artifacts/${artifactId}/zip`,
+        OPENCLAW_PLAIN_GH_BIN: resolvePlainGhBin(),
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
 }
 
 function rate() {
@@ -60,69 +152,1503 @@ function rate() {
   }
 }
 
-const core = rate();
-if (core) {
-  const reset = new Date(core.reset * 1000).toISOString();
-  console.log(`rate: remaining=${core.remaining}/${core.limit} reset=${reset}`);
-  if (core.remaining < 20) {
-    console.error("rate too low for CI summary; wait for reset before polling");
-    process.exit(3);
+export function validateParentRunBinding(parentView, parentRest, expectedRunId) {
+  const workflowPath = String(parentRest.path ?? "").split("@", 1)[0];
+  if (
+    String(parentRest.id) !== String(expectedRunId) ||
+    parentRest.event !== "workflow_dispatch" ||
+    workflowPath !== ".github/workflows/full-release-validation.yml" ||
+    Number(parentRest.run_attempt) !== Number(parentView.attempt) ||
+    parentRest.head_branch !== parentView.headBranch ||
+    parentRest.head_sha !== parentView.headSha
+  ) {
+    throw new Error(`full release parent run binding mismatch: ${expectedRunId}`);
+  }
+  return parentRest;
+}
+
+export function expectedChildDispatches(parentRunId, parentRunAttempt, parentWorkflowRef) {
+  if (!/^[1-9][0-9]*$/u.test(String(parentRunId))) {
+    throw new Error("parent run ID must be a positive decimal");
+  }
+  if (!Number.isSafeInteger(parentRunAttempt) || parentRunAttempt < 1) {
+    throw new Error("parent run attempt must be a positive integer");
+  }
+  if (typeof parentWorkflowRef !== "string" || parentWorkflowRef.length === 0) {
+    throw new Error("parent workflow ref is required");
+  }
+  const dispatchPrefix = `full-release-validation-${parentRunId}-${parentRunAttempt}`;
+  return CHILD_DISPATCHES.map((child) => ({
+    ...child,
+    displayTitle: `${child.name} ${dispatchPrefix}${child.suffix}`,
+    headBranch: child.trustedRef === "main" ? "main" : parentWorkflowRef,
+  }));
+}
+
+export function requiredChildKeysForRerunGroup(rerunGroup) {
+  const childKeys = RERUN_GROUP_CHILD_KEYS.get(rerunGroup);
+  if (!childKeys) {
+    throw new Error(`release validation manifest rerun group is invalid: ${rerunGroup}`);
+  }
+  return new Set(childKeys);
+}
+
+export function expectedSelectedChildDispatches(
+  parentRunId,
+  parentRunAttempt,
+  parentWorkflowRef,
+  selectedKeys,
+) {
+  return expectedChildDispatches(parentRunId, parentRunAttempt, parentWorkflowRef).filter((child) =>
+    selectedKeys.has(child.manifestKey),
+  );
+}
+
+export function selectExactChildRun(runs, expectedDisplayTitle, expectedHeadBranch) {
+  const matches = runs.filter(
+    (run) =>
+      run.event === "workflow_dispatch" &&
+      run.display_title === expectedDisplayTitle &&
+      run.head_branch === expectedHeadBranch,
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `multiple child runs have exact dispatch title and branch: ${expectedDisplayTitle} (${expectedHeadBranch})`,
+    );
+  }
+  return matches[0];
+}
+
+export function selectExactChildRunFromPages(runPages, expectedDisplayTitle, expectedHeadBranch) {
+  let exactMatch;
+  for (const runs of runPages) {
+    const match = selectExactChildRun(runs, expectedDisplayTitle, expectedHeadBranch);
+    if (match) {
+      if (exactMatch) {
+        throw new Error(
+          `multiple child runs have exact dispatch title and branch: ${expectedDisplayTitle} (${expectedHeadBranch})`,
+        );
+      }
+      exactMatch = match;
+    }
+    if (runs.length < 100) {
+      break;
+    }
+  }
+  return exactMatch;
+}
+
+function findExactChildRun(child, repository = DEFAULT_REPO) {
+  const runPages = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const query = new URLSearchParams({
+      event: "workflow_dispatch",
+      branch: child.headBranch,
+      page: String(page),
+      per_page: "100",
+    });
+    const runs =
+      githubRestJson(`actions/workflows/${child.workflow}/runs?${query.toString()}`, repository)
+        .workflow_runs ?? [];
+    runPages.push(runs);
+    if (runs.length < 100) {
+      break;
+    }
+  }
+  return selectExactChildRunFromPages(runPages, child.displayTitle, child.headBranch);
+}
+
+function findParentJobsAll(parentRunId, repository = DEFAULT_REPO) {
+  const jobs = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const query = new URLSearchParams({
+      filter: "all",
+      page: String(page),
+      per_page: "100",
+    });
+    const pageJobs =
+      githubRestJson(`actions/runs/${parentRunId}/jobs?${query.toString()}`, repository).jobs ?? [];
+    jobs.push(...pageJobs);
+    if (pageJobs.length < 100) {
+      break;
+    }
+  }
+  return jobs;
+}
+
+function parentJobLog(jobId, repository = DEFAULT_REPO) {
+  return gh(["api", `repos/${repository}/actions/jobs/${jobId}/logs`]);
+}
+
+function normalizeOptionalRunId(value, label) {
+  if (value === "") {
+    return "";
+  }
+  if (!/^[1-9][0-9]*$/u.test(String(value))) {
+    throw new Error(`${label} must be empty or a positive decimal run ID`);
+  }
+  return String(value);
+}
+
+function normalizeRequiredRunId(value, label) {
+  const runId = normalizeOptionalRunId(value, label);
+  if (!runId) {
+    throw new Error(`${label} is required`);
+  }
+  return runId;
+}
+
+function normalizeRepository(value) {
+  const repository = String(value ?? "");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+    throw new Error("repository must use the owner/name form");
+  }
+  return repository;
+}
+
+function normalizeWorkflowRef(value, label) {
+  const workflowRef = String(value ?? "");
+  if (
+    workflowRef.length === 0 ||
+    workflowRef.length > 255 ||
+    /[\u0000-\u001f\u007f~^:?*[\\\s]/u.test(workflowRef)
+  ) {
+    throw new Error(`${label} is invalid`);
+  }
+  return workflowRef;
+}
+
+function normalizeSha(value, label) {
+  const sha = String(value ?? "");
+  if (!/^[a-f0-9]{40}$/u.test(sha)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return sha;
+}
+
+function normalizePositiveInteger(value, label) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return number;
+}
+
+function normalizeJsonObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalJson(entry)]),
+    );
+  }
+  return value;
+}
+
+function manifestEvidenceIdentity(manifest) {
+  return canonicalJson({
+    childRunIds: manifest.childRunIds,
+    controls: manifest.controls,
+    releaseProfile: manifest.releaseProfile,
+    rerunGroup: manifest.rerunGroup,
+    runReleaseSoak: manifest.runReleaseSoak,
+    validationInputs: manifest.validationInputs,
+  });
+}
+
+export function validateParentManifest(value, expected) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("release validation manifest must be an object");
+  }
+  if (![2, 3].includes(value.version) || value.workflowName !== "Full Release Validation") {
+    throw new Error("release validation manifest schema is unsupported");
+  }
+  if (String(value.runId) !== String(expected.runId)) {
+    throw new Error("release validation manifest run ID mismatch");
+  }
+  if (
+    !/^[1-9][0-9]*$/u.test(String(value.runAttempt)) ||
+    (expected.runAttempt !== undefined && Number(value.runAttempt) !== Number(expected.runAttempt))
+  ) {
+    throw new Error("release validation manifest run attempt mismatch");
+  }
+  const targetSha = normalizeSha(value.targetSha, "release validation manifest target SHA");
+  if (typeof value.workflowRef !== "string" || value.workflowRef.length === 0) {
+    throw new Error("release validation manifest workflow ref is invalid");
+  }
+  if (expected.workflowRef !== undefined && value.workflowRef !== expected.workflowRef) {
+    throw new Error("release validation manifest workflow ref mismatch");
+  }
+  let workflowSha;
+  let workflowFullRef;
+  let workflowRefType;
+  if (value.version === 3) {
+    workflowSha = normalizeSha(value.workflowSha, "release validation manifest workflow SHA");
+    if (expected.workflowSha !== undefined && workflowSha !== expected.workflowSha) {
+      throw new Error("release validation manifest workflow SHA mismatch");
+    }
+    workflowFullRef = String(value.workflowFullRef ?? "");
+    workflowRefType = String(value.workflowRefType ?? "");
+    if (
+      !["branch", "tag"].includes(workflowRefType) ||
+      workflowFullRef !==
+        `refs/${workflowRefType === "branch" ? "heads" : "tags"}/${value.workflowRef}`
+    ) {
+      throw new Error("release validation manifest workflow full ref is invalid");
+    }
+  } else if (expected.workflowSha !== undefined) {
+    workflowSha = normalizeSha(expected.workflowSha, "release validation workflow SHA");
+  }
+  const rerunGroup = String(value.rerunGroup ?? "");
+  requiredChildKeysForRerunGroup(rerunGroup);
+  const releaseProfile = String(value.releaseProfile ?? "");
+  if (!["beta", "stable", "full"].includes(releaseProfile)) {
+    throw new Error("release validation manifest release profile is invalid");
+  }
+  const runReleaseSoak = String(value.runReleaseSoak ?? "");
+  if (!["true", "false"].includes(runReleaseSoak)) {
+    throw new Error("release validation manifest release soak value is invalid");
+  }
+  const controls = normalizeJsonObject(value.controls, "release validation manifest controls");
+  if (value.version === 3 && controls.performanceReportPublication !== "artifact-only") {
+    throw new Error("release validation manifest performance report publication mode is invalid");
+  }
+  const validationInputs =
+    value.validationInputs === undefined
+      ? undefined
+      : normalizeJsonObject(
+          value.validationInputs,
+          "release validation manifest validation inputs",
+        );
+  const childRuns = value.childRuns;
+  if (!childRuns || typeof childRuns !== "object" || Array.isArray(childRuns)) {
+    throw new Error("release validation manifest childRuns is invalid");
+  }
+  const childRunIds = {
+    normalCi: normalizeOptionalRunId(childRuns.normalCi, "normal CI run ID"),
+    npmTelegram: normalizeOptionalRunId(childRuns.npmTelegram, "npm Telegram run ID"),
+    pluginPrerelease: normalizeOptionalRunId(
+      childRuns.pluginPrerelease,
+      "plugin prerelease run ID",
+    ),
+    productPerformance: normalizeOptionalRunId(
+      childRuns.productPerformance?.runId ?? "",
+      "performance run ID",
+    ),
+    releaseChecks: normalizeOptionalRunId(childRuns.releaseChecks, "release checks run ID"),
+  };
+  let evidenceReuse;
+  if (value.evidenceReuse !== undefined) {
+    const reuse = normalizeJsonObject(
+      value.evidenceReuse,
+      "release validation manifest evidence reuse",
+    );
+    if (reuse.policy !== EVIDENCE_REUSE_POLICY) {
+      throw new Error("release validation manifest evidence reuse policy is invalid");
+    }
+    if (!/^[a-f0-9]{40}$/u.test(String(reuse.evidenceSha))) {
+      throw new Error("release validation manifest evidence SHA is invalid");
+    }
+    if (
+      !Array.isArray(reuse.changedPaths) ||
+      reuse.changedPaths.some(
+        (changedPath) => typeof changedPath !== "string" || changedPath.length === 0,
+      ) ||
+      new Set(reuse.changedPaths).size !== reuse.changedPaths.length
+    ) {
+      throw new Error("release validation manifest evidence changed paths are invalid");
+    }
+    evidenceReuse = {
+      changedPaths: reuse.changedPaths,
+      evidenceSha: String(reuse.evidenceSha),
+      policy: reuse.policy,
+      runId: normalizeRequiredRunId(reuse.runId, "evidence reuse root run ID"),
+      selectedRunId: normalizeRequiredRunId(reuse.selectedRunId, "evidence reuse selected run ID"),
+    };
+  }
+  return {
+    childRunIds,
+    controls,
+    evidenceReuse,
+    releaseProfile,
+    rerunGroup,
+    runAttempt: Number(value.runAttempt),
+    runId: String(value.runId),
+    runReleaseSoak,
+    targetRef: String(value.targetRef ?? ""),
+    targetSha,
+    validationInputs,
+    version: value.version,
+    workflowFullRef,
+    workflowSha,
+    workflowRef: value.workflowRef,
+    workflowRefType,
+  };
+}
+
+export function validateEvidenceReuseChain(currentManifest, selectedManifest, rootManifest) {
+  const reuse = currentManifest.evidenceReuse;
+  if (!reuse) {
+    throw new Error("release validation manifest does not authorize evidence reuse");
+  }
+  if (reuse.changedPaths.length !== 0) {
+    throw new Error("full release evidence reuse requires an exact target with no changed paths");
+  }
+  if (rootManifest.evidenceReuse || selectedManifest.evidenceReuse) {
+    throw new Error("evidence reuse must select a root execution manifest");
+  }
+  if (
+    !currentManifest.validationInputs ||
+    !selectedManifest.validationInputs ||
+    !rootManifest.validationInputs
+  ) {
+    throw new Error("evidence reuse manifests must record validation inputs");
+  }
+  if (rootManifest.runId !== reuse.runId) {
+    throw new Error("evidence reuse root manifest run ID mismatch");
+  }
+  if (selectedManifest.runId !== reuse.selectedRunId) {
+    throw new Error("evidence reuse selected manifest run ID mismatch");
+  }
+  if (selectedManifest.targetSha !== reuse.evidenceSha) {
+    throw new Error("evidence reuse selected manifest SHA mismatch");
+  }
+  if (
+    currentManifest.targetSha !== reuse.evidenceSha ||
+    rootManifest.targetSha !== reuse.evidenceSha
+  ) {
+    throw new Error("full release evidence reuse target SHA mismatch");
+  }
+  if (selectedManifest.runId !== rootManifest.runId) {
+    throw new Error("evidence reuse selected manifest is not the chain root");
+  }
+
+  const rootIdentity = JSON.stringify(manifestEvidenceIdentity(rootManifest));
+  for (const [label, manifest] of [
+    ["selected", selectedManifest],
+    ["current", currentManifest],
+  ]) {
+    if (JSON.stringify(manifestEvidenceIdentity(manifest)) !== rootIdentity) {
+      throw new Error(`evidence reuse ${label} manifest policy differs from the chain root`);
+    }
+  }
+  return rootManifest.targetSha;
+}
+
+export function selectedChildKeys(parentJobs) {
+  return new Set(
+    CHILD_DISPATCHES.filter((child) => {
+      const parentJob = parentJobs.find((job) => job.name === child.parentJobName);
+      return parentJob && parentJob.conclusion !== "skipped";
+    }).map((child) => child.manifestKey),
+  );
+}
+
+export function manifestChildEntries(manifest, children, selectedKeys) {
+  return children.flatMap((child) => {
+    const runId = manifest.childRunIds[child.manifestKey];
+    if (!runId) {
+      if (selectedKeys.has(child.manifestKey)) {
+        throw new Error(`selected child is missing from manifest: ${child.name}`);
+      }
+      return [];
+    }
+    return [{ child, runId }];
+  });
+}
+
+function childDispatchAttempt(displayTitle, child, parentRunId, parentRunAttempt) {
+  const prefix = `${child.name} full-release-validation-${parentRunId}-`;
+  if (!displayTitle.startsWith(prefix) || !displayTitle.endsWith(child.suffix)) {
+    return undefined;
+  }
+  const attemptEnd = child.suffix ? -child.suffix.length : undefined;
+  const attemptText = displayTitle.slice(prefix.length, attemptEnd);
+  if (!/^[1-9][0-9]*$/u.test(attemptText)) {
+    return undefined;
+  }
+  const attempt = Number(attemptText);
+  if (!Number.isSafeInteger(attempt) || attempt > parentRunAttempt) {
+    return undefined;
+  }
+  return attempt;
+}
+
+function parentJobExecutionFingerprint(job) {
+  return canonicalJson({
+    completedAt: job.completed_at,
+    conclusion: job.conclusion,
+    name: job.name,
+    startedAt: job.started_at,
+    status: job.status,
+    steps: (job.steps ?? []).map((step) => ({
+      completedAt: step.completed_at,
+      conclusion: step.conclusion,
+      name: step.name,
+      number: step.number,
+      startedAt: step.started_at,
+      status: step.status,
+    })),
+  });
+}
+
+function selectedAttemptParentJob(parentJobs, child, parentManifest) {
+  const slotJobs = parentJobs.filter((job) => job.name === child.parentJobName);
+  if (slotJobs.length === 0) {
+    throw new Error(`manifest parent job is missing: ${child.name}`);
+  }
+  const latestAttempt = Math.max(...slotJobs.map((job) => Number(job.run_attempt)));
+  if (latestAttempt !== parentManifest.runAttempt) {
+    throw new Error(`manifest parent job latest attempt mismatch: ${child.name}`);
+  }
+  const currentJobs = slotJobs.filter(
+    (job) => Number(job.run_attempt) === parentManifest.runAttempt,
+  );
+  if (currentJobs.length !== 1) {
+    throw new Error(`manifest parent job is not unique at the selected attempt: ${child.name}`);
+  }
+  const currentJob = currentJobs[0];
+  if (currentJob.status !== "completed" || currentJob.conclusion !== "success") {
+    throw new Error(`manifest parent job is not completed/success: ${child.name}`);
+  }
+  return { currentJob, slotJobs };
+}
+
+export function resolveManifestChildOriginAttempt(run, child, parentManifest, parentJobs) {
+  const correlatedAttempt = childDispatchAttempt(
+    String(run.display_title ?? ""),
+    child,
+    parentManifest.runId,
+    parentManifest.runAttempt,
+  );
+  if (correlatedAttempt !== undefined) {
+    return correlatedAttempt;
+  }
+  if (run.display_title !== child.name) {
+    return undefined;
+  }
+
+  const { currentJob, slotJobs } = selectedAttemptParentJob(parentJobs, child, parentManifest);
+  const currentFingerprint = JSON.stringify(parentJobExecutionFingerprint(currentJob));
+  const carriedOriginAttempts = slotJobs
+    .filter(
+      (job) =>
+        Number(job.run_attempt) < parentManifest.runAttempt &&
+        job.status === "completed" &&
+        job.conclusion === "success" &&
+        JSON.stringify(parentJobExecutionFingerprint(job)) === currentFingerprint,
+    )
+    .map((job) => Number(job.run_attempt));
+  return carriedOriginAttempts.length > 0
+    ? Math.min(...carriedOriginAttempts)
+    : parentManifest.runAttempt;
+}
+
+export function selectManifestParentJob(parentJobs, child, parentManifest, originAttempt) {
+  const { currentJob, slotJobs } = selectedAttemptParentJob(parentJobs, child, parentManifest);
+  if (originAttempt === parentManifest.runAttempt) {
+    return currentJob;
+  }
+
+  const originJobs = slotJobs.filter((job) => Number(job.run_attempt) === originAttempt);
+  if (originJobs.length !== 1) {
+    throw new Error(`manifest parent job origin is not unique: ${child.name}`);
+  }
+  const originJob = originJobs[0];
+  if (originJob.status !== "completed" || originJob.conclusion !== "success") {
+    throw new Error(`manifest parent job origin is not completed/success: ${child.name}`);
+  }
+  if (
+    JSON.stringify(parentJobExecutionFingerprint(currentJob)) !==
+    JSON.stringify(parentJobExecutionFingerprint(originJob))
+  ) {
+    throw new Error(`manifest parent job carry-forward fingerprint mismatch: ${child.name}`);
+  }
+  return currentJob;
+}
+
+function childRunIdsFromParentLog(log, repository = DEFAULT_REPO) {
+  const escapedRepo = repository.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const pattern = new RegExp(
+    `https://github\\.com/${escapedRepo}/actions/runs/([1-9][0-9]*)`,
+    "gu",
+  );
+  return new Set(Array.from(log.matchAll(pattern), (match) => match[1]));
+}
+
+export function validateManifestChildRun(
+  run,
+  child,
+  runId,
+  parentManifest,
+  parentJobs,
+  selectedParentJobLog,
+  repository = DEFAULT_REPO,
+) {
+  if (String(run.id) !== String(runId)) {
+    throw new Error(`manifest child run ID mismatch: ${child.name}`);
+  }
+  const originAttempt = resolveManifestChildOriginAttempt(run, child, parentManifest, parentJobs);
+  if (
+    run.event !== "workflow_dispatch" ||
+    run.head_branch !== child.headBranch ||
+    (child.trustedRef === "parent" && run.head_sha !== parentManifest.workflowSha) ||
+    !/^[a-f0-9]{40}$/u.test(String(run.head_sha)) ||
+    run.actor?.login !== "github-actions[bot]" ||
+    run.triggering_actor?.login !== "github-actions[bot]" ||
+    !Number.isSafeInteger(Number(run.run_attempt)) ||
+    Number(run.run_attempt) < 1 ||
+    originAttempt === undefined
+  ) {
+    throw new Error(`manifest child dispatch tuple mismatch: ${child.name}`);
+  }
+  const workflowPath = String(run.path ?? "").split("@", 1)[0];
+  if (workflowPath !== `.github/workflows/${child.workflow}`) {
+    throw new Error(`manifest child workflow mismatch: ${child.name}`);
+  }
+  selectManifestParentJob(parentJobs, child, parentManifest, originAttempt);
+  const emittedChildRunIds = childRunIdsFromParentLog(selectedParentJobLog, repository);
+  if (emittedChildRunIds.size !== 1 || !emittedChildRunIds.has(String(runId))) {
+    throw new Error(`manifest child run is not uniquely emitted by its parent job: ${child.name}`);
+  }
+  if (
+    child.manifestKey !== "npmTelegram" &&
+    !selectedParentJobLog.includes(`TARGET_SHA: ${parentManifest.targetSha}`)
+  ) {
+    throw new Error(`manifest parent job target SHA mismatch: ${child.name}`);
+  }
+  if (
+    child.manifestKey === "productPerformance" &&
+    !selectedParentJobLog.includes("-f publish_reports=false")
+  ) {
+    throw new Error("manifest performance child is not dispatched in artifact-only mode");
+  }
+  return run;
+}
+
+export function validatePerformanceArtifactOnlyJobs(jobs, runAttempt) {
+  const normalizedRunAttempt = normalizePositiveInteger(runAttempt, "performance run attempt");
+  const currentJobs = jobs.filter((job) => Number(job.run_attempt) === normalizedRunAttempt);
+  const guards = currentJobs.filter((job) => job.name === "Verify artifact-only report mode");
+  if (
+    guards.length !== 1 ||
+    guards[0].status !== "completed" ||
+    guards[0].conclusion !== "success"
+  ) {
+    throw new Error("performance artifact-only guard is missing or unsuccessful");
+  }
+  const unsafePublisher = currentJobs.find(
+    (job) =>
+      String(job.name ?? "").startsWith("Publish ") &&
+      String(job.name ?? "").endsWith(" report") &&
+      job.conclusion !== "skipped",
+  );
+  if (unsafePublisher) {
+    throw new Error(`performance report publisher was not skipped: ${unsafePublisher.name}`);
+  }
+  return guards[0];
+}
+
+function manifestArtifactName(runId, runAttempt) {
+  const normalizedRunId = normalizeRequiredRunId(runId, "full release run ID");
+  const normalizedRunAttempt = normalizePositiveInteger(runAttempt, "full release run attempt");
+  return `full-release-validation-${normalizedRunId}-${normalizedRunAttempt}`;
+}
+
+function legacyManifestArtifactName(runId) {
+  return `full-release-validation-${normalizeRequiredRunId(runId, "full release run ID")}`;
+}
+
+export function validateManifestArtifactIdentity(
+  artifact,
+  { artifactDigest, artifactId, runAttempt, runId },
+) {
+  const normalizedArtifactId = normalizeRequiredRunId(artifactId, "manifest artifact ID");
+  const normalizedRunId = normalizeRequiredRunId(runId, "full release run ID");
+  const normalizedRunAttempt = normalizePositiveInteger(runAttempt, "full release run attempt");
+  const normalizedDigest = String(artifactDigest ?? "");
+  if (!/^sha256:[a-f0-9]{64}$/u.test(normalizedDigest)) {
+    throw new Error(`release validation manifest artifact digest is invalid: ${normalizedRunId}`);
+  }
+  const canonicalName = manifestArtifactName(normalizedRunId, normalizedRunAttempt);
+  const legacyName = legacyManifestArtifactName(normalizedRunId);
+  const validName =
+    artifact.name === canonicalName || (normalizedRunAttempt === 1 && artifact.name === legacyName);
+  if (
+    String(artifact.id) !== normalizedArtifactId ||
+    !validName ||
+    artifact.digest !== normalizedDigest ||
+    artifact.expired !== false ||
+    String(artifact.workflow_run?.id) !== normalizedRunId ||
+    !Number.isSafeInteger(Number(artifact.size_in_bytes)) ||
+    Number(artifact.size_in_bytes) < 1
+  ) {
+    throw new Error(`release validation manifest artifact identity mismatch: ${normalizedRunId}`);
+  }
+  return artifact;
+}
+
+export function selectManifestArtifact(artifacts, runId, runAttempt) {
+  const expectedName = manifestArtifactName(runId, runAttempt);
+  const canonicalMatches = artifacts.filter(
+    (artifact) =>
+      artifact.name === expectedName &&
+      artifact.expired === false &&
+      String(artifact.workflow_run?.id) === String(runId),
+  );
+  if (canonicalMatches.length > 1) {
+    throw new Error(`multiple release validation manifest artifacts found: ${runId}`);
+  }
+  const canonicalArtifact = canonicalMatches[0];
+  if (canonicalArtifact) {
+    return validateManifestArtifactIdentity(canonicalArtifact, {
+      artifactDigest: canonicalArtifact.digest,
+      artifactId: canonicalArtifact.id,
+      runAttempt,
+      runId,
+    });
+  }
+
+  const legacyName = legacyManifestArtifactName(runId);
+  const legacyMatches = artifacts.filter(
+    (artifact) =>
+      artifact.name === legacyName &&
+      artifact.expired === false &&
+      String(artifact.workflow_run?.id) === String(runId),
+  );
+  if (legacyMatches.length > 1) {
+    throw new Error(`multiple legacy release validation manifest artifacts found: ${runId}`);
+  }
+  const legacyArtifact = legacyMatches[0];
+  if (!legacyArtifact) {
+    return undefined;
+  }
+  if (Number(runAttempt) !== 1) {
+    throw new Error(`legacy release validation manifest requires run attempt 1: ${runId}`);
+  }
+  return validateManifestArtifactIdentity(legacyArtifact, {
+    artifactDigest: legacyArtifact.digest,
+    artifactId: legacyArtifact.id,
+    runAttempt,
+    runId,
+  });
+}
+
+export function validateManifestArtifactCompatibility(artifact, manifest, runId, runAttempt) {
+  if (artifact.name === manifestArtifactName(runId, runAttempt)) {
+    return artifact;
+  }
+  if (
+    Number(runAttempt) === 1 &&
+    artifact.name === legacyManifestArtifactName(runId) &&
+    manifest?.version === 2
+  ) {
+    return artifact;
+  }
+  throw new Error(`legacy release validation manifest artifact is not compatible: ${runId}`);
+}
+
+export function readManifestArtifactArchive(archivePath, expectedDigest) {
+  const archiveSize = statSync(archivePath).size;
+  if (
+    !Number.isSafeInteger(archiveSize) ||
+    archiveSize < 1 ||
+    archiveSize > MAX_MANIFEST_ARTIFACT_ZIP_BYTES
+  ) {
+    throw new Error("release validation manifest artifact compressed size is invalid");
+  }
+  const archiveBytes = readFileSync(archivePath);
+  if (archiveBytes.byteLength !== archiveSize) {
+    throw new Error("release validation manifest artifact changed while being verified");
+  }
+  const actualDigest = `sha256:${createHash("sha256").update(archiveBytes).digest("hex")}`;
+  if (actualDigest !== expectedDigest) {
+    throw new Error("release validation manifest artifact digest mismatch");
+  }
+
+  let entryList;
+  try {
+    entryList = execFileSync("unzip", ["-Z", "-1", archivePath], {
+      encoding: "utf8",
+      maxBuffer: MAX_MANIFEST_ENTRY_LIST_BYTES,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    throw new Error("release validation manifest artifact entry list is invalid");
+  }
+  const entries = entryList.split(/\r?\n/u).filter((entry) => entry.length > 0);
+  if (entries.length !== 1 || entries[0] !== MANIFEST_ARTIFACT_ENTRY) {
+    throw new Error(
+      `release validation manifest artifact must contain only ${MANIFEST_ARTIFACT_ENTRY}`,
+    );
+  }
+
+  let manifestBytes;
+  try {
+    manifestBytes = execFileSync("unzip", ["-p", archivePath, MANIFEST_ARTIFACT_ENTRY], {
+      maxBuffer: MAX_MANIFEST_JSON_BYTES + 1,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch {
+    throw new Error("release validation manifest artifact entry could not be read safely");
+  }
+  if (manifestBytes.byteLength < 1 || manifestBytes.byteLength > MAX_MANIFEST_JSON_BYTES) {
+    throw new Error("release validation manifest artifact entry size is invalid");
+  }
+  return JSON.parse(manifestBytes.toString("utf8"));
+}
+
+function downloadParentManifestEvidence(
+  runId,
+  runAttempt,
+  repository = DEFAULT_REPO,
+  manifestPath,
+) {
+  const artifacts = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const pageArtifacts =
+      githubRestJson(`actions/runs/${runId}/artifacts?per_page=100&page=${page}`, repository)
+        .artifacts ?? [];
+    artifacts.push(...pageArtifacts);
+    if (pageArtifacts.length < 100) {
+      break;
+    }
+  }
+  const listedArtifact = selectManifestArtifact(artifacts, runId, runAttempt);
+  if (!listedArtifact) {
+    return undefined;
+  }
+  const artifact = validateManifestArtifactIdentity(
+    githubRestJson(`actions/artifacts/${listedArtifact.id}`, repository),
+    {
+      artifactDigest: listedArtifact.digest,
+      artifactId: listedArtifact.id,
+      runAttempt,
+      runId,
+    },
+  );
+  const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-ci-summary-"));
+  try {
+    const archivePath = join(downloadDir, "manifest.zip");
+    downloadArtifactZip(String(artifact.id), archivePath, repository);
+    const manifest = readManifestArtifactArchive(archivePath, artifact.digest);
+    validateManifestArtifactCompatibility(artifact, manifest, runId, runAttempt);
+    if (manifestPath) {
+      const providedManifest = JSON.parse(readFileSync(resolve(manifestPath), "utf8"));
+      if (
+        JSON.stringify(canonicalJson(providedManifest)) !== JSON.stringify(canonicalJson(manifest))
+      ) {
+        throw new Error("provided release validation manifest differs from the run artifact");
+      }
+    }
+    return { artifact, manifest };
+  } finally {
+    rmSync(downloadDir, { force: true, recursive: true });
   }
 }
 
-const parent = jsonGh([
-  "run",
-  "view",
-  runId,
-  "--repo",
-  repo,
-  "--json",
-  "status,conclusion,createdAt,headSha,url,jobs",
-]);
-
-console.log(`parent: ${runId} ${parent.status}/${parent.conclusion || "none"}`);
-console.log(`sha: ${parent.headSha}`);
-console.log(`url: ${parent.url}`);
-
-for (const job of parent.jobs ?? []) {
-  const marker = job.conclusion || job.status;
-  console.log(`parent-job: ${marker} ${job.name}`);
+function tryDownloadParentManifest(runId, runAttempt, repository = DEFAULT_REPO) {
+  return downloadParentManifestEvidence(runId, runAttempt, repository)?.manifest;
 }
 
-const since = parent.createdAt;
-const runsQuery = new URLSearchParams({
-  per_page: "100",
-  created: `>=${since}`,
-  exclude_pull_requests: "true",
-});
-const childWorkflowNames = new Set([
-  "CI",
-  "OpenClaw Release Checks",
-  "Plugin Prerelease",
-  "NPM Telegram Beta E2E",
-  "Full Release Validation",
-]);
-const runs = githubRestJson(`actions/runs?${runsQuery.toString()}`).workflow_runs ?? [];
-const runList = runs
-  .filter(
-    (run) =>
-      run.created_at >= since &&
-      run.head_sha === parent.headSha &&
-      childWorkflowNames.has(run.name),
-  )
-  .map((run) =>
-    [run.id, run.name, run.status, run.conclusion ?? "", run.head_sha, run.html_url].join("\t"),
-  )
-  .join("\n");
-
-if (!runList) {
-  console.log("children: none found yet");
-  process.exit(0);
+function workflowPath(run) {
+  return String(run.path ?? "").split("@", 1)[0];
 }
 
-console.log("children:");
-for (const line of runList.split("\n")) {
-  const [id, name, status, conclusion, sha, url] = line.split("\t");
-  console.log(`child: ${id} ${name} ${status}/${conclusion || "none"} sha=${sha}`);
-  console.log(`child-url: ${url}`);
+function normalizedManifestArtifact(artifact, runAttempt) {
+  return {
+    digest: artifact.digest,
+    id: String(artifact.id),
+    name: artifact.name,
+    runAttempt,
+    sizeInBytes: Number(artifact.size_in_bytes),
+  };
+}
+
+function validateManifestArtifactBinding(artifact, manifest, parentRun, runId) {
+  validateManifestArtifactCompatibility(artifact, manifest, runId, parentRun.run_attempt);
+  if (
+    String(artifact.workflow_run?.id) !== String(runId) ||
+    artifact.workflow_run?.head_branch !== parentRun.head_branch ||
+    artifact.workflow_run?.head_sha !== parentRun.head_sha
+  ) {
+    throw new Error(`release validation manifest artifact binding mismatch: ${runId}`);
+  }
+}
+
+function validateCompletedParentRun(parentView, parentRest, repository, runId) {
+  validateParentRunBinding(parentView, parentRest, runId);
+  if (
+    parentView.status !== "completed" ||
+    parentView.conclusion !== "success" ||
+    parentRest.status !== "completed" ||
+    parentRest.conclusion !== "success" ||
+    parentRest.repository?.full_name !== repository
+  ) {
+    throw new Error(`full release parent run is not completed/success: ${runId}`);
+  }
+}
+
+export function createReleaseEvidenceClient(repository = DEFAULT_REPO) {
+  const normalizedRepository = normalizeRepository(repository);
+  return {
+    compareCommits(base, head) {
+      return githubRestJson(`compare/${base}...${head}`, normalizedRepository);
+    },
+    getJobLog(jobId) {
+      return parentJobLog(jobId, normalizedRepository);
+    },
+    getParentJobs(runId) {
+      return findParentJobsAll(runId, normalizedRepository);
+    },
+    getRun(runId) {
+      return githubRestJson(`actions/runs/${runId}`, normalizedRepository);
+    },
+    getRunView(runId) {
+      return jsonGh([
+        "run",
+        "view",
+        String(runId),
+        "--repo",
+        normalizedRepository,
+        "--json",
+        "status,conclusion,attempt,headBranch,headSha,url,jobs",
+      ]);
+    },
+    loadManifest(runId, runAttempt, manifestPath) {
+      return downloadParentManifestEvidence(runId, runAttempt, normalizedRepository, manifestPath);
+    },
+  };
+}
+
+function loadValidatedParentEvidence({ client, manifestPath, repository, runId }) {
+  const parentView = client.getRunView(runId);
+  const parentRun = client.getRun(runId);
+  validateCompletedParentRun(parentView, parentRun, repository, runId);
+
+  const manifestEvidence = client.loadManifest(runId, parentRun.run_attempt, manifestPath);
+  if (!manifestEvidence) {
+    throw new Error(`successful parent run is missing its release validation manifest: ${runId}`);
+  }
+  const manifest = validateParentManifest(manifestEvidence.manifest, {
+    runAttempt: parentRun.run_attempt,
+    runId,
+    workflowRef: parentRun.head_branch,
+    workflowSha: parentRun.head_sha,
+  });
+  validateManifestArtifactBinding(manifestEvidence.artifact, manifest, parentRun, runId);
+
+  return {
+    artifact: manifestEvidence.artifact,
+    manifest,
+    manifestJson: canonicalJson(manifestEvidence.manifest),
+    parentRun,
+    parentView,
+  };
+}
+
+function trustedWorkflowFullRef(workflowRef) {
+  return `refs/heads/${workflowRef}`;
+}
+
+function validateTrustedProducerIdentity(evidence, client, verifier, trustedWorkflowRef) {
+  const { manifest, parentRun } = evidence;
+  const expectedFullRef = trustedWorkflowFullRef(trustedWorkflowRef);
+  if (manifest.workflowRef !== trustedWorkflowRef) {
+    throw new Error(
+      `release evidence producer must run from trusted workflow ref: ${trustedWorkflowRef}`,
+    );
+  }
+  const runPath = String(parentRun.path ?? "");
+  const [runWorkflowPath, runWorkflowFullRef] = runPath.split("@", 2);
+  if (runWorkflowPath !== ".github/workflows/full-release-validation.yml") {
+    throw new Error("release evidence producer workflow path is not trusted");
+  }
+  if (runWorkflowFullRef && runWorkflowFullRef !== expectedFullRef) {
+    throw new Error("release evidence producer workflow full ref is not trusted");
+  }
+
+  let workflowRefProof = "legacy-v2-main-ancestry";
+  if (manifest.version === 3) {
+    if (manifest.workflowRefType !== "branch" || manifest.workflowFullRef !== expectedFullRef) {
+      throw new Error("release evidence producer workflow full ref is not trusted");
+    }
+    workflowRefProof = "manifest-v3-branch";
+  }
+
+  const comparison = client.compareCommits(manifest.workflowSha, verifier.sourceSha);
+  if (
+    !["ahead", "identical"].includes(String(comparison.status)) ||
+    comparison.merge_base_commit?.sha !== manifest.workflowSha
+  ) {
+    throw new Error("release evidence producer is not on the trusted main verifier lineage");
+  }
+
+  return {
+    producerOnTrustedMainLineage: true,
+    workflowFullRef: expectedFullRef,
+    workflowQualifiedPath: `${runWorkflowPath}@${expectedFullRef}`,
+    workflowRefProof,
+    workflowRefType: "branch",
+    workflowRunPath: runPath,
+  };
+}
+
+function normalizedParentTuple(evidence, identity) {
+  const { manifest, parentRun } = evidence;
+  return {
+    artifact: normalizedManifestArtifact(evidence.artifact, manifest.runAttempt),
+    conclusion: parentRun.conclusion,
+    manifest: evidence.manifestJson,
+    manifestVersion: manifest.version,
+    runAttempt: manifest.runAttempt,
+    runId: manifest.runId,
+    status: parentRun.status,
+    targetSha: manifest.targetSha,
+    url: parentRun.html_url ?? evidence.parentView.url,
+    ...identity,
+    workflowPath: workflowPath(parentRun),
+    workflowRef: manifest.workflowRef,
+    workflowSha: manifest.workflowSha,
+  };
+}
+
+export function resolveVerifierIdentity(
+  sourceSha,
+  verifierSourceContent,
+  repositoryRoot = RELEASE_EVIDENCE_REPO_ROOT,
+) {
+  let normalizedSourceSha = sourceSha ?? process.env.GITHUB_SHA;
+  if (!/^[a-f0-9]{40}$/u.test(String(normalizedSourceSha ?? ""))) {
+    try {
+      normalizedSourceSha = execFileSync("git", ["-C", repositoryRoot, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      normalizedSourceSha = null;
+    }
+  }
+  if (!/^[a-f0-9]{40}$/u.test(String(normalizedSourceSha ?? ""))) {
+    throw new Error("release evidence verifier source SHA is unavailable");
+  }
+  const script = readFileSync(RELEASE_EVIDENCE_FILE);
+  const scriptSha256 = createHash("sha256").update(script).digest("hex");
+  let sourceScript;
+  if (verifierSourceContent !== undefined) {
+    sourceScript = Buffer.from(verifierSourceContent);
+  } else {
+    try {
+      sourceScript = execFileSync(
+        "git",
+        ["-C", repositoryRoot, "show", `${normalizedSourceSha}:${RELEASE_EVIDENCE_SCRIPT}`],
+        {
+          maxBuffer: 16 * 1024 * 1024,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    } catch {
+      throw new Error("release evidence verifier source blob is unavailable");
+    }
+  }
+  const sourceScriptSha256 = createHash("sha256").update(sourceScript).digest("hex");
+  if (scriptSha256 !== sourceScriptSha256) {
+    throw new Error("release evidence verifier script differs from its source SHA");
+  }
+  return {
+    schemaVersion: 3,
+    script: RELEASE_EVIDENCE_SCRIPT,
+    scriptSha256,
+    sourceSha: normalizedSourceSha,
+  };
+}
+
+function validateStrictChildRun({ child, client, parentEvidence, parentJobs, repository, runId }) {
+  const run = client.getRun(runId);
+  const originAttempt = resolveManifestChildOriginAttempt(
+    run,
+    child,
+    parentEvidence.manifest,
+    parentJobs,
+  );
+  if (originAttempt === undefined) {
+    throw new Error(`manifest child dispatch tuple mismatch: ${child.name}`);
+  }
+  const parentJob = selectManifestParentJob(
+    parentJobs,
+    child,
+    parentEvidence.manifest,
+    originAttempt,
+  );
+  validateManifestChildRun(
+    run,
+    child,
+    runId,
+    parentEvidence.manifest,
+    parentJobs,
+    client.getJobLog(parentJob.id),
+    repository,
+  );
+  if (
+    run.repository?.full_name !== repository ||
+    run.status !== "completed" ||
+    run.conclusion !== "success" ||
+    run.head_sha !== parentEvidence.manifest.workflowSha
+  ) {
+    throw new Error(`manifest child run is not exact completed/success evidence: ${child.name}`);
+  }
+  if (child.manifestKey === "productPerformance") {
+    validatePerformanceArtifactOnlyJobs(client.getParentJobs(runId), run.run_attempt);
+  }
+
+  return {
+    conclusion: run.conclusion,
+    dispatchNonce: `full-release-validation-${parentEvidence.manifest.runId}-${originAttempt}${child.suffix}`,
+    displayTitle: run.display_title,
+    event: run.event,
+    headBranch: run.head_branch,
+    parentJobId: String(parentJob.id),
+    path: workflowPath(run),
+    role: child.manifestKey,
+    runAttempt: normalizePositiveInteger(run.run_attempt, `${child.name} run attempt`),
+    runId: String(run.id),
+    sourceParentAttempt: originAttempt,
+    sourceParentRunId: parentEvidence.manifest.runId,
+    status: run.status,
+    url: run.html_url,
+    workflowSha: run.head_sha,
+    ...(child.manifestKey === "productPerformance" ? { reportPublication: "artifact-only" } : {}),
+  };
+}
+
+export function validateReleaseRunEvidence(
+  {
+    manifestPath,
+    repository = DEFAULT_REPO,
+    runId,
+    trustedWorkflowRef = "main",
+    verifierSourceContent,
+    verifierSourceSha,
+  },
+  client,
+) {
+  const normalizedRepository = normalizeRepository(repository);
+  const normalizedRunId = normalizeRequiredRunId(runId, "full release run ID");
+  const normalizedTrustedWorkflowRef = normalizeWorkflowRef(
+    trustedWorkflowRef,
+    "trusted workflow ref",
+  );
+  const evidenceClient = client ?? createReleaseEvidenceClient(normalizedRepository);
+  const verifier = resolveVerifierIdentity(verifierSourceSha, verifierSourceContent);
+  const currentEvidence = loadValidatedParentEvidence({
+    client: evidenceClient,
+    manifestPath,
+    repository: normalizedRepository,
+    runId: normalizedRunId,
+  });
+
+  let rootEvidence = currentEvidence;
+  let selectedEvidence = currentEvidence;
+  const reuse = currentEvidence.manifest.evidenceReuse;
+  if (reuse) {
+    rootEvidence = loadValidatedParentEvidence({
+      client: evidenceClient,
+      repository: normalizedRepository,
+      runId: reuse.runId,
+    });
+    selectedEvidence =
+      reuse.selectedRunId === reuse.runId
+        ? rootEvidence
+        : loadValidatedParentEvidence({
+            client: evidenceClient,
+            repository: normalizedRepository,
+            runId: reuse.selectedRunId,
+          });
+    validateEvidenceReuseChain(
+      currentEvidence.manifest,
+      selectedEvidence.manifest,
+      rootEvidence.manifest,
+    );
+  }
+
+  const producerIdentities = new Map();
+  for (const evidence of [currentEvidence, selectedEvidence, rootEvidence]) {
+    if (!producerIdentities.has(evidence.manifest.runId)) {
+      producerIdentities.set(
+        evidence.manifest.runId,
+        validateTrustedProducerIdentity(
+          evidence,
+          evidenceClient,
+          verifier,
+          normalizedTrustedWorkflowRef,
+        ),
+      );
+    }
+  }
+  const selectedKeys = requiredChildKeysForRerunGroup(rootEvidence.manifest.rerunGroup);
+  const expectedChildren = expectedSelectedChildDispatches(
+    rootEvidence.manifest.runId,
+    rootEvidence.manifest.runAttempt,
+    rootEvidence.manifest.workflowRef,
+    selectedKeys,
+  );
+  const parentJobs = evidenceClient.getParentJobs(rootEvidence.manifest.runId);
+  const children = manifestChildEntries(rootEvidence.manifest, expectedChildren, selectedKeys).map(
+    ({ child, runId: childRunId }) =>
+      validateStrictChildRun({
+        child,
+        client: evidenceClient,
+        parentEvidence: rootEvidence,
+        parentJobs,
+        repository: normalizedRepository,
+        runId: childRunId,
+      }),
+  );
+
+  const current = normalizedParentTuple(
+    currentEvidence,
+    producerIdentities.get(currentEvidence.manifest.runId),
+  );
+  const root = normalizedParentTuple(
+    rootEvidence,
+    producerIdentities.get(rootEvidence.manifest.runId),
+  );
+  const childConclusions = Object.fromEntries(
+    children.map((child) => [child.role, child.conclusion]),
+  );
+  return canonicalJson({
+    children,
+    conclusions: {
+      allRequiredSucceeded: children.every((child) => child.conclusion === "success"),
+      children: childConclusions,
+      current: current.conclusion,
+      root: root.conclusion,
+    },
+    controls: rootEvidence.manifest.controls,
+    current,
+    directRoot: !reuse,
+    evidenceReuse: reuse
+      ? {
+          changedPaths: reuse.changedPaths,
+          evidenceSha: reuse.evidenceSha,
+          policy: reuse.policy,
+          rootRunId: reuse.runId,
+          selectedRunId: reuse.selectedRunId,
+        }
+      : null,
+    manifest: rootEvidence.manifestJson,
+    releaseProfile: rootEvidence.manifest.releaseProfile,
+    repository: normalizedRepository,
+    rerunGroup: rootEvidence.manifest.rerunGroup,
+    root,
+    runReleaseSoak: rootEvidence.manifest.runReleaseSoak === "true",
+    schema: RELEASE_EVIDENCE_SCHEMA,
+    producerOnTrustedMainLineage: true,
+    trustedWorkflowFullRef: trustedWorkflowFullRef(normalizedTrustedWorkflowRef),
+    trustedWorkflowRef: normalizedTrustedWorkflowRef,
+    valid: true,
+    validationInputs: rootEvidence.manifest.validationInputs ?? null,
+    verifier,
+  });
+}
+
+export function parseReleaseCiSummaryArgs(argv) {
+  const options = {
+    json: false,
+    manifestPath: undefined,
+    repository: DEFAULT_REPO,
+    runId: undefined,
+    trustedWorkflowRef: "main",
+    validate: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--validate-run") {
+      options.validate = true;
+      options.runId = argv[++index];
+    } else if (argument === "--repo") {
+      options.repository = argv[++index];
+    } else if (argument === "--manifest") {
+      options.manifestPath = argv[++index];
+    } else if (argument === "--trusted-workflow-ref") {
+      options.trustedWorkflowRef = argv[++index];
+    } else if (argument === "--json") {
+      options.json = true;
+    } else if (!argument.startsWith("-") && !options.runId && !options.validate) {
+      options.runId = argument;
+    } else {
+      throw new Error(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  if (!options.validate && options.manifestPath) {
+    throw new Error("--manifest requires --validate-run");
+  }
+  if (!options.runId) {
+    throw new Error("full release run ID is required");
+  }
+  return options;
+}
+
+function printUsage() {
+  console.error(
+    [
+      "usage: release-ci-summary.mjs <full-release-run-id>",
+      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main] [--manifest path] --json",
+    ].join("\n"),
+  );
+}
+
+function main() {
+  let options;
+  try {
+    options = parseReleaseCiSummaryArgs(process.argv.slice(2));
+  } catch (error) {
+    printUsage();
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+  const { repository, runId } = options;
+
+  if (options.validate) {
+    try {
+      const evidence = validateReleaseRunEvidence({
+        manifestPath: options.manifestPath,
+        repository,
+        runId,
+        trustedWorkflowRef: options.trustedWorkflowRef,
+      });
+      console.log(JSON.stringify(evidence, null, options.json ? 2 : 0));
+    } catch (error) {
+      const failure = {
+        error: error instanceof Error ? error.message : String(error),
+        schema: RELEASE_EVIDENCE_SCHEMA,
+        valid: false,
+      };
+      if (options.json) {
+        console.log(JSON.stringify(failure, null, 2));
+      } else {
+        console.error(failure.error);
+      }
+      process.exit(1);
+    }
+    return;
+  }
+
+  const core = rate();
+  if (core) {
+    const reset = new Date(core.reset * 1000).toISOString();
+    console.log(`rate: remaining=${core.remaining}/${core.limit} reset=${reset}`);
+    if (core.remaining < 20) {
+      console.error("rate too low for CI summary; wait for reset before polling");
+      process.exit(3);
+    }
+  }
+
+  const parent = jsonGh([
+    "run",
+    "view",
+    runId,
+    "--repo",
+    repository,
+    "--json",
+    "status,conclusion,attempt,headBranch,headSha,url,jobs",
+  ]);
+  validateParentRunBinding(parent, githubRestJson(`actions/runs/${runId}`, repository), runId);
+
+  console.log(`parent: ${runId} ${parent.status}/${parent.conclusion || "none"}`);
+  console.log(`workflow-ref: ${parent.headBranch}`);
+  console.log(`workflow-sha: ${parent.headSha}`);
+  console.log(`url: ${parent.url}`);
+
+  for (const job of parent.jobs ?? []) {
+    const marker = job.conclusion || job.status;
+    console.log(`parent-job: ${marker} ${job.name}`);
+  }
+
+  const currentManifestRaw = tryDownloadParentManifest(runId, parent.attempt, repository);
+  let children;
+  if (currentManifestRaw) {
+    const currentManifest = validateParentManifest(currentManifestRaw, {
+      runAttempt: parent.attempt,
+      runId,
+      workflowRef: parent.headBranch,
+      workflowSha: parent.headSha,
+    });
+    console.log(`candidate-sha: ${currentManifest.targetSha}`);
+    console.log(`manifest-run: ${currentManifest.runId}/${currentManifest.runAttempt}`);
+
+    let sourceManifest = currentManifest;
+    let sourceParent = parent;
+    if (currentManifest.evidenceReuse) {
+      const rootRunId = currentManifest.evidenceReuse.runId;
+      const rootParent = jsonGh([
+        "run",
+        "view",
+        rootRunId,
+        "--repo",
+        repository,
+        "--json",
+        "status,conclusion,attempt,headBranch,headSha,url,jobs",
+      ]);
+      validateParentRunBinding(
+        rootParent,
+        githubRestJson(`actions/runs/${rootRunId}`, repository),
+        rootRunId,
+      );
+      if (rootParent.status !== "completed" || rootParent.conclusion !== "success") {
+        throw new Error(`evidence root run is not completed/success: ${rootRunId}`);
+      }
+      const rootManifestRaw = tryDownloadParentManifest(rootRunId, rootParent.attempt, repository);
+      if (!rootManifestRaw) {
+        throw new Error(`evidence root manifest is unavailable: ${rootRunId}`);
+      }
+      const rootManifest = validateParentManifest(rootManifestRaw, {
+        runAttempt: rootParent.attempt,
+        runId: rootRunId,
+        workflowRef: rootParent.headBranch,
+        workflowSha: rootParent.headSha,
+      });
+
+      const selectedRunId = currentManifest.evidenceReuse.selectedRunId;
+      let selectedManifest = rootManifest;
+      if (selectedRunId !== rootRunId) {
+        const selectedParent = jsonGh([
+          "run",
+          "view",
+          selectedRunId,
+          "--repo",
+          repository,
+          "--json",
+          "status,conclusion,attempt,headBranch,headSha,url,jobs",
+        ]);
+        validateParentRunBinding(
+          selectedParent,
+          githubRestJson(`actions/runs/${selectedRunId}`, repository),
+          selectedRunId,
+        );
+        if (selectedParent.status !== "completed" || selectedParent.conclusion !== "success") {
+          throw new Error(`selected evidence run is not completed/success: ${selectedRunId}`);
+        }
+        const selectedManifestRaw = tryDownloadParentManifest(
+          selectedRunId,
+          selectedParent.attempt,
+          repository,
+        );
+        if (!selectedManifestRaw) {
+          throw new Error(`selected evidence manifest is unavailable: ${selectedRunId}`);
+        }
+        selectedManifest = validateParentManifest(selectedManifestRaw, {
+          runAttempt: selectedParent.attempt,
+          runId: selectedRunId,
+          workflowRef: selectedParent.headBranch,
+          workflowSha: selectedParent.headSha,
+        });
+      }
+
+      const evidenceSha = validateEvidenceReuseChain(
+        currentManifest,
+        selectedManifest,
+        rootManifest,
+      );
+      sourceManifest = rootManifest;
+      sourceParent = rootParent;
+      console.log(`evidence-selected-run: ${selectedRunId}`);
+      console.log(`evidence-root-run: ${rootRunId}`);
+      console.log(`evidence-sha: ${evidenceSha}`);
+    }
+
+    const expectedChildren = expectedSelectedChildDispatches(
+      sourceManifest.runId,
+      sourceManifest.runAttempt,
+      sourceManifest.workflowRef,
+      requiredChildKeysForRerunGroup(sourceManifest.rerunGroup),
+    );
+    const sourceParentJobs = findParentJobsAll(sourceManifest.runId, repository);
+    children = manifestChildEntries(
+      sourceManifest,
+      expectedChildren,
+      requiredChildKeysForRerunGroup(sourceManifest.rerunGroup),
+    ).map(({ child, runId: childRunId }) => {
+      const run = githubRestJson(`actions/runs/${childRunId}`, repository);
+      const originAttempt = resolveManifestChildOriginAttempt(
+        run,
+        child,
+        sourceManifest,
+        sourceParentJobs,
+      );
+      if (originAttempt === undefined) {
+        throw new Error(`manifest child dispatch tuple mismatch: ${child.name}`);
+      }
+      const parentJob = selectManifestParentJob(
+        sourceParentJobs,
+        child,
+        sourceManifest,
+        originAttempt,
+      );
+      const validatedRun = validateManifestChildRun(
+        run,
+        child,
+        childRunId,
+        { ...sourceManifest, workflowSha: sourceParent.headSha },
+        sourceParentJobs,
+        parentJobLog(parentJob.id, repository),
+        repository,
+      );
+      if (child.manifestKey === "productPerformance") {
+        validatePerformanceArtifactOnlyJobs(
+          findParentJobsAll(childRunId, repository),
+          run.run_attempt,
+        );
+      }
+      return { child, run: validatedRun };
+    });
+  } else {
+    console.log("candidate-sha: unavailable (release validation manifest not uploaded)");
+    if (parent.status === "completed" && parent.conclusion === "success") {
+      throw new Error("successful parent run is missing its release validation manifest");
+    }
+    const selectedKeys = selectedChildKeys(parent.jobs ?? []);
+    children = expectedSelectedChildDispatches(
+      runId,
+      parent.attempt,
+      parent.headBranch,
+      selectedKeys,
+    )
+      .map((child) => {
+        const run = findExactChildRun(child, repository);
+        if (!run) {
+          console.log(
+            `child-missing: ${child.name} title=${child.displayTitle} branch=${child.headBranch}`,
+          );
+        }
+        return { child, run };
+      })
+      .filter((entry) => entry.run);
+  }
+  if (children.length === 0) {
+    console.log("children: none found yet");
+    return;
+  }
+
+  console.log("children:");
+  for (const { child, run } of children) {
+    console.log(
+      `child: ${run.id} ${child.name} ${run.status}/${run.conclusion || "none"} branch=${run.head_branch} workflow_sha=${run.head_sha}`,
+    );
+    console.log(`child-url: ${run.html_url}`);
+  }
+}
+
+if (process.argv[1]?.endsWith("release-ci-summary.mjs")) {
+  main();
 }

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -60,7 +60,7 @@ on:
           - npm-telegram
           - performance
       reuse_evidence:
-        description: Reuse the newest prior green full validation when the target differs only by release metadata such as changelog and version stamps
+        description: Reuse the newest prior green full validation only for the exact same target SHA and inputs
         required: false
         default: true
         type: boolean
@@ -89,6 +89,11 @@ on:
         required: false
         default: ""
         type: string
+      dispatch_release_evidence:
+        description: Dispatch the validated run to openclaw/releases after child proof succeeds
+        required: false
+        default: false
+        type: boolean
       package_acceptance_package_spec:
         description: Optional published package spec for Package Acceptance; blank uses the SHA-built release artifact
         required: false
@@ -139,10 +144,10 @@ jobs:
       - name: Checkout trusted workflow helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           path: workflow
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Resolve target SHA
@@ -236,7 +241,7 @@ jobs:
   evidence_reuse:
     name: Check for reusable validation evidence
     needs: [resolve_target]
-    if: inputs.rerun_group == 'all' && inputs.reuse_evidence
+    if: inputs.rerun_group == 'all' && inputs.reuse_evidence && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -251,10 +256,10 @@ jobs:
       - name: Checkout trusted workflow helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           path: workflow
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Checkout target SHA
@@ -263,7 +268,7 @@ jobs:
           ref: ${{ needs.resolve_target.outputs.sha }}
           path: target
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Find reusable validation evidence
@@ -319,13 +324,14 @@ jobs:
           EVIDENCE_SHA: ${{ steps.find.outputs.evidence_sha }}
           CHANGED_PATHS: ${{ steps.find.outputs.changed_paths }}
         run: |
+          changed_paths_summary="$(jq -r 'if length == 0 then "none" else join(", ") end' <<< "${CHANGED_PATHS:-[]}")"
           {
             echo "## Validation evidence reuse"
             echo
             if [[ "$REUSE" == "true" ]]; then
               echo "- Reusing evidence: ${EVIDENCE_RUN_URL}"
               echo "- Evidence SHA: \`${EVIDENCE_SHA}\`"
-              echo "- Release-metadata-only delta: \`${CHANGED_PATHS:-none}\`"
+              echo "- Exact-target reuse changed paths: \`${changed_paths_summary}\`"
             else
               echo "- No reusable evidence: ${REUSE_REASON:-unknown}"
             fi
@@ -345,7 +351,7 @@ jobs:
         with:
           ref: ${{ needs.resolve_target.outputs.sha }}
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Verify Docker runtime-assets prune path
         env:
@@ -375,6 +381,7 @@ jobs:
           TARGET_REF: ${{ inputs.ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -383,7 +390,7 @@ jobs:
             local dispatch_run_name="$2"
             shift 2
 
-            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count
+            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count child_head_sha encoded_workflow_ref current_workflow_sha
             gh_with_retry() {
               local output status attempt
               for attempt in 1 2 3 4 5 6; do
@@ -406,6 +413,14 @@ jobs:
               printf '%s\n' "$output" >&2
               return "$status"
             }
+            encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
+            current_workflow_sha="$(
+              gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha
+            )"
+            if [[ "$current_workflow_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
+              return 1
+            fi
             # A failed dispatch POST can still create a run. Never retry it; recover only by exact run name.
             set +e
             dispatch_output="$(gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1)"
@@ -481,6 +496,14 @@ jobs:
               fi
             }
             trap cancel_child EXIT INT TERM
+
+            child_head_sha="$(fetch_child_run_json | jq -r '.head_sha // ""')"
+            if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
+              cancel_child
+              trap - EXIT INT TERM
+              exit 1
+            fi
 
             poll_count=0
             while true; do
@@ -540,6 +563,7 @@ jobs:
           TARGET_REF: ${{ inputs.ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -548,7 +572,7 @@ jobs:
             local dispatch_run_name="$2"
             shift 2
 
-            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count
+            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count child_head_sha encoded_workflow_ref current_workflow_sha
             gh_with_retry() {
               local output status attempt
               for attempt in 1 2 3 4 5 6; do
@@ -571,6 +595,14 @@ jobs:
               printf '%s\n' "$output" >&2
               return "$status"
             }
+            encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
+            current_workflow_sha="$(
+              gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha
+            )"
+            if [[ "$current_workflow_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
+              return 1
+            fi
             # A failed dispatch POST can still create a run. Never retry it; recover only by exact run name.
             set +e
             dispatch_output="$(gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1)"
@@ -647,6 +679,14 @@ jobs:
             }
             trap cancel_child EXIT INT TERM
 
+            child_head_sha="$(fetch_child_run_json | jq -r '.head_sha // ""')"
+            if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
+              cancel_child
+              trap - EXIT INT TERM
+              exit 1
+            fi
+
             poll_count=0
             while true; do
               status="$(fetch_child_run_json | jq -r '.status')"
@@ -705,6 +745,7 @@ jobs:
           TARGET_REF: ${{ inputs.ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
@@ -723,7 +764,7 @@ jobs:
             local dispatch_run_name="$2"
             shift 2
 
-            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count run_json
+            local dispatch_output dispatch_status matches_json match_count run_id status conclusion url poll_count run_json child_head_sha encoded_workflow_ref current_workflow_sha
             gh_with_retry() {
               local output status attempt
               for attempt in 1 2 3 4 5 6; do
@@ -746,6 +787,14 @@ jobs:
               printf '%s\n' "$output" >&2
               return "$status"
             }
+            encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
+            current_workflow_sha="$(
+              gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha
+            )"
+            if [[ "$current_workflow_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
+              return 1
+            fi
             # A failed dispatch POST can still create a run. Never retry it; recover only by exact run name.
             set +e
             dispatch_output="$(gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1)"
@@ -881,6 +930,14 @@ jobs:
             }
             trap cancel_child EXIT INT TERM
 
+            child_head_sha="$(fetch_child_run_json | jq -r '.head_sha // ""')"
+            if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
+              cancel_child
+              trap - EXIT INT TERM
+              exit 1
+            fi
+
             poll_count=0
             while true; do
               status="$(fetch_child_run_json | jq -r '.status')"
@@ -1001,6 +1058,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}
           PROVIDER_MODE: ${{ inputs.npm_telegram_provider_mode }}
@@ -1030,6 +1088,15 @@ jobs:
             printf '%s\n' "$output" >&2
             return "$status"
           }
+
+          encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
+          current_workflow_sha="$(
+            gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha
+          )"
+          if [[ "$current_workflow_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+            echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
+            exit 1
+          fi
 
           args=(-f package_spec="$PACKAGE_SPEC" -f harness_ref="$TARGET_SHA" -f provider_mode="$PROVIDER_MODE")
           if [[ -n "${SCENARIO// }" ]]; then
@@ -1093,6 +1160,14 @@ jobs:
           }
           trap cancel_child EXIT INT TERM
 
+          child_head_sha="$(gh_with_retry run view "$run_id" --json headSha --jq '.headSha // ""')"
+          if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+            echo "::error::npm-telegram-beta-e2e.yml child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
+            cancel_child
+            trap - EXIT INT TERM
+            exit 1
+          fi
+
           fail_fast_failed_jobs() {
             local failed_jobs_json
             failed_jobs_json="$(
@@ -1153,6 +1228,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -1179,6 +1255,15 @@ jobs:
             return "$status"
           }
 
+          encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
+          current_workflow_sha="$(
+            gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha
+          )"
+          if [[ "$current_workflow_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+            echo "::error::Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch." >&2
+            exit 1
+          fi
+
           {
             echo "### Product performance"
             echo
@@ -1187,6 +1272,7 @@ jobs:
             echo "- Repeat: \`3\`"
             echo "- Deep profile: \`false\`"
             echo "- Live OpenAI candidate: \`false\`"
+            echo "- Report publication: disabled (artifacts only)"
             echo "- Release impact: blocking"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -1203,6 +1289,7 @@ jobs:
             -f deep_profile=false \
             -f live_openai_candidate=false \
             -f fail_on_regression=true \
+            -f publish_reports=false \
             -f dispatch_id="$dispatch_id" 2>&1)"
           dispatch_status=$?
           set -e
@@ -1253,6 +1340,14 @@ jobs:
             fi
           }
           trap cancel_child EXIT INT TERM
+
+          child_head_sha="$(gh_with_retry run view "$run_id" --json headSha --jq '.headSha // ""')"
+          if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+            echo "::error::openclaw-performance.yml child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}."
+            cancel_child
+            trap - EXIT INT TERM
+            exit 1
+          fi
 
           poll_count=0
           while true; do
@@ -1319,6 +1414,7 @@ jobs:
           RERUN_GROUP: ${{ inputs.rerun_group }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          PARENT_WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -1409,8 +1505,8 @@ jobs:
             head_sha="$(jq -r '.headSha // ""' <<< "$run_json")"
             echo "${label}: ${status}/${conclusion} attempt ${attempt} head ${head_sha}: ${url}"
 
-            if [[ ( "$CHILD_WORKFLOW_REF" == release-ci/* || "$CHILD_WORKFLOW_REF" =~ ^extended-stable/[0-9]{4}\.([1-9]|1[0-2])\.33$ ) && -n "${TARGET_SHA// }" && "$head_sha" != "$TARGET_SHA" ]]; then
-              echo "::error::${label} child run used ${head_sha}, expected ${TARGET_SHA}. Dispatch Full Release Validation from a release-ci or extended-stable ref pinned to the target SHA, not a moving branch."
+            if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
+              echo "::error::${label} child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}. Use the SHA-pinned release helper when a moving branch cannot stay fixed."
               return 1
             fi
 
@@ -1598,7 +1694,7 @@ jobs:
                 echo
                 echo "- Evidence run: ${EVIDENCE_RUN_URL}"
                 echo "- Evidence SHA: \`${EVIDENCE_SHA}\`"
-                echo "- Target SHA: \`${TARGET_SHA}\` (release-metadata-only delta)"
+                echo "- Target SHA: \`${TARGET_SHA}\` (exact-target evidence reuse)"
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           elif [[ "$RERUN_GROUP" == "all" && "$DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT" != "success" ]]; then
@@ -1679,6 +1775,7 @@ jobs:
           exit "$failed"
 
       - name: Request release evidence update
+        if: ${{ inputs.dispatch_release_evidence }}
         env:
           RELEASES_DISPATCH_TOKEN: ${{ secrets.OPENCLAW_RELEASES_DISPATCH_TOKEN }}
           TARGET_REF: ${{ inputs.ref }}
@@ -1698,7 +1795,7 @@ jobs:
           # so durable evidence must reference that run id, not this wrapper.
           notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE} after child workflows completed; the parent summary re-checks current child run conclusions."
           if [[ "$EVIDENCE_REUSE" == "true" && -n "${EVIDENCE_ROOT_RUN_ID// }" ]]; then
-            notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE}, which reused green evidence from chain-root run ${EVIDENCE_ROOT_RUN_ID}; the release target differs from the validated SHA only by release metadata."
+            notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE}, which reused green evidence from chain-root run ${EVIDENCE_ROOT_RUN_ID} for the exact same target SHA and inputs."
             GITHUB_RUN_ID_VALUE="$EVIDENCE_ROOT_RUN_ID"
           fi
           if [[ -z "${RELEASES_DISPATCH_TOKEN// }" ]]; then
@@ -1778,7 +1875,10 @@ jobs:
           PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}
           PERFORMANCE_CONCLUSION: ${{ needs.performance.outputs.conclusion }}
           EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
+          EVIDENCE_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_run_id }}
           EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
+          EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
+          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths }}
           EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}
@@ -1798,16 +1898,35 @@ jobs:
               --arg runId "$GITHUB_RUN_ID" \
               --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
               --arg workflowRef "$GITHUB_REF_NAME" \
+              --arg workflowSha "$GITHUB_SHA" \
+              --arg workflowFullRef "$GITHUB_REF" \
+              --arg workflowRefType "$GITHUB_REF_TYPE" \
               --arg targetRef "$TARGET_REF" \
               --arg targetSha "$TARGET_SHA" \
+              --arg evidenceRunId "$EVIDENCE_RUN_ID" \
               --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
+              --arg evidenceSha "$EVIDENCE_SHA" \
+              --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
               '. + {
+                version: 3,
                 runId: $runId,
                 runAttempt: $runAttempt,
                 workflowRef: $workflowRef,
+                workflowSha: $workflowSha,
+                workflowFullRef: $workflowFullRef,
+                workflowRefType: $workflowRefType,
                 targetRef: $targetRef,
                 targetSha: $targetSha,
-                evidenceReuse: {runId: $evidenceRootRunId}
+                evidenceReuse: {
+                  policy: "exact-target-full-validation-v1",
+                  runId: $evidenceRootRunId,
+                  selectedRunId: $evidenceRunId,
+                  evidenceSha: $evidenceSha,
+                  changedPaths: $evidenceChangedPaths
+                },
+                controls: ((.controls // {}) + {
+                  performanceReportPublication: "artifact-only"
+                })
               }' <<< "$EVIDENCE_MANIFEST" > "${manifest_dir}/full-release-validation-manifest.json"
             exit 0
           fi
@@ -1816,6 +1935,9 @@ jobs:
             --arg runId "$GITHUB_RUN_ID" \
             --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
             --arg workflowRef "$GITHUB_REF_NAME" \
+            --arg workflowSha "$GITHUB_SHA" \
+            --arg workflowFullRef "$GITHUB_REF" \
+            --arg workflowRefType "$GITHUB_REF_TYPE" \
             --arg targetRef "$TARGET_REF" \
             --arg targetSha "$TARGET_SHA" \
             --arg releaseProfile "$RELEASE_PROFILE" \
@@ -1835,11 +1957,14 @@ jobs:
             --arg packageAcceptancePackageSpec "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \
             --arg codexPluginSpec "$CODEX_PLUGIN_SPEC" \
             '{
-              version: 2,
+              version: 3,
               workflowName: $workflowName,
               runId: $runId,
               runAttempt: $runAttempt,
               workflowRef: $workflowRef,
+              workflowSha: $workflowSha,
+              workflowFullRef: $workflowFullRef,
+              workflowRefType: $workflowRefType,
               targetRef: $targetRef,
               targetSha: $targetSha,
               releaseProfile: $releaseProfile,
@@ -1856,7 +1981,8 @@ jobs:
               },
               controls: {
                 stableSoakRequired: ($releaseProfile == "stable" or $releaseProfile == "full"),
-                performanceBlocking: true
+                performanceBlocking: true,
+                performanceReportPublication: "artifact-only"
               },
               childRuns: {
                 normalCi: $normalCiRunId,
@@ -1875,6 +2001,15 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
+          name: full-release-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-validation
+          if-no-files-found: error
+
+      - name: Upload legacy release validation manifest alias
+        if: ${{ success() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
           name: full-release-validation-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-validation
           if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -15,6 +15,14 @@ on:
         required: false
         default: latest
         type: string
+      root_image_transport:
+        description: Root Dockerfile image transport
+        required: false
+        default: registry
+        type: choice
+        options:
+          - registry
+          - no-push-artifact
   workflow_call:
     inputs:
       ref:
@@ -31,10 +39,16 @@ on:
         required: false
         default: latest
         type: string
+      root_image_transport:
+        description: Root Dockerfile image transport
+        required: false
+        default: registry
+        type: string
 
 permissions:
+  actions: read
   contents: read
-  packages: write
+  packages: read
 
 concurrency:
   group: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && format('{0}-{1}-{2}', github.workflow, github.event_name, github.run_id) || format('{0}-{1}', github.workflow, github.ref) }}
@@ -54,7 +68,42 @@ jobs:
       run_bun_global_install_smoke: ${{ steps.manifest.outputs.run_bun_global_install_smoke }}
       target_sha: ${{ steps.manifest.outputs.target_sha }}
       dockerfile_image: ${{ steps.manifest.outputs.dockerfile_image }}
+      root_image_transport: ${{ steps.manifest.outputs.root_image_transport }}
+      workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
+      workflow_sha: ${{ steps.workflow.outputs.workflow_sha }}
     steps:
+      # github.workflow_sha identifies the caller during workflow_call. Resolve the called
+      # workflow SHA from job context so trusted harness checkouts cannot drift to candidate code.
+      - name: Resolve job workflow identity
+        id: workflow
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+          if (
+            typeof job.workflow_repository !== "string" ||
+            !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(job.workflow_repository)
+          ) {
+            throw new Error("job.workflow_repository must be an owner/repository slug");
+          }
+          if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
+            throw new Error("job.workflow_sha must be a full lowercase commit SHA");
+          }
+          const outputPath = process.env.GITHUB_OUTPUT;
+          if (!outputPath) {
+            throw new Error("GITHUB_OUTPUT is required");
+          }
+          fs.appendFileSync(
+            outputPath,
+            `workflow_repository=${job.workflow_repository}\nworkflow_sha=${job.workflow_sha}\n`,
+          );
+          NODE
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -68,9 +117,12 @@ jobs:
         id: manifest
         env:
           OPENCLAW_CI_EVENT_NAME: ${{ github.event_name }}
+          OPENCLAW_CI_ROOT_IMAGE_TRANSPORT: ${{ inputs.root_image_transport || 'registry' }}
           OPENCLAW_CI_WORKFLOW_BUN_GLOBAL_INSTALL_SMOKE: ${{ inputs.run_bun_global_install_smoke || 'false' }}
         run: |
+          set -euo pipefail
           event_name="${OPENCLAW_CI_EVENT_NAME:-}"
+          root_image_transport="${OPENCLAW_CI_ROOT_IMAGE_TRANSPORT:-registry}"
           workflow_bun_global_install_smoke="${OPENCLAW_CI_WORKFLOW_BUN_GLOBAL_INSTALL_SMOKE:-false}"
           docs_only=false
           run_fast_install_smoke=true
@@ -79,7 +131,18 @@ jobs:
           run_install_smoke=true
           target_sha="$(git rev-parse HEAD)"
           owner="$(printf '%s' "${GITHUB_REPOSITORY_OWNER:-openclaw}" | tr '[:upper:]' '[:lower:]')"
-          dockerfile_image="ghcr.io/${owner}/openclaw-dockerfile-smoke:${target_sha}"
+          case "$root_image_transport" in
+            registry)
+              dockerfile_image="ghcr.io/${owner}/openclaw-dockerfile-smoke:${target_sha}"
+              ;;
+            no-push-artifact)
+              dockerfile_image="openclaw-dockerfile-smoke-local:${target_sha}"
+              ;;
+            *)
+              echo "root_image_transport must be registry or no-push-artifact." >&2
+              exit 1
+              ;;
+          esac
           if [ "$event_name" = "schedule" ]; then
             run_bun_global_install_smoke=true
           elif [ "$event_name" = "workflow_dispatch" ] || [ "$event_name" = "workflow_call" ]; then
@@ -95,6 +158,7 @@ jobs:
             echo "run_bun_global_install_smoke=$run_bun_global_install_smoke"
             echo "target_sha=$target_sha"
             echo "dockerfile_image=$dockerfile_image"
+            echo "root_image_transport=$root_image_transport"
           } >> "$GITHUB_OUTPUT"
 
   install-smoke-fast:
@@ -104,11 +168,12 @@ jobs:
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
       - name: Checkout CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
@@ -210,7 +275,17 @@ jobs:
     needs: [preflight]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
     outputs:
+      archive_sha256: ${{ steps.image_artifact.outputs.archive_sha256 }}
+      artifact_digest: ${{ steps.image_artifact_upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.image_artifact_upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.image_artifact.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.image_artifact.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.image_artifact.outputs.run_id }}
+      image_exists: ${{ steps.existing.outputs.exists }}
       image_ref: ${{ steps.image.outputs.image_ref }}
     env:
       DOCKER_BUILD_SUMMARY: "false"
@@ -219,10 +294,20 @@ jobs:
       - name: Checkout CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Checkout trusted image artifact helper
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          path: .release-harness
           persist-credentials: false
 
       - name: Log in to GHCR
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
@@ -231,6 +316,7 @@ jobs:
 
       - name: Check for existing root Dockerfile smoke image
         id: existing
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         env:
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
         run: |
@@ -244,25 +330,59 @@ jobs:
           fi
 
       - name: Set up Blacksmith Docker Builder
-        if: steps.existing.outputs.exists != 'true'
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
         with:
           max-cache-size-mb: 800000
 
-      # Build once with the matrix extension and publish by target SHA. Use a
-      # direct buildx command so release jobs emit Docker progress and time out.
-      - name: Build and push root Dockerfile smoke image
-        if: steps.existing.outputs.exists != 'true'
+      - name: Build local root Dockerfile smoke image
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
         env:
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
         run: |
           timeout --kill-after=30s 45m docker buildx build \
             --progress=plain \
-            --push \
+            --load \
             --build-arg OPENCLAW_EXTENSIONS=matrix \
             -t "$IMAGE_REF" \
             -f ./Dockerfile \
             .
+
+      - name: Pack root Dockerfile image artifact
+        id: image_artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/install-smoke-root-image"
+          artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            pack "$artifact_dir" install-smoke-root "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+          archive_sha256="$(
+            jq -er '.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
+              "$artifact_dir/shared-image-artifact.json"
+          )"
+          {
+            echo "archive_sha256=$archive_sha256"
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$artifact_dir"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload root Dockerfile image artifact
+        id: image_artifact_upload
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.image_artifact.outputs.artifact_name }}
+          path: ${{ steps.image_artifact.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
 
       - name: Record root image output
         id: image
@@ -273,6 +393,7 @@ jobs:
       - name: Summarize root image
         env:
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
+          ROOT_IMAGE_TRANSPORT: ${{ needs.preflight.outputs.root_image_transport }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
           {
@@ -280,34 +401,29 @@ jobs:
             echo
             echo "- Target SHA: \`${TARGET_SHA}\`"
             echo "- Image: \`${IMAGE_REF}\`"
-            echo "- Reused existing image: \`${{ steps.existing.outputs.exists }}\`"
+            echo "- Transport: \`${ROOT_IMAGE_TRANSPORT}\`"
+            if [[ "$ROOT_IMAGE_TRANSPORT" == "registry" ]]; then
+              echo "- Reused existing image: \`${{ steps.existing.outputs.exists }}\`"
+            else
+              echo "- Artifact: \`${{ steps.image_artifact.outputs.artifact_name }}\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  qr_package_install_smoke:
-    needs: [preflight]
-    if: needs.preflight.outputs.run_full_install_smoke == 'true'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          persist-credentials: false
-
-      - name: Run QR package install smoke
-        env:
-          OPENCLAW_QR_SMOKE_FORCE_INSTALL: "1"
-        run: bash scripts/e2e/qr-import-docker.sh
-
-  root_dockerfile_smokes:
+  push_root_dockerfile_image:
     needs: [preflight, root_dockerfile_image]
-    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    if: needs.preflight.outputs.root_image_transport == 'registry' && needs.root_dockerfile_image.outputs.image_exists != 'true'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Checkout CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
       - name: Log in to GHCR
@@ -317,10 +433,202 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Set up Blacksmith Docker Builder
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        with:
+          max-cache-size-mb: 800000
+
+      # The registry path publishes one matrix-extension image by target SHA.
+      # A direct buildx command keeps progress visible and fails on timeout.
+      - name: Build and push root Dockerfile smoke image
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+        run: |
+          timeout --kill-after=30s 45m docker buildx build \
+            --progress=plain \
+            --push \
+            --build-arg OPENCLAW_EXTENSIONS=matrix \
+            -t "$IMAGE_REF" \
+            -f ./Dockerfile \
+            .
+
+  root_dockerfile_image_ready:
+    needs: [preflight, root_dockerfile_image, push_root_dockerfile_image]
+    if: always() && needs.preflight.result == 'success' && needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Verify root Dockerfile image preparation
+        env:
+          IMAGE_EXISTS: ${{ needs.root_dockerfile_image.outputs.image_exists }}
+          PREPARE_RESULT: ${{ needs.root_dockerfile_image.result }}
+          PUSH_RESULT: ${{ needs.push_root_dockerfile_image.result }}
+          ROOT_IMAGE_TRANSPORT: ${{ needs.preflight.outputs.root_image_transport }}
+        run: |
+          set -euo pipefail
+          if [[ "$PREPARE_RESULT" != "success" ]]; then
+            echo "Root Dockerfile image preparation ended with ${PREPARE_RESULT}." >&2
+            exit 1
+          fi
+          if [[ "$ROOT_IMAGE_TRANSPORT" == "registry" && "$IMAGE_EXISTS" != "true" ]]; then
+            if [[ "$PUSH_RESULT" != "success" ]]; then
+              echo "Root Dockerfile registry image publication ended with ${PUSH_RESULT}." >&2
+              exit 1
+            fi
+          elif [[ "$PUSH_RESULT" != "skipped" ]]; then
+            echo "Unexpected root Dockerfile registry publication result: ${PUSH_RESULT}." >&2
+            exit 1
+          fi
+
+  qr_package_install_smoke:
+    needs: [preflight]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout CLI
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Run QR package install smoke
+        env:
+          OPENCLAW_QR_SMOKE_FORCE_INSTALL: "1"
+        run: bash scripts/e2e/qr-import-docker.sh
+
+  root_dockerfile_smokes:
+    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    env:
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ needs.preflight.outputs.root_image_transport == 'no-push-artifact' && '1' || '0' }}
+    steps:
+      - name: Checkout CLI
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Checkout trusted image artifact helper
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          path: .release-harness
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        if: needs.preflight.outputs.root_image_transport == 'registry'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Pull root Dockerfile smoke image
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: timeout --kill-after=30s 600s docker pull "$IMAGE_REF"
+
+      - name: Validate root Dockerfile image artifact binding
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image archive SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run attempt is missing or invalid." >&2
+            exit 1
+          }
+          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "Root image artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+              echo "Root image artifact producer run attempt does not match the requested tuple." >&2
+              exit 1
+            }
+
+      - name: Download root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-root-image
+          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
+            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+
+      - name: Require local root Dockerfile image
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Run root Dockerfile CLI smoke
         env:
@@ -403,27 +711,39 @@ jobs:
           '
 
   installer_smoke:
-    needs: [preflight, root_dockerfile_image]
+    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ needs.preflight.outputs.root_image_transport == 'no-push-artifact' && '1' || '0' }}
     steps:
       - name: Checkout trusted installer harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
           persist-credentials: false
 
       - name: Checkout candidate CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
           path: candidate
           persist-credentials: false
 
+      - name: Checkout trusted image artifact helper
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          path: .release-harness
+          persist-credentials: false
+
       - name: Log in to GHCR
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
@@ -431,9 +751,107 @@ jobs:
           password: ${{ github.token }}
 
       - name: Pull root Dockerfile smoke image
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: timeout --kill-after=30s 600s docker pull "$IMAGE_REF"
+
+      - name: Validate root Dockerfile image artifact binding
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image archive SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run attempt is missing or invalid." >&2
+            exit 1
+          }
+          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "Root image artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+              echo "Root image artifact producer run attempt does not match the requested tuple." >&2
+              exit 1
+            }
+
+      - name: Download root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-root-image
+          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
+            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+
+      - name: Require local root Dockerfile image
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
@@ -502,17 +920,29 @@ jobs:
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli --version latest --no-onboard && /tmp/openclaw-cli/bin/openclaw --version'
 
   bun_global_install_smoke:
-    needs: [preflight, root_dockerfile_image]
+    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
     if: needs.preflight.outputs.run_full_install_smoke == 'true' && needs.preflight.outputs.run_bun_global_install_smoke == 'true'
     runs-on: ubuntu-24.04
+    env:
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ needs.preflight.outputs.root_image_transport == 'no-push-artifact' && '1' || '0' }}
     steps:
       - name: Checkout CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          persist-credentials: false
+
+      - name: Checkout trusted image artifact helper
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          path: .release-harness
           persist-credentials: false
 
       - name: Log in to GHCR
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
@@ -520,9 +950,107 @@ jobs:
           password: ${{ github.token }}
 
       - name: Pull root Dockerfile smoke image
+        if: needs.preflight.outputs.root_image_transport == 'registry'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: timeout --kill-after=30s 600s docker pull "$IMAGE_REF"
+
+      - name: Validate root Dockerfile image artifact binding
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Root image archive SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Root image artifact run attempt is missing or invalid." >&2
+            exit 1
+          }
+          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "Root image artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+              echo "Root image artifact producer run attempt does not match the requested tuple." >&2
+              exit 1
+            }
+
+      - name: Download root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-root-image
+          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load root Dockerfile image artifact
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
+            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+
+      - name: Require local root Dockerfile image
+        if: needs.preflight.outputs.root_image_transport == 'no-push-artifact'
+        env:
+          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
+        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Setup Node environment for Bun smoke
         uses: ./.github/actions/setup-node-env
@@ -548,7 +1076,7 @@ jobs:
       - name: Checkout CLI
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder

--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -20,8 +20,43 @@ on:
         required: false
         default: ""
         type: string
+      package_artifact_id:
+        description: Immutable GitHub artifact id for package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_artifact_digest:
+        description: GitHub artifact service SHA-256 digest without the sha256 prefix
+        required: false
+        default: ""
+        type: string
+      package_sha256:
+        description: Expected SHA-256 for the OpenClaw package tarball
+        required: false
+        default: ""
+        type: string
       package_artifact_run_id:
-        description: Advanced run id containing package_artifact_name; blank downloads from this run
+        description: Producer run id containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_artifact_run_attempt:
+        description: Producer run attempt containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_file_name:
+        description: Exact OpenClaw tarball filename inside package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_source_sha:
+        description: Exact source commit recorded in the package tarball
+        required: false
+        default: ""
+        type: string
+      package_version:
+        description: Exact OpenClaw package version
         required: false
         default: ""
         type: string
@@ -68,8 +103,43 @@ on:
         required: false
         default: ""
         type: string
+      package_artifact_digest:
+        description: GitHub artifact service SHA-256 digest without the sha256 prefix
+        required: false
+        default: ""
+        type: string
       package_artifact_run_id:
-        description: Optional run id containing package_artifact_name
+        description: Producer run id containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_artifact_run_attempt:
+        description: Producer run attempt containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_artifact_id:
+        description: Immutable GitHub artifact id for package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_sha256:
+        description: Expected SHA-256 for the OpenClaw package tarball
+        required: false
+        default: ""
+        type: string
+      package_file_name:
+        description: Exact OpenClaw tarball filename inside package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_source_sha:
+        description: Exact source commit recorded in the package tarball
+        required: false
+        default: ""
+        type: string
+      package_version:
+        description: Exact OpenClaw package version
         required: false
         default: ""
         type: string
@@ -136,6 +206,7 @@ jobs:
         with:
           ref: ${{ inputs.harness_ref || github.sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
@@ -163,7 +234,15 @@ jobs:
       - name: Validate inputs and secrets
         env:
           PACKAGE_SPEC: ${{ inputs.package_spec }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest || '' }}
+          PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id || '' }}
           PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name || '' }}
+          PACKAGE_ARTIFACT_RUN_ATTEMPT: ${{ inputs.package_artifact_run_attempt || '' }}
+          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id || '' }}
+          PACKAGE_FILE_NAME: ${{ inputs.package_file_name || '' }}
+          PACKAGE_SHA256: ${{ inputs.package_sha256 || '' }}
+          PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha || '' }}
+          PACKAGE_VERSION: ${{ inputs.package_version || '' }}
           PROVIDER_MODE: ${{ inputs.provider_mode }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
@@ -172,11 +251,40 @@ jobs:
         run: |
           set -euo pipefail
 
+          artifact_tuple_present=0
+          for value in \
+            "$PACKAGE_ARTIFACT_DIGEST" \
+            "$PACKAGE_ARTIFACT_ID" \
+            "$PACKAGE_ARTIFACT_NAME" \
+            "$PACKAGE_ARTIFACT_RUN_ATTEMPT" \
+            "$PACKAGE_ARTIFACT_RUN_ID" \
+            "$PACKAGE_FILE_NAME" \
+            "$PACKAGE_SHA256" \
+            "$PACKAGE_SOURCE_SHA" \
+            "$PACKAGE_VERSION"; do
+            if [[ -n "${value// }" ]]; then
+              artifact_tuple_present=1
+            fi
+          done
           if [[ -z "${PACKAGE_ARTIFACT_NAME// }" ]]; then
+            if [[ "$artifact_tuple_present" == "1" ]]; then
+              echo "Artifact-backed Telegram E2E requires all artifact identity fields or none." >&2
+              exit 1
+            fi
             if [[ ! "${PACKAGE_SPEC}" =~ ^openclaw@(alpha|beta|latest|[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*|-(alpha|beta)\.[1-9][0-9]*)?)$ ]]; then
               echo "package_spec must be openclaw@alpha, openclaw@beta, openclaw@latest, or an exact OpenClaw release version; got: ${PACKAGE_SPEC}" >&2
               exit 1
             fi
+          elif [[ ! "$PACKAGE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ||
+                  ! "$PACKAGE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ ||
+                  ! "$PACKAGE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ||
+                  ! "$PACKAGE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ||
+                  ! "$PACKAGE_FILE_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$ ||
+                  ! "$PACKAGE_SHA256" =~ ^[0-9a-f]{64}$ ||
+                  ! "$PACKAGE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ||
+                  -z "${PACKAGE_VERSION// }" ]]; then
+            echo "Artifact-backed Telegram E2E requires the complete immutable artifact and package identity tuple." >&2
+            exit 1
           fi
           case "${PROVIDER_MODE}" in
             mock-openai | live-frontier) ;;
@@ -200,18 +308,65 @@ jobs:
             require_var OPENAI_API_KEY
           fi
 
+      - name: Validate package artifact identity
+        if: inputs.package_artifact_name != ''
+        env:
+          ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ inputs.package_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]] || {
+            echo "Package Telegram artifact name does not bind the declared producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+            echo "Package Telegram artifact identity does not match the requested immutable tuple." >&2
+            exit 1
+          }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+            echo "Package Telegram artifact producer run attempt does not match the requested tuple." >&2
+            exit 1
+          }
+
       - name: Download package-under-test artifact
-        if: inputs.package_artifact_name != '' && inputs.package_artifact_run_id == ''
+        if: inputs.package_artifact_name != '' && inputs.package_artifact_run_id == github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name }}
+          artifact-ids: ${{ inputs.package_artifact_id }}
           path: .artifacts/telegram-package-under-test
+          run-id: ${{ inputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Download package-under-test artifact from release run
-        if: inputs.package_artifact_name != '' && inputs.package_artifact_run_id != ''
+        if: inputs.package_artifact_name != '' && inputs.package_artifact_run_id != github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name }}
+          artifact-ids: ${{ inputs.package_artifact_id }}
           path: .artifacts/telegram-package-under-test
           run-id: ${{ inputs.package_artifact_run_id }}
           github-token: ${{ github.token }}
@@ -234,6 +389,10 @@ jobs:
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           INPUT_SCENARIO: ${{ inputs.scenario }}
           PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name || '' }}
+          PACKAGE_FILE_NAME: ${{ inputs.package_file_name || '' }}
+          PACKAGE_SHA256: ${{ inputs.package_sha256 || '' }}
+          PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha || '' }}
+          PACKAGE_VERSION: ${{ inputs.package_version || '' }}
         run: |
           set -euo pipefail
 
@@ -260,6 +419,11 @@ jobs:
 
           if [[ -n "${PACKAGE_ARTIFACT_NAME// }" ]]; then
             package_dir=".artifacts/telegram-package-under-test"
+            declared_package_tgz="${package_dir}/${PACKAGE_FILE_NAME}"
+            [[ -f "$declared_package_tgz" ]] || {
+              echo "Package Telegram artifact is missing the declared package tarball." >&2
+              exit 1
+            }
             manifest="${package_dir}/preflight-manifest.json"
             if [[ -f "${manifest}" ]]; then
               package_tgz="$(
@@ -367,6 +531,28 @@ jobs:
           }
           NODE
             fi
+            [[ "$(basename "$package_tgz")" == "$PACKAGE_FILE_NAME" ]] || {
+              echo "Package Telegram artifact tarball differs from package_file_name." >&2
+              exit 1
+            }
+            actual_package_sha256="$(sha256sum "$package_tgz" | awk '{print $1}')"
+            if [[ "$actual_package_sha256" != "$PACKAGE_SHA256" ]]; then
+              echo "Package Telegram artifact SHA-256 differs from package_sha256." >&2
+              exit 1
+            fi
+            actual_package_version="$(
+              tar -xOf "$package_tgz" package/package.json |
+                jq -er '.version | select(type == "string" and length > 0)'
+            )"
+            actual_package_source_sha="$(
+              tar -xOf "$package_tgz" package/dist/build-info.json |
+                jq -er '.commit | select(type == "string" and test("^[0-9a-f]{40}$"))'
+            )"
+            [[ "$actual_package_source_sha" == "$PACKAGE_SOURCE_SHA" &&
+              "$actual_package_version" == "$PACKAGE_VERSION" ]] || {
+              echo "Package Telegram artifact source SHA/version differs from the declared identity." >&2
+              exit 1
+            }
             export OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ="${package_tgz}"
             if [[ -z "${OPENCLAW_NPM_TELEGRAM_PACKAGE_LABEL// }" ]]; then
               export OPENCLAW_NPM_TELEGRAM_PACKAGE_LABEL="$(basename "${package_tgz}")"

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -57,12 +57,27 @@ on:
         default: ""
         type: string
       candidate_artifact_name:
-        description: Optional current-run artifact name containing the candidate OpenClaw tarball
+        description: Optional artifact name containing the candidate OpenClaw tarball
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_id:
+        description: Immutable GitHub artifact id for candidate_artifact_name
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_digest:
+        description: Exact upload-artifact SHA-256 digest for candidate_artifact_id
         required: false
         default: ""
         type: string
       candidate_artifact_run_id:
-        description: Optional workflow run id for candidate_artifact_name
+        description: Exact workflow run id that produced candidate_artifact_id
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_run_attempt:
+        description: Exact workflow run attempt that produced candidate_artifact_id
         required: false
         default: ""
         type: string
@@ -78,6 +93,11 @@ on:
         type: string
       candidate_source_sha:
         description: Optional source SHA used to build the candidate tarball
+        required: false
+        default: ""
+        type: string
+      candidate_sha256:
+        description: Exact candidate tarball SHA-256
         required: false
         default: ""
         type: string
@@ -141,12 +161,27 @@ on:
         default: ""
         type: string
       candidate_artifact_name:
-        description: Optional current-run artifact name containing the candidate OpenClaw tarball
+        description: Optional artifact name containing the candidate OpenClaw tarball
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_id:
+        description: Immutable GitHub artifact id for candidate_artifact_name
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_digest:
+        description: Exact upload-artifact SHA-256 digest for candidate_artifact_id
         required: false
         default: ""
         type: string
       candidate_artifact_run_id:
-        description: Optional workflow run id for candidate_artifact_name
+        description: Exact workflow run id that produced candidate_artifact_id
+        required: false
+        default: ""
+        type: string
+      candidate_artifact_run_attempt:
+        description: Exact workflow run attempt that produced candidate_artifact_id
         required: false
         default: ""
         type: string
@@ -162,6 +197,11 @@ on:
         type: string
       candidate_source_sha:
         description: Optional source SHA used to build the candidate tarball
+        required: false
+        default: ""
+        type: string
+      candidate_sha256:
+        description: Exact candidate tarball SHA-256
         required: false
         default: ""
         type: string
@@ -201,9 +241,19 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: ${{ inputs.advisory }}
     outputs:
+      baseline_artifact_digest: ${{ steps.upload_baseline.outputs.artifact-digest }}
+      baseline_artifact_id: ${{ steps.upload_baseline.outputs.artifact-id }}
+      baseline_artifact_run_attempt: ${{ github.run_attempt }}
+      baseline_artifact_run_id: ${{ github.run_id }}
       baseline_file_name: ${{ steps.baseline_metadata.outputs.file_name }}
+      baseline_sha256: ${{ steps.baseline_metadata.outputs.sha256 }}
       baseline_spec: ${{ steps.baseline.outputs.value }}
+      candidate_artifact_digest: ${{ steps.upload_candidate.outputs.artifact-digest }}
+      candidate_artifact_id: ${{ steps.upload_candidate.outputs.artifact-id }}
+      candidate_artifact_run_attempt: ${{ github.run_attempt }}
+      candidate_artifact_run_id: ${{ github.run_id }}
       candidate_file_name: ${{ steps.candidate_metadata.outputs.file_name }}
+      candidate_sha256: ${{ steps.candidate_metadata.outputs.sha256 }}
       candidate_version: ${{ steps.candidate_metadata.outputs.version }}
       matrix: ${{ steps.matrix.outputs.value }}
       source_sha: ${{ steps.candidate_metadata.outputs.source_sha }}
@@ -337,7 +387,75 @@ jobs:
           ref: ${{ steps.workflow_ref.outputs.value }}
           path: workflow
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: Validate provided candidate artifact binding
+        if: inputs.candidate_artifact_name != '' || inputs.candidate_artifact_id != '' || inputs.candidate_artifact_digest != '' || inputs.candidate_artifact_run_id != '' || inputs.candidate_artifact_run_attempt != '' || inputs.candidate_file_name != '' || inputs.candidate_sha256 != '' || inputs.candidate_version != '' || inputs.candidate_source_sha != ''
+        env:
+          ARTIFACT_DIGEST: ${{ inputs.candidate_artifact_digest }}
+          ARTIFACT_ID: ${{ inputs.candidate_artifact_id }}
+          ARTIFACT_NAME: ${{ inputs.candidate_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ inputs.candidate_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ inputs.candidate_artifact_run_id }}
+          CANDIDATE_FILE_NAME: ${{ inputs.candidate_file_name }}
+          CANDIDATE_SHA256: ${{ inputs.candidate_sha256 }}
+          CANDIDATE_SOURCE_SHA: ${{ inputs.candidate_source_sha }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${ARTIFACT_NAME// }" ||
+                ! "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ||
+                ! "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ||
+                ! "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ||
+                ! "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ||
+                -z "${CANDIDATE_FILE_NAME// }" ||
+                ! "$CANDIDATE_SHA256" =~ ^[a-f0-9]{64}$ ||
+                ! "$CANDIDATE_SOURCE_SHA" =~ ^[a-f0-9]{40}$ ||
+                -z "${CANDIDATE_VERSION// }" ]]; then
+            echo "Candidate artifact selection requires the complete immutable artifact and package identity tuple." >&2
+            exit 1
+          fi
+          [[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]] || {
+            echo "Candidate artifact name does not bind the declared producer run attempt." >&2
+            exit 1
+          }
+          if [[ "$INPUT_REF" =~ ^[a-f0-9]{40}$ && "$CANDIDATE_SOURCE_SHA" != "$INPUT_REF" ]]; then
+            echo "Candidate package source SHA does not match the selected exact ref." >&2
+            exit 1
+          fi
+
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "Candidate artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+              echo "Candidate artifact producer run attempt does not match the requested tuple." >&2
+              exit 1
+            }
 
       - name: Checkout public source ref
         if: inputs.candidate_artifact_name == ''
@@ -347,7 +465,7 @@ jobs:
           ref: ${{ inputs.ref }}
           path: source
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
           submodules: recursive
 
       - name: Setup Node.js
@@ -376,72 +494,70 @@ jobs:
             --source-dir source \
             --output-dir "${OUTPUT_DIR}"
 
-      - name: Download current-run candidate artifact
-        if: inputs.candidate_artifact_name != '' && inputs.candidate_artifact_run_id == ''
+      - name: Download provided candidate artifact
+        if: inputs.candidate_artifact_name != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.candidate_artifact_name }}
-          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
-
-      - name: Download previous-run candidate artifact
-        if: inputs.candidate_artifact_name != '' && inputs.candidate_artifact_run_id != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ inputs.candidate_artifact_name }}
+          artifact-ids: ${{ inputs.candidate_artifact_id }}
+          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/input
           run-id: ${{ inputs.candidate_artifact_run_id }}
           github-token: ${{ github.token }}
-          path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
 
-      - name: Capture provided candidate artifact metadata
+      - name: Resolve provided candidate package
         if: inputs.candidate_artifact_name != ''
         env:
-          PACKAGE_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
+          INPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/input
+          OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
           INPUT_CANDIDATE_FILE_NAME: ${{ inputs.candidate_file_name }}
+          INPUT_CANDIDATE_SHA256: ${{ inputs.candidate_sha256 }}
           INPUT_CANDIDATE_VERSION: ${{ inputs.candidate_version }}
           INPUT_CANDIDATE_SOURCE_SHA: ${{ inputs.candidate_source_sha }}
           CANDIDATE_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json
+        shell: bash
         run: |
+          set -euo pipefail
+          node workflow/scripts/resolve-openclaw-package-candidate.mjs \
+            --source artifact \
+            --artifact-dir "$INPUT_DIR" \
+            --package-sha256 "$INPUT_CANDIDATE_SHA256" \
+            --output-dir "$OUTPUT_DIR" \
+            --output-name "$INPUT_CANDIDATE_FILE_NAME" \
+            --metadata "$OUTPUT_DIR/package-candidate.json"
+          actual_sha256="$(
+            jq -er '.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
+              "$OUTPUT_DIR/package-candidate.json"
+          )"
+          actual_source_sha="$(
+            jq -er '.packageSourceSha | select(type == "string" and test("^[a-f0-9]{40}$"))' \
+              "$OUTPUT_DIR/package-candidate.json"
+          )"
+          actual_version="$(
+            jq -er '.version | select(type == "string" and length > 0)' \
+              "$OUTPUT_DIR/package-candidate.json"
+          )"
+          [[ "$actual_sha256" == "$INPUT_CANDIDATE_SHA256" &&
+            "$actual_source_sha" == "$INPUT_CANDIDATE_SOURCE_SHA" &&
+            "$actual_version" == "$INPUT_CANDIDATE_VERSION" ]] || {
+            echo "Resolved candidate package identity differs from the declared exact tuple." >&2
+            exit 1
+          }
+          export ACTUAL_SHA256="$actual_sha256"
+          export ACTUAL_SOURCE_SHA="$actual_source_sha"
+          export ACTUAL_VERSION="$actual_version"
           node <<'NODE'
           const fs = require("node:fs");
-          const path = require("node:path");
-
-          const packageDir = process.env.PACKAGE_DIR;
-          function resolveTarballFileName(value, label) {
-            const fileName = typeof value === "string" ? value.trim() : "";
-            if (
-              !fileName.endsWith(".tgz") ||
-              fileName.includes("\0") ||
-              fileName !== path.basename(fileName) ||
-              fileName !== path.win32.basename(fileName)
-            ) {
-              throw new Error(`${label} must be a local .tgz filename.`);
-            }
-            return fileName;
-          }
-          const requestedFileName = process.env.INPUT_CANDIDATE_FILE_NAME.trim();
-          const files = fs.readdirSync(packageDir).filter((file) => file.endsWith(".tgz"));
-          const selectedCandidateFileName = requestedFileName || (files.length === 1 ? files[0] : "");
-          if (!selectedCandidateFileName) {
-            throw new Error(`Expected exactly one candidate .tgz in ${packageDir}; found ${files.length}.`);
-          }
-          const candidateFileName = resolveTarballFileName(
-            selectedCandidateFileName,
-            "candidate_file_name",
-          );
-          if (!fs.existsSync(path.join(packageDir, candidateFileName))) {
-            throw new Error(`Provided candidate artifact does not contain ${candidateFileName}.`);
-          }
-          const candidateVersion = process.env.INPUT_CANDIDATE_VERSION.trim();
-          if (!candidateVersion) {
-            throw new Error("candidate_version is required when candidate_artifact_name is provided.");
-          }
-          const sourceSha = process.env.INPUT_CANDIDATE_SOURCE_SHA.trim();
-          if (!/^[0-9a-f]{40}$/iu.test(sourceSha)) {
-            throw new Error("candidate_source_sha must be a full commit SHA when candidate_artifact_name is provided.");
-          }
           fs.writeFileSync(
             process.env.CANDIDATE_JSON,
-            `${JSON.stringify({ candidateFileName, candidateVersion, sourceSha }, null, 2)}\n`,
+            `${JSON.stringify(
+              {
+                candidateFileName: process.env.INPUT_CANDIDATE_FILE_NAME,
+                candidateSha256: process.env.ACTUAL_SHA256,
+                candidateVersion: process.env.ACTUAL_VERSION,
+                sourceSha: process.env.ACTUAL_SOURCE_SHA,
+              },
+              null,
+              2,
+            )}\n`,
           );
           NODE
 
@@ -472,13 +588,43 @@ jobs:
         id: candidate_metadata
         env:
           CANDIDATE_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json
+          PACKAGE_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package
         run: |
           node <<'NODE' >>"$GITHUB_OUTPUT"
+          const crypto = require("node:crypto");
           const fs = require("node:fs");
+          const path = require("node:path");
           const payload = JSON.parse(fs.readFileSync(process.env.CANDIDATE_JSON, "utf8"));
-          process.stdout.write(`file_name=${payload.candidateFileName}\n`);
-          process.stdout.write(`version=${payload.candidateVersion}\n`);
-          process.stdout.write(`source_sha=${payload.sourceSha}\n`);
+          const fileName =
+            typeof payload.candidateFileName === "string" ? payload.candidateFileName.trim() : "";
+          const version =
+            typeof payload.candidateVersion === "string" ? payload.candidateVersion.trim() : "";
+          const sourceSha = typeof payload.sourceSha === "string" ? payload.sourceSha.trim() : "";
+          if (
+            !fileName.endsWith(".tgz") ||
+            fileName.includes("\0") ||
+            fileName !== path.basename(fileName) ||
+            fileName !== path.win32.basename(fileName)
+          ) {
+            throw new Error("Candidate manifest file name must be a local .tgz filename.");
+          }
+          if (!version) {
+            throw new Error("Candidate manifest version is missing.");
+          }
+          if (!/^[0-9a-f]{40}$/u.test(sourceSha)) {
+            throw new Error("Candidate manifest source SHA must be a lowercase full commit SHA.");
+          }
+          const tarball = path.join(process.env.PACKAGE_DIR, fileName);
+          const sha256 = crypto.createHash("sha256").update(fs.readFileSync(tarball)).digest("hex");
+          const declaredSha256 =
+            typeof payload.candidateSha256 === "string" ? payload.candidateSha256.trim() : "";
+          if (declaredSha256 && declaredSha256 !== sha256) {
+            throw new Error("Candidate manifest SHA-256 differs from the candidate tarball.");
+          }
+          process.stdout.write(`file_name=${fileName}\n`);
+          process.stdout.write(`sha256=${sha256}\n`);
+          process.stdout.write(`version=${version}\n`);
+          process.stdout.write(`source_sha=${sourceSha}\n`);
           NODE
 
       - name: Capture baseline metadata
@@ -488,6 +634,7 @@ jobs:
           BASELINE_PACK_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline/pack.json
         run: |
           node <<'NODE' >>"$GITHUB_OUTPUT"
+          const crypto = require("node:crypto");
           const fs = require("node:fs");
           const path = require("node:path");
           function resolveTarballFileName(value, label) {
@@ -505,21 +652,28 @@ jobs:
           const payload = JSON.parse(fs.readFileSync(process.env.BASELINE_PACK_JSON, "utf8"));
           const entry = Array.isArray(payload) ? payload.at(-1) : null;
           const fileName = resolveTarballFileName(entry?.filename, "Baseline npm pack filename");
+          const sha256 = crypto
+            .createHash("sha256")
+            .update(fs.readFileSync(path.join(path.dirname(process.env.BASELINE_PACK_JSON), fileName)))
+            .digest("hex");
           process.stdout.write(`file_name=${fileName}\n`);
+          process.stdout.write(`sha256=${sha256}\n`);
           NODE
 
       - name: Upload candidate artifact
+        id: upload_candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}
+          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/package/${{ steps.candidate_metadata.outputs.file_name }}
           if-no-files-found: error
 
       - name: Upload baseline artifact
         if: ${{ inputs.mode != 'fresh' }}
+        id: upload_baseline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: openclaw-cross-os-release-checks-baseline-${{ github.run_id }}
+          name: openclaw-cross-os-release-checks-baseline-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline/${{ steps.baseline_metadata.outputs.file_name }}
           if-no-files-found: error
 
@@ -563,7 +717,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.workflow_ref }}
           path: workflow
           fetch-depth: 1
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -578,20 +732,140 @@ jobs:
           lockfile-path: workflow/pnpm-lock.yaml
           use-actions-cache: "false"
 
+      - name: Validate prepared candidate artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare.outputs.candidate_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare.outputs.candidate_artifact_id }}
+          ARTIFACT_NAME: ${{ format('openclaw-cross-os-release-checks-candidate-{0}-{1}', needs.prepare.outputs.candidate_artifact_run_id, needs.prepare.outputs.candidate_artifact_run_attempt) }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.candidate_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
+          BASELINE_ARTIFACT_DIGEST: ${{ needs.prepare.outputs.baseline_artifact_digest }}
+          BASELINE_ARTIFACT_ID: ${{ needs.prepare.outputs.baseline_artifact_id }}
+          BASELINE_ARTIFACT_NAME: ${{ format('openclaw-cross-os-release-checks-baseline-{0}-{1}', needs.prepare.outputs.baseline_artifact_run_id, needs.prepare.outputs.baseline_artifact_run_attempt) }}
+          BASELINE_ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare.outputs.baseline_artifact_run_attempt }}
+          BASELINE_ARTIFACT_RUN_ID: ${{ needs.prepare.outputs.baseline_artifact_run_id }}
+          BASELINE_SHA256: ${{ needs.prepare.outputs.baseline_sha256 }}
+          CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
+          CANDIDATE_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
+          GH_TOKEN: ${{ github.token }}
+          SUITE: ${{ matrix.suite }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+            "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
+            -n "${ARTIFACT_NAME// }" &&
+            "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
+            "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Prepared candidate artifact binding is incomplete." >&2
+            exit 1
+          }
+          [[ "$CANDIDATE_SHA256" =~ ^[a-f0-9]{64}$ &&
+            "$CANDIDATE_SOURCE_SHA" =~ ^[a-f0-9]{40}$ &&
+            -n "${CANDIDATE_VERSION// }" ]] || {
+            echo "Prepared candidate package identity is incomplete." >&2
+            exit 1
+          }
+          if [[ "$SUITE" == "packaged-upgrade" ]]; then
+            [[ "$BASELINE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+              "$BASELINE_ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ &&
+              -n "${BASELINE_ARTIFACT_NAME// }" &&
+              "$BASELINE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
+              "$BASELINE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
+              "$BASELINE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+              echo "Prepared baseline artifact binding is incomplete." >&2
+              exit 1
+            }
+          fi
+          node <<'NODE'
+          const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+          const repository = process.env.GITHUB_REPOSITORY;
+          const token = process.env.GH_TOKEN;
+          const suite = process.env.SUITE;
+          const tuples = [
+            {
+              digest: process.env.ARTIFACT_DIGEST,
+              id: process.env.ARTIFACT_ID,
+              label: "candidate",
+              name: process.env.ARTIFACT_NAME,
+              runAttempt: process.env.ARTIFACT_RUN_ATTEMPT,
+              runId: process.env.ARTIFACT_RUN_ID,
+            },
+          ];
+          if (suite === "packaged-upgrade") {
+            tuples.push({
+              digest: process.env.BASELINE_ARTIFACT_DIGEST,
+              id: process.env.BASELINE_ARTIFACT_ID,
+              label: "baseline",
+              name: process.env.BASELINE_ARTIFACT_NAME,
+              runAttempt: process.env.BASELINE_ARTIFACT_RUN_ATTEMPT,
+              runId: process.env.BASELINE_ARTIFACT_RUN_ID,
+            });
+          }
+
+          const request = async (path) => {
+            const response = await fetch(`${apiUrl}/repos/${repository}/${path}`, {
+              headers: {
+                Accept: "application/vnd.github+json",
+                Authorization: `Bearer ${token}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+            });
+            if (!response.ok) {
+              throw new Error(`GitHub artifact API ${path} returned ${response.status}.`);
+            }
+            return response.json();
+          };
+
+          async function main() {
+            for (const tuple of tuples) {
+              const artifact = await request(`actions/artifacts/${tuple.id}`);
+              if (
+                String(artifact.id) !== tuple.id ||
+                artifact.name !== tuple.name ||
+                artifact.expired !== false ||
+                artifact.digest !== `sha256:${tuple.digest}` ||
+                String(artifact.workflow_run?.id) !== tuple.runId
+              ) {
+                throw new Error(`Prepared ${tuple.label} artifact identity does not match.`);
+              }
+              const attempt = await request(
+                `actions/runs/${tuple.runId}/attempts/${tuple.runAttempt}`,
+              );
+              if (
+                String(attempt.id) !== tuple.runId ||
+                String(attempt.run_attempt) !== tuple.runAttempt
+              ) {
+                throw new Error(`Prepared ${tuple.label} artifact run attempt does not match.`);
+              }
+            }
+          }
+
+          main().catch((error) => {
+            console.error(error instanceof Error ? error.message : String(error));
+            process.exitCode = 1;
+          });
+          NODE
+
       - name: Download candidate artifact
         id: download_candidate
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}
+          artifact-ids: ${{ needs.prepare.outputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/candidate
+          run-id: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Retry candidate artifact download
         if: ${{ steps.download_candidate.outcome == 'failure' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: openclaw-cross-os-release-checks-candidate-${{ github.run_id }}
+          artifact-ids: ${{ needs.prepare.outputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/candidate
+          run-id: ${{ needs.prepare.outputs.candidate_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Download baseline artifact
         if: ${{ matrix.suite == 'packaged-upgrade' }}
@@ -599,21 +873,27 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: openclaw-cross-os-release-checks-baseline-${{ github.run_id }}
+          artifact-ids: ${{ needs.prepare.outputs.baseline_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline
+          run-id: ${{ needs.prepare.outputs.baseline_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Retry baseline artifact download
         if: ${{ matrix.suite == 'packaged-upgrade' && steps.download_baseline.outcome == 'failure' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: openclaw-cross-os-release-checks-baseline-${{ github.run_id }}
+          artifact-ids: ${{ needs.prepare.outputs.baseline_artifact_id }}
           path: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline
+          run-id: ${{ needs.prepare.outputs.baseline_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Verify release-check inputs
         shell: bash
         env:
           CANDIDATE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/candidate/${{ needs.prepare.outputs.candidate_file_name }}
+          EXPECTED_CANDIDATE_SHA256: ${{ needs.prepare.outputs.candidate_sha256 }}
           BASELINE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline/${{ needs.prepare.outputs.baseline_file_name }}
+          EXPECTED_BASELINE_SHA256: ${{ needs.prepare.outputs.baseline_sha256 }}
           OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
           SUITE: ${{ matrix.suite }}
         run: |
@@ -622,9 +902,39 @@ jobs:
             echo "::error::candidate artifact missing: ${CANDIDATE_TGZ}"
             exit 1
           fi
+          actual_sha256="$(
+            node -e '
+              const crypto = require("node:crypto");
+              const fs = require("node:fs");
+              process.stdout.write(
+                crypto.createHash("sha256").update(fs.readFileSync(process.env.CANDIDATE_TGZ)).digest("hex"),
+              );
+            '
+          )"
+          if [[ ! "$EXPECTED_CANDIDATE_SHA256" =~ ^[a-f0-9]{64}$ ||
+                "$actual_sha256" != "$EXPECTED_CANDIDATE_SHA256" ]]; then
+            echo "::error::candidate artifact SHA-256 does not match the prepared package identity"
+            exit 1
+          fi
           if [[ "${SUITE}" == "packaged-upgrade" ]] && [[ ! -f "${BASELINE_TGZ}" ]]; then
             echo "::error::baseline artifact missing: ${BASELINE_TGZ}"
             exit 1
+          fi
+          if [[ "${SUITE}" == "packaged-upgrade" ]]; then
+            actual_baseline_sha256="$(
+              node -e '
+                const crypto = require("node:crypto");
+                const fs = require("node:fs");
+                process.stdout.write(
+                  crypto.createHash("sha256").update(fs.readFileSync(process.env.BASELINE_TGZ)).digest("hex"),
+                );
+              '
+            )"
+            if [[ ! "$EXPECTED_BASELINE_SHA256" =~ ^[a-f0-9]{64}$ ||
+                  "$actual_baseline_sha256" != "$EXPECTED_BASELINE_SHA256" ]]; then
+              echo "::error::baseline artifact SHA-256 does not match the prepared package identity"
+              exit 1
+            fi
           fi
 
       - name: Run cross-OS release checks

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -48,15 +48,19 @@ on:
         required: false
         default: ""
         type: string
-      package_artifact_name:
-        description: Existing workflow artifact containing openclaw-current.tgz; blank packs the selected ref
+      shared_image_policy:
+        description: Shared Docker image transport
+        required: true
+        default: allow-push
+        type: choice
+        options:
+          - allow-push
+          - existing-only
+          - no-push-artifact
+      shared_image_artifact_namespace:
+        description: Safe unique artifact namespace when shared_image_policy=no-push-artifact
         required: false
-        default: ""
-        type: string
-      package_artifact_run_id:
-        description: Prior run id containing package_artifact_name; blank uses this run or packs the selected ref
-        required: false
-        default: ""
+        default: direct
         type: string
       docker_e2e_bare_image:
         description: Existing bare Docker E2E image to reuse; blank derives from package SHA/ref
@@ -178,10 +182,55 @@ on:
         required: false
         default: ""
         type: string
-      package_artifact_run_id:
-        description: Prior run id containing package_artifact_name; blank uses this run or packs the selected ref
+      package_artifact_id:
+        description: Immutable GitHub artifact id for package_artifact_name
         required: false
         default: ""
+        type: string
+      package_artifact_digest:
+        description: GitHub artifact service SHA-256 digest without the sha256 prefix
+        required: false
+        default: ""
+        type: string
+      package_artifact_run_id:
+        description: Producer run id containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_artifact_run_attempt:
+        description: Producer run attempt containing package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_file_name:
+        description: Exact package tarball filename inside package_artifact_name
+        required: false
+        default: ""
+        type: string
+      package_source_sha:
+        description: Exact source commit recorded in the package tarball
+        required: false
+        default: ""
+        type: string
+      package_sha256:
+        description: Exact root OpenClaw package SHA-256 for no-push image artifacts
+        required: false
+        default: ""
+        type: string
+      package_version:
+        description: Exact OpenClaw package version for no-push image artifacts
+        required: false
+        default: ""
+        type: string
+      shared_image_policy:
+        description: "Shared Docker image transport: allow-push, existing-only, or no-push-artifact"
+        required: false
+        default: allow-push
+        type: string
+      shared_image_artifact_namespace:
+        description: Safe unique artifact namespace when shared_image_policy=no-push-artifact
+        required: false
+        default: direct
         type: string
       docker_e2e_bare_image:
         description: Existing bare Docker E2E image to reuse; blank derives from package SHA/ref
@@ -323,8 +372,9 @@ on:
         required: false
 
 permissions:
+  actions: read
   contents: read
-  packages: write
+  packages: read
   pull-requests: read
 
 env:
@@ -337,7 +387,41 @@ jobs:
     outputs:
       selected_sha: ${{ steps.validate.outputs.selected_sha }}
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
+      workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
+      workflow_sha: ${{ steps.workflow.outputs.workflow_sha }}
     steps:
+      # github.workflow_sha identifies the caller during workflow_call. Resolve the called
+      # workflow SHA from job context so trusted harness checkouts cannot drift to candidate code.
+      - name: Resolve job workflow identity
+        id: workflow
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+          if (
+            typeof job.workflow_repository !== "string" ||
+            !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(job.workflow_repository)
+          ) {
+            throw new Error("job.workflow_repository must be an owner/repository slug");
+          }
+          if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
+            throw new Error("job.workflow_sha must be a full lowercase commit SHA");
+          }
+          const outputPath = process.env.GITHUB_OUTPUT;
+          if (!outputPath) {
+            throw new Error("GITHUB_OUTPUT is required");
+          }
+          fs.appendFileSync(
+            outputPath,
+            `workflow_repository=${job.workflow_repository}\nworkflow_sha=${job.workflow_sha}\n`,
+          );
+          NODE
+
       - name: Checkout workflow repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -347,6 +431,19 @@ jobs:
         id: validate
         env:
           INPUT_REF: ${{ inputs.ref }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          PACKAGE_ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_RUN_ATTEMPT: ${{ inputs.package_artifact_run_attempt }}
+          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+          PACKAGE_FILE_NAME: ${{ inputs.package_file_name }}
+          PACKAGE_SHA256: ${{ inputs.package_sha256 }}
+          PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha }}
+          PACKAGE_VERSION: ${{ inputs.package_version }}
+          PROVIDED_BARE_IMAGE: ${{ inputs.docker_e2e_bare_image }}
+          PROVIDED_FUNCTIONAL_IMAGE: ${{ inputs.docker_e2e_functional_image }}
+          SHARED_IMAGE_ARTIFACT_NAMESPACE: ${{ inputs.shared_image_artifact_namespace }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         shell: bash
         run: |
           set -euo pipefail
@@ -373,6 +470,69 @@ jobs:
             echo "Allowed refs must be reachable from an OpenClaw branch or release tag." >&2
             exit 1
           fi
+
+          package_tuple_present=0
+          for value in \
+            "$PACKAGE_ARTIFACT_DIGEST" \
+            "$PACKAGE_ARTIFACT_ID" \
+            "$PACKAGE_ARTIFACT_NAME" \
+            "$PACKAGE_ARTIFACT_RUN_ATTEMPT" \
+            "$PACKAGE_ARTIFACT_RUN_ID" \
+            "$PACKAGE_FILE_NAME" \
+            "$PACKAGE_SHA256" \
+            "$PACKAGE_SOURCE_SHA" \
+            "$PACKAGE_VERSION"; do
+            if [[ -n "${value// }" ]]; then
+              package_tuple_present=1
+            fi
+          done
+          if [[ "$package_tuple_present" == "1" ]]; then
+            [[ "$PACKAGE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ &&
+              "$PACKAGE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+              -n "${PACKAGE_ARTIFACT_NAME// }" &&
+              "$PACKAGE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
+              "$PACKAGE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
+              "$PACKAGE_FILE_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$ &&
+              "$PACKAGE_SHA256" =~ ^[0-9a-f]{64}$ &&
+              "$PACKAGE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ &&
+              -n "${PACKAGE_VERSION// }" ]] || {
+              echo "Package artifact selection requires the complete immutable artifact and package identity tuple." >&2
+              exit 1
+            }
+            [[ "$PACKAGE_SOURCE_SHA" == "$selected_sha" ]] || {
+              echo "Package source SHA differs from the selected release SHA." >&2
+              exit 1
+            }
+          fi
+
+          case "$SHARED_IMAGE_POLICY" in
+            allow-push)
+              ;;
+            existing-only)
+              if [[ -z "${PROVIDED_BARE_IMAGE// }" && -z "${PROVIDED_FUNCTIONAL_IMAGE// }" ]]; then
+                echo "shared_image_policy=existing-only requires explicit shared image refs." >&2
+                exit 1
+              fi
+              ;;
+            no-push-artifact)
+              [[ "$INPUT_REF" =~ ^[0-9a-f]{40}$ && "$INPUT_REF" == "$selected_sha" ]] || {
+                echo "shared_image_policy=no-push-artifact requires ref to be the exact lowercase target SHA." >&2
+                exit 1
+              }
+              [[ "$SHARED_IMAGE_ARTIFACT_NAMESPACE" =~ ^[a-z0-9][a-z0-9-]{0,47}$ ]] || {
+                echo "shared_image_artifact_namespace must be a lowercase slug up to 48 characters." >&2
+                exit 1
+              }
+              [[ -z "${PROVIDED_BARE_IMAGE// }" && -z "${PROVIDED_FUNCTIONAL_IMAGE// }" ]] || {
+                echo "shared_image_policy=no-push-artifact builds local image artifacts and rejects provided images." >&2
+                exit 1
+              }
+              ;;
+            *)
+              echo "shared_image_policy must be allow-push, existing-only, or no-push-artifact." >&2
+              exit 1
+              ;;
+          esac
 
           echo "selected_sha=$selected_sha" >> "$GITHUB_OUTPUT"
           echo "trusted_reason=$trusted_reason" >> "$GITHUB_OUTPUT"
@@ -513,7 +673,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
 
       - name: Plan release workflow matrices
@@ -756,7 +917,13 @@ jobs:
           fi
 
   validate_docker_e2e:
-    needs: [validate_selected_ref, prepare_docker_e2e_image, plan_release_workflow_matrices]
+    needs:
+      [
+        validate_selected_ref,
+        prepare_docker_e2e_image,
+        docker_e2e_image_ready,
+        plan_release_workflow_matrices,
+      ]
     if: inputs.include_release_path_suites && inputs.docker_lanes == '' && needs.plan_release_workflow_matrices.outputs.docker_e2e_count != '0'
     name: Docker E2E (${{ matrix.label }})
     continue-on-error: ${{ inputs.advisory }}
@@ -824,6 +991,7 @@ jobs:
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: ${{ inputs.published_upgrade_survivor_baseline }}
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: ${{ inputs.published_upgrade_survivor_baselines }}
       OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
       INCLUDE_OPENWEBUI: ${{ inputs.include_openwebui }}
       DOCKER_E2E_CHUNK: ${{ matrix.chunk_id }}
@@ -841,12 +1009,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
 
       - name: Log in to GHCR for shared Docker E2E image
-        if: contains(matrix.profiles, inputs.release_test_profile)
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -893,18 +1062,74 @@ jobs:
         if: contains(matrix.profiles, inputs.release_test_profile) && steps.plan.outputs.needs_package == '1'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate Docker E2E image artifact binding
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Docker E2E image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download Docker E2E image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          path: .artifacts/docker-e2e-images
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load Docker E2E image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
+          FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
+          NEEDS_BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_bare_image }}
+          NEEDS_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_functional_image }}
+          PACKAGE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.package_sha256 }}
+          ARCHIVE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.image_archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          images=()
+          if [[ "$NEEDS_BARE_IMAGE" == "1" ]]; then
+            images+=("$BARE_IMAGE")
+          fi
+          if [[ "$NEEDS_FUNCTIONAL_IMAGE" == "1" ]]; then
+            images+=("$FUNCTIONAL_IMAGE")
+          fi
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/docker-e2e-images docker-e2e "$TARGET_SHA" "$WORKFLOW_SHA" "${images[@]}"
 
       - name: Pull shared bare Docker E2E image
-        if: contains(matrix.profiles, inputs.release_test_profile) && steps.plan.outputs.needs_bare_image == '1'
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_bare_image == '1'
         shell: bash
         run: |
           set -euo pipefail
           bash .release-harness/scripts/ci-docker-pull-retry.sh "${OPENCLAW_DOCKER_E2E_BARE_IMAGE}"
 
       - name: Pull shared functional Docker E2E image
-        if: contains(matrix.profiles, inputs.release_test_profile) && steps.plan.outputs.needs_functional_image == '1'
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_functional_image == '1'
         shell: bash
         run: |
           set -euo pipefail
@@ -1003,7 +1228,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
 
       - name: Build targeted Docker lane groups
@@ -1019,7 +1245,13 @@ jobs:
           echo "groups_json=${groups_json}" >> "$GITHUB_OUTPUT"
 
   validate_docker_lanes:
-    needs: [validate_selected_ref, prepare_docker_e2e_image, plan_docker_lane_groups]
+    needs:
+      [
+        validate_selected_ref,
+        prepare_docker_e2e_image,
+        docker_e2e_image_ready,
+        plan_docker_lane_groups,
+      ]
     if: inputs.docker_lanes != ''
     name: Docker E2E targeted lanes (${{ matrix.group.label }})
     continue-on-error: ${{ inputs.advisory }}
@@ -1087,6 +1319,7 @@ jobs:
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: ${{ inputs.published_upgrade_survivor_baseline }}
       OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: ${{ matrix.group.published_upgrade_survivor_baselines || inputs.published_upgrade_survivor_baselines }}
       OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
       INCLUDE_OPENWEBUI: ${{ inputs.include_openwebui }}
       DOCKER_E2E_LANES: ${{ matrix.group.docker_lanes }}
@@ -1102,11 +1335,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
 
       - name: Log in to GHCR for shared Docker E2E image
+        if: inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -1154,18 +1389,74 @@ jobs:
         if: steps.plan.outputs.needs_package == '1'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate Docker E2E image artifact binding
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Docker E2E image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          path: .artifacts/docker-e2e-images
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
+          FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
+          NEEDS_BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_bare_image }}
+          NEEDS_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_functional_image }}
+          PACKAGE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.package_sha256 }}
+          ARCHIVE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.image_archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          images=()
+          if [[ "$NEEDS_BARE_IMAGE" == "1" ]]; then
+            images+=("$BARE_IMAGE")
+          fi
+          if [[ "$NEEDS_FUNCTIONAL_IMAGE" == "1" ]]; then
+            images+=("$FUNCTIONAL_IMAGE")
+          fi
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/docker-e2e-images docker-e2e "$TARGET_SHA" "$WORKFLOW_SHA" "${images[@]}"
 
       - name: Pull shared bare Docker E2E image
-        if: steps.plan.outputs.needs_bare_image == '1'
+        if: inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_bare_image == '1'
         shell: bash
         run: |
           set -euo pipefail
           bash .release-harness/scripts/ci-docker-pull-retry.sh "${OPENCLAW_DOCKER_E2E_BARE_IMAGE}"
 
       - name: Pull shared functional Docker E2E image
-        if: steps.plan.outputs.needs_functional_image == '1'
+        if: inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_functional_image == '1'
         shell: bash
         run: |
           set -euo pipefail
@@ -1211,17 +1502,20 @@ jobs:
 
       - name: Run targeted Docker E2E lanes
         shell: bash
+        env:
+          ARTIFACT_SUFFIX: ${{ steps.plan.outputs.artifact_suffix }}
+          INCLUDE_RELEASE_PATH_SUITES: ${{ inputs.include_release_path_suites }}
         run: |
           set -euo pipefail
           export OPENCLAW_DOCKER_ALL_LANES="${DOCKER_E2E_LANES}"
           export OPENCLAW_DOCKER_ALL_PREFLIGHT=0
           export OPENCLAW_DOCKER_ALL_FAIL_FAST=0
           export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${INCLUDE_OPENWEBUI}"
-          if [[ "${{ inputs.include_release_path_suites }}" == "true" ]]; then
+          if [[ "$INCLUDE_RELEASE_PATH_SUITES" == "true" ]]; then
             export OPENCLAW_DOCKER_ALL_PROFILE=release-path
           fi
-          export OPENCLAW_DOCKER_ALL_LOG_DIR=".artifacts/docker-tests/targeted-${{ steps.plan.outputs.artifact_suffix }}"
-          export OPENCLAW_DOCKER_ALL_TIMINGS_FILE=".artifacts/docker-tests/targeted-${{ steps.plan.outputs.artifact_suffix }}-timings.json"
+          export OPENCLAW_DOCKER_ALL_LOG_DIR=".artifacts/docker-tests/targeted-${ARTIFACT_SUFFIX}"
+          export OPENCLAW_DOCKER_ALL_TIMINGS_FILE=".artifacts/docker-tests/targeted-${ARTIFACT_SUFFIX}-timings.json"
           export OPENCLAW_DOCKER_ALL_PNPM_COMMAND="$(command -v pnpm)"
           if [[ "${{ steps.plan.outputs.needs_live_image }}" == "1" ]]; then
             OPENCLAW_DOCKER_BUILD_ON_MISSING=1 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" bash .release-harness/scripts/test-live-build-docker.sh
@@ -1251,7 +1545,7 @@ jobs:
           if-no-files-found: error
 
   validate_docker_openwebui:
-    needs: [validate_selected_ref, prepare_docker_e2e_image]
+    needs: [validate_selected_ref, prepare_docker_e2e_image, docker_e2e_image_ready]
     if: inputs.include_openwebui && inputs.docker_lanes == '' && (inputs.release_test_profile == 'stable' || inputs.release_test_profile == 'full')
     name: Docker E2E (openwebui)
     continue-on-error: ${{ inputs.advisory }}
@@ -1267,22 +1561,27 @@ jobs:
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_CURRENT_PACKAGE_TGZ: .artifacts/docker-e2e-package/openclaw-current.tgz
       OPENCLAW_DOCKER_ALL_RELEASE_PROFILE: ${{ inputs.release_test_profile }}
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
     steps:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
 
       - name: Checkout trusted release harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
+          persist-credentials: false
 
       - name: Log in to GHCR for shared Docker E2E image
+        if: inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -1324,18 +1623,74 @@ jobs:
         if: steps.plan.outputs.needs_package == '1'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate Docker E2E image artifact binding
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Docker E2E image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}
+          path: .artifacts/docker-e2e-images
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && needs.prepare_docker_e2e_image.outputs.needs_e2e_image == '1'
+        env:
+          BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
+          FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
+          NEEDS_BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_bare_image }}
+          NEEDS_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.needs_functional_image }}
+          PACKAGE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.package_sha256 }}
+          ARCHIVE_SHA256: ${{ needs.prepare_docker_e2e_image.outputs.image_archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          images=()
+          if [[ "$NEEDS_BARE_IMAGE" == "1" ]]; then
+            images+=("$BARE_IMAGE")
+          fi
+          if [[ "$NEEDS_FUNCTIONAL_IMAGE" == "1" ]]; then
+            images+=("$FUNCTIONAL_IMAGE")
+          fi
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/docker-e2e-images docker-e2e "$TARGET_SHA" "$WORKFLOW_SHA" "${images[@]}"
 
       - name: Pull shared bare Docker E2E image
-        if: steps.plan.outputs.needs_bare_image == '1'
+        if: inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_bare_image == '1'
         shell: bash
         run: |
           set -euo pipefail
           bash .release-harness/scripts/ci-docker-pull-retry.sh "${OPENCLAW_DOCKER_E2E_BARE_IMAGE}"
 
       - name: Pull shared functional Docker E2E image
-        if: steps.plan.outputs.needs_functional_image == '1'
+        if: inputs.shared_image_policy != 'no-push-artifact' && steps.plan.outputs.needs_functional_image == '1'
         shell: bash
         run: |
           set -euo pipefail
@@ -1389,7 +1744,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
     outputs:
       image: ${{ steps.image.outputs.image }}
       bare_image: ${{ steps.image.outputs.bare_image }}
@@ -1399,6 +1754,24 @@ jobs:
       needs_functional_image: ${{ steps.plan.outputs.needs_functional_image }}
       needs_live_image: ${{ steps.plan.outputs.needs_live_image }}
       needs_package: ${{ steps.plan.outputs.needs_package }}
+      bare_exists: ${{ steps.image_exists.outputs.bare_exists }}
+      functional_exists: ${{ steps.image_exists.outputs.functional_exists }}
+      needs_registry_build: ${{ steps.image_exists.outputs.needs_build }}
+      package_sha256: ${{ steps.package.outputs.sha256 }}
+      package_version: ${{ steps.package.outputs.version }}
+      package_artifact_name: ${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || inputs.package_artifact_name }}
+      package_artifact_id: ${{ steps.upload_package.outputs.artifact-id || inputs.package_artifact_id }}
+      package_artifact_digest: ${{ steps.upload_package.outputs.artifact-digest || steps.input_package_artifact.outputs.artifact_digest }}
+      package_artifact_run_id: ${{ steps.upload_package.outputs.artifact-id && github.run_id || steps.input_package_artifact.outputs.run_id }}
+      package_artifact_run_attempt: ${{ steps.upload_package.outputs.artifact-id && github.run_attempt || steps.input_package_artifact.outputs.run_attempt }}
+      package_file_name: ${{ steps.package.outputs.file_name }}
+      package_source_sha: ${{ steps.package.outputs.source_sha }}
+      image_artifact_name: ${{ steps.image_artifact.outputs.artifact_name }}
+      image_archive_sha256: ${{ steps.image_artifact.outputs.archive_sha256 }}
+      image_artifact_id: ${{ steps.upload_image_artifact.outputs.artifact-id }}
+      image_artifact_digest: ${{ steps.upload_image_artifact.outputs.artifact-digest }}
+      image_artifact_run_id: ${{ github.run_id }}
+      image_artifact_run_attempt: ${{ github.run_attempt }}
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -1409,13 +1782,16 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout trusted release harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
+          persist-credentials: false
 
       - name: Plan Docker E2E images
         id: plan
@@ -1455,18 +1831,79 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
+      - name: Validate OpenClaw package artifact identity
+        id: input_package_artifact
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
+        env:
+          ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
+          ARTIFACT_ID: ${{ inputs.package_artifact_id }}
+          ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ inputs.package_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ &&
+            "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
+            -n "${ARTIFACT_NAME// }" &&
+            "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
+            "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "OpenClaw package artifact identity tuple is incomplete." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]] || {
+            echo "OpenClaw package artifact name does not bind the declared producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "OpenClaw package artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+            echo "OpenClaw package artifact producer run attempt does not match the requested tuple." >&2
+            exit 1
+          }
+          {
+            echo "artifact_digest=$ARTIFACT_DIGEST"
+            echo "run_id=$ARTIFACT_RUN_ID"
+            echo "run_attempt=$ARTIFACT_RUN_ATTEMPT"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Download current-run OpenClaw Docker E2E package
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name != '' && inputs.package_artifact_run_id == ''
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != '' && inputs.package_artifact_run_id == github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name }}
+          artifact-ids: ${{ inputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
+          run-id: ${{ inputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Download previous-run OpenClaw Docker E2E package
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_run_id != ''
+        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != '' && inputs.package_artifact_run_id != github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+          artifact-ids: ${{ inputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
           run-id: ${{ inputs.package_artifact_run_id }}
           github-token: ${{ github.token }}
@@ -1484,11 +1921,33 @@ jobs:
       - name: Validate OpenClaw Docker E2E package
         id: package
         if: steps.plan.outputs.needs_package == '1'
+        env:
+          EXPECTED_PACKAGE_FILE_NAME: ${{ inputs.package_file_name }}
+          EXPECTED_PACKAGE_SHA256: ${{ inputs.package_sha256 }}
+          EXPECTED_PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha }}
+          EXPECTED_PACKAGE_VERSION: ${{ inputs.package_version }}
+          SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p .artifacts/docker-e2e-package
           target=".artifacts/docker-e2e-package/openclaw-current.tgz"
+          if [[ -n "${EXPECTED_PACKAGE_FILE_NAME// }" ]]; then
+            input_target=".artifacts/docker-e2e-package/${EXPECTED_PACKAGE_FILE_NAME}"
+            [[ -f "$input_target" ]] || {
+              echo "Declared package tarball is missing from the selected artifact." >&2
+              exit 1
+            }
+            input_digest="$(sha256sum "$input_target" | awk '{print $1}')"
+            [[ "$input_digest" == "$EXPECTED_PACKAGE_SHA256" ]] || {
+              echo "Declared package tarball SHA-256 differs from package_sha256." >&2
+              exit 1
+            }
+            if [[ "$input_target" != "$target" ]]; then
+              cp "$input_target" "$target"
+            fi
+          fi
           if [[ ! -f "$target" ]]; then
             mapfile -t tgzs < <(find .artifacts/docker-e2e-package -type f -name '*.tgz' | sort)
             if [[ "${#tgzs[@]}" -ne 1 ]]; then
@@ -1504,8 +1963,56 @@ jobs:
           finished_at="$(date +%s)"
           echo "Docker E2E package tarball validation finished in $((finished_at - started_at))s."
           digest="$(sha256sum "$target" | awk '{print $1}')"
+          version="$(tar -xOf "$target" package/package.json | jq -r '.version')"
+          name="$(tar -xOf "$target" package/package.json | jq -r '.name')"
+          package_source_sha="$(
+            tar -xOf "$target" package/dist/build-info.json |
+              jq -er '.commit | select(type == "string" and test("^[0-9a-f]{40}$"))'
+          )"
+          if [[ -n "${EXPECTED_PACKAGE_SOURCE_SHA// }" ]]; then
+            [[ "$digest" == "$EXPECTED_PACKAGE_SHA256" &&
+              "$name" == "openclaw" &&
+              "$package_source_sha" == "$EXPECTED_PACKAGE_SOURCE_SHA" &&
+              "$version" == "$EXPECTED_PACKAGE_VERSION" ]] || {
+              echo "Resolved package identity differs from the declared immutable tuple." >&2
+              exit 1
+            }
+          fi
+          if [[ "$SHARED_IMAGE_POLICY" == "no-push-artifact" ]]; then
+            if [[ -n "$EXPECTED_PACKAGE_SHA256" && "$digest" != "$EXPECTED_PACKAGE_SHA256" ]]; then
+              echo "Exact-target package SHA-256 differs from package_sha256." >&2
+              exit 1
+            fi
+            if [[ "$name" != "openclaw" || ( -n "$EXPECTED_PACKAGE_VERSION" && "$version" != "$EXPECTED_PACKAGE_VERSION" ) ]]; then
+              echo "Exact-target package name/version differs from declared package identity." >&2
+              exit 1
+            fi
+            [[ "$package_source_sha" == "$SELECTED_SHA" ]] || {
+              echo "Exact-target package build commit differs from the selected SHA." >&2
+              exit 1
+            }
+            metadata=".artifacts/docker-e2e-package/package-candidate.json"
+            if [[ -f "$metadata" ]]; then
+              jq -e \
+                --arg sha "$SELECTED_SHA" \
+                --arg digest "$digest" \
+                --arg version "$version" \
+                '
+                  .name == "openclaw" and
+                  .packageSourceSha == $sha and
+                  .sha256 == $digest and
+                  .version == $version
+                ' "$metadata" >/dev/null || {
+                  echo "Exact-target package metadata does not bind the selected SHA and tarball." >&2
+                  exit 1
+                }
+            fi
+          fi
           tag="pkg-${digest:0:32}"
           echo "sha256=$digest" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "file_name=openclaw-current.tgz" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$package_source_sha" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           {
             echo "Docker E2E package: \`$target\`"
@@ -1513,10 +2020,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload OpenClaw Docker E2E package
-        if: steps.plan.outputs.needs_package == '1' && (inputs.package_artifact_name == '' || inputs.package_artifact_run_id != '')
+        id: upload_package
+        if: steps.plan.outputs.needs_package == '1' && (inputs.package_artifact_id == '' || inputs.package_artifact_run_id != github.run_id)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+          name: docker-e2e-package-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/docker-e2e-package/openclaw-current.tgz
           if-no-files-found: error
 
@@ -1528,12 +2036,18 @@ jobs:
           SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           PROVIDED_BARE_IMAGE: ${{ inputs.docker_e2e_bare_image }}
           PROVIDED_FUNCTIONAL_IMAGE: ${{ inputs.docker_e2e_functional_image }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         run: |
           set -euo pipefail
           repository="${GITHUB_REPOSITORY,,}"
           image_tag="${PACKAGE_TAG:-$SELECTED_SHA}"
-          bare_image="${PROVIDED_BARE_IMAGE:-ghcr.io/${repository}-docker-e2e-bare:${image_tag}}"
-          functional_image="${PROVIDED_FUNCTIONAL_IMAGE:-ghcr.io/${repository}-docker-e2e-functional:${image_tag}}"
+          if [[ "$SHARED_IMAGE_POLICY" == "no-push-artifact" ]]; then
+            bare_image="openclaw-docker-e2e-bare:${image_tag}"
+            functional_image="openclaw-docker-e2e-functional:${image_tag}"
+          else
+            bare_image="${PROVIDED_BARE_IMAGE:-ghcr.io/${repository}-docker-e2e-bare:${image_tag}}"
+            functional_image="${PROVIDED_FUNCTIONAL_IMAGE:-ghcr.io/${repository}-docker-e2e-functional:${image_tag}}"
+          fi
           image="$functional_image"
           echo "image=$image" >> "$GITHUB_OUTPUT"
           echo "bare_image=$bare_image" >> "$GITHUB_OUTPUT"
@@ -1542,7 +2056,7 @@ jobs:
           echo "Shared Docker E2E functional image: \`$functional_image\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log in to GHCR
-        if: steps.plan.outputs.needs_e2e_image == '1'
+        if: steps.plan.outputs.needs_e2e_image == '1' && (inputs.shared_image_policy == 'allow-push' || inputs.shared_image_policy == 'existing-only')
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -1550,11 +2064,12 @@ jobs:
 
       - name: Check existing shared Docker E2E images
         id: image_exists
-        if: steps.plan.outputs.needs_e2e_image == '1'
+        if: steps.plan.outputs.needs_e2e_image == '1' && (inputs.shared_image_policy == 'allow-push' || inputs.shared_image_policy == 'existing-only')
         shell: bash
         env:
           PROVIDED_BARE_IMAGE: ${{ inputs.docker_e2e_bare_image }}
           PROVIDED_FUNCTIONAL_IMAGE: ${{ inputs.docker_e2e_functional_image }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         run: |
           set -euo pipefail
           bare_exists=0
@@ -1585,21 +2100,162 @@ jobs:
             fi
           fi
 
+          if [[ "$SHARED_IMAGE_POLICY" == "existing-only" && "$needs_build" == "1" ]]; then
+            echo "shared_image_policy=existing-only forbids building or pushing missing shared images." >&2
+            exit 1
+          fi
+
           echo "bare_exists=$bare_exists" >> "$GITHUB_OUTPUT"
           echo "functional_exists=$functional_exists" >> "$GITHUB_OUTPUT"
           echo "needs_build=$needs_build" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker builder
-        if: steps.image_exists.outputs.needs_build == '1'
+        if: inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_e2e_image == '1'
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        with:
+          max-cache-size-mb: 800000
+
+      - name: Build bare Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_bare_image == '1'
+        shell: bash
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.bare_image }}
+        run: |
+          set -euo pipefail
+          timeout --kill-after=30s 45m docker buildx build \
+            --load \
+            --file ./scripts/e2e/Dockerfile \
+            --target bare \
+            --platform linux/amd64 \
+            --tag "$IMAGE_REF" \
+            --sbom=true \
+            --provenance=mode=max \
+            .
+
+      - name: Build functional Docker E2E image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_functional_image == '1'
+        shell: bash
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.functional_image }}
+        run: |
+          set -euo pipefail
+          timeout --kill-after=30s 45m docker buildx build \
+            --load \
+            --file ./scripts/e2e/Dockerfile \
+            --target functional \
+            --build-context openclaw_package=.artifacts/docker-e2e-package \
+            --platform linux/amd64 \
+            --tag "$IMAGE_REF" \
+            --sbom=true \
+            --provenance=mode=max \
+            .
+
+      - name: Pack Docker E2E image artifact
+        id: image_artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_e2e_image == '1'
+        shell: bash
+        env:
+          BARE_IMAGE: ${{ steps.image.outputs.bare_image }}
+          FUNCTIONAL_IMAGE: ${{ steps.image.outputs.functional_image }}
+          NEEDS_BARE_IMAGE: ${{ steps.plan.outputs.needs_bare_image }}
+          NEEDS_FUNCTIONAL_IMAGE: ${{ steps.plan.outputs.needs_functional_image }}
+          PACKAGE_SHA256: ${{ steps.package.outputs.sha256 }}
+          SHARED_IMAGE_ARTIFACT_NAMESPACE: ${{ inputs.shared_image_artifact_namespace }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/docker-e2e-shared-images"
+          artifact_name="docker-e2e-shared-images-${SHARED_IMAGE_ARTIFACT_NAMESPACE}-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          images=()
+          if [[ "$NEEDS_BARE_IMAGE" == "1" ]]; then
+            images+=("$BARE_IMAGE")
+          fi
+          if [[ "$NEEDS_FUNCTIONAL_IMAGE" == "1" ]]; then
+            images+=("$FUNCTIONAL_IMAGE")
+          fi
+          OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            pack "$artifact_dir" docker-e2e "$TARGET_SHA" "$WORKFLOW_SHA" "${images[@]}"
+          archive_sha256="$(jq -er '.archive.sha256 | select(test("^[a-f0-9]{64}$"))' \
+            "$artifact_dir/shared-image-artifact.json")"
+          {
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$artifact_dir"
+            echo "archive_sha256=$archive_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload Docker E2E image artifact
+        id: upload_image_artifact
+        if: inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_e2e_image == '1'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.image_artifact.outputs.artifact_name }}
+          path: ${{ steps.image_artifact.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  push_docker_e2e_images:
+    needs: [validate_selected_ref, prepare_docker_e2e_image]
+    if: inputs.shared_image_policy == 'allow-push' && needs.prepare_docker_e2e_image.outputs.needs_registry_build == '1'
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
+    timeout-minutes: ${{ inputs.release_test_profile == 'full' && 90 || 60 }}
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download OpenClaw Docker E2E package
+        if: needs.prepare_docker_e2e_image.outputs.needs_functional_image == '1' && needs.prepare_docker_e2e_image.outputs.functional_exists != '1'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}
+          path: .artifacts/docker-e2e-package
+          run-id: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Normalize OpenClaw Docker E2E package
+        if: needs.prepare_docker_e2e_image.outputs.needs_functional_image == '1' && needs.prepare_docker_e2e_image.outputs.functional_exists != '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=".artifacts/docker-e2e-package/openclaw-current.tgz"
+          if [[ ! -f "$target" ]]; then
+            mapfile -t tgzs < <(find .artifacts/docker-e2e-package -type f -name '*.tgz' | sort)
+            if [[ "${#tgzs[@]}" -ne 1 ]]; then
+              echo "Expected exactly one package tarball for the registry image build; found ${#tgzs[@]}." >&2
+              exit 1
+            fi
+            cp "${tgzs[0]}" "$target"
+          fi
+
+      - name: Log in to GHCR
+        run: bash scripts/ci-docker-login-ghcr.sh
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Setup Docker builder
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
         with:
           max-cache-size-mb: 800000
 
       - name: Build and push bare Docker E2E image
-        if: steps.plan.outputs.needs_bare_image == '1' && steps.image_exists.outputs.bare_exists != '1'
+        if: needs.prepare_docker_e2e_image.outputs.needs_bare_image == '1' && needs.prepare_docker_e2e_image.outputs.bare_exists != '1'
         shell: bash
         env:
-          IMAGE_REF: ${{ steps.image.outputs.bare_image }}
+          IMAGE_REF: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
         run: |
           set -euo pipefail
           build_cmd=(
@@ -1627,10 +2283,10 @@ jobs:
           done
 
       - name: Build and push functional Docker E2E image
-        if: steps.plan.outputs.needs_functional_image == '1' && steps.image_exists.outputs.functional_exists != '1'
+        if: needs.prepare_docker_e2e_image.outputs.needs_functional_image == '1' && needs.prepare_docker_e2e_image.outputs.functional_exists != '1'
         shell: bash
         env:
-          IMAGE_REF: ${{ steps.image.outputs.functional_image }}
+          IMAGE_REF: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
         run: |
           set -euo pipefail
           build_cmd=(
@@ -1658,6 +2314,37 @@ jobs:
             sleep "$sleep_seconds"
           done
 
+  docker_e2e_image_ready:
+    needs: [prepare_docker_e2e_image, push_docker_e2e_images]
+    if: always() && needs.prepare_docker_e2e_image.result != 'skipped'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify Docker E2E image preparation
+        env:
+          PREPARE_RESULT: ${{ needs.prepare_docker_e2e_image.result }}
+          PUSH_RESULT: ${{ needs.push_docker_e2e_images.result }}
+          NEEDS_REGISTRY_BUILD: ${{ needs.prepare_docker_e2e_image.outputs.needs_registry_build }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$PREPARE_RESULT" != "success" ]]; then
+            echo "Docker E2E image preparation ended with ${PREPARE_RESULT}." >&2
+            exit 1
+          fi
+          if [[ "$SHARED_IMAGE_POLICY" == "allow-push" && "$NEEDS_REGISTRY_BUILD" == "1" ]]; then
+            if [[ "$PUSH_RESULT" != "success" ]]; then
+              echo "Docker E2E registry image publication ended with ${PUSH_RESULT}." >&2
+              exit 1
+            fi
+          elif [[ "$PUSH_RESULT" != "skipped" ]]; then
+            echo "Unexpected Docker E2E registry publication result: ${PUSH_RESULT}." >&2
+            exit 1
+          fi
+
   prepare_live_test_image:
     needs: validate_selected_ref
     if: inputs.include_live_suites && (inputs.live_suite_filter == '' || startsWith(inputs.live_suite_filter, 'live-') || startsWith(inputs.live_suite_filter, 'docker-live-models'))
@@ -1666,9 +2353,16 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      packages: write
+      packages: read
     outputs:
       live_image: ${{ steps.image.outputs.live_image }}
+      image_exists: ${{ steps.image_exists.outputs.exists }}
+      image_artifact_name: ${{ steps.image_artifact.outputs.artifact_name }}
+      image_archive_sha256: ${{ steps.image_artifact.outputs.archive_sha256 }}
+      image_artifact_id: ${{ steps.upload_image_artifact.outputs.artifact-id }}
+      image_artifact_digest: ${{ steps.upload_image_artifact.outputs.artifact-digest }}
+      image_artifact_run_id: ${{ github.run_id }}
+      image_artifact_run_attempt: ${{ github.run_attempt }}
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -1678,23 +2372,39 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout trusted release harness
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          path: .release-harness
+          persist-credentials: false
 
       - name: Resolve shared live-test image tag
         id: image
         shell: bash
         env:
           SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         run: |
           set -euo pipefail
           repository="${GITHUB_REPOSITORY,,}"
           live_image_extensions="matrix,acpx"
           live_image_tag_suffix="${live_image_extensions//,/-}"
-          live_image="ghcr.io/${repository}-live-test:${SELECTED_SHA}-${live_image_tag_suffix}"
+          if [[ "$SHARED_IMAGE_POLICY" == "no-push-artifact" ]]; then
+            live_image="openclaw-live-test:${SELECTED_SHA}-${live_image_tag_suffix}"
+          else
+            live_image="ghcr.io/${repository}-live-test:${SELECTED_SHA}-${live_image_tag_suffix}"
+          fi
           echo "live_image=${live_image}" >> "$GITHUB_OUTPUT"
           echo "live_image_extensions=${live_image_extensions}" >> "$GITHUB_OUTPUT"
           echo "Shared live-test image: \`${live_image}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log in to GHCR
+        if: inputs.shared_image_policy != 'no-push-artifact'
         run: bash scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -1702,6 +2412,9 @@ jobs:
 
       - name: Check existing shared live-test image
         id: image_exists
+        if: inputs.shared_image_policy != 'no-push-artifact'
+        env:
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1709,17 +2422,21 @@ jobs:
             echo "Shared live-test image already exists: ${{ steps.image.outputs.live_image }}"
             echo "exists=1" >> "$GITHUB_OUTPUT"
           else
+            if [[ "$SHARED_IMAGE_POLICY" == "existing-only" ]]; then
+              echo "shared_image_policy=existing-only forbids building or pushing a missing live-test image." >&2
+              exit 1
+            fi
             echo "exists=0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Docker builder
-        if: steps.image_exists.outputs.exists != '1'
+        if: inputs.shared_image_policy == 'no-push-artifact'
         uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
         with:
           max-cache-size-mb: 800000
 
-      - name: Build and push shared live-test image
-        if: steps.image_exists.outputs.exists != '1'
+      - name: Build shared live-test image
+        if: inputs.shared_image_policy == 'no-push-artifact'
         uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
         with:
           context: .
@@ -1731,11 +2448,128 @@ jobs:
           tags: ${{ steps.image.outputs.live_image }}
           sbom: true
           provenance: mode=max
+          load: true
+          push: false
+
+      - name: Pack live-test image artifact
+        id: image_artifact
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          LIVE_IMAGE: ${{ steps.image.outputs.live_image }}
+          SHARED_IMAGE_ARTIFACT_NAMESPACE: ${{ inputs.shared_image_artifact_namespace }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/live-test-shared-image"
+          artifact_name="live-test-shared-image-${SHARED_IMAGE_ARTIFACT_NAMESPACE}-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            pack "$artifact_dir" live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
+          archive_sha256="$(jq -er '.archive.sha256 | select(test("^[a-f0-9]{64}$"))' \
+            "$artifact_dir/shared-image-artifact.json")"
+          {
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$artifact_dir"
+            echo "archive_sha256=$archive_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload live-test image artifact
+        id: upload_image_artifact
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.image_artifact.outputs.artifact_name }}
+          path: ${{ steps.image_artifact.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  push_live_test_image:
+    needs: [validate_selected_ref, prepare_live_test_image]
+    if: inputs.shared_image_policy == 'allow-push' && needs.prepare_live_test_image.outputs.image_exists != '1'
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        run: bash scripts/ci-docker-login-ghcr.sh
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Setup Docker builder
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        with:
+          max-cache-size-mb: 800000
+
+      - name: Build and push shared live-test image
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
+        with:
+          context: .
+          file: ./Dockerfile
+          target: build
+          build-args: |
+            OPENCLAW_EXTENSIONS=matrix,acpx
+          platforms: linux/amd64
+          tags: ${{ needs.prepare_live_test_image.outputs.live_image }}
+          sbom: true
+          provenance: mode=max
+          load: false
           push: true
+
+  live_test_image_ready:
+    needs: [prepare_live_test_image, push_live_test_image]
+    if: always() && needs.prepare_live_test_image.result != 'skipped'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify live-test image preparation
+        env:
+          IMAGE_EXISTS: ${{ needs.prepare_live_test_image.outputs.image_exists }}
+          PREPARE_RESULT: ${{ needs.prepare_live_test_image.result }}
+          PUSH_RESULT: ${{ needs.push_live_test_image.result }}
+          SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$PREPARE_RESULT" != "success" ]]; then
+            echo "Live-test image preparation ended with ${PREPARE_RESULT}." >&2
+            exit 1
+          fi
+          if [[ "$SHARED_IMAGE_POLICY" == "allow-push" && "$IMAGE_EXISTS" != "1" ]]; then
+            if [[ "$PUSH_RESULT" != "success" ]]; then
+              echo "Live-test registry image publication ended with ${PUSH_RESULT}." >&2
+              exit 1
+            fi
+          elif [[ "$PUSH_RESULT" != "skipped" ]]; then
+            echo "Unexpected live-test registry publication result: ${PUSH_RESULT}." >&2
+            exit 1
+          fi
 
   validate_live_models_docker:
     name: Docker live models (${{ matrix.provider_label }})
-    needs: [validate_selected_ref, prepare_live_test_image, plan_release_workflow_matrices]
+    needs:
+      [
+        validate_selected_ref,
+        prepare_live_test_image,
+        live_test_image_ready,
+        plan_release_workflow_matrices,
+      ]
     if: inputs.include_live_suites && inputs.live_model_providers == '' && (inputs.live_suite_filter == '' || inputs.live_suite_filter == 'docker-live-models') && needs.plan_release_workflow_matrices.outputs.live_models_count != '0'
     continue-on-error: ${{ inputs.advisory || inputs.live_advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
@@ -1783,6 +2617,7 @@ jobs:
       OPENCLAW_LIVE_MODELS: ${{ matrix.models || 'modern' }}
       OPENCLAW_LIVE_MAX_MODELS: ${{ matrix.max_models || '6' }}
       OPENCLAW_LIVE_MODEL_TIMEOUT_MS: "45000"
+      OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
       OPENCLAW_VITEST_MAX_WORKERS: "2"
     steps:
@@ -1792,14 +2627,59 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout trusted live Docker harness
         if: contains(matrix.profiles, inputs.release_test_profile)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
+          persist-credentials: false
+
+      - name: Validate live-test image artifact binding
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_live_test_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_live_test_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "live-test image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download live-test image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          path: .artifacts/live-test-image
+          run-id: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load live-test image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.prepare_live_test_image.outputs.image_archive_sha256 }}
+          LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
       - name: Setup Node environment
         if: contains(matrix.profiles, inputs.release_test_profile)
@@ -1813,7 +2693,7 @@ jobs:
         run: bash scripts/ci-hydrate-live-auth.sh
 
       - name: Log in to GHCR
-        if: contains(matrix.profiles, inputs.release_test_profile)
+        if: contains(matrix.profiles, inputs.release_test_profile) && inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -1863,7 +2743,7 @@ jobs:
 
   validate_live_models_docker_targeted:
     name: Docker live models (selected providers)
-    needs: [validate_selected_ref, prepare_live_test_image]
+    needs: [validate_selected_ref, prepare_live_test_image, live_test_image_ready]
     if: inputs.include_live_suites && inputs.live_model_providers != '' && (inputs.live_suite_filter == '' || inputs.live_suite_filter == 'docker-live-models')
     continue-on-error: ${{ inputs.advisory || inputs.live_advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
@@ -1907,6 +2787,7 @@ jobs:
       OPENCLAW_LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
       OPENCLAW_LIVE_MAX_MODELS: "6"
       OPENCLAW_LIVE_MODEL_TIMEOUT_MS: "45000"
+      OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
       OPENCLAW_VITEST_MAX_WORKERS: "2"
     steps:
@@ -1915,13 +2796,58 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout trusted live Docker harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
+          persist-credentials: false
+
+      - name: Validate live-test image artifact binding
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_live_test_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_live_test_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "live-test image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download live-test image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          path: .artifacts/live-test-image
+          run-id: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load live-test image artifact
+        if: inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.prepare_live_test_image.outputs.image_archive_sha256 }}
+          LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -1991,6 +2917,7 @@ jobs:
         run: bash scripts/ci-hydrate-live-auth.sh
 
       - name: Log in to GHCR
+        if: inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -2305,7 +3232,9 @@ jobs:
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-anthropic' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-anthropic-')) || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-opencode-go' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-opencode-go-')))
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          persist-credentials: false
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
 
@@ -2388,7 +3317,7 @@ jobs:
 
   validate_live_docker_provider_suites:
     name: Docker live suites (${{ matrix.label }})
-    needs: [validate_selected_ref, prepare_live_test_image]
+    needs: [validate_selected_ref, prepare_live_test_image, live_test_image_ready]
     if: inputs.include_live_suites && !inputs.live_models_only && (inputs.live_suite_filter == '' || startsWith(inputs.live_suite_filter, 'live-'))
     continue-on-error: ${{ inputs.advisory || inputs.live_advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
@@ -2546,6 +3475,7 @@ jobs:
       OPENCLAW_GEMINI_SETTINGS_JSON: ${{ secrets.OPENCLAW_GEMINI_SETTINGS_JSON }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
       OPENCLAW_LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
+      OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
       OPENCLAW_LIVE_VIDEO_GENERATION_SKIP_PROVIDERS: ""
       OPENCLAW_LIVE_VYDRA_VIDEO: "1"
@@ -2557,14 +3487,59 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout trusted live shard harness
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
+          persist-credentials: false
+
+      - name: Validate live-test image artifact binding
+        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group) && inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_live_test_image.outputs.image_artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_live_test_image.outputs.image_artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "live-test image" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download live-test image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group) && inputs.shared_image_policy == 'no-push-artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.prepare_live_test_image.outputs.image_artifact_id }}
+          path: .artifacts/live-test-image
+          run-id: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load live-test image artifact
+        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group) && inputs.shared_image_policy == 'no-push-artifact'
+        env:
+          ARCHIVE_SHA256: ${{ needs.prepare_live_test_image.outputs.image_archive_sha256 }}
+          LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+            bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            load .artifacts/live-test-image live-test "$TARGET_SHA" "$WORKFLOW_SHA" "$LIVE_IMAGE"
 
       - name: Setup Node environment
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
@@ -2578,7 +3553,7 @@ jobs:
         run: bash scripts/ci-hydrate-live-auth.sh
 
       - name: Log in to GHCR
-        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group)
+        if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || inputs.live_suite_filter == matrix.suite_group) && inputs.shared_image_policy != 'no-push-artifact'
         run: bash .release-harness/scripts/ci-docker-login-ghcr.sh
         env:
           GHCR_USERNAME: ${{ github.actor }}
@@ -2781,7 +3756,9 @@ jobs:
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          persist-credentials: false
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
           fetch-depth: 1
           path: .release-harness
 

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -42,10 +42,15 @@ on:
         required: false
         default: false
         type: boolean
+      publish_reports:
+        description: Publish completed reports to openclaw/clawgrit-reports
+        required: false
+        default: true
+        type: boolean
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: a2dd84e7d65507e614afaff850d3932d18c859b6
+        default: 24c26969e57d4d49f9d1a5071af85dd3d79daa2d
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -148,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'a2dd84e7d65507e614afaff850d3932d18c859b6' }}
+      KOVA_REF: ${{ inputs.kova_ref || '24c26969e57d4d49f9d1a5071af85dd3d79daa2d' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}
@@ -281,6 +286,13 @@ jobs:
           git -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
           git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
           git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
+          node - "$KOVA_SRC" <<'NODE'
+          const root = process.argv[2];
+          for (const dependency of ["mock-ai-provider", "zod"]) {
+            require.resolve(dependency, { paths: [root] });
+          }
+          NODE
           cat > "$HOME/.local/bin/kova" <<EOF
           #!/usr/bin/env bash
           export KOVA_HOME="${KOVA_HOME}"
@@ -740,7 +752,7 @@ jobs:
   publish:
     name: Publish ${{ matrix.title }} report
     needs: [resolve_target, kova]
-    if: ${{ always() && needs.resolve_target.result == 'success' && needs.kova.result != 'cancelled' }}
+    if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.publish_reports == true)) && needs.resolve_target.result == 'success' && needs.kova.result != 'cancelled' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -1104,3 +1116,28 @@ jobs:
             write_publish_failure "$attempt"
             exit 1
           done
+
+  artifact_only_guard:
+    name: Verify artifact-only report mode
+    needs: [resolve_target, kova, publish]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.publish_reports != true }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify report publisher stayed disabled
+        env:
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISH_RESULT" != "skipped" ]]; then
+            echo "::error::Artifact-only performance mode requires the report publisher to stay skipped; got ${PUBLISH_RESULT}."
+            exit 1
+          fi
+          {
+            echo "### Artifact-only report mode"
+            echo
+            echo "Clawgrit report publication stayed disabled; Kova evidence is available only as workflow artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           path: workflow
           fetch-depth: 1
 
@@ -522,9 +522,14 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
+      packages: read
     outputs:
+      artifact_digest: ${{ steps.release_package_upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.release_package_upload.outputs.artifact-id }}
       artifact_name: ${{ steps.artifact.outputs.name }}
+      artifact_run_attempt: ${{ steps.artifact.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.artifact.outputs.run_id }}
+      package_file_name: ${{ steps.artifact.outputs.file_name }}
       package_sha256: ${{ steps.package.outputs.sha256 }}
       package_version: ${{ steps.package.outputs.package_version }}
       source_sha: ${{ steps.package.outputs.source_sha }}
@@ -532,13 +537,19 @@ jobs:
       - name: Checkout trusted workflow ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
-          ref: ${{ github.ref_name }}
+          persist-credentials: false
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Set artifact metadata
         id: artifact
-        run: echo "name=release-package-under-test" >> "$GITHUB_OUTPUT"
+        run: |
+          {
+            echo "file_name=openclaw-current.tgz"
+            echo "name=release-package-under-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            echo "run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "run_id=${GITHUB_RUN_ID}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -570,11 +581,15 @@ jobs:
           digest="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).sha256")"
           version="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).version")"
           source_sha="$(node -p "JSON.parse(require('fs').readFileSync('.artifacts/docker-e2e-package/package-candidate.json', 'utf8')).packageSourceSha")"
+          if [[ "$source_sha" != "$PACKAGE_REF" ]]; then
+            echo "Release package source SHA differs from the selected release SHA: expected $PACKAGE_REF, found ${source_sha:-<missing>}." >&2
+            exit 1
+          fi
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
           {
             echo "## Release package artifact"
             echo
-            echo "- Artifact: \`release-package-under-test\`"
+            echo "- Artifact: \`${{ steps.artifact.outputs.name }}\`"
             echo "- Package: \`$package_label\`"
             echo "- SHA-256: \`$digest\`"
             echo "- Version: \`$version\`"
@@ -582,24 +597,65 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release package artifact
+        id: release_package_upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: release-package-under-test
+          name: ${{ steps.artifact.outputs.name }}
           path: |
-            .artifacts/docker-e2e-package/openclaw-current.tgz
+            .artifacts/docker-e2e-package/${{ steps.artifact.outputs.file_name }}
             .artifacts/docker-e2e-package/package-candidate.json
           retention-days: 14
           if-no-files-found: error
+
+      - name: Validate release package artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ steps.release_package_upload.outputs.artifact-digest }}
+          ARTIFACT_ID: ${{ steps.release_package_upload.outputs.artifact-id }}
+          ARTIFACT_NAME: ${{ steps.artifact.outputs.name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ steps.artifact.outputs.run_attempt }}
+          ARTIFACT_RUN_ID: ${{ steps.artifact.outputs.run_id }}
+          PACKAGE_FILE_NAME: ${{ steps.artifact.outputs.file_name }}
+          PACKAGE_SHA256: ${{ steps.package.outputs.sha256 }}
+          PACKAGE_SOURCE_SHA: ${{ steps.package.outputs.source_sha }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.package_version }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Release package artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Release package artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" == "$GITHUB_RUN_ID" &&
+            "$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT" ]] || {
+            echo "Release package artifact run binding is invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_NAME" == "release-package-under-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" &&
+            "$PACKAGE_FILE_NAME" == "openclaw-current.tgz" ]] || {
+            echo "Release package artifact name or tarball filename is invalid." >&2
+            exit 1
+          }
+          [[ "$PACKAGE_SHA256" =~ ^[a-f0-9]{64}$ &&
+            "$PACKAGE_SOURCE_SHA" =~ ^[a-f0-9]{40}$ &&
+            -n "${PACKAGE_VERSION// }" ]] || {
+            echo "Release package identity is incomplete." >&2
+            exit 1
+          }
 
   install_smoke_release_checks:
     needs: [resolve_target]
     if: contains(fromJSON('["all","install-smoke"]'), needs.resolve_target.outputs.rerun_group)
     permissions:
+      actions: read
       contents: read
-      packages: write
+      packages: read
     uses: ./.github/workflows/install-smoke.yml
     with:
       ref: ${{ needs.resolve_target.outputs.revision }}
+      root_image_transport: no-push-artifact
       run_bun_global_install_smoke: true
 
   cross_os_release_checks:
@@ -613,8 +669,13 @@ jobs:
       provider: ${{ needs.resolve_target.outputs.provider }}
       mode: ${{ needs.resolve_target.outputs.mode }}
       suite_filter: ${{ needs.resolve_target.outputs.cross_os_suite_filter }}
+      candidate_artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
+      candidate_artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
       candidate_artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}
-      candidate_file_name: openclaw-current.tgz
+      candidate_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.artifact_run_attempt }}
+      candidate_artifact_run_id: ${{ needs.prepare_release_package.outputs.artifact_run_id }}
+      candidate_file_name: ${{ needs.prepare_release_package.outputs.package_file_name }}
+      candidate_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       candidate_version: ${{ needs.prepare_release_package.outputs.package_version }}
       candidate_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
       openai_model: openai/gpt-5.5
@@ -636,7 +697,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
       pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
@@ -652,6 +713,8 @@ jobs:
       include_live_suites: true
       release_test_profile: ${{ needs.resolve_target.outputs.release_profile }}
       live_suite_filter: ${{ needs.resolve_target.outputs.live_suite_filter }}
+      shared_image_artifact_namespace: release-live
+      shared_image_policy: no-push-artifact
     secrets: &live_e2e_release_secrets
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
@@ -707,7 +770,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
       pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
@@ -718,8 +781,18 @@ jobs:
       include_openwebui: ${{ needs.resolve_target.outputs.release_profile != 'beta' }}
       include_live_suites: false
       release_test_profile: ${{ needs.resolve_target.outputs.release_profile }}
+      package_artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
+      package_artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
       package_artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}
+      package_artifact_run_attempt: ${{ needs.prepare_release_package.outputs.artifact_run_attempt }}
+      package_artifact_run_id: ${{ needs.prepare_release_package.outputs.artifact_run_id }}
+      package_file_name: ${{ needs.prepare_release_package.outputs.package_file_name }}
+      package_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
+      package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
+      package_version: ${{ needs.prepare_release_package.outputs.package_version }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
+      shared_image_artifact_namespace: release-docker
+      shared_image_policy: no-push-artifact
     secrets: *live_e2e_release_secrets
 
   package_acceptance_release_checks:
@@ -729,21 +802,30 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
       pull-requests: read
     uses: ./.github/workflows/package-acceptance.yml
     with:
       advisory: false
-      workflow_ref: ${{ github.ref_name }}
+      workflow_ref: ${{ github.sha }}
       source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}
       package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
+      artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
+      artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
       artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}
+      artifact_run_attempt: ${{ needs.prepare_release_package.outputs.artifact_run_attempt }}
+      artifact_run_id: ${{ needs.prepare_release_package.outputs.artifact_run_id }}
+      package_file_name: ${{ needs.prepare_release_package.outputs.package_file_name }}
       package_sha256: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.release_package_spec == '') && needs.prepare_release_package.outputs.package_sha256 || '' }}
+      package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
+      package_version: ${{ needs.prepare_release_package.outputs.package_version }}
       suite_profile: custom
       docker_lanes: doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update plugin-binding-command-escape
       published_upgrade_survivor_baselines: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'last-stable-4 2026.4.23 2026.5.2 2026.4.15' || '' }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_target.outputs.run_release_soak == 'true' && 'reported-issues' || '' }}
       telegram_mode: mock-openai
+      shared_image_artifact_namespace: release-package
+      shared_image_policy: no-push-artifact
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
@@ -840,7 +922,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -959,7 +1041,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1070,7 +1152,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1234,7 +1316,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1308,7 +1390,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1432,7 +1514,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1573,7 +1655,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1698,7 +1780,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 
@@ -1820,7 +1902,7 @@ jobs:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          persist-credentials: true
+          persist-credentials: false
           ref: ${{ needs.resolve_target.outputs.revision }}
           fetch-depth: 1
 

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -35,7 +35,7 @@ on:
         default: ""
         type: string
       package_sha256:
-        description: Expected package SHA-256; required for source=url or source=trusted-url
+        description: Expected package SHA-256; required for source=url, source=trusted-url, or source=artifact
         required: false
         default: ""
         type: string
@@ -53,6 +53,50 @@ on:
         description: Artifact name containing one .tgz when source=artifact
         required: false
         default: package-under-test
+        type: string
+      artifact_id:
+        description: Immutable GitHub artifact id when source=artifact
+        required: false
+        default: ""
+        type: string
+      artifact_digest:
+        description: GitHub artifact service SHA-256 digest without the sha256 prefix
+        required: false
+        default: ""
+        type: string
+      artifact_run_attempt:
+        description: Producer run attempt when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_file_name:
+        description: Exact package tarball filename when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_source_sha:
+        description: Exact source commit recorded in the package when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_version:
+        description: Exact package version when source=artifact
+        required: false
+        default: ""
+        type: string
+      shared_image_policy:
+        description: Shared Docker image transport for package acceptance
+        required: true
+        default: allow-push
+        type: choice
+        options:
+          - allow-push
+          - existing-only
+          - no-push-artifact
+      shared_image_artifact_namespace:
+        description: Unique artifact namespace when shared_image_policy=no-push-artifact
+        required: false
+        default: package-acceptance
         type: string
       suite_profile:
         description: Acceptance profile
@@ -136,7 +180,7 @@ on:
         default: ""
         type: string
       package_sha256:
-        description: Expected package SHA-256; required for source=url or source=trusted-url
+        description: Expected package SHA-256; required for source=url, source=trusted-url, or source=artifact
         required: false
         default: ""
         type: string
@@ -154,6 +198,46 @@ on:
         description: Artifact name containing one .tgz when source=artifact
         required: false
         default: package-under-test
+        type: string
+      artifact_id:
+        description: Immutable GitHub artifact id when source=artifact
+        required: false
+        default: ""
+        type: string
+      artifact_digest:
+        description: GitHub artifact service SHA-256 digest without the sha256 prefix
+        required: false
+        default: ""
+        type: string
+      artifact_run_attempt:
+        description: Producer run attempt when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_file_name:
+        description: Exact package tarball filename when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_source_sha:
+        description: Exact source commit recorded in the package when source=artifact
+        required: false
+        default: ""
+        type: string
+      package_version:
+        description: Exact package version when source=artifact
+        required: false
+        default: ""
+        type: string
+      shared_image_policy:
+        description: "Shared Docker image transport: allow-push, existing-only, or no-push-artifact"
+        required: false
+        default: allow-push
+        type: string
+      shared_image_artifact_namespace:
+        description: Unique artifact namespace when shared_image_policy=no-push-artifact
+        required: false
+        default: package-acceptance
         type: string
       suite_profile:
         description: "Acceptance profile: smoke, package, product, full, or custom"
@@ -190,6 +274,31 @@ on:
         required: false
         default: ""
         type: string
+    outputs:
+      package_artifact_digest:
+        description: GitHub artifact service digest for the canonical package
+        value: ${{ jobs.resolve_package.outputs.package_artifact_digest }}
+      package_artifact_id:
+        description: Immutable GitHub artifact id for the canonical package
+        value: ${{ jobs.resolve_package.outputs.package_artifact_id }}
+      package_artifact_run_attempt:
+        description: Producer run attempt for the canonical package artifact
+        value: ${{ jobs.resolve_package.outputs.package_artifact_run_attempt }}
+      package_artifact_run_id:
+        description: Producer run id for the canonical package artifact
+        value: ${{ jobs.resolve_package.outputs.package_artifact_run_id }}
+      package_file_name:
+        description: Canonical package tarball filename
+        value: ${{ jobs.resolve_package.outputs.package_file_name }}
+      package_source_sha:
+        description: Source commit recorded in the canonical package
+        value: ${{ jobs.resolve_package.outputs.package_source_sha }}
+      package_sha256:
+        description: Canonical OpenClaw package SHA-256
+        value: ${{ jobs.resolve_package.outputs.package_sha256 }}
+      package_version:
+        description: Canonical OpenClaw package version
+        value: ${{ jobs.resolve_package.outputs.package_version }}
     secrets:
       OPENCLAW_TRUSTED_PACKAGE_TOKEN:
         required: false
@@ -293,7 +402,7 @@ on:
 permissions:
   actions: read
   contents: read
-  packages: write
+  packages: read
   pull-requests: read
 
 concurrency:
@@ -303,7 +412,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
-  PACKAGE_ARTIFACT_NAME: package-under-test
+  PACKAGE_ARTIFACT_NAME: package-under-test-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   resolve_package:
@@ -316,6 +425,11 @@ jobs:
       include_openwebui: ${{ steps.profile.outputs.include_openwebui }}
       include_release_path_suites: ${{ steps.profile.outputs.include_release_path_suites }}
       package_artifact_name: ${{ steps.profile.outputs.package_artifact_name }}
+      package_artifact_digest: ${{ steps.upload_package.outputs.artifact-digest }}
+      package_artifact_id: ${{ steps.upload_package.outputs.artifact-id }}
+      package_artifact_run_attempt: ${{ github.run_attempt }}
+      package_artifact_run_id: ${{ github.run_id }}
+      package_file_name: ${{ steps.resolve.outputs.package_file_name }}
       package_source_sha: ${{ steps.resolve.outputs.package_source_sha }}
       package_sha256: ${{ steps.resolve.outputs.sha256 }}
       package_version: ${{ steps.resolve.outputs.package_version }}
@@ -329,6 +443,7 @@ jobs:
         with:
           ref: ${{ inputs.workflow_ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -337,28 +452,81 @@ jobs:
           install-bun: ${{ inputs.source == 'ref' && 'true' || 'false' }}
           install-deps: "false"
 
-      - name: Download current-run package artifact input
-        if: inputs.source == 'artifact' && inputs.artifact_run_id == ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ inputs.artifact_name }}
-          path: .artifacts/package-candidate-input
-
-      - name: Download previous-run package artifact input
-        if: inputs.source == 'artifact' && inputs.artifact_run_id != ''
+      - name: Validate package artifact input identity
+        id: input_artifact
+        if: inputs.source == 'artifact'
         env:
+          ARTIFACT_DIGEST: ${{ inputs.artifact_digest }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
           ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ inputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          EXPECTED_PACKAGE_SHA256: ${{ inputs.package_sha256 }}
+          EXPECTED_PACKAGE_FILE_NAME: ${{ inputs.package_file_name }}
+          EXPECTED_PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha }}
+          EXPECTED_PACKAGE_VERSION: ${{ inputs.package_version }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${ARTIFACT_NAME// }" ]]; then
-            echo "artifact_name is required when source=artifact." >&2
+          if [[ ! "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ||
+                ! "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ||
+                -z "${ARTIFACT_NAME// }" ||
+                ! "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ||
+                ! "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ||
+                ! "$EXPECTED_PACKAGE_FILE_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$ ||
+                ! "$EXPECTED_PACKAGE_SHA256" =~ ^[0-9a-f]{64}$ ||
+                ! "$EXPECTED_PACKAGE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ||
+                -z "${EXPECTED_PACKAGE_VERSION// }" ]]; then
+            echo "source=artifact requires the complete immutable artifact and package identity tuple." >&2
             exit 1
           fi
-          mkdir -p .artifacts/package-candidate-input
-          gh run download "$ARTIFACT_RUN_ID" -n "$ARTIFACT_NAME" -D .artifacts/package-candidate-input
+          [[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]] || {
+            echo "Package artifact name does not bind the declared producer run attempt." >&2
+            exit 1
+          }
+          artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")"
+          jq -e \
+            --arg digest "sha256:${ARTIFACT_DIGEST}" \
+            --arg id "$ARTIFACT_ID" \
+            --arg name "$ARTIFACT_NAME" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '
+              (.id | tostring) == $id and
+              .name == $name and
+              .expired == false and
+              .digest == $digest and
+              (.workflow_run.id | tostring) == $run_id
+            ' <<< "$artifact_json" >/dev/null || {
+              echo "Package artifact identity does not match the requested immutable tuple." >&2
+              exit 1
+            }
+          attempt_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}"
+          )"
+          jq -e \
+            --arg attempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg run_id "$ARTIFACT_RUN_ID" \
+            '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+            <<< "$attempt_json" >/dev/null || {
+            echo "Package artifact producer run attempt does not match the requested tuple." >&2
+            exit 1
+          }
+          {
+            echo "artifact_digest=$ARTIFACT_DIGEST"
+            echo "run_attempt=$ARTIFACT_RUN_ATTEMPT"
+            echo "run_id=$ARTIFACT_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download package artifact input
+        if: inputs.source == 'artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ inputs.artifact_id }}
+          path: .artifacts/package-candidate-input
+          run-id: ${{ inputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Resolve package candidate
         id: resolve
@@ -368,6 +536,9 @@ jobs:
           PACKAGE_SPEC: ${{ inputs.package_spec }}
           PACKAGE_URL: ${{ inputs.package_url }}
           PACKAGE_SHA256: ${{ inputs.package_sha256 }}
+          PACKAGE_FILE_NAME: ${{ inputs.package_file_name }}
+          PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha }}
+          PACKAGE_VERSION: ${{ inputs.package_version }}
           TRUSTED_SOURCE_ID: ${{ inputs.trusted_source_id }}
           OPENCLAW_TRUSTED_PACKAGE_TOKEN: ${{ secrets.OPENCLAW_TRUSTED_PACKAGE_TOKEN }}
         shell: bash
@@ -376,6 +547,16 @@ jobs:
           artifact_dir=""
           if [[ "$SOURCE" == "artifact" ]]; then
             artifact_dir=".artifacts/package-candidate-input"
+            artifact_tarball="${artifact_dir}/${PACKAGE_FILE_NAME}"
+            [[ -f "$artifact_tarball" ]] || {
+              echo "Declared package tarball is missing from the selected artifact." >&2
+              exit 1
+            }
+            artifact_sha256="$(sha256sum "$artifact_tarball" | awk '{print $1}')"
+            [[ "$artifact_sha256" == "$PACKAGE_SHA256" ]] || {
+              echo "Selected artifact package SHA-256 differs from package_sha256." >&2
+              exit 1
+            }
           fi
 
           node scripts/resolve-openclaw-package-candidate.mjs \
@@ -390,6 +571,22 @@ jobs:
             --output-name openclaw-current.tgz \
             --metadata .artifacts/docker-e2e-package/package-candidate.json \
             --github-output "$GITHUB_OUTPUT"
+          echo "package_file_name=openclaw-current.tgz" >> "$GITHUB_OUTPUT"
+          if [[ "$SOURCE" == "artifact" ]]; then
+            jq -e \
+              --arg digest "$PACKAGE_SHA256" \
+              --arg source_sha "$PACKAGE_SOURCE_SHA" \
+              --arg version "$PACKAGE_VERSION" \
+              '
+                .name == "openclaw" and
+                .sha256 == $digest and
+                .packageSourceSha == $source_sha and
+                .version == $version
+              ' .artifacts/docker-e2e-package/package-candidate.json >/dev/null || {
+              echo "Resolved package identity differs from the declared immutable tuple." >&2
+              exit 1
+            }
+          fi
 
       - name: Select acceptance profile
         id: profile
@@ -492,6 +689,7 @@ jobs:
           node scripts/resolve-upgrade-survivor-baselines.mjs "${args[@]}" >/dev/null
 
       - name: Upload package-under-test artifact
+        id: upload_package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ env.PACKAGE_ARTIFACT_NAME }}
@@ -503,6 +701,12 @@ jobs:
 
       - name: Summarize package candidate
         env:
+          INPUT_ARTIFACT_DIGEST: ${{ steps.input_artifact.outputs.artifact_digest }}
+          INPUT_ARTIFACT_ID: ${{ inputs.artifact_id }}
+          INPUT_ARTIFACT_RUN_ATTEMPT: ${{ steps.input_artifact.outputs.run_attempt }}
+          INPUT_ARTIFACT_RUN_ID: ${{ steps.input_artifact.outputs.run_id }}
+          OUTPUT_ARTIFACT_DIGEST: ${{ steps.upload_package.outputs.artifact-digest }}
+          OUTPUT_ARTIFACT_ID: ${{ steps.upload_package.outputs.artifact-id }}
           PACKAGE_SHA256: ${{ steps.resolve.outputs.sha256 }}
           PACKAGE_VERSION: ${{ steps.resolve.outputs.package_version }}
           PACKAGE_REF: ${{ inputs.package_ref }}
@@ -528,6 +732,14 @@ jobs:
             fi
             echo "- Version: \`${PACKAGE_VERSION}\`"
             echo "- SHA-256: \`${PACKAGE_SHA256}\`"
+            echo "- Artifact id: \`${OUTPUT_ARTIFACT_ID}\`"
+            echo "- Artifact digest: \`${OUTPUT_ARTIFACT_DIGEST}\`"
+            echo "- Artifact producer: run \`${GITHUB_RUN_ID}\`, attempt \`${GITHUB_RUN_ATTEMPT}\`"
+            if [[ "$SOURCE" == "artifact" ]]; then
+              echo "- Input artifact id: \`${INPUT_ARTIFACT_ID}\`"
+              echo "- Input artifact digest: \`${INPUT_ARTIFACT_DIGEST}\`"
+              echo "- Input artifact producer: run \`${INPUT_ARTIFACT_RUN_ID}\`, attempt \`${INPUT_ARTIFACT_RUN_ATTEMPT}\`"
+            fi
             echo "- Profile: \`${SUITE_PROFILE}\`"
             echo "- Published upgrade survivor baseline: \`${PUBLISHED_UPGRADE_SURVIVOR_BASELINE}\`"
             echo "- Published upgrade survivor baselines: \`${PUBLISHED_UPGRADE_SURVIVOR_BASELINES}\`"
@@ -545,31 +757,42 @@ jobs:
         with:
           ref: ${{ inputs.workflow_ref }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Download package-under-test artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ needs.resolve_package.outputs.package_artifact_name }}
+          artifact-ids: ${{ needs.resolve_package.outputs.package_artifact_id }}
           path: .artifacts/docker-e2e-package
+          run-id: ${{ needs.resolve_package.outputs.package_artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Enforce public package integrity
         env:
+          EXPECTED_PACKAGE_SHA256: ${{ needs.resolve_package.outputs.package_sha256 }}
           OPENCLAW_PACKAGE_TARBALL_CHECK_TIMINGS: "0"
         shell: bash
         run: |
           set -euo pipefail
-          node scripts/check-openclaw-package-tarball.mjs .artifacts/docker-e2e-package/openclaw-current.tgz
+          package=".artifacts/docker-e2e-package/openclaw-current.tgz"
+          actual_sha256="$(sha256sum "$package" | awk '{print $1}')"
+          [[ "$actual_sha256" == "$EXPECTED_PACKAGE_SHA256" ]] || {
+            echo "Canonical package artifact SHA-256 differs from the resolver output." >&2
+            exit 1
+          }
+          node scripts/check-openclaw-package-tarball.mjs "$package"
 
   docker_acceptance:
-    name: Docker product acceptance
+    name: Docker product acceptance (artifact-only)
     needs: [resolve_package, package_integrity]
+    if: inputs.shared_image_policy == 'no-push-artifact'
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
       pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
-    with:
+    with: &docker_acceptance_inputs
       advisory: ${{ inputs.advisory }}
       ref: ${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}
       include_repo_e2e: false
@@ -580,9 +803,19 @@ jobs:
       published_upgrade_survivor_baselines: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baselines }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_package.outputs.published_upgrade_survivor_scenarios }}
       package_artifact_name: ${{ needs.resolve_package.outputs.package_artifact_name }}
+      package_artifact_digest: ${{ needs.resolve_package.outputs.package_artifact_digest }}
+      package_artifact_id: ${{ needs.resolve_package.outputs.package_artifact_id }}
+      package_artifact_run_attempt: ${{ needs.resolve_package.outputs.package_artifact_run_attempt }}
+      package_artifact_run_id: ${{ needs.resolve_package.outputs.package_artifact_run_id }}
+      package_file_name: ${{ needs.resolve_package.outputs.package_file_name }}
+      package_sha256: ${{ needs.resolve_package.outputs.package_sha256 }}
+      package_source_sha: ${{ needs.resolve_package.outputs.package_source_sha }}
+      package_version: ${{ needs.resolve_package.outputs.package_version }}
       include_live_suites: ${{ needs.resolve_package.outputs.include_live_suites == 'true' }}
       live_models_only: false
-    secrets:
+      shared_image_artifact_namespace: ${{ inputs.shared_image_artifact_namespace }}
+      shared_image_policy: ${{ inputs.shared_image_policy }}
+    secrets: &docker_acceptance_secrets
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -630,6 +863,19 @@ jobs:
       OPENCLAW_GEMINI_SETTINGS_JSON: ${{ secrets.OPENCLAW_GEMINI_SETTINGS_JSON }}
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
 
+  docker_acceptance_registry:
+    name: Docker product acceptance (registry)
+    needs: [resolve_package, package_integrity]
+    if: inputs.shared_image_policy != 'no-push-artifact'
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      pull-requests: read
+    uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+    with: *docker_acceptance_inputs
+    secrets: *docker_acceptance_secrets
+
   package_telegram:
     name: Telegram package acceptance
     needs: [resolve_package, package_integrity]
@@ -639,6 +885,14 @@ jobs:
       advisory: ${{ inputs.advisory }}
       package_spec: ${{ inputs.package_spec }}
       package_artifact_name: ${{ needs.resolve_package.outputs.package_artifact_name }}
+      package_artifact_digest: ${{ needs.resolve_package.outputs.package_artifact_digest }}
+      package_artifact_id: ${{ needs.resolve_package.outputs.package_artifact_id }}
+      package_artifact_run_attempt: ${{ needs.resolve_package.outputs.package_artifact_run_attempt }}
+      package_artifact_run_id: ${{ needs.resolve_package.outputs.package_artifact_run_id }}
+      package_file_name: ${{ needs.resolve_package.outputs.package_file_name }}
+      package_sha256: ${{ needs.resolve_package.outputs.package_sha256 }}
+      package_source_sha: ${{ needs.resolve_package.outputs.package_source_sha }}
+      package_version: ${{ needs.resolve_package.outputs.package_version }}
       package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}
       harness_ref: ${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}
       provider_mode: ${{ needs.resolve_package.outputs.telegram_mode }}
@@ -650,7 +904,14 @@ jobs:
 
   summary:
     name: Verify package acceptance
-    needs: [resolve_package, package_integrity, docker_acceptance, package_telegram]
+    needs:
+      [
+        resolve_package,
+        package_integrity,
+        docker_acceptance,
+        docker_acceptance_registry,
+        package_telegram,
+      ]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -658,7 +919,8 @@ jobs:
       - name: Verify package acceptance results
         env:
           ADVISORY: ${{ inputs.advisory }}
-          DOCKER_RESULT: ${{ needs.docker_acceptance.result }}
+          DOCKER_ARTIFACT_RESULT: ${{ needs.docker_acceptance.result }}
+          DOCKER_REGISTRY_RESULT: ${{ needs.docker_acceptance_registry.result }}
           PACKAGE_INTEGRITY_RESULT: ${{ needs.package_integrity.result }}
           PACKAGE_TELEGRAM_RESULT: ${{ needs.package_telegram.result }}
           RESOLVE_RESULT: ${{ needs.resolve_package.result }}
@@ -666,11 +928,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          docker_result="$DOCKER_ARTIFACT_RESULT"
+          if [[ "$docker_result" == "skipped" ]]; then
+            docker_result="$DOCKER_REGISTRY_RESULT"
+          fi
+          if [[ "$DOCKER_ARTIFACT_RESULT" != "skipped" && "$DOCKER_REGISTRY_RESULT" != "skipped" ]]; then
+            echo "::error::Both Docker acceptance transports ran; expected exactly one."
+            exit 1
+          fi
+          if [[ "$DOCKER_ARTIFACT_RESULT" == "skipped" && "$DOCKER_REGISTRY_RESULT" == "skipped" ]]; then
+            echo "::error::No Docker acceptance transport ran; expected exactly one."
+            exit 1
+          fi
           failed=0
           for item in \
             "resolve_package=${RESOLVE_RESULT}" \
             "package_integrity=${PACKAGE_INTEGRITY_RESULT}" \
-            "docker_acceptance=${DOCKER_RESULT}" \
+            "docker_acceptance=${docker_result}" \
             "package_telegram=${PACKAGE_TELEGRAM_RESULT}"
           do
             name="${item%%=*}"

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 1
           fetch-tags: false
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Build plugin prerelease manifest
@@ -228,7 +228,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -264,7 +264,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -337,7 +337,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -369,7 +369,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
           fetch-depth: 1
           fetch-tags: false
-          persist-credentials: true
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -539,7 +539,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
+      packages: read
       pull-requests: read
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
@@ -551,6 +551,8 @@ jobs:
       targeted_docker_lane_group_size: 4
       include_live_suites: false
       live_models_only: false
+      shared_image_artifact_namespace: plugin-prerelease
+      shared_image_policy: no-push-artifact
 
   plugin-prerelease-suite:
     permissions:

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -272,13 +272,13 @@ A legacy fallback correction tag may reuse base-package evidence only when the c
 
 ## Release test boxes
 
-`Full Release Validation` is how operators kick off all pre-release tests from one entrypoint. For a pinned commit proof on a fast-moving branch, use the helper so every child workflow runs from a temporary branch fixed at the target SHA:
+`Full Release Validation` is how operators kick off all pre-release tests from one entrypoint. For a pinned commit proof on a fast-moving branch, use the helper so every child workflow runs from a temporary branch fixed at one trusted `main` workflow SHA while the requested commit remains the candidate under test:
 
 ```bash
 pnpm ci:full-release --sha <full-sha>
 ```
 
-The helper pushes `release-ci/<sha>-...`, dispatches `Full Release Validation` from that branch with `ref=<sha>`, verifies every child workflow `headSha` matches the target, then deletes the temporary branch. This avoids proving a newer `main` child run by accident.
+The helper fetches current `origin/main`, pushes `release-ci/<workflow-sha>-...` at that trusted workflow commit, dispatches `Full Release Validation` from the temporary branch with `ref=<target-sha>` and `reuse_evidence=false`, verifies every child workflow `headSha` matches the pinned parent workflow SHA, then deletes the temporary branch. Pass `--workflow-sha <trusted-main-sha>` to pin an older commit that is still reachable from current `origin/main`. The workflow itself never writes repository refs. This keeps main-only release tooling available without adding tooling commits to the candidate and avoids proving a newer `main` child run by accident.
 
 For release branch or tag validation, run it from the trusted `main` workflow ref and pass the release branch or tag as `ref`:
 
@@ -294,9 +294,14 @@ gh workflow run full-release-validation.yml \
 
 The workflow resolves the target ref, dispatches manual `CI` with `target_ref=<release-ref>`, then dispatches `OpenClaw Release Checks`. `OpenClaw Release Checks` fans out install smoke, cross-OS release checks, live/E2E Docker release-path coverage when soak is enabled, Package Acceptance with the canonical Telegram package E2E, QA Lab parity, live Matrix, and live Telegram. A full/all run is only acceptable when the `Full Release Validation` summary shows `normal_ci`, `plugin_prerelease`, and `release_checks` as successful, unless a focused rerun intentionally skipped the separate `Plugin Prerelease` child. Use the standalone `npm-telegram` child only for a focused published-package rerun with `release_package_spec` or `npm_telegram_package_spec`. The final verifier summary includes slowest-job tables for each child run, so the release manager can see the current critical path without downloading logs.
 
+The product-performance child is artifact-only in this release path. The
+umbrella dispatches it with `publish_reports=false`, and validation is rejected
+unless its artifact-only guard proves that the Clawgrit report publisher stayed
+skipped.
+
 See [Full release validation](/reference/full-release-validation) for the complete stage matrix, exact workflow job names, stable versus full profile differences, artifacts, and focused rerun handles.
 
-Child workflows are dispatched from the trusted ref that runs `Full Release Validation`, normally `--ref main`, even when the target `ref` points at an older release branch or tag. There is no separate Full Release Validation workflow-ref input; choose the trusted harness by choosing the workflow run ref. Do not use `--ref main -f ref=<sha>` for exact commit proof on moving `main`; raw commit SHAs cannot be workflow dispatch refs, so use `pnpm ci:full-release --sha <sha>` to create the pinned temporary branch.
+Child workflows are dispatched from the trusted ref that runs `Full Release Validation`, normally `--ref main`, even when the target `ref` points at an older release branch or tag. Every child run must use the exact parent workflow SHA; if `main` advances before a child dispatch resolves, the umbrella fails closed. There is no separate Full Release Validation workflow-ref input; choose the trusted harness by choosing the workflow run ref. Do not use `--ref main -f ref=<sha>` for exact commit proof on moving `main`; raw commit SHAs cannot be workflow dispatch refs, so use `pnpm ci:full-release --sha <target-sha>` to create a temporary branch at trusted `origin/main` while keeping the target SHA as the candidate input.
 
 Use `release_profile` to select live/provider breadth:
 
@@ -342,7 +347,15 @@ gh workflow run full-release-validation.yml \
 
 Do not use the full umbrella as the first rerun after a focused fix. If one box fails, use the failed child workflow, job, Docker lane, package profile, model provider, or QA lane for the next proof. Run the full umbrella again only when the fix changed shared release orchestration or made earlier all-box evidence stale. The umbrella's final verifier re-checks the recorded child workflow run ids, so after a child workflow is rerun successfully, rerun only the failed `Verify full validation` parent job.
 
-Release-metadata-only commits (changelog refreshes, version stamps) do not need a new full validation: `rerun_group=all` first checks for a prior green validation whose target differs only by release metadata paths and reuses that evidence, skipping every lane. Newer umbrella runs for the same `release/*` ref and rerun group supersede in-progress ones automatically. Pass `reuse_evidence=false` to force a fresh full run.
+`rerun_group=all` may reuse a prior green umbrella run only when it validated
+the exact same target SHA, release profile, effective soak setting, and
+validation inputs. This is bounded recovery for rerunning the same candidate,
+not cross-SHA evidence reuse. For a changed candidate, including a changelog or
+version-only commit, rerun every package, artifact, install, Docker, or provider
+gate affected by the changed paths or artifact hashes. Newer umbrella runs for
+the same `release/*`
+ref and rerun group supersede in-progress ones automatically. Pass
+`reuse_evidence=false` to force a fresh full run.
 
 For bounded recovery, pass `rerun_group` to the umbrella. `all` is the real release-candidate run, `ci` runs only the normal CI child, `plugin-prerelease` runs only the release-only plugin child, `release-checks` runs every release box, and the narrower release groups are `install-smoke`, `cross-os`, `live-e2e`, `package`, `qa`, `qa-parity`, `qa-live`, and `npm-telegram`. Focused `npm-telegram` reruns require `release_package_spec` or `npm_telegram_package_spec`; full/all runs use the canonical package Telegram E2E inside Package Acceptance. Focused cross-OS reruns can add `cross_os_suite_filter=windows/packaged-upgrade` or another OS/suite filter. QA release-check failures block normal release validation, including required OpenClaw dynamic tool drift in the standard tier. Tideclaw alpha runs may still treat non-package-safety release-check lanes as advisory. With `release_profile=beta`, the `Run repo/live E2E validation` live-provider suites are advisory (warnings, not blockers); stable and full profiles keep them blocking. When `live_suite_filter` explicitly requests a gated QA live lane such as Discord, WhatsApp, or Slack, the matching `OPENCLAW_RELEASE_QA_*_LIVE_CI_ENABLED` repo variable must be enabled; otherwise input capture fails instead of silently skipping the lane.
 

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -24,9 +24,21 @@ gh workflow run full-release-validation.yml \
 ```
 
 `provider` also accepts `anthropic` or `minimax` for cross-OS onboarding and the
-end-to-end agent turn. Child workflows use the trusted workflow ref for the
-harness and the input `ref` for the candidate under test, so new validation
-logic stays available when validating an older release branch or tag.
+end-to-end agent turn. Reusable child jobs resolve the called workflow harness
+from `job.workflow_repository` and `job.workflow_sha`, while the input `ref`
+selects the candidate under test. This keeps current trusted validation logic
+available when validating an older release branch or tag.
+
+Every dispatched child must report the same workflow SHA as the parent
+`Full Release Validation` run. If `main` moves between the parent and child
+dispatches, the umbrella fails closed even when the child itself succeeds. For
+an immutable exact-commit proof, use
+`pnpm ci:full-release --sha <target-sha>`. The helper creates a temporary
+`release-ci/*` ref pinned to current trusted `origin/main`, passes the target
+SHA only as the candidate `ref`, disables evidence reuse, and deletes the ref
+after validation. Pass `--workflow-sha <trusted-main-sha>` to select an older
+workflow commit still reachable from current `origin/main`. The workflow never
+creates or updates repository refs itself.
 
 `release_profile=stable` and `release_profile=full` always run the exhaustive
 live/Docker soak. Pass `run_release_soak=true` to include the same soak lanes
@@ -49,12 +61,15 @@ that plugin, then runs Codex CLI preflight and same-session OpenAI agent turns.
 ## Top-level stages
 
 For `rerun_group=all`, a `Check for reusable validation evidence` job runs
-first: it looks for the newest prior green full validation whose target differs
-from the current target only by release metadata paths (changelog, version
-stamps; see `RELEASE_METADATA_PATHS` in `scripts/changed-lanes.mjs`). When such
-evidence exists, every lane is skipped and the umbrella verifier re-checks the
-evidence run instead, so changelog-only commits do not re-drive hours of
-validation. Pass `reuse_evidence=false` to force a fresh full run.
+first: it looks for the newest prior green full validation for the exact same
+target SHA, release profile, effective soak setting, and validation inputs.
+When such evidence exists, every lane is skipped and the umbrella verifier
+re-checks the immutable parent artifact, child runs, and dispatch logs. This is
+same-candidate rerun recovery only; it does not authorize cross-SHA reuse. For
+a changed candidate, rerun every package, artifact, install, Docker, or provider
+gate affected by that delta. Pass `reuse_evidence=false` to force a fresh full
+run. Evidence reuse runs only when the umbrella itself was dispatched from
+`main`; non-main workflow refs run the selected lanes fresh.
 
 Also for `rerun_group=all`, a `Verify Docker runtime image assets` job builds
 the `runtime-assets` Docker target with
@@ -62,16 +77,35 @@ the `runtime-assets` Docker target with
 other stages and is enforced by the umbrella verifier; lanes no longer wait for
 it before dispatching. A narrower `rerun_group` skips this preflight.
 
-| Stage                   | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Target resolution       | **Job:** `Resolve target ref`<br />**Child workflow:** none<br />**Proves:** resolves the release branch, tag, or full commit SHA and records selected inputs.<br />**Rerun:** rerun the umbrella if this fails.                                                                                                                                                                                                                                             |
-| Docker assets preflight | **Job:** `Verify Docker runtime image assets`<br />**Child workflow:** none<br />**Proves:** the `runtime-assets` Docker build target still succeeds before any other stage dispatches. Runs only for `rerun_group=all`.<br />**Rerun:** rerun the umbrella with `rerun_group=all`.                                                                                                                                                                          |
-| Vitest and normal CI    | **Job:** `Run normal full CI`<br />**Child workflow:** `CI`<br />**Proves:** manual full CI graph against the target ref, including Linux Node lanes, bundled plugin shards, plugin and channel contract shards, Node 22 compatibility, `check-*`, `check-additional-*`, built-artifact smoke checks, docs checks, Python skills, Windows, macOS, Control UI i18n, and Android via the umbrella.<br />**Rerun:** `rerun_group=ci`.                           |
-| Plugin prerelease       | **Job:** `Run plugin prerelease validation`<br />**Child workflow:** `Plugin Prerelease`<br />**Proves:** release-only plugin static checks, agentic plugin coverage, full plugin batch shards, plugin prerelease Docker lanes, and a non-blocking `plugin-inspector-advisory` artifact for compatibility triage.<br />**Rerun:** `rerun_group=plugin-prerelease`.                                                                                           |
-| Release checks          | **Job:** `Run release/live/Docker/QA validation`<br />**Child workflow:** `OpenClaw Release Checks`<br />**Proves:** install smoke, cross-OS package checks, Package Acceptance, QA Lab parity, live Matrix, and live Telegram. Stable and full profiles also run exhaustive live/E2E suites and Docker release-path chunks; beta can opt in with `run_release_soak=true`.<br />**Rerun:** `rerun_group=release-checks` or a narrower release-checks handle. |
-| Package Telegram        | **Job:** `Run package Telegram E2E`<br />**Child workflow:** `NPM Telegram Beta E2E`<br />**Proves:** a focused published-package Telegram E2E when `release_package_spec` or `npm_telegram_package_spec` is set. Full candidate validation uses the canonical Package Acceptance Telegram E2E instead.<br />**Rerun:** `rerun_group=npm-telegram` with `release_package_spec` or `npm_telegram_package_spec`.                                               |
-| Product performance     | **Job:** `Run product performance evidence`<br />**Child workflow:** `OpenClaw Performance`<br />**Proves:** release-profile performance run (`profile=release`, `repeat=3`, `fail_on_regression=true`) against the target SHA. Required (blocking) only for `rerun_group=all` or `rerun_group=performance`; not required for narrower rerun groups.<br />**Rerun:** `rerun_group=performance`.                                                              |
-| Umbrella verifier       | **Job:** `Verify full validation`<br />**Child workflow:** none<br />**Proves:** re-checks recorded child run conclusions and appends slowest-job tables from child workflows.<br />**Rerun:** rerun only this job after rerunning a failed child to green.                                                                                                                                                                                                  |
+| Stage                   | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Target resolution       | **Job:** `Resolve target ref`<br />**Child workflow:** none<br />**Proves:** resolves the release branch, tag, or full commit SHA and records selected inputs.<br />**Rerun:** rerun the umbrella if this fails.                                                                                                                                                                                                                                                                                                            |
+| Docker assets preflight | **Job:** `Verify Docker runtime image assets`<br />**Child workflow:** none<br />**Proves:** the `runtime-assets` Docker build target still succeeds before any other stage dispatches. Runs only for `rerun_group=all`.<br />**Rerun:** rerun the umbrella with `rerun_group=all`.                                                                                                                                                                                                                                         |
+| Vitest and normal CI    | **Job:** `Run normal full CI`<br />**Child workflow:** `CI`<br />**Proves:** manual full CI graph against the target ref, including Linux Node lanes, bundled plugin shards, plugin and channel contract shards, Node 22 compatibility, `check-*`, `check-additional-*`, built-artifact smoke checks, docs checks, Python skills, Windows, macOS, Control UI i18n, and Android via the umbrella.<br />**Rerun:** `rerun_group=ci`.                                                                                          |
+| Plugin prerelease       | **Job:** `Run plugin prerelease validation`<br />**Child workflow:** `Plugin Prerelease`<br />**Proves:** release-only plugin static checks, agentic plugin coverage, full plugin batch shards, plugin prerelease Docker lanes, and a non-blocking `plugin-inspector-advisory` artifact for compatibility triage.<br />**Rerun:** `rerun_group=plugin-prerelease`.                                                                                                                                                          |
+| Release checks          | **Job:** `Run release/live/Docker/QA validation`<br />**Child workflow:** `OpenClaw Release Checks`<br />**Proves:** install smoke, cross-OS package checks, Package Acceptance, QA Lab parity, live Matrix, and live Telegram. Stable and full profiles also run exhaustive live/E2E suites and Docker release-path chunks; beta can opt in with `run_release_soak=true`.<br />**Rerun:** `rerun_group=release-checks` or a narrower release-checks handle.                                                                |
+| Package Telegram        | **Job:** `Run package Telegram E2E`<br />**Child workflow:** `NPM Telegram Beta E2E`<br />**Proves:** a focused published-package Telegram E2E when `release_package_spec` or `npm_telegram_package_spec` is set. Full candidate validation uses the canonical Package Acceptance Telegram E2E instead.<br />**Rerun:** `rerun_group=npm-telegram` with `release_package_spec` or `npm_telegram_package_spec`.                                                                                                              |
+| Product performance     | **Job:** `Run product performance evidence`<br />**Child workflow:** `OpenClaw Performance`<br />**Proves:** release-profile performance run (`profile=release`, `repeat=3`, `fail_on_regression=true`, `publish_reports=false`) against the target SHA. Kova output stays in workflow artifacts and the child must prove its report publisher was skipped. Required (blocking) only for `rerun_group=all` or `rerun_group=performance`; not required for narrower rerun groups.<br />**Rerun:** `rerun_group=performance`. |
+| Umbrella verifier       | **Job:** `Verify full validation`<br />**Child workflow:** none<br />**Proves:** re-checks recorded child run conclusions and appends slowest-job tables from child workflows.<br />**Rerun:** rerun only this job after rerunning a failed child to green.                                                                                                                                                                                                                                                                 |
+
+The umbrella always dispatches product performance in artifact-only mode.
+`OpenClaw Performance` permits report publication only for scheduled runs or a
+manual dispatch that explicitly sets `publish_reports=true`. The artifact-only
+guard must complete successfully, proving the publisher job stayed skipped.
+Fresh and reused evidence records
+`controls.performanceReportPublication=artifact-only`; the verifier and reuse
+selector reject evidence without the matching normalized performance-child
+proof.
+
+The verifier uploads the canonical manifest as
+`full-release-validation-<run-id>-<run-attempt>`. Evidence tooling validates
+its artifact ID, digest, producer run, and attempt before downloading that exact
+artifact ID. It caps the downloaded ZIP, verifies its bytes against the REST
+`sha256:` digest, and streams the only allowed bounded manifest entry without
+extracting the archive. A stable-name alias remains temporarily for older
+publish consumers. The verifier always prefers the attempt-qualified artifact;
+as a transition, it accepts the stable name only for an attempt-1 manifest v2
+producer. It rejects that legacy name for later attempts and manifest v3.
 
 For `ref=main` with `rerun_group=all`, for `release/*` refs, and for Tideclaw
 alpha refs, a newer umbrella run supersedes an older one with the same ref and

--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:?command is required}"
+shift
+artifact_dir=""
+artifact_kind=""
+target_sha=""
+workflow_sha=""
+image_refs=()
+shared_package_sha256="${OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256:-}"
+shared_archive_sha256="${OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256:-}"
+shared_run_id="${OPENCLAW_SHARED_IMAGE_RUN_ID:-}"
+shared_run_attempt="${OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT:-}"
+
+archive_name="shared-images.tar.zst"
+manifest_path=""
+archive_path=""
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+require_sha() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[a-f0-9]{40}$ ]]; then
+    fail "$label must be a lowercase full commit SHA."
+  fi
+}
+
+require_positive_decimal() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    fail "$label must be a positive decimal integer."
+  fi
+}
+
+configure_image_artifact_inputs() {
+  if [[ "$#" -lt 5 ]]; then
+    fail "usage: $0 <pack|load> <artifact-dir> <kind> <target-sha> <workflow-sha> <image-ref>..."
+  fi
+  artifact_dir="$1"
+  artifact_kind="$2"
+  target_sha="$3"
+  workflow_sha="$4"
+  image_refs=("${@:5}")
+  manifest_path="${artifact_dir}/shared-image-artifact.json"
+  archive_path="${artifact_dir}/${archive_name}"
+}
+
+verify_uploaded_artifact() {
+  if [[ "$#" -ne 6 ]]; then
+    fail "usage: $0 verify-upload <label> <artifact-id> <artifact-name> <artifact-digest> <run-id> <run-attempt>"
+  fi
+
+  local artifact_label="$1"
+  local artifact_id="$2"
+  local artifact_name="$3"
+  local artifact_digest="$4"
+  local artifact_run_id="$5"
+  local artifact_run_attempt="$6"
+  require_positive_decimal "$artifact_label artifact ID" "$artifact_id"
+  require_positive_decimal "$artifact_label producer run ID" "$artifact_run_id"
+  require_positive_decimal "$artifact_label producer run attempt" "$artifact_run_attempt"
+  if [[ ! "$artifact_digest" =~ ^[a-f0-9]{64}$ ]]; then
+    fail "$artifact_label artifact digest must be a lowercase SHA-256."
+  fi
+  if [[ -z "${artifact_name// }" || "$artifact_name" == *$'\n'* || "$artifact_name" == *$'\r'* ]]; then
+    fail "$artifact_label artifact name is missing or invalid."
+  fi
+  if [[ "$artifact_name" != *"-${artifact_run_id}-${artifact_run_attempt}" ]]; then
+    fail "$artifact_label artifact name does not bind the producer run attempt."
+  fi
+  if [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    fail "GITHUB_REPOSITORY is missing or invalid."
+  fi
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    fail "GH_TOKEN is required to verify the uploaded artifact."
+  fi
+  command -v gh >/dev/null
+  command -v jq >/dev/null
+
+  local artifact_json attempt_json
+  artifact_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}")"
+  jq -e \
+    --arg digest "sha256:${artifact_digest}" \
+    --arg id "$artifact_id" \
+    --arg name "$artifact_name" \
+    --arg run_id "$artifact_run_id" \
+    '
+      (.id | tostring) == $id and
+      .name == $name and
+      .expired == false and
+      .digest == $digest and
+      (.workflow_run.id | tostring) == $run_id
+    ' <<< "$artifact_json" >/dev/null ||
+    fail "$artifact_label artifact identity does not match the immutable producer tuple."
+
+  attempt_json="$(
+    gh api \
+      "repos/${GITHUB_REPOSITORY}/actions/runs/${artifact_run_id}/attempts/${artifact_run_attempt}"
+  )"
+  jq -e \
+    --arg attempt "$artifact_run_attempt" \
+    --arg run_id "$artifact_run_id" \
+    '(.id | tostring) == $run_id and (.run_attempt | tostring) == $attempt' \
+    <<< "$attempt_json" >/dev/null ||
+    fail "$artifact_label producer run attempt does not match the immutable tuple."
+}
+
+require_common_inputs() {
+  require_sha "target SHA" "$target_sha"
+  require_sha "workflow SHA" "$workflow_sha"
+  if [[ -n "$shared_package_sha256" && ! "$shared_package_sha256" =~ ^[a-f0-9]{64}$ ]]; then
+    fail "shared package SHA-256 must be a lowercase digest."
+  fi
+  if [[ ! "$artifact_kind" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    fail "artifact kind must contain only lowercase letters, digits, and hyphens."
+  fi
+  if [[ "${#image_refs[@]}" -eq 0 ]]; then
+    fail "at least one image ref is required."
+  fi
+  local image_ref
+  declare -A seen_refs=()
+  for image_ref in "${image_refs[@]}"; do
+    if [[ ! "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/@:-]*$ ]]; then
+      fail "image ref contains unsupported characters: $image_ref"
+    fi
+    if [[ -n "${seen_refs[$image_ref]:-}" ]]; then
+      fail "duplicate image ref: $image_ref"
+    fi
+    seen_refs["$image_ref"]=1
+  done
+}
+
+require_safe_pack_destination() {
+  if [[ -z "${RUNNER_TEMP:-}" || "$RUNNER_TEMP" != /* ]]; then
+    fail "RUNNER_TEMP must be an absolute path for artifact packing."
+  fi
+  if [[ "$artifact_dir" != /* ]]; then
+    fail "artifact directory must be absolute for artifact packing."
+  fi
+
+  local artifact_basename artifact_parent resolved_artifact_parent resolved_runner_temp runner_temp
+  runner_temp="${RUNNER_TEMP%/}"
+  artifact_basename="$(basename "$artifact_dir")"
+  artifact_parent="$(dirname "$artifact_dir")"
+  if [[ ! "$artifact_basename" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    fail "artifact directory name contains unsupported characters."
+  fi
+  resolved_runner_temp="$(cd "$RUNNER_TEMP" && pwd -P)"
+  resolved_artifact_parent="$(cd "$artifact_parent" && pwd -P)"
+  if [[ "$resolved_artifact_parent" != "$resolved_runner_temp" ]]; then
+    fail "artifact directory must be a child of RUNNER_TEMP."
+  fi
+  if [[ "$artifact_parent" != "$runner_temp" ||
+    "$artifact_dir" != "${runner_temp}/${artifact_basename}" ||
+    -L "$artifact_dir" ]]; then
+    fail "artifact directory must be a normalized path without symlink or parent traversal."
+  fi
+}
+
+pack_artifact() {
+  require_common_inputs
+  require_safe_pack_destination
+  command -v docker >/dev/null
+  command -v node >/dev/null
+  command -v sha256sum >/dev/null
+  command -v zstd >/dev/null
+
+  local image_list image_ref image_id image_tar archive_sha256 archive_size_bytes
+  local stage_dir stage_manifest_path stage_archive_path
+  image_list="$(mktemp)"
+  image_tar="$(mktemp)"
+  stage_dir="$(mktemp -d "${RUNNER_TEMP}/shared-image-artifact.XXXXXX")"
+  stage_manifest_path="${stage_dir}/shared-image-artifact.json"
+  stage_archive_path="${stage_dir}/${archive_name}"
+  cleanup_pack() {
+    rm -f "$image_list" "$image_tar"
+    if [[ -n "${stage_dir:-}" ]]; then
+      rm -rf -- "$stage_dir"
+    fi
+  }
+  trap cleanup_pack EXIT
+
+  for image_ref in "${image_refs[@]}"; do
+    image_id="$(docker image inspect --format '{{.Id}}' "$image_ref")"
+    if [[ ! "$image_id" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+      fail "image has an invalid config digest: $image_ref"
+    fi
+    printf '%s\t%s\n' "$image_ref" "$image_id" >> "$image_list"
+  done
+
+  docker image save --output "$image_tar" "${image_refs[@]}"
+  zstd -T0 -10 --no-progress -f "$image_tar" -o "$stage_archive_path"
+  zstd -t "$stage_archive_path"
+  archive_sha256="$(sha256sum "$stage_archive_path" | awk '{print $1}')"
+  archive_size_bytes="$(wc -c < "$stage_archive_path" | tr -d '[:space:]')"
+
+  ARCHIVE_SHA256="$archive_sha256" \
+    ARCHIVE_SIZE_BYTES="$archive_size_bytes" \
+    node - "$stage_manifest_path" "$image_list" <<'NODE'
+const fs = require("node:fs");
+
+const [manifestPath, imageListPath] = process.argv.slice(2);
+const images = fs
+  .readFileSync(imageListPath, "utf8")
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => {
+    const [ref, id] = line.split("\t");
+    return { ref, id };
+  });
+const manifest = {
+  schema: "openclaw.shared-docker-image-artifact/v1",
+  schemaVersion: 1,
+  kind: process.env.ARTIFACT_KIND,
+  targetSha: process.env.TARGET_SHA,
+  workflowSha: process.env.WORKFLOW_SHA,
+  packageSha256: process.env.SHARED_PACKAGE_SHA256 || null,
+  packageSourceSha: process.env.SHARED_PACKAGE_SHA256 ? process.env.TARGET_SHA : null,
+  runId: Number(process.env.GITHUB_RUN_ID),
+  runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+  archive: {
+    filename: process.env.ARCHIVE_NAME,
+    format: "docker-tar+zstd",
+    sha256: process.env.ARCHIVE_SHA256,
+    sizeBytes: Number(process.env.ARCHIVE_SIZE_BYTES),
+  },
+  images,
+  conclusion: "success",
+};
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+
+  rm -rf -- "$artifact_dir"
+  mv -- "$stage_dir" "$artifact_dir"
+  stage_dir=""
+  cleanup_pack
+  trap - EXIT
+}
+
+load_artifact() {
+  require_common_inputs
+  if [[ ! "$shared_archive_sha256" =~ ^[a-f0-9]{64}$ ]]; then
+    fail "expected shared image archive SHA-256 must be a lowercase digest."
+  fi
+  command -v docker >/dev/null
+  command -v node >/dev/null
+  command -v sha256sum >/dev/null
+  command -v zstd >/dev/null
+  [[ -f "$manifest_path" ]] || fail "shared Docker image artifact manifest is missing: $manifest_path"
+  [[ -f "$archive_path" ]] || fail "shared Docker image archive is missing: $archive_path"
+
+  local validated_path
+  validated_path="$(mktemp)"
+  cleanup_load() {
+    rm -f "$validated_path"
+  }
+  trap cleanup_load EXIT
+
+  EXPECTED_IMAGES_JSON="$(
+    printf '%s\0' "${image_refs[@]}" |
+      node -e '
+        const fs = require("node:fs");
+        const refs = fs.readFileSync(0).toString("utf8").split("\0").filter(Boolean);
+        process.stdout.write(JSON.stringify(refs));
+      '
+  )" node - "$manifest_path" > "$validated_path" <<'NODE'
+const fs = require("node:fs");
+
+const [manifestPath] = process.argv.slice(2);
+const value = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+const expectedRefs = JSON.parse(process.env.EXPECTED_IMAGES_JSON);
+const fail = (message) => {
+  throw new Error(`invalid shared Docker image artifact: ${message}`);
+};
+
+if (value.schema !== "openclaw.shared-docker-image-artifact/v1") fail("schema");
+if (value.schemaVersion !== 1) fail("schemaVersion");
+if (value.kind !== process.env.ARTIFACT_KIND) fail("kind");
+if (value.targetSha !== process.env.TARGET_SHA) fail("target SHA");
+if (value.workflowSha !== process.env.WORKFLOW_SHA) fail("workflow SHA");
+const expectedPackageSha256 = process.env.SHARED_PACKAGE_SHA256 || null;
+const expectedPackageSourceSha = expectedPackageSha256 ? process.env.TARGET_SHA : null;
+if (value.packageSha256 !== expectedPackageSha256) fail("package SHA-256");
+if (value.packageSourceSha !== expectedPackageSourceSha) fail("package source SHA");
+if (value.runId !== Number(process.env.SHARED_RUN_ID)) fail("run ID");
+if (value.runAttempt !== Number(process.env.SHARED_RUN_ATTEMPT)) fail("run attempt");
+if (value.conclusion !== "success") fail("conclusion");
+if (value.archive?.filename !== "shared-images.tar.zst") fail("archive filename");
+if (value.archive?.format !== "docker-tar+zstd") fail("archive format");
+if (!/^[a-f0-9]{64}$/.test(value.archive?.sha256 ?? "")) fail("archive sha256");
+if (value.archive.sha256 !== process.env.SHARED_ARCHIVE_SHA256) fail("expected archive sha256");
+if (!Number.isSafeInteger(value.archive?.sizeBytes) || value.archive.sizeBytes <= 0) {
+  fail("archive size");
+}
+if (!Array.isArray(value.images) || value.images.length !== expectedRefs.length) {
+  fail("image count");
+}
+for (let index = 0; index < expectedRefs.length; index += 1) {
+  const image = value.images[index];
+  if (image?.ref !== expectedRefs[index]) fail(`image ref ${index}`);
+  if (!/^sha256:[a-f0-9]{64}$/.test(image?.id ?? "")) fail(`image id ${index}`);
+}
+
+process.stdout.write(`${value.archive.sha256}\n${value.archive.sizeBytes}\n`);
+for (const image of value.images) {
+  process.stdout.write(`${image.ref}\t${image.id}\n`);
+}
+NODE
+
+  mapfile -t validated < "$validated_path"
+  if [[ "${#validated[@]}" -ne $((2 + ${#image_refs[@]})) ]]; then
+    fail "invalid shared Docker image artifact: validated manifest output length"
+  fi
+  local actual_archive_sha256 actual_archive_size
+  actual_archive_sha256="$(sha256sum "$archive_path" | awk '{print $1}')"
+  actual_archive_size="$(wc -c < "$archive_path" | tr -d '[:space:]')"
+  if [[ "$actual_archive_sha256" != "${validated[0]}" ]]; then
+    fail "shared Docker image artifact archive SHA-256 mismatch."
+  fi
+  if [[ "$actual_archive_size" != "${validated[1]}" ]]; then
+    fail "shared Docker image artifact archive size mismatch."
+  fi
+  zstd -t "$archive_path"
+  zstd -d --stdout "$archive_path" | docker image load
+
+  local index expected_ref expected_id actual_id
+  for index in "${!image_refs[@]}"; do
+    IFS=$'\t' read -r expected_ref expected_id <<< "${validated[$((index + 2))]}"
+    if [[ "$expected_ref" != "${image_refs[$index]}" ]]; then
+      fail "shared Docker image artifact ref mismatch after validation: ${image_refs[$index]}"
+    fi
+    actual_id="$(docker image inspect --format '{{.Id}}' "$expected_ref")"
+    if [[ "$actual_id" != "$expected_id" ]]; then
+      fail "shared Docker image artifact loaded ID mismatch for $expected_ref."
+    fi
+  done
+
+  cleanup_load
+  trap - EXIT
+}
+
+case "$command_name" in
+  pack | load)
+    configure_image_artifact_inputs "$@"
+    export ARTIFACT_KIND="$artifact_kind"
+    export TARGET_SHA="$target_sha"
+    export WORKFLOW_SHA="$workflow_sha"
+    export ARCHIVE_NAME="$archive_name"
+    export SHARED_PACKAGE_SHA256="$shared_package_sha256"
+    export SHARED_ARCHIVE_SHA256="$shared_archive_sha256"
+    if [[ "$command_name" == "pack" ]]; then
+      require_positive_decimal "GITHUB_RUN_ID" "${GITHUB_RUN_ID:-}"
+      require_positive_decimal "GITHUB_RUN_ATTEMPT" "${GITHUB_RUN_ATTEMPT:-}"
+      export SHARED_RUN_ID="$GITHUB_RUN_ID"
+      export SHARED_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT"
+      export ARCHIVE_SHA256=""
+      export ARCHIVE_SIZE_BYTES=""
+      pack_artifact
+    else
+      require_positive_decimal "OPENCLAW_SHARED_IMAGE_RUN_ID" "$shared_run_id"
+      require_positive_decimal "OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT" "$shared_run_attempt"
+      export SHARED_RUN_ID="$shared_run_id"
+      export SHARED_RUN_ATTEMPT="$shared_run_attempt"
+      load_artifact
+    fi
+    ;;
+  verify-upload)
+    verify_uploaded_artifact "$@"
+    ;;
+  *)
+    echo "usage: $0 <pack|load|verify-upload> ..." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -9,14 +9,17 @@ const DEFAULT_INPUTS = {
   mode: "both",
   release_profile: "full",
   rerun_group: "all",
+  reuse_evidence: "false",
 };
 
 function usage() {
-  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <sha>] [--branch <name>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--workflow-sha <trusted-main-ref>] [--branch <name>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
-Creates a temporary remote branch pinned to the target commit, dispatches Full
-Release Validation from that branch, watches the parent run, verifies all child
-workflow head SHAs match, then deletes the temporary branch by default.`);
+Creates a temporary remote branch pinned to trusted main release tooling,
+dispatches Full Release Validation with the target commit as its ref input,
+watches the parent run, verifies all child workflow head SHAs match the trusted
+workflow SHA, then deletes the temporary branch by default. Exact-target
+evidence reuse is disabled because it is trusted only from main.`);
 }
 
 function run(command, args, options = {}) {
@@ -53,6 +56,7 @@ function readOptionValue(argv, index, optionName) {
 export function parseArgs(argv) {
   const args = {
     sha: "",
+    workflowSha: "",
     branch: "",
     keepBranch: false,
     dryRun: false,
@@ -67,6 +71,11 @@ export function parseArgs(argv) {
     }
     if (arg === "--sha") {
       args.sha = readOptionValue(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg === "--workflow-sha") {
+      args.workflowSha = readOptionValue(argv, i, arg);
       i += 1;
       continue;
     }
@@ -116,6 +125,9 @@ export function parseArgs(argv) {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (args.inputs.reuse_evidence !== "false") {
+    throw new Error("SHA-pinned release validation always disables evidence reuse");
+  }
   return args;
 }
 
@@ -130,6 +142,25 @@ function sanitizeBranchPart(value) {
 function resolveSha(requestedSha) {
   const rev = requestedSha || "HEAD";
   return run("git", ["rev-parse", "--verify", `${rev}^{commit}`], { dryRun: false });
+}
+
+function resolveTrustedWorkflowSha(requestedSha) {
+  run("git", ["fetch", "--no-tags", "origin", "refs/heads/main:refs/remotes/origin/main"], {
+    stdio: "inherit",
+  });
+  const workflowSha = resolveSha(requestedSha || "origin/main");
+  const ancestry = runStatus("git", [
+    "merge-base",
+    "--is-ancestor",
+    workflowSha,
+    "refs/remotes/origin/main",
+  ]);
+  if (ancestry.status !== 0) {
+    throw new Error(
+      `Workflow SHA ${workflowSha} is not reachable from current origin/main; refusing an untrusted release harness.`,
+    );
+  }
+  return workflowSha;
 }
 
 function collectRunId(dispatchOutput) {
@@ -175,7 +206,7 @@ function childRunIds(parentRunId) {
   return [...new Set([...log.matchAll(/actions\/runs\/(\d+)/g)].map((match) => match[1]))];
 }
 
-function verifyChildHeads(parentRunId, sha) {
+function verifyChildHeads(parentRunId, workflowSha) {
   const ids = childRunIds(parentRunId);
   if (ids.length === 0) {
     throw new Error(
@@ -188,29 +219,33 @@ function verifyChildHeads(parentRunId, sha) {
     const json = run("gh", ["run", "view", id, "--json", "name,status,conclusion,headSha,url"]);
     const child = JSON.parse(json);
     const ok =
-      child.headSha === sha && child.status === "completed" && child.conclusion === "success";
+      child.headSha === workflowSha &&
+      child.status === "completed" &&
+      child.conclusion === "success";
     console.log(
       `${ok ? "ok" : "bad"} ${child.name} ${child.status}/${child.conclusion} ${child.headSha} ${child.url}`,
     );
     failed ||= !ok;
   }
   if (failed) {
-    throw new Error(`One or more child workflows failed or did not run at ${sha}.`);
+    throw new Error(`One or more child workflows failed or did not run at ${workflowSha}.`);
   }
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const sha = resolveSha(args.sha);
-  const shortSha = sha.slice(0, 12);
+  const targetSha = resolveSha(args.sha);
+  const workflowSha = resolveTrustedWorkflowSha(args.workflowSha);
+  const shortSha = workflowSha.slice(0, 12);
   const branch = sanitizeBranchPart(args.branch || `release-ci/${shortSha}-${Date.now()}`);
   const remoteBranchRef = `refs/heads/${branch}`;
-  const dispatchInputs = { ref: sha, ...args.inputs };
+  const dispatchInputs = { ref: targetSha, ...args.inputs };
 
-  console.log(`Target SHA: ${sha}`);
+  console.log(`Target SHA: ${targetSha}`);
+  console.log(`Trusted workflow SHA: ${workflowSha}`);
   console.log(`Temporary workflow ref: ${branch}`);
 
-  run("git", ["push", "origin", `${sha}:${remoteBranchRef}`], {
+  run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`], {
     dryRun: args.dryRun,
     stdio: "inherit",
   });
@@ -229,7 +264,7 @@ function main() {
     parentRunId = collectRunId(dispatchOutput);
     if (!parentRunId && !args.dryRun) {
       for (let attempt = 0; attempt < 60; attempt += 1) {
-        parentRunId = findLatestRunId(branch, sha);
+        parentRunId = findLatestRunId(branch, workflowSha);
         if (parentRunId) {
           break;
         }
@@ -256,7 +291,7 @@ function main() {
         `Full Release Validation failed: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
       );
     }
-    verifyChildHeads(parentRunId, sha);
+    verifyChildHeads(parentRunId, workflowSha);
   } finally {
     if (!args.keepBranch) {
       run("git", ["push", "origin", `:${remoteBranchRef}`], {

--- a/scripts/github/find-reusable-release-validation.sh
+++ b/scripts/github/find-reusable-release-validation.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Finds a prior green Full Release Validation run whose evidence still covers
-# the target SHA: same rerun scope, equal-or-broader release profile/soak, and
-# a target delta that is release-metadata-only per check-release-metadata-only.
+# Finds a prior green Full Release Validation run for the exact target SHA.
+# Cross-SHA evidence reuse is intentionally left to the granular delta manifest,
+# which can require fresh package/install/provider closure per changed artifact.
 # Always exits 0 with reuse=true/false; callers fail open to a full validation.
 
 REPO="${GH_REPO:-}"
 WORKFLOW_FILE="full-release-validation.yml"
 TARGET_SHA=""
-WORKFLOW_SHA=""
+VERIFIER_WORKFLOW_SHA=""
 RELEASE_PROFILE=""
 RUN_RELEASE_SOAK="false"
 INPUTS_JSON=""
@@ -17,8 +17,9 @@ REPO_DIR="."
 MAX_CANDIDATES=12
 GITHUB_OUTPUT_FILE="${GITHUB_OUTPUT:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLASSIFIER="${SCRIPT_DIR}/../check-release-metadata-only.mjs"
 PREFLIGHT="${SCRIPT_DIR}/../release-preflight.mjs"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VALIDATOR="${OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR:-${REPO_ROOT}/.agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs}"
 
 usage() {
   cat >&2 <<'EOF'
@@ -27,12 +28,12 @@ Usage: find-reusable-release-validation.sh --target-sha <sha> --workflow-sha <sh
   [--run-release-soak <true|false>] [--repo <owner/repo>] [--repo-dir <path>] \
   [--workflow <file>] [--max-candidates <n>] [--github-output <file>]
 
-Scans recent successful Full Release Validation runs for a validation manifest
-whose targetSha differs from --target-sha only by release metadata paths, whose
-recorded lane-selection inputs match --inputs-json exactly, whose harness
-(.github/workflows tree at the run's head SHA) matches --workflow-sha, and
-whose recorded child runs are still green. Writes reuse=true plus evidence_*
-outputs when found; reuse=false otherwise.
+Scans recent successful Full Release Validation runs for an exact-target
+validation manifest whose recorded lane-selection inputs match --inputs-json
+and whose normalized strict-v3 evidence is accepted by the current trusted-main
+verifier identified by --workflow-sha. The historical producer workflow SHA
+remains independent. Writes reuse=true plus evidence_* outputs when found;
+reuse=false otherwise.
 EOF
 }
 
@@ -43,7 +44,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --workflow-sha)
-      WORKFLOW_SHA="${2:-}"
+      VERIFIER_WORKFLOW_SHA="${2:-}"
       shift 2
       ;;
     --release-profile)
@@ -107,74 +108,43 @@ no_reuse() {
   exit 0
 }
 
-profile_rank() {
-  case "$1" in
-    beta) echo 1 ;;
-    stable) echo 2 ;;
-    full) echo 3 ;;
-    *) echo 0 ;;
-  esac
-}
-
 if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Expected --target-sha to be a full lowercase commit SHA; got: ${TARGET_SHA}" >&2
   exit 2
 fi
-if [[ ! "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-  echo "Expected --workflow-sha to be a full lowercase commit SHA; got: ${WORKFLOW_SHA}" >&2
+if [[ ! "$VERIFIER_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Expected --workflow-sha to be a full lowercase commit SHA; got: ${VERIFIER_WORKFLOW_SHA}" >&2
   exit 2
 fi
 if [[ -z "$REPO" ]]; then
   echo "Expected --repo <owner/repo> or GH_REPO." >&2
   exit 2
 fi
-current_rank="$(profile_rank "$RELEASE_PROFILE")"
-if [[ "$current_rank" == "0" ]]; then
-  no_reuse "unknown release profile ${RELEASE_PROFILE}"
+if [[ "$RUN_RELEASE_SOAK" != "true" && "$RUN_RELEASE_SOAK" != "false" ]]; then
+  echo "Expected --run-release-soak to be true or false; got: ${RUN_RELEASE_SOAK}" >&2
+  exit 2
 fi
+case "$RELEASE_PROFILE" in
+  beta|stable|full) ;;
+  *) no_reuse "unknown release profile ${RELEASE_PROFILE}" ;;
+esac
 expected_inputs=""
-if ! expected_inputs="$(jq -Sc . <<< "$INPUTS_JSON" 2>/dev/null)" || [[ -z "$expected_inputs" ]]; then
+if ! expected_inputs="$(jq -Sc 'if type == "object" then . else error("expected object") end' <<< "$INPUTS_JSON" 2>/dev/null)" || [[ -z "$expected_inputs" ]]; then
   echo "Expected --inputs-json to be a JSON object of lane-selection inputs." >&2
   exit 2
 fi
 
-# A metadata-only diff can still leave the target's version stamps mutually
-# inconsistent (for example package.json bumped without the macOS plist);
-# validate the target state before trusting any prior evidence.
+# Exact-target reuse still requires internally consistent version stamps
+# (for example package.json must agree with the macOS plist).
 if ! (cd "$REPO_DIR" && node "$PREFLIGHT" --macos-versions-only >&2); then
   no_reuse "target version metadata is inconsistent"
 fi
-
-# Evidence must come from an equivalent harness: workflows and their helper
-# scripts run from the workflow ref, so the tree diff between the candidate
-# run's head SHA and the current workflow SHA must itself be metadata-only.
-harness_matches() {
-  local candidate_sha="$1"
-  if [[ "$candidate_sha" == "$WORKFLOW_SHA" ]]; then
-    return 0
-  fi
-  if ! git -C "$REPO_DIR" fetch --quiet --depth=1 origin "$candidate_sha" "$WORKFLOW_SHA"; then
-    return 1
-  fi
-  local harness_paths
-  if ! harness_paths="$(git -C "$REPO_DIR" diff --name-only "$candidate_sha" "$WORKFLOW_SHA")"; then
-    return 1
-  fi
-  if [[ -z "$harness_paths" ]]; then
-    return 0
-  fi
-  local -a harness_path_list=()
-  while IFS= read -r harness_path; do
-    [[ -n "$harness_path" ]] && harness_path_list+=("$harness_path")
-  done <<< "$harness_paths"
-  (cd "$REPO_DIR" && node "$CLASSIFIER" --base "$candidate_sha" --head "$WORKFLOW_SHA" -- "${harness_path_list[@]}")
-}
 
 runs_json=""
 if ! runs_json="$(
   gh api -X GET "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs" \
     -F status=success -F event=workflow_dispatch -F per_page="$MAX_CANDIDATES" \
-    --jq '[.workflow_runs[] | {id, html_url, head_sha}]'
+    --jq '[.workflow_runs[] | {id}]'
 )"; then
   no_reuse "could not list prior successful validation runs"
 fi
@@ -184,157 +154,116 @@ if [[ "$run_count" == "0" ]]; then
   no_reuse "no prior successful validation runs"
 fi
 
-work_dir="$(mktemp -d)"
-trap 'rm -rf "$work_dir"' EXIT
-
 for ((index = 0; index < run_count; index += 1)); do
   run_id="$(jq -r ".[${index}].id" <<< "$runs_json")"
-  run_url="$(jq -r ".[${index}].html_url" <<< "$runs_json")"
-  run_head_sha="$(jq -r ".[${index}].head_sha // \"\"" <<< "$runs_json")"
-
-  if [[ ! "$run_head_sha" =~ ^[0-9a-f]{40}$ ]] || ! harness_matches "$run_head_sha"; then
-    echo "[evidence-reuse] run ${run_id}: harness differs from the current workflow ref beyond release metadata; skipping" >&2
-    continue
-  fi
-
-  artifact_id=""
-  if ! artifact_id="$(
-    gh api "repos/${REPO}/actions/runs/${run_id}/artifacts?per_page=100" \
-      --jq "first(.artifacts[] | select(.name == \"full-release-validation-${run_id}\" and .expired == false) | .id)"
+  validation_record=""
+  if ! validation_record="$(
+    node "$VALIDATOR" \
+      --validate-run "$run_id" \
+      --repo "$REPO" \
+      --trusted-workflow-ref main \
+      --json
   )"; then
-    echo "[evidence-reuse] run ${run_id}: artifact listing failed; skipping" >&2
+    echo "[evidence-reuse] run ${run_id}: shared evidence validator rejected the run; skipping" >&2
     continue
   fi
-  if [[ -z "${artifact_id// }" ]]; then
-    echo "[evidence-reuse] run ${run_id}: no validation manifest artifact; skipping" >&2
+  if ! jq -e \
+    --arg repo "$REPO" \
+    --arg run_id "$run_id" \
+    --arg verifier_sha "$VERIFIER_WORKFLOW_SHA" '
+      . as $record
+      | .schema == "openclaw.release-validation-evidence/v3"
+      and .valid == true
+      and .repository == $repo
+      and .producerOnTrustedMainLineage == true
+      and .trustedWorkflowRef == "main"
+      and .trustedWorkflowFullRef == "refs/heads/main"
+      and .directRoot == true
+      and .evidenceReuse == null
+      and .rerunGroup == "all"
+      and .controls.performanceReportPublication == "artifact-only"
+      and .conclusions.current == "success"
+      and .conclusions.root == "success"
+      and .conclusions.allRequiredSucceeded == true
+      and (.current == .root)
+      and (.root.runId | tostring) == $run_id
+      and (.root.workflowSha | type == "string" and test("^[0-9a-f]{40}$"))
+      and (.root.targetSha | type == "string" and test("^[0-9a-f]{40}$"))
+      and (.root.artifact.digest | type == "string" and test("^sha256:[0-9a-f]{64}$"))
+      and all($record.current, $record.root;
+        .producerOnTrustedMainLineage == true
+        and .workflowFullRef == "refs/heads/main"
+        and .workflowRefType == "branch"
+        and .workflowPath == ".github/workflows/full-release-validation.yml"
+        and .workflowQualifiedPath ==
+          ".github/workflows/full-release-validation.yml@refs/heads/main"
+        and (
+          .workflowRunPath == ".github/workflows/full-release-validation.yml"
+          or .workflowRunPath ==
+            ".github/workflows/full-release-validation.yml@refs/heads/main"
+        )
+        and (
+          (.manifestVersion == 3 and .workflowRefProof == "manifest-v3-branch")
+          or (
+            .manifestVersion == 2
+            and .workflowRefProof == "legacy-v2-main-ancestry"
+          )
+        )
+      )
+      and (.verifier.schemaVersion == 3)
+      and (.verifier.sourceSha == $verifier_sha)
+      and ([.children[].role] | sort) ==
+        ["normalCi", "pluginPrerelease", "productPerformance", "releaseChecks"]
+      and ([.children[].runId] | length == (unique | length))
+      and ([.children[]
+        | select(.role == "productPerformance")
+        | .reportPublication] == ["artifact-only"])
+      and all(.children[];
+        .status == "completed"
+        and .conclusion == "success"
+        and .workflowSha == $record.root.workflowSha
+        and (.sourceParentRunId | tostring) == $run_id
+      )
+    ' <<< "$validation_record" >/dev/null 2>&1; then
+    echo "[evidence-reuse] run ${run_id}: normalized evidence is not a strict direct-root full validation; skipping" >&2
     continue
   fi
 
-  manifest_zip="${work_dir}/manifest-${run_id}.zip"
-  manifest_path="${work_dir}/manifest-${run_id}.json"
-  if ! gh api "repos/${REPO}/actions/artifacts/${artifact_id}/zip" > "$manifest_zip"; then
-    echo "[evidence-reuse] run ${run_id}: manifest download failed; skipping" >&2
-    continue
-  fi
-  if ! unzip -p "$manifest_zip" full-release-validation-manifest.json > "$manifest_path" 2>/dev/null; then
-    echo "[evidence-reuse] run ${run_id}: manifest missing from artifact; skipping" >&2
-    continue
-  fi
-
-  if ! jq -e '
-    (.version >= 2)
-    and (.rerunGroup == "all")
-    and ((.targetSha // "") | test("^[0-9a-f]{40}$"))
-  ' "$manifest_path" >/dev/null 2>&1; then
-    echo "[evidence-reuse] run ${run_id}: manifest is not a full-scope v2 manifest; skipping" >&2
-    continue
-  fi
-
-  prior_profile="$(jq -r '.releaseProfile // ""' "$manifest_path")"
-  prior_rank="$(profile_rank "$prior_profile")"
-  if (( prior_rank < current_rank )); then
-    echo "[evidence-reuse] run ${run_id}: profile ${prior_profile} does not cover ${RELEASE_PROFILE}; skipping" >&2
+  prior_profile="$(jq -r '.releaseProfile // ""' <<< "$validation_record")"
+  if [[ "$prior_profile" != "$RELEASE_PROFILE" ]]; then
+    echo "[evidence-reuse] run ${run_id}: profile ${prior_profile} differs from ${RELEASE_PROFILE}; skipping" >&2
     continue
   fi
   # Lane selection (provider, mode, filters, package specs) changes what the
   # prior run proved; only exact-match manifests are reusable. Manifests
   # written before validationInputs existed never match.
-  manifest_inputs="$(jq -Sc '.validationInputs // empty' "$manifest_path")"
+  manifest_inputs="$(jq -Sc '.validationInputs // empty' <<< "$validation_record")"
   if [[ -z "$manifest_inputs" || "$manifest_inputs" != "$expected_inputs" ]]; then
     echo "[evidence-reuse] run ${run_id}: validation inputs differ from the current request; skipping" >&2
     continue
   fi
-  prior_soak="$(jq -r '.runReleaseSoak // "false"' "$manifest_path")"
-  if [[ "$RUN_RELEASE_SOAK" == "true" && "$prior_soak" != "true" ]]; then
-    echo "[evidence-reuse] run ${run_id}: no soak evidence; skipping" >&2
+  prior_soak="$(jq -r '.runReleaseSoak // false' <<< "$validation_record")"
+  if [[ "$prior_soak" != "$RUN_RELEASE_SOAK" ]]; then
+    echo "[evidence-reuse] run ${run_id}: soak ${prior_soak} differs from ${RUN_RELEASE_SOAK}; skipping" >&2
     continue
   fi
 
-  prior_sha="$(jq -r '.targetSha' "$manifest_path")"
-  # Track count/joined separately: empty-array expansion under `set -u` breaks
-  # on the bash 3.2 that macOS ships.
-  changed_paths=()
-  changed_path_count=0
-  changed_paths_joined=""
+  prior_sha="$(jq -r '.root.targetSha' <<< "$validation_record")"
   if [[ "$prior_sha" != "$TARGET_SHA" ]]; then
-    compare_json=""
-    if ! compare_json="$(
-      gh api "repos/${REPO}/compare/${prior_sha}...${TARGET_SHA}" \
-        --jq '{status, file_count: ((.files // []) | length), files: [(.files // [])[].filename]}'
-    )"; then
-      echo "[evidence-reuse] run ${run_id}: compare ${prior_sha}...${TARGET_SHA} failed; skipping" >&2
-      continue
-    fi
-    compare_status="$(jq -r '.status' <<< "$compare_json")"
-    if [[ "$compare_status" != "ahead" ]]; then
-      echo "[evidence-reuse] run ${run_id}: target is ${compare_status} of prior evidence, not ahead; skipping" >&2
-      continue
-    fi
-    file_count="$(jq -r '.file_count' <<< "$compare_json")"
-    # The compare API truncates at 300 files; a truncated list cannot prove a
-    # metadata-only delta, so fall back to full validation.
-    if (( file_count >= 300 )); then
-      echo "[evidence-reuse] run ${run_id}: delta too large to classify (${file_count} files); skipping" >&2
-      continue
-    fi
-    while IFS= read -r changed_path; do
-      if [[ -n "$changed_path" ]]; then
-        changed_paths+=("$changed_path")
-        changed_path_count=$((changed_path_count + 1))
-        changed_paths_joined="${changed_paths_joined:+${changed_paths_joined} }${changed_path}"
-      fi
-    done < <(jq -r '.files[]' <<< "$compare_json")
-    if (( changed_path_count == 0 )); then
-      echo "[evidence-reuse] run ${run_id}: delta has no file changes" >&2
-    else
-      if ! git -C "$REPO_DIR" fetch --quiet --depth=1 origin "$prior_sha"; then
-        echo "[evidence-reuse] run ${run_id}: could not fetch prior SHA ${prior_sha}; skipping" >&2
-        continue
-      fi
-      if ! (cd "$REPO_DIR" && node "$CLASSIFIER" --base "$prior_sha" --head "$TARGET_SHA" -- "${changed_paths[@]}"); then
-        echo "[evidence-reuse] run ${run_id}: delta is not release-metadata-only; skipping" >&2
-        continue
-      fi
-    fi
-  fi
-
-  # Recorded child runs can be re-run to failure after the parent stays green;
-  # reuse only evidence whose children are still completed/success, matching
-  # the recheck the normal summary performs on its own children.
-  children_healthy=1
-  while IFS= read -r child_run_id; do
-    [[ -n "$child_run_id" ]] || continue
-    if ! child_state="$(gh api "repos/${REPO}/actions/runs/${child_run_id}" --jq '(.status // "") + "/" + (.conclusion // "")')"; then
-      echo "[evidence-reuse] run ${run_id}: could not verify child run ${child_run_id}; skipping" >&2
-      children_healthy=0
-      break
-    fi
-    if [[ "$child_state" != "completed/success" ]]; then
-      echo "[evidence-reuse] run ${run_id}: child run ${child_run_id} is ${child_state}; skipping" >&2
-      children_healthy=0
-      break
-    fi
-  done < <(jq -r '[.childRuns.normalCi // "", .childRuns.pluginPrerelease // "", .childRuns.releaseChecks // "", .childRuns.npmTelegram // "", (.childRuns.productPerformance.runId // "")] | map(select(. != "")) | .[]' "$manifest_path")
-  if [[ "$children_healthy" != "1" ]]; then
+    echo "[evidence-reuse] run ${run_id}: target ${prior_sha} differs from ${TARGET_SHA}; cross-SHA reuse requires granular artifact evidence" >&2
     continue
   fi
 
-  # A reused run may itself be a reuse manifest; evidenceReuse.runId points at
-  # the chain root that actually executed the lanes.
-  evidence_root_run_id="$(jq -r '.evidenceReuse.runId // empty' "$manifest_path")"
-  if [[ -z "${evidence_root_run_id// }" ]]; then
-    evidence_root_run_id="$run_id"
-  fi
-
-  echo "[evidence-reuse] reusing run ${run_id} (${run_url}) for ${TARGET_SHA}: prior sha ${prior_sha}, ${changed_path_count} metadata-only changed files" >&2
+  run_url="$(jq -r '.root.url' <<< "$validation_record")"
+  echo "[evidence-reuse] reusing exact-target run ${run_id} (${run_url}) for ${TARGET_SHA}" >&2
   write_output reuse true
   write_output evidence_run_id "$run_id"
-  write_output evidence_root_run_id "$evidence_root_run_id"
+  write_output evidence_root_run_id "$run_id"
   write_output evidence_run_url "$run_url"
   write_output evidence_sha "$prior_sha"
-  write_output changed_path_count "$changed_path_count"
-  write_output changed_paths "$changed_paths_joined"
-  write_output evidence_manifest "$(jq -c . "$manifest_path")"
+  write_output changed_path_count "0"
+  write_output changed_paths "[]"
+  write_output evidence_manifest "$(jq -c '.manifest' <<< "$validation_record")"
   exit 0
 done
 

--- a/scripts/lib/docker-e2e-image.sh
+++ b/scripts/lib/docker-e2e-image.sh
@@ -93,6 +93,10 @@ docker_e2e_build_or_reuse() {
   if [ "${OPENCLAW_SKIP_DOCKER_BUILD:-0}" = "1" ] || [ "$skip_build" = "1" ]; then
     echo "Reusing Docker image: $image_name"
     if ! docker_e2e_docker_cmd image inspect "$image_name" >/dev/null 2>&1; then
+      if [ "${OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE:-0}" = "1" ]; then
+        echo "Required local Docker E2E image not found: $image_name" >&2
+        return 1
+      fi
       echo "Docker image not found locally; pulling: $image_name"
       if docker_e2e_docker_cmd pull "$image_name"; then
         return 0

--- a/scripts/test-live-build-docker.sh
+++ b/scripts/test-live-build-docker.sh
@@ -54,6 +54,10 @@ if [[ "${OPENCLAW_SKIP_DOCKER_BUILD:-}" == "1" ]]; then
   if docker_e2e_docker_cmd image inspect "$LIVE_IMAGE_NAME" >/dev/null 2>&1; then
     exit 0
   fi
+  if [[ "${OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE:-0}" == "1" ]]; then
+    echo "Required local live-test image not found: $LIVE_IMAGE_NAME" >&2
+    exit 1
+  fi
   echo "==> Live-test image not found locally; pulling: $LIVE_IMAGE_NAME"
   if pull_live_image; then
     exit 0

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -1,13 +1,110 @@
-// Covers the release validation evidence-reuse resolver used by
-// full-release-validation.yml to skip lanes on release-metadata-only deltas.
+// Covers policy selection layered on the strict normalized release evidence
+// produced by release-ci-summary.mjs. Topology validation belongs there.
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = join(process.cwd(), "scripts/github/find-reusable-release-validation.sh");
 const tempDirs = createTempDirTracker();
+
+const REPOSITORY = "openclaw/openclaw";
+const PRODUCER_SHA = "0".repeat(40);
+const VERIFIER_SHA = "c".repeat(40);
+const DEFAULT_INPUTS = {
+  provider: "openai",
+  mode: "both",
+  liveSuiteFilter: "",
+  crossOsSuiteFilter: "",
+  releasePackageSpec: "",
+  packageAcceptancePackageSpec: "",
+  codexPluginSpec: "",
+};
+
+interface ParentTuple {
+  artifact: {
+    digest: string;
+    id: string;
+    name: string;
+    runAttempt: number;
+    sizeInBytes: number;
+  };
+  conclusion: string;
+  manifest: Record<string, unknown>;
+  manifestVersion: number;
+  runAttempt: number;
+  runId: string;
+  status: string;
+  targetSha: string;
+  url: string;
+  producerOnTrustedMainLineage: boolean;
+  workflowFullRef: string;
+  workflowPath: string;
+  workflowQualifiedPath: string;
+  workflowRef: string;
+  workflowRefProof: string;
+  workflowRefType: string;
+  workflowRunPath: string;
+  workflowSha: string;
+}
+
+interface ChildTuple {
+  conclusion: string;
+  dispatchNonce: string;
+  displayTitle: string;
+  event: string;
+  headBranch: string;
+  parentJobId: string;
+  path: string;
+  reportPublication?: string;
+  role: string;
+  runAttempt: number;
+  runId: string;
+  sourceParentAttempt: number;
+  sourceParentRunId: string;
+  status: string;
+  url: string;
+  workflowSha: string;
+}
+
+interface NormalizedEvidence {
+  children: ChildTuple[];
+  conclusions: {
+    allRequiredSucceeded: boolean;
+    children: Record<string, string>;
+    current: string;
+    root: string;
+  };
+  controls: Record<string, unknown>;
+  current: ParentTuple;
+  directRoot: boolean;
+  evidenceReuse: Record<string, unknown> | null;
+  manifest: Record<string, unknown>;
+  releaseProfile: string;
+  repository: string;
+  rerunGroup: string;
+  root: ParentTuple;
+  runReleaseSoak: boolean;
+  schema: string;
+  producerOnTrustedMainLineage: boolean;
+  trustedWorkflowFullRef: string;
+  trustedWorkflowRef: string;
+  valid: boolean;
+  validationInputs: Record<string, string> | null;
+  verifier: {
+    schemaVersion: number;
+    script: string;
+    scriptSha256: string;
+    sourceSha: string | null;
+  };
+}
+
+interface RunFixture {
+  exitCode?: number;
+  record?: NormalizedEvidence;
+  runId: string;
+}
 
 afterEach(() => {
   tempDirs.cleanup();
@@ -43,12 +140,11 @@ function plistFor(shortVersion: string, buildVersion: string): string {
   ].join("\n");
 }
 
-function createRepoPair(options: { plistBuildVersion?: string } = {}) {
+function createRepo(options: { plistBuildVersion?: string } = {}) {
   const origin = tempDirs.make("evidence-reuse-origin-");
   git(origin, ["init", "-q", "-b", "main"]);
-  git(origin, ["config", "user.email", "test-user"]);
+  git(origin, ["config", "user.email", "test-user@example.invalid"]);
   git(origin, ["config", "user.name", "Test User"]);
-  // Allows depth-1 fetches of the prior evidence SHA, matching GitHub remotes.
   git(origin, ["config", "uploadpack.allowReachableSHA1InWant", "true"]);
   writeFileSync(
     join(origin, "package.json"),
@@ -59,18 +155,166 @@ function createRepoPair(options: { plistBuildVersion?: string } = {}) {
     join(origin, "apps/macos/Sources/OpenClaw/Resources/Info.plist"),
     plistFor("2026.7.1", options.plistBuildVersion ?? "2026070100"),
   );
+  mkdirSync(join(origin, "docs/install"), { recursive: true });
+  writeFileSync(join(origin, "docs/install/updating.md"), "# Updating\n");
   writeFileSync(join(origin, "CHANGELOG.md"), "# Changelog\n");
   writeFileSync(join(origin, "index.ts"), "export const value = 1;\n");
   git(origin, ["add", "-A"]);
   git(origin, ["-c", "commit.gpgSign=false", "commit", "-qm", "seed"]);
-  const priorSha = git(origin, ["rev-parse", "HEAD"]);
-  return { origin, priorSha };
+  return { origin, priorSha: git(origin, ["rev-parse", "HEAD"]) };
 }
 
 function cloneHead(origin: string): string {
   const clone = tempDirs.make("evidence-reuse-clone-");
   execFileSync("git", ["clone", "-q", "--depth=1", origin, clone], { encoding: "utf8" });
   return clone;
+}
+
+function normalizedEvidence(options: {
+  producerSha?: string;
+  releaseProfile?: string;
+  runId?: string;
+  soak?: boolean;
+  targetSha: string;
+  validationInputs?: Record<string, string> | null;
+  verifierSha?: string | null;
+}): NormalizedEvidence {
+  const runId = options.runId ?? "111";
+  const producerSha = options.producerSha ?? PRODUCER_SHA;
+  const releaseProfile = options.releaseProfile ?? "full";
+  const soak = options.soak ?? true;
+  const validationInputs =
+    options.validationInputs === undefined ? DEFAULT_INPUTS : options.validationInputs;
+  const manifest = {
+    version: 2,
+    workflowName: "Full Release Validation",
+    workflowRef: "main",
+    runId,
+    runAttempt: "2",
+    targetRef: "release/2026.7.1",
+    targetSha: options.targetSha,
+    rerunGroup: "all",
+    releaseProfile,
+    runReleaseSoak: String(soak),
+    validationInputs,
+    controls: {
+      performanceBlocking: true,
+      performanceReportPublication: "artifact-only",
+      stableSoakRequired: releaseProfile === "stable" || releaseProfile === "full",
+    },
+    childRuns: {
+      normalCi: "201",
+      npmTelegram: "",
+      pluginPrerelease: "202",
+      releaseChecks: "203",
+      productPerformance: {
+        blocking: true,
+        conclusion: "success",
+        runId: "204",
+      },
+    },
+  };
+  const root: ParentTuple = {
+    artifact: {
+      digest: `sha256:${"a".repeat(64)}`,
+      id: "9001",
+      name: `full-release-validation-${runId}-2`,
+      runAttempt: 2,
+      sizeInBytes: 4096,
+    },
+    conclusion: "success",
+    manifest,
+    manifestVersion: 2,
+    runAttempt: 2,
+    runId,
+    status: "completed",
+    targetSha: options.targetSha,
+    url: `https://example.test/runs/${runId}`,
+    producerOnTrustedMainLineage: true,
+    workflowFullRef: "refs/heads/main",
+    workflowPath: ".github/workflows/full-release-validation.yml",
+    workflowQualifiedPath: ".github/workflows/full-release-validation.yml@refs/heads/main",
+    workflowRef: "main",
+    workflowRefProof: "legacy-v2-main-ancestry",
+    workflowRefType: "branch",
+    workflowRunPath: ".github/workflows/full-release-validation.yml",
+    workflowSha: producerSha,
+  };
+  const roles = [
+    ["normalCi", "201", 1, 1, "CI", "ci.yml", "-ci"],
+    [
+      "pluginPrerelease",
+      "202",
+      2,
+      1,
+      "Plugin Prerelease",
+      "plugin-prerelease.yml",
+      "-plugin-prerelease",
+    ],
+    [
+      "releaseChecks",
+      "203",
+      1,
+      2,
+      "OpenClaw Release Checks",
+      "openclaw-release-checks.yml",
+      "-release-checks",
+    ],
+    ["productPerformance", "204", 3, 2, "OpenClaw Performance", "openclaw-performance.yml", ""],
+  ] as const;
+  const children = roles.map(
+    ([role, childRunId, runAttempt, sourceParentAttempt, name, workflow, suffix]) => ({
+      conclusion: "success",
+      dispatchNonce: `full-release-validation-${runId}-${sourceParentAttempt}${suffix}`,
+      displayTitle: `${name} full-release-validation-${runId}-${sourceParentAttempt}${suffix}`,
+      event: "workflow_dispatch",
+      headBranch: "main",
+      parentJobId: `job-${role}`,
+      path: `.github/workflows/${workflow}`,
+      role,
+      runAttempt,
+      runId: childRunId,
+      sourceParentAttempt,
+      sourceParentRunId: runId,
+      status: "completed",
+      url: `https://example.test/runs/${childRunId}`,
+      workflowSha: producerSha,
+      ...(role === "productPerformance" ? { reportPublication: "artifact-only" } : {}),
+    }),
+  );
+  return {
+    children,
+    conclusions: {
+      allRequiredSucceeded: true,
+      children: Object.fromEntries(children.map((child) => [child.role, child.conclusion])),
+      current: "success",
+      root: "success",
+    },
+    controls: {
+      performanceReportPublication: "artifact-only",
+    },
+    current: structuredClone(root),
+    directRoot: true,
+    evidenceReuse: null,
+    manifest,
+    releaseProfile,
+    repository: REPOSITORY,
+    rerunGroup: "all",
+    root,
+    runReleaseSoak: soak,
+    schema: "openclaw.release-validation-evidence/v3",
+    producerOnTrustedMainLineage: true,
+    trustedWorkflowFullRef: "refs/heads/main",
+    trustedWorkflowRef: "main",
+    valid: true,
+    validationInputs,
+    verifier: {
+      schemaVersion: 3,
+      script: ".agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs",
+      scriptSha256: "b".repeat(64),
+      sourceSha: options.verifierSha === undefined ? VERIFIER_SHA : options.verifierSha,
+    },
+  };
 }
 
 const FAKE_GH = `#!/usr/bin/env bash
@@ -87,10 +331,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 fixture="\${FAKE_GH_FIXTURES}/$(printf '%s' "$endpoint" | tr '/?' '__')"
-if [[ "$endpoint" == */zip ]]; then
-  [[ -f "\${fixture}.bin" ]] || { echo "no fixture for $endpoint" >&2; exit 1; }
-  exec cat "\${fixture}.bin"
-fi
 [[ -f "\${fixture}.json" ]] || { echo "no fixture for $endpoint" >&2; exit 1; }
 if [[ -n "$jq_expr" ]]; then
   exec jq -r "$jq_expr" "\${fixture}.json"
@@ -98,16 +338,42 @@ fi
 exec cat "\${fixture}.json"
 `;
 
-interface FixtureOptions {
-  runId?: string;
-  headSha: string;
-  manifest?: Record<string, unknown>;
-  compare?: { base: string; head: string; status: string; files: string[] } | undefined;
-  childRunStates?: Record<string, string>;
+const FAKE_VALIDATOR = `#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runIndex = process.argv.indexOf("--validate-run");
+const repoIndex = process.argv.indexOf("--repo");
+const trustedRefIndex = process.argv.indexOf("--trusted-workflow-ref");
+if (
+  runIndex < 0 ||
+  repoIndex < 0 ||
+  trustedRefIndex < 0 ||
+  process.argv[repoIndex + 1] !== "openclaw/openclaw" ||
+  process.argv[trustedRefIndex + 1] !== "main"
+) {
+  console.error("validator invocation contract mismatch");
+  process.exit(2);
+}
+const fixture = JSON.parse(
+  readFileSync(join(process.env.FAKE_VALIDATOR_FIXTURES, \`\${process.argv[runIndex + 1]}.json\`), "utf8"),
+);
+if (fixture.exitCode) {
+  console.error("fixture validator rejection");
+  process.exit(fixture.exitCode);
+}
+process.stdout.write(\`\${JSON.stringify(fixture.record)}\\n\`);
+`;
+
+function fixtureName(fixtures: string, endpoint: string): string {
+  return join(fixtures, `${endpoint.replaceAll(/[/?]/gu, "_")}.json`);
 }
 
-function setUpFixtures(options: FixtureOptions): { fixtures: string; binDir: string } {
-  const runId = options.runId ?? "111";
+function setUpFixtures(runs: RunFixture[]): {
+  binDir: string;
+  fixtures: string;
+  validatorPath: string;
+} {
   const root = tempDirs.make("evidence-reuse-fixtures-");
   const fixtures = join(root, "fixtures");
   const binDir = join(root, "bin");
@@ -115,93 +381,35 @@ function setUpFixtures(options: FixtureOptions): { fixtures: string; binDir: str
   mkdirSync(binDir, { recursive: true });
   writeFileSync(join(binDir, "gh"), FAKE_GH);
   chmodSync(join(binDir, "gh"), 0o755);
+  const validatorPath = join(root, "validator.mjs");
+  writeFileSync(validatorPath, FAKE_VALIDATOR);
 
   writeFileSync(
-    join(
+    fixtureName(
       fixtures,
-      "repos_openclaw_openclaw_actions_workflows_full-release-validation.yml_runs.json",
+      "repos/openclaw/openclaw/actions/workflows/full-release-validation.yml/runs",
     ),
-    JSON.stringify({
-      workflow_runs: [
-        {
-          id: Number(runId),
-          html_url: `https://example.test/runs/${runId}`,
-          head_sha: options.headSha,
-        },
-      ],
-    }),
+    JSON.stringify({ workflow_runs: runs.map(({ runId }) => ({ id: Number(runId) })) }),
   );
-  if (options.manifest) {
+  for (const run of runs) {
     writeFileSync(
-      join(fixtures, `repos_openclaw_openclaw_actions_runs_${runId}_artifacts_per_page=100.json`),
-      JSON.stringify({
-        artifacts: [{ id: 999, name: `full-release-validation-${runId}`, expired: false }],
-      }),
-    );
-    const manifestDir = join(root, "manifest");
-    mkdirSync(manifestDir, { recursive: true });
-    writeFileSync(
-      join(manifestDir, "full-release-validation-manifest.json"),
-      JSON.stringify(options.manifest),
-    );
-    execFileSync(
-      "zip",
-      [
-        "-q",
-        "-j",
-        join(root, "manifest.zip"),
-        join(manifestDir, "full-release-validation-manifest.json"),
-      ],
-      {
-        encoding: "utf8",
-      },
-    );
-    execFileSync("cp", [
-      join(root, "manifest.zip"),
-      join(fixtures, "repos_openclaw_openclaw_actions_artifacts_999_zip.bin"),
-    ]);
-  }
-  if (options.compare) {
-    writeFileSync(
-      join(
-        fixtures,
-        `repos_openclaw_openclaw_compare_${options.compare.base}...${options.compare.head}.json`,
-      ),
-      JSON.stringify({
-        status: options.compare.status,
-        files: options.compare.files.map((filename) => ({ filename })),
-      }),
+      join(fixtures, `${run.runId}.json`),
+      JSON.stringify({ exitCode: run.exitCode ?? 0, record: run.record }),
     );
   }
-  for (const [childRunId, state] of Object.entries(options.childRunStates ?? {})) {
-    const [status, conclusion] = state.split("/");
-    writeFileSync(
-      join(fixtures, `repos_openclaw_openclaw_actions_runs_${childRunId}.json`),
-      JSON.stringify({ status, conclusion }),
-    );
-  }
-  return { fixtures, binDir };
+  return { binDir, fixtures, validatorPath };
 }
 
-const DEFAULT_INPUTS = {
-  provider: "openai",
-  mode: "both",
-  liveSuiteFilter: "",
-  crossOsSuiteFilter: "",
-  releasePackageSpec: "",
-  packageAcceptancePackageSpec: "",
-  codexPluginSpec: "",
-};
-
 function runResolver(args: {
-  repoDir: string;
-  targetSha: string;
-  workflowSha: string;
-  releaseProfile: string;
-  runReleaseSoak?: string;
-  inputs?: Record<string, string>;
-  fixtures: string;
   binDir: string;
+  fixtures: string;
+  inputs?: unknown;
+  releaseProfile?: string;
+  repoDir: string;
+  runReleaseSoak?: string;
+  targetSha: string;
+  validatorPath: string;
+  verifierSha?: string;
 }) {
   return spawnSync(
     "bash",
@@ -210,15 +418,15 @@ function runResolver(args: {
       "--target-sha",
       args.targetSha,
       "--workflow-sha",
-      args.workflowSha,
+      args.verifierSha ?? VERIFIER_SHA,
       "--release-profile",
-      args.releaseProfile,
+      args.releaseProfile ?? "full",
       "--run-release-soak",
-      args.runReleaseSoak ?? "false",
+      args.runReleaseSoak ?? "true",
       "--inputs-json",
-      JSON.stringify(args.inputs ?? DEFAULT_INPUTS),
+      JSON.stringify(args.inputs === undefined ? DEFAULT_INPUTS : args.inputs),
       "--repo",
-      "openclaw/openclaw",
+      REPOSITORY,
       "--repo-dir",
       args.repoDir,
     ],
@@ -227,9 +435,11 @@ function runResolver(args: {
       encoding: "utf8",
       env: {
         ...process.env,
-        PATH: `${args.binDir}:${process.env.PATH}`,
         FAKE_GH_FIXTURES: args.fixtures,
+        FAKE_VALIDATOR_FIXTURES: args.fixtures,
         GITHUB_OUTPUT: "",
+        OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: args.validatorPath,
+        PATH: `${args.binDir}:${process.env.PATH}`,
       },
     },
   );
@@ -248,273 +458,386 @@ function parseOutput(output: string): Record<string, string> {
   );
 }
 
-function manifestFor(targetSha: string, overrides: Record<string, unknown> = {}) {
-  return {
-    version: 2,
-    workflowName: "Full Release Validation",
-    runId: "111",
-    rerunGroup: "all",
-    releaseProfile: "stable",
-    runReleaseSoak: "true",
-    targetSha,
-    validationInputs: DEFAULT_INPUTS,
-    childRuns: { normalCi: "201", productPerformance: { runId: "202" } },
-    ...overrides,
-  };
-}
-
-const HEALTHY_CHILDREN = { "201": "completed/success", "202": "completed/success" };
-
 describe("scripts/github/find-reusable-release-validation.sh", () => {
-  it("reuses evidence when the delta is release-metadata-only", () => {
-    const { origin, priorSha } = createRepoPair();
-    const targetSha = commitFile(
-      origin,
-      "CHANGELOG.md",
-      "# Changelog\n\n- entry\n",
-      "docs(changelog): refresh",
-    );
+  it("reuses pre-tooling trusted-main evidence for the exact target", () => {
+    const { origin, priorSha } = createRepo();
     const clone = cloneHead(origin);
-    // The candidate ran when the branch was at priorSha; the current dispatch
-    // runs from the branch tip, so the harness delta equals the target delta.
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha),
-      compare: { base: priorSha, head: targetSha, status: "ahead", files: ["CHANGELOG.md"] },
-      childRunStates: HEALTHY_CHILDREN,
-    });
+    const record = normalizedEvidence({ targetSha: priorSha });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
 
     const result = runResolver({
-      repoDir: clone,
-      targetSha,
-      workflowSha: targetSha,
-      releaseProfile: "stable",
-      fixtures,
       binDir,
+      fixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+      validatorPath,
     });
+
     expect(result.status).toBe(0);
+    expect(record.root.workflowSha).not.toBe(record.root.targetSha);
+    expect(record.verifier.sourceSha).not.toBe(record.root.workflowSha);
+    expect(new Set(record.children.map((child) => child.sourceParentAttempt)).size).toBe(2);
     const output = parseOutput(result.stdout);
     expect(output).toMatchObject({
-      reuse: "true",
-      evidence_run_id: "111",
+      changed_path_count: "0",
       evidence_root_run_id: "111",
+      evidence_run_id: "111",
       evidence_sha: priorSha,
-      changed_path_count: "1",
-      changed_paths: "CHANGELOG.md",
+      reuse: "true",
     });
+    expect(JSON.parse(output.changed_paths ?? "null")).toEqual([]);
     expect(JSON.parse(output.evidence_manifest ?? "{}")).toMatchObject({ targetSha: priorSha });
   });
 
-  it("reuses identical targets without comparing and resolves the chain root", () => {
-    const { origin, priorSha } = createRepoPair();
+  it("accepts exact-target trusted-main evidence without a compare request", () => {
+    const { origin, priorSha } = createRepo();
     const clone = cloneHead(origin);
-    // No compare fixture: an identical target must not hit the compare API.
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha, { evidenceReuse: { runId: "42" } }),
-      childRunStates: HEALTHY_CHILDREN,
+    const record = normalizedEvidence({
+      producerSha: priorSha,
+      targetSha: priorSha,
+      verifierSha: priorSha,
     });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
 
     const result = runResolver({
+      binDir,
+      fixtures,
       repoDir: clone,
       targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
-      binDir,
+      validatorPath,
+      verifierSha: priorSha,
     });
+
     expect(result.status).toBe(0);
     expect(parseOutput(result.stdout)).toMatchObject({
-      reuse: "true",
-      evidence_run_id: "111",
-      evidence_root_run_id: "42",
       changed_path_count: "0",
+      changed_paths: "[]",
+      reuse: "true",
     });
   });
 
-  it("rejects deltas that touch non-metadata paths", () => {
-    const { origin, priorSha } = createRepoPair();
-    const targetSha = commitFile(
-      origin,
-      "index.ts",
-      "export const value = 2;\n",
-      "fix: change code",
-    );
+  it.each([
+    ["beta", "beta"],
+    ["stable", "stable"],
+    ["full", "full"],
+  ] as const)("accepts exact profile identity %s -> %s", (priorProfile, requestedProfile) => {
+    const { origin, priorSha } = createRepo();
     const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha),
-      compare: { base: priorSha, head: targetSha, status: "ahead", files: ["index.ts"] },
+    const record = normalizedEvidence({
+      releaseProfile: priorProfile,
+      targetSha: priorSha,
+    });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+    const result = runResolver({
+      binDir,
+      fixtures,
+      releaseProfile: requestedProfile,
+      repoDir: clone,
+      targetSha: priorSha,
+      validatorPath,
     });
 
-    // The candidate harness matches the pinned workflow SHA; only the target
-    // delta is non-metadata here.
+    expect(result.status).toBe(0);
+    expect(parseOutput(result.stdout)).toMatchObject({ reuse: "true" });
+  });
+
+  it("skips validator rejection and selects the next strict record", () => {
+    const { origin, priorSha } = createRepo();
+    const clone = cloneHead(origin);
+    const record = normalizedEvidence({ runId: "111", targetSha: priorSha });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([
+      { exitCode: 1, runId: "222" },
+      { record, runId: "111" },
+    ]);
+
     const result = runResolver({
-      repoDir: clone,
-      targetSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
       binDir,
+      fixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+      validatorPath,
     });
+
+    expect(result.status).toBe(0);
+    expect(parseOutput(result.stdout)).toMatchObject({ evidence_run_id: "111", reuse: "true" });
+    expect(result.stderr).toContain("run 222: shared evidence validator rejected the run");
+  });
+
+  it.each([
+    {
+      label: "reused wrapper",
+      mutate(record: NormalizedEvidence) {
+        record.directRoot = false;
+        record.evidenceReuse = { rootRunId: "42" };
+      },
+    },
+    {
+      label: "untrusted producer ref",
+      mutate(record: NormalizedEvidence) {
+        record.trustedWorkflowRef = "release/2026.7.1";
+      },
+    },
+    {
+      label: "missing trusted-main lineage proof",
+      mutate(record: NormalizedEvidence) {
+        record.producerOnTrustedMainLineage = false;
+      },
+    },
+    {
+      label: "tag-qualified producer workflow",
+      mutate(record: NormalizedEvidence) {
+        record.root.workflowFullRef = "refs/tags/main";
+        record.current.workflowFullRef = "refs/tags/main";
+      },
+    },
+    {
+      label: "verifier source drift",
+      mutate(record: NormalizedEvidence) {
+        record.verifier.sourceSha = "d".repeat(40);
+      },
+    },
+    {
+      label: "non-full rerun group",
+      mutate(record: NormalizedEvidence) {
+        record.rerunGroup = "package";
+      },
+    },
+    {
+      label: "publishing performance reports",
+      mutate(record: NormalizedEvidence) {
+        record.controls.performanceReportPublication = "publish";
+      },
+    },
+    {
+      label: "missing performance report publication proof",
+      mutate(record: NormalizedEvidence) {
+        const performance = record.children.find((child) => child.role === "productPerformance");
+        if (!performance) {
+          throw new Error("missing product performance child");
+        }
+        delete performance.reportPublication;
+      },
+    },
+    {
+      label: "missing required role",
+      mutate(record: NormalizedEvidence) {
+        record.children.pop();
+      },
+    },
+    {
+      label: "duplicate child run id",
+      mutate(record: NormalizedEvidence) {
+        record.children[1].runId = record.children[0].runId;
+      },
+    },
+    {
+      label: "failed child",
+      mutate(record: NormalizedEvidence) {
+        record.children[0].conclusion = "failure";
+      },
+    },
+    {
+      label: "extra child role",
+      mutate(record: NormalizedEvidence) {
+        record.children.push({
+          ...record.children[0],
+          role: "npmTelegram",
+          runId: "205",
+        });
+      },
+    },
+    {
+      label: "invalid root artifact digest",
+      mutate(record: NormalizedEvidence) {
+        record.root.artifact.digest = "sha256:not-a-digest";
+        record.current.artifact.digest = "sha256:not-a-digest";
+      },
+    },
+  ])("rejects normalized evidence that is not reusable: $label", ({ mutate }) => {
+    const { origin, priorSha } = createRepo();
+    const clone = cloneHead(origin);
+    const record = normalizedEvidence({ targetSha: priorSha });
+    mutate(record);
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+    const result = runResolver({
+      binDir,
+      fixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+      validatorPath,
+    });
+
     expect(result.status).toBe(0);
     expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+    expect(result.stderr).toContain("not a strict direct-root full validation");
   });
 
-  it("rejects evidence from a narrower release profile or diverged history", () => {
-    const { origin, priorSha } = createRepoPair();
+  it.each([
+    {
+      expected: "profile beta differs from stable",
+      label: "beta evidence for stable",
+      recordOptions: { releaseProfile: "beta" },
+      resolverOptions: { releaseProfile: "stable" },
+    },
+    {
+      expected: "profile beta differs from full",
+      label: "beta evidence for full",
+      recordOptions: { releaseProfile: "beta" },
+      resolverOptions: { releaseProfile: "full" },
+    },
+    {
+      expected: "profile stable differs from beta",
+      label: "stable evidence for beta",
+      recordOptions: { releaseProfile: "stable" },
+      resolverOptions: { releaseProfile: "beta" },
+    },
+    {
+      expected: "profile full differs from beta",
+      label: "full evidence for beta",
+      recordOptions: { releaseProfile: "full" },
+      resolverOptions: { releaseProfile: "beta" },
+    },
+    {
+      expected: "profile full differs from stable",
+      label: "full evidence for stable",
+      recordOptions: { releaseProfile: "full" },
+      resolverOptions: { releaseProfile: "stable" },
+    },
+    {
+      expected: "validation inputs differ",
+      label: "different lane inputs",
+      recordOptions: { validationInputs: { ...DEFAULT_INPUTS, provider: "anthropic" } },
+      resolverOptions: {},
+    },
+    {
+      expected: "soak false differs from true",
+      label: "missing required soak",
+      recordOptions: { soak: false },
+      resolverOptions: { runReleaseSoak: "true" },
+    },
+    {
+      expected: "soak true differs from false",
+      label: "extra soak evidence",
+      recordOptions: { soak: true },
+      resolverOptions: { runReleaseSoak: "false" },
+    },
+  ])(
+    "rejects evidence with incompatible policy coverage: $label",
+    ({ expected, recordOptions, resolverOptions }) => {
+      const { origin, priorSha } = createRepo();
+      const clone = cloneHead(origin);
+      const record = normalizedEvidence({ targetSha: priorSha, ...recordOptions });
+      const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+      const result = runResolver({
+        binDir,
+        fixtures,
+        repoDir: clone,
+        targetSha: priorSha,
+        validatorPath,
+        ...resolverOptions,
+      });
+
+      expect(result.status).toBe(0);
+      expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+      expect(result.stderr).toContain(expected);
+    },
+  );
+
+  it("rejects cross-SHA reuse even for a changelog-only delta", () => {
+    const { origin, priorSha } = createRepo();
     const targetSha = commitFile(
       origin,
       "CHANGELOG.md",
-      "# Changelog\n\n- entry\n",
+      "# Changelog\n\n- beta3\n",
       "docs(changelog): refresh",
     );
     const clone = cloneHead(origin);
+    const record = normalizedEvidence({ targetSha: priorSha });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
 
-    const beta = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha, { releaseProfile: "beta" }),
-    });
-    const betaResult = runResolver({
+    const result = runResolver({
+      binDir,
+      fixtures,
       repoDir: clone,
       targetSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures: beta.fixtures,
-      binDir: beta.binDir,
-    });
-    expect(betaResult.status).toBe(0);
-    expect(parseOutput(betaResult.stdout)).toMatchObject({ reuse: "false" });
-
-    const diverged = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha),
-      compare: { base: priorSha, head: targetSha, status: "diverged", files: ["CHANGELOG.md"] },
-    });
-    const divergedResult = runResolver({
-      repoDir: clone,
-      targetSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures: diverged.fixtures,
-      binDir: diverged.binDir,
-    });
-    expect(divergedResult.status).toBe(0);
-    expect(parseOutput(divergedResult.stdout)).toMatchObject({ reuse: "false" });
-  });
-
-  it("rejects evidence recorded for different lane-selection inputs", () => {
-    const { origin, priorSha } = createRepoPair();
-    const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha, {
-        validationInputs: { ...DEFAULT_INPUTS, provider: "anthropic" },
-      }),
-      childRunStates: HEALTHY_CHILDREN,
+      validatorPath,
     });
 
-    const result = runResolver({
-      repoDir: clone,
-      targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
-      binDir,
-    });
     expect(result.status).toBe(0);
     expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+    expect(result.stderr).toContain("cross-SHA reuse requires granular artifact evidence");
   });
 
-  it("rejects evidence whose recorded child runs are no longer green", () => {
-    const { origin, priorSha } = createRepoPair();
+  it("rejects target version metadata that is internally inconsistent", () => {
+    const { origin, priorSha } = createRepo({ plistBuildVersion: "2026061000" });
     const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha),
-      childRunStates: { "201": "completed/failure", "202": "completed/success" },
-    });
+    const record = normalizedEvidence({ targetSha: priorSha });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
 
     const result = runResolver({
+      binDir,
+      fixtures,
       repoDir: clone,
       targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
-      binDir,
+      validatorPath,
     });
+
     expect(result.status).toBe(0);
-    expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+    expect(parseOutput(result.stdout)).toMatchObject({
+      reuse: "false",
+      reuse_reason: "target version metadata is inconsistent",
+    });
   });
 
-  it("rejects evidence whose harness differs beyond release metadata", () => {
-    const { origin, priorSha } = createRepoPair();
-    git(origin, ["checkout", "-q", "-b", "harness-drift"]);
-    const driftSha = commitFile(
-      origin,
-      "index.ts",
-      "export const value = 3;\n",
-      "ci: change harness logic",
-    );
-    git(origin, ["checkout", "-q", "main"]);
+  it.each([
+    { inputs: [], label: "array inputs", runReleaseSoak: "true" },
+    { inputs: null, label: "null inputs", runReleaseSoak: "true" },
+    { inputs: DEFAULT_INPUTS, label: "invalid soak flag", runReleaseSoak: "yes" },
+  ])("rejects invalid resolver arguments: $label", ({ inputs, runReleaseSoak }) => {
+    const { origin, priorSha } = createRepo();
     const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: driftSha,
-      manifest: manifestFor(priorSha),
-      childRunStates: HEALTHY_CHILDREN,
-    });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([]);
 
     const result = runResolver({
-      repoDir: clone,
-      targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
       binDir,
+      fixtures,
+      inputs,
+      repoDir: clone,
+      runReleaseSoak,
+      targetSha: priorSha,
+      validatorPath,
     });
-    expect(result.status).toBe(0);
-    expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+
+    expect(result.status).toBe(2);
   });
 
-  it("rejects targets whose version stamps are internally inconsistent", () => {
-    const { origin, priorSha } = createRepoPair({ plistBuildVersion: "2026061000" });
+  it("reports no reuse when no prior successful runs exist", () => {
+    const { origin, priorSha } = createRepo();
     const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({
-      headSha: priorSha,
-      manifest: manifestFor(priorSha),
-      childRunStates: HEALTHY_CHILDREN,
-    });
+    const { binDir, fixtures, validatorPath } = setUpFixtures([]);
 
     const result = runResolver({
+      binDir,
+      fixtures,
       repoDir: clone,
       targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "stable",
-      fixtures,
-      binDir,
+      validatorPath,
     });
+
     expect(result.status).toBe(0);
-    const output = parseOutput(result.stdout);
-    expect(output.reuse).toBe("false");
-    expect(output.reuse_reason).toContain("version metadata");
+    expect(parseOutput(result.stdout)).toMatchObject({
+      reuse: "false",
+      reuse_reason: "no prior successful validation runs",
+    });
   });
 
-  it("reports no reuse when no prior runs or manifests exist", () => {
-    const { origin, priorSha } = createRepoPair();
-    const clone = cloneHead(origin);
-    const { fixtures, binDir } = setUpFixtures({ headSha: priorSha });
-
-    const result = runResolver({
-      repoDir: clone,
-      targetSha: priorSha,
-      workflowSha: priorSha,
-      releaseProfile: "beta",
-      fixtures,
-      binDir,
-    });
-    expect(result.status).toBe(0);
-    const output = parseOutput(result.stdout);
-    expect(output.reuse).toBe("false");
-    expect(output.reuse_reason).toContain("no prior validation run covers");
+  it("rewrites inherited v3 producer identity to the current immutable workflow SHA", () => {
+    const workflow = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    expect(workflow).toContain('--arg workflowSha "$GITHUB_SHA"');
+    expect(workflow).toContain("workflowSha: $workflowSha");
+    expect(workflow).toContain("ref: ${{ github.sha }}");
   });
 });

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -7,6 +7,8 @@ describe("full-release-validation-at-sha", () => {
       parseArgs([
         "--sha",
         "abc123",
+        "--workflow-sha",
+        "origin/main",
         "--branch",
         "release/proof",
         "--keep-branch",
@@ -23,17 +25,29 @@ describe("full-release-validation-at-sha", () => {
       inputs: {
         mode: "linux",
         provider: "anthropic",
+        reuse_evidence: "false",
       },
       sha: "abc123",
+      workflowSha: "origin/main",
     });
   });
 
   it("rejects missing option values", () => {
     expect(() => parseArgs(["--sha", "--dry-run"])).toThrow("--sha requires a value");
     expect(() => parseArgs(["--sha", "-h"])).toThrow("--sha requires a value");
+    expect(() => parseArgs(["--workflow-sha", "--dry-run"])).toThrow(
+      "--workflow-sha requires a value",
+    );
+    expect(() => parseArgs(["--workflow-sha", "-h"])).toThrow("--workflow-sha requires a value");
     expect(() => parseArgs(["--branch"])).toThrow("--branch requires a value");
     expect(() => parseArgs(["--branch", "-h"])).toThrow("--branch requires a value");
     expect(() => parseArgs(["-f", "--dry-run"])).toThrow("-f requires a value");
     expect(() => parseArgs(["-f", "-h"])).toThrow("-f requires a value");
+  });
+
+  it("cannot enable evidence reuse on a temporary SHA-pinned workflow ref", () => {
+    expect(() => parseArgs(["-f", "reuse_evidence=true"])).toThrow(
+      "always disables evidence reuse",
+    );
   });
 });

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -1,0 +1,401 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const INSTALL_SMOKE = ".github/workflows/install-smoke.yml";
+const RELEASE_CHECKS = ".github/workflows/openclaw-release-checks.yml";
+
+type WorkflowStep = {
+  env?: Record<string, unknown>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  env?: Record<string, unknown>;
+  if?: string;
+  needs?: string | string[];
+  outputs?: Record<string, unknown>;
+  permissions?: Record<string, unknown>;
+  steps?: WorkflowStep[];
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: Record<string, WorkflowJob>;
+  on?: {
+    workflow_call?: { inputs?: Record<string, Record<string, unknown>> };
+    workflow_dispatch?: { inputs?: Record<string, Record<string, unknown>> };
+  };
+  permissions?: Record<string, unknown>;
+};
+
+function readWorkflow(path: string): Workflow {
+  return parse(readFileSync(path, "utf8")) as Workflow;
+}
+
+function job(workflow: Workflow, name: string): WorkflowJob {
+  const found = workflow.jobs[name];
+  expect(found, name).toBeDefined();
+  return found!;
+}
+
+function step(workflowJob: WorkflowJob, name: string): WorkflowStep {
+  const found = workflowJob.steps?.find((candidate) => candidate.name === name);
+  expect(found, name).toBeDefined();
+  return found!;
+}
+
+describe("install smoke no-push root image transport", () => {
+  it("keeps registry transport as the default and validates the selected mode", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE);
+    const dispatchInput = workflow.on?.workflow_dispatch?.inputs?.root_image_transport;
+    const callInput = workflow.on?.workflow_call?.inputs?.root_image_transport;
+    expect(dispatchInput).toMatchObject({
+      default: "registry",
+      options: ["registry", "no-push-artifact"],
+      type: "choice",
+    });
+    expect(callInput).toMatchObject({
+      default: "registry",
+      type: "string",
+    });
+    expect(workflow.permissions).toMatchObject({
+      actions: "read",
+      contents: "read",
+      packages: "read",
+    });
+
+    const preflight = job(workflow, "preflight");
+    expect(preflight.outputs?.root_image_transport).toBe(
+      "${{ steps.manifest.outputs.root_image_transport }}",
+    );
+    expect(preflight.outputs?.workflow_repository).toBe(
+      "${{ steps.workflow.outputs.workflow_repository }}",
+    );
+    expect(preflight.outputs?.workflow_sha).toBe("${{ steps.workflow.outputs.workflow_sha }}");
+    const workflowIdentity = step(preflight, "Resolve job workflow identity");
+    expect(workflowIdentity.env?.JOB_CONTEXT).toBe("${{ toJSON(job) }}");
+    expect(workflowIdentity.run).toContain(
+      "job.workflow_repository must be an owner/repository slug",
+    );
+    expect(workflowIdentity.run).toContain("job.workflow_sha must be a full lowercase commit SHA");
+    const manifest = step(preflight, "Build install-smoke CI manifest");
+    expect(manifest.env?.OPENCLAW_CI_ROOT_IMAGE_TRANSPORT).toBe(
+      "${{ inputs.root_image_transport || 'registry' }}",
+    );
+    expect(manifest.run).toContain("registry)");
+    expect(manifest.run).toContain("no-push-artifact)");
+    expect(manifest.run).toContain(
+      'dockerfile_image="ghcr.io/${owner}/openclaw-dockerfile-smoke:${target_sha}"',
+    );
+    expect(manifest.run).toContain(
+      'dockerfile_image="openclaw-dockerfile-smoke-local:${target_sha}"',
+    );
+    expect(manifest.run).toContain("root_image_transport must be registry or no-push-artifact");
+
+    const trustedCheckouts = Object.entries(workflow.jobs).flatMap(([jobName, workflowJob]) =>
+      (workflowJob.steps ?? [])
+        .filter((candidate) => candidate.name?.startsWith("Checkout trusted "))
+        .map((candidate) => ({ candidate, jobName })),
+    );
+    expect(trustedCheckouts).toHaveLength(5);
+    for (const { candidate, jobName } of trustedCheckouts) {
+      expect(candidate.with, jobName).toMatchObject({
+        repository: "${{ needs.preflight.outputs.workflow_repository }}",
+        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        "persist-credentials": false,
+      });
+    }
+  });
+
+  it("builds one local target image and uploads provenance-bound bytes", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE);
+    const producer = job(workflow, "root_dockerfile_image");
+    expect(producer.permissions).toEqual({
+      contents: "read",
+      packages: "read",
+    });
+    expect(producer.outputs?.archive_sha256).toBe(
+      "${{ steps.image_artifact.outputs.archive_sha256 }}",
+    );
+    expect(producer.outputs?.artifact_digest).toBe(
+      "${{ steps.image_artifact_upload.outputs.artifact-digest }}",
+    );
+    expect(producer.outputs?.artifact_id).toBe(
+      "${{ steps.image_artifact_upload.outputs.artifact-id }}",
+    );
+    expect(producer.outputs?.artifact_name).toBe(
+      "${{ steps.image_artifact.outputs.artifact_name }}",
+    );
+    expect(producer.outputs?.artifact_run_attempt).toBe(
+      "${{ steps.image_artifact.outputs.run_attempt }}",
+    );
+    expect(producer.outputs?.artifact_run_id).toBe("${{ steps.image_artifact.outputs.run_id }}");
+    expect(producer.outputs?.image_exists).toBe("${{ steps.existing.outputs.exists }}");
+    expect(step(producer, "Checkout CLI").with).toMatchObject({
+      ref: "${{ needs.preflight.outputs.target_sha }}",
+      "persist-credentials": false,
+    });
+
+    const trustedCheckout = step(producer, "Checkout trusted image artifact helper");
+    expect(trustedCheckout.if).toBe(
+      "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+    );
+    expect(trustedCheckout.with).toMatchObject({
+      repository: "${{ needs.preflight.outputs.workflow_repository }}",
+      ref: "${{ needs.preflight.outputs.workflow_sha }}",
+      path: ".release-harness",
+      "persist-credentials": false,
+    });
+
+    expect(step(producer, "Log in to GHCR").if).toBe(
+      "needs.preflight.outputs.root_image_transport == 'registry'",
+    );
+    expect(step(producer, "Check for existing root Dockerfile smoke image").if).toBe(
+      "needs.preflight.outputs.root_image_transport == 'registry'",
+    );
+    expect(
+      producer.steps?.some(
+        (candidate) => candidate.name === "Build and push root Dockerfile smoke image",
+      ),
+    ).toBe(false);
+
+    const localBuild = step(producer, "Build local root Dockerfile smoke image");
+    expect(localBuild.if).toBe(
+      "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+    );
+    expect(localBuild.run).toContain("--load");
+    expect(localBuild.run).not.toContain("--push");
+    expect(localBuild.run).toContain('-t "$IMAGE_REF"');
+
+    const pack = step(producer, "Pack root Dockerfile image artifact");
+    expect(pack.if).toBe("needs.preflight.outputs.root_image_transport == 'no-push-artifact'");
+    expect(pack.env).toMatchObject({
+      IMAGE_REF: "${{ needs.preflight.outputs.dockerfile_image }}",
+      TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+      WORKFLOW_SHA: "${{ needs.preflight.outputs.workflow_sha }}",
+    });
+    expect(pack.run).toContain(
+      'artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+    );
+    expect(pack.run).toContain(
+      'pack "$artifact_dir" install-smoke-root "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"',
+    );
+    expect(pack.run).toContain(
+      'jq -er \'.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))\'',
+    );
+    expect(pack.run).toContain('echo "archive_sha256=$archive_sha256"');
+    expect(pack.run).toContain('echo "run_attempt=$GITHUB_RUN_ATTEMPT"');
+    expect(pack.run).toContain('echo "run_id=$GITHUB_RUN_ID"');
+
+    const upload = step(producer, "Upload root Dockerfile image artifact");
+    expect(upload.id).toBe("image_artifact_upload");
+    expect(upload.if).toBe("needs.preflight.outputs.root_image_transport == 'no-push-artifact'");
+    expect(upload.uses).toBe("actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a");
+    expect(upload.with).toMatchObject({
+      "compression-level": 0,
+      "if-no-files-found": "error",
+      name: "${{ steps.image_artifact.outputs.artifact_name }}",
+      path: "${{ steps.image_artifact.outputs.artifact_path }}",
+    });
+
+    const registryPublisher = job(workflow, "push_root_dockerfile_image");
+    expect(registryPublisher.permissions).toEqual({
+      contents: "read",
+      packages: "write",
+    });
+    expect(registryPublisher.if).toBe(
+      "needs.preflight.outputs.root_image_transport == 'registry' && needs.root_dockerfile_image.outputs.image_exists != 'true'",
+    );
+    expect(step(registryPublisher, "Checkout CLI").with).toMatchObject({
+      ref: "${{ needs.preflight.outputs.target_sha }}",
+      "persist-credentials": false,
+    });
+    expect(step(registryPublisher, "Log in to GHCR").if).toBeUndefined();
+    const registryBuild = step(registryPublisher, "Build and push root Dockerfile smoke image");
+    expect(registryBuild.run).toContain("--push");
+    expect(registryBuild.run).not.toContain("--load");
+
+    const writeScopedJobs = Object.entries(workflow.jobs)
+      .filter(([, candidate]) => candidate.permissions?.packages === "write")
+      .map(([name]) => name);
+    expect(writeScopedJobs).toEqual(["push_root_dockerfile_image"]);
+
+    const ready = job(workflow, "root_dockerfile_image_ready");
+    expect(ready.needs).toEqual([
+      "preflight",
+      "root_dockerfile_image",
+      "push_root_dockerfile_image",
+    ]);
+    expect(ready.if).toContain("always()");
+    const verify = step(ready, "Verify root Dockerfile image preparation");
+    expect(verify.run).toContain('if [[ "$PREPARE_RESULT" != "success" ]]');
+    expect(verify.run).toContain(
+      'if [[ "$ROOT_IMAGE_TRANSPORT" == "registry" && "$IMAGE_EXISTS" != "true" ]]',
+    );
+    expect(verify.run).toContain('elif [[ "$PUSH_RESULT" != "skipped" ]]');
+  });
+
+  it("verifies and loads the artifact in every consumer without registry fallback", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE);
+    for (const [jobName, checkoutName] of [
+      ["install-smoke-fast", "Checkout CLI"],
+      ["qr_package_install_smoke", "Checkout CLI"],
+      ["root_dockerfile_smokes", "Checkout CLI"],
+      ["installer_smoke", "Checkout candidate CLI"],
+      ["bun_global_install_smoke", "Checkout CLI"],
+      ["docker-e2e-fast", "Checkout CLI"],
+    ]) {
+      const checkout = step(job(workflow, jobName), checkoutName);
+      expect(checkout.with?.ref, jobName).toBe("${{ needs.preflight.outputs.target_sha }}");
+      expect(checkout.with?.["persist-credentials"], jobName).toBe(false);
+    }
+
+    for (const jobName of [
+      "root_dockerfile_smokes",
+      "installer_smoke",
+      "bun_global_install_smoke",
+    ]) {
+      const consumer = job(workflow, jobName);
+      expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
+      expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe(
+        "${{ needs.preflight.outputs.root_image_transport == 'no-push-artifact' && '1' || '0' }}",
+      );
+      const trustedCheckout = step(consumer, "Checkout trusted image artifact helper");
+      expect(trustedCheckout.if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+      );
+      expect(trustedCheckout.with, jobName).toMatchObject({
+        repository: "${{ needs.preflight.outputs.workflow_repository }}",
+        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        path: ".release-harness",
+        "persist-credentials": false,
+      });
+
+      expect(step(consumer, "Log in to GHCR").if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'registry'",
+      );
+      expect(step(consumer, "Pull root Dockerfile smoke image").if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'registry'",
+      );
+
+      const binding = step(consumer, "Validate root Dockerfile image artifact binding");
+      expect(binding.if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+      );
+      expect(binding.env, jobName).toMatchObject({
+        ARCHIVE_SHA256: "${{ needs.root_dockerfile_image.outputs.archive_sha256 }}",
+        ARTIFACT_DIGEST: "${{ needs.root_dockerfile_image.outputs.artifact_digest }}",
+        ARTIFACT_ID: "${{ needs.root_dockerfile_image.outputs.artifact_id }}",
+        ARTIFACT_NAME: "${{ needs.root_dockerfile_image.outputs.artifact_name }}",
+        ARTIFACT_RUN_ATTEMPT: "${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}",
+        ARTIFACT_RUN_ID: "${{ needs.root_dockerfile_image.outputs.artifact_run_id }}",
+        GH_TOKEN: "${{ github.token }}",
+        TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+      });
+      expect(binding.run, jobName).toContain('[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]');
+      expect(binding.run, jobName).toContain('[[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]]');
+      expect(binding.run, jobName).toContain('[[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]]');
+      expect(binding.run, jobName).toContain('[[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]]');
+      expect(binding.run, jobName).toContain('[[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]');
+      expect(binding.run, jobName).not.toContain(
+        '"$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"',
+      );
+      expect(binding.run, jobName).toContain(
+        'expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"',
+      );
+      expect(binding.run, jobName).toContain(
+        "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}",
+      );
+      expect(binding.run, jobName).toContain('--arg digest "sha256:${ARTIFACT_DIGEST}"');
+      expect(binding.run, jobName).toContain('--arg id "$ARTIFACT_ID"');
+      expect(binding.run, jobName).toContain('--arg name "$ARTIFACT_NAME"');
+      expect(binding.run, jobName).toContain("(.id | tostring) == $id");
+      expect(binding.run, jobName).toContain(".name == $name");
+      expect(binding.run, jobName).toContain(".expired == false");
+      expect(binding.run, jobName).toContain(".digest == $digest");
+      expect(binding.run, jobName).toContain("(.workflow_run.id | tostring) == $run_id");
+      expect(binding.run, jobName).toContain(
+        "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+      );
+      expect(binding.run, jobName).toContain("(.run_attempt | tostring) == $attempt");
+
+      const download = step(consumer, "Download root Dockerfile image artifact");
+      expect(download.if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+      );
+      expect(download.uses, jobName).toBe(
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+      );
+      expect(download.with, jobName).toMatchObject({
+        "artifact-ids": "${{ needs.root_dockerfile_image.outputs.artifact_id }}",
+        "github-token": "${{ github.token }}",
+        path: "${{ runner.temp }}/install-smoke-root-image",
+        "run-id": "${{ needs.root_dockerfile_image.outputs.artifact_run_id }}",
+      });
+      expect(download.with?.name, jobName).toBeUndefined();
+      expect(
+        consumer.steps?.findIndex(
+          (candidate) => candidate.name === "Validate root Dockerfile image artifact binding",
+        ),
+        jobName,
+      ).toBeLessThan(
+        consumer.steps?.findIndex(
+          (candidate) => candidate.name === "Download root Dockerfile image artifact",
+        ) ?? -1,
+      );
+
+      const load = step(consumer, "Verify and load root Dockerfile image artifact");
+      expect(load.if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+      );
+      expect(load.env, jobName).toMatchObject({
+        IMAGE_REF: "${{ needs.root_dockerfile_image.outputs.image_ref }}",
+        OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256:
+          "${{ needs.root_dockerfile_image.outputs.archive_sha256 }}",
+        OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT:
+          "${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}",
+        OPENCLAW_SHARED_IMAGE_RUN_ID: "${{ needs.root_dockerfile_image.outputs.artifact_run_id }}",
+        TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+        WORKFLOW_SHA: "${{ needs.preflight.outputs.workflow_sha }}",
+      });
+      expect(load.run, jobName).toContain(
+        'load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root',
+      );
+      expect(load.run, jobName).toContain("set -euo pipefail");
+      expect(load.run, jobName).toContain('"$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"');
+
+      const requireLocal = step(consumer, "Require local root Dockerfile image");
+      expect(requireLocal.if, jobName).toBe(
+        "needs.preflight.outputs.root_image_transport == 'no-push-artifact'",
+      );
+      expect(requireLocal.run, jobName).toBe('docker image inspect "$IMAGE_REF" >/dev/null');
+    }
+
+    expect(job(workflow, "install-smoke-fast").env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE).toBe(
+      "1",
+    );
+  });
+
+  it("selects no-push transport with read-only package access from release checks", () => {
+    const release = readWorkflow(RELEASE_CHECKS);
+    const caller = job(release, "install_smoke_release_checks");
+    expect(caller.uses).toBe("./.github/workflows/install-smoke.yml");
+    expect(caller.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      packages: "read",
+    });
+    expect(caller.with).toMatchObject({
+      ref: "${{ needs.resolve_target.outputs.revision }}",
+      root_image_transport: "no-push-artifact",
+      run_bun_global_install_smoke: true,
+    });
+  });
+});

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -2,12 +2,54 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 const WORKFLOW_PATH = ".github/workflows/openclaw-cross-os-release-checks-reusable.yml";
+const RELEASE_CHECKS_PATH = ".github/workflows/openclaw-release-checks.yml";
 const WRAPPER_PATH = "scripts/github/run-openclaw-cross-os-release-checks.sh";
 const SCRIPT_PATH = "scripts/openclaw-cross-os-release-checks.ts";
 const HARNESS = "bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh";
 const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
+
+type WorkflowStep = {
+  env?: Record<string, unknown>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  outputs?: Record<string, unknown>;
+  steps?: WorkflowStep[];
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: Record<string, WorkflowJob>;
+  on?: {
+    workflow_call?: { inputs?: Record<string, Record<string, unknown>> };
+    workflow_dispatch?: { inputs?: Record<string, Record<string, unknown>> };
+  };
+};
+
+function readWorkflow(path: string): Workflow {
+  return parse(readFileSync(path, "utf8")) as Workflow;
+}
+
+function job(workflow: Workflow, name: string): WorkflowJob {
+  const found = workflow.jobs[name];
+  expect(found, name).toBeDefined();
+  return found!;
+}
+
+function step(workflowJob: WorkflowJob, name: string): WorkflowStep {
+  const found = workflowJob.steps?.find((candidate) => candidate.name === name);
+  expect(found, name).toBeDefined();
+  return found!;
+}
 
 describe("cross-OS release checks workflow", () => {
   it("runs the TypeScript release harness through the Windows-safe wrapper", () => {
@@ -28,13 +70,267 @@ describe("cross-OS release checks workflow", () => {
   it("keeps release artifact tarball filenames local before upload paths use them", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
-    expect(workflow.match(/function resolveTarballFileName/g)).toHaveLength(2);
+    expect(workflow.match(/function resolveTarballFileName/g)).toHaveLength(1);
     expect(workflow.match(/path\.win32\.basename\(fileName\)/g)).toHaveLength(2);
     expect(workflow).toContain("candidate_file_name");
     expect(workflow).toContain("Baseline npm pack filename");
     expect(workflow).toContain("fileName !== path.basename(fileName)");
     expect(workflow).toContain("fileName !== path.win32.basename(fileName)");
     expect(workflow).toContain("process.stdout.write(`file_name=${fileName}\\n`);");
+  });
+
+  it("binds the prepared release package to an immutable artifact and package tuple", () => {
+    const release = readWorkflow(RELEASE_CHECKS_PATH);
+    const producer = job(release, "prepare_release_package");
+    expect(producer.outputs).toMatchObject({
+      artifact_digest: "${{ steps.release_package_upload.outputs.artifact-digest }}",
+      artifact_id: "${{ steps.release_package_upload.outputs.artifact-id }}",
+      artifact_name: "${{ steps.artifact.outputs.name }}",
+      artifact_run_attempt: "${{ steps.artifact.outputs.run_attempt }}",
+      artifact_run_id: "${{ steps.artifact.outputs.run_id }}",
+      package_file_name: "${{ steps.artifact.outputs.file_name }}",
+      package_sha256: "${{ steps.package.outputs.sha256 }}",
+      package_version: "${{ steps.package.outputs.package_version }}",
+      source_sha: "${{ steps.package.outputs.source_sha }}",
+    });
+    expect(step(producer, "Checkout trusted workflow ref").with).toMatchObject({
+      ref: "${{ github.sha }}",
+      "persist-credentials": false,
+    });
+
+    const metadata = step(producer, "Set artifact metadata");
+    expect(metadata.run).toContain(
+      "name=release-package-under-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
+    );
+    expect(metadata.run).toContain("file_name=openclaw-current.tgz");
+    expect(metadata.run).toContain("run_attempt=${GITHUB_RUN_ATTEMPT}");
+    expect(metadata.run).toContain("run_id=${GITHUB_RUN_ID}");
+
+    const upload = step(producer, "Upload release package artifact");
+    expect(upload.id).toBe("release_package_upload");
+    expect(upload.with).toMatchObject({
+      name: "${{ steps.artifact.outputs.name }}",
+      "if-no-files-found": "error",
+    });
+
+    const binding = step(producer, "Validate release package artifact binding");
+    expect(binding.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ steps.release_package_upload.outputs.artifact-digest }}",
+      ARTIFACT_ID: "${{ steps.release_package_upload.outputs.artifact-id }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ steps.artifact.outputs.run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ steps.artifact.outputs.run_id }}",
+      PACKAGE_SHA256: "${{ steps.package.outputs.sha256 }}",
+      PACKAGE_SOURCE_SHA: "${{ steps.package.outputs.source_sha }}",
+      PACKAGE_VERSION: "${{ steps.package.outputs.package_version }}",
+    });
+    expect(binding.run).toContain('[[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]]');
+    expect(binding.run).toContain('"$ARTIFACT_RUN_ID" == "$GITHUB_RUN_ID"');
+    expect(binding.run).toContain('"$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
+    expect(binding.run).toContain('"$PACKAGE_SHA256" =~ ^[a-f0-9]{64}$');
+    expect(binding.run).toContain('"$PACKAGE_SOURCE_SHA" =~ ^[a-f0-9]{40}$');
+
+    const crossOs = job(release, "cross_os_release_checks");
+    expect(crossOs.with).toMatchObject({
+      candidate_artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
+      candidate_artifact_id: "${{ needs.prepare_release_package.outputs.artifact_id }}",
+      candidate_artifact_name: "${{ needs.prepare_release_package.outputs.artifact_name }}",
+      candidate_artifact_run_attempt:
+        "${{ needs.prepare_release_package.outputs.artifact_run_attempt }}",
+      candidate_artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
+      candidate_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
+      candidate_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
+      candidate_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
+      candidate_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+    });
+
+    expect(job(release, "docker_e2e_release_checks").with).toMatchObject({
+      package_artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
+      package_artifact_id: "${{ needs.prepare_release_package.outputs.artifact_id }}",
+      package_artifact_name: "${{ needs.prepare_release_package.outputs.artifact_name }}",
+      package_artifact_run_attempt:
+        "${{ needs.prepare_release_package.outputs.artifact_run_attempt }}",
+      package_artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
+      package_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
+      package_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
+      package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
+      package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+    });
+    expect(job(release, "package_acceptance_release_checks").with).toMatchObject({
+      artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
+      artifact_id: "${{ needs.prepare_release_package.outputs.artifact_id }}",
+      artifact_name: "${{ needs.prepare_release_package.outputs.artifact_name }}",
+      artifact_run_attempt: "${{ needs.prepare_release_package.outputs.artifact_run_attempt }}",
+      artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
+      package_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
+      package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
+      package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+      workflow_ref: "${{ github.sha }}",
+    });
+  });
+
+  it("downloads and re-exports exact candidate artifacts only by immutable id", () => {
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    for (const inputName of [
+      "candidate_artifact_digest",
+      "candidate_artifact_id",
+      "candidate_artifact_name",
+      "candidate_artifact_run_attempt",
+      "candidate_artifact_run_id",
+      "candidate_file_name",
+      "candidate_sha256",
+      "candidate_source_sha",
+      "candidate_version",
+    ]) {
+      expect(workflow.on?.workflow_dispatch?.inputs?.[inputName], inputName).toMatchObject({
+        default: "",
+        type: "string",
+      });
+      expect(workflow.on?.workflow_call?.inputs?.[inputName], inputName).toMatchObject({
+        default: "",
+        type: "string",
+      });
+    }
+
+    const prepare = job(workflow, "prepare");
+    expect(prepare.outputs).toMatchObject({
+      baseline_artifact_digest: "${{ steps.upload_baseline.outputs.artifact-digest }}",
+      baseline_artifact_id: "${{ steps.upload_baseline.outputs.artifact-id }}",
+      baseline_artifact_run_attempt: "${{ github.run_attempt }}",
+      baseline_artifact_run_id: "${{ github.run_id }}",
+      baseline_sha256: "${{ steps.baseline_metadata.outputs.sha256 }}",
+      candidate_artifact_digest: "${{ steps.upload_candidate.outputs.artifact-digest }}",
+      candidate_artifact_id: "${{ steps.upload_candidate.outputs.artifact-id }}",
+      candidate_artifact_run_attempt: "${{ github.run_attempt }}",
+      candidate_artifact_run_id: "${{ github.run_id }}",
+      candidate_sha256: "${{ steps.candidate_metadata.outputs.sha256 }}",
+      candidate_version: "${{ steps.candidate_metadata.outputs.version }}",
+      source_sha: "${{ steps.candidate_metadata.outputs.source_sha }}",
+    });
+    for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
+      for (const checkout of workflowJob.steps?.filter((candidate) =>
+        candidate.uses?.startsWith("actions/checkout@"),
+      ) ?? []) {
+        expect(checkout.with?.["persist-credentials"], `${jobName}:${checkout.name}`).toBe(false);
+      }
+    }
+
+    const inputBinding = step(prepare, "Validate provided candidate artifact binding");
+    expect(inputBinding.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ inputs.candidate_artifact_digest }}",
+      ARTIFACT_ID: "${{ inputs.candidate_artifact_id }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ inputs.candidate_artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ inputs.candidate_artifact_run_id }}",
+      CANDIDATE_SHA256: "${{ inputs.candidate_sha256 }}",
+      CANDIDATE_SOURCE_SHA: "${{ inputs.candidate_source_sha }}",
+      CANDIDATE_VERSION: "${{ inputs.candidate_version }}",
+    });
+    expect(inputBinding.run).toContain('! "$ARTIFACT_ID" =~ ^[1-9][0-9]*$');
+    expect(inputBinding.run).toContain('! "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$');
+    expect(inputBinding.run).toContain(
+      '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
+    );
+    expect(inputBinding.run).toContain('--arg digest "sha256:${ARTIFACT_DIGEST}"');
+    expect(inputBinding.run).toContain(
+      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+    );
+    expect(inputBinding.run).toContain('"$CANDIDATE_SOURCE_SHA" != "$INPUT_REF"');
+
+    const inputDownload = step(prepare, "Download provided candidate artifact");
+    expect(inputDownload.with).toMatchObject({
+      "artifact-ids": "${{ inputs.candidate_artifact_id }}",
+      "run-id": "${{ inputs.candidate_artifact_run_id }}",
+    });
+    expect(inputDownload.with?.name).toBeUndefined();
+    expect(
+      prepare.steps?.findIndex(
+        (candidate) => candidate.name === "Validate provided candidate artifact binding",
+      ),
+    ).toBeLessThan(
+      prepare.steps?.findIndex(
+        (candidate) => candidate.name === "Download provided candidate artifact",
+      ) ?? -1,
+    );
+
+    const resolve = step(prepare, "Resolve provided candidate package");
+    expect(resolve.run).toContain("resolve-openclaw-package-candidate.mjs");
+    expect(resolve.run).toContain("--source artifact");
+    expect(resolve.run).toContain('--package-sha256 "$INPUT_CANDIDATE_SHA256"');
+    expect(resolve.run).toContain('"$actual_sha256" == "$INPUT_CANDIDATE_SHA256"');
+    expect(resolve.run).toContain('"$actual_source_sha" == "$INPUT_CANDIDATE_SOURCE_SHA"');
+    expect(resolve.run).toContain('"$actual_version" == "$INPUT_CANDIDATE_VERSION"');
+
+    const upload = step(prepare, "Upload candidate artifact");
+    expect(upload.id).toBe("upload_candidate");
+    expect(upload.with?.name).toBe(
+      "openclaw-cross-os-release-checks-candidate-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+    const baselineUpload = step(prepare, "Upload baseline artifact");
+    expect(baselineUpload.id).toBe("upload_baseline");
+    expect(baselineUpload.with?.name).toBe(
+      "openclaw-cross-os-release-checks-baseline-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+
+    const consumer = job(workflow, "cross_os_release_checks");
+    const binding = step(consumer, "Validate prepared candidate artifact binding");
+    expect(binding.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ needs.prepare.outputs.candidate_artifact_digest }}",
+      ARTIFACT_ID: "${{ needs.prepare.outputs.candidate_artifact_id }}",
+      ARTIFACT_NAME:
+        "${{ format('openclaw-cross-os-release-checks-candidate-{0}-{1}', needs.prepare.outputs.candidate_artifact_run_id, needs.prepare.outputs.candidate_artifact_run_attempt) }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ needs.prepare.outputs.candidate_artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ needs.prepare.outputs.candidate_artifact_run_id }}",
+      BASELINE_ARTIFACT_DIGEST: "${{ needs.prepare.outputs.baseline_artifact_digest }}",
+      BASELINE_ARTIFACT_ID: "${{ needs.prepare.outputs.baseline_artifact_id }}",
+      BASELINE_ARTIFACT_NAME:
+        "${{ format('openclaw-cross-os-release-checks-baseline-{0}-{1}', needs.prepare.outputs.baseline_artifact_run_id, needs.prepare.outputs.baseline_artifact_run_attempt) }}",
+      BASELINE_ARTIFACT_RUN_ATTEMPT: "${{ needs.prepare.outputs.baseline_artifact_run_attempt }}",
+      BASELINE_ARTIFACT_RUN_ID: "${{ needs.prepare.outputs.baseline_artifact_run_id }}",
+      BASELINE_SHA256: "${{ needs.prepare.outputs.baseline_sha256 }}",
+      CANDIDATE_SHA256: "${{ needs.prepare.outputs.candidate_sha256 }}",
+      CANDIDATE_SOURCE_SHA: "${{ needs.prepare.outputs.source_sha }}",
+      CANDIDATE_VERSION: "${{ needs.prepare.outputs.candidate_version }}",
+      GH_TOKEN: "${{ github.token }}",
+    });
+    expect(binding.run).not.toContain('"$ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
+    expect(binding.run).not.toContain('"$BASELINE_ARTIFACT_RUN_ATTEMPT" == "$GITHUB_RUN_ATTEMPT"');
+    expect(binding.run).toContain("actions/artifacts/${tuple.id}");
+    expect(binding.run).toContain("artifact.expired !== false");
+    expect(binding.run).toContain("artifact.digest !== `sha256:${tuple.digest}`");
+    expect(binding.run).toContain("String(artifact.workflow_run?.id) !== tuple.runId");
+    expect(binding.run).toContain("actions/runs/${tuple.runId}/attempts/${tuple.runAttempt}");
+    expect(binding.run).toContain("String(attempt.run_attempt) !== tuple.runAttempt");
+
+    for (const name of ["Download candidate artifact", "Retry candidate artifact download"]) {
+      const download = step(consumer, name);
+      expect(download.with?.["artifact-ids"], name).toBe(
+        "${{ needs.prepare.outputs.candidate_artifact_id }}",
+      );
+      expect(download.with?.["github-token"], name).toBe("${{ github.token }}");
+      expect(download.with?.["run-id"], name).toBe(
+        "${{ needs.prepare.outputs.candidate_artifact_run_id }}",
+      );
+      expect(download.with?.name, name).toBeUndefined();
+    }
+    for (const name of ["Download baseline artifact", "Retry baseline artifact download"]) {
+      const download = step(consumer, name);
+      expect(download.with?.["artifact-ids"], name).toBe(
+        "${{ needs.prepare.outputs.baseline_artifact_id }}",
+      );
+      expect(download.with?.["github-token"], name).toBe("${{ github.token }}");
+      expect(download.with?.["run-id"], name).toBe(
+        "${{ needs.prepare.outputs.baseline_artifact_run_id }}",
+      );
+      expect(download.with?.name, name).toBeUndefined();
+    }
+    const verify = step(consumer, "Verify release-check inputs");
+    expect(verify.env?.EXPECTED_CANDIDATE_SHA256).toBe(
+      "${{ needs.prepare.outputs.candidate_sha256 }}",
+    );
+    expect(verify.run).toContain('"$actual_sha256" != "$EXPECTED_CANDIDATE_SHA256"');
+    expect(verify.env?.EXPECTED_BASELINE_SHA256).toBe(
+      "${{ needs.prepare.outputs.baseline_sha256 }}",
+    );
+    expect(verify.run).toContain('"$actual_baseline_sha256" != "$EXPECTED_BASELINE_SHA256"');
   });
 
   it("executes the release harness directly with Node", () => {

--- a/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
@@ -76,11 +76,10 @@ describe("extended-stable Full Release Validation workflow", () => {
       expect(run).toContain(child.target);
     }
 
+    expect(fullValidation).toContain("PARENT_WORKFLOW_SHA: ${{ github.sha }}");
+    expect(fullValidation).toContain('if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]');
     expect(fullValidation).toContain(
-      '"$CHILD_WORKFLOW_REF" =~ ^extended-stable/[0-9]{4}\\.([1-9]|1[0-2])\\.33$',
-    );
-    expect(fullValidation).toContain(
-      "Dispatch Full Release Validation from a release-ci or extended-stable ref pinned to the target SHA",
+      "child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}",
     );
   });
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -80,12 +80,22 @@ describe("OpenClaw performance workflow", () => {
     expect(workflow).toContain("Optional parent workflow dispatch identifier");
   });
 
-  it("pins the Kova evaluator that reads agent payloads", () => {
+  it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "a2dd84e7d65507e614afaff850d3932d18c859b6";
+    const kovaRef = "24c26969e57d4d49f9d1a5071af85dd3d79daa2d";
+    const install = findStep("Install OCM and Kova");
+    const installRun = install.run ?? "";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);
+    expect(installRun).toContain(
+      'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
+    );
+    expect(installRun).toContain('for (const dependency of ["mock-ai-provider", "zod"])');
+    expect(installRun).toContain("require.resolve(dependency, { paths: [root] })");
+    expect(
+      installRun.indexOf('npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund'),
+    ).toBeLessThan(installRun.indexOf('cat > "$HOME/.local/bin/kova"'));
   });
 
   it("resolves each target once before benchmark and publication fan out", () => {
@@ -144,7 +154,7 @@ describe("OpenClaw performance workflow", () => {
 
     expect(publisher?.needs).toEqual(["resolve_target", "kova"]);
     expect(publisher?.if).toBe(
-      "${{ always() && needs.resolve_target.result == 'success' && needs.kova.result != 'cancelled' }}",
+      "${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.publish_reports == true)) && needs.resolve_target.result == 'success' && needs.kova.result != 'cancelled' }}",
     );
     expect(publisher?.["runs-on"]).toBe("ubuntu-24.04");
     expect(publisher?.permissions?.actions).toBe("read");
@@ -158,6 +168,32 @@ describe("OpenClaw performance workflow", () => {
     expect(prepareIndex).toBeGreaterThan(downloadIndex);
     expect(appTokenIndex).toBeGreaterThan(prepareIndex);
     expect(pushIndex).toBeGreaterThan(appTokenIndex);
+  });
+
+  it("keeps report publication opt-out artifact-only for final release validation", () => {
+    const workflowText = readFileSync(WORKFLOW, "utf8");
+    const fullReleaseText = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    const publisher = readWorkflow().jobs?.publish;
+
+    expect(workflowText).toContain("publish_reports:");
+    expect(workflowText).toContain("default: true");
+    expect(publisher?.if).toContain("inputs.publish_reports == true");
+    expect(fullReleaseText).toContain("-f publish_reports=false");
+    expect(fullReleaseText).toContain("Report publication: disabled (artifacts only)");
+  });
+
+  it("fails closed when artifact-only mode does not keep the publisher skipped", () => {
+    const guard = readWorkflow().jobs?.artifact_only_guard;
+    const verify = findStep("Verify report publisher stayed disabled", "artifact_only_guard");
+
+    expect(guard?.needs).toEqual(["resolve_target", "kova", "publish"]);
+    expect(guard?.if).toBe(
+      "${{ always() && github.event_name == 'workflow_dispatch' && inputs.publish_reports != true }}",
+    );
+    expect(guard?.permissions?.contents).toBe("read");
+    expect(verify.env?.PUBLISH_RESULT).toBe("${{ needs.publish.result }}");
+    expect(verify.run).toContain('[[ "$PUBLISH_RESULT" != "skipped" ]]');
+    expect(verify.run).toContain("Artifact-only performance mode requires");
   });
 
   it("mints only a short-lived repo-scoped ClawSweeper app token", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -140,6 +140,8 @@ function expectTextToIncludeAll(text: string | undefined, snippets: string[]): v
 
 function runPackageAcceptanceSummary(params: {
   advisory?: boolean;
+  dockerArtifactResult?: string;
+  dockerRegistryResult?: string;
   telegramEnabled: boolean;
   telegramResult: string;
 }) {
@@ -152,12 +154,41 @@ function runPackageAcceptanceSummary(params: {
     encoding: "utf8",
     env: {
       ADVISORY: String(params.advisory ?? false),
-      DOCKER_RESULT: "success",
+      DOCKER_ARTIFACT_RESULT: params.dockerArtifactResult ?? "success",
+      DOCKER_REGISTRY_RESULT: params.dockerRegistryResult ?? "skipped",
       PACKAGE_INTEGRITY_RESULT: "success",
       PACKAGE_TELEGRAM_RESULT: params.telegramResult,
       PATH: process.env.PATH,
       RESOLVE_RESULT: "success",
       TELEGRAM_ENABLED: String(params.telegramEnabled),
+    },
+  });
+}
+
+function runNpmTelegramInputValidation(overrides: Record<string, string>) {
+  const job = workflowJob(NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e");
+  const script = workflowStep(job, "Validate inputs and secrets").run;
+  if (!script) {
+    throw new Error("Expected npm Telegram input validation script");
+  }
+  return spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      OPENCLAW_QA_CONVEX_SECRET_CI: "test-secret",
+      OPENCLAW_QA_CONVEX_SITE_URL: "https://example.invalid",
+      PACKAGE_ARTIFACT_DIGEST: "",
+      PACKAGE_ARTIFACT_ID: "",
+      PACKAGE_ARTIFACT_NAME: "",
+      PACKAGE_ARTIFACT_RUN_ATTEMPT: "",
+      PACKAGE_ARTIFACT_RUN_ID: "",
+      PACKAGE_FILE_NAME: "",
+      PACKAGE_SHA256: "",
+      PACKAGE_SOURCE_SHA: "",
+      PACKAGE_SPEC: "openclaw@beta",
+      PACKAGE_VERSION: "",
+      PATH: process.env.PATH,
+      PROVIDER_MODE: "mock-openai",
+      ...overrides,
     },
   });
 }
@@ -492,7 +523,8 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain('--trusted-source-id "$TRUSTED_SOURCE_ID"');
     expect(workflow).toContain("scripts/resolve-openclaw-package-candidate.mjs");
     expect(workflow).toContain('--package-ref "$PACKAGE_REF"');
-    expect(workflow).toContain('gh run download "$ARTIFACT_RUN_ID"');
+    expect(workflow).toContain("artifact-ids: ${{ inputs.artifact_id }}");
+    expect(workflow).toContain("actions/artifacts/${ARTIFACT_ID}");
     expect(workflow).toContain("name: ${{ env.PACKAGE_ARTIFACT_NAME }}");
     expect(workflow).toContain("pull-requests: read");
     expect(workflow).toContain(
@@ -506,9 +538,8 @@ describe("package acceptance workflow", () => {
     );
     expect(workflow).toContain("package_integrity:");
     expect(workflow).toContain("name: Package integrity");
-    expect(workflow).toContain(
-      "node scripts/check-openclaw-package-tarball.mjs .artifacts/docker-e2e-package/openclaw-current.tgz",
-    );
+    expect(workflow).toContain('node scripts/check-openclaw-package-tarball.mjs "$package"');
+    expect(workflow).toContain('[[ "$actual_sha256" == "$EXPECTED_PACKAGE_SHA256" ]]');
     expect(workflow).toContain("needs: [resolve_package, package_integrity]");
     expect(workflow).toContain("package_integrity=${PACKAGE_INTEGRITY_RESULT}");
   });
@@ -544,6 +575,30 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain(
       "package_artifact_name: ${{ needs.resolve_package.outputs.package_artifact_name }}",
     );
+    expect(workflow).toContain(
+      "package_artifact_digest: ${{ needs.resolve_package.outputs.package_artifact_digest }}",
+    );
+    expect(workflow).toContain(
+      "package_artifact_id: ${{ needs.resolve_package.outputs.package_artifact_id }}",
+    );
+    expect(workflow).toContain(
+      "package_artifact_run_attempt: ${{ needs.resolve_package.outputs.package_artifact_run_attempt }}",
+    );
+    expect(workflow).toContain(
+      "package_artifact_run_id: ${{ needs.resolve_package.outputs.package_artifact_run_id }}",
+    );
+    expect(workflow).toContain(
+      "package_file_name: ${{ needs.resolve_package.outputs.package_file_name }}",
+    );
+    expect(workflow).toContain(
+      "package_sha256: ${{ needs.resolve_package.outputs.package_sha256 }}",
+    );
+    expect(workflow).toContain(
+      "package_source_sha: ${{ needs.resolve_package.outputs.package_source_sha }}",
+    );
+    expect(workflow).toContain(
+      "package_version: ${{ needs.resolve_package.outputs.package_version }}",
+    );
     expect(workflow).toContain("telegram_scenarios:");
     expect(workflow).toContain("scenario: ${{ inputs.telegram_scenarios }}");
     expect(workflow).toContain(
@@ -573,7 +628,7 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain("Published upgrade survivor scenarios:");
   });
 
-  it("requires pinned full release child workflows to run at the resolved target SHA", () => {
+  it("requires full release child workflows to run at the parent workflow SHA", () => {
     const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
     const releaseChecksWorkflow = readFileSync(RELEASE_CHECKS_WORKFLOW, "utf8");
     const performanceJob = workflow.slice(
@@ -583,6 +638,7 @@ describe("package acceptance workflow", () => {
 
     expect(workflow).toContain("TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}");
     expect(workflow).toContain("CHILD_WORKFLOW_REF: ${{ github.ref_name }}");
+    expect(workflow).toContain("PARENT_WORKFLOW_SHA: ${{ github.sha }}");
     expect(workflow).toContain("release_package_spec:");
     expect(workflow).toContain('args+=(-f release_package_spec="$RELEASE_PACKAGE_SPEC")');
     expect(workflow).toContain("package_acceptance_package_spec:");
@@ -599,8 +655,12 @@ describe("package acceptance workflow", () => {
     );
     expect(workflow).toContain("--json status,conclusion,url,attempt,headSha,jobs");
     expect(workflow).toContain(
-      '[[ ( "$CHILD_WORKFLOW_REF" == release-ci/* || "$CHILD_WORKFLOW_REF" =~ ^extended-stable/[0-9]{4}\\.([1-9]|1[0-2])\\.33$ ) && -n "${TARGET_SHA// }" && "$head_sha" != "$TARGET_SHA" ]]',
+      'gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha',
     );
+    expect(workflow).toContain(
+      "Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch.",
+    );
+    expect(workflow).toContain('if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then');
     expect(workflow).toContain('gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1');
     expect(performanceJob).toContain(
       'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
@@ -615,9 +675,11 @@ describe("package acceptance workflow", () => {
     expect(performanceJob).not.toContain(
       "did not return an Actions run URL; refusing to guess from recent workflow_dispatch runs",
     );
-    expect(workflow).toContain("child run used ${head_sha}, expected ${TARGET_SHA}");
     expect(workflow).toContain(
-      "Dispatch Full Release Validation from a release-ci or extended-stable ref pinned to the target SHA",
+      "child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}",
+    );
+    expect(workflow).toContain(
+      "Use the SHA-pinned release helper when a moving branch cannot stay fixed",
     );
     expect(workflow).toContain("| Child | Result | Minutes | Head SHA | Run |");
     expect(releaseChecksWorkflow).toContain("refs/heads/release-ci/[0-9a-f]{12}-[0-9]+");
@@ -647,6 +709,10 @@ describe("package acceptance workflow", () => {
       expect(script).not.toContain("gh_with_retry workflow run");
       expectTextToIncludeAll(script, [
         "A failed dispatch POST can still create a run. Never retry it",
+        'encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF"',
+        'gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha',
+        '"$current_workflow_sha" != "$PARENT_WORKFLOW_SHA"',
+        "refusing dispatch.",
         "set +e",
         "dispatch_status=$?",
         'if [[ "$dispatch_status" -ne 0 && ! "$dispatch_output" =~ $GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN ]]',
@@ -716,7 +782,7 @@ describe("package acceptance workflow", () => {
 
     const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
     const retryCalls = workflow.split("\n").filter((line) => line.includes("gh_with_retry "));
-    expect(retryCalls).toHaveLength(30);
+    expect(retryCalls).toHaveLength(37);
     for (const call of retryCalls) {
       expect(call).toMatch(/gh_with_retry (api|run view)/u);
     }
@@ -760,6 +826,57 @@ describe("package acceptance workflow", () => {
 });
 
 describe("package artifact reuse", () => {
+  it("binds package acceptance input artifacts to the complete producer tuple", () => {
+    const resolvePackage = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "resolve_package");
+    expect(
+      workflowStep(resolvePackage, "Checkout package workflow ref").with?.["persist-credentials"],
+    ).toBe(false);
+    const identity = workflowStep(resolvePackage, "Validate package artifact input identity");
+    expect(identity.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ inputs.artifact_digest }}",
+      ARTIFACT_ID: "${{ inputs.artifact_id }}",
+      ARTIFACT_NAME: "${{ inputs.artifact_name }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ inputs.artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}",
+      EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
+      EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",
+      EXPECTED_PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha }}",
+      EXPECTED_PACKAGE_VERSION: "${{ inputs.package_version }}",
+    });
+    expectTextToIncludeAll(identity.run, [
+      "source=artifact requires the complete immutable artifact and package identity tuple.",
+      '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
+      '--arg digest "sha256:${ARTIFACT_DIGEST}"',
+      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+    ]);
+    expect(workflowStep(resolvePackage, "Download package artifact input").with).toMatchObject({
+      "artifact-ids": "${{ inputs.artifact_id }}",
+      "github-token": "${{ github.token }}",
+      "run-id": "${{ inputs.artifact_run_id }}",
+    });
+    const resolve = workflowStep(resolvePackage, "Resolve package candidate");
+    expect(resolve.env).toMatchObject({
+      PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
+      PACKAGE_SHA256: "${{ inputs.package_sha256 }}",
+      PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha }}",
+      PACKAGE_VERSION: "${{ inputs.package_version }}",
+    });
+    expectTextToIncludeAll(resolve.run, [
+      'artifact_tarball="${artifact_dir}/${PACKAGE_FILE_NAME}"',
+      "Selected artifact package SHA-256 differs from package_sha256.",
+      "Resolved package identity differs from the declared immutable tuple.",
+    ]);
+
+    const packageIntegrity = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "package_integrity");
+    expect(
+      workflowStep(packageIntegrity, "Download package-under-test artifact").with,
+    ).toMatchObject({
+      "artifact-ids": "${{ needs.resolve_package.outputs.package_artifact_id }}",
+      "github-token": "${{ github.token }}",
+      "run-id": "${{ needs.resolve_package.outputs.package_artifact_run_id }}",
+    });
+  });
+
   it("lets reusable Docker E2E consume an already resolved package artifact", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
     const packageJson = readFileSync(PACKAGE_JSON, "utf8");
@@ -767,7 +884,14 @@ describe("package artifact reuse", () => {
     const publishedUpgradeSurvivor = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
 
     expect(workflow).toContain("package_artifact_name:");
+    expect(workflow).toContain("package_artifact_digest:");
+    expect(workflow).toContain("package_artifact_id:");
+    expect(workflow).toContain("package_artifact_run_attempt:");
     expect(workflow).toContain("package_artifact_run_id:");
+    expect(workflow).toContain("package_file_name:");
+    expect(workflow).toContain("package_source_sha:");
+    expect(workflow).toContain("package_sha256:");
+    expect(workflow).toContain("package_version:");
     expect(workflow).toContain("published_upgrade_survivor_baseline:");
     expect(workflow).toContain("published_upgrade_survivor_baselines:");
     expect(workflow).toContain("published_upgrade_survivor_scenarios:");
@@ -785,14 +909,19 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("Download current-run OpenClaw Docker E2E package");
     expect(workflow).toContain("Download previous-run OpenClaw Docker E2E package");
-    expect(workflow).toContain("inputs.package_artifact_name != ''");
+    expect(workflow).toContain("inputs.package_artifact_id != ''");
     expect(workflow).toContain(
       'bare_image="${PROVIDED_BARE_IMAGE:-ghcr.io/${repository}-docker-e2e-bare:${image_tag}}"',
     );
     expect(workflow).toContain(
       'functional_image="${PROVIDED_FUNCTIONAL_IMAGE:-ghcr.io/${repository}-docker-e2e-functional:${image_tag}}"',
     );
-    expect(workflow).toContain("name: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}");
+    expect(workflow).toContain("artifact-ids: ${{ inputs.package_artifact_id }}");
+    expect(workflow).toContain(
+      '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
+    );
+    expect(workflow).toContain('--arg digest "sha256:${ARTIFACT_DIGEST}"');
+    expect(workflow).toContain("actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}");
     expect(workflow).not.toContain("uses: ./.github/actions/docker-e2e-plan");
     expect(workflow).toContain("Checkout trusted release harness");
     expect(workflow).toContain("OPENCLAW_DOCKER_E2E_REPO_ROOT:");
@@ -1904,9 +2033,7 @@ describe("package artifact reuse", () => {
     const workflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
 
     expect(workflow).toContain("package_telegram:");
-    expect(workflow).toContain(
-      "needs: [resolve_package, package_integrity, docker_acceptance, package_telegram]",
-    );
+    expect(workflow).toContain("docker_acceptance_registry,");
     expect(workflow).toContain("PACKAGE_TELEGRAM_RESULT:");
     expect(workflow).toContain("package_telegram=${PACKAGE_TELEGRAM_RESULT}");
     expect(workflow).not.toContain("npm_telegram:");
@@ -1933,6 +2060,18 @@ describe("package artifact reuse", () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain("::error::package_telegram ended with skipped");
+  });
+
+  it("rejects package acceptance when no Docker transport ran", () => {
+    const result = runPackageAcceptanceSummary({
+      dockerArtifactResult: "skipped",
+      dockerRegistryResult: "skipped",
+      telegramEnabled: false,
+      telegramResult: "skipped",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("::error::No Docker acceptance transport ran");
   });
 
   it("preserves advisory handling for an unexpectedly skipped Telegram lane", () => {
@@ -1985,6 +2124,7 @@ describe("package artifact reuse", () => {
       CHILD_WORKFLOW_REF: "${{ github.ref_name }}",
       GH_TOKEN: "${{ github.token }}",
       PACKAGE_SPEC: "${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}",
+      PARENT_WORKFLOW_SHA: "${{ github.sha }}",
       PROVIDER_MODE: "${{ inputs.npm_telegram_provider_mode }}",
       SCENARIO: "${{ inputs.npm_telegram_scenario }}",
       TARGET_SHA: "${{ needs.resolve_target.outputs.sha }}",
@@ -1994,6 +2134,7 @@ describe("package artifact reuse", () => {
       'dispatch_output="$(gh workflow run npm-telegram-beta-e2e.yml --ref "$CHILD_WORKFLOW_REF" "${args[@]}" 2>&1)"',
       ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
       "The dispatch was not retried to avoid creating a duplicate child.",
+      'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
       '-f harness_ref="$TARGET_SHA"',
       'args=(-f package_spec="$PACKAGE_SPEC"',
       'args+=(-f scenario="$SCENARIO")',
@@ -2056,43 +2197,83 @@ describe("package artifact reuse", () => {
       "Download package-under-test artifact from release run",
     );
     const validateStep = workflowStep(job, "Validate inputs and secrets");
+    const identityStep = workflowStep(job, "Validate package artifact identity");
     const runStep = workflowStep(job, "Run package Telegram E2E");
 
     expect(currentRunDownload).toEqual({
-      if: "inputs.package_artifact_name != '' && inputs.package_artifact_run_id == ''",
+      if: "inputs.package_artifact_name != '' && inputs.package_artifact_run_id == github.run_id",
       name: "Download package-under-test artifact",
       uses: DOWNLOAD_ARTIFACT_V8,
       with: {
-        name: "${{ inputs.package_artifact_name }}",
+        "artifact-ids": "${{ inputs.package_artifact_id }}",
+        "github-token": "${{ github.token }}",
         path: ".artifacts/telegram-package-under-test",
+        "run-id": "${{ inputs.package_artifact_run_id }}",
       },
     });
     expect(releaseRunDownload).toEqual({
-      if: "inputs.package_artifact_name != '' && inputs.package_artifact_run_id != ''",
+      if: "inputs.package_artifact_name != '' && inputs.package_artifact_run_id != github.run_id",
       name: "Download package-under-test artifact from release run",
       uses: DOWNLOAD_ARTIFACT_V8,
       with: {
+        "artifact-ids": "${{ inputs.package_artifact_id }}",
         "github-token": "${{ github.token }}",
-        name: "${{ inputs.package_artifact_name }}",
         path: ".artifacts/telegram-package-under-test",
         "run-id": "${{ inputs.package_artifact_run_id }}",
       },
     });
     expectTextToIncludeAll(validateStep.run, [
       'if [[ -z "${PACKAGE_ARTIFACT_NAME// }" ]]; then',
+      "Artifact-backed Telegram E2E requires all artifact identity fields or none.",
       "package_spec must be openclaw@alpha",
+      "Artifact-backed Telegram E2E requires the complete immutable artifact and package identity tuple.",
     ]);
+    expect(identityStep.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ inputs.package_artifact_digest }}",
+      ARTIFACT_ID: "${{ inputs.package_artifact_id }}",
+      ARTIFACT_NAME: "${{ inputs.package_artifact_name }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ inputs.package_artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ inputs.package_artifact_run_id }}",
+    });
+    expectTextToIncludeAll(identityStep.run, [
+      '[[ "$ARTIFACT_NAME" == *"-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}" ]]',
+      "actions/artifacts/${ARTIFACT_ID}",
+      '--arg digest "sha256:${ARTIFACT_DIGEST}"',
+      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+      "Package Telegram artifact producer run attempt does not match the requested tuple.",
+    ]);
+    expect(runStep.env).toMatchObject({
+      PACKAGE_FILE_NAME: "${{ inputs.package_file_name || '' }}",
+      PACKAGE_SHA256: "${{ inputs.package_sha256 || '' }}",
+      PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha || '' }}",
+      PACKAGE_VERSION: "${{ inputs.package_version || '' }}",
+    });
     expectTextToIncludeAll(runStep.run, [
+      'declared_package_tgz="${package_dir}/${PACKAGE_FILE_NAME}"',
       'manifest="${package_dir}/preflight-manifest.json"',
       'candidate_manifest="${package_dir}/package-candidate.json"',
       'find "${package_dir}" -type f -name "*.tgz"',
       "package artifact manifest contains duplicate package metadata",
       "package artifact tarball set does not match preflight manifest",
       "package candidate manifest does not match the OpenClaw tarball",
+      "Package Telegram artifact SHA-256 differs from package_sha256.",
       "package candidate digest mismatch",
+      "Package Telegram artifact tarball differs from package_file_name.",
+      "Package Telegram artifact source SHA/version differs from the declared identity.",
       'export OPENCLAW_NPM_TELEGRAM_PACKAGE_DIR="${package_dir}"',
       'export OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ="${package_tgz}"',
     ]);
+  });
+
+  it("rejects partial npm Telegram artifact identity instead of falling back to npm", () => {
+    const result = runNpmTelegramInputValidation({
+      PACKAGE_ARTIFACT_ID: "123",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Artifact-backed Telegram E2E requires all artifact identity fields or none.",
+    );
   });
 
   it("lets CI Telegram consumers wait on Convex leases instead of GitHub concurrency", () => {

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -287,7 +287,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
           with: {
             "fetch-depth": 1,
             "fetch-tags": false,
-            "persist-credentials": true,
+            "persist-credentials": false,
             ref: "${{ needs.preflight.outputs.checkout_revision }}",
             submodules: false,
           },
@@ -487,7 +487,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       permissions: {
         actions: "read",
         contents: "read",
-        packages: "write",
+        packages: "read",
         "pull-requests": "read",
       },
       uses: "./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
@@ -499,6 +499,8 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
         include_repo_e2e: false,
         live_models_only: false,
         ref: "${{ needs.preflight.outputs.checkout_revision }}",
+        shared_image_artifact_namespace: "plugin-prerelease",
+        shared_image_policy: "no-push-artifact",
         targeted_docker_lane_group_size: 4,
       },
     });

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1,0 +1,1479 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  expectedChildDispatches,
+  expectedSelectedChildDispatches,
+  manifestChildEntries,
+  parseReleaseCiSummaryArgs,
+  readManifestArtifactArchive,
+  requiredChildKeysForRerunGroup,
+  resolveManifestChildOriginAttempt,
+  selectExactChildRun,
+  selectExactChildRunFromPages,
+  selectManifestArtifact,
+  selectManifestParentJob,
+  selectedChildKeys,
+  validateEvidenceReuseChain,
+  validateManifestArtifactCompatibility,
+  validateManifestArtifactIdentity,
+  validateManifestChildRun,
+  validateParentManifest,
+  validateParentRunBinding,
+  validatePerformanceArtifactOnlyJobs,
+  validateReleaseRunEvidence,
+} from "../../.agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs";
+
+const SCRIPT = ".agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs";
+const MANIFEST_ARTIFACT_ENTRY = "full-release-validation-manifest.json";
+
+function crc32(input: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of input) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function u16(value: number): Buffer {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value);
+  return buffer;
+}
+
+function u32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function makeStoredZip(files: Record<string, string>): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const [name, contents] of Object.entries(files)) {
+    const nameBuffer = Buffer.from(name, "utf8");
+    const contentsBuffer = Buffer.from(contents, "utf8");
+    const checksum = crc32(contentsBuffer);
+    const localHeader = Buffer.concat([
+      u32(0x04034b50),
+      u16(20),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(checksum),
+      u32(contentsBuffer.length),
+      u32(contentsBuffer.length),
+      u16(nameBuffer.length),
+      u16(0),
+      nameBuffer,
+    ]);
+    localParts.push(localHeader, contentsBuffer);
+    centralParts.push(
+      Buffer.concat([
+        u32(0x02014b50),
+        u16(20),
+        u16(20),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32(checksum),
+        u32(contentsBuffer.length),
+        u32(contentsBuffer.length),
+        u16(nameBuffer.length),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32((0o100644 << 16) >>> 0),
+        u32(offset),
+        nameBuffer,
+      ]),
+    );
+    offset += localHeader.length + contentsBuffer.length;
+  }
+
+  const localData = Buffer.concat(localParts);
+  const centralDirectory = Buffer.concat(centralParts);
+  return Buffer.concat([
+    localData,
+    centralDirectory,
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(Object.keys(files).length),
+    u16(Object.keys(files).length),
+    u32(centralDirectory.length),
+    u32(localData.length),
+    u16(0),
+  ]);
+}
+
+function artifactDigest(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function rawManifest({
+  evidenceReuse,
+  rerunGroup = "all",
+  runId = "29090000000",
+  targetSha = "a".repeat(40),
+  version = 2,
+  workflowFullRef,
+  workflowRefType,
+  workflowSha,
+}: {
+  evidenceReuse?: Record<string, unknown>;
+  rerunGroup?: string;
+  runId?: string;
+  targetSha?: string;
+  version?: 2 | 3;
+  workflowFullRef?: string;
+  workflowRefType?: "branch" | "tag";
+  workflowSha?: string;
+}) {
+  return {
+    childRuns: {
+      normalCi: "101",
+      npmTelegram: "",
+      pluginPrerelease: "202",
+      productPerformance: { blocking: true, conclusion: "success", runId: "303" },
+      releaseChecks: "404",
+    },
+    controls: {
+      performanceBlocking: true,
+      performanceReportPublication: "artifact-only",
+      stableSoakRequired: false,
+    },
+    evidenceReuse,
+    releaseProfile: "beta",
+    rerunGroup,
+    runAttempt: "2",
+    runId,
+    runReleaseSoak: "false",
+    targetSha,
+    validationInputs: {
+      codexPluginSpec: "",
+      crossOsSuiteFilter: "",
+      liveSuiteFilter: "",
+      mode: "direct",
+      packageAcceptancePackageSpec: "",
+      provider: "openai",
+      releasePackageSpec: "",
+    },
+    version,
+    workflowName: "Full Release Validation",
+    workflowRef: "main",
+    ...(workflowSha ? { workflowSha } : {}),
+    ...(version === 3
+      ? {
+          workflowFullRef: workflowFullRef ?? "refs/heads/main",
+          workflowRefType: workflowRefType ?? "branch",
+        }
+      : {}),
+  };
+}
+
+function trustedMainPackageFixture({
+  manifestVersion = 2,
+  parentPath = ".github/workflows/full-release-validation.yml",
+  targetSha = "8".repeat(40),
+  workflowFullRef,
+  workflowRef = "main",
+  workflowRefType,
+  workflowSha = "0".repeat(40),
+}: {
+  manifestVersion?: 2 | 3;
+  parentPath?: string;
+  targetSha?: string;
+  workflowFullRef?: string;
+  workflowRef?: string;
+  workflowRefType?: "branch" | "tag";
+  workflowSha?: string;
+} = {}) {
+  const runId = "29071366025";
+  const childRunId = "29071382629";
+  const manifest = rawManifest({
+    rerunGroup: "package",
+    runId,
+    targetSha,
+    version: manifestVersion,
+    workflowFullRef,
+    workflowRefType,
+    workflowSha,
+  });
+  manifest.childRuns = {
+    normalCi: "",
+    npmTelegram: "",
+    pluginPrerelease: "",
+    productPerformance: { blocking: true, conclusion: "", runId: "" },
+    releaseChecks: childRunId,
+  };
+  manifest.releaseProfile = "full";
+  manifest.runAttempt = "1";
+  manifest.runReleaseSoak = "true";
+  manifest.workflowRef = workflowRef;
+
+  const parentRun = {
+    conclusion: "success",
+    event: "workflow_dispatch",
+    head_branch: workflowRef,
+    head_sha: workflowSha,
+    html_url: `https://github.com/openclaw/openclaw/actions/runs/${runId}`,
+    id: Number(runId),
+    path: parentPath,
+    repository: { full_name: "openclaw/openclaw" },
+    run_attempt: 1,
+    status: "completed",
+  };
+  const parentView = {
+    attempt: 1,
+    conclusion: "success",
+    headBranch: workflowRef,
+    headSha: workflowSha,
+    jobs: [],
+    status: "completed",
+    url: parentRun.html_url,
+  };
+  const child = expectedChildDispatches(runId, 1, workflowRef).find(
+    (entry) => entry.manifestKey === "releaseChecks",
+  );
+  if (!child) {
+    throw new Error("missing release checks child fixture");
+  }
+  const parentJob = {
+    completed_at: "2026-07-10T01:10:00Z",
+    conclusion: "success",
+    id: 86293408710,
+    name: child.parentJobName,
+    run_attempt: 1,
+    started_at: "2026-07-10T01:00:00Z",
+    status: "completed",
+    steps: [],
+  };
+  const childRun = {
+    actor: { login: "github-actions[bot]" },
+    conclusion: "success",
+    display_title: child.displayTitle,
+    event: "workflow_dispatch",
+    head_branch: workflowRef,
+    head_sha: workflowSha,
+    html_url: `https://github.com/openclaw/openclaw/actions/runs/${childRunId}`,
+    id: Number(childRunId),
+    path: ".github/workflows/openclaw-release-checks.yml",
+    repository: { full_name: "openclaw/openclaw" },
+    run_attempt: 1,
+    status: "completed",
+    triggering_actor: { login: "github-actions[bot]" },
+  };
+  const artifact = {
+    digest: `sha256:${"9".repeat(64)}`,
+    expired: false,
+    id: 8220114429,
+    name: `full-release-validation-${runId}-1`,
+    size_in_bytes: 507,
+    workflow_run: {
+      head_branch: workflowRef,
+      head_sha: workflowSha,
+      id: Number(runId),
+    },
+  };
+  const client = {
+    compareCommits(base: string, head: string) {
+      expect(base).toBe(workflowSha);
+      return {
+        merge_base_commit: { sha: workflowSha },
+        status: base === head ? "identical" : "ahead",
+      };
+    },
+    getJobLog(jobId: number) {
+      expect(jobId).toBe(parentJob.id);
+      return [
+        `TARGET_SHA: ${targetSha}`,
+        `Dispatched openclaw-release-checks.yml: ${childRun.html_url}`,
+      ].join("\n");
+    },
+    getParentJobs(requestedRunId: string) {
+      expect(requestedRunId).toBe(runId);
+      return [parentJob];
+    },
+    getRun(requestedRunId: string) {
+      if (String(requestedRunId) === runId) {
+        return parentRun;
+      }
+      if (String(requestedRunId) === childRunId) {
+        return childRun;
+      }
+      throw new Error(`unexpected run: ${requestedRunId}`);
+    },
+    getRunView(requestedRunId: string) {
+      expect(requestedRunId).toBe(runId);
+      return parentView;
+    },
+    loadManifest(requestedRunId: string, requestedRunAttempt: number) {
+      expect(requestedRunId).toBe(runId);
+      expect(requestedRunAttempt).toBe(1);
+      return { artifact, manifest };
+    },
+  };
+
+  return { artifact, childRun, client, manifest, parentRun, runId, targetSha, workflowSha };
+}
+
+describe("release CI summary child correlation", () => {
+  it("parses the reusable strict validation CLI without changing positional summary mode", () => {
+    expect(
+      parseReleaseCiSummaryArgs([
+        "--validate-run",
+        "29071366025",
+        "--repo",
+        "openclaw/openclaw",
+        "--manifest",
+        "/tmp/manifest.json",
+        "--json",
+      ]),
+    ).toEqual({
+      json: true,
+      manifestPath: "/tmp/manifest.json",
+      repository: "openclaw/openclaw",
+      runId: "29071366025",
+      trustedWorkflowRef: "main",
+      validate: true,
+    });
+    expect(parseReleaseCiSummaryArgs(["29071366025"])).toMatchObject({
+      repository: "openclaw/openclaw",
+      runId: "29071366025",
+      trustedWorkflowRef: "main",
+      validate: false,
+    });
+    expect(() => parseReleaseCiSummaryArgs(["--manifest", "/tmp/manifest.json"])).toThrow(
+      "--manifest requires --validate-run",
+    );
+  });
+
+  it("selects one immutable manifest artifact bound to the exact parent run", () => {
+    const { artifact, runId } = trustedMainPackageFixture();
+    const legacyArtifact = {
+      ...artifact,
+      id: artifact.id + 1,
+      name: `full-release-validation-${runId}`,
+    };
+    expect(selectManifestArtifact([artifact], runId, 1)).toBe(artifact);
+    expect(selectManifestArtifact([legacyArtifact, artifact], runId, 1)).toBe(artifact);
+    expect(selectManifestArtifact([legacyArtifact], runId, 1)).toBe(legacyArtifact);
+    expect(validateManifestArtifactCompatibility(legacyArtifact, { version: 2 }, runId, 1)).toBe(
+      legacyArtifact,
+    );
+    expect(
+      selectManifestArtifact(
+        [{ ...artifact, workflow_run: { ...artifact.workflow_run, id: 1 } }],
+        runId,
+        1,
+      ),
+    ).toBeUndefined();
+    expect(() =>
+      selectManifestArtifact([artifact, { ...artifact, id: artifact.id + 1 }], runId, 1),
+    ).toThrow("multiple release validation manifest artifacts");
+    expect(() =>
+      selectManifestArtifact(
+        [legacyArtifact, { ...legacyArtifact, id: legacyArtifact.id + 1 }],
+        runId,
+        1,
+      ),
+    ).toThrow("multiple legacy release validation manifest artifacts");
+    expect(() => selectManifestArtifact([legacyArtifact], runId, 2)).toThrow(
+      "legacy release validation manifest requires run attempt 1",
+    );
+    expect(() =>
+      validateManifestArtifactCompatibility(legacyArtifact, { version: 3 }, runId, 1),
+    ).toThrow("legacy release validation manifest artifact is not compatible");
+    expect(selectManifestArtifact([artifact], runId, 2)).toBeUndefined();
+    expect(() => selectManifestArtifact([{ ...artifact, digest: undefined }], runId, 1)).toThrow(
+      "manifest artifact digest is invalid",
+    );
+    expect(() =>
+      validateManifestArtifactIdentity(
+        { ...artifact, digest: `sha256:${"8".repeat(64)}` },
+        {
+          artifactDigest: artifact.digest,
+          artifactId: artifact.id,
+          runAttempt: 1,
+          runId,
+        },
+      ),
+    ).toThrow("manifest artifact identity mismatch");
+    expect(() =>
+      validateManifestArtifactIdentity(
+        { ...artifact, id: artifact.id + 1 },
+        {
+          artifactDigest: artifact.digest,
+          artifactId: artifact.id,
+          runAttempt: 1,
+          runId,
+        },
+      ),
+    ).toThrow("manifest artifact identity mismatch");
+
+    const source = readFileSync(SCRIPT, "utf8");
+    expect(source).toContain("actions/artifacts/${artifactId}/zip");
+    expect(source).not.toContain('"--name",');
+    expect(source).not.toContain("gh run download");
+    expect(source).toContain(
+      "downloadParentManifestEvidence(runId, runAttempt, normalizedRepository, manifestPath)",
+    );
+  });
+
+  it("hashes and safely streams one bounded manifest entry from the exact artifact ZIP", () => {
+    const root = mkdtempSync(join(tmpdir(), "release-manifest-artifact-"));
+    try {
+      const archivePath = join(root, "manifest.zip");
+      const manifest = { runAttempt: 1, runId: "29071366025" };
+      const archive = makeStoredZip({
+        [MANIFEST_ARTIFACT_ENTRY]: JSON.stringify(manifest),
+      });
+      writeFileSync(archivePath, archive);
+      expect(readManifestArtifactArchive(archivePath, artifactDigest(archive))).toEqual(manifest);
+      expect(() => readManifestArtifactArchive(archivePath, `sha256:${"0".repeat(64)}`)).toThrow(
+        "artifact digest mismatch",
+      );
+
+      const extraEntryArchive = makeStoredZip({
+        [MANIFEST_ARTIFACT_ENTRY]: JSON.stringify(manifest),
+        "unexpected.json": "{}",
+      });
+      writeFileSync(archivePath, extraEntryArchive);
+      expect(() =>
+        readManifestArtifactArchive(archivePath, artifactDigest(extraEntryArchive)),
+      ).toThrow(`must contain only ${MANIFEST_ARTIFACT_ENTRY}`);
+
+      const oversizedManifestArchive = makeStoredZip({
+        [MANIFEST_ARTIFACT_ENTRY]: "x".repeat(128 * 1024 + 1),
+      });
+      writeFileSync(archivePath, oversizedManifestArchive);
+      expect(() =>
+        readManifestArtifactArchive(archivePath, artifactDigest(oversizedManifestArchive)),
+      ).toThrow("artifact entry size is invalid");
+
+      const oversizedArchive = Buffer.alloc(256 * 1024 + 1);
+      writeFileSync(archivePath, oversizedArchive);
+      expect(() =>
+        readManifestArtifactArchive(archivePath, artifactDigest(oversizedArchive)),
+      ).toThrow("artifact compressed size is invalid");
+
+      const source = readFileSync(SCRIPT, "utf8");
+      expect(source).toContain('execFileSync("unzip", ["-p", archivePath');
+      expect(source).not.toContain('execFileSync("unzip", ["-q", archivePath, "-d"');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("bridges only attempt-one manifest v2 artifacts with the legacy stable name", () => {
+    const legacyV2 = trustedMainPackageFixture();
+    legacyV2.artifact.name = `full-release-validation-${legacyV2.runId}`;
+    expect(
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: legacyV2.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        legacyV2.client,
+      ).root.artifact.name,
+    ).toBe(legacyV2.artifact.name);
+
+    const legacyV3 = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowSha: "a".repeat(40),
+    });
+    legacyV3.artifact.name = `full-release-validation-${legacyV3.runId}`;
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: legacyV3.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        legacyV3.client,
+      ),
+    ).toThrow("legacy release validation manifest artifact is not compatible");
+  });
+
+  it("normalizes a pre-tooling trusted-main producer separately from the current verifier", () => {
+    const fixture = trustedMainPackageFixture({
+      targetSha: "8".repeat(40),
+      workflowSha: "0".repeat(40),
+    });
+    const verifierSourceSha = "c".repeat(40);
+    const evidence = validateReleaseRunEvidence(
+      {
+        repository: "openclaw/openclaw",
+        runId: fixture.runId,
+        verifierSourceContent: readFileSync(SCRIPT),
+        verifierSourceSha,
+      },
+      fixture.client,
+    );
+
+    expect(evidence).toMatchObject({
+      directRoot: true,
+      evidenceReuse: null,
+      releaseProfile: "full",
+      repository: "openclaw/openclaw",
+      rerunGroup: "package",
+      runReleaseSoak: true,
+      schema: "openclaw.release-validation-evidence/v3",
+      producerOnTrustedMainLineage: true,
+      trustedWorkflowFullRef: "refs/heads/main",
+      trustedWorkflowRef: "main",
+      valid: true,
+      verifier: {
+        schemaVersion: 3,
+        sourceSha: verifierSourceSha,
+      },
+    });
+    expect(evidence.root).toMatchObject({
+      manifestVersion: 2,
+      runAttempt: 1,
+      runId: fixture.runId,
+      targetSha: fixture.targetSha,
+      producerOnTrustedMainLineage: true,
+      workflowFullRef: "refs/heads/main",
+      workflowPath: ".github/workflows/full-release-validation.yml",
+      workflowQualifiedPath: ".github/workflows/full-release-validation.yml@refs/heads/main",
+      workflowRef: "main",
+      workflowRefProof: "legacy-v2-main-ancestry",
+      workflowRefType: "branch",
+      workflowSha: fixture.workflowSha,
+    });
+    expect(evidence.root.workflowSha).not.toBe(evidence.root.targetSha);
+    expect(evidence.verifier.sourceSha).not.toBe(evidence.root.workflowSha);
+    expect(evidence.children).toEqual([
+      expect.objectContaining({
+        conclusion: "success",
+        dispatchNonce: `full-release-validation-${fixture.runId}-1-release-checks`,
+        headBranch: "main",
+        role: "releaseChecks",
+        runAttempt: 1,
+        runId: String(fixture.childRun.id),
+        sourceParentAttempt: 1,
+        workflowSha: fixture.workflowSha,
+      }),
+    ]);
+    expect(evidence.root.artifact).toEqual({
+      digest: fixture.artifact.digest,
+      id: String(fixture.artifact.id),
+      name: fixture.artifact.name,
+      runAttempt: 1,
+      sizeInBytes: fixture.artifact.size_in_bytes,
+    });
+  });
+
+  it("accepts a trusted-main producer when the candidate is the same main commit", () => {
+    const sharedSha = "a".repeat(40);
+    const fixture = trustedMainPackageFixture({
+      targetSha: sharedSha,
+      workflowSha: sharedSha,
+    });
+    expect(
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ).root,
+    ).toMatchObject({
+      targetSha: sharedSha,
+      workflowRef: "main",
+      workflowSha: sharedSha,
+    });
+  });
+
+  it("binds v3 producer evidence to the exact trusted branch ref", () => {
+    const fixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowSha: "a".repeat(40),
+    });
+    const evidence = validateReleaseRunEvidence(
+      {
+        repository: "openclaw/openclaw",
+        runId: fixture.runId,
+        verifierSourceContent: readFileSync(SCRIPT),
+        verifierSourceSha: "c".repeat(40),
+      },
+      fixture.client,
+    );
+    expect(evidence.root).toMatchObject({
+      producerOnTrustedMainLineage: true,
+      workflowFullRef: "refs/heads/main",
+      workflowRefProof: "manifest-v3-branch",
+      workflowRefType: "branch",
+      workflowRunPath: ".github/workflows/full-release-validation.yml",
+    });
+  });
+
+  it("rejects a v3 producer dispatched from a tag named main", () => {
+    const fixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowFullRef: "refs/tags/main",
+      workflowRefType: "tag",
+      workflowSha: "a".repeat(40),
+    });
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toThrow("producer workflow full ref is not trusted");
+  });
+
+  it("rejects a legacy producer outside the trusted main verifier lineage", () => {
+    const fixture = trustedMainPackageFixture({ workflowSha: "a".repeat(40) });
+    fixture.client.compareCommits = () => ({
+      merge_base_commit: { sha: "d".repeat(40) },
+      status: "diverged",
+    });
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toThrow("producer is not on the trusted main verifier lineage");
+  });
+
+  it("rejects a candidate branch producer even when its SHA differs from the target", () => {
+    const fixture = trustedMainPackageFixture({
+      targetSha: "8".repeat(40),
+      workflowRef: "release/2026.7.1",
+      workflowSha: "7".repeat(40),
+    });
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          trustedWorkflowRef: "main",
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toThrow("producer must run from trusted workflow ref: main");
+  });
+
+  it("rejects dirty verifier bytes and a forged verifier source SHA", () => {
+    const fixture = trustedMainPackageFixture();
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceContent: "different verifier bytes",
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toThrow("verifier script differs from its source SHA");
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceSha: "f".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toThrow("verifier source blob is unavailable");
+  });
+
+  it("binds verifier bytes from the repository root even outside the caller cwd", () => {
+    const repositoryRoot = mkdtempSync(join(tmpdir(), "release-verifier-repo-"));
+    const outsideCwd = mkdtempSync(join(tmpdir(), "release-verifier-cwd-"));
+    try {
+      const scriptPath = join(repositoryRoot, SCRIPT);
+      mkdirSync(join(repositoryRoot, ".agents/skills/release-openclaw-ci/scripts"), {
+        recursive: true,
+      });
+      writeFileSync(scriptPath, readFileSync(SCRIPT));
+      execFileSync("git", ["init", "-q"], { cwd: repositoryRoot });
+      execFileSync("git", ["add", SCRIPT], { cwd: repositoryRoot });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.name=Release Test",
+          "-c",
+          "user.email=release-test@example.invalid",
+          "-c",
+          "commit.gpgSign=false",
+          "commit",
+          "-qm",
+          "test verifier",
+        ],
+        { cwd: repositoryRoot },
+      );
+      const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+      }).trim();
+
+      const moduleUrl = pathToFileURL(resolve(SCRIPT)).href;
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `import { resolveVerifierIdentity } from ${JSON.stringify(moduleUrl)};
+           process.stdout.write(JSON.stringify(resolveVerifierIdentity(
+             process.env.SOURCE_SHA,
+             undefined,
+             process.env.REPOSITORY_ROOT,
+           )));`,
+        ],
+        {
+          cwd: outsideCwd,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            REPOSITORY_ROOT: repositoryRoot,
+            SOURCE_SHA: sourceSha,
+          },
+        },
+      );
+      expect(JSON.parse(output)).toMatchObject({
+        script: SCRIPT,
+        sourceSha,
+      });
+    } finally {
+      rmSync(repositoryRoot, { force: true, recursive: true });
+      rmSync(outsideCwd, { force: true, recursive: true });
+    }
+  });
+
+  it("binds the parent to the exact Full Release Validation REST run", () => {
+    const parentView = {
+      attempt: 2,
+      headBranch: "main",
+      headSha: "a".repeat(40),
+    };
+    const parentRest = {
+      event: "workflow_dispatch",
+      head_branch: parentView.headBranch,
+      head_sha: parentView.headSha,
+      id: 29090000000,
+      path: ".github/workflows/full-release-validation.yml@refs/heads/main",
+      run_attempt: parentView.attempt,
+    };
+
+    expect(validateParentRunBinding(parentView, parentRest, "29090000000")).toBe(parentRest);
+    expect(() =>
+      validateParentRunBinding(
+        parentView,
+        { ...parentRest, path: ".github/workflows/openclaw-release-checks.yml" },
+        "29090000000",
+      ),
+    ).toThrow("full release parent run binding mismatch");
+  });
+
+  it("derives every child title from the exact parent run and attempt", () => {
+    expect(expectedChildDispatches("29090000000", 3, "release/2026.7.1")).toEqual([
+      {
+        displayTitle: "CI full-release-validation-29090000000-3-ci",
+        headBranch: "release/2026.7.1",
+        manifestKey: "normalCi",
+        name: "CI",
+        parentJobName: "Run normal full CI",
+        suffix: "-ci",
+        trustedRef: "parent",
+        workflow: "ci.yml",
+      },
+      {
+        displayTitle:
+          "OpenClaw Release Checks full-release-validation-29090000000-3-release-checks",
+        headBranch: "release/2026.7.1",
+        manifestKey: "releaseChecks",
+        name: "OpenClaw Release Checks",
+        parentJobName: "Run release/live/Docker/QA validation",
+        suffix: "-release-checks",
+        trustedRef: "parent",
+        workflow: "openclaw-release-checks.yml",
+      },
+      {
+        displayTitle: "Plugin Prerelease full-release-validation-29090000000-3-plugin-prerelease",
+        headBranch: "release/2026.7.1",
+        manifestKey: "pluginPrerelease",
+        name: "Plugin Prerelease",
+        parentJobName: "Run plugin prerelease validation",
+        suffix: "-plugin-prerelease",
+        trustedRef: "parent",
+        workflow: "plugin-prerelease.yml",
+      },
+      {
+        displayTitle: "NPM Telegram Beta E2E full-release-validation-29090000000-3-npm-telegram",
+        headBranch: "release/2026.7.1",
+        manifestKey: "npmTelegram",
+        name: "NPM Telegram Beta E2E",
+        parentJobName: "Run package Telegram E2E",
+        suffix: "-npm-telegram",
+        trustedRef: "parent",
+        workflow: "npm-telegram-beta-e2e.yml",
+      },
+      {
+        displayTitle: "OpenClaw Performance full-release-validation-29090000000-3",
+        headBranch: "release/2026.7.1",
+        manifestKey: "productPerformance",
+        name: "OpenClaw Performance",
+        parentJobName: "Run product performance evidence",
+        suffix: "",
+        trustedRef: "parent",
+        workflow: "openclaw-performance.yml",
+      },
+    ]);
+  });
+
+  it("ignores same-SHA and nearby-name runs without the exact parent dispatch binding", () => {
+    const expected = "OpenClaw Performance full-release-validation-29090000000-3";
+    const exact = {
+      display_title: expected,
+      event: "workflow_dispatch",
+      head_branch: "main",
+      head_sha: "a".repeat(40),
+      id: 303,
+    };
+    expect(
+      selectExactChildRun(
+        [
+          {
+            display_title: "OpenClaw Performance",
+            event: "workflow_dispatch",
+            head_branch: "main",
+            head_sha: exact.head_sha,
+            id: 101,
+          },
+          { ...exact, event: "push", id: 202 },
+          exact,
+        ],
+        expected,
+        "main",
+      ),
+    ).toBe(exact);
+  });
+
+  it("fails closed on duplicate exact dispatch bindings and ignores branch collisions", () => {
+    const expected = "CI full-release-validation-29090000000-3-ci";
+    const exact = {
+      display_title: expected,
+      event: "workflow_dispatch",
+      head_branch: "main",
+      id: 1,
+    };
+    expect(
+      selectExactChildRun(
+        [{ ...exact, head_branch: "release/2026.7.1", id: 0 }, exact],
+        expected,
+        "main",
+      ),
+    ).toBe(exact);
+    expect(() => selectExactChildRun([exact, { ...exact, id: 2 }], expected, "main")).toThrow(
+      "multiple child runs have exact dispatch title and branch",
+    );
+
+    const source = readFileSync(SCRIPT, "utf8");
+    expect(source).not.toContain("created_at >= since");
+    expect(source).not.toContain("head_sha === parent.headSha");
+    expect(source).not.toContain("created:");
+    expect(source).toContain("workflow-sha:");
+    expect(source).toContain("candidate-sha:");
+    expect(source).not.toContain("console.log(`sha:");
+    expect(source).toContain("actions/workflows/${child.workflow}/runs");
+  });
+
+  it("returns one exact child after a full bounded pagination scan", () => {
+    const expected = "OpenClaw Performance full-release-validation-29090000000-3";
+    const exact = {
+      display_title: expected,
+      event: "workflow_dispatch",
+      head_branch: "main",
+      id: 999,
+    };
+    const pages = Array.from({ length: 10 }, (_, pageIndex) =>
+      Array.from({ length: 100 }, (_, runIndex) => ({
+        display_title: `decoy-${pageIndex}-${runIndex}`,
+        event: "workflow_dispatch",
+        head_branch: "main",
+        id: pageIndex * 100 + runIndex,
+      })),
+    );
+    pages[9][99] = exact;
+
+    expect(selectExactChildRunFromPages(pages, expected, "main")).toBe(exact);
+    pages[0][0] = { ...exact, id: 1001 };
+    expect(() => selectExactChildRunFromPages(pages, expected, "main")).toThrow(
+      "multiple child runs have exact dispatch title and branch",
+    );
+  });
+
+  it("validates candidate identity and selected child completeness from the parent manifest", () => {
+    const manifest = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    expect(manifest.targetSha).toBe("a".repeat(40));
+    expect(manifest.rerunGroup).toBe("all");
+    const children = expectedChildDispatches(manifest.runId, manifest.runAttempt, "main");
+    const selected = requiredChildKeysForRerunGroup(manifest.rerunGroup);
+    expect(manifestChildEntries(manifest, children, selected).map((entry) => entry.runId)).toEqual([
+      "101",
+      "404",
+      "202",
+      "303",
+    ]);
+
+    const missing = {
+      ...manifest,
+      childRunIds: { ...manifest.childRunIds, normalCi: "" },
+    };
+    expect(() => manifestChildEntries(missing, children, selected)).toThrow(
+      "selected child is missing from manifest: CI",
+    );
+  });
+
+  it("keeps historical non-reuse v2 manifests readable without validation inputs", () => {
+    const legacy = rawManifest({});
+    delete (legacy as { validationInputs?: unknown }).validationInputs;
+    const manifest = validateParentManifest(legacy, {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+
+    expect(manifest.validationInputs).toBeUndefined();
+    expect(manifest.rerunGroup).toBe("all");
+  });
+
+  it("binds v3 manifests to their immutable producer workflow SHA", () => {
+    const workflowSha = "b".repeat(40);
+    const manifest = validateParentManifest(rawManifest({ version: 3, workflowSha }), {
+      runAttempt: 2,
+      runId: "29090000000",
+      workflowRef: "main",
+      workflowSha,
+    });
+    expect(manifest).toMatchObject({
+      version: 3,
+      workflowSha,
+    });
+    expect(() =>
+      validateParentManifest(rawManifest({ version: 3, workflowSha }), {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha: "c".repeat(40),
+      }),
+    ).toThrow("release validation manifest workflow SHA mismatch");
+  });
+
+  it("requires v3 manifests to record artifact-only performance publication", () => {
+    const workflowSha = "b".repeat(40);
+    const missing = rawManifest({ version: 3, workflowSha });
+    delete (
+      missing.controls as {
+        performanceReportPublication?: string;
+      }
+    ).performanceReportPublication;
+    expect(() =>
+      validateParentManifest(missing, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("release validation manifest performance report publication mode is invalid");
+
+    const publishing = rawManifest({ version: 3, workflowSha });
+    publishing.controls.performanceReportPublication = "publish";
+    expect(() =>
+      validateParentManifest(publishing, {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowSha,
+      }),
+    ).toThrow("release validation manifest performance report publication mode is invalid");
+  });
+
+  it("requires a successful artifact-only performance guard for the current attempt", () => {
+    const guard = {
+      conclusion: "success",
+      name: "Verify artifact-only report mode",
+      run_attempt: 2,
+      status: "completed",
+    };
+    const skippedPublisher = {
+      conclusion: "skipped",
+      name: "Publish mock provider report",
+      run_attempt: 2,
+      status: "completed",
+    };
+    expect(
+      validatePerformanceArtifactOnlyJobs(
+        [{ ...guard, conclusion: "failure", run_attempt: 1 }, guard, skippedPublisher],
+        2,
+      ),
+    ).toBe(guard);
+    expect(() => validatePerformanceArtifactOnlyJobs([skippedPublisher], 2)).toThrow(
+      "performance artifact-only guard is missing or unsuccessful",
+    );
+    expect(() =>
+      validatePerformanceArtifactOnlyJobs([{ ...guard, conclusion: "failure" }], 2),
+    ).toThrow("performance artifact-only guard is missing or unsuccessful");
+    expect(() =>
+      validatePerformanceArtifactOnlyJobs(
+        [guard, { ...skippedPublisher, conclusion: "success" }],
+        2,
+      ),
+    ).toThrow("performance report publisher was not skipped");
+  });
+
+  it("requires the child mapped by rerunGroup and scans only selected in-progress workflows", () => {
+    const focused = validateParentManifest(
+      {
+        ...rawManifest({ rerunGroup: "npm-telegram" }),
+        childRuns: {
+          normalCi: "",
+          npmTelegram: "",
+          pluginPrerelease: "",
+          productPerformance: { runId: "" },
+          releaseChecks: "",
+        },
+      },
+      { runAttempt: 2, runId: "29090000000" },
+    );
+    const selected = requiredChildKeysForRerunGroup(focused.rerunGroup);
+    const children = expectedSelectedChildDispatches(
+      focused.runId,
+      focused.runAttempt,
+      focused.workflowRef,
+      selected,
+    );
+    expect(children.map((child) => child.manifestKey)).toEqual(["npmTelegram"]);
+    expect(() => manifestChildEntries(focused, children, selected)).toThrow(
+      "selected child is missing from manifest: NPM Telegram Beta E2E",
+    );
+
+    const inProgress = selectedChildKeys([
+      { conclusion: "skipped", name: "Run normal full CI" },
+      { conclusion: "skipped", name: "Run plugin prerelease validation" },
+      { conclusion: undefined, name: "Run product performance evidence" },
+      { conclusion: "skipped", name: "Run release/live/Docker/QA validation" },
+    ]);
+    expect(
+      expectedSelectedChildDispatches("29090000000", 2, "main", inProgress).map(
+        (child) => child.manifestKey,
+      ),
+    ).toEqual(["productPerformance"]);
+  });
+
+  it("authorizes only exact-target reuse through the selected root manifest", () => {
+    const root = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    const current = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: root.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: root.runId,
+        },
+        runId: "29090000001",
+        targetSha: root.targetSha,
+      }),
+      { runAttempt: 2, runId: "29090000001" },
+    );
+
+    expect(validateEvidenceReuseChain(current, root, root)).toBe(root.targetSha);
+    expect(current.targetSha).toBe(root.targetSha);
+  });
+
+  it("rejects changed paths and cross-SHA targets in Full Release reuse", () => {
+    const root = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    const changedPaths = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: ["CHANGELOG.md"],
+          evidenceSha: root.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: root.runId,
+        },
+        runId: "29090000001",
+        targetSha: root.targetSha,
+      }),
+      { runAttempt: 2, runId: "29090000001" },
+    );
+    expect(() => validateEvidenceReuseChain(changedPaths, root, root)).toThrow(
+      "requires an exact target with no changed paths",
+    );
+
+    const changedTarget = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: root.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: root.runId,
+        },
+        runId: "29090000001",
+        targetSha: "b".repeat(40),
+      }),
+      { runAttempt: 2, runId: "29090000001" },
+    );
+    expect(() => validateEvidenceReuseChain(changedTarget, root, root)).toThrow(
+      "full release evidence reuse target SHA mismatch",
+    );
+  });
+
+  it("rejects exact-target reuse without matching root policy and authorization", () => {
+    const root = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    const current = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: root.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: root.runId,
+        },
+        runId: "29090000001",
+        targetSha: root.targetSha,
+      }),
+      { runAttempt: 2, runId: "29090000001" },
+    );
+    const mismatchedRoot = {
+      ...root,
+      validationInputs: { ...root.validationInputs, provider: "anthropic" },
+    };
+
+    expect(() => validateEvidenceReuseChain(current, mismatchedRoot, mismatchedRoot)).toThrow(
+      "evidence reuse current manifest policy differs from the chain root",
+    );
+    expect(() =>
+      validateEvidenceReuseChain({ ...current, evidenceReuse: undefined }, root, root),
+    ).toThrow("does not authorize evidence reuse");
+  });
+
+  it("rejects any selected manifest that itself reuses evidence", () => {
+    const root = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    const intermediate = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: root.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: root.runId,
+        },
+        runId: "29090000001",
+        targetSha: root.targetSha,
+      }),
+      { runAttempt: 2, runId: "29090000001" },
+    );
+    const current = validateParentManifest(
+      rawManifest({
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: intermediate.targetSha,
+          policy: "exact-target-full-validation-v1",
+          runId: root.runId,
+          selectedRunId: intermediate.runId,
+        },
+        runId: "29090000002",
+        targetSha: intermediate.targetSha,
+      }),
+      { runAttempt: 2, runId: "29090000002" },
+    );
+
+    expect(() => validateEvidenceReuseChain(current, intermediate, root)).toThrow(
+      "evidence reuse must select a root execution manifest",
+    );
+  });
+
+  it("binds each manifest workflow ref to the fetched parent branch", () => {
+    expect(() =>
+      validateParentManifest(rawManifest({}), {
+        runAttempt: 2,
+        runId: "29090000000",
+        workflowRef: "release/2026.7.1",
+      }),
+    ).toThrow("release validation manifest workflow ref mismatch");
+  });
+
+  it("validates manifest child workflow, dispatch tuple, branch, and attempt", () => {
+    const child = expectedChildDispatches("29090000000", 3, "main")[0];
+    const parentManifest = {
+      runAttempt: 3,
+      runId: "29090000000",
+      targetSha: "a".repeat(40),
+      workflowSha: "b".repeat(40),
+    };
+    const parentJobs = [
+      {
+        completed_at: "2026-07-10T01:10:00Z",
+        conclusion: "success",
+        id: 901,
+        name: child.parentJobName,
+        run_attempt: 3,
+        started_at: "2026-07-10T01:00:00Z",
+        status: "completed",
+        steps: [],
+      },
+    ];
+    const parentLog = [
+      `TARGET_SHA: ${parentManifest.targetSha}`,
+      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101",
+    ].join("\n");
+    const run = {
+      actor: { login: "github-actions[bot]" },
+      display_title: child.displayTitle,
+      event: "workflow_dispatch",
+      head_branch: child.headBranch,
+      head_sha: parentManifest.workflowSha,
+      id: 101,
+      path: ".github/workflows/ci.yml@refs/heads/main",
+      run_attempt: 1,
+      triggering_actor: { login: "github-actions[bot]" },
+    };
+    expect(validateManifestChildRun(run, child, "101", parentManifest, parentJobs, parentLog)).toBe(
+      run,
+    );
+    expect(() =>
+      validateManifestChildRun(
+        { ...run, head_branch: "release/2026.7.1" },
+        child,
+        "101",
+        parentManifest,
+        parentJobs,
+        parentLog,
+      ),
+    ).toThrow("manifest child dispatch tuple mismatch");
+    expect(() =>
+      validateParentManifest(rawManifest({}), { runAttempt: 3, runId: "29090000000" }),
+    ).toThrow("release validation manifest run attempt mismatch");
+  });
+
+  it("accepts strongly bound legacy and correlated children across parent attempts", () => {
+    const parentManifest = {
+      runAttempt: 2,
+      runId: "28717729503",
+      targetSha: "a".repeat(40),
+      workflowSha: "b".repeat(40),
+    };
+    const children = expectedChildDispatches(
+      parentManifest.runId,
+      parentManifest.runAttempt,
+      "main",
+    );
+    const fixtures = new Map([
+      ["normalCi", { originAttempt: 2, runId: 28718903263, title: "CI" }],
+      ["pluginPrerelease", { originAttempt: 1, runId: 28717802268, title: "Plugin Prerelease" }],
+      [
+        "productPerformance",
+        {
+          originAttempt: 1,
+          runId: 28717802171,
+          title: "OpenClaw Performance full-release-validation-28717729503-1",
+        },
+      ],
+      ["releaseChecks", { originAttempt: 1, runId: 28717802397, title: "OpenClaw Release Checks" }],
+    ]);
+    const fingerprint = {
+      completed_at: "2026-07-04T20:29:21Z",
+      conclusion: "success",
+      started_at: "2026-07-04T19:53:02Z",
+      status: "completed",
+      steps: [
+        {
+          completed_at: "2026-07-04T20:29:20Z",
+          conclusion: "success",
+          name: "Dispatch and monitor child",
+          number: 1,
+          started_at: "2026-07-04T19:53:03Z",
+          status: "completed",
+        },
+      ],
+    };
+
+    for (const child of children.filter((entry) => fixtures.has(entry.manifestKey))) {
+      const fixture = fixtures.get(child.manifestKey);
+      if (!fixture) {
+        throw new Error(`missing fixture for ${child.manifestKey}`);
+      }
+      const { originAttempt, runId, title } = fixture;
+      const parentJobs = [
+        ...(originAttempt === 1
+          ? [
+              {
+                ...fingerprint,
+                id: 900,
+                name: child.parentJobName,
+                run_attempt: 1,
+              },
+            ]
+          : []),
+        {
+          ...fingerprint,
+          id: 901,
+          name: child.parentJobName,
+          run_attempt: 2,
+        },
+      ];
+      const run = {
+        actor: { login: "github-actions[bot]" },
+        display_title: title,
+        event: "workflow_dispatch",
+        head_branch: child.headBranch,
+        head_sha: parentManifest.workflowSha,
+        id: runId,
+        path: `.github/workflows/${child.workflow}@refs/heads/${child.headBranch}`,
+        run_attempt: 1,
+        triggering_actor: { login: "github-actions[bot]" },
+      };
+      const parentLog = [
+        `TARGET_SHA: ${parentManifest.targetSha}`,
+        ...(child.manifestKey === "productPerformance" ? ["-f publish_reports=false"] : []),
+        `Dispatched ${child.workflow}: https://github.com/openclaw/openclaw/actions/runs/${runId}`,
+      ].join("\n");
+      expect(resolveManifestChildOriginAttempt(run, child, parentManifest, parentJobs)).toBe(
+        originAttempt,
+      );
+      expect(
+        validateManifestChildRun(run, child, String(runId), parentManifest, parentJobs, parentLog),
+      ).toBe(run);
+      if (child.manifestKey === "productPerformance") {
+        expect(() =>
+          validateManifestChildRun(
+            run,
+            child,
+            String(runId),
+            parentManifest,
+            parentJobs,
+            parentLog.replace("-f publish_reports=false\n", ""),
+          ),
+        ).toThrow("manifest performance child is not dispatched in artifact-only mode");
+      }
+    }
+
+    const ci = children.find((child) => child.manifestKey === "normalCi");
+    if (!ci) {
+      throw new Error("missing CI child fixture");
+    }
+    const wrongParent = {
+      display_title: `CI full-release-validation-28717729504-1-ci`,
+      event: "workflow_dispatch",
+      head_branch: "main",
+      id: 101,
+      path: ".github/workflows/ci.yml@refs/heads/main",
+    };
+    const ciJobs = [
+      {
+        ...fingerprint,
+        id: 901,
+        name: ci.parentJobName,
+        run_attempt: 2,
+      },
+    ];
+    const ciLog = [
+      `TARGET_SHA: ${parentManifest.targetSha}`,
+      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101",
+    ].join("\n");
+    expect(() =>
+      validateManifestChildRun(wrongParent, ci, "101", parentManifest, ciJobs, ciLog),
+    ).toThrow("manifest child dispatch tuple mismatch");
+    expect(() =>
+      validateManifestChildRun(
+        {
+          ...wrongParent,
+          display_title: `CI full-release-validation-${parentManifest.runId}-3-ci`,
+        },
+        ci,
+        "101",
+        parentManifest,
+        ciJobs,
+        ciLog,
+      ),
+    ).toThrow("manifest child dispatch tuple mismatch");
+    expect(
+      resolveManifestChildOriginAttempt({ display_title: "CI nearby" }, ci, parentManifest, ciJobs),
+    ).toBeUndefined();
+  });
+
+  it("rejects carried parent jobs whose selected-attempt execution fingerprint changed", () => {
+    const child = expectedChildDispatches("28717729503", 2, "main").find(
+      (entry) => entry.manifestKey === "pluginPrerelease",
+    );
+    if (!child) {
+      throw new Error("missing plugin prerelease fixture");
+    }
+    const parentManifest = { runAttempt: 2, runId: "28717729503" };
+    const parentJobs = [
+      {
+        completed_at: "2026-07-04T20:29:21Z",
+        conclusion: "success",
+        id: 900,
+        name: child.parentJobName,
+        run_attempt: 1,
+        started_at: "2026-07-04T19:53:02Z",
+        status: "completed",
+        steps: [],
+      },
+      {
+        completed_at: "2026-07-04T20:30:21Z",
+        conclusion: "success",
+        id: 901,
+        name: child.parentJobName,
+        run_attempt: 2,
+        started_at: "2026-07-04T19:53:02Z",
+        status: "completed",
+        steps: [],
+      },
+    ];
+
+    expect(() => selectManifestParentJob(parentJobs, child, parentManifest, 1)).toThrow(
+      "manifest parent job carry-forward fingerprint mismatch",
+    );
+  });
+});

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -1,0 +1,788 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const FULL_RELEASE = ".github/workflows/full-release-validation.yml";
+const RELEASE_CHECKS = ".github/workflows/openclaw-release-checks.yml";
+const PACKAGE_ACCEPTANCE = ".github/workflows/package-acceptance.yml";
+const PLUGIN_PRERELEASE = ".github/workflows/plugin-prerelease.yml";
+const LIVE_E2E = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
+const PERFORMANCE = ".github/workflows/openclaw-performance.yml";
+const LIVE_BUILD = "scripts/test-live-build-docker.sh";
+const DOCKER_E2E_IMAGE_HELPER = "scripts/lib/docker-e2e-image.sh";
+
+type WorkflowInput = {
+  default?: boolean | number | string;
+  options?: string[];
+  type?: string;
+};
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, boolean | number | string>;
+};
+
+type WorkflowJob = {
+  env?: Record<string, string>;
+  if?: string;
+  needs?: string | string[];
+  outputs?: Record<string, string>;
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+  uses?: string;
+  with?: Record<string, boolean | number | string>;
+};
+
+type Workflow = {
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    workflow_call?: { inputs?: Record<string, WorkflowInput> };
+    workflow_dispatch?: { inputs?: Record<string, WorkflowInput> };
+  };
+  permissions?: Record<string, string>;
+};
+
+function readWorkflow(path: string): Workflow {
+  return parse(readFileSync(path, "utf8")) as Workflow;
+}
+
+function job(workflow: Workflow, name: string): WorkflowJob {
+  const value = workflow.jobs?.[name];
+  if (!value) {
+    throw new Error(`missing workflow job ${name}`);
+  }
+  return value;
+}
+
+function step(workflowJob: WorkflowJob, name: string): WorkflowStep {
+  const value = workflowJob.steps?.find((candidate) => candidate.name === name);
+  if (!value) {
+    throw new Error(`missing workflow step ${name}`);
+  }
+  return value;
+}
+
+function expectReadOnlyPackagePermission(workflowJob: WorkflowJob): void {
+  expect(workflowJob.permissions?.packages).toBe("read");
+}
+
+describe("release validation no-push transport", () => {
+  it("does not persist Git credentials in validation checkouts", () => {
+    for (const workflowPath of [PLUGIN_PRERELEASE, RELEASE_CHECKS]) {
+      const workflow = readWorkflow(workflowPath);
+      const checkoutSteps = Object.values(workflow.jobs ?? {}).flatMap(
+        (workflowJob) =>
+          workflowJob.steps?.filter((candidate) =>
+            candidate.uses?.startsWith("actions/checkout@"),
+          ) ?? [],
+      );
+      expect(checkoutSteps, workflowPath).not.toHaveLength(0);
+      for (const checkout of checkoutSteps) {
+        expect(checkout.with?.["persist-credentials"], `${workflowPath}:${checkout.name}`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it("runs evidence reuse from an immutable trusted-main workflow checkout", () => {
+    const full = readWorkflow(FULL_RELEASE);
+    for (const jobName of ["resolve_target", "evidence_reuse"]) {
+      const checkout = step(job(full, jobName), "Checkout trusted workflow helper");
+      expect(checkout.with?.ref, jobName).toBe("${{ github.sha }}");
+      expect(checkout.with?.ref, jobName).not.toBe("${{ github.ref_name }}");
+      expect(checkout.with?.["persist-credentials"], jobName).toBe(false);
+    }
+
+    const evidenceReuse = job(full, "evidence_reuse");
+    expect(step(evidenceReuse, "Checkout target SHA").with?.["persist-credentials"]).toBe(false);
+    const dockerAssets = job(full, "docker_runtime_assets_preflight");
+    expect(step(dockerAssets, "Checkout target SHA").with?.["persist-credentials"]).toBe(false);
+    expect(evidenceReuse.if).toContain("github.ref == 'refs/heads/main'");
+    expect(
+      evidenceReuse.steps?.find(
+        (candidate) => candidate.name === "Require trusted main workflow ref",
+      ),
+    ).toBeUndefined();
+
+    const releaseChecks = readWorkflow(RELEASE_CHECKS);
+    const releaseHelper = step(
+      job(releaseChecks, "resolve_target"),
+      "Checkout trusted workflow helper",
+    );
+    expect(releaseHelper.with?.ref).toBe("${{ github.sha }}");
+    expect(releaseHelper.with?.ref).not.toBe("${{ github.ref_name }}");
+    expect(releaseHelper.with?.["persist-credentials"]).toBe(false);
+  });
+
+  it("rejects every child whose workflow SHA differs from the parent workflow SHA", () => {
+    const full = readWorkflow(FULL_RELEASE);
+    for (const [jobName, stepName] of [
+      ["normal_ci", "Dispatch and monitor CI"],
+      ["plugin_prerelease", "Dispatch and monitor plugin prerelease"],
+      ["release_checks", "Dispatch and monitor release checks"],
+      ["npm_telegram", "Dispatch and monitor npm Telegram E2E"],
+      ["performance", "Dispatch and monitor OpenClaw Performance"],
+    ] as const) {
+      const dispatch = step(job(full, jobName), stepName);
+      expect(dispatch.env?.PARENT_WORKFLOW_SHA, jobName).toBe("${{ github.sha }}");
+      expect(dispatch.run, jobName).toContain('"$child_head_sha" != "$PARENT_WORKFLOW_SHA"');
+      expect(dispatch.run, jobName).toContain("expected parent workflow SHA");
+    }
+
+    const verify = step(job(full, "summary"), "Verify child workflow results");
+    expect(verify.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.sha }}");
+    expect(verify.run).toContain('"$head_sha" != "$PARENT_WORKFLOW_SHA"');
+    expect(verify.run).not.toContain('"$head_sha" != "$TARGET_SHA"');
+  });
+
+  it("publishes an attempt-qualified canonical manifest plus a temporary legacy alias", () => {
+    const summary = job(readWorkflow(FULL_RELEASE), "summary");
+    expect(step(summary, "Upload release validation manifest").with).toMatchObject({
+      name: "full-release-validation-${{ github.run_id }}-${{ github.run_attempt }}",
+    });
+    expect(step(summary, "Upload legacy release validation manifest alias").with).toMatchObject({
+      name: "full-release-validation-${{ github.run_id }}",
+      overwrite: true,
+    });
+  });
+
+  it("pins every Full Release Docker caller to artifact-only transport", () => {
+    const fullText = readFileSync(FULL_RELEASE, "utf8");
+    const release = readWorkflow(RELEASE_CHECKS);
+    const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE);
+    const pluginPrerelease = readWorkflow(PLUGIN_PRERELEASE);
+
+    expect(fullText).toContain("dispatch_and_wait plugin-prerelease.yml");
+    expect(fullText).toContain("dispatch_and_wait openclaw-release-checks.yml");
+    expect(fullText).toContain("gh workflow run openclaw-performance.yml");
+
+    const preparePackage = job(release, "prepare_release_package");
+    const live = job(release, "live_repo_e2e_release_checks");
+    const docker = job(release, "docker_e2e_release_checks");
+    const acceptance = job(release, "package_acceptance_release_checks");
+    expectReadOnlyPackagePermission(preparePackage);
+    expectReadOnlyPackagePermission(live);
+    expectReadOnlyPackagePermission(docker);
+    expectReadOnlyPackagePermission(acceptance);
+    expect(step(preparePackage, "Resolve release package artifact").run).toContain(
+      'if [[ "$source_sha" != "$PACKAGE_REF" ]]',
+    );
+    expect(live.with).toMatchObject({
+      shared_image_artifact_namespace: "release-live",
+      shared_image_policy: "no-push-artifact",
+    });
+    expect(docker.with).toMatchObject({
+      package_artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
+      package_artifact_id: "${{ needs.prepare_release_package.outputs.artifact_id }}",
+      package_artifact_name: "${{ needs.prepare_release_package.outputs.artifact_name }}",
+      package_artifact_run_attempt:
+        "${{ needs.prepare_release_package.outputs.artifact_run_attempt }}",
+      package_artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
+      package_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
+      package_sha256: "${{ needs.prepare_release_package.outputs.package_sha256 }}",
+      package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
+      package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+      shared_image_artifact_namespace: "release-docker",
+      shared_image_policy: "no-push-artifact",
+    });
+    expect(acceptance.with).toMatchObject({
+      artifact_digest: "${{ needs.prepare_release_package.outputs.artifact_digest }}",
+      artifact_id: "${{ needs.prepare_release_package.outputs.artifact_id }}",
+      artifact_name: "${{ needs.prepare_release_package.outputs.artifact_name }}",
+      artifact_run_attempt: "${{ needs.prepare_release_package.outputs.artifact_run_attempt }}",
+      artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
+      package_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
+      package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
+      package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
+      shared_image_artifact_namespace: "release-package",
+      shared_image_policy: "no-push-artifact",
+    });
+
+    const standardAcceptance = job(packageAcceptance, "docker_acceptance");
+    const registryAcceptance = job(packageAcceptance, "docker_acceptance_registry");
+    expect(packageAcceptance.permissions?.packages).toBe("read");
+    expect(packageAcceptance.on?.workflow_dispatch?.inputs?.shared_image_policy).toMatchObject({
+      default: "allow-push",
+      options: ["allow-push", "existing-only", "no-push-artifact"],
+      type: "choice",
+    });
+    expect(packageAcceptance.on?.workflow_call?.inputs?.shared_image_policy).toMatchObject({
+      default: "allow-push",
+      type: "string",
+    });
+    expect(standardAcceptance.with?.shared_image_policy).toBe("${{ inputs.shared_image_policy }}");
+    expect(standardAcceptance.with?.shared_image_artifact_namespace).toBe(
+      "${{ inputs.shared_image_artifact_namespace }}",
+    );
+    expect(standardAcceptance.with).toMatchObject({
+      package_artifact_digest: "${{ needs.resolve_package.outputs.package_artifact_digest }}",
+      package_artifact_id: "${{ needs.resolve_package.outputs.package_artifact_id }}",
+      package_artifact_run_attempt:
+        "${{ needs.resolve_package.outputs.package_artifact_run_attempt }}",
+      package_artifact_run_id: "${{ needs.resolve_package.outputs.package_artifact_run_id }}",
+      package_file_name: "${{ needs.resolve_package.outputs.package_file_name }}",
+      package_sha256: "${{ needs.resolve_package.outputs.package_sha256 }}",
+      package_source_sha: "${{ needs.resolve_package.outputs.package_source_sha }}",
+      package_version: "${{ needs.resolve_package.outputs.package_version }}",
+    });
+    expect(standardAcceptance.if).toContain("shared_image_policy == 'no-push-artifact'");
+    expectReadOnlyPackagePermission(standardAcceptance);
+    expect(registryAcceptance.if).toContain("shared_image_policy != 'no-push-artifact'");
+    expect(registryAcceptance.permissions?.packages).toBe("write");
+
+    const pluginDocker = job(pluginPrerelease, "plugin-prerelease-docker-suite");
+    expectReadOnlyPackagePermission(pluginDocker);
+    expect(pluginDocker.with).toMatchObject({
+      shared_image_artifact_namespace: "plugin-prerelease",
+      shared_image_policy: "no-push-artifact",
+    });
+    expect(
+      new Set([
+        live.with?.shared_image_artifact_namespace,
+        docker.with?.shared_image_artifact_namespace,
+        acceptance.with?.shared_image_artifact_namespace,
+        pluginDocker.with?.shared_image_artifact_namespace,
+      ]).size,
+    ).toBe(4);
+  });
+
+  it("builds shared images locally, verifies artifacts, and cannot fall back to a registry", () => {
+    const workflow = readWorkflow(LIVE_E2E);
+    const dispatchPolicy = workflow.on?.workflow_dispatch?.inputs?.shared_image_policy;
+    const callPolicy = workflow.on?.workflow_call?.inputs?.shared_image_policy;
+    expect(dispatchPolicy).toMatchObject({
+      default: "allow-push",
+      options: ["allow-push", "existing-only", "no-push-artifact"],
+    });
+    expect(callPolicy).toMatchObject({ default: "allow-push", type: "string" });
+
+    const validation = job(workflow, "validate_selected_ref");
+    expect(validation.outputs?.workflow_repository).toBe(
+      "${{ steps.workflow.outputs.workflow_repository }}",
+    );
+    expect(validation.outputs?.workflow_sha).toBe("${{ steps.workflow.outputs.workflow_sha }}");
+    const workflowIdentity = step(validation, "Resolve job workflow identity");
+    expect(workflowIdentity.env?.JOB_CONTEXT).toBe("${{ toJSON(job) }}");
+    expect(workflowIdentity.run).toContain(
+      "job.workflow_repository must be an owner/repository slug",
+    );
+    expect(workflowIdentity.run).toContain("job.workflow_sha must be a full lowercase commit SHA");
+    const trustedCheckouts = Object.entries(workflow.jobs ?? {}).flatMap(([jobName, workflowJob]) =>
+      (workflowJob.steps ?? [])
+        .filter((candidate) => candidate.name?.startsWith("Checkout trusted "))
+        .map((candidate) => ({ candidate, jobName })),
+    );
+    expect(trustedCheckouts).toHaveLength(12);
+    for (const { candidate, jobName } of trustedCheckouts) {
+      expect(candidate.with, jobName).toMatchObject({
+        repository: "${{ needs.validate_selected_ref.outputs.workflow_repository }}",
+        ref: "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+        "persist-credentials": false,
+      });
+    }
+
+    const dockerProducer = job(workflow, "prepare_docker_e2e_image");
+    const liveProducer = job(workflow, "prepare_live_test_image");
+    const dockerPublisher = job(workflow, "push_docker_e2e_images");
+    const livePublisher = job(workflow, "push_live_test_image");
+    expect(workflow.permissions?.actions).toBe("read");
+    expect(workflow.permissions?.packages).toBe("read");
+    expectReadOnlyPackagePermission(dockerProducer);
+    expectReadOnlyPackagePermission(liveProducer);
+    expect(dockerPublisher.permissions?.packages).toBe("write");
+    expect(livePublisher.permissions?.packages).toBe("write");
+    expect(dockerPublisher.if).toContain("shared_image_policy == 'allow-push'");
+    expect(livePublisher.if).toContain("shared_image_policy == 'allow-push'");
+    expect(job(workflow, "docker_e2e_image_ready").permissions?.packages).toBeUndefined();
+    expect(job(workflow, "live_test_image_ready").permissions?.packages).toBeUndefined();
+    const packageWriters = Object.entries(workflow.jobs ?? {}).filter(
+      ([, workflowJob]) => workflowJob.permissions?.packages === "write",
+    );
+    expect(packageWriters.map(([name]) => name).sort()).toEqual([
+      "push_docker_e2e_images",
+      "push_live_test_image",
+    ]);
+    for (const [, workflowJob] of packageWriters) {
+      expect(workflowJob.if).toContain("shared_image_policy == 'allow-push'");
+    }
+    const validateSelectedRef = step(
+      job(workflow, "validate_selected_ref"),
+      "Validate selected ref",
+    );
+    const dispatchInputs = workflow.on?.workflow_dispatch?.inputs ?? {};
+    for (const inputName of [
+      "package_artifact_digest",
+      "package_artifact_id",
+      "package_artifact_name",
+      "package_artifact_run_attempt",
+      "package_artifact_run_id",
+      "package_file_name",
+      "package_sha256",
+      "package_source_sha",
+      "package_version",
+    ]) {
+      expect(dispatchInputs[inputName], inputName).toBeUndefined();
+      expect(workflow.on?.workflow_call?.inputs?.[inputName], inputName).toBeDefined();
+    }
+    expect(validateSelectedRef.env?.PACKAGE_ARTIFACT_DIGEST).toBe(
+      "${{ inputs.package_artifact_digest }}",
+    );
+    expect(validateSelectedRef.env?.PACKAGE_ARTIFACT_RUN_ATTEMPT).toBe(
+      "${{ inputs.package_artifact_run_attempt }}",
+    );
+    expect(validateSelectedRef.env?.PACKAGE_ARTIFACT_RUN_ID).toBe(
+      "${{ inputs.package_artifact_run_id }}",
+    );
+    expect(validateSelectedRef.env?.PACKAGE_ARTIFACT_ID).toBe("${{ inputs.package_artifact_id }}");
+    expect(validateSelectedRef.env?.PACKAGE_FILE_NAME).toBe("${{ inputs.package_file_name }}");
+    expect(validateSelectedRef.env?.PACKAGE_SOURCE_SHA).toBe("${{ inputs.package_source_sha }}");
+    expect(validateSelectedRef.run).toContain(
+      "Package artifact selection requires the complete immutable artifact and package identity tuple.",
+    );
+    expect(validateSelectedRef.run).toContain('"$PACKAGE_SOURCE_SHA" == "$selected_sha"');
+    for (const name of [
+      "prepare_docker_e2e_image",
+      "prepare_live_test_image",
+      "validate_live_models_docker",
+      "validate_live_models_docker_targeted",
+      "validate_live_docker_provider_suites",
+    ]) {
+      const checkoutSteps = job(workflow, name).steps?.filter((candidate) =>
+        candidate.uses?.startsWith("actions/checkout@"),
+      );
+      expect(checkoutSteps, name).not.toHaveLength(0);
+      for (const checkout of checkoutSteps ?? []) {
+        expect(checkout.with?.["persist-credentials"], `${name}:${checkout.name}`).toBe(false);
+      }
+    }
+    expect(dockerProducer.outputs?.image_artifact_name).toContain("image_artifact");
+    expect(liveProducer.outputs?.image_artifact_name).toContain("image_artifact");
+    for (const producer of [dockerProducer, liveProducer]) {
+      expect(producer.outputs?.image_archive_sha256).toContain("archive_sha256");
+      expect(producer.outputs?.image_artifact_id).toContain("artifact-id");
+      expect(producer.outputs?.image_artifact_digest).toContain("artifact-digest");
+      expect(producer.outputs?.image_artifact_run_id).toBe("${{ github.run_id }}");
+      expect(producer.outputs?.image_artifact_run_attempt).toBe("${{ github.run_attempt }}");
+    }
+    expect(dockerProducer.outputs?.package_artifact_id).toContain("artifact-id");
+    expect(dockerProducer.outputs?.package_artifact_digest).toContain("artifact-digest");
+    expect(dockerProducer.outputs?.package_artifact_run_attempt).toContain("run_attempt");
+    expect(dockerProducer.outputs?.package_artifact_run_id).toContain("run_id");
+    expect(dockerProducer.outputs?.package_file_name).toContain("file_name");
+    expect(dockerProducer.outputs?.package_source_sha).toContain("source_sha");
+
+    const packageIdentity = step(dockerProducer, "Validate OpenClaw package artifact identity");
+    expect(packageIdentity.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ inputs.package_artifact_digest }}",
+      ARTIFACT_ID: "${{ inputs.package_artifact_id }}",
+      ARTIFACT_NAME: "${{ inputs.package_artifact_name }}",
+      ARTIFACT_RUN_ATTEMPT: "${{ inputs.package_artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ inputs.package_artifact_run_id }}",
+    });
+    expect(packageIdentity.run).toContain('--arg digest "sha256:${ARTIFACT_DIGEST}"');
+    expect(packageIdentity.run).toContain(
+      "actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}",
+    );
+    expect(packageIdentity.run).toContain("artifact_digest=$ARTIFACT_DIGEST");
+    for (const [name, condition] of [
+      [
+        "Download current-run OpenClaw Docker E2E package",
+        "inputs.package_artifact_run_id == github.run_id",
+      ],
+      [
+        "Download previous-run OpenClaw Docker E2E package",
+        "inputs.package_artifact_run_id != github.run_id",
+      ],
+    ] as const) {
+      const packageDownload = step(dockerProducer, name);
+      expect(packageDownload.if).toContain(condition);
+      expect(packageDownload.with).toMatchObject({
+        "artifact-ids": "${{ inputs.package_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        "run-id": "${{ inputs.package_artifact_run_id }}",
+      });
+    }
+
+    for (const name of [
+      "Build bare Docker E2E image artifact",
+      "Build functional Docker E2E image artifact",
+    ]) {
+      const build = step(dockerProducer, name);
+      expect(build.if).toContain("shared_image_policy == 'no-push-artifact'");
+      expect(build.run).toContain("--load");
+      expect(build.run).not.toContain("--push");
+    }
+    const packDockerArtifact = step(dockerProducer, "Pack Docker E2E image artifact");
+    expect(packDockerArtifact.env?.PACKAGE_SHA256).toBe("${{ steps.package.outputs.sha256 }}");
+    expect(packDockerArtifact.run).toContain("shared-image-artifact.sh");
+    expect(packDockerArtifact.run).toContain(
+      "docker-e2e-shared-images-${SHARED_IMAGE_ARTIFACT_NAMESPACE}-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
+    );
+    expect(packDockerArtifact.run).toContain(
+      'OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256"',
+    );
+    expect(packDockerArtifact.run).toContain("archive_sha256=");
+    const validatePackage = step(dockerProducer, "Validate OpenClaw Docker E2E package");
+    expect(validatePackage.env).toMatchObject({
+      EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
+      EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",
+      EXPECTED_PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha }}",
+      EXPECTED_PACKAGE_VERSION: "${{ inputs.package_version }}",
+    });
+    expect(validatePackage.run).toContain('"$SHARED_IMAGE_POLICY" == "no-push-artifact"');
+    expect(validatePackage.run).toContain(
+      "Resolved package identity differs from the declared immutable tuple.",
+    );
+    expect(validatePackage.run).toContain("package/dist/build-info.json");
+    expect(validatePackage.run).toContain('[[ "$package_source_sha" == "$SELECTED_SHA" ]]');
+    const targetedRun = step(
+      job(workflow, "validate_docker_lanes"),
+      "Run targeted Docker E2E lanes",
+    );
+    expect(targetedRun.env).toMatchObject({
+      ARTIFACT_SUFFIX: "${{ steps.plan.outputs.artifact_suffix }}",
+      INCLUDE_RELEASE_PATH_SUITES: "${{ inputs.include_release_path_suites }}",
+    });
+    expect(targetedRun.run).toContain('if [[ "$INCLUDE_RELEASE_PATH_SUITES" == "true" ]]');
+    expect(targetedRun.run).not.toContain("${{ inputs.");
+    for (const workflowJob of Object.values(workflow.jobs ?? {})) {
+      for (const workflowStep of workflowJob.steps ?? []) {
+        for (const inputName of ["shared_image_policy", "package_sha256", "package_version"]) {
+          expect(workflowStep.run ?? "", `${workflowStep.name}:${inputName}`).not.toContain(
+            `\${{ inputs.${inputName} }}`,
+          );
+        }
+      }
+    }
+    expect(readFileSync(LIVE_E2E, "utf8")).not.toContain("fromJSON(toJSON(job)).workflow_");
+    expect(readFileSync(LIVE_E2E, "utf8")).not.toContain("${{ github.workflow_sha }}");
+    const artifactPackAndLoadSteps = Object.values(workflow.jobs ?? {}).flatMap((workflowJob) =>
+      (workflowJob.steps ?? []).filter((candidate) => candidate.env?.WORKFLOW_SHA !== undefined),
+    );
+    expect(artifactPackAndLoadSteps).toHaveLength(8);
+    for (const artifactStep of artifactPackAndLoadSteps) {
+      expect(artifactStep.env?.WORKFLOW_SHA, artifactStep.name).toBe(
+        "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+      );
+    }
+    expect(step(dockerProducer, "Upload Docker E2E image artifact")).toMatchObject({
+      id: "upload_image_artifact",
+      if: "inputs.shared_image_policy == 'no-push-artifact' && steps.plan.outputs.needs_e2e_image == '1'",
+      with: { "if-no-files-found": "error" },
+    });
+    expect(step(liveProducer, "Pack live-test image artifact").run).toContain(
+      "shared-image-artifact.sh",
+    );
+    expect(step(liveProducer, "Pack live-test image artifact").run).toContain(
+      "live-test-shared-image-${SHARED_IMAGE_ARTIFACT_NAMESPACE}-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
+    );
+    expect(step(liveProducer, "Upload live-test image artifact")).toMatchObject({
+      id: "upload_image_artifact",
+      if: "inputs.shared_image_policy == 'no-push-artifact'",
+      with: { "if-no-files-found": "error" },
+    });
+    expect(step(liveProducer, "Build shared live-test image").with).toMatchObject({
+      load: true,
+      push: false,
+    });
+    const dockerLoginCondition = step(dockerProducer, "Log in to GHCR").if;
+    expect(dockerLoginCondition).toContain("shared_image_policy == 'allow-push'");
+    expect(dockerLoginCondition).toContain("shared_image_policy == 'existing-only'");
+    expect(step(liveProducer, "Log in to GHCR").if).toContain(
+      "shared_image_policy != 'no-push-artifact'",
+    );
+    expect(step(dockerProducer, "Check existing shared Docker E2E images").if).toContain(
+      "shared_image_policy == 'allow-push'",
+    );
+    expect(step(liveProducer, "Check existing shared live-test image").if).toContain(
+      "shared_image_policy != 'no-push-artifact'",
+    );
+
+    const shellPushSteps = Object.entries(workflow.jobs ?? {}).flatMap(([jobName, workflowJob]) =>
+      (workflowJob.steps ?? [])
+        .filter((candidate) => candidate.run?.includes("--push"))
+        .map((candidate) => ({ candidate, jobName })),
+    );
+    expect(shellPushSteps.map(({ candidate }) => candidate.name).sort()).toEqual([
+      "Build and push bare Docker E2E image",
+      "Build and push functional Docker E2E image",
+    ]);
+    for (const { jobName } of shellPushSteps) {
+      expect(jobName).toBe("push_docker_e2e_images");
+    }
+    expect(step(livePublisher, "Build and push shared live-test image").with?.push).toBe(true);
+    expect(step(dockerPublisher, "Download OpenClaw Docker E2E package").with).toMatchObject({
+      "artifact-ids": "${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}",
+      "github-token": "${{ github.token }}",
+      "run-id": "${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}",
+    });
+
+    for (const name of [
+      "validate_docker_e2e",
+      "validate_docker_lanes",
+      "validate_docker_openwebui",
+    ]) {
+      const consumer = job(workflow, name);
+      expect(consumer.needs).toContain("docker_e2e_image_ready");
+      expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE).toContain("no-push-artifact");
+      expect(step(consumer, "Download OpenClaw Docker E2E package").with).toMatchObject({
+        "artifact-ids": "${{ needs.prepare_docker_e2e_image.outputs.package_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        "run-id": "${{ needs.prepare_docker_e2e_image.outputs.package_artifact_run_id }}",
+      });
+      const binding = step(consumer, "Validate Docker E2E image artifact binding");
+      expect(binding.if).toContain("shared_image_policy == 'no-push-artifact'");
+      expect(binding.env).toMatchObject({
+        ARTIFACT_DIGEST: "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_digest }}",
+        ARTIFACT_ID: "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}",
+        ARTIFACT_NAME: "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_name }}",
+        ARTIFACT_RUN_ATTEMPT:
+          "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}",
+        ARTIFACT_RUN_ID: "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}",
+        GH_TOKEN: "${{ github.token }}",
+      });
+      expect(binding.run).toContain('verify-upload "Docker E2E image"');
+      expect(binding.run).toContain('"$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST"');
+      expect(binding.run).toContain('"$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"');
+      const download = step(consumer, "Download Docker E2E image artifact");
+      expect(download.if).toContain("shared_image_policy == 'no-push-artifact'");
+      expect(download.with).toMatchObject({
+        "artifact-ids": "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        "run-id": "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}",
+      });
+      expect(consumer.steps?.indexOf(binding) ?? -1).toBeLessThan(
+        consumer.steps?.indexOf(download) ?? -1,
+      );
+      const loadArtifact = step(consumer, "Verify and load Docker E2E image artifact");
+      expect(loadArtifact.env?.ARCHIVE_SHA256).toBe(
+        "${{ needs.prepare_docker_e2e_image.outputs.image_archive_sha256 }}",
+      );
+      expect(loadArtifact.env?.PACKAGE_SHA256).toBe(
+        "${{ needs.prepare_docker_e2e_image.outputs.package_sha256 }}",
+      );
+      expect(loadArtifact.env?.OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT).toBe(
+        "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_attempt }}",
+      );
+      expect(loadArtifact.env?.OPENCLAW_SHARED_IMAGE_RUN_ID).toBe(
+        "${{ needs.prepare_docker_e2e_image.outputs.image_artifact_run_id }}",
+      );
+      expect(loadArtifact.run).toContain("shared-image-artifact.sh");
+      expect(loadArtifact.run).toContain('OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256"');
+      expect(loadArtifact.run).toContain('OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256="$PACKAGE_SHA256"');
+      expect(step(consumer, "Log in to GHCR for shared Docker E2E image").if).toContain(
+        "shared_image_policy != 'no-push-artifact'",
+      );
+      for (const pullName of [
+        "Pull shared bare Docker E2E image",
+        "Pull shared functional Docker E2E image",
+      ]) {
+        expect(step(consumer, pullName).if).toContain("shared_image_policy != 'no-push-artifact'");
+      }
+    }
+
+    for (const name of [
+      "validate_live_models_docker",
+      "validate_live_models_docker_targeted",
+      "validate_live_docker_provider_suites",
+    ]) {
+      const consumer = job(workflow, name);
+      expect(consumer.needs).toContain("live_test_image_ready");
+      expect(consumer.env?.OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE).toContain("no-push-artifact");
+      const binding = step(consumer, "Validate live-test image artifact binding");
+      expect(binding.if).toContain("shared_image_policy == 'no-push-artifact'");
+      expect(binding.env).toMatchObject({
+        ARTIFACT_DIGEST: "${{ needs.prepare_live_test_image.outputs.image_artifact_digest }}",
+        ARTIFACT_ID: "${{ needs.prepare_live_test_image.outputs.image_artifact_id }}",
+        ARTIFACT_NAME: "${{ needs.prepare_live_test_image.outputs.image_artifact_name }}",
+        ARTIFACT_RUN_ATTEMPT:
+          "${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}",
+        ARTIFACT_RUN_ID: "${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}",
+        GH_TOKEN: "${{ github.token }}",
+      });
+      expect(binding.run).toContain('verify-upload "live-test image"');
+      expect(binding.run).toContain('"$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST"');
+      expect(binding.run).toContain('"$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"');
+      const download = step(consumer, "Download live-test image artifact");
+      expect(download.if).toContain("shared_image_policy == 'no-push-artifact'");
+      expect(download.with).toMatchObject({
+        "artifact-ids": "${{ needs.prepare_live_test_image.outputs.image_artifact_id }}",
+        "github-token": "${{ github.token }}",
+        "run-id": "${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}",
+      });
+      expect(consumer.steps?.indexOf(binding) ?? -1).toBeLessThan(
+        consumer.steps?.indexOf(download) ?? -1,
+      );
+      const loadArtifact = step(consumer, "Verify and load live-test image artifact");
+      expect(loadArtifact.env?.ARCHIVE_SHA256).toBe(
+        "${{ needs.prepare_live_test_image.outputs.image_archive_sha256 }}",
+      );
+      expect(loadArtifact.env?.OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT).toBe(
+        "${{ needs.prepare_live_test_image.outputs.image_artifact_run_attempt }}",
+      );
+      expect(loadArtifact.env?.OPENCLAW_SHARED_IMAGE_RUN_ID).toBe(
+        "${{ needs.prepare_live_test_image.outputs.image_artifact_run_id }}",
+      );
+      expect(loadArtifact.run).toContain("shared-image-artifact.sh");
+      expect(loadArtifact.run).toContain('OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256="$ARCHIVE_SHA256"');
+      expect(step(consumer, "Log in to GHCR").if).toContain(
+        "shared_image_policy != 'no-push-artifact'",
+      );
+    }
+
+    const liveBuild = readFileSync(LIVE_BUILD, "utf8");
+    const requireLocalIndex = liveBuild.indexOf("OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE");
+    const pullIndex = liveBuild.indexOf("Live-test image not found locally; pulling");
+    expect(requireLocalIndex).toBeGreaterThanOrEqual(0);
+    expect(pullIndex).toBeGreaterThan(requireLocalIndex);
+    expect(liveBuild).toContain("Required local live-test image not found");
+  });
+
+  it("keeps performance evidence artifact-only when dispatched by Full Release", () => {
+    const fullText = readFileSync(FULL_RELEASE, "utf8");
+    const performance = readWorkflow(PERFORMANCE);
+    const publisher = job(performance, "publish");
+    const dangerousSteps = [
+      "Prepare clawgrit report commit",
+      "Create clawgrit reports app token",
+      "Publish to clawgrit reports",
+    ];
+
+    expect(performance.on?.workflow_dispatch?.inputs?.publish_reports).toMatchObject({
+      default: true,
+      type: "boolean",
+    });
+    expect(fullText).toContain("-f publish_reports=false");
+    expect(fullText).toContain("Report publication: disabled (artifacts only)");
+    expect(fullText).toContain('performanceReportPublication: "artifact-only"');
+    expect(publisher.if).toContain("inputs.publish_reports == true");
+    const guard = job(performance, "artifact_only_guard");
+    expect(guard.if).toContain("inputs.publish_reports != true");
+    expect(step(guard, "Verify report publisher stayed disabled").run).toContain(
+      '[[ "$PUBLISH_RESULT" != "skipped" ]]',
+    );
+    for (const name of dangerousSteps) {
+      expect(step(publisher, name)).toBeDefined();
+    }
+
+    for (const [name, workflowJob] of Object.entries(performance.jobs ?? {})) {
+      if (name === "publish") {
+        continue;
+      }
+      const text = JSON.stringify(workflowJob);
+      expect(text).not.toContain("CLAWGRIT_REPORTS_APP_TOKEN");
+      expect(text).not.toContain("create-github-app-token");
+      expect(text).not.toContain("git push");
+    }
+  });
+
+  it("fails a missing required local live image before any registry pull", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-live-local-image-"));
+    const bin = join(root, "bin");
+    const calls = join(root, "docker.log");
+    try {
+      mkdirSync(bin);
+      writeFileSync(calls, "");
+      const docker = join(bin, "docker");
+      writeFileSync(
+        docker,
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [[ "$1" == "image" && "$2" == "inspect" ]]; then
+  exit 1
+fi
+if [[ "$1" == "pull" ]]; then
+  exit 0
+fi
+exit 2
+`,
+      );
+      chmodSync(docker, 0o755);
+
+      const result = spawnSync("bash", [resolve(LIVE_BUILD)], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          DOCKER_COMMAND_TIMEOUT: "5s",
+          FAKE_DOCKER_LOG: calls,
+          OPENCLAW_LIVE_IMAGE: "openclaw-live-test:required-local",
+          OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE: "1",
+          OPENCLAW_SKIP_DOCKER_BUILD: "1",
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+        },
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "Required local live-test image not found: openclaw-live-test:required-local",
+      );
+      expect(readFileSync(calls, "utf8")).toBe("image inspect openclaw-live-test:required-local\n");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails a missing required local Docker E2E image before pull or build fallback", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-docker-e2e-local-image-"));
+    const bin = join(root, "bin");
+    const calls = join(root, "docker.log");
+    try {
+      mkdirSync(bin);
+      writeFileSync(calls, "");
+      const docker = join(bin, "docker");
+      writeFileSync(
+        docker,
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [[ "$1" == "image" && "$2" == "inspect" ]]; then
+  exit 1
+fi
+if [[ "$1" == "pull" ]]; then
+  exit 0
+fi
+exit 2
+`,
+      );
+      chmodSync(docker, 0o755);
+
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `source "$1"
+docker_e2e_build_or_reuse "openclaw-e2e:required-local" "required local image test"`,
+          "bash",
+          resolve(DOCKER_E2E_IMAGE_HELPER),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            FAKE_DOCKER_LOG: calls,
+            OPENCLAW_DOCKER_BUILD_ON_MISSING: "1",
+            OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1",
+            OPENCLAW_SKIP_DOCKER_BUILD: "1",
+            PATH: `${bin}:${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "Required local Docker E2E image not found: openclaw-e2e:required-local",
+      );
+      expect(readFileSync(calls, "utf8")).toBe("image inspect openclaw-e2e:required-local\n");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -14,6 +14,20 @@ const PROFILE_GATED_STATIC_MATRIX_ALLOWLIST = [
   "validate_live_media_provider_suites",
 ];
 
+// Direct dispatches build from the selected ref. Only trusted workflow callers
+// may provide the complete immutable package artifact tuple.
+const WORKFLOW_CALL_ONLY_INPUTS = new Set([
+  "package_artifact_name",
+  "package_artifact_id",
+  "package_artifact_digest",
+  "package_artifact_run_id",
+  "package_artifact_run_attempt",
+  "package_file_name",
+  "package_source_sha",
+  "package_sha256",
+  "package_version",
+]);
+
 const PROFILE_EXPECTATIONS = [
   {
     profile: "minimum",
@@ -98,10 +112,17 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       }
     }
 
-    for (const trigger of ["workflow_call", "workflow_dispatch"]) {
-      expect(Object.keys(definition.on[trigger].inputs)).toEqual(
-        expect.arrayContaining([...referencedInputs]),
-      );
+    expect(Object.keys(definition.on.workflow_call.inputs)).toEqual(
+      expect.arrayContaining([...referencedInputs]),
+    );
+    expect(Object.keys(definition.on.workflow_dispatch.inputs)).toEqual(
+      expect.arrayContaining(
+        [...referencedInputs].filter((input) => !WORKFLOW_CALL_ONLY_INPUTS.has(input)),
+      ),
+    );
+    for (const input of WORKFLOW_CALL_ONLY_INPUTS) {
+      expect(definition.on.workflow_call.inputs).toHaveProperty(input);
+      expect(definition.on.workflow_dispatch.inputs).not.toHaveProperty(input);
     }
     expect(definition.on.workflow_dispatch.inputs.live_advisory).toEqual(
       definition.on.workflow_call.inputs.live_advisory,

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -1,0 +1,467 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const HELPER = resolve("scripts/docker/shared-image-artifact.sh");
+const TARGET_SHA = "a".repeat(40);
+const WORKFLOW_SHA = "b".repeat(40);
+const PACKAGE_SHA256 = "c".repeat(64);
+const ARTIFACT_DIGEST = "d".repeat(64);
+const ARTIFACT_ID = "789";
+const ARTIFACT_NAME = "docker-e2e-shared-images-release-aabbccddeeff-123456-2";
+const ARTIFACT_RUN_ATTEMPT = "2";
+const ARTIFACT_RUN_ID = "123456";
+const IMAGE_REFS = ["openclaw-docker-e2e-bare:pkg-test", "openclaw-docker-e2e-functional:pkg-test"];
+
+function imageId(ref: string): string {
+  return `sha256:${createHash("sha256").update(ref).digest("hex")}`;
+}
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function runHelper(params: {
+  artifactDir: string;
+  command: "load" | "pack";
+  env: NodeJS.ProcessEnv;
+  imageRefs?: string[];
+}) {
+  return spawnSync(
+    "bash",
+    [
+      HELPER,
+      params.command,
+      params.artifactDir,
+      "docker-e2e",
+      TARGET_SHA,
+      WORKFLOW_SHA,
+      ...(params.imageRefs ?? IMAGE_REFS),
+    ],
+    {
+      encoding: "utf8",
+      env: params.env,
+    },
+  );
+}
+
+function verifyUploadedArtifact(
+  fixture: ReturnType<typeof createFixture>,
+  params: {
+    artifactDigest?: string;
+    artifactName?: string;
+    env?: NodeJS.ProcessEnv;
+    runAttempt?: string;
+    runId?: string;
+  } = {},
+) {
+  return spawnSync(
+    "bash",
+    [
+      HELPER,
+      "verify-upload",
+      "Docker E2E image",
+      ARTIFACT_ID,
+      params.artifactName ?? ARTIFACT_NAME,
+      params.artifactDigest ?? ARTIFACT_DIGEST,
+      params.runId ?? ARTIFACT_RUN_ID,
+      params.runAttempt ?? ARTIFACT_RUN_ATTEMPT,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...fixture.env, ...params.env },
+    },
+  );
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-shared-image-artifact-"));
+  const bin = join(root, "bin");
+  const artifactDir = join(root, "artifact");
+  const dockerLog = join(root, "docker.log");
+  const ghLog = join(root, "gh.log");
+  mkdirSync(bin);
+  writeFileSync(dockerLog, "");
+  writeFileSync(ghLog, "");
+
+  writeExecutable(
+    join(bin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+
+image_id() {
+  printf '%s' "$1" | sha256sum | awk '{print "sha256:" $1}'
+}
+
+if [[ "$1" == "image" && "$2" == "inspect" ]]; then
+  ref="\${5:?image ref required}"
+  id="$(image_id "$ref")"
+  if [[ "\${FAKE_DOCKER_FORCE_ID_MISMATCH:-0}" == "1" ]]; then
+    id="sha256:$(printf 'mismatch:%s' "$ref" | sha256sum | awk '{print $1}')"
+  fi
+  printf '%s\\n' "$id"
+  exit 0
+fi
+
+if [[ "$1" == "image" && "$2" == "save" ]]; then
+  shift 2
+  output=""
+  refs=()
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --output)
+        output="\${2:?output path required}"
+        shift 2
+        ;;
+      *)
+        refs+=("$1")
+        shift
+        ;;
+    esac
+  done
+  : > "$output"
+  for ref in "\${refs[@]}"; do
+    printf '%s\\t%s\\n' "$ref" "$(image_id "$ref")" >> "$output"
+  done
+  exit 0
+fi
+
+if [[ "$1" == "image" && "$2" == "load" ]]; then
+  cat >/dev/null
+  exit 0
+fi
+
+echo "unexpected docker invocation: $*" >&2
+exit 2
+`,
+  );
+
+  writeExecutable(
+    join(bin, "zstd"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "-t" ]]; then
+  test -s "$2"
+  exit 0
+fi
+if [[ "$1" == "-d" && "$2" == "--stdout" ]]; then
+  cat "$3"
+  exit 0
+fi
+
+source_path=""
+output_path=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -f)
+      source_path="\${2:?source path required}"
+      shift 2
+      ;;
+    -o)
+      output_path="\${2:?output path required}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cp "$source_path" "$output_path"
+`,
+  );
+
+  writeExecutable(
+    join(bin, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_GH_LOG"
+[[ "$1" == "api" ]] || {
+  echo "unexpected gh invocation: $*" >&2
+  exit 2
+}
+path="$2"
+case "$path" in
+  "repos/\${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}")
+    printf '{"id":%s,"name":"%s","expired":%s,"digest":"sha256:%s","workflow_run":{"id":%s}}\\n' \
+      "$FAKE_ARTIFACT_ID" "$FAKE_ARTIFACT_NAME" "$FAKE_ARTIFACT_EXPIRED" \
+      "$FAKE_ARTIFACT_DIGEST" "$FAKE_ARTIFACT_RUN_ID"
+    ;;
+  "repos/\${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}")
+    printf '{"id":%s,"run_attempt":%s}\\n' \
+      "$FAKE_ATTEMPT_RUN_ID" "$FAKE_ARTIFACT_RUN_ATTEMPT"
+    ;;
+  *)
+    echo "unexpected gh api path: $path" >&2
+    exit 2
+    ;;
+esac
+`,
+  );
+
+  const env = {
+    ...process.env,
+    FAKE_ARTIFACT_DIGEST: ARTIFACT_DIGEST,
+    FAKE_ARTIFACT_EXPIRED: "false",
+    FAKE_ARTIFACT_ID: ARTIFACT_ID,
+    FAKE_ARTIFACT_NAME: ARTIFACT_NAME,
+    FAKE_ARTIFACT_RUN_ATTEMPT: ARTIFACT_RUN_ATTEMPT,
+    FAKE_ARTIFACT_RUN_ID: ARTIFACT_RUN_ID,
+    FAKE_ATTEMPT_RUN_ID: ARTIFACT_RUN_ID,
+    FAKE_DOCKER_LOG: dockerLog,
+    FAKE_GH_LOG: ghLog,
+    GH_TOKEN: "test-token",
+    GITHUB_REPOSITORY: "openclaw/openclaw",
+    GITHUB_RUN_ATTEMPT: "2",
+    GITHUB_RUN_ID: "123456",
+    PATH: `${bin}:${process.env.PATH ?? ""}`,
+    RUNNER_TEMP: root,
+    OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256: PACKAGE_SHA256,
+  };
+  return { artifactDir, dockerLog, env, ghLog, root };
+}
+
+function expectedArchiveEnv(fixture: ReturnType<typeof createFixture>): NodeJS.ProcessEnv {
+  const manifest = JSON.parse(
+    readFileSync(join(fixture.artifactDir, "shared-image-artifact.json"), "utf8"),
+  );
+  return {
+    ...fixture.env,
+    OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: manifest.archive.sha256,
+    OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: String(manifest.runAttempt),
+    OPENCLAW_SHARED_IMAGE_RUN_ID: String(manifest.runId),
+  };
+}
+
+describe("shared Docker image artifacts", () => {
+  it("binds uploaded artifacts to the exact service tuple and producer attempt", () => {
+    const fixture = createFixture();
+    try {
+      const verified = verifyUploadedArtifact(fixture);
+      expect(verified.status, `${verified.stdout}\n${verified.stderr}`).toBe(0);
+      expect(readFileSync(fixture.ghLog, "utf8")).toContain(
+        `api repos/openclaw/openclaw/actions/artifacts/${ARTIFACT_ID}`,
+      );
+      expect(readFileSync(fixture.ghLog, "utf8")).toContain(
+        `api repos/openclaw/openclaw/actions/runs/${ARTIFACT_RUN_ID}/attempts/${ARTIFACT_RUN_ATTEMPT}`,
+      );
+
+      const digestMismatch = verifyUploadedArtifact(fixture, {
+        artifactDigest: "e".repeat(64),
+      });
+      expect(digestMismatch.status).not.toBe(0);
+      expect(digestMismatch.stderr).toContain(
+        "artifact identity does not match the immutable producer tuple",
+      );
+
+      const attemptMismatch = verifyUploadedArtifact(fixture, {
+        env: { FAKE_ARTIFACT_RUN_ATTEMPT: "3" },
+      });
+      expect(attemptMismatch.status).not.toBe(0);
+      expect(attemptMismatch.stderr).toContain(
+        "producer run attempt does not match the immutable tuple",
+      );
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("packs provenance-bound images and verifies them before loading", () => {
+    const fixture = createFixture();
+    try {
+      const packed = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "pack",
+        env: fixture.env,
+      });
+      expect(packed.status, `${packed.stdout}\n${packed.stderr}`).toBe(0);
+
+      const archive = readFileSync(join(fixture.artifactDir, "shared-images.tar.zst"));
+      const manifest = JSON.parse(
+        readFileSync(join(fixture.artifactDir, "shared-image-artifact.json"), "utf8"),
+      );
+      expect(manifest).toEqual({
+        archive: {
+          filename: "shared-images.tar.zst",
+          format: "docker-tar+zstd",
+          sha256: createHash("sha256").update(archive).digest("hex"),
+          sizeBytes: archive.length,
+        },
+        conclusion: "success",
+        images: IMAGE_REFS.map((ref) => ({ id: imageId(ref), ref })),
+        kind: "docker-e2e",
+        packageSha256: PACKAGE_SHA256,
+        packageSourceSha: TARGET_SHA,
+        runAttempt: 2,
+        runId: 123456,
+        schema: "openclaw.shared-docker-image-artifact/v1",
+        schemaVersion: 1,
+        targetSha: TARGET_SHA,
+        workflowSha: WORKFLOW_SHA,
+      });
+
+      writeFileSync(fixture.dockerLog, "");
+      const loaded = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: { ...expectedArchiveEnv(fixture), GITHUB_RUN_ATTEMPT: "3" },
+      });
+      expect(loaded.status, `${loaded.stdout}\n${loaded.stderr}`).toBe(0);
+      const calls = readFileSync(fixture.dockerLog, "utf8");
+      expect(calls).toContain("image load");
+      for (const ref of IMAGE_REFS) {
+        expect(calls).toContain(`image inspect --format {{.Id}} ${ref}`);
+      }
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails before loading when provenance or archive bytes differ", () => {
+    const fixture = createFixture();
+    try {
+      const packed = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "pack",
+        env: fixture.env,
+      });
+      expect(packed.status, packed.stderr).toBe(0);
+
+      for (const variant of [
+        {
+          env: {
+            ...expectedArchiveEnv(fixture),
+            OPENCLAW_SHARED_IMAGE_RUN_ID: "654321",
+          },
+          imageRefs: IMAGE_REFS,
+          expected: "run ID",
+        },
+        {
+          env: expectedArchiveEnv(fixture),
+          imageRefs: [IMAGE_REFS[0], "openclaw-docker-e2e-functional:wrong"],
+          expected: "image ref 1",
+        },
+        {
+          env: {
+            ...expectedArchiveEnv(fixture),
+            OPENCLAW_SHARED_IMAGE_PACKAGE_SHA256: "d".repeat(64),
+          },
+          imageRefs: IMAGE_REFS,
+          expected: "package SHA-256",
+        },
+      ]) {
+        writeFileSync(fixture.dockerLog, "");
+        const result = runHelper({
+          artifactDir: fixture.artifactDir,
+          command: "load",
+          env: variant.env,
+          imageRefs: variant.imageRefs,
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(variant.expected);
+        expect(readFileSync(fixture.dockerLog, "utf8")).not.toContain("image load");
+      }
+
+      const archivePath = join(fixture.artifactDir, "shared-images.tar.zst");
+      writeFileSync(archivePath, `${readFileSync(archivePath, "utf8")}tampered`);
+      writeFileSync(fixture.dockerLog, "");
+      const tampered = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: expectedArchiveEnv(fixture),
+      });
+      expect(tampered.status).not.toBe(0);
+      expect(tampered.stderr).toContain("archive SHA-256 mismatch");
+      expect(readFileSync(fixture.dockerLog, "utf8")).not.toContain("image load");
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects unsafe pack destinations and loaded image ID drift", () => {
+    const fixture = createFixture();
+    try {
+      const unsafe = runHelper({
+        artifactDir: fixture.root,
+        command: "pack",
+        env: fixture.env,
+      });
+      expect(unsafe.status).not.toBe(0);
+      expect(unsafe.stderr).toContain("artifact directory must be a child of RUNNER_TEMP");
+
+      const packed = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "pack",
+        env: fixture.env,
+      });
+      expect(packed.status, packed.stderr).toBe(0);
+
+      writeFileSync(fixture.dockerLog, "");
+      const mismatch = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: { ...expectedArchiveEnv(fixture), FAKE_DOCKER_FORCE_ID_MISMATCH: "1" },
+      });
+      expect(mismatch.status).not.toBe(0);
+      expect(mismatch.stderr).toContain("loaded ID mismatch");
+      expect(readFileSync(fixture.dockerLog, "utf8")).toContain("image load");
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("requires an external expected archive digest before loading", () => {
+    const fixture = createFixture();
+    try {
+      const packed = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "pack",
+        env: fixture.env,
+      });
+      expect(packed.status, packed.stderr).toBe(0);
+
+      const missingRunEnv = expectedArchiveEnv(fixture);
+      delete missingRunEnv.OPENCLAW_SHARED_IMAGE_RUN_ID;
+      delete missingRunEnv.OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT;
+      const missingRun = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: missingRunEnv,
+      });
+      expect(missingRun.status).not.toBe(0);
+      expect(missingRun.stderr).toContain("OPENCLAW_SHARED_IMAGE_RUN_ID");
+      expect(readFileSync(fixture.dockerLog, "utf8")).not.toContain("image load");
+
+      const missing = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: {
+          ...fixture.env,
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: "2",
+          OPENCLAW_SHARED_IMAGE_RUN_ID: "123456",
+        },
+      });
+      expect(missing.status).not.toBe(0);
+      expect(missing.stderr).toContain("expected shared image archive SHA-256");
+      expect(readFileSync(fixture.dockerLog, "utf8")).not.toContain("image load");
+
+      const mismatched = runHelper({
+        artifactDir: fixture.artifactDir,
+        command: "load",
+        env: {
+          ...expectedArchiveEnv(fixture),
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: "d".repeat(64),
+        },
+      });
+      expect(mismatched.status).not.toBe(0);
+      expect(mismatched.stderr).toContain("expected archive sha256");
+      expect(readFileSync(fixture.dockerLog, "utf8")).not.toContain("image load");
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+});

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1432,11 +1432,12 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     };
 
     expect(step("Checkout trusted installer harness").with).toMatchObject({
-      ref: "${{ github.workflow_sha }}",
+      repository: "${{ needs.preflight.outputs.workflow_repository }}",
+      ref: "${{ needs.preflight.outputs.workflow_sha }}",
       "persist-credentials": false,
     });
     expect(step("Checkout candidate CLI").with).toMatchObject({
-      ref: "${{ inputs.ref || github.ref }}",
+      ref: "${{ needs.preflight.outputs.target_sha }}",
       path: "candidate",
       "persist-credentials": false,
     });


### PR DESCRIPTION
## What Problem This Solves

Release validation could mutate shared container state while proving an unpublished candidate, and retries could consume weakly bound or moving workflow evidence. That made prepublish proof unsafe and unnecessarily expensive.

## Why This Change Was Made

This adds artifact-only Docker/image transport, immutable run/artifact/package binding, exact-target evidence recovery, trusted called-workflow repository/SHA pinning, and a strict release summary verifier. Publication remains in explicit release workflows; Full Release Validation itself does not push images or publish reports.

## User Impact

Release operators can validate an exact candidate without publishing packages, tags, reports, or container images. Product runtime behavior is unchanged.

## Evidence

- Testbox `tbx_01kx675dd56pc1t6rb20w11v1g`: 181/181 focused workflow/helper tests passed.
- `pnpm check:changed`: typecheck, core/extensions/scripts lint, guards, and import-cycle checks passed.
- Final immutable-helper delta: focused 9/9 Testbox tests passed.
- All changed workflows passed actionlint; oxfmt, docs index, and `git diff --check` passed.
- Fresh structured autoreview: no actionable findings, patch correct, confidence 0.78.
- Trusted checkout audit: 5 install-smoke and 12 live/E2E harness checkouts pin called workflow repository + SHA with credentials disabled.

AI-assisted: yes; exact-head hosted CI remains the merge gate.