### PR TITLE
fix(ci): align OpenAI auth contract with provider default

### DIFF
--- a/extensions/openai/provider-auth.contract.test.ts
+++ b/extensions/openai/provider-auth.contract.test.ts
@@ -1,6 +1,7 @@
 // Openai tests cover provider auth.contract plugin behavior.
 import { describeOpenAICodexProviderAuthContract } from "openclaw/plugin-sdk/provider-test-contracts";
 import { vi } from "vitest";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "./default-models.js";
 
 const loginOpenAICodexOAuthMock = vi.hoisted(() => vi.fn());
 
@@ -9,5 +10,6 @@ vi.mock("./openai-chatgpt-oauth.runtime.js", () => ({
 }));
 
 describeOpenAICodexProviderAuthContract(() => import("./index.js"), {
+  expectedCodexDefaultModel: OPENAI_CODEX_DEFAULT_MODEL,
   loginOpenAICodexOAuthMock,
 });

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -29,6 +29,7 @@ export type ProviderAuthContractPluginLoader = () => Promise<{
 }>;
 
 export type OpenAICodexProviderAuthContractOptions = {
+  expectedCodexDefaultModel: string;
   loginOpenAICodexOAuthMock: ReturnType<typeof vi.fn<LoginOpenAICodexOAuth>>;
 };
 
@@ -80,6 +81,7 @@ function buildOpenAICodexOAuthResult(params: {
   refresh: string;
   expires: number;
   email?: string;
+  defaultModel: string;
 }) {
   return {
     profiles: [
@@ -99,12 +101,12 @@ function buildOpenAICodexOAuthResult(params: {
       agents: {
         defaults: {
           models: {
-            "openai/gpt-5.5": {},
+            [params.defaultModel]: {},
           },
         },
       },
     },
-    defaultModel: "openai/gpt-5.5",
+    defaultModel: params.defaultModel,
     notes: undefined,
   };
 }
@@ -146,7 +148,7 @@ export function describeOpenAICodexProviderAuthContract(
   const state = {
     authStore: { version: 1, profiles: {} } as AuthProfileStore,
   };
-  const { loginOpenAICodexOAuthMock } = options;
+  const { expectedCodexDefaultModel, loginOpenAICodexOAuthMock } = options;
 
   describe("openai provider ChatGPT auth contract", () => {
     installSharedAuthProfileStoreHooks(state);
@@ -166,6 +168,7 @@ export function describeOpenAICodexProviderAuthContract(
           access: params.access,
           refresh: "refresh-token",
           expires: 1_700_000_000_000,
+          defaultModel: expectedCodexDefaultModel,
         }),
       );
     }
@@ -193,6 +196,7 @@ export function describeOpenAICodexProviderAuthContract(
           refresh: "refresh-token",
           expires: 1_700_000_000_000,
           email: "user@example.com",
+          defaultModel: expectedCodexDefaultModel,
         }),
       );
     });
@@ -219,6 +223,7 @@ export function describeOpenAICodexProviderAuthContract(
           refresh: "refresh-token",
           expires: 1_700_000_000_000,
           email: "jwt-user@example.com",
+          defaultModel: expectedCodexDefaultModel,
         }),
       );
     });
@@ -277,6 +282,7 @@ export function describeOpenAICodexProviderAuthContract(
           access: "not-a-jwt-token",
           refresh: "refresh-token",
           expires: 1_700_000_000_000,
+          defaultModel: expectedCodexDefaultModel,
         }),
       );
     });


### PR DESCRIPTION
Closes #103750

AI-assisted: Codex

## What Problem This Solves

Resolves a release-validation regression where Plugin Prerelease failed six OpenAI ChatGPT/Codex OAuth contract assertions after fresh Codex setups moved from GPT-5.5 to GPT-5.6 Sol.

## Why This Change Was Made

The shared provider-auth test contract now requires the owning extension to supply its expected Codex default model. The OpenAI contract passes `OPENAI_CODEX_DEFAULT_MODEL`, keeping the reusable identity/auth assertions aligned with the provider-owned default without duplicating a model literal in shared test infrastructure.

## User Impact

No production behavior changes. Maintainers can run the OpenAI plugin prerelease and full release-validation lanes without a stale GPT-5.5 test expectation cancelling the remaining extension and Docker fanout.

## Evidence

- Before: Plugin Prerelease run 29101126635 failed `checks-node-extensions-shard-7` with six identical `openai/gpt-5.5` expected vs `openai/gpt-5.6-sol` received diffs: https://github.com/openclaw/openclaw/actions/runs/29101126635/job/86390028801
- `corepack pnpm test extensions/openai/provider-auth.contract.test.ts` on Blacksmith Testbox lease `tbx_01kx68cssa6v0czk2wge2aynss`: 7/7 passed.
- `corepack pnpm test:extension openai` on the same Testbox lease: 403/403 passed across 29 files.
- `corepack pnpm check:changed` on the same Testbox lease: passed (core/extension typechecks, lint, and boundary guards).
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
- Codex contract check at sibling Codex SHA `656a2d0905c9e0b9bdade1badab07ef6d42ca17c`: `codex-rs/models-manager/models.json` places `gpt-5.6-sol` first; `codex-rs/models-manager/src/manager.rs` sorts by priority and marks the first picker-visible model as default through `codex-rs/protocol/src/openai_models.rs`.
