### PR TITLE
fix(release): preserve beta validation evidence

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -455,7 +455,9 @@ describe("qa scenario catalog", () => {
     expect(interruptedStatusAssertion).toBeDefined();
     const interruptedStatusContract = JSON.stringify(interruptedStatusAssertion);
     expect(interruptedStatusContract).toContain("waited.stopReason === 'restart'");
-    expect(interruptedStatusContract).toContain("waited.stopReason === 'aborted'");
+    expect(interruptedStatusContract).toContain(
+      "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex' && waited.stopReason === 'aborted'",
+    );
     expect(interruptedStatusContract).toContain("EmbeddedAttemptSessionTakeoverError");
     expect(interruptedStatusContract).toContain("AbortError");
     expect(interruptedStatusContract).toContain("This operation was aborted");

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -96,7 +96,7 @@ flow:
             - expr: started.runId
             - expr: liveTurnTimeoutMs(env, 180000)
         - assert:
-            expr: "waited.status === 'ok' || waited.status === 'timeout' || (waited.status === 'error' && (waited.stopReason === 'restart' || waited.stopReason === 'aborted' || String(waited.error ?? '').includes('EmbeddedAttemptSessionTakeoverError') || String(waited.error ?? '').includes('AbortError') || String(waited.error ?? '').includes('This operation was aborted')))"
+            expr: "waited.status === 'ok' || waited.status === 'timeout' || (waited.status === 'error' && (waited.stopReason === 'restart' || (env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex' && waited.stopReason === 'aborted') || String(waited.error ?? '').includes('EmbeddedAttemptSessionTakeoverError') || String(waited.error ?? '').includes('AbortError') || String(waited.error ?? '').includes('This operation was aborted')))"
             message:
               expr: "`interrupted agent run ended with unexpected status: ${JSON.stringify(waited)}`"
         - set: interruptedMatches

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -481,6 +481,18 @@ if (Number(updateStep.exitCode ?? 1) !== 0) {
 if (typeof updateStep.command !== "string" || !updateStep.command.includes(expectedUrl)) {
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
 }
+const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
+if (!doctorStep) {
+  throw new Error("missing openclaw doctor step in update JSON");
+}
+// Exit 86 is the updater's explicit recoverable post-install doctor contract.
+const doctorSucceeded = doctorStep.exitCode === 0;
+const doctorWasAdvisory =
+  doctorStep.exitCode === 86 &&
+  doctorStep.advisory?.kind === "package-post-install-doctor";
+if (!doctorSucceeded && !doctorWasAdvisory) {
+  throw new Error(`openclaw doctor step failed: ${JSON.stringify(doctorStep)}`);
+}
 NODE
 
   echo "==> Verify updated version"

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -425,7 +425,8 @@ fs.writeFileSync(
 );
 NODE
   tar -czf "$tarball" -C "$fixture_root" package
-  node scripts/e2e/lib/plugins/npm-registry-server.mjs \
+  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
+    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
     "$port_file" \
     "@openclaw/brave-plugin" \
     "2026.5.2" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -314,7 +314,8 @@ fs.writeFileSync(
 );
 NODE
   tar -czf "$tarball" -C "$fixture_root" package
-  node scripts/e2e/lib/plugins/npm-registry-server.mjs \
+  OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org \
+    node scripts/e2e/lib/plugins/npm-registry-server.mjs \
     "$port_file" \
     "@openclaw/brave-plugin" \
     "2026.5.2" \

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2062,6 +2062,16 @@ grep -qx -- "OPENCLAW_E2E_COMMAND_TIMEOUT=23s" "$TMPDIR/package-args"
     }
   });
 
+  it("lets upgrade survivor fixture registries resolve transitive public packages", () => {
+    const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
+    const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+
+    for (const script of [runner, publishedRunner]) {
+      expect(script).toContain("OPENCLAW_NPM_REGISTRY_UPSTREAM=https://registry.npmjs.org");
+      expect(script).toContain("node scripts/e2e/lib/plugins/npm-registry-server.mjs");
+    }
+  });
+
   it("wraps package-backed scenario OpenClaw CLI calls with the shared timeout helper", () => {
     const paths = [
       CODEX_ON_DEMAND_DOCKER_E2E_PATH,

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -149,6 +149,45 @@ function normalizeInstallE2eAgentOutput(output: string) {
   }
 }
 
+function extractInstallSmokeUpdateJsonParser(): string {
+  const script = readFileSync(SMOKE_RUNNER_PATH, "utf8");
+  const match = script.match(
+    /UPDATE_JSON="\$UPDATE_JSON" \\\n[\s\S]*?node - <<'NODE'\n([\s\S]*?)\nNODE\n\n  echo "==> Verify updated version"/u,
+  );
+  if (!match) {
+    throw new Error("install smoke update JSON parser was not found");
+  }
+  return match[1];
+}
+
+function validateInstallSmokeUpdateJson(doctorStep?: Record<string, unknown>) {
+  const updateUrl = "http://candidate.invalid/openclaw.tgz";
+  const payload = {
+    status: "ok",
+    before: { version: "2026.7.0" },
+    after: { version: "2026.7.1" },
+    steps: [
+      {
+        name: "global update",
+        exitCode: 0,
+        command: `npm install ${updateUrl}`,
+      },
+      ...(doctorStep ? [doctorStep] : []),
+    ],
+  };
+  return spawnSync(process.execPath, ["-"], {
+    encoding: "utf8",
+    input: extractInstallSmokeUpdateJsonParser(),
+    env: {
+      ...process.env,
+      UPDATE_JSON: JSON.stringify(payload),
+      UPDATE_EXPECT_VERSION: payload.after.version,
+      UPDATE_BASELINE_VERSION: payload.before.version,
+      UPDATE_TAG_URL: updateUrl,
+    },
+  });
+}
+
 function expectInstallDockerfileContract(
   dockerfilePath: string,
   runnerPath: string,
@@ -1012,6 +1051,47 @@ describe("install-sh smoke runner", () => {
     expect(script).toContain("unterminated update JSON object");
     expect(script).toContain("verify_candidate_ai_runtime");
     expect(script).toContain("openclaw infer image providers --json");
+  });
+
+  it.each([
+    ["successful", { name: "openclaw doctor", exitCode: 0 }],
+    [
+      "recoverable advisory",
+      {
+        name: "openclaw doctor",
+        exitCode: 86,
+        advisory: { kind: "package-post-install-doctor", message: "repair deferred" },
+      },
+    ],
+  ])("accepts a %s package post-install doctor result", (_label, doctorStep) => {
+    const result = validateInstallSmokeUpdateJson(doctorStep);
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it.each([
+    ["missing", undefined, "missing openclaw doctor step"],
+    ["fatal", { name: "openclaw doctor", exitCode: 1 }, "openclaw doctor step failed"],
+    ["untyped advisory", { name: "openclaw doctor", exitCode: 86 }, "openclaw doctor step failed"],
+    [
+      "wrong advisory kind",
+      { name: "openclaw doctor", exitCode: 86, advisory: { kind: "other" } },
+      "openclaw doctor step failed",
+    ],
+    [
+      "wrong advisory exit",
+      {
+        name: "openclaw doctor",
+        exitCode: 1,
+        advisory: { kind: "package-post-install-doctor" },
+      },
+      "openclaw doctor step failed",
+    ],
+  ])("rejects a %s package post-install doctor result", (_label, doctorStep, error) => {
+    const result = validateInstallSmokeUpdateJson(doctorStep);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(error);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Fixes three release-validation gaps that can hide a broken beta candidate:

- the configured-plugin upgrade fixture cannot resolve public transitive packages through its local registry;
- installer smoke can accept missing or malformed post-install doctor evidence;
- the restart scenario can accept an aborted outcome from the OpenClaw runtime even though that allowance belongs only to Codex.

## Why This Change Was Made

This forward-ports three signed, release-proven fixes without changing product runtime behavior. The upgrade fixture proxies public package misses to npm, installer smoke validates the required doctor step while retaining the documented advisory exit, and the QA assertion is scoped to the Codex runtime.

## User Impact

Release operators get reliable failure signals from configured-plugin upgrades, installer doctor verification, and OpenClaw/Codex restart parity. There is no end-user runtime change.

## Evidence

- Exact commits are `-x` forward-ports of release commits `30f54a5fe1e`, `0782a94452d`, and `ac54f80430c`; stable patch IDs are `a036959f9501`, `5c90c03797a0`, and `1115e92a4f15`.
- Final trusted base `db39fe807202` plus the exact seven-path patch produced tree `aca775269f72`, identical to local head `ee55a602c4dd`.
- Testbox `tbx_01kx696v225r2c77w5spxwq73q`: final-tree focused proof passed `273/273` (`164` Docker helper, `71` installer, `38` QA catalog).
- Same final tree: `gateway-restart-inflight-run` passed with `--runtime-pair openclaw,codex --provider-mode mock-openai`.
- Same patch IDs and seven changed paths: `check:changed` passed all-project tsgo, core/extensions/scripts lint, guards, and import-cycle checks. Subsequent base commits did not overlap the seven paths.
- Same patch IDs: published `openclaw@2026.6.11` configured-plugin upgrade survivor passed candidate packaging, doctor, gateway health/readiness, and status probes.
- Fresh repository autoreview: no findings; patch correct at confidence `0.86`.

Changelog is not required for validation-only tooling.

AI-assisted; maintainer-reviewed source, scenario, and exact-tree evidence are included above.
