### PR TITLE
fix: keep performance validation compatible with CLI-only Kova dependencies

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -289,10 +289,15 @@ jobs:
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
           const root = process.argv[2];
-          for (const dependency of ["mock-ai-provider", "zod"]) {
-            require.resolve(dependency, { paths: [root] });
-          }
+          require.resolve("mock-ai-provider/package.json", { paths: [root] });
+          require.resolve("zod", { paths: [root] });
           NODE
+          mock_provider_bin="$KOVA_SRC/node_modules/.bin/mock-ai-provider"
+          if [[ ! -x "$mock_provider_bin" ]]; then
+            echo "Kova dependency mock-ai-provider did not install its CLI executable." >&2
+            exit 1
+          fi
+          "$mock_provider_bin" --version
           cat > "$HOME/.local/bin/kova" <<EOF
           #!/usr/bin/env bash
           export KOVA_HOME="${KOVA_HOME}"

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -88,16 +88,30 @@ describe("OpenClaw performance workflow", () => {
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);
+    expect(workflow).toContain("PERFORMANCE_MODEL_ID: gpt-5.6");
+    expect(workflow).toContain("Kova live OpenAI GPT 5.6 agent turn");
+  });
+
+  it("validates Kova's CLI-only dependency contract after installation", () => {
+    const install = findStep("Install OCM and Kova");
+    const installRun = install.run ?? "";
+
     expect(installRun).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );
-    expect(installRun).toContain('for (const dependency of ["mock-ai-provider", "zod"])');
-    expect(installRun).toContain("require.resolve(dependency, { paths: [root] })");
+    expect(installRun).toContain(
+      'require.resolve("mock-ai-provider/package.json", { paths: [root] })',
+    );
+    expect(installRun).not.toContain('require.resolve("mock-ai-provider", { paths: [root] })');
+    expect(installRun).toContain('require.resolve("zod", { paths: [root] })');
+    expect(installRun).toContain(
+      'mock_provider_bin="$KOVA_SRC/node_modules/.bin/mock-ai-provider"',
+    );
+    expect(installRun).toContain('[[ ! -x "$mock_provider_bin" ]]');
+    expect(installRun).toContain('"$mock_provider_bin" --version');
     expect(
       installRun.indexOf('npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund'),
     ).toBeLessThan(installRun.indexOf('cat > "$HOME/.local/bin/kova"'));
-    expect(workflow).toContain("PERFORMANCE_MODEL_ID: gpt-5.6");
-    expect(workflow).toContain("Kova live OpenAI GPT 5.6 agent turn");
   });
 
   it("resolves each target once before benchmark and publication fan out", () => {


### PR DESCRIPTION
Closes #103806

## What Problem This Solves

Fixes an issue where all expanded release performance lanes stopped before producing evidence because the install sanity check rejected Kova's correctly installed CLI-only `mock-ai-provider` package.

## Why This Change Was Made

The workflow now validates the dependency surface Kova actually owns: resolvable package metadata plus an executable `mock-ai-provider` binary that answers `--version`. It keeps the pinned `npm ci` and bare `zod` module-resolution checks, and the workflow-contract test explicitly rejects reintroducing bare package-root resolution for the CLI-only dependency.

## User Impact

Release operators can run mock, deep-profile, and live Kova performance lanes again. Invalid or incomplete dependency installs still fail closed before the performance scenarios start.

## Evidence

- Before: exact-head [run 29106054027](https://github.com/openclaw/openclaw/actions/runs/29106054027) failed 3/3 producer lanes immediately after installing both Kova dependencies because `require.resolve("mock-ai-provider")` targeted a package root with no `main` or `exports`; publisher failures were artifact-less fallout.
- Exact pinned-Kova Testbox smoke (`24c26969e57d4d49f9d1a5071af85dd3d79daa2d`): `npm ci` installed two packages; `mock-ai-provider/package.json` and `zod` resolved; `.bin/mock-ai-provider` was executable and reported `0.1.2`.
- Focused Testbox: `test/scripts/openclaw-performance-workflow.test.ts` passed 25/25 on lease `tbx_01kx6d5mvdzhwfz36h5jxr3kq8`.
- Testbox `check:changed`: tooling lane passed in 49.4s, including repository guards and scripts lint.
- Remote `oxfmt --check` for both changed files: passed.
- `actionlint .github/workflows/openclaw-performance.yml`: passed.
- Fresh autoreview: clean; no accepted/actionable findings (0.98 confidence).
