### PR TITLE
fix(qa-lab): keep saved view text truncation UTF-16 safe

### DIFF
--- a/extensions/qa-lab/web/src/capture-saved-view.test.ts
+++ b/extensions/qa-lab/web/src/capture-saved-view.test.ts
@@ -103,4 +103,20 @@ describe("capture saved views", () => {
 
     expect(normalizeCaptureSavedViews(views)).toHaveLength(12);
   });
+
+  it("keeps bounded saved view text on UTF-16 boundaries", () => {
+    const view = normalizeCaptureSavedView({
+      id: `${"i".repeat(255)}😀after`,
+      name: `${"n".repeat(79)}😀after`,
+      sessionIds: [`${"s".repeat(255)}😀after`],
+      searchText: `${"q".repeat(499)}😀after`,
+    });
+
+    expect(view).toMatchObject({
+      id: "i".repeat(255),
+      name: "n".repeat(79),
+      sessionIds: ["s".repeat(255)],
+      searchText: "q".repeat(499),
+    });
+  });
 });

--- a/extensions/qa-lab/web/src/capture-saved-view.ts
+++ b/extensions/qa-lab/web/src/capture-saved-view.ts
@@ -1,5 +1,5 @@
 // Qa Lab plugin module implements capture saved view behavior.
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CaptureSavedView } from "./ui-render.js";
 
 const MAX_SAVED_VIEWS = 12;
@@ -39,7 +39,7 @@ function readString(value: unknown, maxLength: number): string | null {
     return null;
   }
   const trimmed = value.trim();
-  return trimmed ? sliceUtf16Safe(trimmed, 0, maxLength) : null;
+  return trimmed ? truncateUtf16Safe(trimmed, maxLength) : null;
 }
 
 function readStringArray(value: unknown): string[] {
@@ -48,7 +48,7 @@ function readStringArray(value: unknown): string[] {
   }
   return value
     .filter((item): item is string => typeof item === "string")
-    .map((item) => sliceUtf16Safe(item.trim(), 0, MAX_FILTER_VALUE_LENGTH))
+    .map((item) => truncateUtf16Safe(item.trim(), MAX_FILTER_VALUE_LENGTH))
     .filter(Boolean)
     .slice(0, MAX_FILTER_ITEMS);
 }
@@ -87,7 +87,7 @@ export function normalizeCaptureSavedView(value: unknown): CaptureSavedView | nu
     hostFilter: readStringArray(record.hostFilter),
     searchText:
       typeof record.searchText === "string"
-        ? sliceUtf16Safe(record.searchText, 0, MAX_SEARCH_TEXT_LENGTH)
+        ? truncateUtf16Safe(record.searchText, MAX_SEARCH_TEXT_LENGTH)
         : "",
     headerMode: readEnum(record.headerMode, headerModes, "key"),
     viewMode: readEnum(record.viewMode, viewModes, "list"),

--- a/extensions/qa-lab/web/src/capture-saved-view.ts
+++ b/extensions/qa-lab/web/src/capture-saved-view.ts
@@ -1,4 +1,5 @@
 // Qa Lab plugin module implements capture saved view behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CaptureSavedView } from "./ui-render.js";
 
 const MAX_SAVED_VIEWS = 12;
@@ -38,7 +39,7 @@ function readString(value: unknown, maxLength: number): string | null {
     return null;
   }
   const trimmed = value.trim();
-  return trimmed ? trimmed.slice(0, maxLength) : null;
+  return trimmed ? sliceUtf16Safe(trimmed, 0, maxLength) : null;
 }
 
 function readStringArray(value: unknown): string[] {
@@ -47,7 +48,7 @@ function readStringArray(value: unknown): string[] {
   }
   return value
     .filter((item): item is string => typeof item === "string")
-    .map((item) => item.trim().slice(0, MAX_FILTER_VALUE_LENGTH))
+    .map((item) => sliceUtf16Safe(item.trim(), 0, MAX_FILTER_VALUE_LENGTH))
     .filter(Boolean)
     .slice(0, MAX_FILTER_ITEMS);
 }
@@ -86,7 +87,7 @@ export function normalizeCaptureSavedView(value: unknown): CaptureSavedView | nu
     hostFilter: readStringArray(record.hostFilter),
     searchText:
       typeof record.searchText === "string"
-        ? record.searchText.slice(0, MAX_SEARCH_TEXT_LENGTH)
+        ? sliceUtf16Safe(record.searchText, 0, MAX_SEARCH_TEXT_LENGTH)
         : "",
     headerMode: readEnum(record.headerMode, headerModes, "key"),
     viewMode: readEnum(record.viewMode, viewModes, "list"),


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

Fixes an issue where QA Lab users load or save a capture view with emoji at a saved-text length boundary and the view can contain malformed text.

## Why This Change Was Made

All bounded saved-view strings now use the existing UTF-16-safe truncation helper. The existing code-unit limits remain unchanged; this only backs a cut up to avoid splitting an emoji surrogate pair. No saved-view schema, storage key, or UI behavior outside truncation changes.

## User Impact

Saved capture view names, identifiers, filters, and search text remain well-formed when users work with long emoji-containing values.

## Evidence

- Contributor live proof: started the task-branch OpenClaw gateway and QA Lab HTTP UI, loaded a saved view containing emoji exactly at the ID/name/filter/search length boundaries, then selected it in a real browser. The rendered ID, name, and applied search text were bounded to 255, 79, and 499 UTF-16 code units respectively, with `loneSurrogate: false`.
- Exact-head isolated proof at `fc3c1c8a461402d2b57d68ba208b9532bb090306`: AWS Crabbox run `run_61cb296bd643` passed `pnpm test extensions/qa-lab/web/src/capture-saved-view.test.ts` (5 tests) and `pnpm exec vite build --config extensions/qa-lab/web/vite.config.ts`.
- Targeted formatter check passed for both changed files.
- Fresh exact-head autoreview: clean, confidence 0.99.
