### PR TITLE
fix(release): prevent stale beta validation evidence

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -317,13 +317,24 @@ function closingReferencesIn(text) {
   return references;
 }
 
-function standardRevertedHash(message) {
-  return message
+export function standardRevertedHash(message) {
+  const paragraphs = message
     .trim()
     .split(/\n\s*\n/)
-    .map((paragraph) => paragraph.trim())
-    .map((paragraph) => paragraph.match(/^This reverts commit ([0-9a-f]{7,40})\.$/i)?.[1])
-    .find(Boolean);
+    .map((paragraph) => paragraph.trim());
+  for (const [index, paragraph] of paragraphs.entries()) {
+    const revertedHash = paragraph.match(/^This reverts commit ([0-9a-f]{7,40})\.$/i)?.[1];
+    if (!revertedHash) {
+      continue;
+    }
+    // GitHub squash messages can embed a reverted intermediate commit. Its
+    // marker follows the corresponding bullet and does not revert the squash.
+    if (/^\*\s+Revert\b/i.test(paragraphs[index - 1] ?? "")) {
+      continue;
+    }
+    return revertedHash;
+  }
+  return undefined;
 }
 
 function handlesIn(text) {

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -322,6 +322,7 @@ export function standardRevertedHash(message) {
     .trim()
     .split(/\n\s*\n/)
     .map((paragraph) => paragraph.trim());
+  const messageIsRevert = /^revert\b/i.test(paragraphs[0] ?? "");
   for (const [index, paragraph] of paragraphs.entries()) {
     const revertedHash = paragraph.match(/^This reverts commit ([0-9a-f]{7,40})\.$/i)?.[1];
     if (!revertedHash) {
@@ -329,7 +330,7 @@ export function standardRevertedHash(message) {
     }
     // GitHub squash messages can embed a reverted intermediate commit. Its
     // marker follows the corresponding bullet and does not revert the squash.
-    if (/^\*\s+Revert\b/i.test(paragraphs[index - 1] ?? "")) {
+    if (!messageIsRevert && /^\*\s+Revert\b/i.test(paragraphs[index - 1] ?? "")) {
       continue;
     }
     return revertedHash;

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -322,7 +322,9 @@ export function standardRevertedHash(message) {
     .trim()
     .split(/\n\s*\n/)
     .map((paragraph) => paragraph.trim());
-  const messageIsRevert = /^revert\b/i.test(paragraphs[0] ?? "");
+  const messageIsRevert = /^(?:[a-z][a-z0-9-]*(?:\([^)]+\))?!?:\s*)?revert\b/i.test(
+    paragraphs[0] ?? "",
+  );
   for (const [index, paragraph] of paragraphs.entries()) {
     const revertedHash = paragraph.match(/^This reverts commit ([0-9a-f]{7,40})\.$/i)?.[1];
     if (!revertedHash) {

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -482,6 +482,8 @@ if (typeof updateStep.command !== "string" || !updateStep.command.includes(expec
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
 }
 const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
+// Every baseline that passes verify_installed_cli implements this contract;
+// the sole earlier npm artifact has no CLI and cannot reach this parser.
 if (!doctorStep) {
   throw new Error("missing openclaw doctor step in update JSON");
 }

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -9,6 +9,7 @@ import {
   cumulativeShippedPullRequests,
   highlightCountError,
   releaseNoteReferences,
+  standardRevertedHash,
   subtractShippedPullRequests,
   withoutExcludedContributionRecords,
 } from "../../.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs";
@@ -32,6 +33,34 @@ function git(cwd: string, args: string[]): string {
 }
 
 describe("release-note verification", () => {
+  it("ignores nested revert markers in squash-merge bodies", () => {
+    const nestedRevert = [
+      "feat(android): render display math (#101435)",
+      "",
+      "* feat(android): render display math",
+      "",
+      ' * Revert "docs(changelog): note display math"',
+      "",
+      `This reverts commit ${"a".repeat(40)}.`,
+    ].join("\n");
+    const topLevelRevert = [
+      'Revert "fix(qa): keep smoke profile on one channel (#101173)" (#101184)',
+      "",
+      `This reverts commit ${"b".repeat(40)}.`,
+    ].join("\n");
+    const explainedTopLevelRevert = [
+      "revert: restore a provider default",
+      "",
+      "The replacement broke non-native endpoints.",
+      "",
+      `This reverts commit ${"c".repeat(40)}.`,
+    ].join("\n");
+
+    expect(standardRevertedHash(nestedRevert)).toBeUndefined();
+    expect(standardRevertedHash(topLevelRevert)).toBe("b".repeat(40));
+    expect(standardRevertedHash(explainedTopLevelRevert)).toBe("c".repeat(40));
+  });
+
   it("counts only top-level Highlights bullets and enforces the 5-8 policy input", () => {
     const highlights = [
       "### Highlights",

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -57,18 +57,28 @@ describe("release-note verification", () => {
       "",
       "* fix(ui): clear applied chat picker search on empty input",
     ].join("\n");
+    const conventionalSquashRevert = [
+      "chore: revert dependency guard backfill machinery (#87867)",
+      "",
+      '* Revert "ci: isolate dependency guard backfill label (#87882)"',
+      "",
+      `This reverts commit ${"d".repeat(40)}.`,
+      "",
+      "* ci: preserve clawsweeper bot label filter",
+    ].join("\n");
     const explainedTopLevelRevert = [
       "revert: restore a provider default",
       "",
       "The replacement broke non-native endpoints.",
       "",
-      `This reverts commit ${"d".repeat(40)}.`,
+      `This reverts commit ${"e".repeat(40)}.`,
     ].join("\n");
 
     expect(standardRevertedHash(nestedRevert)).toBeUndefined();
     expect(standardRevertedHash(topLevelRevert)).toBe("b".repeat(40));
     expect(standardRevertedHash(squashRevert)).toBe("c".repeat(40));
-    expect(standardRevertedHash(explainedTopLevelRevert)).toBe("d".repeat(40));
+    expect(standardRevertedHash(conventionalSquashRevert)).toBe("d".repeat(40));
+    expect(standardRevertedHash(explainedTopLevelRevert)).toBe("e".repeat(40));
   });
 
   it("counts only top-level Highlights bullets and enforces the 5-8 policy input", () => {

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -48,17 +48,27 @@ describe("release-note verification", () => {
       "",
       `This reverts commit ${"b".repeat(40)}.`,
     ].join("\n");
+    const squashRevert = [
+      "Revert chat session picker inline search (#85527)",
+      "",
+      '* Revert "fix(ui): keep chat session search inline (#85490)"',
+      "",
+      `This reverts commit ${"c".repeat(40)}.`,
+      "",
+      "* fix(ui): clear applied chat picker search on empty input",
+    ].join("\n");
     const explainedTopLevelRevert = [
       "revert: restore a provider default",
       "",
       "The replacement broke non-native endpoints.",
       "",
-      `This reverts commit ${"c".repeat(40)}.`,
+      `This reverts commit ${"d".repeat(40)}.`,
     ].join("\n");
 
     expect(standardRevertedHash(nestedRevert)).toBeUndefined();
     expect(standardRevertedHash(topLevelRevert)).toBe("b".repeat(40));
-    expect(standardRevertedHash(explainedTopLevelRevert)).toBe("c".repeat(40));
+    expect(standardRevertedHash(squashRevert)).toBe("c".repeat(40));
+    expect(standardRevertedHash(explainedTopLevelRevert)).toBe("d".repeat(40));
   });
 
   it("counts only top-level Highlights bullets and enforces the 5-8 policy input", () => {


### PR DESCRIPTION
Related: #103144

## What Problem This Solves

Resolves a problem where release maintainers validating an exact beta candidate could receive stale, incomplete, or cross-build evidence and only discover it late in publication.

## Why This Change Was Made

Makes the release-note verifier preserve real squash-revert targets, recognize the conventional revert body emitted by GitHub, and ignore nested revert markers. It also documents the installer smoke contract next to the enforced doctor checks. Concurrent PR #103796 absorbed the upgrade-proxy, installer-evidence, and Codex restart-harness fixes from the original stack; this PR now contains only the remaining upstream fixes. The current `main` workflow separately pins validated Kova revision `24c26969e57d4d49f9d1a5071af85dd3d79daa2d` at both invocation sites.

## User Impact

Release maintainers get accurate contribution-ledger evidence when merged pull requests are later reverted through either supported squash-revert form. Product runtime behavior is unchanged.

## Evidence

- Reduced exact-head focused release-note suite: 80 tests passed in Testbox run 29106328518.
- Whole-branch changed gate (typecheck, lint, import cycles, policy guards): passed in Testbox run 29105126333.
- Fresh whole-branch structured autoreview: clean, no accepted/actionable findings.
- Exact-candidate release-branch suite: 182 tests passed in Testbox run 29095809729.
- Exact-candidate broad release validation: Crabbox `run_c6f74d8162f9`; `check:changed` passed.
- Exact-head main-port broad gate: Testbox run 29100388591.
- Full Release Validation for the final release candidate follows after this workflow pin lands on `main`.
