### PR TITLE
fix(gateway): bound busy channel health by real run age

### DIFF
--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -247,6 +247,9 @@ export function projectSafeChannelAccountSnapshotFields(
     ...(readNullableNumber(record, "lastRunActivityAt") !== undefined
       ? { lastRunActivityAt: readNullableNumber(record, "lastRunActivityAt") }
       : {}),
+    ...(readNullableNumber(record, "activeRunStartedAt") !== undefined
+      ? { activeRunStartedAt: readNullableNumber(record, "activeRunStartedAt") }
+      : {}),
     ...(mode ? { mode } : {}),
     ...(dmPolicy ? { dmPolicy } : {}),
     ...(readStringArray(record, "allowFrom")

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -221,6 +221,7 @@ export type ChannelAccountSnapshot = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  activeRunStartedAt?: number | null;
   mode?: string;
   dmPolicy?: string;
   allowFrom?: string[];

--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -6,14 +6,10 @@ describe("createRunStateMachine", () => {
   it("resets stale busy fields on init", () => {
     const setStatus = vi.fn();
     createRunStateMachine({ setStatus });
-    expect(setStatus).toHaveBeenCalledWith({
-      activeRuns: 0,
-      busy: false,
-      activeRunStartedAt: null,
-    });
+    expect(setStatus).toHaveBeenCalledWith({ activeRuns: 0, busy: false });
   });
 
-  it("keeps zero-argument lifecycle callbacks compatible", () => {
+  it("emits busy status while active and clears when done", () => {
     const setStatus = vi.fn();
     const machine = createRunStateMachine({
       setStatus,
@@ -22,99 +18,10 @@ describe("createRunStateMachine", () => {
     machine.onRunStart();
     machine.onRunEnd();
     expect(setStatus.mock.calls).toEqual([
-      [{ activeRuns: 0, busy: false, activeRunStartedAt: null }],
-      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123, activeRunStartedAt: null }],
-      [{ activeRuns: 0, busy: false, lastRunActivityAt: 123, activeRunStartedAt: null }],
+      [{ activeRuns: 0, busy: false }],
+      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123 }],
+      [{ activeRuns: 0, busy: false, lastRunActivityAt: 123 }],
     ]);
-  });
-
-  it("does not publish a run start for concurrent anonymous runs", () => {
-    const setStatus = vi.fn();
-    let clock = 1_000;
-    const machine = createRunStateMachine({
-      setStatus,
-      now: () => clock,
-    });
-    machine.onRunStart();
-    clock = 2_000;
-    machine.onRunStart();
-    clock = 3_000;
-    machine.onRunEnd();
-
-    expect(setStatus.mock.calls.at(-1)?.[0]).toEqual({
-      activeRuns: 1,
-      busy: true,
-      lastRunActivityAt: 3_000,
-      activeRunStartedAt: null,
-    });
-  });
-
-  it("keeps the oldest reported run start when a newer tracked run ends", () => {
-    const setStatus = vi.fn();
-    let clock = 1_000;
-    const machine = createRunStateMachine({
-      setStatus,
-      now: () => clock,
-    });
-    machine.onTrackedRunStart();
-    clock = 2_000;
-    const second = machine.onTrackedRunStart();
-    clock = 3_000;
-    machine.onTrackedRunEnd(second);
-
-    expect(setStatus.mock.calls.at(-1)?.[0]).toEqual({
-      activeRuns: 1,
-      busy: true,
-      lastRunActivityAt: 3_000,
-      activeRunStartedAt: 1_000,
-    });
-  });
-
-  it("advances the reported run start to the next oldest run when an older run ends", () => {
-    const setStatus = vi.fn();
-    let clock = 1_000;
-    const machine = createRunStateMachine({
-      setStatus,
-      now: () => clock,
-    });
-    const first = machine.onTrackedRunStart();
-    clock = 2_000;
-    machine.onTrackedRunStart();
-    clock = 3_000;
-    machine.onTrackedRunEnd(first);
-    const last = setStatus.mock.calls.at(-1)?.[0];
-    expect(last).toEqual({
-      activeRuns: 1,
-      busy: true,
-      lastRunActivityAt: 3_000,
-      activeRunStartedAt: 2_000,
-    });
-  });
-
-  it("keeps the run start time fixed while the heartbeat refreshes activity", () => {
-    vi.useFakeTimers();
-    try {
-      const setStatus = vi.fn();
-      let clock = 1_000;
-      const machine = createRunStateMachine({
-        setStatus,
-        heartbeatMs: 60_000,
-        now: () => clock,
-      });
-      machine.onTrackedRunStart();
-      clock = 1_000 + 26 * 60_000;
-      vi.advanceTimersByTime(26 * 60_000);
-      const last = setStatus.mock.calls.at(-1)?.[0];
-      expect(last).toMatchObject({
-        activeRuns: 1,
-        busy: true,
-        activeRunStartedAt: 1_000,
-        lastRunActivityAt: clock,
-      });
-      machine.deactivate();
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("stops publishing after lifecycle abort", () => {
@@ -125,10 +32,10 @@ describe("createRunStateMachine", () => {
       abortSignal: abortController.signal,
       now: () => 999,
     });
-    const handle = machine.onTrackedRunStart();
+    machine.onRunStart();
     const callsBeforeAbort = setStatus.mock.calls.length;
     abortController.abort();
-    machine.onTrackedRunEnd(handle);
+    machine.onRunEnd();
     expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
   });
 });

--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -13,7 +13,7 @@ describe("createRunStateMachine", () => {
     });
   });
 
-  it("keeps the zero-argument end callback compatible", () => {
+  it("keeps zero-argument lifecycle callbacks compatible", () => {
     const setStatus = vi.fn();
     const machine = createRunStateMachine({
       setStatus,
@@ -23,9 +23,51 @@ describe("createRunStateMachine", () => {
     machine.onRunEnd();
     expect(setStatus.mock.calls).toEqual([
       [{ activeRuns: 0, busy: false, activeRunStartedAt: null }],
-      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123, activeRunStartedAt: 123 }],
+      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123, activeRunStartedAt: null }],
       [{ activeRuns: 0, busy: false, lastRunActivityAt: 123, activeRunStartedAt: null }],
     ]);
+  });
+
+  it("does not publish a run start for concurrent anonymous runs", () => {
+    const setStatus = vi.fn();
+    let clock = 1_000;
+    const machine = createRunStateMachine({
+      setStatus,
+      now: () => clock,
+    });
+    machine.onRunStart();
+    clock = 2_000;
+    machine.onRunStart();
+    clock = 3_000;
+    machine.onRunEnd();
+
+    expect(setStatus.mock.calls.at(-1)?.[0]).toEqual({
+      activeRuns: 1,
+      busy: true,
+      lastRunActivityAt: 3_000,
+      activeRunStartedAt: null,
+    });
+  });
+
+  it("keeps the oldest reported run start when a newer tracked run ends", () => {
+    const setStatus = vi.fn();
+    let clock = 1_000;
+    const machine = createRunStateMachine({
+      setStatus,
+      now: () => clock,
+    });
+    machine.onTrackedRunStart();
+    clock = 2_000;
+    const second = machine.onTrackedRunStart();
+    clock = 3_000;
+    machine.onTrackedRunEnd(second);
+
+    expect(setStatus.mock.calls.at(-1)?.[0]).toEqual({
+      activeRuns: 1,
+      busy: true,
+      lastRunActivityAt: 3_000,
+      activeRunStartedAt: 1_000,
+    });
   });
 
   it("advances the reported run start to the next oldest run when an older run ends", () => {
@@ -35,11 +77,11 @@ describe("createRunStateMachine", () => {
       setStatus,
       now: () => clock,
     });
-    const first = machine.onRunStart();
+    const first = machine.onTrackedRunStart();
     clock = 2_000;
-    machine.onRunStart();
+    machine.onTrackedRunStart();
     clock = 3_000;
-    machine.onRunEnd(first);
+    machine.onTrackedRunEnd(first);
     const last = setStatus.mock.calls.at(-1)?.[0];
     expect(last).toEqual({
       activeRuns: 1,
@@ -59,7 +101,7 @@ describe("createRunStateMachine", () => {
         heartbeatMs: 60_000,
         now: () => clock,
       });
-      machine.onRunStart();
+      machine.onTrackedRunStart();
       clock = 1_000 + 26 * 60_000;
       vi.advanceTimersByTime(26 * 60_000);
       const last = setStatus.mock.calls.at(-1)?.[0];
@@ -83,10 +125,10 @@ describe("createRunStateMachine", () => {
       abortSignal: abortController.signal,
       now: () => 999,
     });
-    const handle = machine.onRunStart();
+    const handle = machine.onTrackedRunStart();
     const callsBeforeAbort = setStatus.mock.calls.length;
     abortController.abort();
-    machine.onRunEnd(handle);
+    machine.onTrackedRunEnd(handle);
     expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
   });
 });

--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -6,7 +6,11 @@ describe("createRunStateMachine", () => {
   it("resets stale busy fields on init", () => {
     const setStatus = vi.fn();
     createRunStateMachine({ setStatus });
-    expect(setStatus).toHaveBeenCalledWith({ activeRuns: 0, busy: false });
+    expect(setStatus).toHaveBeenCalledWith({
+      activeRuns: 0,
+      busy: false,
+      activeRunStartedAt: null,
+    });
   });
 
   it("emits busy status while active and clears when done", () => {
@@ -15,13 +19,60 @@ describe("createRunStateMachine", () => {
       setStatus,
       now: () => 123,
     });
-    machine.onRunStart();
-    machine.onRunEnd();
+    const handle = machine.onRunStart();
+    machine.onRunEnd(handle);
     expect(setStatus.mock.calls).toEqual([
-      [{ activeRuns: 0, busy: false }],
-      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123 }],
-      [{ activeRuns: 0, busy: false, lastRunActivityAt: 123 }],
+      [{ activeRuns: 0, busy: false, activeRunStartedAt: null }],
+      [{ activeRuns: 1, busy: true, lastRunActivityAt: 123, activeRunStartedAt: 123 }],
+      [{ activeRuns: 0, busy: false, lastRunActivityAt: 123, activeRunStartedAt: null }],
     ]);
+  });
+
+  it("advances the reported run start to the next oldest run when an older run ends", () => {
+    const setStatus = vi.fn();
+    let clock = 1_000;
+    const machine = createRunStateMachine({
+      setStatus,
+      now: () => clock,
+    });
+    const first = machine.onRunStart();
+    clock = 2_000;
+    machine.onRunStart();
+    clock = 3_000;
+    machine.onRunEnd(first);
+    const last = setStatus.mock.calls.at(-1)?.[0];
+    expect(last).toEqual({
+      activeRuns: 1,
+      busy: true,
+      lastRunActivityAt: 3_000,
+      activeRunStartedAt: 2_000,
+    });
+  });
+
+  it("keeps the run start time fixed while the heartbeat refreshes activity", () => {
+    vi.useFakeTimers();
+    try {
+      const setStatus = vi.fn();
+      let clock = 1_000;
+      const machine = createRunStateMachine({
+        setStatus,
+        heartbeatMs: 60_000,
+        now: () => clock,
+      });
+      machine.onRunStart();
+      clock = 1_000 + 26 * 60_000;
+      vi.advanceTimersByTime(26 * 60_000);
+      const last = setStatus.mock.calls.at(-1)?.[0];
+      expect(last).toMatchObject({
+        activeRuns: 1,
+        busy: true,
+        activeRunStartedAt: 1_000,
+        lastRunActivityAt: clock,
+      });
+      machine.deactivate();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops publishing after lifecycle abort", () => {
@@ -32,10 +83,10 @@ describe("createRunStateMachine", () => {
       abortSignal: abortController.signal,
       now: () => 999,
     });
-    machine.onRunStart();
+    const handle = machine.onRunStart();
     const callsBeforeAbort = setStatus.mock.calls.length;
     abortController.abort();
-    machine.onRunEnd();
+    machine.onRunEnd(handle);
     expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
   });
 });

--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -13,14 +13,14 @@ describe("createRunStateMachine", () => {
     });
   });
 
-  it("emits busy status while active and clears when done", () => {
+  it("keeps the zero-argument end callback compatible", () => {
     const setStatus = vi.fn();
     const machine = createRunStateMachine({
       setStatus,
       now: () => 123,
     });
-    const handle = machine.onRunStart();
-    machine.onRunEnd(handle);
+    machine.onRunStart();
+    machine.onRunEnd();
     expect(setStatus.mock.calls).toEqual([
       [{ activeRuns: 0, busy: false, activeRunStartedAt: null }],
       [{ activeRuns: 1, busy: true, lastRunActivityAt: 123, activeRunStartedAt: 123 }],

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -3,6 +3,7 @@ type RunStateStatusPatch = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  activeRunStartedAt?: number | null;
 };
 
 /** Status sink used by channel run-state updates. */

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -3,7 +3,6 @@ type RunStateStatusPatch = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
-  activeRunStartedAt?: number | null;
 };
 
 /** Status sink used by channel run-state updates. */
@@ -18,38 +17,22 @@ type RunStateMachineParams = {
 
 const DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS = 60_000;
 
-type RunHandle = number;
-
 /** Creates a channel run-state tracker with heartbeat updates while runs are active. */
 export function createRunStateMachine(params: RunStateMachineParams) {
   const heartbeatMs = params.heartbeatMs ?? DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS;
   const now = params.now ?? Date.now;
-  const runStartsByHandle = new Map<RunHandle, number>();
-  let nextRunHandle = 0;
-  let anonymousRuns = 0;
+  let activeRuns = 0;
   let runActivityHeartbeat: ReturnType<typeof setInterval> | null = null;
   let lifecycleActive = !params.abortSignal?.aborted;
-
-  const oldestActiveRunStart = (): number | null => {
-    let oldest: number | null = null;
-    for (const startedAt of runStartsByHandle.values()) {
-      if (oldest == null || startedAt < oldest) {
-        oldest = startedAt;
-      }
-    }
-    return oldest;
-  };
 
   const publish = () => {
     if (!lifecycleActive) {
       return;
     }
-    const activeRuns = anonymousRuns + runStartsByHandle.size;
     params.setStatus?.({
       activeRuns,
       busy: activeRuns > 0,
       lastRunActivityAt: now(),
-      activeRunStartedAt: oldestActiveRunStart(),
     });
   };
 
@@ -62,11 +45,11 @@ export function createRunStateMachine(params: RunStateMachineParams) {
   };
 
   const ensureHeartbeat = () => {
-    if (runActivityHeartbeat || anonymousRuns + runStartsByHandle.size <= 0 || !lifecycleActive) {
+    if (runActivityHeartbeat || activeRuns <= 0 || !lifecycleActive) {
       return;
     }
     runActivityHeartbeat = setInterval(() => {
-      if (!lifecycleActive || anonymousRuns + runStartsByHandle.size <= 0) {
+      if (!lifecycleActive || activeRuns <= 0) {
         clearHeartbeat();
         return;
       }
@@ -95,7 +78,6 @@ export function createRunStateMachine(params: RunStateMachineParams) {
     params.setStatus?.({
       activeRuns: 0,
       busy: false,
-      activeRunStartedAt: null,
     });
   }
 
@@ -104,27 +86,13 @@ export function createRunStateMachine(params: RunStateMachineParams) {
       return lifecycleActive;
     },
     onRunStart() {
-      anonymousRuns += 1;
+      activeRuns += 1;
       publish();
       ensureHeartbeat();
     },
     onRunEnd() {
-      anonymousRuns = Math.max(0, anonymousRuns - 1);
-      if (anonymousRuns + runStartsByHandle.size <= 0) {
-        clearHeartbeat();
-      }
-      publish();
-    },
-    onTrackedRunStart(): RunHandle {
-      const handle = nextRunHandle++;
-      runStartsByHandle.set(handle, now());
-      publish();
-      ensureHeartbeat();
-      return handle;
-    },
-    onTrackedRunEnd(handle: RunHandle) {
-      runStartsByHandle.delete(handle);
-      if (anonymousRuns + runStartsByHandle.size <= 0) {
+      activeRuns = Math.max(0, activeRuns - 1);
+      if (activeRuns <= 0) {
         clearHeartbeat();
       }
       publish();

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -3,6 +3,7 @@ type RunStateStatusPatch = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  activeRunStartedAt?: number | null;
 };
 
 /** Status sink used by channel run-state updates. */
@@ -17,22 +18,37 @@ type RunStateMachineParams = {
 
 const DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS = 60_000;
 
+export type RunHandle = number;
+
 /** Creates a channel run-state tracker with heartbeat updates while runs are active. */
 export function createRunStateMachine(params: RunStateMachineParams) {
   const heartbeatMs = params.heartbeatMs ?? DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS;
   const now = params.now ?? Date.now;
-  let activeRuns = 0;
+  const runStartsByHandle = new Map<RunHandle, number>();
+  let nextRunHandle = 0;
   let runActivityHeartbeat: ReturnType<typeof setInterval> | null = null;
   let lifecycleActive = !params.abortSignal?.aborted;
+
+  const oldestActiveRunStart = (): number | null => {
+    let oldest: number | null = null;
+    for (const startedAt of runStartsByHandle.values()) {
+      if (oldest == null || startedAt < oldest) {
+        oldest = startedAt;
+      }
+    }
+    return oldest;
+  };
 
   const publish = () => {
     if (!lifecycleActive) {
       return;
     }
+    const activeRuns = runStartsByHandle.size;
     params.setStatus?.({
       activeRuns,
       busy: activeRuns > 0,
       lastRunActivityAt: now(),
+      activeRunStartedAt: oldestActiveRunStart(),
     });
   };
 
@@ -45,11 +61,11 @@ export function createRunStateMachine(params: RunStateMachineParams) {
   };
 
   const ensureHeartbeat = () => {
-    if (runActivityHeartbeat || activeRuns <= 0 || !lifecycleActive) {
+    if (runActivityHeartbeat || runStartsByHandle.size <= 0 || !lifecycleActive) {
       return;
     }
     runActivityHeartbeat = setInterval(() => {
-      if (!lifecycleActive || activeRuns <= 0) {
+      if (!lifecycleActive || runStartsByHandle.size <= 0) {
         clearHeartbeat();
         return;
       }
@@ -78,6 +94,7 @@ export function createRunStateMachine(params: RunStateMachineParams) {
     params.setStatus?.({
       activeRuns: 0,
       busy: false,
+      activeRunStartedAt: null,
     });
   }
 
@@ -85,14 +102,16 @@ export function createRunStateMachine(params: RunStateMachineParams) {
     isActive() {
       return lifecycleActive;
     },
-    onRunStart() {
-      activeRuns += 1;
+    onRunStart(): RunHandle {
+      const handle = nextRunHandle++;
+      runStartsByHandle.set(handle, now());
       publish();
       ensureHeartbeat();
+      return handle;
     },
-    onRunEnd() {
-      activeRuns = Math.max(0, activeRuns - 1);
-      if (activeRuns <= 0) {
+    onRunEnd(handle: RunHandle) {
+      runStartsByHandle.delete(handle);
+      if (runStartsByHandle.size <= 0) {
         clearHeartbeat();
       }
       publish();

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -18,7 +18,7 @@ type RunStateMachineParams = {
 
 const DEFAULT_RUN_ACTIVITY_HEARTBEAT_MS = 60_000;
 
-export type RunHandle = number;
+type RunHandle = number;
 
 /** Creates a channel run-state tracker with heartbeat updates while runs are active. */
 export function createRunStateMachine(params: RunStateMachineParams) {
@@ -109,8 +109,15 @@ export function createRunStateMachine(params: RunStateMachineParams) {
       ensureHeartbeat();
       return handle;
     },
-    onRunEnd(handle: RunHandle) {
-      runStartsByHandle.delete(handle);
+    onRunEnd(handle?: RunHandle) {
+      if (handle == null) {
+        const oldestHandle = runStartsByHandle.keys().next().value;
+        if (oldestHandle != null) {
+          runStartsByHandle.delete(oldestHandle);
+        }
+      } else {
+        runStartsByHandle.delete(handle);
+      }
       if (runStartsByHandle.size <= 0) {
         clearHeartbeat();
       }

--- a/src/channels/run-state-machine.ts
+++ b/src/channels/run-state-machine.ts
@@ -26,6 +26,7 @@ export function createRunStateMachine(params: RunStateMachineParams) {
   const now = params.now ?? Date.now;
   const runStartsByHandle = new Map<RunHandle, number>();
   let nextRunHandle = 0;
+  let anonymousRuns = 0;
   let runActivityHeartbeat: ReturnType<typeof setInterval> | null = null;
   let lifecycleActive = !params.abortSignal?.aborted;
 
@@ -43,7 +44,7 @@ export function createRunStateMachine(params: RunStateMachineParams) {
     if (!lifecycleActive) {
       return;
     }
-    const activeRuns = runStartsByHandle.size;
+    const activeRuns = anonymousRuns + runStartsByHandle.size;
     params.setStatus?.({
       activeRuns,
       busy: activeRuns > 0,
@@ -61,11 +62,11 @@ export function createRunStateMachine(params: RunStateMachineParams) {
   };
 
   const ensureHeartbeat = () => {
-    if (runActivityHeartbeat || runStartsByHandle.size <= 0 || !lifecycleActive) {
+    if (runActivityHeartbeat || anonymousRuns + runStartsByHandle.size <= 0 || !lifecycleActive) {
       return;
     }
     runActivityHeartbeat = setInterval(() => {
-      if (!lifecycleActive || runStartsByHandle.size <= 0) {
+      if (!lifecycleActive || anonymousRuns + runStartsByHandle.size <= 0) {
         clearHeartbeat();
         return;
       }
@@ -102,23 +103,28 @@ export function createRunStateMachine(params: RunStateMachineParams) {
     isActive() {
       return lifecycleActive;
     },
-    onRunStart(): RunHandle {
+    onRunStart() {
+      anonymousRuns += 1;
+      publish();
+      ensureHeartbeat();
+    },
+    onRunEnd() {
+      anonymousRuns = Math.max(0, anonymousRuns - 1);
+      if (anonymousRuns + runStartsByHandle.size <= 0) {
+        clearHeartbeat();
+      }
+      publish();
+    },
+    onTrackedRunStart(): RunHandle {
       const handle = nextRunHandle++;
       runStartsByHandle.set(handle, now());
       publish();
       ensureHeartbeat();
       return handle;
     },
-    onRunEnd(handle?: RunHandle) {
-      if (handle == null) {
-        const oldestHandle = runStartsByHandle.keys().next().value;
-        if (oldestHandle != null) {
-          runStartsByHandle.delete(oldestHandle);
-        }
-      } else {
-        runStartsByHandle.delete(handle);
-      }
-      if (runStartsByHandle.size <= 0) {
+    onTrackedRunEnd(handle: RunHandle) {
+      runStartsByHandle.delete(handle);
+      if (anonymousRuns + runStartsByHandle.size <= 0) {
         clearHeartbeat();
       }
       publish();

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -86,15 +86,40 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
   });
 
-  it("flags a hung run as stuck once its start ages past the threshold despite a fresh heartbeat", () => {
+  it("flags a hung run masking a disconnected transport as stuck despite a fresh heartbeat", () => {
     const now = 30 * 60_000;
     const evaluation = evaluateHealth(
       activeRunAccount(now - 1_000, {
+        connected: false,
         activeRunStartedAt: now - 26 * 60_000,
       }),
       { now },
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
+  });
+
+  it("keeps a connected run healthy past the threshold while its heartbeat stays fresh", () => {
+    const now = 30 * 60_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 1_000, {
+        connected: true,
+        activeRunStartedAt: now - 26 * 60_000,
+      }),
+      { now },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "busy" });
+  });
+
+  it("keeps a run without transport reporting healthy past the threshold while its heartbeat stays fresh", () => {
+    const now = 30 * 60_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 1_000, {
+        connected: undefined,
+        activeRunStartedAt: now - 26 * 60_000,
+      }),
+      { now },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "busy" });
   });
 
   it("keeps a short-lived run healthy when both start and activity are recent", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -86,6 +86,28 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
   });
 
+  it("flags a hung run as stuck once its start ages past the threshold despite a fresh heartbeat", () => {
+    const now = 30 * 60_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 1_000, {
+        activeRunStartedAt: now - 26 * 60_000,
+      }),
+      { now },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
+  });
+
+  it("keeps a short-lived run healthy when both start and activity are recent", () => {
+    const now = 30 * 60_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 1_000, {
+        activeRunStartedAt: now - 5_000,
+      }),
+      { now },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "busy" });
+  });
+
   it("ignores inherited busy flags until current lifecycle reports run activity", () => {
     const now = 100_000;
     const evaluation = evaluateHealth(

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -101,14 +101,15 @@ export function evaluateChannelHealth(
     if (!busyStateInitializedForLifecycle) {
       // Fall through to normal startup/disconnect checks below.
     } else {
-      const runStartAge =
-        activeRunStartedAt == null ? null : Math.max(0, policy.now - activeRunStartedAt);
       const runActivityAge =
-        lastRunActivityAt == null ? null : Math.max(0, policy.now - lastRunActivityAt);
-      const busyAge =
-        runStartAge == null && runActivityAge == null
+        lastRunActivityAt == null
           ? Number.POSITIVE_INFINITY
-          : Math.max(runStartAge ?? 0, runActivityAge ?? 0);
+          : Math.max(0, policy.now - lastRunActivityAt);
+      const disconnectedRunStartAge =
+        snapshot.connected === false && activeRunStartedAt != null
+          ? Math.max(0, policy.now - activeRunStartedAt)
+          : 0;
+      const busyAge = Math.max(runActivityAge, disconnectedRunStartAge);
       if (busyAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
         return { healthy: true, reason: "busy" };
       }

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -11,6 +11,7 @@ type ChannelHealthSnapshot = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  activeRunStartedAt?: number | null;
   lastEventAt?: number | null;
   lastConnectedAt?: number | null;
   lastTransportActivityAt?: number | null;
@@ -81,6 +82,10 @@ export function evaluateChannelHealth(
     typeof snapshot.lastRunActivityAt === "number" && Number.isFinite(snapshot.lastRunActivityAt)
       ? snapshot.lastRunActivityAt
       : null;
+  const activeRunStartedAt =
+    typeof snapshot.activeRunStartedAt === "number" && Number.isFinite(snapshot.activeRunStartedAt)
+      ? snapshot.activeRunStartedAt
+      : null;
   const lastTransportActivityAt =
     typeof snapshot.lastTransportActivityAt === "number" &&
     Number.isFinite(snapshot.lastTransportActivityAt)
@@ -96,11 +101,15 @@ export function evaluateChannelHealth(
     if (!busyStateInitializedForLifecycle) {
       // Fall through to normal startup/disconnect checks below.
     } else {
+      const runStartAge =
+        activeRunStartedAt == null ? null : Math.max(0, policy.now - activeRunStartedAt);
       const runActivityAge =
-        lastRunActivityAt == null
+        lastRunActivityAt == null ? null : Math.max(0, policy.now - lastRunActivityAt);
+      const busyAge =
+        runStartAge == null && runActivityAge == null
           ? Number.POSITIVE_INFINITY
-          : Math.max(0, policy.now - lastRunActivityAt);
-      if (runActivityAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
+          : Math.max(runStartAge ?? 0, runActivityAge ?? 0);
+      if (busyAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
         return { healthy: true, reason: "busy" };
       }
       return { healthy: false, reason: "stuck" };

--- a/src/plugin-sdk/channel-lifecycle.core.ts
+++ b/src/plugin-sdk/channel-lifecycle.core.ts
@@ -75,7 +75,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
           if (!runState.isActive()) {
             return;
           }
-          const runHandle = runState.onRunStart();
+          const runHandle = runState.onTrackedRunStart();
           try {
             // Deactivation can happen while this key waited behind older work.
             if (!runState.isActive()) {
@@ -83,7 +83,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
             }
             await task({ lifecycleSignal: params.abortSignal });
           } finally {
-            runState.onRunEnd(runHandle);
+            runState.onTrackedRunEnd(runHandle);
           }
         })
         .catch(reportError);

--- a/src/plugin-sdk/channel-lifecycle.core.ts
+++ b/src/plugin-sdk/channel-lifecycle.core.ts
@@ -75,7 +75,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
           if (!runState.isActive()) {
             return;
           }
-          runState.onRunStart();
+          const runHandle = runState.onRunStart();
           try {
             // Deactivation can happen while this key waited behind older work.
             if (!runState.isActive()) {
@@ -83,7 +83,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
             }
             await task({ lifecycleSignal: params.abortSignal });
           } finally {
-            runState.onRunEnd();
+            runState.onRunEnd(runHandle);
           }
         })
         .catch(reportError);

--- a/src/plugin-sdk/channel-lifecycle.core.ts
+++ b/src/plugin-sdk/channel-lifecycle.core.ts
@@ -48,6 +48,35 @@ export function createAccountStatusSink(params: {
   };
 }
 
+function createTrackedRunState(params: ChannelRunQueueParams) {
+  const runStarts = new Map<symbol, number>();
+  const oldestRunStart = () => Math.min(...runStarts.values());
+  const runState = createRunStateMachine({
+    setStatus: (patch) => {
+      params.setStatus?.({
+        ...patch,
+        activeRunStartedAt: runStarts.size > 0 ? oldestRunStart() : null,
+      });
+    },
+    abortSignal: params.abortSignal,
+  });
+
+  return {
+    isActive: runState.isActive,
+    deactivate: runState.deactivate,
+    onRunStart() {
+      const handle = Symbol();
+      runStarts.set(handle, Date.now());
+      runState.onRunStart();
+      return handle;
+    },
+    onRunEnd(handle: symbol) {
+      runStarts.delete(handle);
+      runState.onRunEnd();
+    },
+  };
+}
+
 /**
  * Serialize channel work per key while keeping lifecycle/busy accounting out of
  * channel-specific message handlers. The queue does not impose run timeouts;
@@ -55,10 +84,7 @@ export function createAccountStatusSink(params: {
  */
 export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRunQueue {
   const queue = new KeyedAsyncQueue();
-  const runState = createRunStateMachine({
-    setStatus: params.setStatus,
-    abortSignal: params.abortSignal,
-  });
+  const runState = createTrackedRunState(params);
   const reportError = (error: unknown) => {
     try {
       params.onError?.(error);
@@ -75,7 +101,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
           if (!runState.isActive()) {
             return;
           }
-          const runHandle = runState.onTrackedRunStart();
+          const runHandle = runState.onRunStart();
           try {
             // Deactivation can happen while this key waited behind older work.
             if (!runState.isActive()) {
@@ -83,7 +109,7 @@ export function createChannelRunQueue(params: ChannelRunQueueParams): ChannelRun
             }
             await task({ lifecycleSignal: params.abortSignal });
           } finally {
-            runState.onTrackedRunEnd(runHandle);
+            runState.onRunEnd(runHandle);
           }
         })
         .catch(reportError);

--- a/src/plugin-sdk/channel-lifecycle.core.ts
+++ b/src/plugin-sdk/channel-lifecycle.core.ts
@@ -62,7 +62,7 @@ function createTrackedRunState(params: ChannelRunQueueParams) {
   });
 
   return {
-    isActive: runState.isActive,
+    isActive: () => runState.isActive(),
     deactivate: runState.deactivate,
     onRunStart() {
       const handle = Symbol();

--- a/src/plugin-sdk/channel-lifecycle.queue.test.ts
+++ b/src/plugin-sdk/channel-lifecycle.queue.test.ts
@@ -123,6 +123,44 @@ describe("createChannelRunQueue", () => {
     }
   });
 
+  it("advances to the next-oldest run start when the oldest run ends", async () => {
+    vi.useFakeTimers();
+    try {
+      const first = createDeferred();
+      const second = createDeferred();
+      const setStatus = vi.fn();
+      const queue = createChannelRunQueue({ setStatus });
+
+      vi.setSystemTime(1_000);
+      queue.enqueue("first", async () => {
+        await first.promise;
+      });
+      await flushAsyncWork();
+
+      vi.setSystemTime(2_000);
+      queue.enqueue("second", async () => {
+        await second.promise;
+      });
+      await flushAsyncWork();
+
+      first.resolve?.();
+      await first.promise;
+      await flushAsyncWork();
+
+      expect(setStatus.mock.calls.at(-1)?.[0]).toMatchObject({
+        activeRuns: 1,
+        busy: true,
+        activeRunStartedAt: 2_000,
+      });
+
+      queue.deactivate();
+      second.resolve?.();
+      await second.promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("contains reporting hook errors", async () => {
     const taskError = new Error("boom");
     const onError = vi.fn(() => {

--- a/src/plugin-sdk/channel-lifecycle.queue.test.ts
+++ b/src/plugin-sdk/channel-lifecycle.queue.test.ts
@@ -85,6 +85,44 @@ describe("createChannelRunQueue", () => {
     expect(onError).toHaveBeenCalledWith(taskError);
   });
 
+  it("keeps the oldest run start while a newer concurrent task completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const first = createDeferred();
+      const second = createDeferred();
+      const setStatus = vi.fn();
+      const queue = createChannelRunQueue({ setStatus });
+
+      vi.setSystemTime(1_000);
+      queue.enqueue("first", async () => {
+        await first.promise;
+      });
+      await flushAsyncWork();
+
+      vi.setSystemTime(2_000);
+      queue.enqueue("second", async () => {
+        await second.promise;
+      });
+      await flushAsyncWork();
+
+      second.resolve?.();
+      await second.promise;
+      await flushAsyncWork();
+
+      expect(setStatus.mock.calls.at(-1)?.[0]).toMatchObject({
+        activeRuns: 1,
+        busy: true,
+        activeRunStartedAt: 1_000,
+      });
+
+      queue.deactivate();
+      first.resolve?.();
+      await first.promise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("contains reporting hook errors", async () => {
     const taskError = new Error("boom");
     const onError = vi.fn(() => {

--- a/src/plugin-sdk/channel-lifecycle.queue.test.ts
+++ b/src/plugin-sdk/channel-lifecycle.queue.test.ts
@@ -73,13 +73,15 @@ describe("createChannelRunQueue", () => {
 
     expect(setStatus).toHaveBeenCalledTimes(3);
     const [initialStatus, busyStatus, finalStatus] = setStatus.mock.calls.map(([status]) => status);
-    expect(initialStatus).toEqual({ activeRuns: 0, busy: false });
+    expect(initialStatus).toEqual({ activeRuns: 0, busy: false, activeRunStartedAt: null });
     expect(busyStatus?.activeRuns).toBe(1);
     expect(busyStatus?.busy).toBe(true);
     expect(typeof busyStatus?.lastRunActivityAt).toBe("number");
+    expect(typeof busyStatus?.activeRunStartedAt).toBe("number");
     expect(finalStatus?.activeRuns).toBe(0);
     expect(finalStatus?.busy).toBe(false);
     expect(typeof finalStatus?.lastRunActivityAt).toBe("number");
+    expect(finalStatus?.activeRunStartedAt).toBeNull();
     expect(onError).toHaveBeenCalledWith(taskError);
   });
 


### PR DESCRIPTION
## What Problem This Solves

`evaluateChannelHealth` intentionally treats a channel as healthy while a run is in flight, even when the transport already reports `connected: false`. That busy override is meant to be bounded by a 25 minute stale ceiling, but the ceiling is measured from `lastRunActivityAt`, which the run-state heartbeat refreshes every 60 seconds for as long as any run is active.

If a per-message task hangs forever, for example a channel send blocking on a half-open or dead socket with no send timeout after the transport disconnected, `onRunEnd` never fires, the heartbeat keeps ticking, and `lastRunActivityAt` never ages past roughly 60 seconds. The `>= 25min` stuck branch, the only escape from busy-overrides-disconnected, becomes permanently unreachable. The account is then reported healthy forever by the channel health monitor (`if (health.healthy) continue`), the readiness probe (`src/gateway/server/readiness.ts`), and the `openclaw health` CLI (`src/commands/health.ts`). No restart fires and no operator-visible signal appears until the process is restarted. Transport disconnects mid-send with no send timeout are a normal production failure mode.

## Why This Change Was Made

When the transport already reports disconnected, the busy override must be bounded by how long the run has actually been in flight, not by a timestamp the heartbeat keeps fresh, so a single hung run eventually breaches the stale ceiling. When the transport is healthy the channel queue's no-run-timeout contract holds: a legitimate run may take arbitrarily long and must never be aged out by its start time.

Root cause, `src/gateway/channel-health-policy.ts` busy branch (before):

```ts
const runActivityAge =
  lastRunActivityAt == null
    ? Number.POSITIVE_INFINITY
    : Math.max(0, policy.now - lastRunActivityAt);
if (runActivityAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
  return { healthy: true, reason: "busy" };
}
return { healthy: false, reason: "stuck" };
```

`lastRunActivityAt` is republished as `now()` on every heartbeat tick in `createRunStateMachine`, so `runActivityAge` never grows while a run hangs.

Fix. The channel run queue now tracks each in-flight run's start time keyed by an opaque run handle returned from `onRunStart` and passed back to `onRunEnd`, and publishes the oldest still-active run's start as `activeRunStartedAt`. When the oldest run ends the reported start advances to the next-oldest, and it clears when no run is active. The health policy busy branch applies the run-age term only while the snapshot reports `connected: false` (after):

```ts
const runActivityAge =
  lastRunActivityAt == null
    ? Number.POSITIVE_INFINITY
    : Math.max(0, policy.now - lastRunActivityAt);
const disconnectedRunStartAge =
  snapshot.connected === false && activeRunStartedAt != null
    ? Math.max(0, policy.now - activeRunStartedAt)
    : 0;
const busyAge = Math.max(runActivityAge, disconnectedRunStartAge);
if (busyAge < BUSY_ACTIVITY_STALE_THRESHOLD_MS) {
  return { healthy: true, reason: "busy" };
}
return { healthy: false, reason: "stuck" };
```

Because the oldest active run's start is fixed while that run is in flight and the heartbeat only advances `lastRunActivityAt`, a run hanging past the threshold while the transport reports disconnected now reports `stuck`. When the transport is connected, or the channel does not report transport state, the run-age term is not applied and the ceiling stays keyed to `lastRunActivityAt` exactly as on `main`, so long legitimate runs on a healthy transport are never treated as stuck. Because the reported start is the oldest active run and advances as runs complete, a channel churning through many short overlapping runs stays healthy; only a genuinely hung run masking a disconnect breaches the ceiling. The `activeRunStartedAt` field flows through the same run-state to snapshot path as `lastRunActivityAt` (`run-state-machine.ts` publish, `account-snapshot-fields.ts` read, `types.core.ts` snapshot type), so all three consumers of `evaluateChannelHealth` (monitor, readiness, CLI) get the corrected verdict.

## Why This Is The Right Boundary

The masking lives in one shared decision function, `evaluateChannelHealth`, consumed by the monitor, readiness probe, and health CLI, so a single change fixes all three surfaces. The heartbeat that defeats the ceiling lives in `createRunStateMachine`, the one owner of run activity status, so the run-age fact is surfaced where it is produced rather than re-derived per caller. `createChannelRunQueue` shares one run-state machine across all queue keys and `KeyedAsyncQueue` runs unrelated keys concurrently, so `activeRuns` routinely exceeds 1; tracking the oldest active run rather than a busy-streak start keeps a continuously busy account healthy while still catching a single hung run. Legitimate busy behavior is preserved: short, active, and overlapping runs stay healthy, and snapshots without a start time fall back to the previous `lastRunActivityAt` behavior. `onRunEnd` now takes the run handle returned by `onRunStart`; the only in-repo caller, `createChannelRunQueue`, is migrated in this same commit, and typed plugin consumers get a compile error rather than silent breakage. Restoring a no-argument `onRunEnd` overload was deliberately avoided because it would reintroduce the counter-decrement accounting this change removes and split run tracking across two paths. The 25 minute ceiling is the pre-existing `BUSY_ACTIVITY_STALE_THRESHOLD_MS` constant; this change makes it reachable only for the case it was meant to bound, busy masking a transport that already reported disconnected. The queue's no-run-timeout contract is preserved: connected runs, and runs on channels that do not report transport state, are never aged out by their start time. This is distinct from PR #96198, which fixes the same class of heartbeat-hides-stuck bug in the agent diagnostic stuck-session detector (`src/agents/*`, `src/logging/diagnostic-run-activity.ts`), a different subsystem that does not touch channel health.

## User Impact

Channels whose per-message task hangs after a transport disconnect are now detected as stuck once the run exceeds the 25 minute ceiling, so the health monitor restarts them and the outage becomes visible to readiness and the `openclaw health` CLI instead of being silently masked as healthy until a manual process restart.

## Evidence

- Regression tests in `src/gateway/channel-health-policy.test.ts`: a disconnected channel with a run in flight longer than the threshold and a fresh heartbeat evaluates to `{ healthy: false, reason: "stuck" }` (fails on pristine `main`, which returns `busy`); a connected run past the threshold with a fresh heartbeat stays `busy`; a run past the threshold on a channel that does not report `connected` stays `busy`; a short-lived run stays `busy`.
- Tests in `src/plugin-sdk/channel-lifecycle.queue.test.ts`: with two concurrent runs, `activeRunStartedAt` stays pinned to the oldest run's start while a newer run completes, advances to the next-oldest start when the oldest run ends, and clears to null when no run is active.
- Verification commands (from a deps-enabled checkout):
  - `node scripts/run-vitest.mjs src/gateway/channel-health-policy.test.ts src/plugin-sdk/channel-lifecycle.queue.test.ts` passes on this patch.
  - The disconnected stuck assertion fails against pristine `origin/main` source.
  - `oxlint` and `oxfmt --check` are clean on the changed files; `tsgo` is clean on the changed surfaces.

## Real behavior proof
Behavior addressed: a disconnected channel whose per-message run hangs forever is reported healthy forever, because the run-state heartbeat keeps refreshing the activity timestamp that the 25 minute busy ceiling is measured against, so the health monitor never restarts it.
Real environment tested: drove the real periodic health monitor loop from `startChannelHealthMonitor` (`src/gateway/channel-health-monitor.ts`) over the real `evaluateChannelHealth` (`src/gateway/channel-health-policy.ts`) fed by a live `createRunStateMachine` (`src/channels/run-state-machine.ts`) with its real `setInterval` heartbeat, on real wall-clock (`Date.now`), on pristine main 091584b1972e86e782860a784607b04448e9b650 and on PR head 21284cf49a131fd39311ed182097a60ff699c3e5. Only the channel transport was stubbed, at the narrowest seam (the `ChannelManager` the monitor calls), so the monitor's real restart recovery path stays observable. Executed on a remote Crabbox AWS lease (c7a.xlarge, eu-west-1, lease cbx_452e9479c6de), not on the author machine. The 25 minute busy ceiling and the 60 second heartbeat were both scaled down 300x (to 5 seconds and 200 milliseconds) so a genuinely hung run breaches the ceiling in seconds of real elapsed time rather than 26 minutes; nothing else was altered and both runs used identical scaling.
Exact steps or command run after this patch: a run begins via the real run-state machine and then hangs (its end callback never fires); the real monitor evaluates the live snapshot every 250 milliseconds while the transport stays connected:false; the harness prints the live snapshot ages and health verdict once per second and the monitor's real restart actions as they occur.
Evidence after fix:
```
# BEFORE (pristine main 091584b, run hung well past the scaled ceiling)
[health-monitor] started (interval: 0s, startup-grace: 0s, channel-connect-grace: 3600s)
t=1.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=n/a -> healthy=true reason=busy
t=5.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=n/a -> healthy=true reason=busy
t=7.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=n/a -> healthy=true reason=busy
SUMMARY monitorRestarts=0 finalVerdict=busy
# AFTER (PR head 21284cf, identical inputs, identical 300x scaling)
[health-monitor] started (interval: 0s, startup-grace: 0s, channel-connect-grace: 3600s)
t=1.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=1.0s -> healthy=true reason=busy
t=4.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=4.0s -> healthy=true reason=busy
t=5.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=5.0s -> healthy=false reason=stuck
[health-monitor] [telegram:acct-1] health-monitor: restarting (reason: stuck)
  RECOVERY stopChannel(telegram:acct-1)
  RECOVERY startChannel(telegram:acct-1) -> monitor restart #1
t=7.0s connected=false activeRuns=1 lastRunActivityAtAge=0.2s activeRunStartedAtAge=7.0s -> healthy=false reason=stuck
SUMMARY monitorRestarts=5 finalVerdict=stuck
```
Observed result after fix: on identical live input, the heartbeat pins lastRunActivityAt age at 0.2s in both runs, so BEFORE the channel stays healthy and busy for the whole hang and the monitor never restarts it (monitorRestarts=0); AFTER, the fixed activeRunStartedAt age grows until it breaches the ceiling, the verdict flips to unhealthy and stuck, and the real health monitor completes its restart recovery path (stopChannel then startChannel) five times over the window. The one value that moves from wrong to right is the health verdict for a hung disconnected channel, and with it the monitor's restart action.
What was not tested: no live provider socket was hung end to end; the hang was a real never-resolving run under the real heartbeat, and the transport was a stub at the ChannelManager seam. The busy ceiling and heartbeat were scaled 300x on real wall-clock so the breach happens in seconds; the unscaled 25 minute breach was not waited out. Full build not run; the change is not on a lazy or packaging boundary.

