### PR TITLE
fix(auto-reply): strip leading newline-separated NO_REPLY sentinel

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -5,12 +5,12 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import { copyReplyPayloadMetadata } from "../reply-payload.js";
 import {
+  hasLeadingSilentToken,
   HEARTBEAT_TOKEN,
   isInternalFormattingArtifact,
   isSilentReplyPayloadText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
-  startsWithSilentToken,
   stripLeadingSilentToken,
   stripSilentToken,
 } from "../tokens.js";
@@ -68,11 +68,11 @@ export function normalizeReplyPayload(
   // token never leaks to end users.  If stripping leaves nothing, treat it as
   // silent just like the exact-match path above.  (#30916, #30955)
   if (text && !isSilentReplyText(text, silentToken)) {
-    const hasLeadingSilentToken = startsWithSilentToken(text, silentToken);
-    if (hasLeadingSilentToken) {
+    const leadingTokenStripped = hasLeadingSilentToken(text, silentToken);
+    if (leadingTokenStripped) {
       text = stripLeadingSilentToken(text, silentToken);
     }
-    if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
+    if (leadingTokenStripped || text.toLowerCase().includes(silentToken.toLowerCase())) {
       text = stripSilentToken(text, silentToken);
       if (!hasContent(text)) {
         opts.onSkip?.("silent");

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -214,6 +214,16 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(result).text).toBe("The user is saying hello");
   });
 
+  it("strips leading newline-separated NO_REPLY token without leaking it to the channel", () => {
+    const result = normalizeReplyPayload({
+      text: "NO_REPLY\n\nWait — the user mentioned me directly. I should respond.\n\nHi! How can I help?",
+    });
+    const reply = expectNormalizedReply(result);
+    expect(reply.text).not.toContain("NO_REPLY");
+    expect(reply.text).toContain("Wait — the user mentioned me directly");
+    expect(reply.text).toContain("Hi! How can I help?");
+  });
+
   it("keeps NO_REPLY when used as leading substantive text", () => {
     const result = normalizeReplyPayload({ text: "NO_REPLY -- nope" });
     expect(expectNormalizedReply(result).text).toBe("NO_REPLY -- nope");

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,6 +1,7 @@
 /** Tests silent-reply and heartbeat token parsing helpers. */
 import { describe, it, expect } from "vitest";
 import {
+  hasLeadingSilentToken,
   isInternalFormattingArtifact,
   isSilentReplyPrefixText,
   isSilentReplyPayloadText,
@@ -281,6 +282,24 @@ describe("startsWithSilentToken", () => {
     expect(startsWithSilentToken("NO_REPLY—note")).toBe(false);
     expect(startsWithSilentToken("NO_REPLY")).toBe(false);
     expect(startsWithSilentToken("  NO_REPLY  ")).toBe(false);
+  });
+});
+
+describe("hasLeadingSilentToken", () => {
+  it("matches leading tokens separated by whitespace or newlines", () => {
+    expect(hasLeadingSilentToken("NO_REPLY The user is saying")).toBe(true);
+    expect(hasLeadingSilentToken("NO_REPLY\n\nThe user is saying")).toBe(true);
+    expect(hasLeadingSilentToken("  no_reply  The user is saying")).toBe(true);
+  });
+
+  it("still matches glued leading tokens", () => {
+    expect(hasLeadingSilentToken("NO_REPLYThe user is saying")).toBe(true);
+  });
+
+  it("rejects punctuation-start content and token-only text", () => {
+    expect(hasLeadingSilentToken("NO_REPLY: explanation")).toBe(false);
+    expect(hasLeadingSilentToken("NO_REPLY—note")).toBe(false);
+    expect(hasLeadingSilentToken("NO_REPLY")).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -287,6 +287,25 @@ export function startsWithSilentToken(
   return getSilentLeadingAttachedRegex(token).test(text);
 }
 
+/**
+ * Check whether text starts with one or more leading silent reply tokens,
+ * including tokens separated from the remaining content by whitespace or
+ * newlines before the first visible (word-start) character.
+ */
+export function hasLeadingSilentToken(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  if (startsWithSilentToken(text, token)) {
+    return true;
+  }
+  const escaped = escapeRegExp(token);
+  return new RegExp(`^(?:\\s*${escaped})+\\s+(?=[\\p{L}\\p{N}])`, "iu").test(text);
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,


### PR DESCRIPTION
## What Problem This Solves

Fixes #103735. A leading `NO_REPLY` silent-reply sentinel separated from real content by newlines/whitespace was delivered to the channel instead of being stripped, leaking the literal token and any interstitial reasoning to end users.

## Why This Change Was Made

`normalizeReplyPayload` only stripped a leading token when it was glued directly to the next visible character (`startsWithSilentToken`). A newline-separated token fell through to the trailing-token stripper, which only removes tokens at the end of the text. The fix uses a new `hasLeadingSilentToken` helper that also matches tokens separated by whitespace/newlines before the first visible word-start content, then applies the existing `stripLeadingSilentToken`.

## User Impact

Model turns that emit `NO_REPLY` followed by a real reply no longer leak the sentinel to users. Token-only or whitespace-only turns remain suppressed as silent replies. Cases like `NO_REPLY -- nope` or `NO_REPLY: explanation` are still preserved as substantive text.

## Evidence

- Added regression tests in `src/auto-reply/tokens.test.ts` for `hasLeadingSilentToken`.
- Added regression test in `src/auto-reply/reply/reply-utils.test.ts` covering the exact repro from the issue.
- `node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts src/auto-reply/reply/reply-utils.test.ts` passes locally (140 tests).