### PR TITLE
fix(docker): restore selected-plugin builds on Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,13 @@ ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 # Copy package.json files for workspace packages used by the install layer.
 # Manifest-only bundled plugins remain valid selections but need no workspace metadata.
-RUN --mount=type=bind,source=packages,target=/tmp/packages,readonly \
-    --mount=type=bind,source=${OPENCLAW_BUNDLED_PLUGIN_DIR},target=/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR},readonly \
-    --mount=type=bind,source=scripts/lib/docker-plugin-selection.mjs,target=/tmp/docker-plugin-selection.mjs,readonly \
-    mkdir -p /out/packages "/out/${OPENCLAW_BUNDLED_PLUGIN_DIR}" && \
+# Use COPY because build-context bind mounts are unreliable across supported
+# Podman/Buildah hosts. Full trees stay in this disposable stage; later stages
+# receive only extracted manifests.
+COPY scripts/lib/docker-plugin-selection.mjs /tmp/docker-plugin-selection.mjs
+COPY packages /tmp/packages
+COPY ${OPENCLAW_BUNDLED_PLUGIN_DIR} /tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}
+RUN mkdir -p /out/packages "/out/${OPENCLAW_BUNDLED_PLUGIN_DIR}" && \
     for manifest in /tmp/packages/*/package.json; do \
       [ -f "$manifest" ] || continue; \
       pkg_dir="${manifest%/package.json}"; \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -130,6 +130,35 @@ describe("Dockerfile", () => {
     );
   });
 
+  it("uses portable copies for workspace dependency inputs", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    const workspaceDepsStart = dockerfile.indexOf(
+      "FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS workspace-deps",
+    );
+    const workspaceDepsEnd = dockerfile.indexOf("FROM ${OPENCLAW_BUN_IMAGE} AS bun-binary");
+
+    expect(workspaceDepsStart).toBeGreaterThan(-1);
+    expect(workspaceDepsEnd).toBeGreaterThan(workspaceDepsStart);
+
+    const workspaceDeps = dockerfile.slice(workspaceDepsStart, workspaceDepsEnd);
+    const extractionIndex = workspaceDeps.indexOf(
+      'RUN mkdir -p /out/packages "/out/${OPENCLAW_BUNDLED_PLUGIN_DIR}"',
+    );
+    const inputCopies = [
+      "COPY scripts/lib/docker-plugin-selection.mjs /tmp/docker-plugin-selection.mjs",
+      "COPY packages /tmp/packages",
+      "COPY ${OPENCLAW_BUNDLED_PLUGIN_DIR} /tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}",
+    ];
+
+    expect(extractionIndex).toBeGreaterThan(-1);
+    for (const copy of inputCopies) {
+      const copyIndex = workspaceDeps.indexOf(copy);
+      expect(copyIndex, copy).toBeGreaterThan(-1);
+      expect(copyIndex, copy).toBeLessThan(extractionIndex);
+    }
+    expect(workspaceDeps).not.toContain("--mount=type=bind");
+  });
+
   it("copies install workspace manifests before pnpm install", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
@@ -151,9 +180,6 @@ describe("Dockerfile", () => {
     expect(packageManifestIndex).toBeGreaterThan(-1);
     expect(extensionManifestIndex).toBeGreaterThan(-1);
     expect(dockerfile).toContain("for manifest in /tmp/packages/*/package.json");
-    expect(dockerfile).toContain(
-      "--mount=type=bind,source=scripts/lib/docker-plugin-selection.mjs,target=/tmp/docker-plugin-selection.mjs,readonly",
-    );
     expect(dockerfile).toContain(
       'node /tmp/docker-plugin-selection.mjs "/tmp/${OPENCLAW_BUNDLED_PLUGIN_DIR}" "$OPENCLAW_EXTENSIONS"',
     );


### PR DESCRIPTION
Closes #103741

## What Problem This Solves

Fixes an issue where operators building source images with selected plugins could hit `MODULE_NOT_FOUND` or `EACCES` in the early `workspace-deps` stage on Podman/Buildah hosts.

Reported and verified on the affected amd64 Podman host by @sallyom.

## Why This Change Was Made

The stage now brings its selector, workspace packages, and bundled plugin sources in through portable `COPY` instructions. Builder-owned cache mounts elsewhere remain unchanged, and only extracted manifests plus the validated plugin selection cross into later stages, so the final runtime image contract stays the same.

This keeps one Dockerfile path for Docker BuildKit and Podman instead of adding a Buildah-only bind relabel option.

## User Impact

Podman users can build selected-plugin source images without build-context bind sources disappearing or becoming unreadable. Unknown, invalid, and ambiguous plugin selections still fail closed.

## Evidence

- Sally's issue repro: the same `COPY` shape completed `workspace-deps` on the affected amd64 host.
- Blacksmith Testbox through Crabbox, x86_64, `tbx_01kx6cj8s7qva0bbgkxnbm4ana` ([Actions run 29106270855](https://github.com/openclaw/openclaw/actions/runs/29106270855)):
  - `corepack pnpm test src/dockerfile.test.ts test/scripts/docker-plugin-selection.test.ts` — 32 tests passed, including the new stage-scoped no-bind regression.
  - Docker 28 BuildKit and rootless Podman 4.9.3 / Buildah 1.33.7 both built `--target workspace-deps --platform linux/amd64` with `OPENCLAW_EXTENSIONS=vault,codex`; Podman rejected `missing-plugin` with the expected fail-closed error.
  - `scripts/e2e/docker-selected-plugins.sh` — unknown selection, dependency-only selections, full image build, and x64 runtime inspection passed.
  - `pnpm check:changed` remote child — fail-safe all lanes passed, including project typechecks, core/extensions/scripts lint, guards, and import-cycle checks.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted or actionable findings.

AI-assisted: yes (Codex). The implementation and proof were reviewed before publication.
