### PR TITLE
fix(auto-reply): strip newline-separated leading NO_REPLY sentinels

### DIFF
--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -36,6 +36,14 @@ describe("sanitizePendingFinalDeliveryText", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK NO_REPLY")).toBe("HEARTBEAT_OK");
   });
 
+  it("strips newline-separated leading NO_REPLY like normal delivery (#103735)", () => {
+    expect(
+      sanitizePendingFinalDeliveryText(
+        "NO_REPLY\n\nWait — the user mentioned me directly.\n\nHi! How can I help?",
+      ),
+    ).toBe("Wait — the user mentioned me directly.\n\nHi! How can I help?");
+  });
+
   it("preserves heartbeat ack text for ack-aware classification", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK short")).toBe("HEARTBEAT_OK short");
   });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -214,6 +214,17 @@ describe("normalizeReplyPayload", () => {
     expect(expectNormalizedReply(result).text).toBe("The user is saying hello");
   });
 
+  it("strips newline-separated leading NO_REPLY without leaking the token (#103735)", () => {
+    const result = normalizeReplyPayload({
+      text: "NO_REPLY\n\nWait — the user mentioned me directly. I should respond.\n\nHi! How can I help?",
+    });
+    const reply = expectNormalizedReply(result);
+    expect(reply.text).toBe(
+      "Wait — the user mentioned me directly. I should respond.\n\nHi! How can I help?",
+    );
+    expect(reply.text).not.toContain("NO_REPLY");
+  });
+
   it("keeps NO_REPLY when used as leading substantive text", () => {
     const result = normalizeReplyPayload({ text: "NO_REPLY -- nope" });
     expect(expectNormalizedReply(result).text).toBe("NO_REPLY -- nope");

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -266,6 +266,14 @@ describe("stripLeadingSilentToken", () => {
   it("strips glued leading token text", () => {
     expect(stripLeadingSilentToken("NO_REPLYThe user is saying")).toBe("The user is saying");
   });
+
+  it("strips newline-separated leading token text (#103735)", () => {
+    expect(
+      stripLeadingSilentToken(
+        "NO_REPLY\n\nWait — the user mentioned me directly.\n\nHi! How can I help?",
+      ),
+    ).toBe("Wait — the user mentioned me directly.\n\nHi! How can I help?");
+  });
 });
 
 describe("startsWithSilentToken", () => {
@@ -273,6 +281,12 @@ describe("startsWithSilentToken", () => {
     expect(startsWithSilentToken("NO_REPLYThe user is saying")).toBe(true);
     expect(startsWithSilentToken("No_RePlYThe user is saying")).toBe(true);
     expect(startsWithSilentToken("no_replyThe user is saying")).toBe(true);
+  });
+
+  it("matches whitespace- or newline-separated leading tokens before word content (#103735)", () => {
+    expect(startsWithSilentToken("NO_REPLY\n\nWait — the user mentioned me")).toBe(true);
+    expect(startsWithSilentToken("NO_REPLY\nHi!")).toBe(true);
+    expect(startsWithSilentToken("no_reply  Hello")).toBe(true);
   });
 
   it("rejects separated substantive prefixes and exact-token-only text", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -243,11 +243,16 @@ function getSilentLeadingAttachedRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  // Match one or more leading occurrences of the token where the final token
-  // is glued directly to visible word-start content (for example
-  // `NO_REPLYhello`), without treating punctuation-start text like
-  // `NO_REPLY: explanation` as a silent prefix.
-  const regex = new RegExp(`^\\s*(?:${escaped}\\s+)*${escaped}(?=[\\p{L}\\p{N}])`, "iu");
+  // Match one or more leading occurrences of the token when the final token is
+  // either glued to word-start content (`NO_REPLYhello`) or separated from it by
+  // whitespace/newlines (`NO_REPLY\n\nWait`). Preserve punctuation-start
+  // substantive forms such as `NO_REPLY: explanation` and `NO_REPLY -- nope`.
+  // Without the whitespace branch, newline-separated leading sentinels fall
+  // through both glued-leading and trailing-only strippers and leak to channels.
+  const regex = new RegExp(
+    `^\\s*(?:${escaped}\\s+)*${escaped}(?:(?=[\\p{L}\\p{N}])|\\s+(?=[\\p{L}\\p{N}]))`,
+    "iu",
+  );
   silentLeadingAttachedRegexByToken.set(token, regex);
   return regex;
 }
@@ -266,8 +271,8 @@ function getSilentLeadingRegex(token: string): RegExp {
 
 /**
  * Strip leading silent reply tokens from text.
- * Handles cases like "NO_REPLYThe user is saying..." where the token
- * is not separated from the following text.
+ * Handles glued forms (`NO_REPLYThe user…`) and whitespace/newline-separated
+ * forms (`NO_REPLY\n\nWait…`) when paired with startsWithSilentToken.
  */
 export function stripLeadingSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
   return text.replace(getSilentLeadingRegex(token), "").trim();
@@ -275,7 +280,8 @@ export function stripLeadingSilentToken(text: string, token: string = SILENT_REP
 
 /**
  * Check whether text starts with one or more leading silent reply tokens where
- * the final token is glued directly to visible content.
+ * the final token is followed by visible word-start content, either glued or
+ * separated by whitespace/newlines.
  */
 export function startsWithSilentToken(
   text: string | undefined,


### PR DESCRIPTION
<!--
Fixes #103735
-->

## What Problem This Solves

Fixes an issue where users would receive a literal `NO_REPLY` control sentinel (and any interstitial reasoning text after it) in channel-visible replies when a model put the silent-reply token on its own leading line, separated from the real answer by newlines.

## Why This Change Was Made

The shared leading-sentinel detector only recognized tokens glued to the next word (`NO_REPLYhello`). A newline-separated leading token failed that check, and the trailing-only stripper could not remove it either, so the full raw text was delivered. This change expands the shared boundary-aware detector used by ordinary delivery and pending-final sanitization so a leading token followed by whitespace/newlines and then word-start content is stripped, while punctuation-start substantive forms (`NO_REPLY: …`, `NO_REPLY -- …`) stay intact.

## User Impact

Channel-visible replies no longer leak a leading `NO_REPLY` sentinel when the model emits it on a separate line before a real answer. Existing glued-token stripping and punctuation-preservation behavior is unchanged.

## Evidence

Verification host: local macOS (Crabbox bypass; Blacksmith Testbox CLI not installed on this host).

Commands run:

```text
node scripts/run-vitest.mjs \
  src/auto-reply/tokens.test.ts \
  src/auto-reply/reply/reply-utils.test.ts \
  src/auto-reply/reply/pending-final-delivery.test.ts
# → 144 tests passed across 3 files

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed
# → lanes=core, coreTests; typecheck + oxlint + guards passed

pnpm test:changed
# → same focused files passed
```

Runtime transcript after the patch (`pnpm exec tsx`):

```text
=== Real behavior proof (#103735) post-fix ===
startsWithSilentToken(issue): true
normalizeReplyPayload text: "Wait — the user mentioned me directly. I should respond.\n\nHi! How can I help?"
normalize contains NO_REPLY: false
pending-final: "Wait — the user mentioned me directly. I should respond.\n\nHi! How can I help?"
preserve NO_REPLY: explanation: "NO_REPLY: explanation"
preserve NO_REPLY -- nope: "NO_REPLY -- nope"
glued still strips: "The user is saying hello"
```

## Real behavior proof

- Behavior addressed: Leading newline-separated `NO_REPLY` sentinels are stripped from ordinary and pending-final delivery text instead of being shown to users.
- Environment: local macOS OpenClaw checkout at commit `6b8c82911`; focused Vitest + `pnpm exec tsx` runtime call of `normalizeReplyPayload` / `sanitizePendingFinalDeliveryText`.
- Current-main contrast: On current main, `startsWithSilentToken("NO_REPLY\n\nWait…")` is false, so `normalizeReplyPayload` leaves the full payload including the literal `NO_REPLY` line. Source-level gap confirmed before the patch (glued-only leading regex + trailing-only stripper).
- Exact steps or command run after this patch:
  1. `pnpm exec tsx` importing `normalizeReplyPayload` and `sanitizePendingFinalDeliveryText` with the issue payload.
  2. Focused Vitest cases for tokens / reply-utils / pending-final covering the same payload.
- Evidence after fix: Runtime and tests both return only the substantive reply (`Wait — … Hi! How can I help?`) with `contains NO_REPLY: false` for both ordinary and pending-final paths.
- Control check: Punctuation-start forms (`NO_REPLY: explanation`, `NO_REPLY -- nope`) remain unchanged; glued leading forms still strip.
- Observed result after fix: The issue payload is normalized to channel-safe text without the sentinel on both delivery paths that share the token helper.
- What was not tested: Live Telegram/Slack/Discord client delivery of a full agent turn; ClawSweeper accepted source-level / unit proof for this issue (`clawsweeper:source-repro`, no `needs-live-repro`).

Fixes #103735

---

AI-assisted contribution: this fix was authored with AI assistance (Grok). The change and proof were reviewed against ClawSweeper guidance for #103735 before submission.
