### PR TITLE
fix(infra): keep restart log tails UTF-16 safe

### DIFF
--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -341,6 +341,10 @@ describe("restart sentinel", () => {
     expect(trimmed?.startsWith("…")).toBe(true);
   });
 
+  it("keeps trimmed log tails UTF-16 safe", () => {
+    expect(trimLogTail("prefix🤖tail", 5)).toBe("…tail");
+  });
+
   it("formats restart messages without volatile timestamps", () => {
     const payloadA = {
       kind: "restart" as const,

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
@@ -372,5 +373,5 @@ export function trimLogTail(input?: string | null, maxChars = 8000) {
   if (text.length <= maxChars) {
     return text;
   }
-  return `…${text.slice(text.length - maxChars)}`;
+  return `…${sliceUtf16Safe(text, text.length - maxChars)}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long update or restart log tails could contain a broken character when truncation landed between the two UTF-16 code units of an emoji or another supplementary-plane character.

The malformed tail was persisted in the restart sentinel and could surface as a replacement character when operators inspected update diagnostics.

## Why This Change Was Made

This is a root-cause fix at the shared restart-log truncation boundary. It uses OpenClaw's existing surrogate-safe slicing helper while preserving the current tail budget, ellipsis, and start-index behavior.

The change does not alter restart sentinel storage, update/restart control flow, config, schema, or cleanup behavior. Open PR #101687 changes cleanup error logging in the same module but does not touch the log-tail truncation path.

## User Impact

Operators can rely on truncated restart and update diagnostics to remain valid UTF-16, including when an emoji crosses the exact tail boundary. In that boundary case, OpenClaw drops the split surrogate pair instead of persisting one invalid half; all other log-tail behavior remains unchanged.

## Evidence

The focused regression reproduced the current failure before the production change:

```text
expected '…�tail' to be '…tail'
Expected: "…tail"
Received: "…�tail"
```

After the fix, the complete restart sentinel test file passed:

```text
Test Files  1 passed (1)
Tests       28 passed (28)
```

Local E2E live proof used a real Node subprocess whose 8,007-code-unit output placed an emoji across the 8,000-unit update-log tail boundary. The production update step captured the output, the restart sentinel persisted it in SQLite, and a real OpenClaw gateway started with the same isolated state and consumed the sentinel:

```text
prepared real update-step output: length=8000 loneSurrogate=false
[gateway] http server listening (9 plugins; 16.0s)
gateway ready and restart sentinel consumed
```

Observed before gateway startup: the persisted tail was exactly 8,000 code units, began with the truncation ellipsis, retained the final `tail`, and contained no lone surrogate. Observed after startup: the gateway had consumed and cleared the sentinel.

Additional validation:

- `node_modules/.bin/oxfmt --check src/infra/restart-sentinel.ts src/infra/restart-sentinel.test.ts`
- `node scripts/run-oxlint.mjs src/infra/restart-sentinel.ts src/infra/restart-sentinel.test.ts`
- `git diff --check`

Not tested: a destructive package-manager self-update was not performed. The live proof exercised the real update subprocess boundary, SQLite restart sentinel persistence, and real gateway startup/consumption with isolated local state.
