### PR TITLE
fix(gateway): reconcile on-disk config after watcher recreate (#103729)

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1828,7 +1828,12 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     vi.restoreAllMocks();
   });
 
-  function startReloaderWithWatchers(watchers: ReturnType<typeof createWatcherMock>[]) {
+  function startReloaderWithWatchers(
+    watchers: ReturnType<typeof createWatcherMock>[],
+    readSnapshot: (() => Promise<ConfigFileSnapshot>) & { mock?: unknown } = vi.fn(async () =>
+      makeSnapshot(),
+    ),
+  ) {
     const watchSpy = vi.spyOn(chokidar, "watch");
     let watcherIndex = 0;
     watchSpy.mockImplementation((_path, options) => {
@@ -1842,7 +1847,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     const reloader = startGatewayConfigReloader({
       initialConfig: { gateway: { reload: { debounceMs: 0 } } },
-      readSnapshot: vi.fn(async () => makeSnapshot()),
+      readSnapshot,
       initialPluginInstallRecords: {},
       readPluginInstallRecords: async () => ({}),
       onNoopConfigCommit: vi.fn(async () => {}),
@@ -1851,7 +1856,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       log,
       watchPath: "/tmp/openclaw.json",
     });
-    return { watchSpy, log, reloader };
+    return { watchSpy, log, reloader, readSnapshot };
   }
 
   it("re-creates the watcher with backoff after a transient error", async () => {
@@ -1876,6 +1881,79 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     expect(log.error).not.toHaveBeenCalled();
 
     await reloader.stop();
+  });
+
+  it("reconciles against on-disk config after re-creating the watcher post-error", async () => {
+    // An external edit (manual, or `openclaw doctor --fix`) can land while the
+    // watcher is down during error-recovery backoff. The re-created watcher uses
+    // ignoreInitial:true, so it emits no event for that edit — a fresh reconcile
+    // read must run after recreation to pick it up.
+    const first = createWatcherMock();
+    const second = createWatcherMock();
+    const readSnapshot = vi.fn(async () => makeSnapshot());
+    const { watchSpy, log, reloader } = startReloaderWithWatchers([first, second], readSnapshot);
+
+    // Startup already applied initialConfig without reading; no reconcile yet.
+    expect(readSnapshot).not.toHaveBeenCalled();
+
+    first.emit("error");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(watchSpy).toHaveBeenCalledTimes(2);
+
+    // Flush the reconcile read scheduled after the fresh watcher is created.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(log.error).not.toHaveBeenCalled();
+
+    await reloader.stop();
+  });
+
+  it("reconciles against on-disk config after degrading to polling mode", async () => {
+    const originalVitest = process.env.VITEST;
+    const originalChokidarPolling = process.env.CHOKIDAR_USEPOLLING;
+    delete process.env.VITEST;
+    delete process.env.CHOKIDAR_USEPOLLING;
+    let reloader: { stop: () => Promise<void>; hotReloadStatus: () => string } | undefined;
+    try {
+      // Native phase: initial watcher + 3 re-creates = 4 watchers, then 1 polling re-create.
+      const watchers = Array.from({ length: 5 }, () => createWatcherMock());
+      const readSnapshot = vi.fn(async () => makeSnapshot());
+      const started = startReloaderWithWatchers(watchers, readSnapshot);
+      const { watchSpy, log } = started;
+      reloader = started.reloader;
+
+      // Drive the native retries to exhaustion (each recreate reconciles too).
+      watchers[0]?.emit("error");
+      await vi.advanceTimersByTimeAsync(500);
+      watchers[1]?.emit("error");
+      await vi.advanceTimersByTimeAsync(2000);
+      watchers[2]?.emit("error");
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(watchSpy).toHaveBeenCalledTimes(4);
+
+      // Fourth native error degrades to polling and re-creates the watcher.
+      watchers[3]?.emit("error");
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("degrading to polling mode"));
+      const readsBeforePollingRecreate = readSnapshot.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(500);
+      expect(watchSpy).toHaveBeenCalledTimes(5);
+
+      // The polling-degrade recreate path must reconcile too.
+      await vi.advanceTimersByTimeAsync(1);
+      expect(readSnapshot.mock.calls.length).toBeGreaterThan(readsBeforePollingRecreate);
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+      if (originalChokidarPolling === undefined) {
+        delete process.env.CHOKIDAR_USEPOLLING;
+      } else {
+        process.env.CHOKIDAR_USEPOLLING = originalChokidarPolling;
+      }
+      await reloader?.stop();
+    }
   });
 
   it("degrades to polling then disables after both native and polling retries are exhausted", async () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -635,10 +635,11 @@ describe("resolveGatewayReloadSettings", () => {
 });
 
 type WatcherHandler = () => void;
-type WatcherEvent = "add" | "change" | "unlink" | "error";
+type WatcherEvent = "add" | "change" | "unlink" | "error" | "ready";
 
 function createWatcherMock(effectiveUsePolling?: boolean) {
   const handlers = new Map<WatcherEvent, WatcherHandler[]>();
+  const onceHandlers = new Map<WatcherEvent, WatcherHandler[]>();
   return {
     effectiveUsePolling,
     options: { usePolling: false },
@@ -648,8 +649,19 @@ function createWatcherMock(effectiveUsePolling?: boolean) {
       handlers.set(event, existing);
       return this;
     },
+    once(event: WatcherEvent, handler: WatcherHandler) {
+      const existing = onceHandlers.get(event) ?? [];
+      existing.push(handler);
+      onceHandlers.set(event, existing);
+      return this;
+    },
     emit(event: WatcherEvent) {
       for (const handler of handlers.get(event) ?? []) {
+        handler();
+      }
+      const pendingOnce = onceHandlers.get(event) ?? [];
+      onceHandlers.set(event, []);
+      for (const handler of pendingOnce) {
         handler();
       }
     },
@@ -1885,9 +1897,10 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
 
   it("reconciles against on-disk config after re-creating the watcher post-error", async () => {
     // An external edit (manual, or `openclaw doctor --fix`) can land while the
-    // watcher is down during error-recovery backoff. The re-created watcher uses
-    // ignoreInitial:true, so it emits no event for that edit — a fresh reconcile
-    // read must run after recreation to pick it up.
+    // watcher is down during error-recovery backoff, or during the new watcher's
+    // initial scan. The re-created watcher uses ignoreInitial:true, so it emits
+    // no event for that edit — a fresh reconcile read must run once the watcher
+    // is ready to pick it up.
     const first = createWatcherMock();
     const second = createWatcherMock();
     const readSnapshot = vi.fn(async () => makeSnapshot());
@@ -1900,7 +1913,12 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
     await vi.advanceTimersByTimeAsync(500);
     expect(watchSpy).toHaveBeenCalledTimes(2);
 
-    // Flush the reconcile read scheduled after the fresh watcher is created.
+    // The reconcile read waits for the recreated watcher's initial scan to
+    // complete; nothing is read until `ready` fires (closes construction→ready race).
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readSnapshot).not.toHaveBeenCalled();
+
+    second.emit("ready");
     await vi.advanceTimersByTimeAsync(1);
     expect(readSnapshot).toHaveBeenCalledTimes(1);
     expect(log.error).not.toHaveBeenCalled();
@@ -1922,7 +1940,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       const { watchSpy, log } = started;
       reloader = started.reloader;
 
-      // Drive the native retries to exhaustion (each recreate reconciles too).
+      // Drive the native retries to exhaustion.
       watchers[0]?.emit("error");
       await vi.advanceTimersByTimeAsync(500);
       watchers[1]?.emit("error");
@@ -1938,7 +1956,8 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       await vi.advanceTimersByTimeAsync(500);
       expect(watchSpy).toHaveBeenCalledTimes(5);
 
-      // The polling-degrade recreate path must reconcile too.
+      // The polling-degrade recreate path must reconcile too, once its watcher is ready.
+      watchers[4]?.emit("ready");
       await vi.advanceTimersByTimeAsync(1);
       expect(readSnapshot.mock.calls.length).toBeGreaterThan(readsBeforePollingRecreate);
     } finally {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -429,7 +429,7 @@ export function startGatewayConfigReloader(opts: {
   let degradedToPolling = false;
   let watcherUsesPolling = false;
 
-  const createWatcher = () => {
+  const createWatcher = (reconcile = false) => {
     if (stopped) {
       return;
     }
@@ -448,6 +448,17 @@ export function startGatewayConfigReloader(opts: {
     watcher = next;
     watcherUsesPolling = next.options.usePolling;
     hotReloadStatus = "active";
+    if (reconcile) {
+      // A recreate (after a watcher error + backoff) leaves an interval with no
+      // live watcher. The new watcher uses ignoreInitial:true, so any config
+      // edit made by an external process (a manual edit, or a separate
+      // `openclaw doctor --fix`) during that down window emits no event and its
+      // file becomes the new baseline. Schedule one reconcile read against the
+      // current on-disk config so such an edit is not silently dropped. The
+      // initial startup watcher does not need this: startup already read and
+      // applied the config before the first watcher existed.
+      scheduleAfter(0);
+    }
   };
 
   const handleWatcherError = (source: typeof watcher, err: unknown) => {
@@ -471,7 +482,7 @@ export function startGatewayConfigReloader(opts: {
         );
         watcherRecreateTimer = setTimeout(() => {
           watcherRecreateTimer = null;
-          createWatcher();
+          createWatcher(true);
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
@@ -492,7 +503,7 @@ export function startGatewayConfigReloader(opts: {
     );
     watcherRecreateTimer = setTimeout(() => {
       watcherRecreateTimer = null;
-      createWatcher();
+      createWatcher(true);
     }, backoff);
   };
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -445,20 +445,29 @@ export function startGatewayConfigReloader(opts: {
     next.on("error", (err) => {
       handleWatcherError(next, err);
     });
-    watcher = next;
-    watcherUsesPolling = next.options.usePolling;
-    hotReloadStatus = "active";
     if (reconcile) {
       // A recreate (after a watcher error + backoff) leaves an interval with no
       // live watcher. The new watcher uses ignoreInitial:true, so any config
       // edit made by an external process (a manual edit, or a separate
-      // `openclaw doctor --fix`) during that down window emits no event and its
-      // file becomes the new baseline. Schedule one reconcile read against the
-      // current on-disk config so such an edit is not silently dropped. The
-      // initial startup watcher does not need this: startup already read and
-      // applied the config before the first watcher existed.
-      scheduleAfter(0);
+      // `openclaw doctor --fix`) during that down window — or during the new
+      // watcher's own initial scan — emits no event and its file becomes the new
+      // baseline. Reconcile once the watcher has finished that scan (`ready`),
+      // when any such edit is guaranteed to be on disk, and read the current
+      // config through the scheduler so it is not silently dropped. Waiting for
+      // `ready` (rather than reading immediately) closes the construction→ready
+      // window, where an edit could otherwise land after an eager read yet still
+      // be folded into the baseline. The initial startup watcher does not need
+      // this: startup already read and applied the config before it existed.
+      next.once("ready", () => {
+        if (stopped || watcher !== next) {
+          return;
+        }
+        scheduleAfter(0);
+      });
     }
+    watcher = next;
+    watcherUsesPolling = next.options.usePolling;
+    hotReloadStatus = "active";
   };
 
   const handleWatcherError = (source: typeof watcher, err: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

The gateway watches `openclaw.json` for hot-reload. When that watcher hits an error (for example EMFILE/ENOSPC inotify exhaustion) it is closed and re-created after a backoff. The re-created watcher is built with `ignoreInitial: true` and no reconciliation read, so any config edit made by an **external process** while no watcher is alive (the error-recovery down window) — a manual edit, or a separate `openclaw doctor --fix` run, neither of which routes through the running gateway's in-process write channel — is silently adopted as the new watcher's baseline and **never scheduled for reload**. The gateway keeps running the stale pre-edit config indefinitely, with no log distinguishing a missed change from a normal quiet period. This is exactly the population the inotify-exhaustion retries exist to serve.

Closes #103729

## Why This Change Was Made

`ignoreInitial: true` is correct for the very first watcher (startup already reads and applies the config). On **recreation**, however, there is an interval with no live watcher during which an on-disk change can occur, and the new watcher's `ignoreInitial: true` guarantees that change produces no event. Both recreate paths share the defect: the native-retry timer and the polling-degrade timer.

## Changes

- `createWatcher` gains an optional `reconcile` parameter. When `true`, it reconciles **once the recreated watcher emits `ready`** — i.e. after chokidar has finished its asynchronous initial scan and established its baseline — by scheduling one read (`scheduleAfter(0)`) of the current on-disk config through the existing scheduler (the canonical seam that owns snapshot reads, validation, diffing, and application). Reconciling on `ready` (rather than eagerly, right after `chokidar.watch()` returns) guarantees any edit that landed during the down window or the initial scan is on disk before the read, closing the construction→`ready` window. A `watcher !== next` guard drops the callback if the watcher was already replaced or stopped.
- Both recreate timers (native-retry and polling-degrade) now call `createWatcher(true)`. The initial startup `createWatcher()` is unchanged, since startup already read and applied the config before the first watcher existed.
- The watcher test mock now models `once` and the `ready` event; two regression tests cover both recreate paths and assert the reconcile fires only after `ready`.

## User Impact

External config edits (manual, or `openclaw doctor --fix`) that land while the watcher is recovering from an inotify/EMFILE error are now applied after the watcher is re-created, instead of being silently dropped until some later unrelated write touches the file again.

## Evidence

**Real behavior proof.** Drove the real `startGatewayConfigReloader` against a real on-disk `openclaw.json` with a real chokidar watcher. A real `error` event was emitted on the live watcher (as inotify exhaustion would raise it); the watcher, the file, the debounce/reload loop, and `readSnapshot` reading the file all stayed real. An external edit (`{"v":3}`) was written during the backoff gap while **no watcher was alive**. Chokidar was run in polling mode, whose down-window semantics are deterministic and cross-platform (a polling watcher snapshots the file at start and `ignoreInitial` suppresses that baseline; an edit predating the watch is folded into the baseline and never emits) — the same silent drop the issue author observed under native Linux inotify, which likewise does not replay events that predate the watch. Timeline (`[ms] event`):

```
# BEFORE (true origin/main, no reconcile)
[0187] watch#0 constructed
[0199] watch#0 EVENT ready
[1113] watch#1 constructed        # recreate after backoff
[1114] watch#1 EVENT ready
reads_after_recreate=0
downwindow_edit(v3)_ever_read=false
raw_config_contents_read=[]        # v3 silently dropped

# AFTER (this PR, identical inputs)
[0015] watch#0 constructed
[0023] watch#0 EVENT ready
[0941] watch#1 constructed        # recreate after backoff
[0941] watch#1 EVENT ready
[0965] readSnapshot -> {"v":3}     # reconcile fires AFTER ready
reads_after_recreate=1
downwindow_edit(v3)_ever_read=true
raw_config_contents_read=["{\"v\":3}"]
```

The reconcile read (965ms) occurs strictly after the recreated watcher's `ready` (941ms), demonstrating the readiness gating.

**Focused tests.** Two tests in `config-reload.test.ts` assert a reconcile read runs after both recreate paths (native retry + polling degrade), and only after the recreated watcher's `ready` event (nothing is read before `ready`). Full suite green:

```
$ npx vitest run src/gateway/config-reload.test.ts
 Test Files  3 passed (3)
      Tests  267 passed (267)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
