### PR TITLE
fix: detect scoped package manager installs

### DIFF
--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -115,6 +115,37 @@ describe("detectPackageManager", () => {
     });
   });
 
+  it("keeps pnpm-owned scoped global package roots without modules metadata", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-global-" }, async (base) => {
+      const globalRoot = path.join(base, "pnpm-global", "5");
+      const nodeModulesRoot = path.join(globalRoot, "node_modules");
+      const packageRoot = path.join(nodeModulesRoot, "@scope", "tool");
+      await writePublishedOpenClawRoot(packageRoot, "@scope/tool");
+      await fs.mkdir(path.join(nodeModulesRoot, ".pnpm"), { recursive: true });
+      await fs.writeFile(path.join(nodeModulesRoot, ".pnpm-workspace-state-v1.json"), "{}", "utf8");
+      await fs.writeFile(path.join(globalRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'", "utf8");
+
+      await expect(detectPackageManager(packageRoot)).resolves.toBe("pnpm");
+    });
+  });
+
+  it("keeps pnpm-owned scoped global package roots that are linked to their source", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-global-link-" }, async (base) => {
+      const globalRoot = path.join(base, "pnpm-global", "5");
+      const nodeModulesRoot = path.join(globalRoot, "node_modules");
+      const sourceRoot = path.join(base, "source");
+      const packageRoot = path.join(nodeModulesRoot, "@scope", "tool");
+      await writePublishedOpenClawRoot(sourceRoot, "@scope/tool");
+      await fs.mkdir(path.dirname(packageRoot), { recursive: true });
+      await fs.symlink(sourceRoot, packageRoot, process.platform === "win32" ? "junction" : "dir");
+      await fs.mkdir(path.join(nodeModulesRoot, ".pnpm"), { recursive: true });
+      await fs.writeFile(path.join(nodeModulesRoot, ".pnpm-workspace-state-v1.json"), "{}", "utf8");
+      await fs.writeFile(path.join(globalRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'", "utf8");
+
+      await expect(detectPackageManager(packageRoot)).resolves.toBe("pnpm");
+    });
+  });
+
   it("keeps pnpm-owned virtual-store package roots that ship npm-shrinkwrap", async () => {
     await withTempDir({ prefix: "openclaw-detect-pm-pnpm-virtual-" }, async (base) => {
       const nodeModulesRoot = path.join(base, "project", "node_modules");

--- a/src/infra/detect-package-manager.test.ts
+++ b/src/infra/detect-package-manager.test.ts
@@ -20,11 +20,11 @@ async function withPackageManagerRoot<T>(
   });
 }
 
-async function writePublishedOpenClawRoot(root: string): Promise<void> {
+async function writePublishedOpenClawRoot(root: string, name = "openclaw"): Promise<void> {
   await fs.mkdir(root, { recursive: true });
   await fs.writeFile(
     path.join(root, "package.json"),
-    JSON.stringify({ name: "openclaw", packageManager: "pnpm@11.2.2" }),
+    JSON.stringify({ name, packageManager: "pnpm@11.2.2" }),
     "utf8",
   );
   await fs.writeFile(path.join(root, "npm-shrinkwrap.json"), "{}", "utf8");
@@ -104,6 +104,17 @@ describe("detectPackageManager", () => {
     });
   });
 
+  it("keeps pnpm-owned scoped direct package roots that ship npm-shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-pnpm-scoped-" }, async (base) => {
+      const nodeModulesRoot = path.join(base, "pnpm-global", "node_modules");
+      const packageRoot = path.join(nodeModulesRoot, "@scope", "tool");
+      await writePublishedOpenClawRoot(packageRoot, "@scope/tool");
+      await fs.writeFile(path.join(nodeModulesRoot, ".modules.yaml"), "layoutVersion: 5", "utf8");
+
+      await expect(detectPackageManager(packageRoot)).resolves.toBe("pnpm");
+    });
+  });
+
   it("keeps pnpm-owned virtual-store package roots that ship npm-shrinkwrap", async () => {
     await withTempDir({ prefix: "openclaw-detect-pm-pnpm-virtual-" }, async (base) => {
       const nodeModulesRoot = path.join(base, "project", "node_modules");
@@ -127,6 +138,25 @@ describe("detectPackageManager", () => {
       await withEnvAsync({ BUN_INSTALL: bunInstall }, async () => {
         const packageRoot = path.join(bunInstall, "install", "global", "node_modules", "openclaw");
         await writePublishedOpenClawRoot(packageRoot);
+
+        await expect(detectPackageManager(packageRoot)).resolves.toBe("bun");
+      });
+    });
+  });
+
+  it("keeps bun-owned scoped global package roots that ship npm-shrinkwrap", async () => {
+    await withTempDir({ prefix: "openclaw-detect-pm-bun-scoped-" }, async (base) => {
+      const bunInstall = path.join(base, "bun-home");
+      await withEnvAsync({ BUN_INSTALL: bunInstall }, async () => {
+        const packageRoot = path.join(
+          bunInstall,
+          "install",
+          "global",
+          "node_modules",
+          "@scope",
+          "tool",
+        );
+        await writePublishedOpenClawRoot(packageRoot, "@scope/tool");
 
         await expect(detectPackageManager(packageRoot)).resolves.toBe("bun");
       });

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -60,7 +60,14 @@ async function isBunOwnedPackageRoot(root: string): Promise<boolean> {
 
 async function isPnpmOwnedPackageRoot(root: string): Promise<boolean> {
   const nodeModulesRoot = resolvePnpmNodeModulesRoot(root);
-  if (!nodeModulesRoot || !(await exists(path.join(nodeModulesRoot, ".modules.yaml")))) {
+  if (
+    !nodeModulesRoot ||
+    !(
+      (await exists(path.join(nodeModulesRoot, ".modules.yaml"))) ||
+      (await exists(path.join(nodeModulesRoot, ".pnpm"))) ||
+      (await exists(path.join(nodeModulesRoot, ".pnpm-workspace-state-v1.json")))
+    )
+  ) {
     return false;
   }
   return true;
@@ -68,7 +75,11 @@ async function isPnpmOwnedPackageRoot(root: string): Promise<boolean> {
 
 /** Detects the package manager that owns a package root from manifests, locks, and install layout. */
 export async function detectPackageManager(root: string): Promise<DetectedPackageManager | null> {
-  const pm = (await readPackageManagerSpec(root))?.split("@")[0]?.trim();
+  const realRoot = await fs.realpath(root).catch(() => root);
+  const packageManagerSpec =
+    (await readPackageManagerSpec(root)) ??
+    (path.resolve(realRoot) === path.resolve(root) ? null : await readPackageManagerSpec(realRoot));
+  const pm = packageManagerSpec?.split("@")[0]?.trim();
   const files = await fs.readdir(root).catch((): string[] => []);
   const hasNpmShrinkwrap = files.includes("npm-shrinkwrap.json");
   const hasPnpmLock = files.includes("pnpm-lock.yaml");

--- a/src/infra/detect-package-manager.ts
+++ b/src/infra/detect-package-manager.ts
@@ -24,6 +24,18 @@ function resolveBunGlobalNodeModules(): string {
   );
 }
 
+function resolveDirectNodeModulesRoot(root: string): string | null {
+  const parent = path.dirname(root);
+  if (path.basename(parent) === "node_modules") {
+    return parent;
+  }
+
+  const grandparent = path.dirname(parent);
+  return path.basename(parent).startsWith("@") && path.basename(grandparent) === "node_modules"
+    ? grandparent
+    : null;
+}
+
 function resolvePnpmNodeModulesRoot(root: string): string | null {
   const resolved = path.resolve(root);
   const parts = resolved.split(path.sep);
@@ -35,12 +47,15 @@ function resolvePnpmNodeModulesRoot(root: string): string | null {
       : path.join(layoutRoot, "node_modules");
   }
 
-  const parent = path.dirname(resolved);
-  return path.basename(parent) === "node_modules" ? parent : null;
+  return resolveDirectNodeModulesRoot(resolved);
 }
 
 async function isBunOwnedPackageRoot(root: string): Promise<boolean> {
-  return path.resolve(path.dirname(root)) === path.resolve(resolveBunGlobalNodeModules());
+  const nodeModulesRoot = resolveDirectNodeModulesRoot(path.resolve(root));
+  return (
+    nodeModulesRoot !== null &&
+    path.resolve(nodeModulesRoot) === path.resolve(resolveBunGlobalNodeModules())
+  );
 }
 
 async function isPnpmOwnedPackageRoot(root: string): Promise<boolean> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scoped packages installed under `node_modules/@scope/name` could be detected as npm-owned when those packages shipped `npm-shrinkwrap.json`, even if the surrounding install layout was owned by pnpm or Bun.

AI-assisted: yes.

## Why This Change Was Made

The package-manager detector now resolves the direct `node_modules` root for both unscoped and scoped package roots before checking pnpm ownership markers or Bun global ownership. It also recognizes pnpm global layouts that expose `.pnpm` or `.pnpm-workspace-state-v1.json` without `.modules.yaml`, and reads package metadata through the real path when pnpm global package roots are linked or junctioned to their source.

## User Impact

Scoped packages installed by pnpm or Bun can now use the correct package manager for follow-up install/update flows instead of falling back to npm solely because the package root includes `npm-shrinkwrap.json`.

## Evidence

- Branch rebased onto `origin/main` `6ec82a907af0b70eed1429f7343afb3a4b09271d`; pushed head is `6af1a283e329c0bda71aa01494cfc72b0bfb759a`.
- Final diff against `origin/main`: `src/infra/detect-package-manager.ts` and `src/infra/detect-package-manager.test.ts` only.
- `node scripts/test-projects.mjs src/infra/detect-package-manager.test.ts` - passed, 1 Vitest shard, 14 tests.
- `.\node_modules\.bin\oxlint.cmd src/infra/detect-package-manager.ts src/infra/detect-package-manager.test.ts` - passed.
- `git diff --check origin/main...HEAD` - passed.
- ACP Codex review was unavailable in this run due authentication; local Codex CLI review was attempted from the authenticated local Codex home but did not return before a 10-minute timeout, so no fresh post-rebase review result is claimed.
- Real pnpm global install proof on Windows with a temporary scoped package containing `npm-shrinkwrap.json`:

```text
command: $env:PATH = <temp>\bin;$env:PATH; pnpm --global-dir <temp>\pnpm-global --global-bin-dir <temp>\bin add -g <temp>\pkg
Already up to date
<temp>\pnpm-global\5:+ @example/scoped-pm-proof 1.0.0 <- ..\..\pkg
Done in 1.3s using pnpm v10.34.4
packageRoot: <temp>\pnpm-global\5\node_modules\@example\scoped-pm-proof
realpath: <temp>\pnpm-global\5\node_modules\@example\scoped-pm-proof
nodeModulesRoot: <temp>\pnpm-global\5\node_modules
has .pnpm marker: True
has .pnpm-workspace-state-v1.json marker: True
detectPackageManager: pnpm
```

- Bun local proof limitation: `BUN_INSTALL=<temp>\bun-home pnpm dlx bun install -g <temp>\pkg` with Bun 1.3.14 created global shims/cache but did not materialize `<temp>\bun-home\install\global\node_modules\@example\scoped-pm-proof` for detector input on this Windows host, so no Bun real-install detector result is claimed. The Bun global root shape remains covered by the focused regression test.