### PR TITLE
fix(feishu): restore websocket liveness timeout

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -469,8 +469,7 @@ describe("createFeishuWSClient proxy handling", () => {
 
     const options = firstWsClientOptions();
     expect(options.wsConfig).toEqual({
-      PingInterval: 30,
-      PingTimeout: 3,
+      pingTimeout: 3,
     });
   });
 
@@ -493,8 +492,7 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.onReconnected).toBe(onReconnected);
     expect(options.onReconnecting).toBe(onReconnecting);
     expect(options.wsConfig).toEqual({
-      PingInterval: 30,
-      PingTimeout: 3,
+      pingTimeout: 3,
     });
   });
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -23,8 +23,7 @@ const FEISHU_USER_AGENT = `openclaw-feishu-builtin/${pluginVersion}/${process.pl
 export { FEISHU_USER_AGENT };
 
 const FEISHU_WS_CONFIG = {
-  PingInterval: 30,
-  PingTimeout: 3,
+  pingTimeout: 3,
 } as const;
 
 /** User-Agent header value for all Feishu API requests. */
@@ -228,8 +227,6 @@ export async function createFeishuWSClient(
     loggerLevel: feishuClientSdk.LoggerLevel.info,
     wsConfig: FEISHU_WS_CONFIG,
     ...(agent ? { agent } : {}),
-  } as ConstructorParameters<typeof feishuClientSdk.WSClient>[0] & {
-    wsConfig: typeof FEISHU_WS_CONFIG;
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on the Feishu WebSocket channel could stop receiving messages after a half-open connection because the intended heartbeat liveness timeout was silently ignored.

## Why This Change Was Made

The existing code passed `PingInterval` and `PingTimeout`, which are server response field names rather than supported `WSClient` constructor options. This change uses the SDK's typed `pingTimeout` option, leaves ping cadence server-controlled, and removes the type assertion that previously allowed unsupported keys to bypass TypeScript validation.

## User Impact

Feishu WebSocket connections now enable the SDK's three-second post-ping liveness watchdog, allowing stale connections to enter the existing reconnect flow without any operator configuration change.

## Evidence

- Real behavior proof against the pinned `@larksuiteoapi/node-sdk@1.68.0` constructor:

  ```json
  {
    "legacyPingTimeoutSec": 0,
    "fixedPingTimeoutSec": 3,
    "legacyPingIntervalMs": 120000,
    "fixedPingIntervalMs": 120000
  }
  ```

  This shows the legacy keys left the watchdog disabled, while `pingTimeout` enables it and preserves the SDK/server-controlled ping interval.
- Feishu plugin test suite: 75 test files passed, 1,031 tests passed.
- `git diff --check`: passed.
- `codex review --base upstream/main`: no actionable findings.
- Not performed: a live forced-disconnect test against a production Feishu app. The constructor probe exercises the real pinned SDK rather than the mocked unit-test boundary.

AI-assisted: Yes. I reviewed the final diff, the pinned SDK source/types, and the validation results.
