### PR TITLE
fix(cron): reject agent toolsAllow clears under creator caps

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2423,38 +2423,27 @@ describe("cron tool", () => {
     });
   });
 
-  it("keeps the creator tool surface when an agentTurn update clears toolsAllow", async () => {
-    callGatewayMock.mockResolvedValueOnce({ ok: true });
-
+  it("rejects agentTurn toolsAllow clears under a creator tool surface", async () => {
     const tool = createTestCronTool({
       agentSessionKey: "agent:main:telegram:group:restricted-room",
       creatorToolAllowlist: ["read", "cron"],
     });
-    await tool.execute("call-update-capped-tools-clear", {
-      action: "update",
-      id: "job-8",
-      patch: {
-        payload: {
-          toolsAllow: null,
-        },
-      },
-    });
 
-    const params = expectSingleGatewayCallMethod("cron.update") as
-      | {
-          patch?: {
-            payload?: {
-              kind?: string;
-              toolsAllow?: string[];
-            };
-          };
-        }
-      | undefined;
-    expect(params?.patch?.payload).toEqual({
-      kind: "agentTurn",
-      toolsAllow: ["read", "cron"],
-      toolsAllowIsDefault: true,
-    });
+    await expect(
+      tool.execute("call-update-capped-tools-clear", {
+        action: "update",
+        id: "job-8",
+        patch: {
+          payload: {
+            toolsAllow: null,
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      "cannot clear toolsAllow from the agent cron tool while a creator tool allowlist is enforced",
+    );
+
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("adds the creator tool surface when updating an existing agentTurn without a payload patch", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -76,6 +76,8 @@ const REMINDER_CONTEXT_MESSAGES_MAX = 10;
 const REMINDER_CONTEXT_PER_MESSAGE_MAX = 220;
 const REMINDER_CONTEXT_TOTAL_MAX = 700;
 const REMINDER_CONTEXT_MARKER = "\n\nRecent context:\n";
+const CRON_AGENT_TOOLS_ALLOW_CLEAR_ERROR =
+  "cannot clear toolsAllow from the agent cron tool while a creator tool allowlist is enforced; use openclaw cron edit --clear-tools from the CLI";
 
 function isMissingOrEmptyObject(value: unknown): boolean {
   return !value || (isRecord(value) && Object.keys(value).length === 0);
@@ -583,6 +585,14 @@ async function capCronAgentTurnUpdatePatchToolsAllow(params: {
   const payload = isRecord(params.patch.payload) ? params.patch.payload : undefined;
   const patchPayloadKind = readCronPayloadKind(payload);
   const patchRequestsAgentTurn = patchPayloadKind === "agentTurn";
+  if (
+    payload &&
+    Object.hasOwn(payload, "toolsAllow") &&
+    payload.toolsAllow === null &&
+    (patchPayloadKind === undefined || patchPayloadKind === "agentTurn")
+  ) {
+    throw new Error(CRON_AGENT_TOOLS_ALLOW_CLEAR_ERROR);
+  }
   if (patchPayloadKind === "agentTurn" && payload && Object.hasOwn(payload, "toolsAllow")) {
     capCronAgentTurnToolsAllow({
       payload,


### PR DESCRIPTION
Related: #101349

## What Problem This Solves

Fixes an issue where users trying to clear a cron job's `toolsAllow` from a restricted agent session would see the agent cron tool accept `toolsAllow: null`, but the patch would be silently re-capped to the creator tool surface instead of actually clearing the allow-list.

## Why This Change Was Made

The agent cron tool now rejects `toolsAllow: null` when a creator tool allowlist is enforced and points operators to `openclaw cron edit --clear-tools`, which continues to use the service-layer clear path. This keeps the CLI backend fail-closed behavior for explicit runtime restrictions and avoids turning explicit cron tool policy into unrestricted CLI runs.

AI-assisted PR: authored with Codex.

## User Impact

Users get a clear error instead of a successful-looking no-op when they ask a restricted agent to clear cron tool policy. Operators can still clear the allow-list intentionally from the CLI, and explicit restricted cron jobs still fail closed on CLI backends that cannot enforce runtime `toolsAllow`.

## Evidence

- `pnpm install --frozen-lockfile`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-101349 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts` -> 142 tests passed
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-101349b OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/cron/service.jobs.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/agents/cli-runner/prepare.test.ts` -> 199 tests passed across 3 files
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-101349c OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/cli/cron-cli.test.ts src/cli/cron-cli/register.cron-edit.test.ts` -> 126 tests passed
- `pnpm exec oxfmt --check src/agents/tools/cron-tool.ts src/agents/tools/cron-tool.test.ts`
- `pnpm exec oxlint src/agents/tools/cron-tool.ts src/agents/tools/cron-tool.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`

Live behavior proof on a temporary local Gateway, with token, temp home, and local URL redacted:

```text
$ OPENCLAW_HOME=<redacted-temp-home> OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_DISABLE_BONJOUR=1 node scripts/run-node.mjs gateway run --dev --reset --port <local-port> --auth token --token <redacted-token> --allow-unconfigured
gateway_ready=true

$ node scripts/run-node.mjs cron add proof-101349 --at +1h --message 'proof job' --agent main --session isolated --tools read,cron --no-deliver --url <local-gateway> --token <redacted-token> --json
{
  "id": "e3270a2c-1009-408d-a414-6fbe199717bf",
  "agentId": "main",
  "name": "proof-101349",
  "payload": {
    "kind": "agentTurn",
    "message": "proof job",
    "toolsAllow": ["read", "cron"]
  },
  "delivery": { "mode": "none", "channel": "last" }
}

$ node --import tsx - <<'NODE'  # production createCronTool, gatewayUrl=<local-gateway>, gatewayToken=<redacted-token>
{
  "agentToolClearRejected": true,
  "message": "cannot clear toolsAllow from the agent cron tool while a creator tool allowlist is enforced; use openclaw cron edit --clear-tools from the CLI"
}

$ node scripts/run-node.mjs cron edit e3270a2c-1009-408d-a414-6fbe199717bf --clear-tools --url <local-gateway> --token <redacted-token>
{
  "id": "e3270a2c-1009-408d-a414-6fbe199717bf",
  "payload": {
    "kind": "agentTurn",
    "message": "proof job"
  }
}

$ node scripts/run-node.mjs cron get e3270a2c-1009-408d-a414-6fbe199717bf --url <local-gateway> --token <redacted-token>
toolsAllow_after_clear=<absent>

$ node scripts/run-node.mjs cron edit e3270a2c-1009-408d-a414-6fbe199717bf --description 'unrelated edit after clear' --url <local-gateway> --token <redacted-token>
{
  "id": "e3270a2c-1009-408d-a414-6fbe199717bf",
  "description": "unrelated edit after clear",
  "payload": {
    "kind": "agentTurn",
    "message": "proof job"
  }
}

$ node scripts/run-node.mjs cron get e3270a2c-1009-408d-a414-6fbe199717bf --url <local-gateway> --token <redacted-token>
toolsAllow_after_unrelated_edit=<absent>

# Assertions
agent_tool_rejects_clear=true
cli_clear_succeeds=true
toolsAllow_after_clear=<absent>
toolsAllow_after_unrelated_edit=<absent>
```
