### PR TITLE
fix(agents): single-flight guard for subagent orphan recovery scans (#103724)

### DIFF
--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -191,6 +191,53 @@ describe("subagent-orphan-recovery", () => {
     );
   });
 
+  it("does not double-resume one orphan across overlapping scans", async () => {
+    // #103724: scan B starts while scan A's resume dispatch is still in flight
+    // (abortedLastRun not yet cleared) with its own private de-dupe set — the
+    // exact shape scheduleOrphanRecovery produces from its three call sites.
+    mockSingleAbortedSession();
+    let releaseResume!: () => void;
+    vi.mocked(gateway.callGateway).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseResume = () => resolve({ runId: "test-run-id" });
+        }),
+    );
+    const activeRuns = createActiveRuns(createTestRunRecord());
+
+    const scanA = recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    // Flush microtasks until scan A parks inside its resume dispatch; the
+    // mocked async boundaries resolve on the microtask queue, no timers.
+    for (let flush = 0; flush < 20 && vi.mocked(gateway.callGateway).mock.calls.length === 0; ) {
+      await Promise.resolve();
+      flush += 1;
+    }
+    expect(gateway.callGateway).toHaveBeenCalledTimes(1);
+
+    const scanB = await recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    expect(scanB.recovered).toBe(0);
+    expect(scanB.failed).toBe(0);
+
+    releaseResume();
+    const resultA = await scanA;
+    expect(resultA.recovered).toBe(1);
+    // The one orphan produced exactly one resume dispatch across both scans.
+    expect(gateway.callGateway).toHaveBeenCalledTimes(1);
+
+    // Once the first scan finishes, later scans run normally again and skip
+    // the recovered session via its cleared abortedLastRun flag.
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: false,
+      },
+    });
+    const scanC = await recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    expect(scanC.skipped).toBe(1);
+    expect(gateway.callGateway).toHaveBeenCalledTimes(1);
+  });
+
   it("skips sessions that are not aborted", async () => {
     await expectSkippedRecovery({
       "agent:main:subagent:test-session-1": {

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -41,6 +41,14 @@ const log = createSubsystemLogger("subagent-interrupted-resume");
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 
+// Overlapping scans double-resume the same orphan: each scheduleOrphanRecovery
+// call carries a private de-dupe set and abortedLastRun only clears after a
+// resume completes, so a second scan launched while a resume is in flight sees
+// the same still-flagged entry (#103724). Mirrors the registry reaper's
+// sweepInProgress: the overlapping scan skips, and the in-flight scan's own
+// retry loop covers anything it misses.
+let recoveryScanInProgress = false;
+
 function isLegacyRestartInterruptedTimeout(
   runRecord: SubagentRunRecord,
   entry: SessionEntry | undefined,
@@ -205,6 +213,12 @@ export async function recoverOrphanedSubagentSessions(params: {
   };
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
   const configChangePattern = /openclaw\.json|openclaw gateway restart|config\.patch/i;
+
+  if (recoveryScanInProgress) {
+    log.info("orphan recovery scan already in progress; skipping overlapping scan");
+    return result;
+  }
+  recoveryScanInProgress = true;
 
   try {
     const activeRuns = params.getActiveRuns();
@@ -393,6 +407,8 @@ export async function recoverOrphanedSubagentSessions(params: {
     if (result.failed === 0) {
       result.failed = 1;
     }
+  } finally {
+    recoveryScanInProgress = false;
   }
 
   if (result.recovered > 0 || result.failed > 0) {


### PR DESCRIPTION
## Summary

Fixes #103724.

On a gateway restart with orphaned subagent sessions, two uncoordinated recovery scans could dispatch two independent resume turns for the same child session — doubling the subagent's real side effects (file edits, tool calls, external API/PR actions) and LLM cost. Three call sites fire `scheduleOrphanRecovery()` (`restoreSubagentRunsOnce`, the post-ready sidecar, reactive reschedules); each builds a **private** `resumedSessionKeys` set, and `abortedLastRun` only clears after a resume completes, so a scan that starts while another scan's resume dispatch is still in flight (up to 10s) sees the same still-flagged entry and resumes it again with a fresh idempotency key.

### Change

`src/agents/subagent-orphan-recovery.ts`: module-level `recoveryScanInProgress` single-flight guard in `recoverOrphanedSubagentSessions`, mirroring the sibling `sweepInProgress` guard the registry's periodic reaper already uses (`subagent-registry.ts`). An overlapping scan logs and returns an empty result; the in-flight scan's own retry loop covers anything it misses, and the guard releases in `finally` so a throwing scan never wedges recovery. Back-to-back (non-overlapping) scans still dedupe via the store's cleared `abortedLastRun` flag, unchanged.

This is the exact repair the issue's proof section validates ("Re-run after adding a module-level in-progress guard (mirroring sweepInProgress)").

## Verification

- New regression `does not double-resume one orphan across overlapping scans` — written first and confirmed failing on main (two `callGateway` resume dispatches for one `childSessionKey`, matching the issue's observed output). It parks scan A's resume dispatch at the gateway RPC boundary, runs scan B with its own private de-dupe set (the exact shape `scheduleOrphanRecovery` produces), and asserts exactly one dispatch across both scans, plus that a later scan runs normally and skips via the cleared flag.
- `pnpm test src/agents/subagent-orphan-recovery.test.ts` — 20 tests passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt, oxlint — clean.

## Real behavior proof

Behavior addressed: two concurrent orphan-recovery scans dispatch two resume turns for one orphaned child session.
Real environment tested: the real `recoverOrphanedSubagentSessions` driven end to end through the module's existing test harness; only the gateway RPC boundary (`callGateway`) is stubbed and parked mid-flight, exactly like the issue's own repro.
Exact steps or command run after this patch: `pnpm test src/agents/subagent-orphan-recovery.test.ts`
Evidence after fix: without the guard the new test fails with 2 resume dispatches for `agent:main:subagent:test-session-1`; with the guard, scan B returns `{recovered: 0, failed: 0}` while scan A completes with `{recovered: 1}` and total dispatches stay at 1.
Observed result after fix: 20/20 tests pass; one resume per orphaned child across overlapping scans.
What was not tested: a live gateway restart with the two real startup call sites racing under wall-clock timing; the race is driven directly through the recovery function at the same boundary the issue's proof used. The issue's secondary `replaceSubagentRunAfterSteer` stale-fallback observation is prevented at the source by the guard (scan B never dispatches), so no separate change there.
