### PR TITLE
fix(codex): preserve Unicode diagnostics boundaries

### DIFF
--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -5,6 +5,7 @@ import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { CODEX_CONTROL_METHODS, type CodexControlMethod } from "./app-server/capabilities.js";
 import {
@@ -1669,7 +1670,7 @@ function formatCodexDiagnosticsTargetLine(target: CodexDiagnosticsTarget): strin
 
 function normalizeDiagnosticsReason(note: string): string | undefined {
   const normalized = normalizeOptionalString(note);
-  return normalized ? normalized.slice(0, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, CODEX_DIAGNOSTICS_REASON_MAX_CHARS) : undefined;
 }
 
 function parseDiagnosticsArgs(args: string): ParsedDiagnosticsArgs {
@@ -2051,7 +2052,10 @@ function pruneCodexDiagnosticsCooldownMap(map: Map<string, number>, now: number)
 }
 
 function formatCodexErrorForDisplay(error: string): string {
-  const safe = formatCodexTextForDisplay(error).slice(0, CODEX_DIAGNOSTICS_ERROR_MAX_CHARS);
+  const safe = truncateUtf16Safe(
+    formatCodexTextForDisplay(error),
+    CODEX_DIAGNOSTICS_ERROR_MAX_CHARS,
+  );
   return escapeCodexChatText(safe) || "unknown error";
 }
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -3154,7 +3154,7 @@ describe("codex command", () => {
     const request = await handleCodexCommand(createContext(`diagnostics ${note}`, sessionFile), {
       deps,
     });
-    expect(request.text.split("\n")).toContain(`Note: ${expectedReason}`);
+    expect(requireResultText(request).split("\n")).toContain(`Note: ${expectedReason}`);
     const token = readDiagnosticsConfirmationToken(request);
     await handleCodexCommand(createContext(`diagnostics confirm ${token}`, sessionFile), { deps });
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -3134,7 +3134,7 @@ describe("codex command", () => {
     });
   });
 
-  it("bounds diagnostics notes before upload", async () => {
+  it("keeps diagnostics notes UTF-16 safe at the upload boundary", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await writeTestBinding(
       { kind: "session", agentId: "main", sessionId: "session-1" },
@@ -3146,7 +3146,9 @@ describe("codex command", () => {
         value: { threadId: "thread-789" },
       }),
     );
-    const note = "x".repeat(2050);
+    // The emoji's surrogate pair straddles the 2048-unit feedback limit.
+    const expectedReason = "x".repeat(2047);
+    const note = `${expectedReason}😀tail`;
     const deps = createDeps({ safeCodexControlRequest });
 
     const request = await handleCodexCommand(createContext(`diagnostics ${note}`, sessionFile), {
@@ -3157,8 +3159,16 @@ describe("codex command", () => {
 
     expect(mockArg(safeCodexControlRequest, 0, 0)).toBeUndefined();
     expect(mockArg(safeCodexControlRequest, 0, 1)).toBe(CODEX_CONTROL_METHODS.feedback);
-    const feedbackParams = requestParams(safeCodexControlRequest);
-    expect(feedbackParams.reason).toBe("x".repeat(2048));
+    expect(requestParams(safeCodexControlRequest)).toEqual({
+      classification: "bug",
+      reason: expectedReason,
+      threadId: "thread-789",
+      includeLogs: true,
+      tags: {
+        source: "openclaw-diagnostics",
+        channel: "test",
+      },
+    });
   });
 
   it("escapes diagnostics notes before showing approval text", async () => {
@@ -3437,6 +3447,35 @@ describe("codex command", () => {
         "- channel test, OpenClaw session session-1, Codex thread &lt;\uff20U123&gt;: bad??? &lt;\uff20U123&gt; \uff3btrusted\uff3d\uff08https://evil\uff09 \uff20here",
         "Inspect locally:",
         "- run codex resume and paste the thread id shown above",
+      ].join("\n"),
+    });
+  });
+
+  it("keeps diagnostics upload errors UTF-16 safe at the display boundary", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1" },
+      { threadId: "thread-error-boundary", cwd: "/repo" },
+    );
+    // The emoji's surrogate pair straddles the 500-unit display limit.
+    const expectedError = "x".repeat(499);
+    const safeCodexControlRequest = vi.fn(async () => ({
+      ok: false as const,
+      error: `${expectedError}😀tail`,
+    }));
+    const deps = createDeps({ safeCodexControlRequest });
+
+    const request = await handleCodexCommand(createContext("diagnostics", sessionFile), { deps });
+    const token = readDiagnosticsConfirmationToken(request);
+
+    await expect(
+      handleCodexCommand(createContext(`diagnostics confirm ${token}`, sessionFile), { deps }),
+    ).resolves.toEqual({
+      text: [
+        "Could not send Codex diagnostics:",
+        `- channel test, OpenClaw session session-1, Codex thread thread-error-boundary: ${expectedError}`,
+        "Inspect locally:",
+        "- `codex resume thread-error-boundary`",
       ].join("\n"),
     });
   });

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -3154,6 +3154,7 @@ describe("codex command", () => {
     const request = await handleCodexCommand(createContext(`diagnostics ${note}`, sessionFile), {
       deps,
     });
+    expect(request.text.split("\n")).toContain(`Note: ${expectedReason}`);
     const token = readDiagnosticsConfirmationToken(request);
     await handleCodexCommand(createContext(`diagnostics confirm ${token}`, sessionFile), { deps });
 


### PR DESCRIPTION
## What Problem This Solves

The Codex diagnostics command used raw UTF-16 prefix slices for both the optional feedback reason (2,048 units) and failed-upload error text shown in chat (500 units). If either boundary lands between an emoji's surrogate halves, OpenClaw can send or display malformed text.

## Why This Change Was Made

- Use the supported plugin SDK UTF-16 truncator at both owner-local boundaries.
- Keep the formatting helpers private instead of expanding production API only for tests.
- Exercise both defects through the real `handleCodexCommand` request/confirm path.
- Assert the exact confirmation note, complete `feedback/upload` payload, and complete failed-upload reply.

Upstream Codex commit `c4318c386de365bd0dd9595a08d55a30bb142d11` defines `feedback/upload.reason` as an optional string and forwards it unchanged to the feedback uploader, so OpenClaw owns its local 2,048-unit policy.

## User Impact

Long diagnostics notes and failed-upload messages no longer acquire replacement glyphs or lone surrogates when an emoji crosses an OpenClaw boundary. Existing limits, escaping, confirmation, cooldown, and upload behavior remain unchanged.

## Evidence

- Command-path coverage places an emoji across the 2,048-unit reason boundary and checks the exact preview line and outbound request.
- Command-path coverage places an emoji across the 500-unit error boundary and checks the exact user-visible reply.
- Contributor credit is preserved in the replacement commit.
