### PR TITLE
fix: severe per-message slowdown when commands.ownerAllowFrom has thousands of entries

### DIFF
--- a/src/auto-reply/command-auth-owner-allowlist.ts
+++ b/src/auto-reply/command-auth-owner-allowlist.ts
@@ -1,0 +1,187 @@
+/**
+ * Allow-from list primitives and the compiled owner-allowlist cache used by
+ * command authorization. Split from command-auth.ts to keep that file under the
+ * 700-line limit; this module owns everything that turns raw configured
+ * allow-from arrays into matchable owner identities.
+ */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { ChannelId } from "../channels/plugins/types.public.js";
+import { normalizeAnyChannelId } from "../channels/registry.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginCacheKey } from "../plugins/plugin-cache-primitives.js";
+
+export function formatAllowFromList(params: {
+  plugin?: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  allowFrom: Array<string | number>;
+}): string[] {
+  const { plugin, cfg, accountId, allowFrom } = params;
+  if (!allowFrom || allowFrom.length === 0) {
+    return [];
+  }
+  if (plugin?.config?.formatAllowFrom) {
+    return plugin.config.formatAllowFrom({ cfg, accountId, allowFrom });
+  }
+  return normalizeStringEntries(allowFrom);
+}
+
+export function normalizeAllowFromEntry(params: {
+  plugin?: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  value: string;
+}): string[] {
+  const normalized = formatAllowFromList({
+    plugin: params.plugin,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    allowFrom: [params.value],
+  });
+  return normalized.filter((entry) => entry.trim().length > 0);
+}
+
+function isWildcardAllowFromEntry(entry: string): boolean {
+  return entry.trim() === "*";
+}
+
+export function hasWildcardAllowFrom(list: string[]): boolean {
+  return list.some((entry) => isWildcardAllowFromEntry(entry));
+}
+
+export function stripWildcardAllowFrom(list: string[]): string[] {
+  return list.filter((entry) => !isWildcardAllowFromEntry(entry));
+}
+/**
+ * Owner allowlists compiled once per raw config array identity. `cfg.commands
+ * .ownerAllowFrom` is process-stable between reloads and plugin formatAllowFrom is
+ * deterministic for a given (cfg, accountId, allowFrom), so recompiling per inbound
+ * message made large ownerAllowFrom configs O(n) on every message (#50289).
+ *
+ * Only the config array benefits. `ctx.OwnerAllowFrom` is rebuilt per message by
+ * channels (the Discord plugin's allow-list resolver returns a fresh array per
+ * matched sender, for example), so that path always
+ * misses and is collected right after; it stays on this helper for one code path,
+ * not for cache hits. Entries are frozen because they are shared across messages.
+ */
+export type PreparedOwnerAllowFrom = {
+  /** Wildcards dropped and duplicates collapsed once at prepare time. */
+  stripped: readonly string[];
+  strippedSet: ReadonlySet<string>;
+};
+
+/**
+ * Config identity is the outer key because plugin formatAllowFrom receives the whole
+ * config, and shallow config merges (`{...cfg, ...}`) hand a new config object the
+ * same nested ownerAllowFrom array. Keying on the array alone would let one config
+ * read normalization performed under another — a wrong-grant risk on an authorization
+ * path. Both levels are weak, so a replaced config or array is collectable.
+ *
+ * Consequence: mutating a configured array in place is no longer observed mid-process.
+ * Runtime reads canonical config and reloads produce fresh objects, so that is the
+ * intended contract rather than an accident.
+ */
+const preparedOwnerAllowFrom = new WeakMap<
+  OpenClawConfig,
+  // Provider filtering and plugin/account formatting produce different lists from one
+  // raw array; keys stay bounded by the providers x accounts actually seen.
+  WeakMap<Array<string | number>, Map<string, PreparedOwnerAllowFrom>>
+>();
+
+const EMPTY_PREPARED_OWNER_ALLOW_FROM: PreparedOwnerAllowFrom = {
+  stripped: Object.freeze<string[]>([]),
+  strippedSet: new Set<string>(),
+};
+
+/** Collapses an already-resolved list. Used for per-message channel-derived owners. */
+export function prepareStrippedList(list: readonly string[]): PreparedOwnerAllowFrom {
+  if (list.length === 0) {
+    return EMPTY_PREPARED_OWNER_ALLOW_FROM;
+  }
+  const stripped = Object.freeze(Array.from(new Set(list)));
+  return { stripped, strippedSet: new Set(stripped) };
+}
+
+export function prepareOwnerAllowFrom(params: {
+  plugin?: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  providerId?: ChannelId;
+  allowFrom?: Array<string | number>;
+}): PreparedOwnerAllowFrom {
+  const raw = params.allowFrom ?? params.cfg.commands?.ownerAllowFrom;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return EMPTY_PREPARED_OWNER_ALLOW_FROM;
+  }
+  let byArray = preparedOwnerAllowFrom.get(params.cfg);
+  if (!byArray) {
+    byArray = new WeakMap();
+    preparedOwnerAllowFrom.set(params.cfg, byArray);
+  }
+  let scopes = byArray.get(raw);
+  if (!scopes) {
+    scopes = new Map();
+    byArray.set(raw, scopes);
+  }
+  // accountId is operator-supplied, so encode dimensions through the shared
+  // structured key helper rather than a separator a value could itself contain.
+  const key = createPluginCacheKey([params.providerId, params.plugin?.id, params.accountId]);
+  const cached = scopes.get(key);
+  if (cached) {
+    return cached;
+  }
+  const stripped = Object.freeze(
+    Array.from(new Set(stripWildcardAllowFrom(resolveOwnerAllowFromList(params)))),
+  );
+  const prepared: PreparedOwnerAllowFrom = {
+    stripped,
+    strippedSet: new Set(stripped),
+  };
+  scopes.set(key, prepared);
+  return prepared;
+}
+
+function resolveOwnerAllowFromList(params: {
+  plugin?: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  providerId?: ChannelId;
+  allowFrom?: Array<string | number>;
+}): string[] {
+  const raw = params.allowFrom ?? params.cfg.commands?.ownerAllowFrom;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return [];
+  }
+  const filtered: string[] = [];
+  for (const entry of raw) {
+    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
+    if (!trimmed) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex > 0) {
+      const prefix = trimmed.slice(0, separatorIndex);
+      const channel = normalizeAnyChannelId(prefix);
+      if (channel) {
+        // Channel-prefixed entries require a known matching provider; webchat leaves it unset.
+        if (!params.providerId || channel !== params.providerId) {
+          continue;
+        }
+        const remainder = trimmed.slice(separatorIndex + 1).trim();
+        if (remainder) {
+          filtered.push(remainder);
+        }
+        continue;
+      }
+    }
+    filtered.push(trimmed);
+  }
+  return formatAllowFromList({
+    plugin: params.plugin,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    allowFrom: filtered,
+  });
+}

--- a/src/auto-reply/command-auth.prepared-allowfrom.test.ts
+++ b/src/auto-reply/command-auth.prepared-allowfrom.test.ts
@@ -1,0 +1,143 @@
+/** Tests that large owner allowlists stay correct once compiled per config array. */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveCommandAuthorization } from "./command-auth.js";
+import type { MsgContext } from "./templating.js";
+import { installDiscordRegistryHooks } from "./test-helpers/command-auth-registry-fixture.js";
+
+installDiscordRegistryHooks();
+
+function makeCtx(senderId: string): MsgContext {
+  return {
+    Provider: "discord",
+    Surface: "discord",
+    ChatType: "direct",
+    From: `discord:${senderId}`,
+    SenderId: senderId,
+  } as MsgContext;
+}
+
+describe("owner allowlist preparation", () => {
+  it("authorizes an owner anywhere in a large allowlist across repeated messages", () => {
+    // The prepared list is cached on the raw config array identity, so a second
+    // message for the same config must not observe a stale or truncated list.
+    const ownerAllowFrom = Array.from({ length: 2000 }, (_, i) => `discord:${i}`);
+    const cfg = {
+      channels: { discord: {} },
+      commands: { ownerAllowFrom },
+    } as unknown as OpenClawConfig;
+
+    for (const senderId of ["0", "1999", "1000"]) {
+      const auth = resolveCommandAuthorization({
+        ctx: makeCtx(senderId),
+        cfg,
+        commandAuthorized: true,
+      });
+      expect(auth.senderIsOwner).toBe(true);
+    }
+
+    const stranger = resolveCommandAuthorization({
+      ctx: makeCtx("2000"),
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(stranger.senderIsOwner).toBe(false);
+  });
+
+  it("keeps separate results for two configs that share entry values", () => {
+    // Distinct raw arrays must get distinct cache slots even with equal contents.
+    const first = {
+      channels: { discord: {} },
+      commands: { ownerAllowFrom: ["discord:alice"] },
+    } as unknown as OpenClawConfig;
+    const second = {
+      channels: { discord: {} },
+      commands: { ownerAllowFrom: ["discord:bob"] },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveCommandAuthorization({ ctx: makeCtx("alice"), cfg: first, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+    expect(
+      resolveCommandAuthorization({ ctx: makeCtx("alice"), cfg: second, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(false);
+    expect(
+      resolveCommandAuthorization({ ctx: makeCtx("bob"), cfg: second, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+  });
+
+  it("does not let one provider read another's compiled scope from a shared array", () => {
+    // Compiled scopes are cached per (providerId, plugin id, accountId). This guards
+    // that they are keyed at all rather than shared process-wide for one config
+    // array: collapsing the key makes telegram inherit discord's owner list and this
+    // assertion flips. It does not isolate providerId on its own — the discord-only
+    // registry fixture makes plugin id co-vary with it.
+    const cfg = {
+      channels: { discord: {}, telegram: {} },
+      commands: { ownerAllowFrom: ["discord:alice", "telegram:bob"] },
+    } as unknown as OpenClawConfig;
+
+    const discordAlice = resolveCommandAuthorization({
+      ctx: makeCtx("alice"),
+      cfg,
+      commandAuthorized: true,
+    });
+    const telegramAlice = resolveCommandAuthorization({
+      ctx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        ChatType: "direct",
+        From: "telegram:alice",
+        SenderId: "alice",
+      } as MsgContext,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(discordAlice.senderIsOwner).toBe(true);
+    expect(telegramAlice.senderIsOwner).toBe(false);
+  });
+
+  it("authorizes correctly for two configs holding the same ownerAllowFrom array", () => {
+    // Shallow config merges ({...cfg}) give a new config object the same nested
+    // array. This pins end-to-end behavior for that shape. It does NOT isolate the
+    // cfg dimension of the cache key: both configs here format identically, so it
+    // passes with or without cfg-identity scoping (verified). Isolating that needs
+    // a plugin whose formatAllowFrom reads a differing cfg field.
+    const shared = ["discord:alice"];
+    const base = {
+      channels: { discord: {} },
+      commands: { ownerAllowFrom: shared },
+    } as unknown as OpenClawConfig;
+    const merged = { ...base } as unknown as OpenClawConfig;
+
+    expect(base.commands?.ownerAllowFrom).toBe(merged.commands?.ownerAllowFrom);
+    expect(
+      resolveCommandAuthorization({ ctx: makeCtx("alice"), cfg: base, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+    expect(
+      resolveCommandAuthorization({ ctx: makeCtx("alice"), cfg: merged, commandAuthorized: true })
+        .senderIsOwner,
+    ).toBe(true);
+  });
+
+  it("still honors a wildcard owner entry after preparation", () => {
+    const cfg = {
+      channels: { discord: {} },
+      commands: { ownerAllowFrom: ["*"] },
+    } as unknown as OpenClawConfig;
+
+    // Wildcards are stripped from the owner identity list, so a wildcard alone
+    // must not silently promote an arbitrary sender to owner.
+    const auth = resolveCommandAuthorization({
+      ctx: makeCtx("anyone"),
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(auth.senderIsOwner).toBe(false);
+  });
+});

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -4,7 +4,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   getLoadedChannelPluginById,
   listLoadedChannelPlugins,
@@ -18,6 +17,15 @@ import {
   isInternalMessageChannel,
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
+import {
+  formatAllowFromList,
+  hasWildcardAllowFrom,
+  normalizeAllowFromEntry,
+  prepareOwnerAllowFrom,
+  prepareStrippedList,
+  stripWildcardAllowFrom,
+  type PreparedOwnerAllowFrom,
+} from "./command-auth-owner-allowlist.js";
 import { isNativeCommandTurn, resolveCommandTurnContext } from "./command-turn-context.js";
 import { shouldUseFromAsSenderFallback } from "./sender-identity.js";
 import type { MsgContext } from "./templating.js";
@@ -49,8 +57,10 @@ type ProviderAllowFromResolution = {
 };
 
 type OwnerAuthorizationState = {
-  commandOwnerCandidates: string[];
-  explicitOwners: string[];
+  commandOwnerCandidates: readonly string[];
+  commandOwnerCandidateSet: ReadonlySet<string>;
+  explicitOwners: readonly string[];
+  explicitOwnerSet: ReadonlySet<string>;
 };
 
 function resolveProviderFromContext(
@@ -132,49 +142,6 @@ function probeInferredProviders(ctx: MsgContext, cfg: OpenClawConfig): InferredP
     candidates,
     droppedResolutionError,
   };
-}
-
-function formatAllowFromList(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  allowFrom: Array<string | number>;
-}): string[] {
-  const { plugin, cfg, accountId, allowFrom } = params;
-  if (!allowFrom || allowFrom.length === 0) {
-    return [];
-  }
-  if (plugin?.config?.formatAllowFrom) {
-    return plugin.config.formatAllowFrom({ cfg, accountId, allowFrom });
-  }
-  return normalizeStringEntries(allowFrom);
-}
-
-function normalizeAllowFromEntry(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  value: string;
-}): string[] {
-  const normalized = formatAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    allowFrom: [params.value],
-  });
-  return normalized.filter((entry) => entry.trim().length > 0);
-}
-
-function isWildcardAllowFromEntry(entry: string): boolean {
-  return entry.trim() === "*";
-}
-
-function hasWildcardAllowFrom(list: string[]): boolean {
-  return list.some((entry) => isWildcardAllowFromEntry(entry));
-}
-
-function stripWildcardAllowFrom(list: string[]): string[] {
-  return list.filter((entry) => !isWildcardAllowFromEntry(entry));
 }
 
 function resolveProviderAllowFrom(params: {
@@ -267,49 +234,6 @@ function describeAllowFromResolutionError(err: unknown): string {
   return "unknown_error";
 }
 
-function resolveOwnerAllowFromList(params: {
-  plugin?: ChannelPlugin;
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  providerId?: ChannelId;
-  allowFrom?: Array<string | number>;
-}): string[] {
-  const raw = params.allowFrom ?? params.cfg.commands?.ownerAllowFrom;
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return [];
-  }
-  const filtered: string[] = [];
-  for (const entry of raw) {
-    const trimmed = normalizeOptionalString(String(entry ?? "")) ?? "";
-    if (!trimmed) {
-      continue;
-    }
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex > 0) {
-      const prefix = trimmed.slice(0, separatorIndex);
-      const channel = normalizeAnyChannelId(prefix);
-      if (channel) {
-        // Channel-prefixed entries require a known matching provider; webchat leaves it unset.
-        if (!params.providerId || channel !== params.providerId) {
-          continue;
-        }
-        const remainder = trimmed.slice(separatorIndex + 1).trim();
-        if (remainder) {
-          filtered.push(remainder);
-        }
-        continue;
-      }
-    }
-    filtered.push(trimmed);
-  }
-  return formatAllowFromList({
-    plugin: params.plugin,
-    cfg: params.cfg,
-    accountId: params.accountId,
-    allowFrom: filtered,
-  });
-}
-
 /**
  * Resolves the commands.allowFrom list for a given provider.
  * Returns the provider-specific list if defined, otherwise the "*" global list.
@@ -380,14 +304,14 @@ function resolveOwnerAuthorizationState(params: {
   configOwnerAllowFrom?: Array<string | number>;
   contextOwnerAllowFrom?: Array<string | number>;
 }): OwnerAuthorizationState {
-  const configOwnerAllowFromList = resolveOwnerAllowFromList({
+  const configOwner = prepareOwnerAllowFrom({
     plugin: params.plugin,
     cfg: params.cfg,
     accountId: params.accountId,
     providerId: params.providerId,
     allowFrom: params.configOwnerAllowFrom,
   });
-  const contextOwnerAllowFromList = resolveOwnerAllowFromList({
+  const contextOwner = prepareOwnerAllowFrom({
     plugin: params.plugin,
     cfg: params.cfg,
     accountId: params.accountId,
@@ -405,22 +329,20 @@ function resolveOwnerAuthorizationState(params: {
     allowAll,
     allowFromList: params.allowFromList,
   });
-  const explicitOwners = Array.from(new Set(stripWildcardAllowFrom(configOwnerAllowFromList)));
-  const contextCommandOwners = stripWildcardAllowFrom(contextOwnerAllowFromList);
   // Channel and context lists can authorize commands within one transport, but only the global
-  // owner list grants owner-only command and action authority.
-  const commandOwnerCandidates = Array.from(
-    new Set(
-      explicitOwners.length > 0
-        ? explicitOwners
-        : contextCommandOwners.length > 0
-          ? contextCommandOwners
-          : channelCommandOwners,
-    ),
-  );
+  // owner list grants owner-only command and action authority. The first two branches reuse an
+  // already-deduped prepared list; only the channel list still needs collapsing per message.
+  const commandOwners: PreparedOwnerAllowFrom =
+    configOwner.stripped.length > 0
+      ? configOwner
+      : contextOwner.stripped.length > 0
+        ? contextOwner
+        : prepareStrippedList(channelCommandOwners);
   return {
-    commandOwnerCandidates,
-    explicitOwners,
+    commandOwnerCandidates: commandOwners.stripped,
+    commandOwnerCandidateSet: commandOwners.strippedSet,
+    explicitOwners: configOwner.stripped,
+    explicitOwnerSet: configOwner.strippedSet,
   };
 }
 
@@ -653,10 +575,10 @@ export function resolveCommandAuthorization(params: {
     chatType: ctx.ChatType,
   });
   const matchedSender = ownerState.explicitOwners.length
-    ? senderCandidates.find((candidate) => ownerState.explicitOwners.includes(candidate))
+    ? senderCandidates.find((candidate) => ownerState.explicitOwnerSet.has(candidate))
     : undefined;
   const matchedCommandOwner = ownerState.commandOwnerCandidates.length
-    ? senderCandidates.find((candidate) => ownerState.commandOwnerCandidates.includes(candidate))
+    ? senderCandidates.find((candidate) => ownerState.commandOwnerCandidateSet.has(candidate))
     : undefined;
   const senderId = matchedSender ?? matchedCommandOwner ?? senderCandidates[0];
 
@@ -689,7 +611,9 @@ export function resolveCommandAuthorization(params: {
 
   return {
     providerId,
-    ownerList: ownerState.explicitOwners,
+    // Copied at this one boundary so the shared prepared list stays immutable while
+    // CommandAuthorization keeps its mutable string[] contract.
+    ownerList: [...ownerState.explicitOwners],
     senderId: senderId || undefined,
     senderIsOwner,
     isAuthorizedSender,


### PR DESCRIPTION
Closes #50289

## What Problem This Solves

Gateways with large `commands.ownerAllowFrom` lists spend increasing time on every inbound message and can emit `lane wait exceeded` warnings. The reporter has 9,282 entries.

Command authorization re-derived the owner allowlist on every message: trimming and parsing each entry, applying channel-prefix filtering, running plugin `formatAllowFrom`, stripping wildcards, de-duplicating, and then matching senders with linear `Array.includes`. All of that scaled with the configured list size and was recomputed per message even though the config array never changed.

Measured on current `main` `bb657eec935`, per-message cost is linear in list size (see Evidence).

## Why This Change Was Made

The configured array is process-stable between config reloads, and plugin `formatAllowFrom` is deterministic for a given `(cfg, accountId, allowFrom)`. So the derived owner list is computed once per raw config array identity and reused, with sender matching moved to a `Set`.

The cache is a `WeakMap` keyed on config identity, then a `WeakMap` on the raw array identity, then a key covering `providerId`, plugin id, and `accountId` — the inputs that change how a single array formats. Config identity is the outer dimension because plugin `formatAllowFrom` receives the whole config and shallow merges (`{...cfg}`) hand a new config object the same nested array; keying on the array alone would let one config read normalization performed under another, which is a wrong-grant risk on an authorization path. Both outer levels are weak, so replaced configs and arrays stay collectable. One consequence is that mutating a configured array in place is no longer observed mid-process; runtime reads canonical config and reloads produce fresh objects, so that is the intended contract. A config reload produces a new array and therefore a new entry; the `WeakMap` lets the old one be collected. Per-message `ctx.OwnerAllowFrom` overrides keep their existing precedence, and channel-derived owners are still collapsed per message because they depend on `ctx.To`.

**This revision is deliberately smaller than the original one.** `main` has since restructured `resolveOwnerAuthorizationState` around a single `commandOwnerCandidates` precedence chain, so this PR was reimplemented against that shape and now caches only the owner allowlists rather than introducing a parallel prepared-list layer across provider resolution. The shipped mutable `CommandAuthorization.ownerList` shape is preserved with one defensive copy at the public boundary, so callers cannot mutate shared cached state.

Relative to #103523, which replaces `.includes` with a `Set` built per message: that removes the lookup cost but keeps the dominant per-message list transformation. Both changes are compatible; if #103523 lands first this PR still removes the remaining rebuild.

## User Impact

Command authorization stops scaling with `commands.ownerAllowFrom` size. At the reporter's 9,282 entries the per-message cost drops from ~1.9 ms to ~0.01 ms and becomes flat rather than linear. Owner, channel-prefix, wildcard, override, and command-allowlist semantics are unchanged, and there is no config, migration, protocol, or Plugin SDK surface change.

## Evidence

### Captured before/after through the production entry point

A standalone `tsx` harness calls the exported `resolveCommandAuthorization` — the function the inbound message path uses — 200 times per size after a warmup, with nothing mocked. Both runs are on the same base, `main` `bb657eec935`, on Node 24.16.0 / macOS 26.5.1; only `src/auto-reply/command-auth.ts` differs.

**Before — clean `main` `bb657eec935`:**

```
  ownerAllowFrom=    0 entries -> 0.0122 ms/message
  ownerAllowFrom= 1000 entries -> 0.1966 ms/message
  ownerAllowFrom= 9282 entries -> 1.9081 ms/message
  ownerAllowFrom=10000 entries -> 2.0095 ms/message
```

**After — this PR's head `12d7c51ecf8`:**

```
  ownerAllowFrom=    0 entries -> 0.0163 ms/message
  ownerAllowFrom= 1000 entries -> 0.0037 ms/message
  ownerAllowFrom= 9282 entries -> 0.0104 ms/message
  ownerAllowFrom=10000 entries -> 0.0084 ms/message
```

Before scales linearly with list size; after is flat. At the reporter's 9,282 entries that is ~183x. Values below ~0.02 ms/message are at this harness's noise floor, which is why the 0-entry rows are not meaningfully different — the claim is the removal of the linear term, not a constant-factor win on small configs.

### Regression proof

`src/auto-reply/command-auth.prepared-allowfrom.test.ts` covers what the cache could plausibly break: an owner at the start, middle, and end of a 2,000-entry list across repeated messages on the same config object; two distinct config arrays with equal-shaped contents not sharing a cache slot; a wildcard-only owner list still not promoting an arbitrary sender; and one provider not reading another's compiled scope from a shared config array. That last one is a verified negative control — collapsing the cache key to `accountId` alone makes it fail. A fifth case pins behavior for two configs sharing one array; it is honestly *not* a negative control for the cfg dimension, since both configs format identically here — isolating that would need a plugin whose `formatAllowFrom` reads a differing cfg field. The cfg-identity scoping is defensive hardening, added after cross-model review flagged the shared-array vector.

- `node scripts/run-vitest.mjs src/auto-reply/command-auth.prepared-allowfrom.test.ts src/auto-reply/command-auth.owner-default.test.ts src/auto-reply/command-control.test.ts` — 63/63 passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` clean on both touched files; `oxfmt` clean; `git diff --check` clean.
- `git diff --numstat` vs its base: `command-auth.ts` +32 −108, new `command-auth-owner-allowlist.ts` +170, tests +119. `main`'s `command-auth.ts` already sits at 699 lines against a 700-line `max-lines` cap, so the allow-from compilation moved into its own module rather than growing that file; `pnpm check:import-cycles` reports 0 cycles.

Proof gap: the harness measures a synthetic 200-message loop on one machine, not a live gateway under real inbound load, and no Crabbox/Testbox breadth lane was available in this contribution envelope. The shape of the curve, not the absolute milliseconds, is the claim. GitHub CI provides publication-time breadth.

AI-assisted implementation and review; the contributor reviewed the resulting diff and evidence before publication.
