### PR TITLE
fix: keep native harness bridge tool caps local

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -480,6 +480,61 @@ describe("createOpenClawCodingTools", () => {
     expectListIncludes(options.pluginToolAllowlist, ["memory_search", "memory_get"]);
   });
 
+  it("does not inherit native-harness bridge runtime allowlists", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      config: testConfig,
+      runtimeToolAllowlist: ["sessions_spawn", "memory_search"],
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    expect(latestCreateOpenClawToolsOptions().pluginToolAllowlist).toEqual([
+      "sessions_spawn",
+      "memory_search",
+    ]);
+    expect(latestCreateOpenClawToolsOptions().inheritedToolAllowlist).toEqual([]);
+  });
+
+  it("inherits embedded runtime toolsAllow when explicitly marked as parent capability", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const runtimeToolAllowlist = ["sessions_spawn", "memory_search"];
+
+    createOpenClawCodingTools({
+      config: testConfig,
+      runtimeToolAllowlist,
+      conversationCapabilityProfile: resolveConversationCapabilityProfile({
+        config: testConfig,
+        runtimeToolAllowlist,
+        inheritRuntimeToolAllowlist: true,
+      }),
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const inheritedAllow = latestCreateOpenClawToolsOptions().inheritedToolAllowlist;
+    expectListIncludes(inheritedAllow, ["sessions_spawn"]);
+    expect(inheritedAllow?.includes("read")).toBe(false);
+    expect(inheritedAllow?.includes("exec")).toBe(false);
+  });
+
+  it("lets direct restricted callers inherit runtime toolsAllow into subagent spawns", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      config: testConfig,
+      runtimeToolAllowlist: ["sessions_spawn", "read"],
+      inheritRuntimeToolAllowlist: true,
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const inheritedAllow = latestCreateOpenClawToolsOptions().inheritedToolAllowlist;
+    expectListIncludes(inheritedAllow, ["sessions_spawn", "read"]);
+    expect(inheritedAllow?.includes("exec")).toBe(false);
+  });
+
   it("preserves runtime-allowed message through restrictive profiles", () => {
     const tools = createOpenClawCodingTools({
       config: { tools: { profile: "minimal" } },

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -407,6 +407,8 @@ type OpenClawCodingToolsOptions = {
   allowGatewaySubagentBinding?: boolean;
   /** Runtime-scoped explicit allowlist used to materialize matching plugin tools. */
   runtimeToolAllowlist?: string[];
+  /** True when runtimeToolAllowlist is real parent authority that child sessions inherit. */
+  inheritRuntimeToolAllowlist?: boolean;
   /** Mutable cron creator cap ref for callers that append final runtime tools later. */
   cronCreatorToolAllowlistRef?: CronCreatorToolAllowlistEntry[];
   /** If true, the model has native vision capability */
@@ -524,6 +526,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       skillsSnapshot: options?.skillsSnapshot,
       sandboxToolPolicy,
       runtimeToolAllowlist: options?.runtimeToolAllowlist,
+      inheritRuntimeToolAllowlist: options?.inheritRuntimeToolAllowlist,
       inputProvenance: options?.inputProvenance,
       trustedInternalHandoff: options?.trustedInternalHandoff,
     });
@@ -544,6 +547,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     subagentPolicy,
     inheritedToolPolicy,
     runtimePluginToolGrant,
+    runtimeToolPolicyForInheritance,
   } = capabilityProfile.policy;
 
   const enableHeartbeatTool =
@@ -1125,6 +1129,11 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       {
         policy: subagentPolicyWithToolSearchControls,
         label: "subagent tools.allow",
+        unavailableCoreToolReason,
+      },
+      {
+        policy: runtimeToolPolicyForInheritance,
+        label: "runtime tools.allow",
         unavailableCoreToolReason,
       },
       { policy: inheritedToolPolicy, label: "inherited tools", unavailableCoreToolReason },

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -249,6 +249,34 @@ describe("resolveConversationCapabilityProfile", () => {
     }
   });
 
+  it("keeps runtime allowlists local unless the caller opts into inheritance", () => {
+    const localRuntimeProfile = resolveConversationCapabilityProfile({
+      runtimeToolAllowlist: ["sessions_spawn", "memory_search"],
+    });
+
+    expect(localRuntimeProfile.policy.explicitToolAllowlist).toEqual([
+      "sessions_spawn",
+      "memory_search",
+    ]);
+    expect(localRuntimeProfile.policy.explicitToolOverrideAllowlist).toEqual([
+      "sessions_spawn",
+      "memory_search",
+    ]);
+    expect(localRuntimeProfile.policy.runtimeToolPolicyForInheritance).toBeUndefined();
+
+    const inheritedRuntimeProfile = resolveConversationCapabilityProfile({
+      runtimeToolAllowlist: ["sessions_spawn", "memory_search"],
+      inheritRuntimeToolAllowlist: true,
+    });
+
+    expect(inheritedRuntimeProfile.policy.runtimeToolPolicyForInheritance).toEqual({
+      allow: ["sessions_spawn", "memory_search"],
+    });
+    expect(inheritedRuntimeProfile.policy.inheritancePolicies).toContain(
+      inheritedRuntimeProfile.policy.runtimeToolPolicyForInheritance,
+    );
+  });
+
   it("does not classify the conversation as shared from a dropped caller group id", () => {
     // Non-group session key cannot vouch for the caller-supplied group facts:
     // the trust check drops them, so scope must stay unknown instead of

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -77,6 +77,8 @@ export type ConversationCapabilityProfileParams = {
   skillsSnapshot?: SkillSnapshot;
   sandboxToolPolicy?: SandboxToolPolicy;
   runtimeToolAllowlist?: string[];
+  /** Persist the runtime allowlist as real parent authority on spawned children. */
+  inheritRuntimeToolAllowlist?: boolean;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
   inputProvenance?: InputProvenance;
   /** Trusted in-process completion handoff; public callers cannot set this fact. */
@@ -171,6 +173,7 @@ export type ResolvedConversationCapabilityProfile = {
     inheritedToolPolicy?: SandboxToolPolicy;
     delegated: boolean;
     requesterPolicySource: RequesterToolPolicySource;
+    runtimeToolPolicyForInheritance?: ToolPolicyLike;
     inheritancePolicies: Array<ToolPolicyLike | undefined>;
     explicitToolAllowlist: string[];
     /** Explicit config/runtime grants only; excludes built-in profile expansion. */
@@ -241,6 +244,8 @@ export function resolveConversationCapabilityProfile(
   const runtimeToolPolicy = params.runtimeToolAllowlist
     ? { allow: params.runtimeToolAllowlist }
     : undefined;
+  const runtimeToolPolicyForInheritance =
+    params.inheritRuntimeToolAllowlist === true ? runtimeToolPolicy : undefined;
   const runtimeToolAlsoAllowlist = uniqueStrings(
     (params.runtimePluginToolGrant?.toolNames ?? []).map((entry) => entry.trim()).filter(Boolean),
   );
@@ -249,12 +254,19 @@ export function resolveConversationCapabilityProfile(
     return merged.length > 0 ? merged : undefined;
   };
   const explicitOverridePolicies = [...configuredOverridePolicies, runtimeToolPolicy];
-  const inheritancePolicies = [
+  const explicitToolAllowlistPolicies = [
     profilePolicy,
     providerProfilePolicy,
     ...configuredOverridePolicies,
     inheritedToolPolicy,
     runtimeToolPolicy,
+  ];
+  const inheritancePolicies = [
+    profilePolicy,
+    providerProfilePolicy,
+    ...configuredOverridePolicies,
+    inheritedToolPolicy,
+    runtimeToolPolicyForInheritance,
   ];
 
   return {
@@ -351,10 +363,11 @@ export function resolveConversationCapabilityProfile(
       inheritedToolPolicy,
       delegated: requesterPolicies.delegated,
       requesterPolicySource: requesterPolicies.requesterPolicySource,
+      runtimeToolPolicyForInheritance,
       inheritancePolicies,
-      explicitToolAllowlist: collectExplicitAllowlist(inheritancePolicies),
+      explicitToolAllowlist: collectExplicitAllowlist(explicitToolAllowlistPolicies),
       explicitToolOverrideAllowlist: collectExplicitAllowlist(explicitOverridePolicies),
-      explicitToolDenylist: collectExplicitDenylist(inheritancePolicies),
+      explicitToolDenylist: collectExplicitDenylist(explicitToolAllowlistPolicies),
       runtimePluginToolGrant: params.runtimePluginToolGrant,
     },
   };

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -169,6 +169,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     skillsSnapshot: params.skillsSnapshot,
     sandboxToolPolicy: params.sandbox?.tools,
     runtimeToolAllowlist: effectiveToolsAllow,
+    inheritRuntimeToolAllowlist: true,
     runtimePluginToolGrant: attempt.runtimePluginToolGrant,
     inputProvenance: attempt.inputProvenance,
     trustedInternalHandoff: attempt.trustedInternalHandoff,

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -169,6 +169,7 @@ async function prepareTriggerRuntime(params: {
         allowGatewaySubagentBinding: true,
         includeCoreTools: toolPlan.includeCoreTools,
         runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
+        inheritRuntimeToolAllowlist: Boolean(toolPlan.runtimeToolAllowlist),
         toolConstructionPlan: toolPlan.codingToolConstructionPlan,
       })
     : [];


### PR DESCRIPTION
Closes #100988

## What Problem This Solves

Fixes an issue where users running a native CLI-harness parent session could spawn an embedded subagent that lost coding tools such as `read`, `write`, `exec`, `apply_patch`, and `process` because the parent bridge-visible OpenClaw tool list was persisted as the child session's inherited allowlist.

## Why This Change Was Made

Runtime tool allowlists are now local tool-surface materialization hints by default, so native harness bridge allowlists can still build/filter the tools exposed over the bridge without being persisted onto spawned child sessions. Embedded runtime `toolsAllow` and direct restricted callers such as cron opt into inheritance, preserving the non-escalation boundary for genuinely restricted parent runs.

## User Impact

CLI-harness parent sessions can delegate to embedded coding subagents without accidentally clamping those children to only gateway bridge tools. Explicit configured tool policies, inherited child policies, embedded runtime `toolsAllow`, and cron `toolsAllow` restrictions still constrain spawned sessions.

## Evidence

AI-assisted PR.

Latest head: `9d7438c96859b8b764efea8554514cffc301231d`.

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-100988-final2 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/cron/trigger-script.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/conversation-capability-profile.test.ts` -> passed, including cron 15 tests and agent/profile 87 tests on the same code path before the test-only gateway-stub type fix.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-100988-final4 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/cron/trigger-script.test.ts` -> passed 15 tests after final rebase.
- `./node_modules/.bin/oxfmt --check --threads=1 src/cron/trigger-script.test.ts src/agents/conversation-capability-profile.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/conversation-capability-profile.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/cron/trigger-script.ts` -> passed.
- `./node_modules/.bin/oxlint src/cron/trigger-script.test.ts src/agents/conversation-capability-profile.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/conversation-capability-profile.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/cron/trigger-script.ts` -> passed.
- `git diff --check` -> passed.
- GitHub `check-test-types` on previous same-code head `ecceae39d0132929042a8ad4d0fa048694c4b6d7` -> passed after the test-only type fix.

### Native Bridge Proof

A temporary stdin `pnpm exec tsx` harness imported production `resolveConversationCapabilityProfile` and `spawnSubagentDirect`, simulated a native CLI-harness parent bridge allowlist, stubbed only the final model gateway/session-store side effects, and inspected the child session patch that `sessions_spawn` persists.

```json
profile_policy {"bridgeExplicitAllowIncludesSessionsSpawn":true,"bridgeInheritanceAllowPolicies":[],"embeddedInheritanceAllowPolicies":[["sessions_spawn","read","exec"]]}
child_session_patch {"status":"accepted","childKeyShape":true,"gatewayMethods":["agent"],"inheritedToolAllow":null,"inheritedAllowClampsCodingTools":false}
```

### Restricted Cron Proof

A separate stdin `pnpm exec tsx` proof ran the real cron trigger runtime path outside Vitest on `9d7438c96859b8b764efea8554514cffc301231d`, with no `subagentSpawnTesting` override and no gateway mock. The temporary config disabled unrelated plugin loading, set cron `toolsAllow` to `["sessions_spawn", "read"]`, built the real trigger runtime, invoked the real `sessions_spawn` tool, and printed the real session-store entry after the child patch was persisted. The final gateway `agent` call intentionally targeted an unused loopback port and was not needed for the persisted child-policy proof.

```json
{
  "proof": "restricted-cron-real-runtime-no-vitest-no-gateway-mock",
  "restrictedToolsAllow": ["sessions_spawn", "read"],
  "runtimeHasSessionsSpawn": true,
  "runtimeHasRead": true,
  "runtimeHasExec": false,
  "gatewayEndpoint": "ws://127.0.0.1:9 (intentionally no listener; final agent start not awaited)",
  "persistedEntries": [
    {
      "key": "agent:main:subagent:<redacted>",
      "inheritedToolAllow": ["read", "sessions_spawn"],
      "spawnDepth": 1,
      "subagentRole": "orchestrator",
      "spawnedBy": "<redacted-present>",
      "spawnedWorkspaceDir": "<redacted-present>"
    }
  ]
}
```
