### PR TITLE
fix(apple): prevent stale thinking after model switches and reconnects

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6691,7 +6691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 350,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "\\\"\\(trimmed)\\\"",
       "surface": "apple",
@@ -6699,7 +6699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 339,
+      "line": 350,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
@@ -22947,7 +22947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1067,
+      "line": 1184,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -22955,7 +22955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1123,
+      "line": 1240,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -272,6 +272,17 @@ struct AppleReviewDemoChatTransport: OpenClawChatTransport {
         try await self.transport.setSessionModel(sessionKey: sessionKey, model: model)
     }
 
+    func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        try await self.transport.patchSessionModel(
+            sessionKey: sessionKey,
+            agentID: agentID,
+            model: model)
+    }
+
     func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
         try await self.transport.setSessionThinking(sessionKey: sessionKey, thinkingLevel: thinkingLevel)
     }

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -493,12 +493,28 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     }
 
     func setSessionModel(sessionKey: String, model: String?) async throws {
-        let target = self.sessionTarget(for: sessionKey)
+        _ = try await self.patchSessionModel(sessionKey: sessionKey, agentID: nil, model: model)
+    }
+
+    func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        let target = self.sessionTarget(for: sessionKey, overrideAgentID: agentID)
         let json = try Self.makeSessionPatchModelParamsJSON(
             sessionKey: target.sessionKey,
             agentId: target.agentID,
             model: model)
-        _ = try await self.gateway.request(method: "sessions.patch", paramsJSON: json, timeoutSeconds: 15)
+        let response = try await self.gateway.request(
+            method: "sessions.patch",
+            paramsJSON: json,
+            timeoutSeconds: 15)
+        return try Self.decodeModelPatchResult(response)
+    }
+
+    static func decodeModelPatchResult(_ data: Data) throws -> OpenClawChatModelPatchResult {
+        try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
     }
 
     func patchSession(
@@ -809,6 +825,15 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         switch evt.event {
         case "tick":
             return .tick
+        case "sessions.changed":
+            guard let payload = evt.payload else { return nil }
+            guard let change = try? GatewayPayloadDecoding.decode(
+                payload,
+                as: OpenClawChatSessionsChangedEvent.self)
+            else {
+                return nil
+            }
+            return .sessionsChanged(change)
         case "seqGap":
             return .seqGap
         case "health":

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -61,6 +61,19 @@ struct IOSGatewayChatTransportTests {
         #expect(completion.completed)
     }
 
+    @Test func `model patch result decodes authoritative Luna thinking state`() throws {
+        let data = Data(
+            #"{"entry":{"thinkingLevel":"ultra"},"resolved":{"modelProvider":"openai","model":"gpt-5.6-luna","thinkingLevel":"max","thinkingLevels":[{"id":"off","label":"off"},{"id":"max","label":"max"}]}}"#
+                .utf8)
+
+        let result = try IOSGatewayChatTransport.decodeModelPatchResult(data)
+
+        #expect(result.modelProvider == "openai")
+        #expect(result.model == "gpt-5.6-luna")
+        #expect(result.thinkingLevel == "max")
+        #expect(result.thinkingLevels?.map(\.id) == ["off", "max"])
+    }
+
     @Test func `routing contract decodes gateway main semantics`() throws {
         let data = Data(#"{"defaultId":"Ops","mainKey":"Work","scope":"global","agents":[]}"#.utf8)
         #expect(try IOSGatewayChatTransport.decodeSessionRoutingContract(data) == "global|work|ops")
@@ -416,6 +429,30 @@ struct IOSGatewayChatTransportTests {
         default:
             Issue.record("expected .sessionMessage from session.message event, got \(String(describing: mapped))")
         }
+    }
+
+    @Test func `maps sessions changed event to authoritative refresh signal`() {
+        let payload = AnyCodable([
+            "sessionKey": AnyCodable("agent:main:main"),
+            "agentId": AnyCodable("main"),
+            "reason": AnyCodable("command-metadata"),
+        ])
+        let frame = EventFrame(
+            type: "event",
+            event: "sessions.changed",
+            payload: payload,
+            seq: 1,
+            stateversion: nil)
+
+        let mapped = IOSGatewayChatTransport.mapEventFrame(frame)
+        guard case let .sessionsChanged(change) = mapped else {
+            Issue.record("expected .sessionsChanged, got \(String(describing: mapped))")
+            return
+        }
+        #expect(change == .init(
+            sessionKey: "agent:main:main",
+            agentId: "main",
+            reason: "command-metadata"))
     }
 
     @Test func `maps chat event to chat`() {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -168,12 +168,28 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func setSessionModel(sessionKey: String, model: String?) async throws {
-        var params = self.sessionParams(for: sessionKey)
+        let target = self.sessionTarget(for: sessionKey)
+        _ = try await self.patchSessionModel(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
+            model: model)
+    }
+
+    func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        var params = ["key": AnyCodable(sessionKey)]
+        if let agentID {
+            params["agentId"] = AnyCodable(agentID)
+        }
         params["model"] = model.map(AnyCodable.init) ?? AnyCodable(NSNull())
-        _ = try await GatewayConnection.shared.request(
+        let data = try await GatewayConnection.shared.request(
             method: "sessions.patch",
             params: params,
             timeoutMs: 15000)
+        return try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
     }
 
     func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
@@ -450,6 +466,15 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
                 return .health(ok: ok)
             case "tick":
                 return .tick
+            case "sessions.changed":
+                guard let payload = evt.payload else { return nil }
+                guard let change = try? JSONDecoder().decode(
+                    OpenClawChatSessionsChangedEvent.self,
+                    from: JSONEncoder().encode(payload))
+                else {
+                    return nil
+                }
+                return .sessionsChanged(change)
             case "chat":
                 guard let payload = evt.payload else { return nil }
                 guard let chat = try? JSONDecoder().decode(
@@ -749,11 +774,13 @@ final class WebChatSwiftUIWindowController {
         OverlayPanelFactory.clearGlobalEventMonitor(&self.dismissMonitor)
     }
 
-    private static func persistedThinkingLevel() -> String? {
-        let stored = UserDefaults.standard.string(forKey: webChatThinkingLevelDefaultsKey)?
+    static func persistedThinkingLevel(defaults: UserDefaults = .standard) -> String? {
+        let stored = defaults.string(forKey: webChatThinkingLevelDefaultsKey)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard let stored, ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive"].contains(stored) else {
+        guard let stored,
+              ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max", "ultra"].contains(stored)
+        else {
             return nil
         }
         return stored

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -85,9 +85,35 @@ struct MacGatewayChatTransportMappingTests {
         let frame = EventFrame(type: "event", event: "tick", payload: nil, seq: 1, stateversion: nil)
         let mapped = MacGatewayChatTransport.mapPushToTransportEvent(.event(frame))
         #expect({
-            if case .tick = mapped { return true }
+            if case .tick = mapped {
+                return true
+            }
             return false
         }())
+    }
+
+    @Test func `sessions changed event maps to authoritative refresh signal`() {
+        let payload = OpenClawProtocol.AnyCodable([
+            "sessionKey": OpenClawProtocol.AnyCodable("agent:main:main"),
+            "agentId": OpenClawProtocol.AnyCodable("main"),
+            "reason": OpenClawProtocol.AnyCodable("command-metadata"),
+        ])
+        let frame = EventFrame(
+            type: "event",
+            event: "sessions.changed",
+            payload: payload,
+            seq: 1,
+            stateversion: nil)
+
+        let mapped = MacGatewayChatTransport.mapPushToTransportEvent(.event(frame))
+        guard case let .sessionsChanged(change) = mapped else {
+            Issue.record("expected .sessionsChanged, got \(String(describing: mapped))")
+            return
+        }
+        #expect(change == .init(
+            sessionKey: "agent:main:main",
+            agentId: "main",
+            reason: "command-metadata"))
     }
 
     @Test func `chat event maps to chat`() {
@@ -154,7 +180,9 @@ struct MacGatewayChatTransportMappingTests {
     @Test func `seq gap maps to seq gap`() {
         let mapped = MacGatewayChatTransport.mapPushToTransportEvent(.seqGap(expected: 1, received: 9))
         #expect({
-            if case .seqGap = mapped { return true }
+            if case .seqGap = mapped {
+                return true
+            }
             return false
         }())
     }

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -59,4 +59,15 @@ struct WebChatSwiftUISmokeTests {
         controller.presentAnchored(anchorProvider: anchor)
         controller.close()
     }
+
+    @Test func `max and Ultra thinking preferences survive reopen`() throws {
+        let suiteName = "WebChatSwiftUISmokeTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        for level in ["max", "ultra"] {
+            defaults.set(level, forKey: "openclaw.webchat.thinkingLevel")
+            #expect(WebChatSwiftUIWindowController.persistedThinkingLevel(defaults: defaults) == level)
+        }
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -51,6 +51,78 @@ public struct OpenClawChatModelChoice: Identifiable, Codable, Sendable, Hashable
     }
 }
 
+/// Authoritative model identity and thinking state returned by `sessions.patch(model)`.
+public struct OpenClawChatModelPatchResult: Decodable, Sendable, Equatable {
+    public let key: String?
+    public let modelProvider: String?
+    public let model: String?
+    public let thinkingLevel: String?
+    public let thinkingLevels: [OpenClawChatThinkingLevelOption]?
+
+    public init(
+        key: String? = nil,
+        modelProvider: String?,
+        model: String?,
+        thinkingLevel: String?,
+        thinkingLevels: [OpenClawChatThinkingLevelOption]? = nil)
+    {
+        self.key = key
+        self.modelProvider = modelProvider
+        self.model = model
+        self.thinkingLevel = thinkingLevel
+        self.thinkingLevels = thinkingLevels
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case entry
+        case resolved
+    }
+
+    private enum EntryKeys: String, CodingKey {
+        case modelProvider
+        case model
+        case providerOverride
+        case modelOverride
+        case thinkingLevel
+    }
+
+    private enum ResolvedKeys: String, CodingKey {
+        case modelProvider
+        case model
+        case thinkingLevel
+        case thinkingLevels
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let entry = try container.nestedContainer(keyedBy: EntryKeys.self, forKey: .entry)
+        self.key = try container.decodeIfPresent(String.self, forKey: .key)
+        let entryModelProvider = try entry.decodeIfPresent(String.self, forKey: .modelProvider)
+            ?? entry.decodeIfPresent(String.self, forKey: .providerOverride)
+        let entryModel = try entry.decodeIfPresent(String.self, forKey: .model)
+            ?? entry.decodeIfPresent(String.self, forKey: .modelOverride)
+        let entryThinkingLevel = try entry.decodeIfPresent(String.self, forKey: .thinkingLevel)
+        if container.contains(.resolved) {
+            let resolved = try container.nestedContainer(keyedBy: ResolvedKeys.self, forKey: .resolved)
+            self.modelProvider = try resolved.decodeIfPresent(String.self, forKey: .modelProvider)
+                ?? entryModelProvider
+            self.model = try resolved.decodeIfPresent(String.self, forKey: .model)
+                ?? entryModel
+            let resolvedThinkingLevel = try resolved.decodeIfPresent(String.self, forKey: .thinkingLevel)
+            self.thinkingLevel = resolvedThinkingLevel ?? entryThinkingLevel
+            self.thinkingLevels = try resolved.decodeIfPresent(
+                [OpenClawChatThinkingLevelOption].self,
+                forKey: .thinkingLevels)
+        } else {
+            self.modelProvider = entryModelProvider
+            self.model = entryModel
+            self.thinkingLevel = entryThinkingLevel
+            self.thinkingLevels = nil
+        }
+    }
+}
+
 public struct OpenClawChatSessionsDefaults: Codable, Sendable {
     public let modelProvider: String?
     public let model: String?

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -3,10 +3,23 @@ import Foundation
 public enum OpenClawChatTransportEvent: Sendable {
     case health(ok: Bool)
     case tick
+    case sessionsChanged(OpenClawChatSessionsChangedEvent)
     case chat(OpenClawChatEventPayload)
     case sessionMessage(OpenClawSessionMessageEventPayload)
     case agent(OpenClawAgentEventPayload)
     case seqGap
+}
+
+public struct OpenClawChatSessionsChangedEvent: Codable, Sendable, Equatable {
+    public let sessionKey: String?
+    public let agentId: String?
+    public let reason: String
+
+    public init(sessionKey: String?, agentId: String? = nil, reason: String) {
+        self.sessionKey = sessionKey
+        self.agentId = agentId
+        self.reason = reason
+    }
 }
 
 /// One immutable transport route used by an entire outbox flush. Route-aware
@@ -146,6 +159,10 @@ public protocol OpenClawChatTransport: Sendable {
     func deleteSession(key: String) async throws
     func forkSession(parentKey: String) async throws -> String
     func setSessionModel(sessionKey: String, model: String?) async throws
+    func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
     func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws
 
     func requestHealth(timeoutMs: Int) async throws -> Bool
@@ -305,6 +322,15 @@ extension OpenClawChatTransport {
             domain: "OpenClawChatTransport",
             code: 0,
             userInfo: [NSLocalizedDescriptionKey: "sessions.patch(model) not supported by this transport"])
+    }
+
+    public func patchSessionModel(
+        sessionKey: String,
+        agentID _: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        try await self.setSessionModel(sessionKey: sessionKey, model: model)
+        return nil
     }
 
     public func setSessionThinking(sessionKey _: String, thinkingLevel _: String) async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -160,6 +160,20 @@ extension OpenClawChatViewModel {
             self.errorText = "Reconnect to verify this message's delivery target before queueing."
             return
         }
+        // Capture the effective value only after model selection settles. Raw
+        // preferences can outlive this process, when model metadata is absent.
+        await self.waitForPendingModelPatches(
+            in: session.key,
+            canonicalSessionKey: deliverySessionKey,
+            agentID: agentID,
+            sessionRoutingContract: routingContract)
+        guard self.isCurrentSession(session) else { return }
+        let thinking = self.effectiveThinkingLevelForSend(
+            self.preferredThinkingLevel,
+            sessionKey: session.key,
+            canonicalSessionKey: deliverySessionKey,
+            agentID: agentID,
+            sessionRoutingContract: routingContract)
         let command = OpenClawChatOutboxCommand(
             id: UUID().uuidString,
             sessionKey: session.key,
@@ -175,7 +189,7 @@ extension OpenClawChatViewModel {
                     data: $0.data,
                     durationSeconds: $0.durationSeconds)
             },
-            thinking: self.effectiveThinkingLevelForSend,
+            thinking: thinking,
             createdAt: Date().timeIntervalSince1970,
             status: .queued,
             retryCount: 0,
@@ -427,7 +441,11 @@ extension OpenClawChatViewModel {
 
     // MARK: - Health
 
-    func pollHealthIfNeeded(force: Bool, sessionSnapshot: SessionSnapshot? = nil) async {
+    func pollHealthIfNeeded(
+        force: Bool,
+        sessionSnapshot: SessionSnapshot? = nil,
+        refreshSessionsOnReconnect: Bool = true) async
+    {
         if !force, let last = lastHealthPollAt, Date().timeIntervalSince(last) < 10 {
             return
         }
@@ -437,7 +455,7 @@ extension OpenClawChatViewModel {
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
                 return
             }
-            self.applyTransportHealth(ok)
+            self.applyTransportHealth(ok, refreshSessionsOnReconnect: refreshSessionsOnReconnect)
         } catch {
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
                 return
@@ -448,11 +466,20 @@ extension OpenClawChatViewModel {
 
     /// Single choke point for health updates so the offline outbox flushes
     /// exactly on the unhealthy -> healthy transition.
-    func applyTransportHealth(_ ok: Bool) {
+    func applyTransportHealth(_ ok: Bool, refreshSessionsOnReconnect: Bool = true) {
         let wasHealthy = self.healthOK
         self.healthOK = ok
+        if !ok, wasHealthy || self.hasCurrentSessionMetadata {
+            self.invalidateSessionMetadataReadiness()
+        }
         if ok, !wasHealthy {
-            self.flushOutboxIfNeeded()
+            guard self.outbox != nil else { return }
+            if self.hasCurrentSessionMetadata {
+                self.flushOutboxIfNeeded()
+            } else if refreshSessionsOnReconnect {
+                let session = self.currentSessionSnapshot()
+                Task { await self.fetchSessions(limit: 50, sessionSnapshot: session) }
+            }
         }
     }
 
@@ -460,6 +487,9 @@ extension OpenClawChatViewModel {
 
     func flushOutboxIfNeeded() {
         guard self.outbox != nil, self.healthOK else { return }
+        // Health is intentionally established before sessions.list. Replays
+        // need the current connection's model/runtime metadata first.
+        guard self.hasCurrentSessionMetadata else { return }
         guard !self.isFlushingOutbox else {
             // Coalesce triggers that land mid-pass (tap-to-retry, enqueue
             // race) so their commands are not stranded until the next
@@ -538,7 +568,11 @@ extension OpenClawChatViewModel {
             // Same ordering contract as the live send path: a run must not
             // start on a stale model while a sessions.patch(model) for its
             // session is still in flight.
-            await self.waitForPendingModelPatches(in: next.sessionKey)
+            await self.waitForPendingModelPatches(
+                in: next.sessionKey,
+                canonicalSessionKey: next.deliverySessionKey,
+                agentID: next.agentID,
+                sessionRoutingContract: next.routingContract)
             self.setOutboxState(.sending, forCommandID: next.id)
             switch await self.deliverOutboxCommand(next, outbox: outbox, routeLease: routeLease) {
             case .continueFlush:
@@ -574,7 +608,10 @@ extension OpenClawChatViewModel {
                 // explicit unsupported level after the gate changes.
                 thinking: self.effectiveThinkingLevelForSend(
                     command.thinking,
-                    sessionKey: command.sessionKey),
+                    sessionKey: command.sessionKey,
+                    canonicalSessionKey: command.deliverySessionKey,
+                    agentID: command.agentID,
+                    sessionRoutingContract: command.routingContract),
                 idempotencyKey: command.id,
                 attachments: command.attachments.map {
                     OpenClawChatAttachmentPayload(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -474,7 +474,7 @@ extension OpenClawChatViewModel {
     private func beginLiveSend(_ draft: SendDraft) -> LiveSendAttempt {
         self.errorText = nil
         let runId = UUID().uuidString
-        let storedThinkingLevel = self.thinkingLevel
+        let storedThinkingLevel = self.preferredThinkingLevel
         self.pendingRuns.insert(runId)
         self.armPendingRunTimeout(runId: runId)
         self.logDiagnostic(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -79,10 +79,18 @@ extension OpenClawChatViewModel {
         }
         let normalizedContract = sessionRoutingContract?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let routeContract: String? = if self.usesMutableContractRouting(
+            sessionKey: candidate,
+            contract: normalizedContract)
+        {
+            normalizedContract?.isEmpty == false ? normalizedContract : nil
+        } else {
+            nil
+        }
         return ModelPatchTarget(
             canonicalSessionKey: targetKey,
             agentID: targetAgentID,
-            sessionRoutingContract: normalizedContract?.isEmpty == false ? normalizedContract : nil)
+            sessionRoutingContract: routeContract)
     }
 
     func sessionEntryForThinking(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -25,6 +25,164 @@ extension OpenClawChatViewModel {
         self.contextUsageFraction = Self.chatContextUsageFraction(for: currentSession)
     }
 
+    /// Session lists publish canonical agent keys even when the UI presents `main`.
+    /// Keep visible model metadata on the same exact-then-alias read path.
+    func currentSessionEntry() -> OpenClawChatSessionEntry? {
+        self.sessions.first(where: { $0.key == self.sessionKey }) ??
+            self.sessions.first(where: {
+                self.matchesCurrentSessionKey(incoming: $0.key, current: self.sessionKey)
+            })
+    }
+
+    func currentModelPatchTarget() -> ModelPatchTarget {
+        let session = self.currentSessionSnapshot()
+        return self.modelPatchTarget(
+            sessionKey: session.key,
+            canonicalSessionKey: self.currentSessionEntry()?.key,
+            agentID: session.deliveryAgentID,
+            sessionRoutingContract: session.sessionRoutingContract)
+    }
+
+    /// Model coordination uses the immutable gateway route, never a presentation alias such as `main`.
+    func modelPatchTarget(
+        sessionKey: String,
+        canonicalSessionKey: String? = nil,
+        agentID: String?,
+        sessionRoutingContract: String?) -> ModelPatchTarget
+    {
+        let presentationKey = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let listedKey = canonicalSessionKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidate = if let listedKey, !listedKey.isEmpty {
+            listedKey
+        } else {
+            presentationKey
+        }
+        let normalizedAgentID = agentID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let routeAgentID = normalizedAgentID?.isEmpty == false ? normalizedAgentID : nil
+        let normalizedCandidate = candidate.lowercased()
+        let targetKey: String
+        let targetAgentID: String?
+        if Self.agentID(fromSessionKey: candidate) != nil || normalizedCandidate == "unknown" {
+            targetKey = candidate
+            targetAgentID = nil
+        } else if normalizedCandidate == "global" {
+            targetKey = candidate
+            targetAgentID = routeAgentID
+        } else if let routeAgentID {
+            targetKey = "agent:\(routeAgentID):\(candidate)"
+            targetAgentID = nil
+        } else {
+            targetKey = candidate
+            targetAgentID = nil
+        }
+        let normalizedContract = sessionRoutingContract?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return ModelPatchTarget(
+            canonicalSessionKey: targetKey,
+            agentID: targetAgentID,
+            sessionRoutingContract: normalizedContract?.isEmpty == false ? normalizedContract : nil)
+    }
+
+    func sessionEntryForThinking(
+        sessionKey: String,
+        canonicalSessionKey: String?,
+        agentID: String?) -> OpenClawChatSessionEntry?
+    {
+        if let canonicalSessionKey,
+           let exact = self.sessions.first(where: { $0.key == canonicalSessionKey })
+        {
+            return exact
+        }
+        if let exact = self.sessions.first(where: { $0.key == sessionKey }) {
+            return exact
+        }
+        return self.sessions.first(where: {
+            Self.matchesCurrentSessionKey(
+                incoming: $0.key,
+                current: sessionKey,
+                mainSessionKey: self.resolvedMainSessionKey,
+                activeAgentId: agentID)
+        })
+    }
+
+    func successfulModelPatchResult(
+        for target: ModelPatchTarget,
+        session: OpenClawChatSessionEntry?) -> OpenClawChatModelPatchResult?
+    {
+        guard let session,
+              let result = self.lastSuccessfulModelPatchResultsByTarget[target]
+        else { return nil }
+        let sessionModel = Self.normalizedModelIdentityComponent(session.model ?? self.sessionDefaults?.model)
+        let sessionProvider = Self.normalizedProvider(session.modelProvider ?? self.sessionDefaults?.modelProvider)
+        let resultModel = Self.normalizedModelIdentityComponent(result.model)
+        let resultProvider = Self.normalizedProvider(result.modelProvider)
+        guard resultModel == nil || resultModel == sessionModel else { return nil }
+        guard resultProvider == nil || resultProvider == sessionProvider else { return nil }
+        return result
+    }
+
+    func sessionIndexForModelState(sessionKey: String) -> Int? {
+        if let exact = self.sessions.firstIndex(where: { $0.key == sessionKey }) {
+            return exact
+        }
+        return self.sessions.firstIndex(where: {
+            self.matchesCurrentSessionKey(incoming: $0.key, current: sessionKey)
+        })
+    }
+
+    func updateCurrentSessionModel(
+        modelID: String?,
+        modelProvider: String?,
+        sessionKey: String,
+        syncSelection: Bool)
+    {
+        let existingIndex = self.sessionIndexForModelState(sessionKey: sessionKey)
+        var updated = existingIndex.map { self.sessions[$0] } ?? self.placeholderSession(key: sessionKey)
+        // Thinking metadata follows model identity; stale options must not survive a model change.
+        let preservesThinkingMetadata =
+            Self.normalizedModelIdentityComponent(updated.model) ==
+            Self.normalizedModelIdentityComponent(modelID) &&
+            Self.normalizedModelIdentityComponent(updated.modelProvider) ==
+            Self.normalizedModelIdentityComponent(modelProvider)
+        updated.modelProvider = modelProvider
+        updated.model = modelID
+        if !preservesThinkingMetadata {
+            updated.contextTokens = nil
+            updated.thinkingLevel = nil
+            updated.thinkingLevels = nil
+            updated.thinkingOptions = nil
+            updated.thinkingDefault = nil
+        }
+        if let index = existingIndex {
+            self.sessions[index] = updated
+        } else {
+            self.sessions.append(updated)
+        }
+        if syncSelection {
+            self.syncSelectedModel()
+        }
+    }
+
+    static func normalizedProvider(_ provider: String?) -> String? {
+        self.normalizedModelIdentityComponent(provider)
+    }
+
+    static func normalizedModelIdentityComponent(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    static func providerQualifiedModelSelectionID(modelID: String, provider: String) -> String {
+        let providerPrefix = "\(provider)/"
+        if modelID.hasPrefix(providerPrefix) {
+            return modelID
+        }
+        return "\(provider)/\(modelID)"
+    }
+
     public var sessionChoices: [OpenClawChatSessionEntry] {
         let now = Date().timeIntervalSince1970 * 1000
         let cutoff = now - (24 * 60 * 60 * 1000)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
@@ -5,39 +5,163 @@ import Foundation
 // extension owns collapsing them into the canonical option list.
 
 extension OpenClawChatViewModel {
-    /// `agent-command.ts` throws for explicit unsupported levels, so hidden controls must send `off`.
-    var effectiveThinkingLevelForSend: String {
-        self.effectiveThinkingLevelForSend(self.thinkingLevel)
+    func applyAdvertisedThinkingLevel(_ level: String) {
+        guard level != self.thinkingLevel else { return }
+        self.thinkingLevel = level
+        self.updateCurrentSessionThinkingLevel(level, sessionKey: self.sessionKey)
     }
 
-    func effectiveThinkingLevelForSend(_ storedLevel: String, sessionKey: String? = nil) -> String {
+    func performSelectThinkingLevel(_ level: String) async {
+        let next = Self.normalizedThinkingLevel(level) ?? "off"
+        guard next != self.preferredThinkingLevel else { return }
+
+        let sessionKey = self.sessionKey
+        self.prefersExplicitThinkingLevel = true
+        self.preferredThinkingLevel = next
+        self.thinkingLevel = next
+        self.syncThinkingLevelOptions()
+        self.updateCurrentSessionThinkingLevel(next, sessionKey: sessionKey)
+        self.onThinkingLevelChanged?(next)
+        self.nextThinkingSelectionRequestID &+= 1
+        let requestID = self.nextThinkingSelectionRequestID
+        self.latestThinkingSelectionRequestIDsBySession[sessionKey] = requestID
+        self.latestThinkingLevelsBySession[sessionKey] = next
+
+        do {
+            try await self.transport.setSessionThinking(sessionKey: sessionKey, thinkingLevel: next)
+            guard requestID == self.latestThinkingSelectionRequestIDsBySession[sessionKey] else {
+                let latest = self.latestThinkingLevelsBySession[sessionKey] ?? next
+                guard latest != next else { return }
+                try? await self.transport.setSessionThinking(sessionKey: sessionKey, thinkingLevel: latest)
+                return
+            }
+        } catch {
+            guard sessionKey == self.sessionKey,
+                  requestID == self.latestThinkingSelectionRequestIDsBySession[sessionKey]
+            else { return }
+            // Best-effort. Persisting the user's local preference matters more than a patch error here.
+        }
+    }
+
+    func updateCurrentSessionThinkingLevels(
+        _ thinkingLevels: [OpenClawChatThinkingLevelOption],
+        sessionKey: String)
+    {
+        guard let index = self.sessionIndexForModelState(sessionKey: sessionKey) else { return }
+        self.sessions[index].thinkingLevels = thinkingLevels
+        self.sessions[index].thinkingOptions = thinkingLevels.map(\.label)
+    }
+
+    func updateCurrentSessionThinkingLevel(_ thinkingLevel: String?, sessionKey: String) {
+        guard let index = self.sessionIndexForModelState(sessionKey: sessionKey) else { return }
+        self.sessions[index].thinkingLevel = thinkingLevel
+    }
+
+    /// `agent-command.ts` throws for explicit unsupported levels, so hidden controls must send `off`.
+    var effectiveThinkingLevelForSend: String {
+        self.effectiveThinkingLevelForSend(self.preferredThinkingLevel)
+    }
+
+    func effectiveThinkingLevelForSend(
+        _ storedLevel: String,
+        sessionKey: String? = nil,
+        canonicalSessionKey: String? = nil,
+        agentID: String? = nil,
+        sessionRoutingContract: String? = nil) -> String
+    {
+        let usesCurrentSession = sessionKey == nil ||
+            (sessionKey == self.sessionKey && canonicalSessionKey == nil && agentID == nil)
+        let session: OpenClawChatSessionEntry?
         let showsPicker: Bool
-        if let sessionKey, sessionKey != self.sessionKey {
+        let target: ModelPatchTarget
+        if !usesCurrentSession, let sessionKey {
+            target = self.modelPatchTarget(
+                sessionKey: sessionKey,
+                canonicalSessionKey: canonicalSessionKey,
+                agentID: agentID,
+                sessionRoutingContract: sessionRoutingContract)
             // Sessions absent from the loaded list resolve to no metadata and fail
-            // open, preserving the queued level — matches shipped flush behavior;
-            // downgrading unknown sessions to "off" would silently strip levels
-            // users explicitly queued for reasoning-capable models.
-            let session = self.sessions.first(where: { $0.key == sessionKey })
+            // open for existing levels. Ultra is new enough that an older or
+            // truncated list must use its shipped High meaning until advertised.
+            session = self.sessionEntryForThinking(
+                sessionKey: sessionKey,
+                canonicalSessionKey: canonicalSessionKey,
+                agentID: agentID)
+            guard session != nil else {
+                let fallback = self.thinkingLevelWithoutGatewayMetadata(
+                    storedLevel,
+                    target: target,
+                    session: nil)
+                return fallback == "ultra" ? "high" : (fallback ?? storedLevel)
+            }
             showsPicker = self.thinkingPickerIsAvailable(
                 for: session,
                 modelChoice: self.sessionModelChoice(for: session))
         } else {
+            session = self.currentSessionEntry()
             showsPicker = self.showsThinkingPicker
+            target = self.currentModelPatchTarget()
         }
-        return showsPicker ? storedLevel : "off"
+        guard showsPicker else { return "off" }
+        let resolved = self.resolvedThinkingLevelOptions(for: session)
+        guard resolved.isGatewayMetadata else {
+            return self.thinkingLevelWithoutGatewayMetadata(
+                storedLevel,
+                target: target,
+                session: session) ?? storedLevel
+        }
+        return Self.normalizedThinkingLevel(
+            storedLevel,
+            options: resolved.options,
+            fallback: session?.thinkingLevel) ?? storedLevel
     }
 
     func syncThinkingLevelOptions() {
-        let currentSession = self.sessions.first(where: { $0.key == self.sessionKey })
+        let currentSession = self.currentSessionEntry()
         self.showsThinkingPicker = self.thinkingPickerIsAvailable(
             for: currentSession,
             modelChoice: self.selectedModelChoice(for: currentSession))
 
-        var options = self.resolvedThinkingLevelOptions(for: currentSession).options
-        if let current = Self.normalizedThinkingLevel(thinkingLevel) {
+        let resolved = self.resolvedThinkingLevelOptions(for: currentSession)
+        var options = resolved.options
+        let target = self.currentModelPatchTarget()
+        let preferred: String? = if resolved.isGatewayMetadata {
+            Self.normalizedThinkingLevel(
+                self.preferredThinkingLevel,
+                options: options,
+                fallback: currentSession?.thinkingLevel)
+        } else {
+            self.thinkingLevelWithoutGatewayMetadata(
+                self.preferredThinkingLevel,
+                target: target,
+                session: currentSession)
+        }
+        let current = preferred ?? Self.normalizedThinkingLevel(currentSession?.thinkingLevel)
+        if let current {
+            self.applyAdvertisedThinkingLevel(current)
             options = Self.withCurrentThinkingOption(options, current: current)
         }
         self.thinkingLevelOptions = options
+    }
+
+    private func thinkingLevelWithoutGatewayMetadata(
+        _ level: String,
+        target: ModelPatchTarget,
+        session: OpenClawChatSessionEntry?) -> String?
+    {
+        let preferred = Self.normalizedThinkingLevel(level)
+        guard preferred == "ultra" else { return preferred }
+        if let patched = Self.normalizedThinkingLevel(
+            self.successfulModelPatchResult(for: target, session: session)?.thinkingLevel)
+        {
+            return patched
+        }
+        // Older gateways accept the legacy Ultra spelling as High but do not
+        // return capability metadata. Never advertise/send more than they run.
+        if self.completedModelPatchTargets.contains(target) {
+            return "high"
+        }
+        return preferred
     }
 
     private func thinkingPickerIsAvailable(
@@ -194,6 +318,8 @@ extension OpenClawChatViewModel {
             return "adaptive"
         case "max":
             return "max"
+        case "ultra":
+            return "ultra"
         case "xhigh", "extrahigh":
             return "xhigh"
         case "off", "none":
@@ -206,10 +332,43 @@ extension OpenClawChatViewModel {
             return "low"
         case "mid", "med", "medium", "thinkharder", "harder":
             return "medium"
-        case "high", "ultra", "ultrathink", "thinkhardest", "highest":
+        case "high", "ultrathink", "thinkhardest", "highest":
             return "high"
         default:
             return trimmed
+        }
+    }
+
+    static func normalizedThinkingLevel(
+        _ level: String?,
+        options: [OpenClawChatThinkingLevelOption],
+        fallback: String? = nil) -> String?
+    {
+        guard let normalized = self.normalizedThinkingLevel(level) else { return nil }
+        guard normalized == "ultra" else { return normalized }
+        let advertised = options.compactMap { self.normalizedThinkingLevel($0.id) }
+        if advertised.contains("ultra") {
+            return "ultra"
+        }
+        if let fallback = self.normalizedThinkingLevel(fallback), advertised.contains(fallback) {
+            return fallback
+        }
+        return advertised
+            .filter { $0 != "off" }
+            .max { self.thinkingLevelRank($0) < self.thinkingLevelRank($1) }
+    }
+
+    private static func thinkingLevelRank(_ level: String) -> Int {
+        switch level {
+        case "off": 0
+        case "minimal": 10
+        case "low": 20
+        case "medium", "adaptive": 30
+        case "high": 40
+        case "xhigh": 60
+        case "max": 70
+        case "ultra": 80
+        default: -1
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -12,6 +12,10 @@ extension OpenClawChatViewModel {
         case .tick:
             let context = self.currentSessionSnapshot()
             Task { await self.pollHealthIfNeeded(force: false, sessionSnapshot: context) }
+        case let .sessionsChanged(change):
+            guard change.reason == "patch" || change.reason == "command-metadata" else { return }
+            let context = self.currentSessionSnapshot()
+            Task { await self.fetchSessions(limit: 50, sessionSnapshot: context) }
         case let .chat(chat):
             self.handleChatEvent(chat)
         case let .sessionMessage(message):

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -544,10 +544,14 @@ public final class OpenClawChatViewModel {
     }
 
     private func usesMutableContractRouting(for contract: String?) -> Bool {
-        if self.usesMutableAgentRouting {
+        self.usesMutableContractRouting(sessionKey: self.sessionKey, contract: contract)
+    }
+
+    func usesMutableContractRouting(sessionKey: String, contract: String?) -> Bool {
+        if Self.agentID(fromSessionKey: sessionKey) == nil {
             return true
         }
-        let parts = self.sessionKey
+        let parts = sessionKey
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
         guard parts.count == 3 else { return false }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -15,7 +15,10 @@ public final class OpenClawChatViewModel {
     public internal(set) var messages: [OpenClawChatMessage] = []
 
     public var input: String = ""
-    public private(set) var thinkingLevel: String
+    /// Setter is module-internal for the thinking-level extension only.
+    public internal(set) var thinkingLevel: String
+    /// User intent stays stable while `thinkingLevel` follows the selected model's advertised levels.
+    var preferredThinkingLevel: String
     /// Setter is module-internal for the thinking-level extension only.
     public internal(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
     /// Setter is module-internal for the thinking-level extension only.
@@ -137,9 +140,9 @@ public final class OpenClawChatViewModel {
         didSet { self.syncContextUsageFraction() }
     }
 
-    private let prefersExplicitThinkingLevel: Bool
+    var prefersExplicitThinkingLevel: Bool
     private let onSessionChanged: (@MainActor (String) -> Void)?
-    private let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
+    let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
     private let diagnosticsLog: (@MainActor @Sendable (String) -> Void)?
     private let attachmentOwnerIsActive: @MainActor () -> Bool
 
@@ -175,6 +178,11 @@ public final class OpenClawChatViewModel {
     private var lastIssuedHistoryRequestID: UInt64 = 0
     private var latestAppliedHistoryRequestID: UInt64 = 0
     private var historyMutationGeneration: UInt64 = 0
+    private var nextSessionsFetchRequestID: UInt64 = 0
+    private var latestAppliedSessionsFetchRequestID: UInt64 = 0
+    /// Outbox replay waits for a sessions list from the current connection generation.
+    var sessionMetadataGeneration: UInt64 = 0
+    var readySessionMetadataGeneration: UInt64?
 
     @ObservationIgnored
     nonisolated(unsafe) var pendingRunTimeoutTasks: [String: Task<Void, Never>] = [:]
@@ -194,14 +202,19 @@ public final class OpenClawChatViewModel {
     // Session switches can overlap in-flight picker patches, so stale completions
     // must compare against the latest request and latest desired value for that session.
     private var nextModelSelectionRequestID: UInt64 = 0
-    private var latestModelSelectionRequestIDsBySession: [String: UInt64] = [:]
-    private var latestModelSelectionIDsBySession: [String: String] = [:]
-    private var lastSuccessfulModelSelectionIDsBySession: [String: String] = [:]
-    private var inFlightModelPatchCountsBySession: [String: Int] = [:]
-    private var modelPatchWaitersBySession: [String: [CheckedContinuation<Void, Never>]] = [:]
-    private var nextThinkingSelectionRequestID: UInt64 = 0
-    private var latestThinkingSelectionRequestIDsBySession: [String: UInt64] = [:]
-    private var latestThinkingLevelsBySession: [String: String] = [:]
+    private var latestModelSelectionRequestIDsByTarget: [ModelPatchTarget: UInt64] = [:]
+    private var lastSuccessfulModelSelectionIDsByTarget: [ModelPatchTarget: String] = [:]
+    /// Rollback and pre-refresh sends need the thinking state from the same successful model patch.
+    var lastSuccessfulModelPatchResultsByTarget: [ModelPatchTarget: OpenClawChatModelPatchResult] = [:]
+    var completedModelPatchTargets: Set<ModelPatchTarget> = []
+    private var inFlightModelPatchCountsByTarget: [ModelPatchTarget: Int] = [:]
+    private var modelPatchRevisionsByTarget: [ModelPatchTarget: UInt64] = [:]
+    private var modelPatchWaitersByTarget: [ModelPatchTarget: [CheckedContinuation<Void, Never>]] = [:]
+    @ObservationIgnored
+    private var modelPatchTailsByTarget: [ModelPatchTarget: ModelPatchTail] = [:]
+    var nextThinkingSelectionRequestID: UInt64 = 0
+    var latestThinkingSelectionRequestIDsBySession: [String: UInt64] = [:]
+    var latestThinkingLevelsBySession: [String: String] = [:]
     private var isCompacting = false
     private var lastCompactAt: Date?
     private let compactCooldown: TimeInterval = 60
@@ -209,6 +222,28 @@ public final class OpenClawChatViewModel {
     private enum SessionSwitchIntent {
         case userInitiated
         case externalSync
+    }
+
+    struct ModelPatchTarget: Hashable {
+        let canonicalSessionKey: String
+        let agentID: String?
+        let sessionRoutingContract: String?
+    }
+
+    private struct ModelSelectionRequest {
+        let id: UInt64
+        let target: ModelPatchTarget
+        let session: SessionSnapshot
+        let sessionEntryKey: String?
+        let rollbackSelectionID: String
+        let previousRequestID: UInt64?
+        let selectionID: String
+        let modelRef: String?
+    }
+
+    private struct ModelPatchTail {
+        let requestID: UInt64
+        let task: Task<Void, Never>
     }
 
     private struct BootstrapContext {
@@ -305,6 +340,7 @@ public final class OpenClawChatViewModel {
         let normalizedThinkingLevel = Self.normalizedThinkingLevel(initialThinkingLevel)
         let initialResolvedThinkingLevel = normalizedThinkingLevel ?? "off"
         self.thinkingLevel = initialResolvedThinkingLevel
+        self.preferredThinkingLevel = initialResolvedThinkingLevel
         self.thinkingLevelOptions = Self.withCurrentThinkingOption(
             Self.baseThinkingLevelOptions,
             current: initialResolvedThinkingLevel)
@@ -484,7 +520,17 @@ public final class OpenClawChatViewModel {
     }
 
     public func selectModel(_ selectionID: String) {
-        Task { await self.performSelectModel(selectionID) }
+        guard let request = self.reserveModelSelection(selectionID) else { return }
+        let previousTail = self.modelPatchTailsByTarget[request.target]?.task
+        let task = Task { [weak self] in
+            await previousTail?.value
+            guard let self else { return }
+            await self.performSelectModel(request)
+            self.finishModelPatchTail(requestID: request.id, target: request.target)
+        }
+        self.modelPatchTailsByTarget[request.target] = ModelPatchTail(
+            requestID: request.id,
+            task: task)
     }
 
     var resolvedMainSessionKey: String {
@@ -789,6 +835,7 @@ extension OpenClawChatViewModel {
             ? Self.normalizedThinkingLevel(payload.thinkingLevel)
             : nil
         if let level = appliedThinkingLevel {
+            self.preferredThinkingLevel = level
             self.thinkingLevel = level
         }
         if syncThinkingOptions || appliedThinkingLevel != nil {
@@ -895,6 +942,7 @@ extension OpenClawChatViewModel {
         self.bootstrapTask?.cancel()
         self.isLoading = true
         self.errorText = nil
+        self.invalidateSessionMetadataReadiness()
         self.healthOK = false
         self.clearPendingRuns(reason: nil)
         self.pendingToolCallsById = [:]
@@ -931,7 +979,10 @@ extension OpenClawChatViewModel {
                 for: context.historyRequest,
                 preservingOptimisticLocalMessages: false,
                 syncThinkingOptions: true)
-            await pollHealthIfNeeded(force: true, sessionSnapshot: context.session)
+            await pollHealthIfNeeded(
+                force: true,
+                sessionSnapshot: context.session,
+                refreshSessionsOnReconnect: false)
             guard self.isCurrentBootstrap(context) else { return }
             await self.fetchSessions(limit: 50, sessionSnapshot: context.session)
             guard self.isCurrentBootstrap(context) else { return }
@@ -1019,21 +1070,83 @@ extension OpenClawChatViewModel {
     }
 
     func fetchSessions(limit: Int?, sessionSnapshot: SessionSnapshot? = nil) async {
-        do {
-            let res = try await transport.listSessions(limit: limit, search: nil, archived: false)
+        self.nextSessionsFetchRequestID &+= 1
+        let sessionsFetchRequestID = self.nextSessionsFetchRequestID
+        let session = sessionSnapshot ?? self.currentSessionSnapshot()
+        let target = self.modelPatchTarget(
+            sessionKey: session.key,
+            canonicalSessionKey: self.isCurrentSession(session) ? self.currentSessionEntry()?.key : nil,
+            agentID: session.deliveryAgentID,
+            sessionRoutingContract: session.sessionRoutingContract)
+        var preservesOverlappingModelPatch = false
+        while true {
+            await self.waitForPendingModelPatches(for: target)
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
                 return
             }
+            let metadataGeneration = self.sessionMetadataGeneration
+            let modelPatchRevision = self.modelPatchRevisionsByTarget[target, default: 0]
+            let res: OpenClawChatSessionsListResponse
+            do {
+                res = try await self.transport.listSessions(limit: limit, search: nil, archived: false)
+            } catch {
+                if self.outbox != nil, self.healthOK, !self.hasCurrentSessionMetadata {
+                    self.applyTransportHealth(false)
+                }
+                return
+            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
+                return
+            }
+            guard sessionsFetchRequestID > self.latestAppliedSessionsFetchRequestID else { return }
+            // A list that straddles a patch or reconnect is stale. Retry in this
+            // owner so bootstrap cannot discard its only authoritative refresh.
+            guard metadataGeneration == self.sessionMetadataGeneration else {
+                preservesOverlappingModelPatch = false
+                continue
+            }
+            guard modelPatchRevision == self.modelPatchRevisionsByTarget[target, default: 0],
+                  self.inFlightModelPatchCountsByTarget[target] == nil
+            else {
+                preservesOverlappingModelPatch = true
+                continue
+            }
+            self.latestAppliedSessionsFetchRequestID = sessionsFetchRequestID
             let organized = OpenClawChatSessionListOrganizer.organize(res.sessions)
             self.sessions = organized
             self.sessionDefaults = res.defaults
+            if preservesOverlappingModelPatch,
+               let selectionID = self.lastSuccessfulModelSelectionIDsByTarget[target]
+            {
+                // A post-patch list retry may still carry the pre-patch row.
+                // Preserve only the route whose patch overlapped this fetch.
+                let patchResult = self.lastSuccessfulModelPatchResultsByTarget[target]
+                self.applySuccessfulModelSelection(
+                    selectionID,
+                    target: target,
+                    sessionEntryKey: patchResult?.key ?? target.canonicalSessionKey,
+                    syncSelection: false,
+                    patchResult: patchResult)
+            }
             self.hasAppliedLiveSessions = true
             self.syncSelectedModel()
-            syncThinkingLevelOptions()
-            persistSessionsToCache(organized)
-        } catch {
-            // Best-effort.
+            self.syncThinkingLevelOptions()
+            self.persistSessionsToCache(organized)
+            self.readySessionMetadataGeneration = metadataGeneration
+            if self.healthOK {
+                self.flushOutboxIfNeeded()
+            }
+            return
         }
+    }
+
+    func invalidateSessionMetadataReadiness() {
+        self.sessionMetadataGeneration &+= 1
+        self.readySessionMetadataGeneration = nil
+    }
+
+    var hasCurrentSessionMetadata: Bool {
+        self.readySessionMetadataGeneration == self.sessionMetadataGeneration
     }
 
     private func fetchModels(sessionSnapshot: SessionSnapshot? = nil) async {
@@ -1210,112 +1323,147 @@ extension OpenClawChatViewModel {
         self.startBootstrap()
     }
 
-    private func performSelectThinkingLevel(_ level: String) async {
-        let next = Self.normalizedThinkingLevel(level) ?? "off"
-        guard next != self.thinkingLevel else { return }
-
-        let sessionKey = self.sessionKey
-        self.thinkingLevel = next
-        syncThinkingLevelOptions()
-        self.updateCurrentSessionThinkingLevel(next, sessionKey: sessionKey)
-        self.onThinkingLevelChanged?(next)
-        self.nextThinkingSelectionRequestID &+= 1
-        let requestID = self.nextThinkingSelectionRequestID
-        self.latestThinkingSelectionRequestIDsBySession[sessionKey] = requestID
-        self.latestThinkingLevelsBySession[sessionKey] = next
-
-        do {
-            try await self.transport.setSessionThinking(sessionKey: sessionKey, thinkingLevel: next)
-            guard requestID == self.latestThinkingSelectionRequestIDsBySession[sessionKey] else {
-                let latest = self.latestThinkingLevelsBySession[sessionKey] ?? next
-                guard latest != next else { return }
-                try? await self.transport.setSessionThinking(sessionKey: sessionKey, thinkingLevel: latest)
-                return
-            }
-        } catch {
-            guard sessionKey == self.sessionKey,
-                  requestID == self.latestThinkingSelectionRequestIDsBySession[sessionKey]
-            else { return }
-            // Best-effort. Persisting the user's local preference matters more than a patch error here.
-        }
-    }
-
-    private func performSelectModel(_ selectionID: String) async {
+    private func reserveModelSelection(_ selectionID: String) -> ModelSelectionRequest? {
         let next = self.normalizedSelectionID(selectionID)
-        guard next != self.modelSelectionID else { return }
+        guard next != self.modelSelectionID else { return nil }
 
-        let sessionKey = self.sessionKey
+        let session = self.currentSessionSnapshot()
+        let sessionEntryKey = self.currentSessionEntry()?.key
+        let target = self.modelPatchTarget(
+            sessionKey: session.key,
+            canonicalSessionKey: sessionEntryKey,
+            agentID: session.deliveryAgentID,
+            sessionRoutingContract: session.sessionRoutingContract)
         let previous = self.modelSelectionID
-        let previousRequestID = self.latestModelSelectionRequestIDsBySession[sessionKey]
+        let rollbackSelectionID = self.lastSuccessfulModelSelectionIDsByTarget[target] ?? previous
+        let previousRequestID = self.latestModelSelectionRequestIDsByTarget[target]
         self.nextModelSelectionRequestID &+= 1
         let requestID = self.nextModelSelectionRequestID
         let nextModelRef = self.modelRef(forSelectionID: next)
-        self.latestModelSelectionRequestIDsBySession[sessionKey] = requestID
-        self.latestModelSelectionIDsBySession[sessionKey] = next
-        self.beginModelPatch(for: sessionKey)
+        self.latestModelSelectionRequestIDsByTarget[target] = requestID
+        self.beginModelPatch(for: target)
         self.modelSelectionID = next
-        syncThinkingLevelOptions()
+        self.syncThinkingLevelOptions()
         self.errorText = nil
-        defer { self.endModelPatch(for: sessionKey) }
+        return ModelSelectionRequest(
+            id: requestID,
+            target: target,
+            session: session,
+            sessionEntryKey: sessionEntryKey,
+            rollbackSelectionID: rollbackSelectionID,
+            previousRequestID: previousRequestID,
+            selectionID: next,
+            modelRef: nextModelRef)
+    }
+
+    private func performSelectModel(_ request: ModelSelectionRequest) async {
+        defer { self.endModelPatch(for: request.target) }
 
         do {
-            try await self.transport.setSessionModel(
-                sessionKey: sessionKey,
-                model: nextModelRef)
-            guard requestID == self.latestModelSelectionRequestIDsBySession[sessionKey] else {
+            let patchResult = try await self.transport.patchSessionModel(
+                sessionKey: request.target.canonicalSessionKey,
+                agentID: request.target.agentID,
+                model: request.modelRef)
+            guard request.id == self.latestModelSelectionRequestIDsByTarget[request.target] else {
                 // Keep older successful patches as rollback state, but do not replay
-                // stale UI/session state over a newer in-flight or completed selection.
-                self.lastSuccessfulModelSelectionIDsBySession[sessionKey] = next
+                // stale UI/session state over a newer queued or completed selection.
+                self.recordSuccessfulModelPatch(
+                    selectionID: request.selectionID,
+                    patchResult: patchResult,
+                    target: request.target)
                 return
             }
-            self.modelPickerStore.recordRecent(next)
+            self.applySuccessfulModelSelection(
+                request.selectionID,
+                target: request.target,
+                sessionEntryKey: patchResult?.key ?? request.sessionEntryKey,
+                syncSelection: self.isCurrentSession(request.session),
+                patchResult: patchResult)
+            self.modelPickerStore.recordRecent(request.selectionID)
             self.modelPickerRecents = self.modelPickerStore.recents
-            self.applySuccessfulModelSelection(next, sessionKey: sessionKey, syncSelection: true)
         } catch {
-            guard requestID == self.latestModelSelectionRequestIDsBySession[sessionKey] else { return }
-            self.latestModelSelectionIDsBySession[sessionKey] = previous
-            if let previousRequestID {
-                self.latestModelSelectionRequestIDsBySession[sessionKey] = previousRequestID
+            guard request.id == self.latestModelSelectionRequestIDsByTarget[request.target] else { return }
+            let rollbackSelectionID = self.lastSuccessfulModelSelectionIDsByTarget[request.target]
+                ?? request.rollbackSelectionID
+            if let previousRequestID = request.previousRequestID {
+                self.latestModelSelectionRequestIDsByTarget[request.target] = previousRequestID
             } else {
-                self.latestModelSelectionRequestIDsBySession.removeValue(forKey: sessionKey)
+                self.latestModelSelectionRequestIDsByTarget.removeValue(forKey: request.target)
             }
-            if self.lastSuccessfulModelSelectionIDsBySession[sessionKey] == previous {
+            if self.lastSuccessfulModelSelectionIDsByTarget[request.target] == rollbackSelectionID {
                 self.applySuccessfulModelSelection(
-                    previous,
-                    sessionKey: sessionKey,
-                    syncSelection: sessionKey == self.sessionKey)
+                    rollbackSelectionID,
+                    target: request.target,
+                    sessionEntryKey: request.sessionEntryKey,
+                    syncSelection: self.isCurrentSession(request.session),
+                    patchResult: self.lastSuccessfulModelPatchResultsByTarget[request.target])
             }
-            guard sessionKey == self.sessionKey else { return }
-            self.modelSelectionID = previous
-            syncThinkingLevelOptions()
+            guard self.isCurrentSession(request.session) else { return }
+            self.modelSelectionID = rollbackSelectionID
+            self.syncThinkingLevelOptions()
             self.errorText = error.localizedDescription
             chatUILogger.error("sessions.patch(model) failed \(error.localizedDescription, privacy: .public)")
         }
     }
 
-    private func beginModelPatch(for sessionKey: String) {
-        self.inFlightModelPatchCountsBySession[sessionKey, default: 0] += 1
+    private func finishModelPatchTail(requestID: UInt64, target: ModelPatchTarget) {
+        guard self.modelPatchTailsByTarget[target]?.requestID == requestID else { return }
+        self.modelPatchTailsByTarget.removeValue(forKey: target)
     }
 
-    private func endModelPatch(for sessionKey: String) {
-        let remaining = max(0, (inFlightModelPatchCountsBySession[sessionKey] ?? 0) - 1)
+    private func beginModelPatch(for target: ModelPatchTarget) {
+        self.modelPatchRevisionsByTarget[target, default: 0] &+= 1
+        self.inFlightModelPatchCountsByTarget[target, default: 0] += 1
+    }
+
+    private func endModelPatch(for target: ModelPatchTarget) {
+        self.modelPatchRevisionsByTarget[target, default: 0] &+= 1
+        let remaining = max(0, (inFlightModelPatchCountsByTarget[target] ?? 0) - 1)
         if remaining == 0 {
-            self.inFlightModelPatchCountsBySession.removeValue(forKey: sessionKey)
-            let waiters = self.modelPatchWaitersBySession.removeValue(forKey: sessionKey) ?? []
+            self.inFlightModelPatchCountsByTarget.removeValue(forKey: target)
+            let waiters = self.modelPatchWaitersByTarget.removeValue(forKey: target) ?? []
             for waiter in waiters {
                 waiter.resume()
             }
             return
         }
-        self.inFlightModelPatchCountsBySession[sessionKey] = remaining
+        self.inFlightModelPatchCountsByTarget[target] = remaining
     }
 
     /// Internal for the outbox flush, which must honor the same ordering
     /// behind in-flight model patches as the live send path.
-    func waitForPendingModelPatches(in sessionKey: String) async {
-        guard (self.inFlightModelPatchCountsBySession[sessionKey] ?? 0) > 0 else { return }
+    func waitForPendingModelPatches(
+        in sessionKey: String,
+        canonicalSessionKey: String? = nil,
+        agentID: String? = nil,
+        sessionRoutingContract: String? = nil) async
+    {
+        let target: ModelPatchTarget
+        if canonicalSessionKey == nil,
+           agentID == nil,
+           sessionRoutingContract == nil,
+           sessionKey == self.sessionKey
+        {
+            let session = self.currentSessionSnapshot()
+            target = self.modelPatchTarget(
+                sessionKey: session.key,
+                canonicalSessionKey: self.currentSessionEntry()?.key,
+                agentID: session.deliveryAgentID,
+                sessionRoutingContract: session.sessionRoutingContract)
+        } else {
+            target = self.modelPatchTarget(
+                sessionKey: sessionKey,
+                canonicalSessionKey: canonicalSessionKey,
+                agentID: agentID,
+                sessionRoutingContract: sessionRoutingContract)
+        }
+        await self.waitForPendingModelPatches(for: target)
+    }
+
+    private func waitForPendingModelPatches(for target: ModelPatchTarget) async {
+        guard (self.inFlightModelPatchCountsByTarget[target] ?? 0) > 0 else { return }
         await withCheckedContinuation { continuation in
-            self.modelPatchWaitersBySession[sessionKey, default: []].append(continuation)
+            self.modelPatchWaitersByTarget[target, default: []].append(continuation)
         }
     }
 
@@ -1342,17 +1490,27 @@ extension OpenClawChatViewModel {
             contextTokens: nil)
     }
 
-    private func syncSelectedModel() {
-        let currentSession = self.sessions.first(where: { $0.key == self.sessionKey })
+    func syncSelectedModel() {
+        let currentSession = self.currentSessionEntry()
+        let target = self.currentModelPatchTarget()
         let explicitModelID = self.normalizedModelSelectionID(
             currentSession?.model,
             provider: currentSession?.modelProvider)
+        let defaultModelID = self.normalizedModelSelectionID(
+            self.sessionDefaults?.model,
+            provider: self.sessionDefaults?.modelProvider)
+        if self.lastSuccessfulModelSelectionIDsByTarget[target] == Self.defaultModelSelectionID,
+           explicitModelID == defaultModelID
+        {
+            self.modelSelectionID = Self.defaultModelSelectionID
+            return
+        }
         if let explicitModelID {
-            self.lastSuccessfulModelSelectionIDsBySession[self.sessionKey] = explicitModelID
+            self.lastSuccessfulModelSelectionIDsByTarget[target] = explicitModelID
             self.modelSelectionID = explicitModelID
             return
         }
-        self.lastSuccessfulModelSelectionIDsBySession[self.sessionKey] = Self.defaultModelSelectionID
+        self.lastSuccessfulModelSelectionIDsByTarget[target] = Self.defaultModelSelectionID
         self.modelSelectionID = Self.defaultModelSelectionID
     }
 
@@ -1420,17 +1578,62 @@ extension OpenClawChatViewModel {
             modelID
     }
 
-    private func applySuccessfulModelSelection(_ selectionID: String, sessionKey: String, syncSelection: Bool) {
-        self.lastSuccessfulModelSelectionIDsBySession[sessionKey] = selectionID
-        let resolved = self.resolvedSessionModelIdentity(forSelectionID: selectionID)
+    private func applySuccessfulModelSelection(
+        _ selectionID: String,
+        target: ModelPatchTarget,
+        sessionEntryKey: String?,
+        syncSelection: Bool,
+        patchResult: OpenClawChatModelPatchResult? = nil)
+    {
+        self.recordSuccessfulModelPatch(
+            selectionID: selectionID,
+            patchResult: patchResult,
+            target: target)
+        if target.canonicalSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "global",
+           let targetAgentID = target.agentID,
+           targetAgentID != self.activeAgentId
+        {
+            return
+        }
+        let resolved: (modelID: String?, modelProvider: String?) = if selectionID == Self.defaultModelSelectionID {
+            (modelID: nil, modelProvider: nil)
+        } else if let model = patchResult?.model {
+            (modelID: model, modelProvider: patchResult?.modelProvider)
+        } else {
+            self.resolvedSessionModelIdentity(forSelectionID: selectionID)
+        }
+        let modelStateKey = sessionEntryKey ?? target.canonicalSessionKey
         self.updateCurrentSessionModel(
             modelID: resolved.modelID,
             modelProvider: resolved.modelProvider,
-            sessionKey: sessionKey,
+            sessionKey: modelStateKey,
             syncSelection: syncSelection)
-        if sessionKey == self.sessionKey {
-            syncThinkingLevelOptions()
+        if let thinkingLevels = patchResult?.thinkingLevels {
+            self.updateCurrentSessionThinkingLevels(thinkingLevels, sessionKey: modelStateKey)
         }
+        if syncSelection,
+           !self.prefersExplicitThinkingLevel,
+           Self.normalizedThinkingLevel(self.preferredThinkingLevel) != "ultra",
+           let thinkingLevel = Self.normalizedThinkingLevel(patchResult?.thinkingLevel)
+        {
+            self.preferredThinkingLevel = thinkingLevel
+        }
+        if let thinkingLevel = Self.normalizedThinkingLevel(patchResult?.thinkingLevel) {
+            self.updateCurrentSessionThinkingLevel(thinkingLevel, sessionKey: modelStateKey)
+        }
+        if syncSelection {
+            self.syncThinkingLevelOptions()
+        }
+    }
+
+    private func recordSuccessfulModelPatch(
+        selectionID: String,
+        patchResult: OpenClawChatModelPatchResult?,
+        target: ModelPatchTarget)
+    {
+        self.lastSuccessfulModelSelectionIDsByTarget[target] = selectionID
+        self.lastSuccessfulModelPatchResultsByTarget[target] = patchResult
+        self.completedModelPatchTargets.insert(target)
     }
 
     private func resolvedSessionModelIdentity(forSelectionID selectionID: String)
@@ -1443,59 +1646,5 @@ extension OpenClawChatViewModel {
             return (choice.modelID, Self.normalizedProvider(choice.provider))
         }
         return (modelRef, nil)
-    }
-
-    private static func normalizedProvider(_ provider: String?) -> String? {
-        self.normalizedModelIdentityComponent(provider)
-    }
-
-    private static func normalizedModelIdentityComponent(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let trimmed, !trimmed.isEmpty else { return nil }
-        return trimmed
-    }
-
-    private static func providerQualifiedModelSelectionID(modelID: String, provider: String) -> String {
-        let providerPrefix = "\(provider)/"
-        if modelID.hasPrefix(providerPrefix) {
-            return modelID
-        }
-        return "\(provider)/\(modelID)"
-    }
-
-    private func updateCurrentSessionThinkingLevel(_ thinkingLevel: String?, sessionKey: String) {
-        guard let index = sessions.firstIndex(where: { $0.key == sessionKey }) else { return }
-        self.sessions[index].thinkingLevel = thinkingLevel
-    }
-
-    private func updateCurrentSessionModel(
-        modelID: String?,
-        modelProvider: String?,
-        sessionKey: String,
-        syncSelection: Bool)
-    {
-        var updated = self.sessions.first(where: { $0.key == sessionKey })
-            ?? self.placeholderSession(key: sessionKey)
-        // Thinking metadata follows model identity; stale options must not survive a model change.
-        let preservesThinkingMetadata =
-            Self.normalizedModelIdentityComponent(updated.model) ==
-            Self.normalizedModelIdentityComponent(modelID) &&
-            Self.normalizedModelIdentityComponent(updated.modelProvider) ==
-            Self.normalizedModelIdentityComponent(modelProvider)
-        updated.modelProvider = modelProvider
-        updated.model = modelID
-        if !preservesThinkingMetadata {
-            updated.thinkingLevels = nil
-            updated.thinkingOptions = nil
-            updated.thinkingDefault = nil
-        }
-        if let index = sessions.firstIndex(where: { $0.key == sessionKey }) {
-            self.sessions[index] = updated
-        } else {
-            self.sessions.append(updated)
-        }
-        if syncSelection {
-            self.syncSelectedModel()
-        }
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -108,6 +108,14 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
         return true
     }
 
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        OpenClawChatSessionsListResponse(ts: nil, path: nil, count: 0, defaults: nil, sessions: [])
+    }
+
     func acquireOutboxRouteLease() async -> OpenClawChatTransportRouteLeaseResult {
         guard self.durableOutboxAvailable else {
             return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -47,10 +47,13 @@ private actor OutboxTransportState {
     var sendResponseErrors = false
     var sendRoutingChanged = false
     var historyFails = false
+    var sessionListFails = false
     var historyRequestCount = 0
     var heldSendGate: DeleteGate?
     var commandListGate: DeleteGate?
     let commandListStarted = DeleteGate()
+    var sessionListGate: DeleteGate?
+    let sessionListStarted = DeleteGate()
     var staleHistoryRows: [AnyCodable]?
 
     func setHeldSendGate(_ gate: DeleteGate?) {
@@ -72,6 +75,17 @@ private actor OutboxTransportState {
         }
     }
 
+    func setSessionListGate(_ gate: DeleteGate?) {
+        self.sessionListGate = gate
+    }
+
+    func awaitSessionListGate() async {
+        await self.sessionListStarted.open()
+        if let sessionListGate {
+            await sessionListGate.wait()
+        }
+    }
+
     func setStaleHistoryRows(_ rows: [AnyCodable]?) {
         self.staleHistoryRows = rows
     }
@@ -90,6 +104,10 @@ private actor OutboxTransportState {
 
     func setHistoryFails(_ fails: Bool) {
         self.historyFails = fails
+    }
+
+    func setSessionListFails(_ fails: Bool) {
+        self.sessionListFails = fails
     }
 
     func recordHistoryRequest(agentID: String?) {
@@ -358,12 +376,18 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
     /// Gated model patch: `setSessionModel` blocks until `releaseModelPatch`
     /// so tests can hold a patch in flight while the outbox flushes.
     private let modelPatchGate = AsyncStream<Void>.makeStream()
+    private let modelPatchStarted = DeleteGate()
 
     func releaseModelPatch() {
         self.modelPatchGate.continuation.yield(())
     }
 
+    func waitUntilModelPatchStarted() async {
+        await self.modelPatchStarted.wait()
+    }
+
     func setSessionModel(sessionKey _: String, model _: String?) async throws {
+        await self.modelPatchStarted.open()
         var iterator = self.modelPatchGate.stream.makeAsyncIterator()
         _ = await iterator.next()
     }
@@ -373,7 +397,9 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
         search _: String?,
         archived _: Bool) async throws -> OpenClawChatSessionsListResponse
     {
-        OpenClawChatSessionsListResponse(
+        await self.state.awaitSessionListGate()
+        guard await !self.state.sessionListFails else { throw OutboxSendError() }
+        return OpenClawChatSessionsListResponse(
             ts: nil,
             path: nil,
             count: self.sessions.count,
@@ -823,6 +849,26 @@ struct ChatViewModelOutboxTests {
         #expect(await transport.state.sentMessages.isEmpty)
     }
 
+    @Test func `offline queue persists the effective thinking level`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let sessions = [outboxSessionEntry(key: "main", thinkingLevels: ["off"])]
+        let transport = OutboxTestTransport(healthy: false, sessions: sessions)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        await MainActor.run {
+            vm.sessions = sessions
+            vm.preferredThinkingLevel = "ultra"
+            vm.syncThinkingLevelOptions()
+        }
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+
+        try await sendWhileOffline(vm, text: "persist the send-safe level")
+        #expect(await store.loadCommands().map(\.thinking) == ["off"])
+    }
+
     @Test func `inert outbox does not capability gate healthy live chat`() async throws {
         let url = try makeOutboxDatabaseURL()
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
@@ -969,6 +1015,79 @@ struct ChatViewModelOutboxTests {
         #expect(await store.loadTranscript(sessionKey: sessionKey, agentID: "agent-a")
             .map { $0.content.compactMap(\.text).joined() } == ["for agent A"])
         #expect(await store.loadTranscript(sessionKey: sessionKey, agentID: "agent-b").isEmpty)
+    }
+
+    @Test func `reconnect waits for canonical session metadata before flushing Ultra`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        #expect(await store.enqueueCommand(OpenClawChatOutboxCommand(
+            id: "alpha-ultra",
+            sessionKey: "main",
+            deliverySessionKey: "agent:alpha:main",
+            routingContract: "per-sender|main|main",
+            agentID: "alpha",
+            text: "use canonical Luna metadata",
+            thinking: "ultra",
+            createdAt: Date().timeIntervalSince1970,
+            status: .queued,
+            retryCount: 0,
+            lastError: nil)))
+        let listGate = DeleteGate()
+        let sessions = [
+            outboxSessionEntry(key: "agent:alpha:main", thinkingLevels: ["off", "max"]),
+            outboxSessionEntry(key: "agent:beta:main", thinkingLevels: ["off", "ultra"]),
+        ]
+        let transport = OutboxTestTransport(healthy: false, sessions: sessions)
+        await transport.state.setSessionListGate(listGate)
+        let vm = await makeOutboxViewModel(
+            transport: transport,
+            outbox: store,
+            sessionKey: "main",
+            activeAgentID: "beta")
+
+        await MainActor.run { vm.load() }
+        await transport.goOnline()
+        await transport.state.sessionListStarted.wait()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await transport.state.sentMessages.isEmpty)
+        #expect(await store.loadCommands().map(\.status) == [.queued])
+
+        await listGate.open()
+        try await waitUntil("canonical Alpha command flushes after list metadata") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentSessionKeys == ["agent:alpha:main"])
+        #expect(await transport.state.sentAgentIDs == ["alpha"])
+        #expect(await transport.state.sentThinkingLevels == ["max"])
+    }
+
+    @Test func `reconnect retries metadata after a transient session list failure`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        #expect(await store.enqueueCommand(outboxTestCommand(
+            id: "retry-metadata",
+            text: "send after retry",
+            createdAt: Date().timeIntervalSince1970)))
+        let transport = OutboxTestTransport(healthy: false)
+        await transport.state.setSessionListFails(true)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        await transport.goOnline()
+        await transport.state.sessionListStarted.wait()
+        try await waitUntil("failed metadata fetch returns to unhealthy") {
+            await MainActor.run { !vm.healthOK }
+        }
+        #expect(await store.loadCommands().map(\.status) == [.queued])
+
+        await transport.state.setSessionListFails(false)
+        await transport.goOnline()
+        try await waitUntil("next healthy transition retries metadata and drains") {
+            await store.loadCommands().isEmpty
+        }
+        #expect(await transport.state.sentMessages == ["send after retry"])
     }
 
     @Test func `unscoped opaque peer ID preserves case in its durable target`() async throws {
@@ -1916,7 +2035,9 @@ private actor DeleteGate {
     }
 
     func wait() async {
-        if self.isOpen { return }
+        if self.isOpen {
+            return
+        }
         await withCheckedContinuation { self.waiters.append($0) }
     }
 }
@@ -2130,6 +2251,7 @@ extension ChatViewModelOutboxTests {
         // must honor the same ordering as live sends and hold until the
         // patch resolves, or the run would start on the stale model.
         await MainActor.run { vm.selectModel("anthropic/claude-test") }
+        await transport.waitUntilModelPatchStarted()
         await transport.goOnline()
         try await Task.sleep(nanoseconds: 100_000_000)
         #expect(await transport.state.sentMessages.isEmpty)
@@ -2139,6 +2261,30 @@ extension ChatViewModelOutboxTests {
             await store.loadCommands().isEmpty
         }
         #expect(await transport.state.sentMessages == ["after the model change"])
+    }
+
+    @Test func `offline enqueue waits for a truly in-flight model patch`() async throws {
+        let url = try makeOutboxDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
+        let transport = OutboxTestTransport(healthy: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+
+        await MainActor.run { vm.load() }
+        await MainActor.run {
+            vm.selectModel("anthropic/claude-test")
+            vm.input = "enqueue after model patch"
+            vm.send()
+        }
+        await transport.waitUntilModelPatchStarted()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await store.loadCommands().isEmpty)
+
+        transport.releaseModelPatch()
+        try await waitUntil("enqueue resumes after model patch") {
+            await store.loadCommands().map(\.text) == ["enqueue after model patch"]
+        }
+        #expect(await transport.state.sentMessages.isEmpty)
     }
 
     @Test func `live send after reconnect queues behind draining outbox rows`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -6981,6 +6981,101 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-beta")
     }
 
+    @Test func `routing contract change preserves model patch ordering for one canonical session`() async throws {
+        let firstPatchGate = AsyncGate()
+        let sessionKey = "agent:alpha:thread"
+        let sessions = sessionsResponse(
+            sessionEntry(key: sessionKey, updatedAt: 1, model: nil))
+        let models = [
+            modelChoice(id: "model-a", name: "Model A", provider: "openai"),
+            modelChoice(id: "model-b", name: "Model B", provider: "openai"),
+        ]
+        let (transport, vm) = await makeViewModel(
+            sessionKey: sessionKey,
+            activeAgentId: "alpha",
+            historyResponses: [historyPayload(sessionKey: sessionKey, sessionId: "sess-thread")],
+            sessionRoutingContract: "per-sender|main|alpha",
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                if model == "openai/model-a" {
+                    await firstPatchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-thread")
+        await MainActor.run { vm.selectModel("openai/model-a") }
+        try await waitUntil("first model patch starts") {
+            await transport.patchedModels() == ["openai/model-a"]
+        }
+
+        await MainActor.run {
+            vm.syncSessionRoutingContract("per-sender|work|alpha")
+            vm.selectModel("openai/model-b")
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await transport.patchedModels() == ["openai/model-a"])
+
+        await firstPatchGate.open()
+        try await waitUntil("second model patch follows the first") {
+            await transport.patchedModels() == ["openai/model-a", "openai/model-b"]
+        }
+        await vm.waitForPendingModelPatches(in: sessionKey)
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/model-b")
+    }
+
+    @Test func `contract-sensitive route change keeps replacement model patch independent`() async throws {
+        let firstPatchGate = AsyncGate()
+        let sessionKey = "agent:alpha:work"
+        let sessions = sessionsResponse(
+            sessionEntry(key: sessionKey, updatedAt: 1, model: nil))
+        let models = [
+            modelChoice(id: "model-a", name: "Model A", provider: "openai"),
+            modelChoice(id: "model-b", name: "Model B", provider: "openai"),
+        ]
+        let oldContract = "global|work|alpha"
+        let newContract = "per-sender|work|alpha"
+        let (transport, vm) = await makeViewModel(
+            sessionKey: sessionKey,
+            activeAgentId: "alpha",
+            historyResponses: [
+                historyPayload(sessionKey: sessionKey, sessionId: "sess-old"),
+                historyPayload(sessionKey: sessionKey, sessionId: "sess-new"),
+            ],
+            sessionRoutingContract: oldContract,
+            sessionsResponses: [sessions, sessions],
+            modelResponses: [models, models],
+            setSessionModelHook: { model in
+                if model == "openai/model-a" {
+                    await firstPatchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-old")
+        await MainActor.run { vm.selectModel("openai/model-a") }
+        try await waitUntil("old-route model patch starts") {
+            await transport.patchedModels() == ["openai/model-a"]
+        }
+
+        await MainActor.run { vm.syncSessionRoutingContract(newContract) }
+        try await waitUntil("replacement route bootstraps") {
+            await MainActor.run { vm.sessionId == "sess-new" }
+        }
+        await MainActor.run { vm.selectModel("openai/model-b") }
+        try await waitUntil("replacement route model patch completes") {
+            await transport.patchedModels() == ["openai/model-a", "openai/model-b"]
+        }
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/model-b")
+
+        await firstPatchGate.open()
+        await vm.waitForPendingModelPatches(
+            in: sessionKey,
+            canonicalSessionKey: sessionKey,
+            agentID: nil,
+            sessionRoutingContract: oldContract)
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/model-b")
+    }
+
     @Test func `late model completion does not replay current session selection into previous session`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let initialSessions = OpenClawChatSessionsListResponse(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -144,7 +144,10 @@ private func sessionEntry(
     thinkingLevel: String? = nil,
     thinkingLevels: [OpenClawChatThinkingLevelOption]? = nil,
     thinkingOptions: [String]? = nil,
-    thinkingDefault: String? = nil) -> OpenClawChatSessionEntry
+    thinkingDefault: String? = nil,
+    totalTokens: Int? = nil,
+    totalTokensFresh: Bool? = nil,
+    contextTokens: Int? = nil) -> OpenClawChatSessionEntry
 {
     OpenClawChatSessionEntry(
         key: key,
@@ -162,10 +165,11 @@ private func sessionEntry(
         verboseLevel: nil,
         inputTokens: nil,
         outputTokens: nil,
-        totalTokens: nil,
+        totalTokens: totalTokens,
+        totalTokensFresh: totalTokensFresh,
         modelProvider: modelProvider,
         model: model,
-        contextTokens: nil,
+        contextTokens: contextTokens,
         thinkingLevels: thinkingLevels,
         thinkingOptions: thinkingOptions,
         thinkingDefault: thinkingDefault)
@@ -221,6 +225,7 @@ private func makeViewModel(
     sessionRoutingContract: String? = nil,
     sessionsResponses: [OpenClawChatSessionsListResponse] = [],
     modelResponses: [[OpenClawChatModelChoice]] = [],
+    modelPatchResults: [OpenClawChatModelPatchResult?] = [],
     commandResponses: [[OpenClawChatCommandChoice]] = [],
     requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
     historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
@@ -255,6 +260,7 @@ private func makeViewModel(
         historyResponses: historyResponses,
         sessionsResponses: sessionsResponses,
         modelResponses: modelResponses,
+        modelPatchResults: modelPatchResults,
         commandResponses: commandResponses,
         requestHistoryHook: requestHistoryHook,
         historyResponseHook: historyResponseHook,
@@ -508,6 +514,7 @@ private actor TestChatTransportState {
     var abortedRunIds: [String] = []
     var waitCompletionRunIds: [String] = []
     var patchedModels: [String?] = []
+    var patchedModelTargets: [(sessionKey: String, agentID: String?)] = []
     var patchedThinkingLevels: [String] = []
     var listSessionsQueries: [TestSessionListQuery] = []
     var renamedLabelsByKey: [(key: String, label: String)] = []
@@ -520,6 +527,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let historyResponses: [OpenClawChatHistoryPayload]
     private let sessionsResponses: [OpenClawChatSessionsListResponse]
     private let modelResponses: [[OpenClawChatModelChoice]]
+    private let modelPatchResults: [OpenClawChatModelPatchResult?]
     private let commandResponses: [[OpenClawChatCommandChoice]]
     private let requestHistoryHook: (@Sendable (String) async throws -> Void)?
     private let historyResponseHook:
@@ -547,6 +555,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         historyResponses: [OpenClawChatHistoryPayload],
         sessionsResponses: [OpenClawChatSessionsListResponse] = [],
         modelResponses: [[OpenClawChatModelChoice]] = [],
+        modelPatchResults: [OpenClawChatModelPatchResult?] = [],
         commandResponses: [[OpenClawChatCommandChoice]] = [],
         requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
         historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
@@ -569,6 +578,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.historyResponses = historyResponses
         self.sessionsResponses = sessionsResponses
         self.modelResponses = modelResponses
+        self.modelPatchResults = modelPatchResults
         self.commandResponses = commandResponses
         self.requestHistoryHook = requestHistoryHook
         self.historyResponseHook = historyResponseHook
@@ -751,11 +761,29 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         return self.commandResponses.last ?? []
     }
 
-    func setSessionModel(sessionKey _: String, model: String?) async throws {
-        await self.state.patchedModelsAppend(model)
+    func setSessionModel(sessionKey: String, model: String?) async throws {
+        _ = try await self.patchSessionModel(sessionKey: sessionKey, agentID: nil, model: model)
+    }
+
+    func patchSessionModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) async throws -> OpenClawChatModelPatchResult?
+    {
+        let index = await self.state.recordPatchedModel(
+            sessionKey: sessionKey,
+            agentID: agentID,
+            model: model)
         if let setSessionModelHook {
             try await setSessionModelHook(model)
         }
+        if index < self.modelPatchResults.count {
+            return self.modelPatchResults[index]
+        }
+        if let last = self.modelPatchResults.last {
+            return last
+        }
+        return nil
     }
 
     func resetSession(sessionKey: String) async throws {
@@ -838,6 +866,10 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         await self.state.patchedModels
     }
 
+    func patchedModelTargets() async -> [(sessionKey: String, agentID: String?)] {
+        await self.state.patchedModelTargets
+    }
+
     func activeSessionKeys() async -> [String] {
         await self.state.activeSessionKeys
     }
@@ -893,7 +925,7 @@ extension TestChatTransportState {
         return self.historyCallCount
     }
 
-    fileprivate func nextSessionsCallIndex() -> Int {
+    private func nextSessionsCallIndex() -> Int {
         defer { self.sessionsCallCount += 1 }
         return self.sessionsCallCount
     }
@@ -942,8 +974,15 @@ extension TestChatTransportState {
         self.sentThinkingLevels.append(v)
     }
 
-    fileprivate func patchedModelsAppend(_ v: String?) {
-        self.patchedModels.append(v)
+    fileprivate func recordPatchedModel(
+        sessionKey: String,
+        agentID: String?,
+        model: String?) -> Int
+    {
+        let index = self.patchedModels.count
+        self.patchedModels.append(model)
+        self.patchedModelTargets.append((sessionKey: sessionKey, agentID: agentID))
+        return index
     }
 
     fileprivate func patchedThinkingLevelsAppend(_ v: String) {
@@ -981,7 +1020,6 @@ extension TestChatTransportState {
     fileprivate func sentMessagesAppend(_ v: String) {
         self.sentMessages.append(v)
     }
-
 
     fileprivate func renamedLabelsAppend(key: String, label: String) {
         self.renamedLabelsByKey.append((key: key, label: label))
@@ -1738,7 +1776,9 @@ struct ChatViewModelTests {
             historyResponses: [firstHistory, replacementHistory],
             requestHistoryHook: { _ in
                 let call = await historyCalls.increment()
-                if call == 1 { await firstHistoryGate.wait() }
+                if call == 1 {
+                    await firstHistoryGate.wait()
+                }
             })
 
         await MainActor.run { vm.load() }
@@ -5311,7 +5351,7 @@ struct ChatViewModelTests {
             count: 1,
             defaults: nil,
             sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
+                sessionEntry(key: "agent:main:main", updatedAt: now, model: nil),
             ])
         let models = [
             modelChoice(
@@ -5384,6 +5424,54 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "main" })?.model } == "gpt-5.4-pro")
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "main" })?.modelProvider } == "openai")
         #expect(modelPickerStore.recents == ["openai/gpt-5.4-pro"])
+    }
+
+    @Test func `distinct model patches are serialized in selection order`() async throws {
+        let firstPatchGate = AsyncGate()
+        let now = Date().timeIntervalSince1970 * 1000
+        let sessions = sessionsResponse(sessionEntry(key: "main", updatedAt: now, model: nil))
+        let models = [
+            modelChoice(id: "gpt-first", name: "First", provider: "openai"),
+            modelChoice(id: "gpt-second", name: "Second", provider: "openai"),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            modelPatchResults: [
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-first",
+                    thinkingLevel: "high"),
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-second",
+                    thinkingLevel: "medium"),
+            ],
+            setSessionModelHook: { model in
+                if model == "openai/gpt-first" {
+                    await firstPatchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await MainActor.run {
+            vm.selectModel("openai/gpt-first")
+            vm.selectModel("openai/gpt-second")
+        }
+        try await waitUntil("first model patch starts") {
+            await transport.patchedModels() == ["openai/gpt-first"]
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await transport.patchedModels() == ["openai/gpt-first"])
+
+        await firstPatchGate.open()
+        try await waitUntil("second model patch follows first") {
+            await transport.patchedModels() == ["openai/gpt-first", "openai/gpt-second"]
+        }
+        await vm.waitForPendingModelPatches(in: "main")
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-second")
+        #expect(await MainActor.run { vm.sessions.first?.model } == "gpt-second")
     }
 
     @Test func `send waits for in flight model patch to finish`() async throws {
@@ -5538,6 +5626,55 @@ struct ChatViewModelTests {
         }
 
         #expect(await transport.patchedModels() == ["openai/gpt-5.4", "openai/gpt-5.4-pro"])
+    }
+
+    @Test func `two failed queued model patches restore the confirmed model`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: now,
+                model: "gpt-original",
+                modelProvider: "openai"))
+        let models = [
+            modelChoice(id: "gpt-original", name: "Original", provider: "openai"),
+            modelChoice(id: "gpt-first", name: "First", provider: "openai"),
+            modelChoice(id: "gpt-second", name: "Second", provider: "openai"),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                guard model == "openai/gpt-first" || model == "openai/gpt-second" else { return }
+                throw NSError(
+                    domain: "test",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "patch failed"])
+            })
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await MainActor.run {
+            vm.selectModel("openai/gpt-first")
+            vm.selectModel("openai/gpt-second")
+        }
+
+        try await waitUntil("both queued patches fail back to the confirmed model") {
+            let patched = await transport.patchedModels()
+            let selectionID = await MainActor.run { vm.modelSelectionID }
+            return patched == ["openai/gpt-first", "openai/gpt-second"] &&
+                selectionID == "openai/gpt-original"
+        }
+        #expect(await MainActor.run { vm.sessions.first?.model } == "gpt-original")
+
+        await MainActor.run { vm.selectModel("openai/gpt-first") }
+        try await waitUntil("failed optimistic model remains retryable") {
+            await transport.patchedModels() == [
+                "openai/gpt-first",
+                "openai/gpt-second",
+                "openai/gpt-first",
+            ]
+        }
     }
 
     @Test @MainActor func `switch session notifies session changed callback`() async throws {
@@ -6666,6 +6803,184 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "other" })?.model } == nil)
     }
 
+    @Test func `late model patch updates captured canonical alias after agent switch`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let sessions = OpenClawChatSessionsListResponse(
+            ts: now,
+            path: nil,
+            count: 1,
+            defaults: nil,
+            sessions: [
+                sessionEntry(key: "agent:alpha:main", updatedAt: now, model: nil),
+            ])
+        let models = [
+            modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
+        ]
+
+        let (transport, vm) = await makeViewModel(
+            activeAgentId: "alpha",
+            historyResponses: [
+                historyPayload(sessionKey: "main", sessionId: "sess-main"),
+                historyPayload(sessionKey: "main", sessionId: "sess-beta"),
+            ],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                if model == "openai/gpt-5.4" {
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        await MainActor.run { vm.selectModel("openai/gpt-5.4") }
+        try await waitUntil("main session model patch starts") {
+            await transport.patchedModels() == ["openai/gpt-5.4"]
+        }
+
+        await MainActor.run { vm.syncActiveAgentId("beta") }
+        try await waitUntil("late patch updates canonical main row") {
+            await MainActor.run {
+                vm.sessions.first(where: { $0.key == "agent:alpha:main" })?.model == "gpt-5.4"
+            }
+        }
+
+        #expect(await MainActor.run { vm.sessions.contains(where: { $0.key == "main" }) } == false)
+        #expect(await MainActor.run { vm.activeAgentId } == "beta")
+        #expect(await MainActor.run { vm.modelSelectionID } == OpenClawChatViewModel.defaultModelSelectionID)
+        let targets = await transport.patchedModelTargets()
+        #expect(targets.count == 1)
+        #expect(targets.first?.sessionKey == "agent:alpha:main")
+        #expect(targets.first?.agentID == nil)
+    }
+
+    @Test func `Alpha model patch does not suppress Beta bootstrap session list`() async throws {
+        let patchGate = AsyncGate()
+        let now = Date().timeIntervalSince1970 * 1000
+        let alphaSessions = sessionsResponse(
+            sessionEntry(
+                key: "agent:alpha:main",
+                updatedAt: now,
+                model: "gpt-alpha",
+                modelProvider: "openai"))
+        let betaSessions = sessionsResponse(
+            sessionEntry(
+                key: "agent:beta:main",
+                updatedAt: now + 1,
+                model: "gpt-beta",
+                modelProvider: "openai"))
+        let models = [
+            modelChoice(id: "gpt-alpha-next", name: "Alpha Next", provider: "openai"),
+            modelChoice(id: "gpt-beta", name: "Beta", provider: "openai"),
+        ]
+        let (transport, vm) = await makeViewModel(
+            activeAgentId: "alpha",
+            historyResponses: [
+                historyPayload(sessionKey: "main", sessionId: "sess-alpha"),
+                historyPayload(sessionKey: "main", sessionId: "sess-beta"),
+            ],
+            sessionsResponses: [alphaSessions, betaSessions],
+            modelResponses: [models, models],
+            setSessionModelHook: { model in
+                if model == "openai/gpt-alpha-next" {
+                    await patchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-alpha")
+        await MainActor.run { vm.selectModel("openai/gpt-alpha-next") }
+        try await waitUntil("Alpha model patch starts") {
+            await transport.patchedModels() == ["openai/gpt-alpha-next"]
+        }
+
+        await MainActor.run { vm.syncActiveAgentId("beta") }
+        try await waitUntil("Beta bootstrap applies while Alpha patch remains pending") {
+            await MainActor.run {
+                vm.activeAgentId == "beta" &&
+                    vm.sessionId == "sess-beta" &&
+                    vm.sessions.first?.key == "agent:beta:main" &&
+                    vm.modelSelectionID == "openai/gpt-beta"
+            }
+        }
+
+        await patchGate.open()
+        try await waitUntil("late Alpha patch stays scoped to Alpha") {
+            await MainActor.run {
+                vm.sessions.first(where: { $0.key == "agent:alpha:main" })?.model == "gpt-alpha-next"
+            }
+        }
+        #expect(await MainActor.run {
+            vm.sessions.first(where: { $0.key == "agent:beta:main" })?.model
+        } == "gpt-beta")
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-beta")
+    }
+
+    @Test func `Beta model patch and send do not wait for pending Alpha main patch`() async throws {
+        let alphaGate = AsyncGate()
+        let now = Date().timeIntervalSince1970 * 1000
+        let alphaSessions = sessionsResponse(
+            sessionEntry(key: "agent:alpha:main", updatedAt: now, model: nil))
+        let betaSessions = sessionsResponse(
+            sessionEntry(key: "agent:beta:main", updatedAt: now + 1, model: nil))
+        let models = [
+            modelChoice(id: "gpt-alpha", name: "Alpha", provider: "openai"),
+            modelChoice(id: "gpt-beta", name: "Beta", provider: "openai"),
+        ]
+        let (transport, vm) = await makeViewModel(
+            activeAgentId: "alpha",
+            historyResponses: [
+                historyPayload(sessionKey: "main", sessionId: "sess-alpha"),
+                historyPayload(sessionKey: "main", sessionId: "sess-beta"),
+            ],
+            sessionsResponses: [alphaSessions, betaSessions],
+            modelResponses: [models, models],
+            modelPatchResults: [
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-alpha",
+                    thinkingLevel: "high"),
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-beta",
+                    thinkingLevel: "medium"),
+            ],
+            setSessionModelHook: { model in
+                if model == "openai/gpt-alpha" {
+                    await alphaGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-alpha")
+        await MainActor.run { vm.selectModel("openai/gpt-alpha") }
+        try await waitUntil("Alpha patch starts") {
+            await transport.patchedModels() == ["openai/gpt-alpha"]
+        }
+
+        await MainActor.run { vm.syncActiveAgentId("beta") }
+        try await waitUntil("Beta bootstrap completes") {
+            await MainActor.run { vm.activeAgentId == "beta" && vm.sessionId == "sess-beta" }
+        }
+        await MainActor.run { vm.selectModel("openai/gpt-beta") }
+        try await waitUntil("Beta patch completes independently") {
+            await MainActor.run {
+                vm.modelSelectionID == "openai/gpt-beta" &&
+                    vm.sessions.first(where: { $0.key == "agent:beta:main" })?.model == "gpt-beta"
+            }
+        }
+
+        await sendUserMessage(vm, text: "Beta stays independent")
+        _ = try await waitForLastSentRunId(transport)
+        #expect(await transport.lastSentSessionKey() == "main")
+        #expect(await transport.sentAgentIDs().last == "beta")
+
+        await alphaGate.open()
+        try await waitUntil("Alpha patch completes without replacing Beta state") {
+            await MainActor.run {
+                vm.sessions.first(where: { $0.key == "agent:alpha:main" })?.model == "gpt-alpha"
+            }
+        }
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-beta")
+    }
+
     @Test func `late model completion does not replay current session selection into previous session`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let initialSessions = OpenClawChatSessionsListResponse(
@@ -6683,7 +6998,11 @@ struct ChatViewModelTests {
             count: 2,
             defaults: nil,
             sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
+                sessionEntry(
+                    key: "main",
+                    updatedAt: now,
+                    model: "gpt-5.4",
+                    modelProvider: "openai"),
                 sessionEntry(key: "other", updatedAt: now - 1000, model: "openai/gpt-5.4-pro"),
             ])
         let models = [
@@ -6732,6 +7051,12 @@ struct ChatViewModelTests {
                     vm.sessions.first(where: { $0.key == "main" })?.modelProvider == "openai"
             }
         }
+        transport.emit(.sessionsChanged(.init(sessionKey: "main", reason: "patch")))
+        try await waitUntil("authoritative sessions refresh applies the other session patch") {
+            await MainActor.run {
+                vm.sessions.first(where: { $0.key == "other" })?.model == "openai/gpt-5.4-pro"
+            }
+        }
 
         #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-5.4")
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "main" })?.model } == "gpt-5.4")
@@ -6768,6 +7093,257 @@ struct ChatViewModelTests {
 
         #expect(await MainActor.run { vm.thinkingLevel } == "medium")
         #expect(await MainActor.run { callbackState.values } == ["medium"])
+    }
+
+    @Test @MainActor func `Ultra is canonical while ultrathink remains a high alias`() {
+        #expect(OpenClawChatViewModel.normalizedThinkingLevel("ultra") == "ultra")
+        #expect(OpenClawChatViewModel.normalizedThinkingLevel("ULTRA") == "ultra")
+        #expect(OpenClawChatViewModel.normalizedThinkingLevel("ultrathink") == "high")
+        #expect(
+            OpenClawChatViewModel.normalizedThinkingLevel(
+                "ultra",
+                options: [thinkingOption("off"), thinkingOption("high"), thinkingOption("max")],
+                fallback: "max") == "max")
+        #expect(
+            OpenClawChatViewModel.normalizedThinkingLevel(
+                "ultra",
+                options: [thinkingOption("off"), thinkingOption("max"), thinkingOption("ultra")],
+                fallback: "max") == "ultra")
+        #expect(
+            OpenClawChatViewModel.normalizedThinkingLevel(
+                "ultra",
+                options: [thinkingOption("off"), thinkingOption("low"), thinkingOption("medium")]) == "medium")
+    }
+
+    @Test func `decodes authoritative model patch thinking state`() throws {
+        let data = Data(
+            #"{"entry":{"thinkingLevel":"max"},"resolved":{"modelProvider":"openai","model":"gpt-5.6-luna","thinkingLevel":"max","thinkingLevels":[{"id":"off","label":"off"},{"id":"max","label":"max"}]}}"#
+                .utf8)
+
+        let result = try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
+
+        #expect(result.modelProvider == "openai")
+        #expect(result.model == "gpt-5.6-luna")
+        #expect(result.thinkingLevel == "max")
+        #expect(result.thinkingLevels?.map(\.id) == ["off", "max"])
+    }
+
+    @Test func `model patch decoder falls back to entry when resolved is absent`() throws {
+        let data = Data(
+            #"{"key":"agent:main:main","entry":{"providerOverride":"openai","modelOverride":"gpt-5.6-sol","thinkingLevel":"high"}}"#
+                .utf8)
+
+        let result = try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
+
+        #expect(result.key == "agent:main:main")
+        #expect(result.modelProvider == "openai")
+        #expect(result.model == "gpt-5.6-sol")
+        #expect(result.thinkingLevel == "high")
+        #expect(result.thinkingLevels == nil)
+    }
+
+    @Test func `model patch decoder uses entry thinking when resolved omits it`() throws {
+        let data = Data(
+            #"{"entry":{"thinkingLevel":"high"},"resolved":{"modelProvider":"openai","model":"gpt-5.6-sol"}}"#.utf8)
+
+        let result = try JSONDecoder().decode(OpenClawChatModelPatchResult.self, from: data)
+
+        #expect(result.modelProvider == "openai")
+        #expect(result.model == "gpt-5.6-sol")
+        #expect(result.thinkingLevel == "high")
+        #expect(result.thinkingLevels == nil)
+    }
+
+    @Test func `Sol Ultra round trip through Luna Max survives stale session list`() async throws {
+        let staleListGate = AsyncGate()
+        let gateNextList = AsyncCounter()
+        let solLevels = ["off", "low", "medium", "high", "max", "ultra"].map {
+            thinkingOption($0)
+        }
+        let lunaLevels = ["off", "low", "medium", "high", "max"].map { thinkingOption($0) }
+        let initialSessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "gpt-5.6-sol",
+                modelProvider: "openai",
+                thinkingLevel: "ultra",
+                thinkingLevels: solLevels))
+        let models = [
+            modelChoice(id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true),
+            modelChoice(id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", reasoning: true),
+            modelChoice(id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai", reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: "sess-main")],
+            sessionsResponses: [initialSessions],
+            modelResponses: [models],
+            modelPatchResults: [
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-5.6-luna",
+                    thinkingLevel: "max",
+                    thinkingLevels: lunaLevels),
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "gpt-5.6-terra",
+                    thinkingLevel: "max",
+                    thinkingLevels: solLevels),
+            ],
+            listSessionsHook: { _ in
+                guard await gateNextList.current() > 0 else { return nil }
+                await staleListGate.wait()
+                return initialSessions
+            },
+            initialThinkingLevel: "ultra")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("Sol Ultra metadata loaded") {
+            await MainActor.run {
+                vm.modelSelectionID == "openai/gpt-5.6-sol" &&
+                    vm.thinkingLevel == "ultra" &&
+                    vm.thinkingLevelOptions.map(\.id) == solLevels.map(\.id)
+            }
+        }
+
+        let baselineListCount = await transport.listSessionsQueries().count
+        _ = await gateNextList.increment()
+        let staleFetch = Task { await vm.fetchSessions(limit: 200) }
+        try await waitUntil("stale Sol session list starts") {
+            await transport.listSessionsQueries().count > baselineListCount
+        }
+
+        await MainActor.run { vm.selectModel("openai/gpt-5.6-luna") }
+        try await waitUntil("Luna model patch starts") {
+            await transport.patchedModels() == ["openai/gpt-5.6-luna"]
+        }
+        await vm.waitForPendingModelPatches(in: "main")
+        await staleListGate.open()
+        await staleFetch.value
+
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-5.6-luna")
+        #expect(await MainActor.run { vm.thinkingLevel } == "max")
+        #expect(await MainActor.run { vm.thinkingLevelOptions.map(\.id) } == lunaLevels.map(\.id))
+        _ = try await sendMessageAndEmitFinal(transport: transport, vm: vm, text: "use Luna Max")
+        try await waitUntil("Luna send uses Max") {
+            await transport.sentThinkingLevels() == ["max"]
+        }
+        try await waitUntil("Luna run finishes") {
+            await MainActor.run { vm.pendingRunCount == 0 }
+        }
+
+        await MainActor.run { vm.selectModel("openai/gpt-5.6-terra") }
+        try await waitUntil("Terra model patch starts") {
+            await transport.patchedModels() == ["openai/gpt-5.6-luna", "openai/gpt-5.6-terra"]
+        }
+        await vm.waitForPendingModelPatches(in: "main")
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-5.6-terra")
+        #expect(await MainActor.run { vm.thinkingLevel } == "ultra")
+        #expect(await MainActor.run { vm.thinkingLevelOptions.map(\.id) } == solLevels.map(\.id))
+        _ = try await sendMessageAndEmitFinal(transport: transport, vm: vm, text: "restore Terra Ultra")
+        try await waitUntil("Terra send restores Ultra") {
+            await transport.sentThinkingLevels() == ["max", "ultra"]
+        }
+    }
+
+    @Test func `legacy model patch without thinking metadata advertises and sends High`() async throws {
+        let levels = ["off", "high", "max", "ultra"].map { thinkingOption($0) }
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "gpt-5.6-sol",
+                modelProvider: "openai",
+                thinkingLevel: "ultra",
+                thinkingLevels: levels))
+        let models = [
+            modelChoice(id: "gpt-5.6-sol", name: "Sol", provider: "openai", reasoning: true),
+            modelChoice(id: "legacy-reasoning", name: "Legacy", provider: "openai", reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: "sess-main")],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            modelPatchResults: [
+                OpenClawChatModelPatchResult(
+                    modelProvider: "openai",
+                    model: "legacy-reasoning",
+                    thinkingLevel: nil),
+            ],
+            initialThinkingLevel: "ultra")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        await MainActor.run { vm.selectModel("openai/legacy-reasoning") }
+        await vm.waitForPendingModelPatches(in: "main")
+
+        #expect(await MainActor.run { vm.thinkingLevel } == "high")
+        #expect(await MainActor.run { vm.thinkingLevelOptions.map(\.id).contains("ultra") } == false)
+        _ = try await sendMessageAndEmitFinal(transport: transport, vm: vm, text: "legacy Ultra")
+        try await waitUntil("legacy gateway receives High") {
+            await transport.sentThinkingLevels() == ["high"]
+        }
+    }
+
+    @Test func `sessions changed model refresh ignores an older list response`() async throws {
+        let staleListGate = AsyncGate()
+        let listCallCount = AsyncCounter()
+        let solLevels = ["off", "high", "max", "ultra"].map { thinkingOption($0) }
+        let lunaLevels = ["off", "high", "max"].map { thinkingOption($0) }
+        let solSessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "gpt-5.6-sol",
+                modelProvider: "openai",
+                thinkingLevel: "ultra",
+                thinkingLevels: solLevels))
+        let lunaSessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 2,
+                model: "gpt-5.6-luna",
+                modelProvider: "openai",
+                thinkingLevel: "max",
+                thinkingLevels: lunaLevels))
+        let models = [
+            modelChoice(id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true),
+            modelChoice(id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(sessionId: "sess-main")],
+            sessionsResponses: [solSessions],
+            modelResponses: [models],
+            listSessionsHook: { _ in
+                let call = await listCallCount.increment()
+                if call == 1 {
+                    return nil
+                }
+                if call == 2 {
+                    await staleListGate.wait()
+                    return solSessions
+                }
+                return lunaSessions
+            },
+            initialThinkingLevel: "ultra")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        transport.emit(.sessionsChanged(.init(sessionKey: "main", reason: "command-metadata")))
+        try await waitUntil("older sessions refresh starts") {
+            await listCallCount.current() >= 2
+        }
+        transport.emit(.sessionsChanged(.init(sessionKey: "main", reason: "command-metadata")))
+        try await waitUntil("newer Luna refresh applies") {
+            await MainActor.run {
+                vm.modelSelectionID == "openai/gpt-5.6-luna" &&
+                    vm.thinkingLevel == "max" &&
+                    vm.thinkingLevelOptions.map(\.id) == lunaLevels.map(\.id)
+            }
+        }
+
+        await staleListGate.open()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-5.6-luna")
+        #expect(await MainActor.run { vm.thinkingLevel } == "max")
     }
 
     @Test func `server provided thinking levels outside menu are preserved for send`() async throws {
@@ -7210,10 +7786,12 @@ struct ChatViewModelTests {
             await transport.patchedModels() == ["openai/model-y"]
         }
         await MainActor.run { vm.selectModel("openai/model-x") }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await transport.patchedModels() == ["openai/model-y"])
+        await modelPatchGate.release()
         try await waitUntil("model X re-selection patched") {
             await transport.patchedModels() == ["openai/model-y", "openai/model-x"]
         }
-        await modelPatchGate.release()
         await vm.waitForPendingModelPatches(in: "main")
 
         #expect(await MainActor.run { vm.sessions.first?.thinkingLevels?.map(\.id) } == ["off"])
@@ -7232,7 +7810,10 @@ struct ChatViewModelTests {
                 modelProvider: "openai",
                 thinkingLevels: [thinkingOption("off")],
                 thinkingOptions: ["off"],
-                thinkingDefault: "off"))
+                thinkingDefault: "off",
+                totalTokens: 100,
+                totalTokensFresh: true,
+                contextTokens: 1000))
         let models = [
             modelChoice(id: "model-x", name: "Model X", provider: "openai", reasoning: true),
             modelChoice(id: "model-y", name: "Model Y", provider: "openai", reasoning: true),
@@ -7244,6 +7825,7 @@ struct ChatViewModelTests {
 
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
         #expect(await MainActor.run { !vm.showsThinkingPicker })
+        #expect(await MainActor.run { vm.contextUsageFraction } == 0.1)
 
         await MainActor.run { vm.selectModel("openai/model-y") }
         try await waitUntil("model Y patch completed") {
@@ -7256,6 +7838,9 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.sessions.first?.thinkingLevels == nil })
         #expect(await MainActor.run { vm.sessions.first?.thinkingOptions == nil })
         #expect(await MainActor.run { vm.sessions.first?.thinkingDefault == nil })
+        #expect(await MainActor.run { vm.sessions.first?.thinkingLevel == nil })
+        #expect(await MainActor.run { vm.sessions.first?.contextTokens == nil })
+        #expect(await MainActor.run { vm.contextUsageFraction == nil })
     }
 
     @Test func `default model selection resolves session model reasoning`() async throws {
@@ -7706,7 +8291,7 @@ struct ChatViewModelSessionManagementTests {
         }
     }
 
-    @Test func `fetchSessionList sends search and archived to the server`() async throws {
+    @Test func `fetchSessionList sends search and archived to the server`() async {
         let archivedEntry = sessionEntry(key: "agent:main:old", updatedAt: 10, archived: true)
         let (transport, vm) = await makeViewModel(
             historyResponses: [historyPayload()],
@@ -7723,7 +8308,7 @@ struct ChatViewModelSessionManagementTests {
         #expect(queries.contains(TestSessionListQuery(limit: 200, search: "trip", archived: false)))
     }
 
-    @Test func `restore session only reports success when the patch lands`() async throws {
+    @Test func `restore session only reports success when the patch lands`() async {
         let (transport, vm) = await makeViewModel(
             historyResponses: [historyPayload()],
             setSessionArchivedHook: { key, archived in

--- a/scripts/protocol-event-coverage.allowlist.json
+++ b/scripts/protocol-event-coverage.allowlist.json
@@ -4,7 +4,6 @@
     "session.operation": "Chat UI derives run state from chat/agent events; no session.operation consumer yet.",
     "session.tool": "Session tool stream is not rendered by the iOS chat surface yet.",
     "task.suggestion": "Task suggestion cards are a Control UI-only surface; iOS does not render them.",
-    "sessions.changed": "iOS refreshes session lists via explicit sessions.* requests instead of this push event.",
     "presence": "Presence roster is a control-UI (web/desktop) surface; iOS does not render it.",
     "shutdown": "iOS relies on socket close plus reconnect/backoff instead of the shutdown notice.",
     "heartbeat": "iOS liveness uses tick and WebSocket-level ping; heartbeat is unused.",


### PR DESCRIPTION
Closes #103766
Related: #98021, #103415

## What Problem This Solves

Fixes an issue where Apple chat users could send a stale or unsupported thinking level after switching models, agents, or sessions, or after reconnecting with queued messages. Concurrent model changes and session refreshes could overwrite newer state, especially when multiple agents shared the visible `main` alias.

## Why This Change Was Made

Model changes now use immutable canonical session targets, reserve selections synchronously, and serialize patches independently per target. Session-list refreshes retry when they overlap a model patch, while live and queued sends wait for the relevant patch and current connection metadata before selecting a thinking level.

The clients consume authoritative model and thinking metadata returned by the Gateway, clear model-owned thinking and context state when the model changes, and refresh on relevant `sessions.changed` events. Ultra falls back to High when a completed patch provides no authoritative Ultra capability metadata. Existing transports retain their `setSessionModel` fallback, and `ultrathink` remains a High alias.

## User Impact

iOS and macOS chat now keep the selected model, agent route, and supported thinking level aligned through rapid model changes and reconnects. Distinct agents no longer interfere when both appear as `main`, queued messages do not replay with stale Ultra state, and supported Max/Ultra preferences survive reopening.

## Evidence

- Exact final head: `5136f5071e62985d73d4e804b4ba335fc16b7f54` on `48b8dff5304738fd74c4e107a7d2b0452a0ccc1e`; the only delta after behavior-tested `a86a7fd616d5` is generated/allowlist metadata.
- SwiftFormat: 0/17 files needed changes; `swiftc -frontend -parse`: 17/17; `git diff --check`: clean.
- Shared ChatViewModel proof: 240 Swift Testing cases across five suites plus 16 attachment XCTest cases, 256 total, all passed.
- Source-blind behavior validation: 7 pass, 0 fail, 0 blocked, covering stale lists, Sol Ultra → Luna Max → Terra Ultra, route-sensitive serialization, cross-agent isolation, reconnect metadata, transient retry, and legacy Ultra → High fallback.
- Autoreview found and fixed one real route-identity race; the final whole-branch rerun was clean with no actionable findings.
- Xcode 26.6 proof before the final shared ordering fix: macOS mapping 10/10, macOS smoke 3/3, and iOS `IOSGatewayChatTransportTests` 30/30. The final ordering fix is covered by the 256-test shared suite; exact final-head Xcode 26 `macos-swift` and `ios-build` remain the hosted CI gate because the local Xcode 26.6 installation became unavailable.
- Direct Codex contract inspection confirmed canonical Max/Ultra parsing, Ultra → Max wire mapping, and separate Sol/Terra/Luna catalog entries in current `openai/codex` source.
- Exact protocol-event coverage and native i18n inventory checks pass after removing the obsolete iOS `sessions.changed` exemption and refreshing generated source locations.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29103981880
  - iOS build passed on macOS 26.3, Xcode 26.5, Swift 6.3.2: https://github.com/openclaw/openclaw/actions/runs/29103981880/job/86399801427
  - macOS Swift lint/format, release build, no-Talk dependency guard, and tests passed on the same toolchain: https://github.com/openclaw/openclaw/actions/runs/29103981880/job/86399801442
  - The macOS job's built-in retry passed all 795 tests across 123 suites after one unrelated first-attempt `GatewayChannelDeviceTokenRetryTests` timing failure.
