### PR TITLE
fix(memory-host): keep redacted token hints UTF-16 safe

### DIFF
--- a/packages/memory-host-sdk/src/host/batch-error-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-error-utils.test.ts
@@ -1,6 +1,6 @@
 // Memory Host SDK tests cover batch error utils behavior.
 import { describe, expect, it } from "vitest";
-import { extractBatchErrorMessage, formatUnavailableBatchError } from "./batch-error-utils.js";
+import { extractBatchErrorMessage, formatUnavailableBatchError } from "../engine-embeddings.js";
 
 describe("extractBatchErrorMessage", () => {
   it("returns the first top-level error message", () => {
@@ -29,5 +29,37 @@ describe("formatUnavailableBatchError", () => {
   it("formats errors and non-error values", () => {
     expect(formatUnavailableBatchError(new Error("boom"))).toBe("error file unavailable: boom");
     expect(formatUnavailableBatchError("unreachable")).toBe("error file unavailable: unreachable");
+  });
+
+  it.each([
+    {
+      boundary: "leading",
+      secret: `abcde😀${"x".repeat(9)}wxyz`,
+      expected: "abcde...wxyz",
+    },
+    {
+      boundary: "trailing",
+      secret: `abcdef${"x".repeat(9)}😀abc`,
+      expected: "abcdef...abc",
+    },
+    {
+      boundary: "intact pairs",
+      secret: `abcd😀${"x".repeat(9)}😀ab`,
+      expected: "abcd😀...😀ab",
+    },
+    {
+      boundary: "ASCII",
+      secret: "abcdef1234567890ghij",
+      expected: "abcdef...ghij",
+    },
+  ])("keeps exported $boundary token hints UTF-16 safe", ({ secret, expected }) => {
+    const serialized = JSON.stringify({
+      error: formatUnavailableBatchError(new Error(`API_TOKEN=${secret}`)),
+    });
+    const parsed = JSON.parse(serialized) as { error: string };
+
+    expect(parsed.error).toBe(`error file unavailable: API_TOKEN=${expected}`);
+    expect(parsed.error).not.toMatch(/[\uD800-\uDFFF]/u);
+    expect(serialized).not.toContain(secret);
   });
 });

--- a/packages/memory-host-sdk/src/host/error-utils.ts
+++ b/packages/memory-host-sdk/src/host/error-utils.ts
@@ -1,4 +1,6 @@
 // Memory Host SDK helper module supports error utils behavior.
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 const SECRET_PATTERNS: RegExp[] = [
   /\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g,
   /[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature)=([^&\s"'<>]+)/gi,
@@ -26,7 +28,7 @@ function maskToken(token: string): string {
   if (token.length < 18) {
     return "***";
   }
-  return `${token.slice(0, 6)}...${token.slice(-4)}`;
+  return `${sliceUtf16Safe(token, 0, 6)}...${sliceUtf16Safe(token, -4)}`;
 }
 
 function redactPemBlock(block: string): string {


### PR DESCRIPTION
## What Problem This Solves

[#103341](https://github.com/openclaw/openclaw/pull/103341) fixed malformed Unicode token hints in the core logger, but the independently localized memory-host error formatter retained the same raw UTF-16 slicing pattern. A secret with an emoji crossing either retained edge could therefore still produce an unpaired surrogate in memory-host errors exposed through embedding batch helpers, SQLite/QMD diagnostics, or JSON result surfaces.

## Why This Change Was Made

This completes the bug-class fix at the remaining owner. Both retained memory-host hint edges now use the existing `sliceUtf16Safe` helper. The memory-host format remains deliberately unchanged: six/four UTF-16-unit budgets, `...` as its separator, full masking for short values, and no additional disclosed characters.

The regression exercises the exported memory-host engine entrypoint rather than only the private formatter. It covers both split edges, intact emoji pairs, ASCII parity, a JSON serialize/parse round trip, and absence of the original secret.

## User Impact

Memory indexing and embedding error paths no longer introduce malformed Unicode while redacting long secrets. Existing ASCII hints and masking thresholds are unchanged.

## Evidence

- Current-main source proof: `packages/memory-host-sdk/src/host/error-utils.ts` still used raw `slice(0, 6)` and `slice(-4)` after #103341 landed; either boundary can return a lone surrogate.
- Duplicate audit: no open PR touches the memory-host formatter, and exact searches found no competing fix.
- Fresh exact-head autoreview: clean, patch-correct confidence 0.91.
- `git diff --check`: passed.
- `oxfmt --check` on both touched files: passed.
- One-shot Testbox [run 29107562708](https://github.com/openclaw/openclaw/actions/runs/29107562708) verified exact head `c436e835f1b32af9aa8cabc0183f8a2ec085e2db` and tree `6dd00937f64dda6068efcaa524e5dc219342f440` before and after proof. The memory-host negative control failed only the leading/trailing split cases while intact emoji and ASCII cases passed; the pre-#103341 logger failed its matching regression.
- Fixed focused suites passed: memory-host 8/8 and logging 117/117.
- A live `node --import tsx` probe exercised the exported memory-host entrypoint and production logger through a JSON round trip; both strings were well-formed, the raw token was absent, and each surface retained its existing `...` / `…` separator.
- `check:changed` passed for `core` and `coreTests`, including production/test typechecks, lint with zero findings, import-cycle analysis, and repository guards.
- Hosted CI is running on the same head and will be confirmed before merge.

Follow-up credit is preserved from #103341: co-authored with @zhangguiping-xydt.
