### PR TITLE
test: cover ClickClack tail cursor fallback

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -153,6 +153,26 @@ describe("ClickClack gateway", () => {
     await run;
   });
 
+  it("falls back to the last startup page cursor when the server omits the tail cursor", async () => {
+    mocks.client.eventPage.mockResolvedValueOnce({
+      events: [createBacklogEvent(1, "message.created"), createBacklogEvent(2)],
+    });
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    expect(mocks.client.eventPage).toHaveBeenCalledWith("workspace-1", { includeTail: true });
+    expect(mocks.client.websocket).toHaveBeenCalledWith("workspace-1", "cursor-2");
+    expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
+
+    abort.abort();
+    await run;
+  });
+
   it("drains and processes every reconnect page before reopening realtime", async () => {
     const firstSocket = new FakeSocket();
     const secondSocket = new FakeSocket();

--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -154,6 +154,24 @@ describe("ClickClack HTTP client", () => {
     expect(legacyEvents).toEqual([]);
   });
 
+  it("ignores non-string tail cursors for old or malformed event pages", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        events: [{ id: "evt-1", cursor: "cursor-1" }],
+        tail_cursor: 123,
+      }),
+    );
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "test-token",
+      fetch: fetchMock,
+    });
+
+    await expect(client.eventPage("workspace-1", { includeTail: true })).resolves.toEqual({
+      events: [{ id: "evt-1", cursor: "cursor-1" }],
+    });
+  });
+
   it("sends only safe bounded request correlation", async () => {
     const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
       Response.json({ user: { id: "usr_1" } }),


### PR DESCRIPTION
Related: #102486
Related: openclaw/clickclack#46

## What

Tests-only follow-up to #102486. Adds regression coverage for two ClickClack startup paths:

1. Gateway falls back to the last startup page cursor when the server omits `tail_cursor`
2. HTTP client drops non-string `tail_cursor` values (defensive guard for malformed responses)

No production code changes.

## Why

The merged #102486 implementation depends on a server-captured `tail_cursor`, with an old-server fallback when that field is absent. These tests lock both paths so future edits cannot quietly reopen startup backlog replay.

AI-assisted. Authored by ragesaq; code by Chisel; model `openai/gpt-5.5`.

## Real Behavior Proof

### Proof 1: ClickClack-stock omits `tail_cursor`

Live call against our running ClickClack-stock instance (`:8100`), which does NOT implement `tail_cursor`:

```
GET /api/realtime/events?workspace_id=wsp_01ktq4zg9a9cj7bhah8fqnmcya&include_tail=true&limit=2

Response:
{
  "events": [
    { "cursor": "cur_01ktxqf9dczwhfw9mbxmfengga", "type": "message.updated", "seq": 1518 },
    { "cursor": "cur_01ktxqg0m56r97b77kv3cedx7t", "type": "message.created", "seq": 1519 }
  ]
}
```

**`tail_cursor`: ABSENT.** The gateway must fall back to the last event cursor (`cur_01ktxqg0m56r97b77kv3cedx7t`). This is exactly the path the new gateway test covers.

### Proof 2: HTTP client drops non-string `tail_cursor`

Exercised the production `createClickClackClient.eventPage()` against a mock server returning `tail_cursor: 123` (numeric):

```
Mock server returned: { events: [...], tail_cursor: 123 }
Client parsed result: { events: [{ id: "evt-1", cursor: "cursor-1" }] }

PASS: tailCursor omitted - typeof guard at http-client.ts:126 works
```

Positive control (string `tail_cursor: "cursor-tail-42"`): correctly preserved as `tailCursor` in the result.

### Proof 3: Server source confirms

ClickClack-stock `listEvents` handler at `server.go:833`:
```go
writeResult(w, map[string]any{"events": events}, err)
```
No `tail_cursor` field emitted. The `include_tail` query param is accepted but not used (older server). This is the production server our fleet runs against.

## Validation

```
pnpm test:extension clickclack → 64/64 passed (8 files)
pnpm tsgo:extensions → passed
pnpm check:bundled-channel-config-metadata → passed
git diff --check → clean
```

`codex review` blocked locally (CLI auth 401). No production code changed.

Anvil mutation-checked both tests (RED-on-broken): mutating fallback logic or typeof guard failed exactly the corresponding new test, confirming both are load-bearing.