### PR TITLE
fix(memory): drop bare heartbeat acks (with decoration) from dreaming corpus

### DIFF
--- a/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
@@ -22,6 +22,7 @@ export {
   resolveStorePath,
   resolveSessionAgentId,
   resolveSessionTranscriptsDirForAgent,
+  stripHeartbeatToken,
   stripInboundMetadata,
   stripInternalRuntimeContext,
   type SessionEntry,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -25,7 +25,7 @@ export {
 
 // Session and reply helpers.
 export { isHeartbeatUserMessage } from "../../../../src/auto-reply/heartbeat-filter.js";
-export { HEARTBEAT_PROMPT } from "../../../../src/auto-reply/heartbeat.js";
+export { HEARTBEAT_PROMPT, stripHeartbeatToken } from "../../../../src/auto-reply/heartbeat.js";
 export { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 export {
   HEARTBEAT_TOKEN,

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -945,4 +945,50 @@ describe("buildSessionEntry", () => {
     const entry = requireSessionEntry(await buildSessionEntry(filePath));
     expect(entry.messageTimestampsMs).toStrictEqual([0]);
   });
+
+  it("drops bare heartbeat acknowledgements including decoration variants (#103720)", async () => {
+    const jsonlLines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "What is the weather?" } }),
+      // Bare token — already handled by the previous exact-string match.
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "HEARTBEAT_OK" } }),
+      // Trailing punctuation — leaked before because it was not an exact match.
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "HEARTBEAT_OK." } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "HEARTBEAT_OK!!!" } }),
+      // Markdown / HTML wrappers — leaked before.
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "**HEARTBEAT_OK**" } }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "<b>HEARTBEAT_OK</b>" },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "heartbeat-ack-session.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+
+    // Only the real user turn survives; the bare token and its pure-decoration
+    // variants are filtered so they never become dreaming-corpus snippets.
+    expect(entry.content).toBe("User: What is the weather?");
+    expect(entry.lineMap).toStrictEqual([1]);
+  });
+
+  it("preserves genuine assistant prose that merely contains HEARTBEAT_OK (#103720)", async () => {
+    // Any real word content beyond the token means the message is substantive
+    // and must stay searchable in the dreaming corpus. We cannot tell a genuine
+    // short explanation apart from a heartbeat ack without trusted heartbeat
+    // ownership, so we only drop pure token+decoration and keep everything else.
+    const shortExplanation = "HEARTBEAT_OK means the periodic check succeeded.";
+    const ackWithNote = "HEARTBEAT_OK. No pending tasks this cycle.";
+    const jsonlLines = [
+      JSON.stringify({ type: "message", message: { role: "assistant", content: shortExplanation } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: ackWithNote } }),
+    ];
+    const filePath = path.join(tmpDir, "heartbeat-prose-session.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+
+    expect(entry.content).toBe(`Assistant: ${shortExplanation}\nAssistant: ${ackWithNote}`);
+    expect(entry.lineMap).toStrictEqual([1, 2]);
+  });
 });

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -10,7 +10,6 @@ import {
   isDreamingNarrativeSessionStoreKey,
   extractAgentIdFromSessionsDir,
   HEARTBEAT_PROMPT,
-  HEARTBEAT_TOKEN,
   hasInterSessionUserProvenance,
   isCompactionCheckpointTranscriptFileName,
   isCronRunSessionKey,
@@ -21,6 +20,7 @@ import {
   isUsageCountedSessionTranscriptFileName,
   parseUsageCountedSessionIdFromFileName,
   resolveSessionTranscriptsDirForAgent,
+  stripHeartbeatToken,
   stripInboundMetadata,
   stripInternalRuntimeContext,
 } from "./openclaw-runtime-session.js";
@@ -665,11 +665,20 @@ function sanitizeSessionText(text: string, role: "user" | "assistant"): string |
     return null;
   }
   // Assistant-side machinery acks: HEARTBEAT_OK is the canonical "all clear,
-  // nothing to do" reply to a heartbeat tick. Drop on the assistant side
-  // directly so we do not have to rely on cross-message coupling with the
-  // preceding user message (which a real user could spoof).
-  if (role === "assistant" && normalized === HEARTBEAT_TOKEN) {
-    return null;
+  // nothing to do" reply to a heartbeat tick. Drop it on the assistant side
+  // directly rather than coupling to the preceding user message (which a real
+  // user could spoof). Reuse the canonical token stripper, but only drop when
+  // the token carries no substantive prose — i.e. the message is the bare
+  // token plus pure punctuation/markup decoration ("HEARTBEAT_OK.",
+  // "**HEARTBEAT_OK**"). Without trusted heartbeat ownership we cannot treat
+  // an arbitrary short reply that merely contains the token (e.g. "HEARTBEAT_OK
+  // means the check passed.") as an ack, so any surviving letter or digit keeps
+  // the message in the corpus.
+  if (role === "assistant") {
+    const strippedHeartbeat = stripHeartbeatToken(normalized, { mode: "message" });
+    if (strippedHeartbeat.didStrip && !/[\p{L}\p{N}]/u.test(strippedHeartbeat.text)) {
+      return null;
+    }
   }
   const withoutSystemEnvelope = normalized.replace(GENERATED_SYSTEM_MESSAGE_RE, "").trim();
   if (isExecCompletionEvent(withoutSystemEnvelope)) {


### PR DESCRIPTION
## What Problem This Solves

Heartbeat acknowledgements that are not the exact string `HEARTBEAT_OK` leak into the dreaming session corpus as low-confidence snippets, where they crowd out real content in the Light and REM phases and produce illegible "A memory trace surfaced, but details were unavailable in this run." ghost entries in `DREAMS.md`.

## Root Cause

`sanitizeSessionText` in `packages/memory-host-sdk/src/host/session-files.ts` dropped an assistant reply only when `normalized === "HEARTBEAT_OK"`. Decoration variants of the bare token — trailing punctuation (`HEARTBEAT_OK.`, `HEARTBEAT_OK!!!`), markdown/HTML wrappers (`**HEARTBEAT_OK**`, `<b>HEARTBEAT_OK</b>`) — did not match and were indexed.

## Changes

- Reuse the canonical `stripHeartbeatToken` parser (already used by the heartbeat filter) via the memory-host-sdk runtime facade.
- `sanitizeSessionText` now drops an assistant message only when, after removing the token, **no letter or digit survives** (`/[\p{L}\p{N}]/u`) — i.e. it is the bare token plus pure punctuation/markup decoration.
- Tests: bare token and decoration variants are dropped; genuine prose that merely contains the token is preserved.

## Scope / Boundary (updated after review)

An earlier revision reused `isHeartbeatOkResponse`, whose 300-char acknowledgement budget classified any short reply containing the token as an ack. As the review noted, that over-drops legitimate content — e.g. `HEARTBEAT_OK means the periodic check succeeded.` would be silently removed from indexed memory.

This revision narrows the drop to **decoration only**:

- We deliberately do **not** gate on heartbeat ownership via the preceding user message: the existing code comment rejects that cross-message coupling because a real user could spoof the heartbeat prompt text, and there is no per-message heartbeat provenance at this ingestion boundary.
- Any assistant reply that carries real prose beyond the token — including non-ASCII prose — is preserved.
- Token-free natural-language acknowledgements remain out of scope (they are a prompt/model-compliance concern, and were never matched by the previous exact-string rule either). Issue 1 in the report (deleted/reset transcripts ingested by dreaming) is also intentionally unchanged: those archives are deliberately retained for `memory_search` (see the comment and the `indexes usage-counted reset/deleted archives` test in `session-files.ts`); the broader ingestion scope is tracked in #72611.

## Evidence

**1. Focused tests (RED before, GREEN after)** — a new regression test preserves a short genuine token-bearing reply; it failed on the previous revision and passes now:

```
$ npx vitest run packages/memory-host-sdk/src/host/session-files.test.ts -t "buildSessionEntry"
 Test Files  1 passed (1)
      Tests  12 passed | 28 skipped (40)
```

**2. Real behavior proof** — a standalone script (not a test harness) runs the actual `buildSessionEntry` corpus builder on a realistic heartbeat transcript and prints the resulting corpus content:

```
Assistant message -> corpus verdict:
  DROPPED  "HEARTBEAT_OK"
  DROPPED  "HEARTBEAT_OK."
  DROPPED  "HEARTBEAT_OK!!!"
  DROPPED  "**HEARTBEAT_OK**"
  DROPPED  "<b>HEARTBEAT_OK</b>"
  KEPT     "HEARTBEAT_OK means the periodic check succeeded."
  KEPT     "HEARTBEAT_OK 表示这一轮心跳检查已通过。"
  KEPT     "The digest job failed because the API token expired."

--- Resulting corpus content ---
Assistant: HEARTBEAT_OK means the periodic check succeeded.
Assistant: HEARTBEAT_OK 表示这一轮心跳检查已通过。
Assistant: The digest job failed because the API token expired.

RESULT: PASS — bare/decorated acks dropped, genuine prose preserved.
```

- The 3 `listSessionTranscriptCorpusEntriesForAgent` failures observed locally are pre-existing Windows path-casing issues (`c:\...` vs `C:\...`); they fail identically on a clean `origin/main` baseline with this change stashed, so they are unrelated to this PR.

Related: #103720

🤖 Generated with [Claude Code](https://claude.com/claude-code)
