### PR TITLE
fix: Codex runtime rejected for Codex provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.

--- a/src/agents/session-runtime-compat.ts
+++ b/src/agents/session-runtime-compat.ts
@@ -24,6 +24,27 @@ export function resolvePersistedSessionRuntimeId(
   return normalizeOptionalAgentRuntimeId(entry?.agentHarnessId);
 }
 
+/** Resolves a runtime id only when it can serve the selected provider. */
+export function resolveCompatibleAgentRuntimeForProvider(params: {
+  provider?: string | null;
+  runtime?: string | null;
+  cfg?: OpenClawConfig;
+}): string | undefined {
+  const runtime = normalizeOptionalAgentRuntimeId(params.runtime);
+  if (!runtime || isDefaultAgentRuntimeId(runtime)) {
+    return undefined;
+  }
+  if (runtime === "openclaw") {
+    return runtime;
+  }
+  const provider = params.provider?.trim().toLowerCase() ?? "";
+  // The Codex harness owns both OpenClaw's virtual Codex namespace and canonical OpenAI routes.
+  if (runtime === "codex" && (provider === "codex" || provider === "openai")) {
+    return runtime;
+  }
+  return isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg }) ? runtime : undefined;
+}
+
 /** Resolves a persisted runtime override only when it can serve the selected provider. */
 export function resolveSessionRuntimeOverrideForProvider(params: {
   provider?: string | null;
@@ -32,16 +53,9 @@ export function resolveSessionRuntimeOverrideForProvider(params: {
 }): string | undefined {
   // agentHarnessId records the runtime that produced the existing transcript;
   // it must not override the runtime selected for the next turn.
-  const runtime = normalizeOptionalAgentRuntimeId(params.entry?.agentRuntimeOverride);
-  if (!runtime || isDefaultAgentRuntimeId(runtime)) {
-    return undefined;
-  }
-  if (runtime === "openclaw") {
-    return runtime;
-  }
-  const provider = params.provider?.trim().toLowerCase() ?? "";
-  if (provider === "openai" && runtime === "codex") {
-    return runtime;
-  }
-  return isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg }) ? runtime : undefined;
+  return resolveCompatibleAgentRuntimeForProvider({
+    provider: params.provider,
+    runtime: params.entry?.agentRuntimeOverride,
+    cfg: params.cfg,
+  });
 }

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -86,6 +86,19 @@ describe("resolveSessionRuntimeOverrideForProvider", () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    { provider: "openai", expected: "codex" },
+    { provider: "codex", expected: "codex" },
+    { provider: "anthropic", expected: undefined },
+  ])("resolves Codex runtime compatibility for $provider", ({ provider, expected }) => {
+    expect(
+      resolveSessionRuntimeOverrideForProvider({
+        provider,
+        entry: { agentRuntimeOverride: "codex" },
+      }),
+    ).toBe(expected);
+  });
+
   it("keeps CLI runtime pins only when the runtime serves the selected provider", () => {
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [],

--- a/src/auto-reply/reply/directive-handling.model-runtime.ts
+++ b/src/auto-reply/reply/directive-handling.model-runtime.ts
@@ -3,9 +3,11 @@ import {
   isDefaultAgentRuntimeId,
   normalizeOptionalAgentRuntimeId,
 } from "../../agents/agent-runtime-id.js";
-import { resolveCliRuntimeModelBackendBinding } from "../../agents/cli-backends.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
-import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
+import {
+  resolveCompatibleAgentRuntimeForProvider,
+  resolveSessionRuntimeOverrideForProvider,
+} from "../../agents/session-runtime-compat.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -42,21 +44,15 @@ export function resolveModelRuntimeDirective(params: {
   if (isDefaultAgentRuntimeId(runtime)) {
     return { kind: "clear" };
   }
-  if (runtime === "openclaw") {
-    return { kind: "set", runtime };
-  }
 
   const provider = normalizeProviderId(params.provider);
-  if (provider === "openai" && runtime === "codex") {
-    return { kind: "set", runtime };
-  }
-  const backend = resolveCliRuntimeModelBackendBinding({
-    config: params.cfg,
+  const compatibleRuntime = resolveCompatibleAgentRuntimeForProvider({
     provider,
     runtime,
+    cfg: params.cfg,
   });
-  if (backend) {
-    return { kind: "set", runtime: backend.runtime };
+  if (compatibleRuntime) {
+    return { kind: "set", runtime: compatibleRuntime };
   }
 
   return {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1306,14 +1306,17 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe(OPENAI_DATE_PROFILE_ID);
   });
 
-  it("persists provider-compatible runtime overrides for mixed-content messages", async () => {
+  it.each([
+    ["openai/gpt-4o", "openai", "gpt-4o"],
+    ["codex/gpt-5.5", "codex", "gpt-5.5"],
+  ])("persists provider-compatible runtime overrides for %s", async (modelKey, provider, model) => {
     const { persisted, sessionEntry } = await persistModelDirectiveForTest({
-      command: "/model openai/gpt-4o --runtime codex hello",
-      allowedModelKeys: ["openai/gpt-4o"],
+      command: `/model ${modelKey} --runtime codex hello`,
+      allowedModelKeys: [modelKey],
     });
 
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+    expect(sessionEntry.providerOverride).toBe(provider);
+    expect(sessionEntry.modelOverride).toBe(model);
     expect(sessionEntry.agentRuntimeOverride).toBe("codex");
     expect(persisted.runtimeChange).toEqual({ kind: "set", runtime: "codex" });
   });
@@ -1441,6 +1444,16 @@ describe("/model chat UX", () => {
       agentRuntimeOverride: "openclaw",
     });
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects the Codex runtime for providers the harness does not support", async () => {
+    const { persisted, sessionEntry } = await persistModelDirectiveForTest({
+      command: "/model anthropic/claude-opus-4-6 --runtime codex hello",
+      allowedModelKeys: ["anthropic/claude-opus-4-6"],
+    });
+
+    expect(persisted.errorText).toBe('Runtime "codex" is not supported for anthropic.');
+    expect(sessionEntry.agentRuntimeOverride).toBeUndefined();
   });
 
   it("rejects unsupported mixed thinking before mutating the model/runtime transaction", async () => {


### PR DESCRIPTION
Closes #103762

## What Problem This Solves

Fixes an issue where users selecting a `codex/*` model with `/model ... --runtime codex` received `Runtime "codex" is not supported for codex` before the bundled Codex harness could run. The same deterministic rejection broke the native Codex release-check lane.

## Why This Change Was Made

The bundled Codex harness supports both the virtual `codex` provider and canonical `openai` routes. This change gives explicit model/runtime transactions and persisted-session recovery one shared compatibility resolver, allowing those two supported routes while continuing to reject unrelated provider/runtime pairs.

The live test remains unchanged because its `codex/gpt-5.5` command is the user-visible regression proof, not stale coverage.

## User Impact

Users can explicitly select the Codex runtime for `codex/*` models, and that runtime pin remains valid on subsequent turns. Unsupported combinations such as Anthropic models with the Codex runtime still fail closed.

## Evidence

- Before: Release Checks run https://github.com/openclaw/openclaw/actions/runs/29101127440, job https://github.com/openclaw/openclaw/actions/runs/29101127440/job/86390824884 rejected `/model codex/gpt-5.5 --runtime codex`.
- Focused Testbox: `corepack pnpm test src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/agent-runner-execution.test.ts` — 2 files, 335 tests passed on `tbx_01kx6a8h2q10v8sqf5dxbtj6va`.
- Broad Testbox: `corepack pnpm check:changed` — passed typechecks, core/extensions/scripts lint, and repository guards on `tbx_01kx68pa36ma56r1zfnvzdrncr`.
- `git diff --check` — passed.
- Fresh autoreview — no accepted/actionable findings; patch correct at 0.91 confidence.
- Dependency contract: inspected the pinned `@openai/codex` 0.144.1 app-server protocol and thread-start configuration path; provider is optional at the app-server boundary and the virtual OpenClaw `codex` provider is intentionally left to native Codex provider/auth selection.

AI-assisted implementation and validation: Codex.
