### PR TITLE
fix: defer plugin metadata snapshot until after fallible reload succeeds

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1434,11 +1434,6 @@ export async function startGatewayServer(
           cancelled: true,
         };
       }
-      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
-        config: params.nextConfig,
-        env: process.env,
-        workspaceDir: defaultWorkspaceDir,
-      });
       const loaded = prepareGatewayPluginLoad({
         cfg: params.nextConfig,
         workspaceDir: defaultWorkspaceDir,
@@ -1447,6 +1442,15 @@ export async function startGatewayServer(
         hostServices: pluginHostServices,
         baseMethods,
         pluginLookUpTable: nextPluginLookUpTable,
+      });
+      // Publish the plugin metadata snapshot only after the fallible load
+      // succeeds. If prepareGatewayPluginLoad throws, the current metadata
+      // must stay describing the still-running plugin set so capability
+      // lookups remain consistent with the live runtime.
+      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
+        config: params.nextConfig,
+        env: process.env,
+        workspaceDir: defaultWorkspaceDir,
       });
       const previousPluginServices = runtimeState.pluginServices;
       runtimeState.pluginServices = null;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1443,15 +1443,6 @@ export async function startGatewayServer(
         baseMethods,
         pluginLookUpTable: nextPluginLookUpTable,
       });
-      // Publish the plugin metadata snapshot only after the fallible load
-      // succeeds. If prepareGatewayPluginLoad throws, the current metadata
-      // must stay describing the still-running plugin set so capability
-      // lookups remain consistent with the live runtime.
-      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
-        config: params.nextConfig,
-        env: process.env,
-        workspaceDir: defaultWorkspaceDir,
-      });
       const previousPluginServices = runtimeState.pluginServices;
       runtimeState.pluginServices = null;
       if (previousPluginServices) {
@@ -1459,6 +1450,17 @@ export async function startGatewayServer(
           log.warn(`plugin services stop failed during reload: ${String(err)}`);
         });
       }
+      // Publish the plugin metadata snapshot after the fallible load succeeds
+      // and previous services have stopped. This avoids a window where
+      // concurrent capability lookups see new metadata while the old runtime
+      // is still active. If prepareGatewayPluginLoad throws, neither this
+      // metadata update nor the runtime replacement runs, preserving the
+      // previous consistent state.
+      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
+        config: params.nextConfig,
+        env: process.env,
+        workspaceDir: defaultWorkspaceDir,
+      });
       replaceAttachedPluginRuntime(loaded);
       await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
       try {


### PR DESCRIPTION
## What Problem This Solves

During gateway plugin hot reload, `setCurrentPluginMetadataSnapshot` was called at `server.impl.ts:1437` **before** `prepareGatewayPluginLoad` at `:1442` — the fallible module load/registration step.

When `prepareGatewayPluginLoad` threw, the exception was swallowed by `runReload`'s catch in `config-reload.ts:395`, but the process-global current plugin metadata had already been committed to the new plugin set. The live plugin runtime kept executing the old, still-loaded plugin code, but every consumer that consulted `resolvePluginMetadataSnapshot` / `getCurrentPluginMetadataSnapshot` now answered using the new manifest that never loaded. This divergence persisted for the life of the process.

Impact: capability-availability decisions could silently offer a tool the running code does not support, or silently withhold one it does support.

## Evidence

**Fix**: Moved `setCurrentPluginMetadataSnapshot` to **after** `prepareGatewayPluginLoad` completes successfully. Now if the fallible load throws, both the runtime and the process-global metadata stay describing the previously loaded plugin set — a clean no-op.

The change is minimal and purely reorders two existing calls without changing their arguments or any other logic.

**Root cause trace** (from the issue):
```
server.impl.ts:1437  setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, …)  ← committed FIRST
server.impl.ts:1442  const loaded = prepareGatewayPluginLoad(…)                   ← fallible, throws
server.impl.ts:1458  replaceAttachedPluginRuntime(loaded)                         ← never runs
```

After fix:
```
server.impl.ts:1442  const loaded = prepareGatewayPluginLoad(…)                   ← fallible, throws → clean abort
server.impl.ts:14xx  setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, …)  ← only reached if load succeeded
server.impl.ts:1458  replaceAttachedPluginRuntime(loaded)                         ← still runs after metadata
```

**Validation**: Logic-only change at a single call site. The existing startup-time `setCurrentPluginMetadataSnapshot` call (line 702) is in a separate code path and is unaffected.

Fixes #103778