### PR TITLE
fix(codex): keep diagnostics reason truncation UTF-16 safe

### DIFF
--- a/extensions/codex/src/command-handlers.test.ts
+++ b/extensions/codex/src/command-handlers.test.ts
@@ -1,0 +1,37 @@
+// Codex tests cover command handler behavior.
+import { describe, expect, it } from "vitest";
+import { normalizeDiagnosticsReason } from "./command-handlers.js";
+
+describe("normalizeDiagnosticsReason", () => {
+  it("returns undefined for empty input", () => {
+    expect(normalizeDiagnosticsReason("")).toBeUndefined();
+    expect(normalizeDiagnosticsReason("   ")).toBeUndefined();
+  });
+
+  it("returns the original string when within the char limit", () => {
+    expect(normalizeDiagnosticsReason("short reason")).toBe("short reason");
+  });
+
+  it("truncates long reasons", () => {
+    const input = "x".repeat(3_000);
+    const result = normalizeDiagnosticsReason(input);
+    expect(result?.length).toBeLessThanOrEqual(2048);
+  });
+
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    // 2047 'x's + rocket emoji (2 UTF-16 code units) = 2049 code units.
+    // On main, slice(0, 2048) cuts between the pair, leaving an orphan high
+    // surrogate (U+D83D) at the end.
+    //
+    // truncateUtf16Safe detects the boundary split and backs off by one code
+    // unit (returning 2047 chars) so the partial emoji is dropped cleanly.
+    const input = `${"x".repeat(2047)}\u{1F680}`;
+    const result = normalizeDiagnosticsReason(input);
+    expect(result).toBeDefined();
+    // truncateUtf16Safe backs off by one to avoid the split: 2048 → 2047
+    expect(result!.length).toBe(2047);
+    // The final code unit must not be an orphan high surrogate
+    const lastCode = result!.codePointAt(result!.length - 1);
+    expect(lastCode).toBe(0x78); // 'x'
+  });
+});

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -1,5 +1,6 @@
 // Codex plugin module implements command handlers behavior.
 import crypto from "node:crypto";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentDir, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
@@ -1667,9 +1668,9 @@ function formatCodexDiagnosticsTargetLine(target: CodexDiagnosticsTarget): strin
   return `- ${parts.join(", ")}`;
 }
 
-function normalizeDiagnosticsReason(note: string): string | undefined {
+export function normalizeDiagnosticsReason(note: string): string | undefined {
   const normalized = normalizeOptionalString(note);
-  return normalized ? normalized.slice(0, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
 }
 
 function parseDiagnosticsArgs(args: string): ParsedDiagnosticsArgs {


### PR DESCRIPTION
## What Problem This Solves

`normalizeDiagnosticsReason()` in `extensions/codex/src/command-handlers.ts` uses `normalized.slice(0, 2048)` to truncate user-provided diagnostics notes. When the 2048-char boundary lands in a surrogate pair, the result ends with an orphan high surrogate.

**Proof on main:**
```js
const input = "x".repeat(2047) + "🚀";     // length 2049
const result = input.slice(0, 2048);         // on main
result[2047] === "\ud83d"                     // → true, orphan high surrogate
```

## Why This Change Was Made

1. Exported `normalizeDiagnosticsReason` for direct testing
2. Replaced `normalized.slice(0, N)` with `truncateUtf16Safe(normalized, N)`
3. Added 4 test cases including surrogate-pair boundary proof

## User Impact

- Codex diagnostics reason notes keep emoji intact at the 2048-char boundary
- No behavior change for ASCII text

## Evidence

- New test file `command-handlers.test.ts` with boundary test: 2047 chars + emoji → verified no broken surrogate in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)