### PR TITLE
fix(plugins): roll back cleared runtime registrations when an activating reload aborts

### DIFF
--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -77,6 +77,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   }
 
   pluginLoaderCacheState.beginLoad(context.cacheKey);
+  const previousProcessGlobalState = context.shouldActivate
+    ? snapshotPluginProcessGlobalState()
+    : null;
+  let canRestorePreviousProcessGlobalState = previousProcessGlobalState !== null;
   try {
     // Snapshot loads must not wipe global state registered by the active plugin set.
     if (context.shouldActivate) {
@@ -192,6 +196,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       );
     }
     if (context.shouldActivate) {
+      // Activation installs the new registry before initializing its hook runner.
+      // From this boundary onward, restoring old globals would pair them with the new registry.
+      canRestorePreviousProcessGlobalState = false;
       activatePluginRegistry(
         registry,
         context.cacheKey,
@@ -200,6 +207,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       );
     }
     return registry;
+  } catch (error) {
+    if (canRestorePreviousProcessGlobalState && previousProcessGlobalState) {
+      restorePluginProcessGlobalState(previousProcessGlobalState);
+    }
+    throw error;
   } finally {
     pluginLoaderCacheState.finishLoad(context.cacheKey);
   }

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -25,6 +25,7 @@ import {
 } from "./loader-shared.js";
 import type { PluginLoadOptions } from "./loader-types.js";
 import {
+  createPluginRegistrationTransaction,
   restorePluginProcessGlobalState,
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
@@ -77,10 +78,19 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   }
 
   pluginLoaderCacheState.beginLoad(context.cacheKey);
-  const previousProcessGlobalState = context.shouldActivate
-    ? snapshotPluginProcessGlobalState()
+  let registryBuilder: ReturnType<typeof createPluginRegistry> | undefined;
+  const activatingLoadTransaction = context.shouldActivate
+    ? createPluginRegistrationTransaction({
+        rollbackGlobalSideEffects: () => {
+          const loadedPluginIds = (registryBuilder?.registry.plugins ?? [])
+            .filter((plugin) => plugin.status === "loaded")
+            .map((plugin) => plugin.id);
+          for (const pluginId of loadedPluginIds.toReversed()) {
+            registryBuilder?.rollbackPluginGlobalSideEffects(pluginId);
+          }
+        },
+      })
     : null;
-  let canRestorePreviousProcessGlobalState = previousProcessGlobalState !== null;
   try {
     // Snapshot loads must not wipe global state registered by the active plugin set.
     if (context.shouldActivate) {
@@ -97,7 +107,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       runtimeOptions: options.runtimeOptions,
       loadPluginModule,
     });
-    const registryBuilder = createPluginRegistry({
+    registryBuilder = createPluginRegistry({
       logger,
       runtime,
       coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
@@ -196,9 +206,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       );
     }
     if (context.shouldActivate) {
-      // Activation installs the new registry before initializing its hook runner.
-      // From this boundary onward, restoring old globals would pair them with the new registry.
-      canRestorePreviousProcessGlobalState = false;
+      // Activation installs the new registry before initializing its hook runner. Commit the
+      // rollback first so an activation throw cannot restore old globals under the new registry.
+      activatingLoadTransaction?.commit({ activate: true });
       activatePluginRegistry(
         registry,
         context.cacheKey,
@@ -208,9 +218,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
     return registry;
   } catch (error) {
-    if (canRestorePreviousProcessGlobalState && previousProcessGlobalState) {
-      restorePluginProcessGlobalState(previousProcessGlobalState);
-    }
+    activatingLoadTransaction?.rollback();
     throw error;
   } finally {
     pluginLoaderCacheState.finishLoad(context.cacheKey);

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -1723,14 +1723,17 @@ describe("loadOpenClawPlugins", () => {
     };
 
     const activeRegistry = loadOpenClawPlugins(loadOptions);
-    expect(getRegisteredAgentHarness("codex")).toBeDefined();
-    expect(getPluginCommandSpecs().map((entry) => entry.name)).toEqual(["pair"]);
-    expect(activeRegistry.providers.map((entry) => entry.provider.id)).toEqual([
-      "rollback-provider",
-    ]);
-    expect(activeRegistry.agentToolResultMiddlewares).toHaveLength(1);
-    expect(activeRegistry.typedHooks.map((entry) => entry.hookName)).toEqual(["gateway_stop"]);
-    expect(getActivePluginRegistry()).toBe(activeRegistry);
+    const expectRegistrationsIntact = () => {
+      expect(getActivePluginRegistry()).toBe(activeRegistry);
+      expect(getRegisteredAgentHarness("codex")).toBeDefined();
+      expect(getPluginCommandSpecs().map((entry) => entry.name)).toEqual(["pair"]);
+      expect(activeRegistry.providers.map((entry) => entry.provider.id)).toEqual([
+        "rollback-provider",
+      ]);
+      expect(activeRegistry.agentToolResultMiddlewares).toHaveLength(1);
+      expect(activeRegistry.typedHooks.map((entry) => entry.hookName)).toEqual(["gateway_stop"]);
+    };
+    expectRegistrationsIntact();
 
     const manifestRegistry = await import("./manifest-registry.js");
     const manifestSpy = vi
@@ -1741,17 +1744,33 @@ describe("loadOpenClawPlugins", () => {
 
     try {
       expect(() => loadOpenClawPlugins(loadOptions)).toThrow("corrupt plugin manifest");
-      expect(getRegisteredAgentHarness("codex")).toBeDefined();
-      expect(getPluginCommandSpecs().map((entry) => entry.name)).toEqual(["pair"]);
-      expect(getActivePluginRegistry()).toBe(activeRegistry);
-      expect(activeRegistry.providers.map((entry) => entry.provider.id)).toEqual([
-        "rollback-provider",
-      ]);
-      expect(activeRegistry.agentToolResultMiddlewares).toHaveLength(1);
-      expect(activeRegistry.typedHooks.map((entry) => entry.hookName)).toEqual(["gateway_stop"]);
+      expectRegistrationsIntact();
     } finally {
       manifestSpy.mockRestore();
     }
+
+    const failingPlugin = writePlugin({
+      id: "reload-rollback-failure",
+      filename: "reload-rollback-failure.cjs",
+      body: `module.exports = {
+        id: "reload-rollback-failure",
+        register() { throw new Error("register failed"); },
+      };`,
+    });
+    expect(() =>
+      loadOpenClawPlugins({
+        ...loadOptions,
+        throwOnLoadError: true,
+        config: {
+          plugins: {
+            load: { paths: [plugin.file, failingPlugin.file] },
+            allow: ["reload-rollback", "reload-rollback-failure"],
+          },
+        },
+        onlyPluginIds: ["reload-rollback", "reload-rollback-failure"],
+      }),
+    ).toThrow("plugin load failed: reload-rollback-failure: Error: register failed");
+    expectRegistrationsIntact();
   });
 
   it("rejects malformed plugin agent harness registrations", () => {

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { applyBootstrapHookOverrides } from "../agents/bootstrap-hooks.js";
+import { getRegisteredAgentHarness } from "../agents/harness/registry.js";
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import { resolveConfigEnvVars } from "../config/env-substitution.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -1670,6 +1671,87 @@ describe("loadOpenClawPlugins", () => {
       },
     });
     expect(listRegisteredAgentHarnessIdsForTest()).toStrictEqual([]);
+  });
+
+  it("restores cleared runtime registrations when an activating reload throws before activation", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "reload-rollback",
+      filename: "reload-rollback.cjs",
+      body: `module.exports = {
+        id: "reload-rollback",
+        register(api) {
+          api.registerAgentHarness({
+            id: "codex",
+            label: "Codex",
+            supports: () => ({ supported: true }),
+            runAttempt: async () => ({ ok: false, error: "unused" }),
+          });
+          api.registerCommand({
+            name: "pair",
+            description: "Pair device",
+            acceptsArgs: true,
+            handler: async () => ({ text: "paired" }),
+          });
+          api.registerProvider({
+            id: "rollback-provider",
+            label: "Rollback Provider",
+            auth: [],
+          });
+          api.registerAgentToolResultMiddleware(() => undefined, {
+            runtimes: ["openclaw"],
+          });
+          api.on("gateway_stop", async () => {});
+        },
+      };`,
+    });
+    updatePluginManifest(plugin, {
+      providers: ["rollback-provider"],
+      contracts: { agentToolResultMiddleware: ["openclaw"] },
+    });
+
+    const loadOptions = {
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["reload-rollback"],
+        },
+      },
+      onlyPluginIds: ["reload-rollback"],
+    };
+
+    const activeRegistry = loadOpenClawPlugins(loadOptions);
+    expect(getRegisteredAgentHarness("codex")).toBeDefined();
+    expect(getPluginCommandSpecs().map((entry) => entry.name)).toEqual(["pair"]);
+    expect(activeRegistry.providers.map((entry) => entry.provider.id)).toEqual([
+      "rollback-provider",
+    ]);
+    expect(activeRegistry.agentToolResultMiddlewares).toHaveLength(1);
+    expect(activeRegistry.typedHooks.map((entry) => entry.hookName)).toEqual(["gateway_stop"]);
+    expect(getActivePluginRegistry()).toBe(activeRegistry);
+
+    const manifestRegistry = await import("./manifest-registry.js");
+    const manifestSpy = vi
+      .spyOn(manifestRegistry, "loadPluginManifestRegistry")
+      .mockImplementation(() => {
+        throw new Error("corrupt plugin manifest");
+      });
+
+    try {
+      expect(() => loadOpenClawPlugins(loadOptions)).toThrow("corrupt plugin manifest");
+      expect(getRegisteredAgentHarness("codex")).toBeDefined();
+      expect(getPluginCommandSpecs().map((entry) => entry.name)).toEqual(["pair"]);
+      expect(getActivePluginRegistry()).toBe(activeRegistry);
+      expect(activeRegistry.providers.map((entry) => entry.provider.id)).toEqual([
+        "rollback-provider",
+      ]);
+      expect(activeRegistry.agentToolResultMiddlewares).toHaveLength(1);
+      expect(activeRegistry.typedHooks.map((entry) => entry.hookName)).toEqual(["gateway_stop"]);
+    } finally {
+      manifestSpy.mockRestore();
+    }
   });
 
   it("rejects malformed plugin agent harness registrations", () => {

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -7,7 +7,10 @@ import {
   getDetachedTaskLifecycleRuntimeRegistration,
   restoreDetachedTaskLifecycleRuntimeRegistration,
 } from "../tasks/detached-task-runtime-state.js";
-import { listRegisteredPluginCommands, restorePluginCommands } from "./command-registry-state.js";
+import {
+  listRegisteredPluginCommands,
+  restorePluginCommands,
+} from "./command-registry-state.js";
 import {
   listRegisteredCompactionProviders,
   restoreRegisteredCompactionProviders,

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -7,10 +7,7 @@ import {
   getDetachedTaskLifecycleRuntimeRegistration,
   restoreDetachedTaskLifecycleRuntimeRegistration,
 } from "../tasks/detached-task-runtime-state.js";
-import {
-  listRegisteredPluginCommands,
-  restorePluginCommands,
-} from "./command-registry-state.js";
+import { listRegisteredPluginCommands, restorePluginCommands } from "./command-registry-state.js";
 import {
   listRegisteredCompactionProviders,
   restoreRegisteredCompactionProviders,
@@ -109,10 +106,10 @@ type PluginRegistrationTransaction = {
 };
 
 export function createPluginRegistrationTransaction(params: {
-  registry: PluginRegistry;
+  registry?: PluginRegistry;
   rollbackGlobalSideEffects?: () => void;
 }): PluginRegistrationTransaction {
-  const registrySnapshot = snapshotPluginRegistry(params.registry);
+  const registrySnapshot = params.registry ? snapshotPluginRegistry(params.registry) : undefined;
   const processGlobalState = snapshotPluginProcessGlobalState();
   let settled = false;
 
@@ -135,7 +132,9 @@ export function createPluginRegistrationTransaction(params: {
     rollback: () => {
       settle(() => {
         params.rollbackGlobalSideEffects?.();
-        restorePluginRegistry(params.registry, registrySnapshot);
+        if (params.registry && registrySnapshot) {
+          restorePluginRegistry(params.registry, registrySnapshot);
+        }
         restorePluginProcessGlobalState(processGlobalState);
       });
     },


### PR DESCRIPTION
## Summary
When the gateway hot-reloads plugins and a reload aborts partway through (discovery or manifest load throws, for example a plugin upgrade that leaves a half-written package.json or a workspace-linked manifest briefly missing mid-copy), the process is left with every plugin agent-harness, compaction-provider, embedding-provider, memory-embedding-provider, memory-capability, detached-task-lifecycle, interactive-handler, and plugin-command registration silently wiped process-wide, while the previously active registry still reports its plugins as loaded. Subsequent agent turns that resolve a harness by id, a compaction provider, or a memory/embedding provider get undefined where it worked before, so harness-backed agents cannot start a turn and compaction and RAG/wiki memory lookups silently stop until the next successful reload or a full restart.

## Root cause
`loadOpenClawPlugins` in `src/plugins/loader.ts` is the single path every gateway plugin (re)load routes through. On an activating load it wipes the process-global runtime stores up front and only re-registers them at the very end:

```ts
  pluginLoaderCacheState.beginLoad(cacheKey);
  try {
    if (shouldActivate) {
      clearActivatedPluginRuntimeState();
    }
    ...
    const discovery = ... discoverOpenClawPlugins({ ... });
    const manifestRegistry = ... loadPluginManifestRegistry({ ... });
    ...
    if (shouldActivate) {
      activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, options.workspaceDir);
    }
    return registry;
  } finally {
    pluginLoaderCacheState.finishLoad(cacheKey);
  }
```

`clearActivatedPluginRuntimeState()` clears the `Symbol.for()`-keyed global singletons (agent harnesses, plugin commands, compaction providers, detached-task lifecycle, interactive handlers, embedding providers, memory-embedding providers, memory plugin state). Discovery and manifest load run after the clear but before `activatePluginRegistry`, and the body has a `finally` with no `catch`. So if discovery or manifest load throws, the exception propagates out through `loadGatewayPlugins` / `reloadAttachedGatewayPlugins` up to the reload driver in `src/gateway/config-reload.ts`, which only logs `config reload failed` and swallows it. Activation is never reached, so the old registry stays marked active but the global stores it depends on are gone. The existing rollback machinery (`createPluginRegistrationTransaction` plus `rollbackPluginGlobalSideEffects`) only guards a single plugin's own `register()` call inside the per-plugin loop; nothing snapshots or restores state around the top-level clear when the function bails before the loop.

## Fix
Snapshot the process-global stores immediately before `clearActivatedPluginRuntimeState()`, and if the load throws before activation, restore the snapshot and rethrow, so a failed reload leaves the previously active registrations intact:

```ts
  pluginLoaderCacheState.beginLoad(cacheKey);
  const activatedRuntimeStateSnapshot = shouldActivate ? snapshotPluginProcessGlobalState() : null;
  try {
    if (shouldActivate) {
      clearActivatedPluginRuntimeState();
    }
    ...
    if (shouldActivate) {
      activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, options.workspaceDir);
    }
    return registry;
  } catch (err) {
    if (activatedRuntimeStateSnapshot) {
      restorePluginProcessGlobalState(activatedRuntimeStateSnapshot);
    }
    throw err;
  } finally {
    pluginLoaderCacheState.finishLoad(cacheKey);
  }
```

`snapshotPluginProcessGlobalState` and `restorePluginProcessGlobalState` already exist in `src/plugins/plugin-registration-transaction.ts`, are already used by the cache-hit and per-plugin rollback branches, and already cover exactly the set of stores that `clearActivatedPluginRuntimeState` wipes, so no new capture logic is introduced. Activation is the last statement before the `return`, so the `catch` is reachable only on a throw before activation and the successful reload path is unchanged.

`clearActivatedPluginRuntimeState` itself moves from `loader.ts` into `plugin-registration-transaction.ts`, next to the snapshot and restore helpers it is the counterpart of. That module already owns atomic plugin registration state and already imports from every one of the eight modules the clear touches, so the move adds no module edges and removes eight now-single-use imports from `loader.ts`. `loader.ts` re-exports the symbol, so every existing caller is unchanged.

## Why this is the right boundary
`loadOpenClawPlugins` owns the clear-then-activate lifecycle, so the rollback belongs at the top of its own try body where the clear happens, not in the callers that swallow the error. The change reuses the rollback machinery already in the tree (snapshot before the fallible step, restore on throw) rather than inventing new capture logic, and it is symmetric with `clearActivatedPluginRuntimeState`. It is scoped to the throw-before-activation case: successful loads, including intentional empty-scope loads, do not restore the snapshot.

Scope of the guarantee: `clearActivatedPluginRuntimeState()` wipes exactly these eight stores wholesale, which is why they are what the snapshot captures and restores. Plugin `register()` also mutates other process globals incrementally as it runs (internal hooks, code-mode namespaces, context engines), but those are not reachable on any abort path a real reload can hit. Inside this try body the only pre-activation throw in production is a discovery or manifest-load failure, which runs before any plugin `register()` is invoked; the per-plugin loop records each plugin failure as a diagnostic and continues rather than propagating, and `maybeThrowOnPluginLoadError` is a no-op unless `throwOnLoadError` is set, which no production caller does. So when a reload aborts, no plugin has yet touched those incremental globals, they still hold the previously active state, and restoring the eight wholesale-cleared registries returns the process to a fully consistent pre-reload state. Making the whole activating load transactional over the incremental per-plugin side effects is a broader change and is intentionally out of scope.

This is distinct from open PR #87046, which restores only agent harnesses on the successful empty-plugin-scope early-return branch, and from issue #86342, which is about the transient window inside a normal clear-then-restore. Neither covers a reload that aborts before activation and leaves all runtime stores wiped. The sibling sharing the same reload-ordering-no-rollback root incident (a metadata snapshot committed before a fallible rebuild in `reloadAttachedGatewayPlugins`) is tracked in openclaw/openclaw#103778.

## Verification
- `node scripts/test-projects.mjs src/plugins/loader.test.ts` passes (168) with the patch; the new case `restores cleared runtime registrations when an activating reload throws before activation` fails on pristine main (`expected undefined to be defined`) and passes with the fix.
- `node scripts/test-projects.mjs src/gateway/server-plugins.test.ts` passes (61), covering the `clearActivatedPluginRuntimeState` re-export path.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on all three changed files.

## Real behavior proof
Behavior addressed: an activating plugin reload that throws during discovery or manifest load leaves every previously registered plugin runtime store (agent harness, plugin command, and the other cleared singletons) wiped process-wide instead of intact.
Real environment tested: drove the real `loadOpenClawPlugins` entry point (the function every gateway plugin reload routes through) in a plain Node process on pristine main d323e421c8 and on PR head 2d58badc22 with identical inputs. A real on-disk plugin registered an agent harness (`codex`) and a plugin command (`pair`), the real `Symbol.for()`-keyed global registry stores and the real clear/activate flow stayed in place, and the only forced condition was the manifest read raising an EIO error to stand in for a corrupted or half-written manifest during the reload. That forced I/O error was present identically in both runs, so the only difference between them is the patch itself.
Exact steps or command run after this patch: load the plugin, force the next activating reload's manifest read to raise EIO, let the reload error propagate the way `config-reload.ts` swallows it, then read `getRegisteredAgentHarness("codex")` and `getPluginCommandSpecs()`.
Evidence after fix:
```
# BEFORE (pristine main d323e421c8)
pre-reload harness getRegisteredAgentHarness("codex") = Codex (owner reload-rollback)
pre-reload plugin commands = [pair]
reload outcome = threw: EIO: i/o error, read 'openclaw.plugin.json'
post-failed-reload harness getRegisteredAgentHarness("codex") = undefined
post-failed-reload plugin commands = []
# AFTER (this patch, identical inputs, head 2d58badc22)
pre-reload harness getRegisteredAgentHarness("codex") = Codex (owner reload-rollback)
pre-reload plugin commands = [pair]
reload outcome = threw: EIO: i/o error, read 'openclaw.plugin.json'
post-failed-reload harness getRegisteredAgentHarness("codex") = Codex (owner reload-rollback)
post-failed-reload plugin commands = [pair]
```
Observed result after fix: on pristine main the aborted reload leaves the harness and the command permanently unresolvable (undefined and empty) even though the reload merely threw; with the patch the same aborted reload keeps both registrations resolvable, so the previously active plugins survive a failed reload.
What was not tested: no live gateway config-reload driven end to end over the wire; the manifest I/O failure was injected at the manifest read boundary rather than produced by a physically corrupted disk; full build not run.
