### PR TITLE
fix(plugins): treat path-like provider ids as no bundled policy surface (#103744)

### DIFF
--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -20,6 +20,7 @@ import {
   loadBundledPluginPublicArtifactModuleSync,
   loadPluginPublicArtifactModuleSync,
 } from "./public-surface-loader.js";
+import { isBundledPluginDirName } from "./public-surface-runtime.js";
 
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
 const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
@@ -86,6 +87,13 @@ function resolveCachedProviderPolicySurface(params: {
 export function resolveDirectBundledProviderPolicySurface(
   pluginId: string,
 ): BundledProviderPolicySurface | null {
+  // Provider ids reach this on request paths (sessions.list, spawn, model
+  // routes). Custom providers and mis-parsed `provider:org/model` refs are not
+  // bundled plugin dirs; resolve them to "no surface" instead of letting the
+  // path-like dir name crash the loader and the request (#103744).
+  if (!isBundledPluginDirName(pluginId)) {
+    return null;
+  }
   return resolveCachedProviderPolicySurface({
     cacheKey: `${resolveBundledPluginsDir() ?? ""}\0${pluginId}`,
     loadModule: (artifactBasename) =>

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -52,6 +52,15 @@ describe("provider public artifacts", () => {
     vi.resetModules();
   });
 
+  it("returns null instead of throwing for provider ids that cannot be bundled dir names", () => {
+    // Custom providers and mis-parsed `provider:org/model` refs reach policy
+    // lookup on request paths like sessions.list; a path-like provider id must
+    // resolve to "no bundled surface", not crash the request (#103744).
+    expect(resolveBundledProviderPolicySurface("my-ngc:nvidia")).toBeNull();
+    expect(resolveBundledProviderPolicySurface("z-ai/glm-5.2")).toBeNull();
+    expect(resolveBundledProviderPolicySurface("..")).toBeNull();
+  });
+
   it("loads a lightweight bundled provider policy artifact smoke", () => {
     const surface = resolveBundledProviderPolicySurface("openai");
     expect(surface?.normalizeConfig).toBeTypeOf("function");

--- a/src/plugins/public-surface-runtime.ts
+++ b/src/plugins/public-surface-runtime.ts
@@ -41,20 +41,25 @@ export function normalizeBundledPluginArtifactSubpath(artifactBasename: string):
   return normalized;
 }
 
+/** True when the value can name a bundled plugin directory (one path segment). */
+export function isBundledPluginDirName(dirName: string): boolean {
+  const normalized = dirName.trim();
+  return (
+    Boolean(normalized) &&
+    normalized !== "." &&
+    normalized !== ".." &&
+    !normalized.includes("/") &&
+    !normalized.includes("\\") &&
+    !normalized.includes(":")
+  );
+}
+
 /** Normalizes a bundled plugin directory name and rejects path-like values. */
 function normalizeBundledPluginDirName(dirName: string): string {
-  const normalized = dirName.trim();
-  if (
-    !normalized ||
-    normalized === "." ||
-    normalized === ".." ||
-    normalized.includes("/") ||
-    normalized.includes("\\") ||
-    normalized.includes(":")
-  ) {
+  if (!isBundledPluginDirName(dirName)) {
     throw new Error(`Bundled plugin dirName must be a single directory: ${dirName}`);
   }
-  return normalized;
+  return dirName.trim();
 }
 
 /** Resolves a source-tree public surface artifact path for bundled plugin development. */


### PR DESCRIPTION
## Summary

Fixes #103744.

`sessions_list` (and any other request path that resolves provider policy — `sessions_spawn`, status) crashed with `Error: Bundled plugin dirName must be a single directory: my-ngc:nvidia` whenever a session referenced a model from a custom provider whose derived provider id contains `:` or `/`. NGC-style model ids (`org/model`) make this deterministic: `parseModelRef` splits `my-ngc:nvidia/nemotron-3-ultra-550b-a55b` at the first `/`, deriving provider `my-ngc:nvidia`, and that string flowed into `resolveBundledProviderPolicySurface` → `loadBundledPluginPublicArtifactModuleSync({ dirName: providerId })` → `normalizeBundledPluginDirName`, which throws on path-like values.

The core defect: a provider id is not necessarily a bundled-plugin directory name, but the policy lookup treated every provider id as one and let the validation error escape on request paths. `normalizeProviderId` only lowercases, so the `:`/`/` survive.

### Change

- `src/plugins/public-surface-runtime.ts`: extract the existing validation into an `isBundledPluginDirName` predicate; `normalizeBundledPluginDirName` keeps throwing for actual loader misuse.
- `src/plugins/provider-public-artifacts.ts`: `tryLoadBundledProviderPolicySurface` returns null for ids that cannot name a bundled plugin directory — custom providers simply have no bundled policy surface. The security-relevant validation still guards every real path resolution.

The mis-parse of `provider:org/model` references in `parseModelRef` is a separate, adjacent question (that colon syntax is only a compat alias for `openrouter:auto` today); this PR fixes the crash at the owner boundary so no provider id shape can take down `sessions_list`.

## Verification

- New regression (written first, confirmed failing on main with the exact reported error): `resolveBundledProviderPolicySurface("my-ngc:nvidia")`, `("z-ai/glm-5.2")`, and `("..")` return null instead of throwing.
- `pnpm test src/plugins src/agents/model-selection.test.ts` — 2,685 passed. The 3 failures (`plugin-registry-snapshot`, `sdk-alias`) fail identically on unmodified `main` in this environment (verified via `git stash` baseline run) and are unrelated.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt, oxlint — clean.

## Real behavior proof

Behavior addressed: `sessions_list` crashes with "Bundled plugin dirName must be a single directory: <provider>:<namespace>" for sessions referencing custom-provider models with `org/model` ids.
Real environment tested: the real `resolveBundledProviderPolicySurface` production path with the exact provider id from the issue repro (`my-ngc:nvidia`), driven through the existing provider-public-artifacts test harness against the real bundled plugin registry.
Exact steps or command run after this patch: `pnpm test src/plugins/provider-public-artifacts.test.ts src/plugins/public-surface-runtime.test.ts src/plugins/public-surface-loader.test.ts`
Evidence after fix: before the patch the new test fails with `Error: Bundled plugin dirName must be a single directory: my-ngc:nvidia` (the issue's exact error); after the patch all 28 tests in the three touched suites pass and the lookup returns null.
Observed result after fix: policy lookup degrades to "no bundled surface" for path-like provider ids; valid bundled providers (openai, minimax, moonshot smoke tests) still resolve their surfaces.
What was not tested: an end-to-end `sessions_list` call against a live gateway with an NGC proxy provider configured; the crash site is fully covered at the resolver boundary that every such request path shares.
