### PR TITLE
fix(channels): honor empty catalog docs prefixes

### DIFF
--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -179,7 +179,7 @@ The released `setup`/`ChannelSetupInput` adapter stays available for existing ex
 | `aliases`                              | `string[]` | Extra lookup aliases for channel selection.                                   |
 | `preferOver`                           | `string[]` | Lower-priority plugin/channel ids this channel should outrank.                |
 | `systemImage`                          | `string`   | Optional icon/system-image name for channel UI catalogs.                      |
-| `selectionDocsPrefix`                  | `string`   | Prefix text before docs links in selection surfaces.                          |
+| `selectionDocsPrefix`                  | `string`   | Prefix before docs links; omit for default or use `""` to suppress it.        |
 | `selectionDocsOmitLabel`               | `boolean`  | Show the docs path directly instead of a labeled docs link in selection copy. |
 | `selectionExtras`                      | `string[]` | Extra short strings appended in selection copy.                               |
 | `markdownCapable`                      | `boolean`  | Marks the channel as markdown-capable for outbound formatting decisions.      |

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -177,7 +177,7 @@ The released `setup`/`ChannelSetupInput` adapter stays available for existing ex
 | `aliases`                              | `string[]` | Extra lookup aliases for channel selection.                                   |
 | `preferOver`                           | `string[]` | Lower-priority plugin/channel ids this channel should outrank.                |
 | `systemImage`                          | `string`   | Optional icon/system-image name for channel UI catalogs.                      |
-| `selectionDocsPrefix`                  | `string`   | Prefix text before docs links in selection surfaces.                          |
+| `selectionDocsPrefix`                  | `string`   | Prefix before docs links; omit for default or use `""` to suppress it.        |
 | `selectionDocsOmitLabel`               | `boolean`  | Show the docs path directly instead of a labeled docs link in selection copy. |
 | `selectionExtras`                      | `string[]` | Extra short strings appended in selection copy.                               |
 | `markdownCapable`                      | `boolean`  | Marks the channel as markdown-capable for outbound formatting decisions.      |

--- a/src/channels/chat-meta-shared.ts
+++ b/src/channels/chat-meta-shared.ts
@@ -37,7 +37,6 @@ function toChatChannelMeta(params: {
     detailLabel: normalizeOptionalString(params.channel.detailLabel),
     systemImage: normalizeOptionalString(params.channel.systemImage),
     arrayFieldMode: "non-empty",
-    selectionDocsPrefixMode: "defined",
   });
 }
 

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -53,6 +53,36 @@ function writeChannelCatalog(
 }
 
 describe("channel plugin catalog", () => {
+  it.each([
+    ["omitted", undefined, undefined],
+    ["empty", "", ""],
+    ["spaced", "  See docs:  ", "  See docs:  "],
+  ] as const)("preserves %s selection docs prefixes", (_label, prefix, expected) => {
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        pluginId: "workspace-chat",
+        origin: "workspace",
+        rootDir: "/tmp/workspace-chat",
+        packageName: "@workspace/chat",
+        channel: {
+          id: "custom-chat",
+          label: "Custom Chat",
+          selectionLabel: "Custom Chat",
+          docsPath: "/channels/custom-chat",
+          blurb: "workspace",
+          ...(prefix !== undefined ? { selectionDocsPrefix: prefix } : {}),
+        },
+        install: { localPath: "/tmp/workspace-chat" },
+      },
+    ] satisfies PluginChannelCatalogEntry[]);
+
+    const entry = getChannelPluginCatalogEntry("custom-chat", {
+      workspaceDir: "/tmp",
+    });
+
+    expect(entry?.meta.selectionDocsPrefix).toBe(expected);
+  });
+
   it("keeps third-party channel ids mapped with catalog install trust", () => {
     const options = {
       workspaceDir: "/tmp/openclaw-channel-catalog-empty-workspace",

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -159,4 +159,58 @@ describe("channel plugin catalog", () => {
       "After official update",
     );
   });
+
+  it("preserves explicit empty selection docs prefixes from package channel metadata", () => {
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        pluginId: "workspace-chat",
+        origin: "workspace",
+        rootDir: "/tmp/workspace-chat",
+        packageName: "@workspace/chat",
+        channel: {
+          id: "custom-chat",
+          label: "Custom Chat",
+          selectionLabel: "Custom Chat",
+          docsPath: "/channels/custom-chat",
+          blurb: "workspace",
+          selectionDocsPrefix: "",
+          selectionDocsOmitLabel: true,
+        },
+        install: { localPath: "/tmp/workspace-chat" },
+      },
+    ] satisfies PluginChannelCatalogEntry[]);
+
+    const entry = getChannelPluginCatalogEntry("custom-chat", {
+      workspaceDir: "/tmp",
+    });
+
+    expect(entry?.meta.selectionDocsPrefix).toBe("");
+    expect(entry?.meta.selectionDocsOmitLabel).toBe(true);
+  });
+
+  it("does not trim non-empty selection docs prefixes from package channel metadata", () => {
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        pluginId: "workspace-chat",
+        origin: "workspace",
+        rootDir: "/tmp/workspace-chat",
+        packageName: "@workspace/chat",
+        channel: {
+          id: "custom-chat",
+          label: "Custom Chat",
+          selectionLabel: "Custom Chat",
+          docsPath: "/channels/custom-chat",
+          blurb: "workspace",
+          selectionDocsPrefix: "  See docs:  ",
+        },
+        install: { localPath: "/tmp/workspace-chat" },
+      },
+    ] satisfies PluginChannelCatalogEntry[]);
+
+    const entry = getChannelPluginCatalogEntry("custom-chat", {
+      workspaceDir: "/tmp",
+    });
+
+    expect(entry?.meta.selectionDocsPrefix).toBe("  See docs:  ");
+  });
 });

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -304,7 +304,6 @@ function buildCatalogEntryFromManifest(params: {
       detailLabel: channel.detailLabel?.trim(),
       ...(systemImage ? { systemImage } : {}),
       arrayFieldMode: "defined",
-      selectionDocsPrefixMode: "truthy",
     }),
     install,
     installSource: describePluginInstallSource(install, {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -301,7 +301,7 @@ function buildCatalogEntryFromManifest(params: {
       detailLabel: channel.detailLabel?.trim(),
       ...(systemImage ? { systemImage } : {}),
       arrayFieldMode: "defined",
-      selectionDocsPrefixMode: "truthy",
+      selectionDocsPrefixMode: "defined",
     }),
     install,
     installSource: describePluginInstallSource(install, {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -301,7 +301,6 @@ function buildCatalogEntryFromManifest(params: {
       detailLabel: channel.detailLabel?.trim(),
       ...(systemImage ? { systemImage } : {}),
       arrayFieldMode: "defined",
-      selectionDocsPrefixMode: "defined",
     }),
     install,
     installSource: describePluginInstallSource(install, {

--- a/src/channels/plugins/channel-meta.ts
+++ b/src/channels/plugins/channel-meta.ts
@@ -28,10 +28,14 @@ export function buildManifestChannelMeta(params: {
 }): ChannelMeta {
   const hasArrayField = (value: readonly string[] | undefined) =>
     params.arrayFieldMode === "defined" ? value !== undefined : Boolean(value?.length);
+  const selectionDocsPrefix =
+    typeof params.channel.selectionDocsPrefix === "string"
+      ? params.channel.selectionDocsPrefix
+      : undefined;
   const hasSelectionDocsPrefix =
     params.selectionDocsPrefixMode === "defined"
-      ? params.channel.selectionDocsPrefix !== undefined
-      : Boolean(params.channel.selectionDocsPrefix);
+      ? selectionDocsPrefix !== undefined
+      : Boolean(selectionDocsPrefix);
 
   return {
     id: params.id,
@@ -42,7 +46,7 @@ export function buildManifestChannelMeta(params: {
     blurb: params.blurb,
     ...(hasArrayField(params.channel.aliases) ? { aliases: params.channel.aliases } : {}),
     ...(params.channel.order !== undefined ? { order: params.channel.order } : {}),
-    ...(hasSelectionDocsPrefix ? { selectionDocsPrefix: params.channel.selectionDocsPrefix } : {}),
+    ...(hasSelectionDocsPrefix ? { selectionDocsPrefix } : {}),
     ...(params.channel.selectionDocsOmitLabel !== undefined
       ? { selectionDocsOmitLabel: params.channel.selectionDocsOmitLabel }
       : {}),

--- a/src/channels/plugins/channel-meta.ts
+++ b/src/channels/plugins/channel-meta.ts
@@ -8,7 +8,6 @@ import { resolveChannelExposure } from "./exposure.js";
 import type { ChannelMeta } from "./types.core.js";
 
 type ArrayFieldMode = "defined" | "non-empty";
-type OptionalStringMode = "defined" | "truthy";
 
 /**
  * Builds normalized channel metadata from a plugin manifest channel declaration.
@@ -24,14 +23,9 @@ export function buildManifestChannelMeta(params: {
   detailLabel?: string;
   systemImage?: string;
   arrayFieldMode: ArrayFieldMode;
-  selectionDocsPrefixMode: OptionalStringMode;
 }): ChannelMeta {
   const hasArrayField = (value: readonly string[] | undefined) =>
     params.arrayFieldMode === "defined" ? value !== undefined : Boolean(value?.length);
-  const hasSelectionDocsPrefix =
-    params.selectionDocsPrefixMode === "defined"
-      ? params.channel.selectionDocsPrefix !== undefined
-      : Boolean(params.channel.selectionDocsPrefix);
 
   return {
     id: params.id,
@@ -42,7 +36,9 @@ export function buildManifestChannelMeta(params: {
     blurb: params.blurb,
     ...(hasArrayField(params.channel.aliases) ? { aliases: params.channel.aliases } : {}),
     ...(params.channel.order !== undefined ? { order: params.channel.order } : {}),
-    ...(hasSelectionDocsPrefix ? { selectionDocsPrefix: params.channel.selectionDocsPrefix } : {}),
+    ...(typeof params.channel.selectionDocsPrefix === "string"
+      ? { selectionDocsPrefix: params.channel.selectionDocsPrefix }
+      : {}),
     ...(params.channel.selectionDocsOmitLabel !== undefined
       ? { selectionDocsOmitLabel: params.channel.selectionDocsOmitLabel }
       : {}),

--- a/src/channels/plugins/channel-meta.ts
+++ b/src/channels/plugins/channel-meta.ts
@@ -8,7 +8,6 @@ import { resolveChannelExposure } from "./exposure.js";
 import type { ChannelMeta } from "./types.core.js";
 
 type ArrayFieldMode = "defined" | "non-empty";
-type OptionalStringMode = "defined" | "truthy";
 
 /**
  * Builds normalized channel metadata from a plugin manifest channel declaration.
@@ -24,7 +23,6 @@ export function buildManifestChannelMeta(params: {
   detailLabel?: string;
   systemImage?: string;
   arrayFieldMode: ArrayFieldMode;
-  selectionDocsPrefixMode: OptionalStringMode;
 }): ChannelMeta {
   const hasArrayField = (value: readonly string[] | undefined) =>
     params.arrayFieldMode === "defined" ? value !== undefined : Boolean(value?.length);
@@ -32,10 +30,6 @@ export function buildManifestChannelMeta(params: {
     typeof params.channel.selectionDocsPrefix === "string"
       ? params.channel.selectionDocsPrefix
       : undefined;
-  const hasSelectionDocsPrefix =
-    params.selectionDocsPrefixMode === "defined"
-      ? selectionDocsPrefix !== undefined
-      : Boolean(selectionDocsPrefix);
 
   return {
     id: params.id,
@@ -46,7 +40,7 @@ export function buildManifestChannelMeta(params: {
     blurb: params.blurb,
     ...(hasArrayField(params.channel.aliases) ? { aliases: params.channel.aliases } : {}),
     ...(params.channel.order !== undefined ? { order: params.channel.order } : {}),
-    ...(hasSelectionDocsPrefix ? { selectionDocsPrefix } : {}),
+    ...(selectionDocsPrefix !== undefined ? { selectionDocsPrefix } : {}),
     ...(params.channel.selectionDocsOmitLabel !== undefined
       ? { selectionDocsOmitLabel: params.channel.selectionDocsOmitLabel }
       : {}),

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -547,6 +547,42 @@ describe("resolveChannelSetupSelectionContributions", () => {
     expect(lines).toEqual(["Zalo\\nBot — Setup\\nhelp"]);
   });
 
+  it.each([
+    ["empty", "", ""],
+    ["whitespace", " \t ", "Docs:"],
+    ["control-only", "\u001B[2K\u0007", "Docs:"],
+  ] as const)("normalizes %s selection docs prefixes", (_label, prefix, expected) => {
+    resolveChannelSetupEntries.mockReturnValue(
+      makeChannelSetupEntries({
+        entries: [
+          {
+            id: "custom-chat",
+            meta: {
+              id: "custom-chat",
+              label: "Custom Chat",
+              selectionLabel: "Custom Chat",
+              docsPath: "/channels/custom-chat",
+              blurb: "External channel.",
+              selectionDocsPrefix: prefix,
+            },
+          },
+        ],
+      }),
+    );
+
+    resolveChannelSelectionNoteLines({
+      cfg: {} as never,
+      installedPlugins: [],
+      selection: ["custom-chat"],
+    });
+
+    const [selectionMeta] = requireFirstMockCall(
+      formatChannelSelectionLine.mock.calls,
+      "selection line",
+    );
+    expect(selectionMeta?.selectionDocsPrefix).toBe(expected);
+  });
+
   it("localizes built-in channel blurbs before selection notes", () => {
     resolveChannelSetupEntries.mockReturnValue(
       makeChannelSetupEntries({

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -517,6 +517,46 @@ describe("resolveChannelSetupSelectionContributions", () => {
     expect(lines).toEqual(["Zalo\\nBot — Setup\\nhelp"]);
   });
 
+  it("preserves explicit empty channel selection docs prefixes before selection notes", () => {
+    resolveChannelSetupEntries.mockReturnValue(
+      makeChannelSetupEntries({
+        entries: [
+          {
+            id: "telegram",
+            meta: {
+              id: "telegram",
+              label: "Telegram",
+              selectionLabel: "Telegram",
+              docsPath: "/channels/telegram",
+              blurb: "Chat over Telegram.",
+              selectionDocsPrefix: "",
+              selectionDocsOmitLabel: true,
+            },
+          },
+        ],
+      }),
+    );
+
+    const lines = resolveChannelSelectionNoteLines({
+      cfg: {} as never,
+      installedPlugins: [],
+      selection: ["telegram"],
+    });
+
+    expect(formatChannelSelectionLine).toHaveBeenCalledOnce();
+    const [selectionMeta] = requireFirstMockCall(
+      formatChannelSelectionLine.mock.calls,
+      "selection line",
+    );
+    expect(selectionMeta).toEqual(
+      expect.objectContaining({
+        selectionDocsPrefix: "",
+        selectionDocsOmitLabel: true,
+      }),
+    );
+    expect(lines).toEqual(["Telegram — Chat over Telegram."]);
+  });
+
   it("localizes built-in channel blurbs before selection notes", () => {
     resolveChannelSetupEntries.mockReturnValue(
       makeChannelSetupEntries({

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -557,6 +557,41 @@ describe("resolveChannelSetupSelectionContributions", () => {
     expect(lines).toEqual(["Telegram — Chat over Telegram."]);
   });
 
+  it.each([
+    ["whitespace-only", " \t "],
+    ["control-only", "\u001B[2K\u0007"],
+  ])("restores the default for %s channel selection docs prefixes", (_label, prefix) => {
+    resolveChannelSetupEntries.mockReturnValue(
+      makeChannelSetupEntries({
+        entries: [
+          {
+            id: "custom-chat",
+            meta: {
+              id: "custom-chat",
+              label: "Custom Chat",
+              selectionLabel: "Custom Chat",
+              docsPath: "/channels/custom-chat",
+              blurb: "External channel.",
+              selectionDocsPrefix: prefix,
+            },
+          },
+        ],
+      }),
+    );
+
+    resolveChannelSelectionNoteLines({
+      cfg: {} as never,
+      installedPlugins: [],
+      selection: ["custom-chat"],
+    });
+
+    const [selectionMeta] = requireFirstMockCall(
+      formatChannelSelectionLine.mock.calls,
+      "selection line",
+    );
+    expect(selectionMeta?.selectionDocsPrefix).toBe("Docs:");
+  });
+
   it("localizes built-in channel blurbs before selection notes", () => {
     resolveChannelSetupEntries.mockReturnValue(
       makeChannelSetupEntries({

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -153,19 +153,23 @@ function formatSetupDisplayList(values: readonly string[] | undefined): string[]
 }
 
 function formatSetupDisplayMeta(meta: ChannelMeta): ChannelMeta {
+  const { selectionDocsPrefix, ...displayMeta } = meta;
   const safeId = formatSetupDisplayText(meta.id, "<invalid channel>");
   const safeLabel = formatSetupDisplayText(meta.label, safeId);
-  const safeSelectionDocsPrefix = formatSetupOptionalDisplayText(meta.selectionDocsPrefix);
+  const safeSelectionDocsPrefix =
+    selectionDocsPrefix === "" ? "" : formatSetupOptionalDisplayText(selectionDocsPrefix?.trim());
   const safeSelectionExtras = formatSetupDisplayList(meta.selectionExtras);
   return {
-    ...meta,
+    ...displayMeta,
     id: safeId,
     label: safeLabel,
     selectionLabel: formatSetupDisplayText(meta.selectionLabel, safeLabel),
     docsPath: formatSetupDisplayText(meta.docsPath, "/"),
     ...(meta.docsLabel ? { docsLabel: formatSetupDisplayText(meta.docsLabel, safeId) } : {}),
     blurb: formatSetupFreeText(meta.blurb),
-    ...(safeSelectionDocsPrefix ? { selectionDocsPrefix: safeSelectionDocsPrefix } : {}),
+    ...(safeSelectionDocsPrefix !== undefined
+      ? { selectionDocsPrefix: safeSelectionDocsPrefix }
+      : {}),
     ...(safeSelectionExtras ? { selectionExtras: safeSelectionExtras } : {}),
   };
 }
@@ -180,11 +184,12 @@ function formatChannelPrimerBlurb(channel: { id: string; blurb: string }): strin
 }
 
 function formatChannelSelectionMeta(meta: ChannelMeta): ChannelMeta {
-  return formatSetupDisplayMeta({
+  const formatted = formatSetupDisplayMeta({
     ...meta,
     blurb: formatChannelPrimerBlurb(meta),
-    selectionDocsPrefix: meta.selectionDocsPrefix ?? t("common.docs"),
   });
+  formatted.selectionDocsPrefix ??= t("common.docs");
+  return formatted;
 }
 
 function localizeChannelStatusLabel(label: string): string {

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -134,6 +134,10 @@ function formatSetupOptionalDisplayText(value: string | undefined): string | und
   return safe || undefined;
 }
 
+function formatSetupDefinedDisplayText(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : sanitizeTerminalText(value).trim();
+}
+
 function formatSetupDisplayList(values: readonly string[] | undefined): string[] | undefined {
   const safe = (values ?? []).flatMap((value) => {
     const sanitized = formatSetupOptionalDisplayText(value);
@@ -145,7 +149,7 @@ function formatSetupDisplayList(values: readonly string[] | undefined): string[]
 function formatSetupDisplayMeta(meta: ChannelMeta): ChannelMeta {
   const safeId = formatSetupDisplayText(meta.id, "<invalid channel>");
   const safeLabel = formatSetupDisplayText(meta.label, safeId);
-  const safeSelectionDocsPrefix = formatSetupOptionalDisplayText(meta.selectionDocsPrefix);
+  const safeSelectionDocsPrefix = formatSetupDefinedDisplayText(meta.selectionDocsPrefix);
   const safeSelectionExtras = formatSetupDisplayList(meta.selectionExtras);
   return {
     ...meta,
@@ -155,7 +159,9 @@ function formatSetupDisplayMeta(meta: ChannelMeta): ChannelMeta {
     docsPath: formatSetupDisplayText(meta.docsPath, "/"),
     ...(meta.docsLabel ? { docsLabel: formatSetupDisplayText(meta.docsLabel, safeId) } : {}),
     blurb: formatSetupFreeText(meta.blurb),
-    ...(safeSelectionDocsPrefix ? { selectionDocsPrefix: safeSelectionDocsPrefix } : {}),
+    ...(safeSelectionDocsPrefix !== undefined
+      ? { selectionDocsPrefix: safeSelectionDocsPrefix }
+      : {}),
     ...(safeSelectionExtras ? { selectionExtras: safeSelectionExtras } : {}),
   };
 }

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -134,8 +134,17 @@ function formatSetupOptionalDisplayText(value: string | undefined): string | und
   return safe || undefined;
 }
 
-function formatSetupDefinedDisplayText(value: string | undefined): string | undefined {
-  return value === undefined ? undefined : sanitizeTerminalText(value).trim();
+function formatSetupDefinedDisplayText(
+  value: string | undefined,
+  fallback?: string,
+): string | undefined {
+  if (value === "") {
+    return "";
+  }
+  if (value?.trim() === "") {
+    return formatSetupOptionalDisplayText(fallback);
+  }
+  return formatSetupOptionalDisplayText(value) ?? formatSetupOptionalDisplayText(fallback);
 }
 
 function formatSetupDisplayList(values: readonly string[] | undefined): string[] | undefined {
@@ -146,13 +155,20 @@ function formatSetupDisplayList(values: readonly string[] | undefined): string[]
   return safe.length > 0 ? safe : undefined;
 }
 
-function formatSetupDisplayMeta(meta: ChannelMeta): ChannelMeta {
+function formatSetupDisplayMeta(
+  meta: ChannelMeta,
+  selectionDocsPrefixFallback?: string,
+): ChannelMeta {
+  const { selectionDocsPrefix, ...metaWithoutSelectionDocsPrefix } = meta;
   const safeId = formatSetupDisplayText(meta.id, "<invalid channel>");
   const safeLabel = formatSetupDisplayText(meta.label, safeId);
-  const safeSelectionDocsPrefix = formatSetupDefinedDisplayText(meta.selectionDocsPrefix);
+  const safeSelectionDocsPrefix = formatSetupDefinedDisplayText(
+    selectionDocsPrefix,
+    selectionDocsPrefixFallback,
+  );
   const safeSelectionExtras = formatSetupDisplayList(meta.selectionExtras);
   return {
-    ...meta,
+    ...metaWithoutSelectionDocsPrefix,
     id: safeId,
     label: safeLabel,
     selectionLabel: formatSetupDisplayText(meta.selectionLabel, safeLabel),
@@ -176,11 +192,13 @@ function formatChannelPrimerBlurb(channel: { id: string; blurb: string }): strin
 }
 
 function formatChannelSelectionMeta(meta: ChannelMeta): ChannelMeta {
-  return formatSetupDisplayMeta({
-    ...meta,
-    blurb: formatChannelPrimerBlurb(meta),
-    selectionDocsPrefix: meta.selectionDocsPrefix ?? t("common.docs"),
-  });
+  return formatSetupDisplayMeta(
+    {
+      ...meta,
+      blurb: formatChannelPrimerBlurb(meta),
+    },
+    t("common.docs"),
+  );
 }
 
 function localizeChannelStatusLabel(label: string): string {

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -120,7 +120,7 @@ function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
   return Object.freeze(value);
 }
 
-function writePackageManifest(rootDir: string, channelLabel: string) {
+function writePackageManifest(rootDir: string, channelLabel: string, selectionDocsPrefix?: string) {
   const packageJsonPath = path.join(rootDir, "package.json");
   fs.writeFileSync(
     packageJsonPath,
@@ -134,6 +134,7 @@ function writePackageManifest(rootDir: string, channelLabel: string) {
         channel: {
           id: "installed",
           label: channelLabel,
+          ...(selectionDocsPrefix !== undefined ? { selectionDocsPrefix } : {}),
         },
       },
     }),
@@ -142,9 +143,12 @@ function writePackageManifest(rootDir: string, channelLabel: string) {
   return packageJsonPath;
 }
 
-function createIndexWithPackageJson(rootDir: string): InstalledPluginIndex {
+function createIndexWithPackageJson(
+  rootDir: string,
+  selectionDocsPrefix?: string,
+): InstalledPluginIndex {
   const index = createIndexWithFileSignatures(rootDir);
-  const packageJsonPath = writePackageManifest(rootDir, "Installed");
+  const packageJsonPath = writePackageManifest(rootDir, "Installed", selectionDocsPrefix);
   const record = index.plugins[0];
   if (!record) {
     throw new Error("expected index record");
@@ -179,6 +183,16 @@ function createIndexWithUnhashedPackageJson(rootDir: string): InstalledPluginInd
 }
 
 describe("loadPluginManifestRegistryForInstalledIndex", () => {
+  const loadRegistry = (index: InstalledPluginIndex) =>
+    loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
   it("reuses frozen installed-index fingerprints when file signatures are persisted", () => {
     const rootDir = makeTempDir();
     writePlugin(rootDir, "installed", "installed-");
@@ -328,6 +342,38 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(third.plugins[0]?.packageDependencies).toEqual({
       "runtime-dep": "1.0.0",
     });
+  });
+
+  it("preserves empty docs prefixes from package channel metadata", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "installed", "installed-");
+
+    const registry = loadRegistry(createIndexWithPackageJson(rootDir, ""));
+
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsPrefix).toBe("");
+  });
+
+  it("preserves empty docs prefixes from persisted installed-index metadata", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "installed", "installed-");
+    const index = createIndex(rootDir);
+    const record = expectDefined(index.plugins[0], "index.plugins[0] test invariant");
+
+    const registry = loadRegistry({
+      ...index,
+      plugins: [
+        {
+          ...record,
+          packageChannel: {
+            id: "installed",
+            label: "Installed",
+            selectionDocsPrefix: "",
+          },
+        },
+      ],
+    });
+
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsPrefix).toBe("");
   });
 
   it("reuses installed package json path validation across registry loads", () => {

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -398,6 +398,69 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(reused.diagnostics).toEqual([]);
   });
 
+  it("preserves explicit empty package channel docs prefixes from package metadata", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "installed", "installed-");
+    const index = createIndexWithPackageJson(rootDir);
+    fs.writeFileSync(
+      path.join(rootDir, "package.json"),
+      JSON.stringify({
+        openclaw: {
+          channel: {
+            id: "installed",
+            label: "Installed",
+            selectionDocsPrefix: "",
+            selectionDocsOmitLabel: true,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsPrefix).toBe("");
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsOmitLabel).toBe(true);
+  });
+
+  it("preserves explicit empty package channel docs prefixes from persisted index metadata", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "installed", "installed-");
+    const index = createIndex(rootDir);
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: {
+        ...index,
+        plugins: [
+          {
+            ...expectDefined(index.plugins[0], "index.plugins[0] test invariant"),
+            packageChannel: {
+              id: "installed",
+              label: "Installed",
+              selectionDocsPrefix: "",
+              selectionDocsOmitLabel: true,
+            },
+          },
+        ],
+      },
+      env: {
+        OPENCLAW_VERSION: "2026.4.25",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsPrefix).toBe("");
+    expect(registry.plugins[0]?.packageChannel?.selectionDocsOmitLabel).toBe(true);
+  });
+
   it("reconstructs bundle candidates with their bundle manifest format", () => {
     const rootDir = makeTempDir();
     fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  readStringValue,
+} from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import {
   resolveChannelSetupFieldCliAttributeName,
@@ -400,12 +403,15 @@ function normalizePersistedPackageChannel(value: unknown): PluginPackageChannel 
     "docsLabel",
     "blurb",
     "systemImage",
-    "selectionDocsPrefix",
   ] as const) {
     const normalized = normalizeOptionalString(value[key]);
     if (normalized) {
       channel[key] = normalized;
     }
+  }
+  const selectionDocsPrefix = readStringValue(value.selectionDocsPrefix);
+  if (selectionDocsPrefix !== undefined) {
+    channel.selectionDocsPrefix = selectionDocsPrefix;
   }
   if (typeof value.order === "number" && Number.isFinite(value.order)) {
     channel.order = value.order;

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -369,12 +369,14 @@ function normalizePersistedPackageChannel(value: unknown): PluginPackageChannel 
     "docsLabel",
     "blurb",
     "systemImage",
-    "selectionDocsPrefix",
   ] as const) {
     const normalized = normalizeOptionalString(value[key]);
     if (normalized) {
       channel[key] = normalized;
     }
+  }
+  if (typeof value.selectionDocsPrefix === "string") {
+    channel.selectionDocsPrefix = value.selectionDocsPrefix;
   }
   if (typeof value.order === "number" && Number.isFinite(value.order)) {
     channel.order = value.order;


### PR DESCRIPTION
## What Problem This Solves

Channel plugins can set `selectionDocsPrefix: ""` to suppress the default
`Docs:` label. External catalog and installed-plugin metadata paths did not
preserve that intentional empty-string sentinel consistently, and invalid
whitespace/control-only values could leak through instead of using the
localized fallback.

## Why This Change Was Made

The repair preserves the public distinction at the boundaries that own it:

- manifest/catalog metadata preserves every actual string, including `""`;
- installed package and persisted registry metadata preserve the same value;
- terminal setup formatting preserves exact `""`, sanitizes meaningful text,
  and falls back for omitted or invalid whitespace/control-only values; and
- plugin SDK docs define omission versus explicit empty-string behavior.

The contributor patch was transplanted onto current `main` and compressed to
net +5 production lines. Original contributor credit is retained in the commit.

## User Impact

Channel plugins can intentionally suppress the docs label with
`selectionDocsPrefix: ""`. Omitted, whitespace-only, and control-only values
continue to use the localized default prefix.

## Evidence

Exact reviewed head: `e375e04a7dc600c337c76e86146bed11c2c21627`.

- Regression tests failed on current `main` at the catalog, installed metadata,
  whitespace, and control-character boundaries before the fix.
- Focused Vitest: 57 tests passed.
- Channel contracts: 494 tests passed.
- Plugin contracts: 1,077 tests passed.
- `pnpm build`, `pnpm check:docs`, changed-file gates, extension boundary check,
  and `git diff --check` passed.
- Fresh branch autoreview reported no actionable findings.

The exact-head secretless runtime harness exercised real bundled Telegram
manifest discovery/selection formatting plus a temporary external plugin:

- Telegram retained its real links without adding `Docs:`.
- Explicit empty prefix suppressed `Docs:`.
- Omitted, whitespace-only, and control-only prefixes used the localized
  fallback.
- No credentials or transport calls were used.
