### PR TITLE
fix(doctor): preserve install policy config

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -560,6 +560,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("installs a missing configured OpenClaw channel plugin from npm by default", async () => {
+    const cfg = {
+      security: { installPolicy: { enabled: true } },
+      channels: {
+        matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+      },
+    } satisfies OpenClawConfig;
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
         id: "matrix",
@@ -576,11 +582,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
-      cfg: {
-        channels: {
-          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
-        },
-      },
+      cfg,
       env: {},
     });
 
@@ -591,6 +593,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       expectedPluginId: "matrix",
       expectedIntegrity: "sha512-test",
       trustedSourceLinkedOfficialInstall: true,
+      config: cfg,
     });
     const records = mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords);
     expectRecordFields((records as Record<string, unknown>).matrix, {
@@ -609,6 +612,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("uses an explicit ClawHub install spec before npm", async () => {
+    const cfg = {
+      security: { installPolicy: { enabled: true } },
+      channels: {
+        matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+      },
+    } satisfies OpenClawConfig;
     const reviewNotice =
       "╭─ REVIEW RECOMMENDED - ClawHub has not completed a fresh clean check ─╮\n" +
       "│ • Status:            security scan is pending                         │\n" +
@@ -655,17 +664,14 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
-      cfg: {
-        channels: {
-          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
-        },
-      },
+      cfg,
       env: {},
     });
 
     const clawHubCall = expectRecordFields(mockCallArg(mocks.installPluginFromClawHub), {
       spec: "clawhub:@openclaw/plugin-matrix@stable",
       expectedPluginId: "matrix",
+      config: cfg,
     });
     expect(clawHubCall.logger).toEqual(expect.objectContaining({ terminalLinks: false }));
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -1702,6 +1708,14 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("retries npm repair as an update when the install target appears stale", async () => {
+    const cfg = {
+      security: { installPolicy: { enabled: true } },
+      plugins: {
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    } satisfies OpenClawConfig;
     const npmRoot = makeTempDir();
     const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "discord");
     mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
@@ -1737,13 +1751,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
-      cfg: {
-        plugins: {
-          entries: {
-            discord: { enabled: true },
-          },
-        },
-      },
+      cfg,
       env: {
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
@@ -1754,11 +1762,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       spec: expectedNpmInstallSpec("@openclaw/discord"),
       npmDir: npmRoot,
       mode: "install",
+      config: cfg,
     });
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec, 1), {
       spec: expectedNpmInstallSpec("@openclaw/discord"),
       npmDir: npmRoot,
       mode: "update",
+      config: cfg,
     });
     expect(result.warnings).toEqual([]);
     expect(result.records.discord?.installPath).toBe(packageDir);

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -1042,6 +1042,7 @@ function formatInstalledConfiguredPluginChange(params: {
 
 async function installCandidate(params: {
   candidate: DownloadableInstallCandidate;
+  config: OpenClawConfig;
   records: Record<string, PluginInstallRecord>;
   env: NodeJS.ProcessEnv;
   updateChannel?: UpdateChannel;
@@ -1118,6 +1119,7 @@ async function installCandidate(params: {
     const clawhubInstallSpecLabel = sanitizeTerminalText(clawhubInstallSpec);
     const clawhubResult = await installPluginFromClawHub({
       spec: clawhubInstallSpec,
+      config: params.config,
       extensionsDir,
       env: params.env,
       expectedPluginId: candidate.pluginId,
@@ -1191,6 +1193,7 @@ async function installCandidate(params: {
   const npmInstallMode = params.mode === "update" || existingNpmPackagePath ? "update" : "install";
   let result = await installPluginFromNpmSpec({
     spec: npmInstallSpec,
+    config: params.config,
     extensionsDir,
     npmDir,
     expectedPluginId: candidate.pluginId,
@@ -1203,6 +1206,7 @@ async function installCandidate(params: {
   if (!result.ok && npmInstallMode === "install" && isPluginAlreadyExistsError(result.error)) {
     result = await installPluginFromNpmSpec({
       spec: npmInstallSpec,
+      config: params.config,
       extensionsDir,
       npmDir,
       expectedPluginId: candidate.pluginId,
@@ -2126,6 +2130,7 @@ async function repairMissingPluginInstalls(params: {
     const previousRecords = nextRecords;
     const installed = await installCandidate({
       candidate,
+      config: params.cfg,
       records: nextRecords,
       env,
       updateChannel,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw doctor` to repair a missing configured plugin could have the install-policy decision evaluated against an older process-level configuration snapshot instead of the exact candidate configuration Doctor was repairing.

This matters when Doctor mutates or recovers configuration in-process: plugin discovery and repair use the current candidate, while ClawHub/npm installation previously had to fall back to ambient runtime config for `security.installPolicy`.

## Why This Change Was Made

Doctor now passes its current candidate config through the private missing-plugin repair helper to ClawHub, npm install, and the npm install-to-update retry. This keeps all three policy decisions aligned with the configuration snapshot that selected the repair candidate; it does not change install-policy rules or broaden supported install sources.

## User Impact

Doctor repairs now consistently honor the install policy from the configuration being repaired, including in-process recovery and mutation paths, instead of potentially consulting stale ambient config.

## Evidence

Failing-first regression proof before the source change:

```text
expected undefined to deeply equal { security: { installPolicy: { enabled: true } }, ... }
Tests 2 failed | 81 skipped
```

Real Doctor behavior proof was captured on equivalent patch head `14dfabb504f361c3ddea799c49988abbdd88d27a`, then based on `5aea34ad8c210ddba5a678d64c559da8414baea7`:

- Ran in an isolated temporary `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`
- Used the production CLI config guard to pin an ambient policy that returns `allow`
- Replaced only the on-disk candidate with a policy that returns `block`
- Invoked the production Doctor command entrypoint with `--fix --yes --non-interactive`
- Used a real missing-plugin npm declaration and a published npm spec; the candidate policy blocked the preflight before install side effects

Redacted terminal evidence:

```text
PROOF ambient snapshot command: <temp>/ambient-allow.cjs
PROOF candidate file command: <temp>/candidate-block.cjs
PROOF invoking real doctor command entrypoint with --fix --yes --non-interactive

Failed to install missing configured plugin "guardrail-bridge" from
@openclaw/discord@2026.6.11: blocked by install policy: candidate
policy blocks proof install

PROOF policy invocation log:
CANDIDATE_BLOCK {"targetName":"guardrail-bridge","targetType":"plugin",
"request":{"kind":"plugin-npm","mode":"install",
"requestedSpecifier":"@openclaw/discord@2026.6.11"}}
```

The policy log contained `CANDIDATE_BLOCK` and no `AMBIENT_ALLOW`, proving the missing-plugin repair used the candidate snapshot. No plugin payload was installed.

ClawSweeper reviewed exact head `fc459301988b82744c11e8484a6e1265206c2acf`, marked the proof sufficient and the patch ready for maintainer review, and requested only a current-main refresh plus routine exact-head checks.

The current head `c61a64b199c495a0ab26940bddac84887aed8caa` rebases the same patch onto `main@03cab29505254de6d9aca4ebfc81f5b28b645600`. The only conflict was the upstream config type-module rename in the test import; the current `types.js` path and all upstream Codex Supervisor coverage were preserved.

Current-head local validation:

- focused Doctor test file: `84 passed`
- targeted `oxfmt --check`: passed
- targeted `oxlint`: passed
- `pnpm tsgo:core`: passed
- `git diff --check origin/main...HEAD`: passed

The first cold run timed out only in the newly added upstream Codex Supervisor migration test at its 120-second limit after a full workspace dependency refresh. The same test then passed directly in 58.75 seconds, and the complete warm test file passed 84/84 in 60.90 seconds.

After the push, `main` advanced by two more commits to `4b33199a65af2ad65c1d948f6e3473f186504173`; neither commit touches either PR file. GitHub exact-head CI is running on `c61a64b19`.

The regression assertions verify that the same explicit `OpenClawConfig` reaches the ClawHub install, npm install, and npm update-retry calls.
