### PR TITLE
fix(anthropic): delegate adaptive Claude CLI effort

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -127,7 +127,7 @@ The bundled `claude-cli` backend prefers Claude Code's native skill resolver. Wh
 
 Claude CLI has its own noninteractive permission mode; OpenClaw maps that to the existing exec policy instead of adding Claude-specific config. For OpenClaw-managed Claude live sessions, the effective exec policy is authoritative: YOLO (`tools.exec.security: "full"` and `tools.exec.ask: "off"`) launches Claude with `--permission-mode bypassPermissions`, while a restrictive policy launches it with `--permission-mode default`. Per-agent `agents.list[].tools.exec` settings override the global `tools.exec` for that agent. Raw backend args may still include `--permission-mode`, but live Claude launches normalize that flag to match the effective policy.
 
-The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `adaptive`/`medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
+The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. `adaptive` removes configured `--effort` flags and supplies no replacement, so Claude Code resolves effective effort from its own environment, settings, and model defaults. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
 
 Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -59,7 +59,7 @@ title: "Thinking levels"
 ## Application by agent
 
 - **Embedded OpenClaw**: the resolved level is passed to the in-process OpenClaw agent runtime.
-- **Claude CLI backend**: non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; see [CLI backends](/gateway/cli-backends).
+- **Claude CLI backend**: concrete non-off levels are passed to Claude Code as `--effort` when using `claude-cli`; `adaptive` removes configured effort flags and delegates effective effort to Claude Code's environment, settings, and model defaults. See [CLI backends](/gateway/cli-backends).
 
 ## Fast mode (/fast)
 

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -101,50 +101,65 @@ describe("Claude CLI model aliases", () => {
 });
 
 describe("resolveClaudeCliExecutionArgs", () => {
-  it("omits effort args when thinking is off", () => {
+  it.each(["off", undefined] as const)(
+    "preserves configured effort args when thinking is %s",
+    (thinkingLevel) => {
+      const baseArgs = ["-p", "--effort", "xhigh", "--effort=low"];
+
+      expect(
+        resolveClaudeCliExecutionArgs({
+          workspaceDir: "/tmp",
+          provider: "claude-cli",
+          modelId: "claude-sonnet-4-6",
+          thinkingLevel,
+          useResume: false,
+          baseArgs,
+        }),
+      ).toEqual(baseArgs);
+    },
+  );
+
+  it.each([
+    ["minimal", "low"],
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "high"],
+    ["xhigh", "xhigh"],
+    ["max", "max"],
+  ] as const)("maps %s thinking to --effort %s", (thinkingLevel, effort) => {
     expect(
       resolveClaudeCliExecutionArgs({
         workspaceDir: "/tmp",
         provider: "claude-cli",
-        modelId: "claude-sonnet-4-6",
-        thinkingLevel: "off",
+        modelId: "claude-opus-4-7",
+        thinkingLevel,
         useResume: false,
-        baseArgs: ["-p", "--output-format", "stream-json"],
+        baseArgs: ["-p"],
       }),
-    ).toEqual(["-p", "--output-format", "stream-json"]);
+    ).toEqual(["-p", "--effort", effort]);
   });
 
-  it("maps OpenClaw thinking levels to Claude effort args", () => {
+  it("strips configured effort args when thinking is adaptive", () => {
     expect(
       resolveClaudeCliExecutionArgs({
         workspaceDir: "/tmp",
         provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "minimal",
-        useResume: false,
-        baseArgs: ["-p"],
-      }),
-    ).toEqual(["-p", "--effort", "low"]);
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-7",
+        modelId: "claude-opus-4-8",
         thinkingLevel: "adaptive",
-        useResume: false,
-        baseArgs: ["-p"],
-      }),
-    ).toEqual(["-p", "--effort", "medium"]);
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-7",
-        thinkingLevel: "xhigh",
         useResume: true,
-        baseArgs: ["-p", "--resume", "{sessionId}"],
+        baseArgs: [
+          "-p",
+          "--effort",
+          "xhigh",
+          "--output-format",
+          "stream-json",
+          "--effort=low",
+          "--verbose",
+          "--resume",
+          "{sessionId}",
+        ],
       }),
-    ).toEqual(["-p", "--resume", "{sessionId}", "--effort", "xhigh"]);
+    ).toEqual(["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"]);
   });
 
   it("replaces static effort args when a session thinking level is active", () => {

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -89,6 +89,10 @@ const CLAUDE_NO_TOOLS_VALUE = "";
 const CLAUDE_DENY_MCP_TOOLS_VALUE = "mcp__*";
 
 type ClaudeCliEffort = "low" | "medium" | "high" | "xhigh" | "max";
+type ClaudeCliEffortArgAction =
+  | { mode: "preserve" }
+  | { mode: "omit" }
+  | { mode: "set"; effort: ClaudeCliEffort };
 
 /** Explicit thinking opt-out for Claude CLI routes unsupported by Claude Code. */
 export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
@@ -205,25 +209,25 @@ export function normalizeClaudeSettingSourcesArgs(args?: string[]): string[] | u
   return normalized;
 }
 
-/** Map OpenClaw thinking levels to Claude CLI effort flags for a model id. */
-function mapClaudeCliThinkingLevelToEffort(
-  thinkingLevel?: string | null,
-): ClaudeCliEffort | undefined {
+/** Resolve whether a run preserves, removes, or sets a Claude CLI effort override. */
+function resolveClaudeCliEffortArgAction(thinkingLevel?: string | null): ClaudeCliEffortArgAction {
   switch (normalizeOptionalLowercaseString(thinkingLevel)) {
     case "minimal":
     case "low":
-      return "low";
+      return { mode: "set", effort: "low" };
     case "adaptive":
+      // Adaptive runs delegate effort to Claude Code, so no static override may survive.
+      return { mode: "omit" };
     case "medium":
-      return "medium";
+      return { mode: "set", effort: "medium" };
     case "high":
-      return "high";
+      return { mode: "set", effort: "high" };
     case "xhigh":
-      return "xhigh";
+      return { mode: "set", effort: "xhigh" };
     case "max":
-      return "max";
+      return { mode: "set", effort: "max" };
     default:
-      return undefined;
+      return { mode: "preserve" };
   }
 }
 
@@ -333,11 +337,15 @@ export function resolveClaudeCliExecutionArgs(
   if (context.executionMode === "side-question") {
     return resolveClaudeCliSideQuestionExecutionArgs(context.baseArgs);
   }
-  const effort = mapClaudeCliThinkingLevelToEffort(context.thinkingLevel);
-  if (!effort) {
-    return [...context.baseArgs];
+  const action = resolveClaudeCliEffortArgAction(context.thinkingLevel);
+  switch (action.mode) {
+    case "preserve":
+      return [...context.baseArgs];
+    case "omit":
+      return stripClaudeEffortArgs(context.baseArgs);
+    case "set":
+      return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, action.effort];
   }
-  return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, effort];
 }
 
 /** Normalize Claude CLI backend config before registration or execution. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -345,6 +345,8 @@ export function resolveClaudeCliExecutionArgs(
       return stripClaudeEffortArgs(context.baseArgs);
     case "set":
       return [...stripClaudeEffortArgs(context.baseArgs), CLAUDE_EFFORT_ARG, action.effort];
+    default:
+      return action satisfies never;
   }
 }
 


### PR DESCRIPTION
Closes #103245

Supersedes #103296 while preserving @dankorotin's authorship in the commit trailer.

## What Problem This Solves

The `claude-cli` backend translated OpenClaw `adaptive` thinking into a fixed
`--effort medium` argument. This silently pinned every affected Claude Code
session instead of allowing Claude Code to select effort through its own
environment, user settings, and model default.

## Why This Change Was Made

Claude Code's current CLI accepts concrete `--effort` values (`low`, `medium`,
`high`, `xhigh`, and `max`) but no `adaptive` value. Its official model
configuration documentation defines omission as falling through to environment,
configured effort, and then the model default.

The provider-owned resolver now represents the decision as a closed action:

- `adaptive`: remove both split and equals-form static effort flags; append none
- concrete OpenClaw level: remove static effort flags; append the mapped value
- `off` or absent level: preserve configured backend arguments unchanged

This keeps the generic CLI runner plugin-agnostic and applies identically to
fresh and resumed argument sets before process spawn. Live Claude sessions also
fingerprint the resolved argv, so an effort change rotates the process instead
of reusing stale startup flags.

## User Impact

`thinkingDefault: "adaptive"` and `/think adaptive` no longer become a hidden
medium-effort pin on `claude-cli`. Explicit levels retain their existing mapping,
and explicit backend effort configuration remains available when OpenClaw
thinking is off or inherited.

## Evidence

- Source negative control: current `main` maps `adaptive` to `--effort medium`.
- Focused regression coverage checks split and equals-form removal, all concrete
  mappings, preservation for off/absent thinking, and resumed argv.
- Claude Code 2.1.205 installed help confirms the five accepted concrete CLI
  values; the current official package is 2.1.206.
- Official contract: https://code.claude.com/docs/en/model-config#adjust-effort-level
- `oxfmt --check` on all four files: pass.
- `oxlint` on both TypeScript files: pass.
- `git diff --check`: pass.
- Fresh Codex autoreview: no accepted/actionable findings, confidence 0.97.

Remote focused, negative-control, changed-gate, and authenticated Claude CLI
proof will be added before merge.
