### PR TITLE
fix(browser): avoid duplicate upload events

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -93,20 +93,6 @@ export async function armFileUploadViaPlaywright(opts: {
         return;
       }
       await fileChooser.setFiles(uploadPathsResult.paths);
-      try {
-        const input =
-          typeof fileChooser.element === "function"
-            ? await Promise.resolve(fileChooser.element())
-            : null;
-        if (input) {
-          await input.evaluate((el) => {
-            el.dispatchEvent(new Event("input", { bubbles: true }));
-            el.dispatchEvent(new Event("change", { bubbles: true }));
-          });
-        }
-      } catch {
-        // Best-effort for sites that don't react to setFiles alone.
-      }
     })
     .catch(() => {
       // Ignore timeouts; the chooser may never appear.

--- a/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
@@ -45,16 +45,22 @@ vi.mock("./paths.js", () => {
 
 const { setInputFilesViaPlaywright } = await import("./pw-tools-core.interactions.js");
 
-function seedSingleLocatorPage(): { setInputFiles: ReturnType<typeof vi.fn> } {
+function seedSingleLocatorPage(): {
+  setInputFiles: ReturnType<typeof vi.fn>;
+  elementHandle: ReturnType<typeof vi.fn>;
+} {
   const setInputFiles = vi.fn(async () => {});
+  const elementHandle = vi.fn(async () => {
+    throw new Error("manual upload event dispatch is forbidden");
+  });
   locator = {
     setInputFiles,
-    elementHandle: vi.fn(async () => null),
+    elementHandle,
   };
   page = {
     locator: vi.fn(() => ({ first: () => locator })),
   };
-  return { setInputFiles };
+  return { setInputFiles, elementHandle };
 }
 
 describe("setInputFilesViaPlaywright", () => {
@@ -68,8 +74,8 @@ describe("setInputFilesViaPlaywright", () => {
     });
   });
 
-  it("revalidates upload paths and uses resolved canonical paths for inputRef", async () => {
-    const { setInputFiles } = seedSingleLocatorPage();
+  it("sets resolved files once and leaves browser events to Playwright", async () => {
+    const { setInputFiles, elementHandle } = seedSingleLocatorPage();
 
     await setInputFilesViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -83,6 +89,8 @@ describe("setInputFilesViaPlaywright", () => {
     });
     expect(refLocator).toHaveBeenCalledWith(page, "e7");
     expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"]);
+    expect(setInputFiles).toHaveBeenCalledTimes(1);
+    expect(elementHandle).not.toHaveBeenCalled();
   });
 
   it("throws and skips setInputFiles when use-time validation fails", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1497,17 +1497,6 @@ export async function setInputFilesViaPlaywright(opts: {
   } catch (err) {
     throw toFriendlyInteractionError(err, inputRef || element);
   }
-  try {
-    const handle = await locator.elementHandle();
-    if (handle) {
-      await handle.evaluate((el) => {
-        el.dispatchEvent(new Event("input", { bubbles: true }));
-        el.dispatchEvent(new Event("change", { bubbles: true }));
-      });
-    }
-  } catch {
-    // Best-effort for sites that don't react to setInputFiles alone.
-  }
 }
 
 async function executeSingleAction(

--- a/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
@@ -26,7 +26,10 @@ installPwToolsCoreTestHooks();
 const { armFileUploadViaPlaywright } = await import("./pw-tools-core.downloads.js");
 
 function createFileChooserPageMocks() {
-  const fileChooser = { setFiles: vi.fn(async () => {}) };
+  const element = vi.fn(async () => {
+    throw new Error("manual upload event dispatch is forbidden");
+  });
+  const fileChooser = { setFiles: vi.fn(async () => {}), element };
   const press = vi.fn(async () => {});
   const waitForEvent = vi.fn(async () => fileChooser);
   setPwToolsCoreCurrentPage({
@@ -44,7 +47,7 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     });
   });
 
-  it("sets files using resolved inbound media paths", async () => {
+  it("sets resolved files once and leaves browser events to Playwright", async () => {
     const { fileChooser } = createFileChooserPageMocks();
 
     await armFileUploadViaPlaywright({
@@ -59,6 +62,8 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
         "/home/user/.openclaw/media/inbound/report.pdf",
       ]);
     });
+    expect(fileChooser.setFiles).toHaveBeenCalledTimes(1);
+    expect(fileChooser.element).not.toHaveBeenCalled();
   });
 
   it("escapes the chooser when paths are outside managed upload roots", async () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #103753.

Managed-browser uploads currently deliver two `input` events and two `change` events for one selected file. Playwright emits the browser-correct pair, then OpenClaw manually dispatches a second synthetic pair. Application handlers can therefore validate, process, submit, or measure the same upload twice.

This affects both managed Playwright upload paths:

- the armed file-chooser flow backed by `FileChooser.setFiles()`
- direct `inputRef` / CSS selector uploads backed by `Locator.setInputFiles()`

## Why This Change Was Made

The fix removes both post-upload redispatch blocks and leaves event delivery to Playwright. It adds no fallback, compatibility shim, helper, configuration, or alternate runtime path.

This is the best fix because OpenClaw pins `playwright-core` 1.61.1, and that dependency already owns the complete file-input event contract:

- Playwright `v1.61.1` (`39e3553a4f283a41134d75d7e404484bd9e6865a`) implements the canonical upload path in `packages/playwright-core/src/server/dom.ts`.
- `FileChooser.setFiles()` delegates to `ElementHandle.setInputFiles()`.
- Playwright's injected implementation assigns `input.files`, then emits one composed `input` event followed by one `change` event.
- Playwright's own `page-set-input-files` tests require exactly that ordered pair for filesystem uploads.

Keeping a conditional redispatch, deduplicating callbacks afterward, or special-casing sites would preserve two competing event owners and could not manufacture trusted browser events. Deleting the duplicate owner restores the dependency contract directly.

Regression tests make the ownership boundary explicit: successful chooser uploads must not request `FileChooser.element()`, and successful direct uploads must not request `Locator.elementHandle()` after Playwright has set the files.

## User Impact

One managed-browser upload now produces one Playwright-owned `input` / `change` pair. Sites no longer receive duplicate validation, upload, submission, analytics, or state-update callbacks.

The browser tool schema, CLI, Gateway route, upload roots, path validation, multi-file support, refs/selectors, arming behavior, and timeouts are unchanged. Chrome MCP's separate `upload_file` path is unaffected.

Release-note context: managed browser uploads no longer emit duplicate native and synthetic file-input callbacks.

## Evidence

### Reproduction and dependency contract

- Current-`main` reproduction from #103753, real Chrome 150 and Playwright 1.61.1:
  - direct upload: `input`, `change`, synthetic `input`, synthetic `change`
  - chooser upload: `input`, `change`, synthetic `input`, synthetic `change`
- Independent Playwright 1.61.1 probe: both `Locator.setInputFiles()` and `FileChooser.setFiles()` emit exactly one ordered `input`, `change` pair with one selected file.
- Upstream contract checked at `microsoft/playwright@39e3553a4f283a41134d75d7e404484bd9e6865a`:
  - `packages/playwright-core/src/client/fileChooser.ts:46-47`
  - `packages/playwright-core/src/server/dom.ts:723-760`
  - `packages/injected/src/injectedScript.ts:946-966`
  - `tests/page/page-set-input-files.spec.ts:354-401`

### Focused regression tests

```shell
node scripts/run-vitest.mjs \
  extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts \
  extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts \
  extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts \
  extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
```

- Result: 4 files, 15 tests passed on Blacksmith Testbox through Crabbox
  (`tbx_01kx6902pxe1zr04narrybkcpw`).

### Live candidate proof

- Candidate SHA: `43e5621c48acdf36421d33168b5bbbb24c5f71df`.
- Environment: isolated real Gateway, managed Chrome for Testing `149.0.7827.55`, real
  `openai/gpt-5.4` agent through OpenClaw's built-in runtime.
- Canonical agent session: `upload-event-proof-1783697854`; transcript validation
  required one direct `element=#direct` upload and one atomic chooser-ref upload.
- Direct upload result: exactly `input,change`, total callbacks `2`, selected files `1`.
- Chooser upload result: exactly `input,change`, total callbacks `2`, selected files `1`.
- Combined callback count: `4`; no duplicate pair on either path.
- Gateway remained healthy through the agent turn and shut down cleanly after proof.
- Secret scan: the OpenAI key did not appear in the Gateway log or canonical transcript.

### Checks

- `git diff --check`: passed.
- Path-scoped `pnpm check:changed` for the four touched browser files passed on
  `tbx_01kx6902pxe1zr04narrybkcpw`.
- Candidate build for live proof: `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm build` passed.
- Fresh autoreview: clean, no accepted/actionable findings (`patch is correct`, confidence
  `0.98`).
- Exact-head CI / native prepare proof: `[TODO: run IDs and result before merge]`

No documentation or changelog file changes are required: the public upload API is unchanged, and `CHANGELOG.md` is release-generated.
