### PR TITLE
fix(clawdock): preserve sourced zsh PATH

### DIFF
--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -122,10 +122,10 @@ _clawdock_ensure_dir() {
   fi
 
   # Auto-detect from common paths
-  local found_path=""
-  for path in "${CLAWDOCK_COMMON_PATHS[@]}"; do
-    if [[ -f "${path}/docker-compose.yml" ]]; then
-      found_path="$path"
+  local candidate found_path=""
+  for candidate in "${CLAWDOCK_COMMON_PATHS[@]}"; do
+    if [[ -f "${candidate}/docker-compose.yml" ]]; then
+      found_path="$candidate"
       break
     fi
   done

--- a/test/scripts/clawdock-helpers.test.ts
+++ b/test/scripts/clawdock-helpers.test.ts
@@ -1,5 +1,5 @@
 // Clawdock Helpers tests cover clawdock helpers script behavior.
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,12 +9,67 @@ import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const shellCases = [
+  { available: true, shell: "bash" },
+  {
+    available: spawnSync("zsh", ["--version"], { stdio: "ignore" }).status === 0,
+    shell: "zsh",
+  },
+];
 
 async function writeExecutable(file: string, content: string) {
   await writeFile(file, content, { mode: 0o755 });
 }
 
 describe("scripts/clawdock/clawdock-helpers.sh", () => {
+  for (const { available, shell } of shellCases) {
+    it.runIf(available)(
+      `preserves caller state while auto-detecting the checkout in ${shell}`,
+      async () => {
+        const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-clawdock-"));
+        try {
+          const homeDir = path.join(tempDir, "home");
+          const projectDir = path.join(homeDir, "openclaw");
+          const confirmFile = path.join(tempDir, "confirm.txt");
+          await mkdir(projectDir, { recursive: true });
+          await writeFile(path.join(projectDir, "docker-compose.yml"), "services: {}\n");
+          await writeFile(confirmFile, "\n");
+
+          await execFileAsync(
+            shell,
+            [
+              "-c",
+              [
+                'path_before="$PATH"',
+                'candidate="caller-value"',
+                "source scripts/clawdock/clawdock-helpers.sh || exit 1",
+                '_clawdock_ensure_dir < "$CLAWDOCK_CONFIRM_FILE" || exit 1',
+                '[[ "$PATH" == "$path_before" ]] || exit 1',
+                '[[ "$candidate" == "caller-value" ]] || exit 1',
+                '[[ "$CLAWDOCK_DIR" == "$HOME/openclaw" ]] || exit 1',
+              ].join("\n"),
+            ],
+            {
+              cwd: repoRoot,
+              env: {
+                ...process.env,
+                CLAWDOCK_CONFIRM_FILE: confirmFile,
+                CLAWDOCK_DIR: "",
+                HOME: homeDir,
+              },
+            },
+          );
+
+          await expect(readFile(path.join(homeDir, ".clawdock", "config"), "utf8")).resolves.toBe(
+            `CLAWDOCK_DIR="${projectDir}"\n`,
+          );
+        } finally {
+          await rm(tempDir, { force: true, recursive: true });
+        }
+      },
+    );
+  }
+
   it("loads the standard docker-compose.override.yml before ClawDock extra overrides", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-clawdock-"));
     try {


### PR DESCRIPTION
## What Problem This Solves

ClawDock's documented install path sources `clawdock-helpers.sh` from `.zshrc`. Its checkout auto-detection loop uses `path` as an undeclared loop variable; in zsh, lowercase `path` is the special array tied bidirectionally to `PATH`. The first ClawDock command therefore replaces the caller's command search path with the detected checkout.

This supersedes #90875 while preserving @lshgdut's diagnosis and contributor credit. The original pull request uses the fork's default branch and accumulated unrelated synchronization commits, so this replacement keeps the fix as one reviewable commit on current `main`.

## Why This Change Was Made

- Rename the loop variable to `candidate` and make it function-local. Localizing it fixes zsh's special-parameter collision without introducing a new caller-variable leak in either supported shell.
- Exercise the actual `_clawdock_ensure_dir` path under Bash and zsh when available. The regression checks the caller's exact `PATH`, an existing `candidate` variable, the detected checkout, and the persisted ClawDock config.
- Keep the owner boundary inside the sourced shell helper; no Docker, config-shape, or command behavior changes are needed.

## User Impact

The first ClawDock command no longer destroys `PATH` in a sourced zsh session. Bash behavior and checkout auto-detection remain unchanged.

## Evidence

- Current-`main` negative control (`911f8ec68f8`, zsh 5.9): the real `_clawdock_ensure_dir` call changed a 966-byte `PATH` to only the temporary `~/openclaw` path; the harness failed its byte-equality assertion with exit 42. The same path preserved `PATH` under Bash 3.2.
- Fixed live path (`0b6dd1e2667`): the real helper preserved all 966 bytes of `PATH`, preserved caller `candidate=caller-value`, selected `~/openclaw`, and wrote `.clawdock/config` under both zsh 5.9 and Bash 3.2.
- `bash -n scripts/clawdock/clawdock-helpers.sh`
- `zsh -n scripts/clawdock/clawdock-helpers.sh`
- `oxfmt --check test/scripts/clawdock-helpers.test.ts scripts/clawdock/clawdock-helpers.sh`
- Fresh exact-head structured autoreview: clean, no accepted/actionable findings, correctness 0.98.
- Exact-head hosted CI [run 29106488134](https://github.com/openclaw/openclaw/actions/runs/29106488134), attempt 2: passed. The changed ClawDock suite passed; attempt 1's sole unrelated SIGTERM timing failure passed on rerun.
- Testbox-through-Crabbox `tbx_01kx6eae2fev60m5kb63syzpmf`, [run 29108107528](https://github.com/openclaw/openclaw/actions/runs/29108107528): asserted exact clean head `0b6dd1e2667` and tree `6cf3a1afe1d`; installed zsh 5.9; reproduced current-main's zsh PATH collapse while Bash remained unchanged; passed fixed Bash and zsh probes, focused tests 4/4, and the relevant tooling changed gate. The one-shot box stopped after success.
