### PR TITLE
fix: prevent CLI MCP children from widening sandbox tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **CLI loopback sandbox scope:** apply configured sandbox allow/deny policy to loopback tools and bind each bundled CLI MCP grant to its Gateway runtime, session/delivery context, and active execution attempt, preventing child-rewritten headers or stale bearers from widening tool visibility. (#103074) Thanks @pgondhi987.
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **CLI loopback sandbox scope:** apply configured sandbox allow/deny policy to loopback tools and bind each bundled CLI MCP grant to its Gateway runtime, session/delivery context, and active execution attempt, preventing child-rewritten headers or stale bearers from widening tool visibility. (#103074) Thanks @pgondhi987.
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Control UI workspace avatars:** inline validated agent avatar files in bootstrap and identity responses so Personal card images render without unauthenticated avatar-route requests, while preserving configured emoji precedence. (#102892, #97602) Thanks @LZY3538.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -277,8 +277,8 @@ CLI backends do not receive OpenClaw tool calls directly, but a backend can opt 
 
 When bundle MCP is enabled, OpenClaw:
 
-- spawns a loopback HTTP MCP server that exposes gateway tools to the CLI process, authenticated with a per-session token (`OPENCLAW_MCP_TOKEN`);
-- scopes tool access to the current session, account, and channel context;
+- spawns a loopback HTTP MCP server that exposes gateway tools to the CLI process, authenticated with a per-run context grant (`OPENCLAW_MCP_TOKEN`) active only for the current execution attempt;
+- binds tool access to the Gateway-selected session, account, and channel context instead of trusting child-process headers;
 - loads enabled bundle-MCP servers for the current workspace and merges them with any existing backend MCP config/settings shape;
 - rewrites the launch config using the backend-owned integration mode from the owning plugin.
 

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -3759,6 +3759,42 @@ ${JSON.stringify({
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");
   });
 
+  it("cleans live-turn resources when capture activation fails before spawn", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    const context = buildPreparedCliRunContext({
+      provider: "claude-cli",
+      model: "sonnet",
+      runId: "run-live-capture-activation-failure",
+      mcpDeliveryCapture: true,
+    });
+
+    await expect(
+      runClaudeLiveSessionTurn({
+        context,
+        args: [],
+        env: {},
+        prompt: "hi",
+        useResume: false,
+        noOutputTimeoutMs: 1_000,
+        getProcessSupervisor: () => ({
+          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+          cancel: vi.fn(),
+          cancelScope: vi.fn(),
+          getRecord: vi.fn(),
+        }),
+        onAssistantDelta: () => {},
+        onMcpCaptureReady: () => {
+          throw new Error("grant activation failed");
+        },
+        cleanup,
+      }),
+    ).rejects.toThrow("grant activation failed");
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(supervisorSpawnMock).not.toHaveBeenCalled();
+  });
+
   it("uses a fresh Claude live process and capture key for every captured turn", async () => {
     const logWarnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
     const cancels: Array<ReturnType<typeof vi.fn>> = [];

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1370,6 +1370,14 @@ export async function runClaudeLiveSessionTurn(params: {
     }
   }
   let cleanupTurnArtifacts = Boolean(session);
+  let notifiedMcpCaptureKey: string | undefined;
+  const notifyMcpCaptureReady = (captureKey: string | undefined) => {
+    if (!captureKey || notifiedMcpCaptureKey === captureKey) {
+      return;
+    }
+    params.onMcpCaptureReady?.(captureKey);
+    notifiedMcpCaptureKey = captureKey;
+  };
   try {
     ensureLiveSessionCapacity(key, params.context);
   } catch (error) {
@@ -1431,6 +1439,17 @@ export async function runClaudeLiveSessionTurn(params: {
         });
       }
       const generation = crypto.randomUUID();
+      const mcpCaptureKey = params.context.mcpDeliveryCapture ? crypto.randomUUID() : undefined;
+      if (mcpCaptureKey) {
+        // Fence the Gateway grant before the capture-bearing child can issue
+        // its first loopback request during process startup.
+        try {
+          notifyMcpCaptureReady(mcpCaptureKey);
+        } catch (error) {
+          await cleanup();
+          throw error;
+        }
+      }
       const createSession = createClaudeLiveSession({
         context: params.context,
         argv,
@@ -1438,7 +1457,7 @@ export async function runClaudeLiveSessionTurn(params: {
         generation,
         fingerprint,
         key,
-        mcpCaptureKey: params.context.mcpDeliveryCapture ? crypto.randomUUID() : undefined,
+        mcpCaptureKey,
         noOutputTimeoutMs: params.noOutputTimeoutMs,
         supervisor: params.getProcessSupervisor(),
         cleanup,
@@ -1480,9 +1499,7 @@ export async function runClaudeLiveSessionTurn(params: {
     throw new Error("Claude CLI live session is already handling a turn");
   }
   const liveSession = session;
-  if (liveSession.mcpCaptureKey) {
-    params.onMcpCaptureReady?.(liveSession.mcpCaptureKey);
-  }
+  notifyMcpCaptureReady(liveSession.mcpCaptureKey);
   liveSession.noOutputTimeoutMs = params.noOutputTimeoutMs;
   liveSession.stderr = "";
 

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -1,6 +1,6 @@
 // Covers CLI execution paths where the process supervisor keeps stdout capture
 // disabled and the runner must parse streamed chunks without relying on tails.
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   markMcpLoopbackRequestFinished,
   markMcpLoopbackRequestStarted,
@@ -2066,9 +2066,36 @@ describe("executePreparedCliRun supervisor output capture", () => {
     ]);
   });
 
-  it("captures non-Claude JSONL sends and gives every attempt a unique token", async () => {
+  it("deactivates a Claude live capture when process startup fails", async () => {
+    const context = buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" });
+    context.mcpDeliveryCapture = true;
+    context.preparedBackend.backend.liveSession = "claude-stdio";
+    const activateCapture = vi.fn<(captureKey: string) => void>();
+    const deactivateCapture = vi.fn<(captureKey: string) => void>();
+    context.preparedBackend.mcpClientGrantCapture = {
+      activate: activateCapture,
+      deactivate: deactivateCapture,
+    };
+    supervisorSpawnMock.mockRejectedValueOnce(new Error("spawn failed"));
+
+    await expect(executePreparedCliRun(context)).rejects.toThrow("spawn failed");
+
+    expect(activateCapture).toHaveBeenCalledOnce();
+    expect(deactivateCapture).toHaveBeenCalledExactlyOnceWith(activateCapture.mock.calls[0]?.[0]);
+    expect(activateCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      supervisorSpawnMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("captures non-Claude JSONL sends and fences every attempt with a unique key", async () => {
     const context = buildPreparedCliRunContext({ output: "jsonl", provider: "local-cli" });
     context.mcpDeliveryCapture = true;
+    const activateCapture = vi.fn<(captureKey: string) => void>();
+    const deactivateCapture = vi.fn<(captureKey: string) => void>();
+    context.preparedBackend.mcpClientGrantCapture = {
+      activate: activateCapture,
+      deactivate: deactivateCapture,
+    };
     const captureKeys: string[] = [];
     supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
       const input = args[0] as SupervisorSpawnInput;
@@ -2106,5 +2133,10 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(second.didSendViaMessagingTool).toBe(true);
     expect(captureKeys).toHaveLength(2);
     expect(captureKeys[0]).not.toBe(captureKeys[1]);
+    expect(activateCapture.mock.calls.map(([captureKey]) => captureKey)).toEqual(captureKeys);
+    expect(deactivateCapture.mock.calls.map(([captureKey]) => captureKey)).toEqual(captureKeys);
+    expect(deactivateCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      activateCapture.mock.invocationCallOrder[1] ?? Number.POSITIVE_INFINITY,
+    );
   });
 });

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -377,10 +377,7 @@ function formatCliEnvKeyList(keys: readonly string[]): string {
 function buildCliEnvMcpLog(childEnv: Record<string, string>): string {
   return [
     `token=${childEnv.OPENCLAW_MCP_TOKEN ? "set" : "missing"}`,
-    `sessionKey=${childEnv.OPENCLAW_MCP_SESSION_KEY ? "set" : "<empty>"}`,
-    `agentId=${childEnv.OPENCLAW_MCP_AGENT_ID || "<empty>"}`,
-    `accountId=${childEnv.OPENCLAW_MCP_ACCOUNT_ID || "<empty>"}`,
-    `messageChannel=${childEnv.OPENCLAW_MCP_MESSAGE_CHANNEL || "<empty>"}`,
+    `capture=${childEnv.OPENCLAW_MCP_CLI_CAPTURE_KEY ? "set" : "missing"}`,
   ].join(" ");
 }
 
@@ -933,7 +930,7 @@ export async function executePreparedCliRun(
           });
           cliBackendLog.info(`cli argv: ${backend.command} ${logArgs.join(" ")}`);
           cliBackendLog.info(`cli env auth: ${buildCliEnvAuthLog(env)}`);
-          if (env.OPENCLAW_MCP_TOKEN || env.OPENCLAW_MCP_SESSION_KEY || env.OPENCLAW_MCP_AGENT_ID) {
+          if (env.OPENCLAW_MCP_TOKEN) {
             cliBackendLog.info(`cli env mcp: ${buildCliEnvMcpLog(env)}`);
           }
         }
@@ -1032,6 +1029,7 @@ export async function executePreparedCliRun(
           if (gatewayCaptureKey) {
             throw new Error("CLI MCP capture key changed during an active attempt");
           }
+          context.preparedBackend.mcpClientGrantCapture?.activate(captureKey);
           gatewayCaptureKey = captureKey;
           const isAdmittedPotentialMessagingDelivery = (toolName: string) => {
             return isMessagingTool(normalizeCliMessagingToolName(toolName));
@@ -1906,9 +1904,18 @@ export async function executePreparedCliRun(
         } finally {
           // Captured MCP calls may settle after the CLI process exits. Drain
           // first so finalization can use their trusted terminal outcomes.
-          finalizeParsedTools();
-          if (gatewayCaptureKey) {
-            clearMcpLoopbackToolCallCapture(gatewayCaptureKey);
+          try {
+            finalizeParsedTools();
+          } finally {
+            if (gatewayCaptureKey) {
+              // Drain accepted work, then fence this exact grant generation before
+              // clearing observers; otherwise a late request escapes accounting.
+              try {
+                context.preparedBackend.mcpClientGrantCapture?.deactivate(gatewayCaptureKey);
+              } finally {
+                clearMcpLoopbackToolCallCapture(gatewayCaptureKey);
+              }
+            }
           }
         }
         try {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -16,6 +16,10 @@ import {
   registerContextEngineForOwner,
 } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import type {
+  McpLoopbackClientGrant,
+  McpLoopbackRequestContext,
+} from "../../gateway/mcp-grant-store.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { clearMemoryPluginState, registerMemoryPromptSection } from "../../plugins/memory-state.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -117,26 +121,19 @@ function createTestMcpLoopbackServerConfig(port: number) {
         alwaysLoad: true,
         headers: {
           Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
-          "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
-          "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
-          "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
-          "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
-          "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
-          "x-openclaw-client-caps": "${OPENCLAW_MCP_CLIENT_CAPS}",
-          "x-openclaw-current-channel-id": "${OPENCLAW_MCP_CURRENT_CHANNEL_ID}",
-          "x-openclaw-current-thread-ts": "${OPENCLAW_MCP_CURRENT_THREAD_TS}",
-          "x-openclaw-current-message-id": "${OPENCLAW_MCP_CURRENT_MESSAGE_ID}",
-          "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
-          "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
-          "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-          "x-openclaw-task-suggestion-delivery-mode":
-            "${OPENCLAW_MCP_TASK_SUGGESTION_DELIVERY_MODE}",
-          "x-openclaw-require-explicit-message-target":
-            "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
           "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
         },
       },
     },
+  };
+}
+
+function createTestMcpLoopbackClientGrant(params: {
+  context: McpLoopbackRequestContext;
+}): McpLoopbackClientGrant {
+  return {
+    token: "loopback-token",
+    context: structuredClone(params.context),
   };
 }
 
@@ -274,9 +271,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
-      resolveMcpLoopbackBearerToken: vi.fn((runtime, senderIsOwner) =>
-        senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken,
-      ),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
+      revokeMcpLoopbackClientGrant: vi.fn(() => true),
       resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
       resolveOpenClawReferencePaths: vi.fn(async () => ({ docsPath: null, sourcePath: null })),
       prepareClaudeCliSkillsPlugin: vi.fn(async () => ({
@@ -828,7 +824,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime,
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
-      resolveMcpLoopbackBearerToken: vi.fn(() => "loopback-token"),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
       resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
     });
 
@@ -929,6 +925,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         ?.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
       throw new Error("Gemini auth profile was selected but no credential material was found");
     });
+    const revokeMcpLoopbackClientGrant = vi.fn(() => true);
     cliBackendsTesting.setDepsForTest({
       resolvePluginSetupCliBackend: () => undefined,
       resolveRuntimeCliBackends: () => [
@@ -952,7 +949,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime,
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
-      resolveMcpLoopbackBearerToken: vi.fn(() => "loopback-token"),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
+      revokeMcpLoopbackClientGrant,
       resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
     });
 
@@ -974,6 +972,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(generatedSystemSettingsPath).toBeTruthy();
       expect(fs.existsSync(generatedSystemSettingsPath ?? "")).toBe(false);
+      expect(revokeMcpLoopbackClientGrant).toHaveBeenCalledExactlyOnceWith("loopback-token");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -1056,7 +1055,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime,
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
-      resolveMcpLoopbackBearerToken: vi.fn(() => "loopback-token"),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
       resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
       prepareClaudeCliSkillsPlugin: vi.fn(async () => ({
         args: ["--plugin-dir", skillsPluginDir],
@@ -1143,7 +1142,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       makeBootstrapWarn: vi.fn(() => () => undefined),
       getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
-      resolveMcpLoopbackBearerToken: vi.fn(() => "token"),
+      mintMcpLoopbackClientGrant: vi.fn(createTestMcpLoopbackClientGrant),
       resolveMcpLoopbackScopedTools: vi.fn(() => ({
         agentId: "main",
         tools: [
@@ -2739,6 +2738,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       }));
       const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
       const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+      const activateMcpLoopbackClientGrantCapture = vi.fn(() => true);
+      const deactivateMcpLoopbackClientGrantCapture = vi.fn(() => true);
+      const mintMcpLoopbackClientGrant = vi.fn(createTestMcpLoopbackClientGrant);
+      const revokeMcpLoopbackClientGrant = vi.fn(() => true);
       const resolveMcpLoopbackScopedTools = vi.fn(() => ({
         agentId: "main",
         tools: [
@@ -2755,6 +2758,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         getActiveMcpLoopbackRuntime,
         ensureMcpLoopbackServer,
         createMcpLoopbackServerConfig,
+        activateMcpLoopbackClientGrantCapture,
+        deactivateMcpLoopbackClientGrantCapture,
+        mintMcpLoopbackClientGrant,
+        revokeMcpLoopbackClientGrant,
         resolveMcpLoopbackScopedTools,
       });
       cliBackendsTesting.setDepsForTest({
@@ -2921,7 +2928,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("passes current turn kind into bundle MCP loopback env", async () => {
+  it("binds current turn context into the bundle MCP client grant", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
       const getActiveMcpLoopbackRuntime = vi.fn(() => ({
@@ -2931,6 +2938,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       }));
       const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
       const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+      const activateMcpLoopbackClientGrantCapture = vi.fn(() => true);
+      const deactivateMcpLoopbackClientGrantCapture = vi.fn(() => true);
+      const mintMcpLoopbackClientGrant = vi.fn(createTestMcpLoopbackClientGrant);
+      const revokeMcpLoopbackClientGrant = vi.fn(() => true);
       const resolveMcpLoopbackScopedTools = vi.fn(() => ({
         agentId: "main",
         tools: [
@@ -2947,6 +2958,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         getActiveMcpLoopbackRuntime,
         ensureMcpLoopbackServer,
         createMcpLoopbackServerConfig,
+        activateMcpLoopbackClientGrantCapture,
+        deactivateMcpLoopbackClientGrantCapture,
+        mintMcpLoopbackClientGrant,
+        revokeMcpLoopbackClientGrant,
         resolveMcpLoopbackScopedTools,
       });
       cliBackendsTesting.setDepsForTest({
@@ -2990,18 +3005,39 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.preparedBackend.env).toMatchObject({
-        OPENCLAW_MCP_SESSION_ID: "session-test",
-        OPENCLAW_MCP_MESSAGE_CHANNEL: "telegram",
-        OPENCLAW_MCP_CLIENT_CAPS: "tool-events,inline-widgets",
-        OPENCLAW_MCP_CURRENT_CHANNEL_ID: "telegram:-100123:topic:42",
-        OPENCLAW_MCP_CURRENT_THREAD_TS: "42",
-        OPENCLAW_MCP_CURRENT_MESSAGE_ID: "reply-message-1",
-        OPENCLAW_MCP_CURRENT_INBOUND_AUDIO: "true",
-        OPENCLAW_MCP_INBOUND_EVENT_KIND: "room_event",
-        OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE: "message_tool_only",
-        OPENCLAW_MCP_TASK_SUGGESTION_DELIVERY_MODE: "gateway",
-        OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET: "true",
+        OPENCLAW_MCP_TOKEN: "loopback-token",
         OPENCLAW_MCP_CLI_CAPTURE_KEY: "",
+      });
+      expect(mintMcpLoopbackClientGrant).toHaveBeenCalledWith({
+        context: {
+          sessionKey: "agent:main:telegram:group:chat123",
+          sessionId: "session-test",
+          messageProvider: "telegram",
+          clientCaps: ["tool-events", "inline-widgets"],
+          currentChannelId: "telegram:-100123:topic:42",
+          currentThreadTs: "42",
+          currentMessageId: "reply-message-1",
+          currentInboundAudio: true,
+          accountId: undefined,
+          inboundEventKind: "room_event",
+          sourceReplyDeliveryMode: "message_tool_only",
+          taskSuggestionDeliveryMode: "gateway",
+          requireExplicitMessageTarget: true,
+          senderIsOwner: false,
+        },
+        runtimeOwnerToken: "loopback-owner-token",
+      });
+      context.preparedBackend.mcpClientGrantCapture?.activate("capture-test");
+      context.preparedBackend.mcpClientGrantCapture?.deactivate("capture-test");
+      expect(activateMcpLoopbackClientGrantCapture).toHaveBeenCalledExactlyOnceWith({
+        token: "loopback-token",
+        runtimeOwnerToken: "loopback-owner-token",
+        captureKey: "capture-test",
+      });
+      expect(deactivateMcpLoopbackClientGrantCapture).toHaveBeenCalledExactlyOnceWith({
+        token: "loopback-token",
+        runtimeOwnerToken: "loopback-owner-token",
+        captureKey: "capture-test",
       });
       expect(context.mcpDeliveryCapture).toBe(true);
       expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith(
@@ -3017,6 +3053,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.systemPrompt).not.toContain(
         "The target defaults to the current source channel",
       );
+      await context.preparedBackend.cleanup?.();
+      expect(revokeMcpLoopbackClientGrant).toHaveBeenCalledExactlyOnceWith("loopback-token");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -5,18 +5,26 @@ import { ensureSystemPromptCacheBoundary } from "@openclaw/ai/internal/shared";
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfig } from "../../config/config.js";
+import { resolveMainSessionKey } from "../../config/sessions.js";
 import type { CliBackendConfig } from "../../config/types.agent-defaults.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   assertContextEngineHostSupport,
   buildGenericCliContextEngineHostSupport,
 } from "../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveContextEngine } from "../../context-engine/registry.js";
+import {
+  activateMcpLoopbackClientGrantCapture,
+  deactivateMcpLoopbackClientGrantCapture,
+  mintMcpLoopbackClientGrant,
+  revokeMcpLoopbackClientGrant,
+  type McpLoopbackRequestContext,
+} from "../../gateway/mcp-grant-store.js";
 import { ensureMcpLoopbackServer } from "../../gateway/mcp-http.js";
 import {
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
-  resolveMcpLoopbackBearerToken,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import { resolveMcpLoopbackScopedTools } from "../../gateway/mcp-http.runtime.js";
 import { buildCrestodianToolsMcpServerConfig } from "../../mcp/openclaw-tools-serve-config.js";
@@ -109,7 +117,10 @@ const prepareDeps = {
   getActiveMcpLoopbackRuntime,
   ensureMcpLoopbackServer,
   createMcpLoopbackServerConfig,
-  resolveMcpLoopbackBearerToken,
+  activateMcpLoopbackClientGrantCapture,
+  deactivateMcpLoopbackClientGrantCapture,
+  mintMcpLoopbackClientGrant,
+  revokeMcpLoopbackClientGrant,
   resolveMcpLoopbackScopedTools,
   resolveOpenClawReferencePaths: async (
     params: Parameters<typeof import("../docs-path.js").resolveOpenClawReferencePaths>[0],
@@ -142,6 +153,45 @@ function canTransportSystemPrompt(backend: CliBackendConfig): boolean {
       backend.systemPromptArg || backend.systemPromptFileArg || backend.systemPromptFileConfigKey,
     )
   );
+}
+
+function normalizeOptionalMcpContextValue(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
+}
+
+function buildCliMcpGrantContext(params: {
+  run: RunCliAgentParams;
+  config: OpenClawConfig;
+  requireExplicitMessageTarget: boolean;
+}): McpLoopbackRequestContext {
+  const rawSessionKey = params.run.sessionKey?.trim() ?? "";
+  const sessionKey =
+    !rawSessionKey || rawSessionKey === "main"
+      ? resolveMainSessionKey(params.config)
+      : rawSessionKey;
+  const clientCaps = uniqueStrings(
+    (params.run.clientCaps ?? []).map((cap) => cap.trim()).filter(Boolean),
+  );
+  return {
+    sessionKey,
+    sessionId: normalizeOptionalMcpContextValue(params.run.sessionId),
+    messageProvider:
+      normalizeMessageChannel(params.run.messageChannel ?? params.run.messageProvider) ?? undefined,
+    clientCaps: clientCaps.length > 0 ? clientCaps : undefined,
+    currentChannelId: normalizeOptionalMcpContextValue(params.run.currentChannelId),
+    currentThreadTs: normalizeOptionalMcpContextValue(params.run.currentThreadTs),
+    currentMessageId:
+      params.run.currentMessageId == null
+        ? undefined
+        : normalizeOptionalMcpContextValue(String(params.run.currentMessageId)),
+    currentInboundAudio: params.run.currentInboundAudio === true ? true : undefined,
+    accountId: normalizeOptionalMcpContextValue(params.run.agentAccountId),
+    inboundEventKind: params.run.currentInboundEventKind,
+    sourceReplyDeliveryMode: params.run.sourceReplyDeliveryMode,
+    taskSuggestionDeliveryMode: params.run.taskSuggestionDeliveryMode,
+    requireExplicitMessageTarget: params.requireExplicitMessageTarget ? true : undefined,
+    senderIsOwner: params.run.senderIsOwner === true,
+  };
 }
 
 function buildCliSessionDriftUserContext(
@@ -569,6 +619,49 @@ export async function prepareCliRunContext(
   let preparedExecution: Awaited<ReturnType<NonNullable<typeof backendResolved.prepareExecution>>> =
     undefined;
   try {
+    const mcpClientGrant = mcpLoopbackRuntime
+      ? prepareDeps.mintMcpLoopbackClientGrant({
+          context: buildCliMcpGrantContext({
+            run: params,
+            config: params.config ?? getRuntimeConfig(),
+            requireExplicitMessageTarget,
+          }),
+          runtimeOwnerToken: mcpLoopbackRuntime.ownerToken,
+        })
+      : undefined;
+    const mcpClientGrantCapture =
+      mcpClientGrant && mcpLoopbackRuntime
+        ? {
+            activate: (captureKey: string) => {
+              const activated = prepareDeps.activateMcpLoopbackClientGrantCapture({
+                token: mcpClientGrant.token,
+                runtimeOwnerToken: mcpLoopbackRuntime.ownerToken,
+                captureKey,
+              });
+              if (!activated) {
+                throw new Error("CLI MCP client grant is no longer valid for this Gateway runtime");
+              }
+            },
+            deactivate: (captureKey: string) => {
+              prepareDeps.deactivateMcpLoopbackClientGrantCapture({
+                token: mcpClientGrant.token,
+                runtimeOwnerToken: mcpLoopbackRuntime.ownerToken,
+                captureKey,
+              });
+            },
+          }
+        : undefined;
+    let mcpClientGrantRevoked = false;
+    const cleanupMcpClientGrant = mcpClientGrant
+      ? async () => {
+          if (mcpClientGrantRevoked) {
+            return;
+          }
+          mcpClientGrantRevoked = true;
+          prepareDeps.revokeMcpLoopbackClientGrant(mcpClientGrant.token);
+        }
+      : undefined;
+    cleanupPreparedResources = cleanupMcpClientGrant;
     const preparedBackend = await prepareCliBundleMcpConfig({
       enabled: bundleMcpEnabled || crestodianMcpConfig !== undefined,
       mode: backendResolved.bundleMcpMode,
@@ -579,35 +672,26 @@ export async function prepareCliRunContext(
       additionalConfig: mcpLoopbackRuntime
         ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
         : undefined,
-      env: mcpLoopbackRuntime
-        ? {
-            OPENCLAW_MCP_TOKEN: prepareDeps.resolveMcpLoopbackBearerToken(
-              mcpLoopbackRuntime,
-              params.senderIsOwner === true,
-            ),
-            OPENCLAW_MCP_AGENT_ID: sessionAgentId ?? "",
-            OPENCLAW_MCP_ACCOUNT_ID: params.agentAccountId ?? "",
-            OPENCLAW_MCP_SESSION_KEY: params.sessionKey ?? "",
-            OPENCLAW_MCP_SESSION_ID: params.sessionId,
-            OPENCLAW_MCP_MESSAGE_CHANNEL: params.messageChannel ?? params.messageProvider ?? "",
-            OPENCLAW_MCP_CLIENT_CAPS: params.clientCaps?.join(",") ?? "",
-            OPENCLAW_MCP_CURRENT_CHANNEL_ID: params.currentChannelId ?? "",
-            OPENCLAW_MCP_CURRENT_THREAD_TS: params.currentThreadTs ?? "",
-            OPENCLAW_MCP_CURRENT_MESSAGE_ID:
-              params.currentMessageId != null ? String(params.currentMessageId) : "",
-            OPENCLAW_MCP_CURRENT_INBOUND_AUDIO: params.currentInboundAudio === true ? "true" : "",
-            OPENCLAW_MCP_INBOUND_EVENT_KIND: params.currentInboundEventKind ?? "",
-            OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE: params.sourceReplyDeliveryMode ?? "",
-            OPENCLAW_MCP_TASK_SUGGESTION_DELIVERY_MODE: params.taskSuggestionDeliveryMode ?? "",
-            OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET: requireExplicitMessageTarget
-              ? "true"
-              : "",
-            OPENCLAW_MCP_CLI_CAPTURE_KEY: "",
-          }
-        : undefined,
+      env:
+        mcpLoopbackRuntime && mcpClientGrant
+          ? {
+              OPENCLAW_MCP_TOKEN: mcpClientGrant.token,
+              OPENCLAW_MCP_CLI_CAPTURE_KEY: "",
+            }
+          : undefined,
       warn: (message) => cliBackendLog.warn(message),
     });
-    cleanupPreparedResources = preparedBackend.cleanup;
+    const cleanupPreparedBackend =
+      preparedBackend.cleanup || cleanupMcpClientGrant
+        ? async () => {
+            try {
+              await preparedBackend.cleanup?.();
+            } finally {
+              await cleanupMcpClientGrant?.();
+            }
+          }
+        : undefined;
+    cleanupPreparedResources = cleanupPreparedBackend;
     const prepareExecutionContext = {
       config: params.config,
       workspaceDir,
@@ -632,12 +716,12 @@ export async function prepareCliRunContext(
       },
     );
     const preparedBackendCleanup =
-      preparedBackend.cleanup || preparedExecution?.cleanup
+      cleanupPreparedBackend || preparedExecution?.cleanup
         ? async () => {
             try {
               await preparedExecution?.cleanup?.();
             } finally {
-              await preparedBackend.cleanup?.();
+              await cleanupPreparedBackend?.();
             }
           }
         : undefined;
@@ -705,6 +789,7 @@ export async function prepareCliRunContext(
       ...(preparedBackendBeforeExecution
         ? { beforeExecution: preparedBackendBeforeExecution }
         : {}),
+      ...(mcpClientGrantCapture ? { mcpClientGrantCapture } : {}),
       ...(preparedCleanup ? { cleanup: preparedCleanup } : {}),
     };
     const promptTools =

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -177,6 +177,11 @@ export type CliPreparedBackend = {
   backend: CliBackendConfig;
   beforeExecution?: () => Promise<void>;
   cleanup?: () => Promise<void>;
+  /** Gateway-owned capture fence for this prepared bundle-MCP client. */
+  mcpClientGrantCapture?: {
+    activate: (captureKey: string) => void;
+    deactivate: (captureKey: string) => void;
+  };
   mcpConfigHash?: string;
   mcpResumeHash?: string;
   env?: Record<string, string>;

--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -1,18 +1,29 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  resetAttachGrantsForTest,
+  activateMcpLoopbackClientGrantCapture,
   attachGrantStoreSize,
+  deactivateMcpLoopbackClientGrantCapture,
+  mcpLoopbackClientGrantStoreSize,
   mintAttachGrant,
+  mintMcpLoopbackClientGrant,
   resolveAttachGrant,
+  resolveMcpLoopbackClientGrant,
+  resetAttachGrantsForTest,
+  resetMcpLoopbackClientGrantsForTest,
   revokeAttachGrant,
   revokeAttachGrantsForSession,
+  revokeMcpLoopbackClientGrant,
+  revokeMcpLoopbackClientGrantsForRuntime,
   sweepExpiredAttachGrants,
 } from "./mcp-grant-store.js";
 
 const T0 = 1_000_000_000_000;
 
 describe("mcp-grant-store", () => {
-  beforeEach(() => resetAttachGrantsForTest());
+  beforeEach(() => {
+    resetAttachGrantsForTest();
+    resetMcpLoopbackClientGrantsForTest();
+  });
 
   it("mints a grant bound to the sessionKey with a token and a TTL window", () => {
     const g = mintAttachGrant({ sessionKey: "agent:main:main", ttlMs: 60_000, nowMs: T0 });
@@ -83,5 +94,140 @@ describe("mcp-grant-store", () => {
     expect(attachGrantStoreSize()).toBe(1);
     mintAttachGrant({ sessionKey: "s", ttlMs: 1_000, nowMs: T0 + 5_000 });
     expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("binds an immutable Gateway-selected context to a loopback client grant", () => {
+    const context = {
+      sessionKey: " agent:main:telegram:group:1 ",
+      sessionId: "session-1",
+      messageProvider: "telegram",
+      clientCaps: ["tool-events"],
+      currentChannelId: "telegram:-1001",
+      currentThreadTs: "42",
+      currentMessageId: "message-1",
+      currentInboundAudio: true,
+      accountId: "account-1",
+      inboundEventKind: "room_event" as const,
+      sourceReplyDeliveryMode: "message_tool_only" as const,
+      taskSuggestionDeliveryMode: "gateway" as const,
+      requireExplicitMessageTarget: true,
+      senderIsOwner: false,
+    };
+    const grant = mintMcpLoopbackClientGrant({
+      context,
+      runtimeOwnerToken: "runtime-one",
+    });
+    expect(
+      activateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-one",
+      }),
+    ).toBe(true);
+
+    context.clientCaps.push("caller-mutation");
+    grant.context.clientCaps?.push("return-value-mutation");
+
+    expect(
+      resolveMcpLoopbackClientGrant({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-one",
+      })?.context,
+    ).toEqual({
+      ...context,
+      sessionKey: "agent:main:telegram:group:1",
+      clientCaps: ["tool-events"],
+    });
+  });
+
+  it("admits only the active capture on the grant's Gateway runtime", () => {
+    const grant = mintMcpLoopbackClientGrant({
+      context: { sessionKey: "agent:main:first", senderIsOwner: false },
+      runtimeOwnerToken: "runtime-one",
+    });
+    const resolve = (runtimeOwnerToken: string, captureKey: string) =>
+      resolveMcpLoopbackClientGrant({
+        token: grant.token,
+        runtimeOwnerToken,
+        captureKey,
+      });
+
+    expect(resolve("runtime-one", "capture-a")).toBeUndefined();
+    expect(
+      activateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-other",
+        captureKey: "capture-a",
+      }),
+    ).toBe(false);
+    expect(
+      activateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-a",
+      }),
+    ).toBe(true);
+    expect(resolve("runtime-other", "capture-a")).toBeUndefined();
+    expect(resolve("runtime-one", "capture-forged")).toBeUndefined();
+    expect(resolve("runtime-one", "capture-a")?.captureKey).toBe("capture-a");
+
+    expect(
+      activateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-b",
+      }),
+    ).toBe(true);
+    expect(resolve("runtime-one", "capture-a")).toBeUndefined();
+    expect(
+      deactivateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-a",
+      }),
+    ).toBe(false);
+    expect(resolve("runtime-one", "capture-b")?.captureKey).toBe("capture-b");
+    expect(
+      deactivateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: "runtime-one",
+        captureKey: "capture-b",
+      }),
+    ).toBe(true);
+    expect(resolve("runtime-one", "capture-b")).toBeUndefined();
+  });
+
+  it("revokes client grants by token or exact Gateway runtime", () => {
+    const mintForRuntime = (runtimeOwnerToken: string, sessionKey: string) =>
+      mintMcpLoopbackClientGrant({
+        context: { sessionKey, senderIsOwner: false },
+        runtimeOwnerToken,
+      });
+    const first = mintForRuntime("runtime-one", "agent:main:first");
+    mintForRuntime("runtime-one", "agent:main:second");
+    const successor = mintForRuntime("runtime-two", "agent:main:successor");
+
+    expect(revokeMcpLoopbackClientGrantsForRuntime("runtime-one")).toBe(2);
+    expect(mcpLoopbackClientGrantStoreSize()).toBe(1);
+    expect(revokeMcpLoopbackClientGrant(first.token)).toBe(false);
+    expect(revokeMcpLoopbackClientGrant(successor.token)).toBe(true);
+    expect(revokeMcpLoopbackClientGrant(successor.token)).toBe(false);
+    expect(mcpLoopbackClientGrantStoreSize()).toBe(0);
+  });
+
+  it("requires a session key for loopback client grants", () => {
+    expect(() =>
+      mintMcpLoopbackClientGrant({
+        context: { sessionKey: "  ", senderIsOwner: false },
+        runtimeOwnerToken: "runtime-one",
+      }),
+    ).toThrow(/sessionKey is required/);
+    expect(() =>
+      mintMcpLoopbackClientGrant({
+        context: { sessionKey: "agent:main:main", senderIsOwner: false },
+        runtimeOwnerToken: "  ",
+      }),
+    ).toThrow(/runtimeOwnerToken is required/);
   });
 });

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -1,4 +1,26 @@
 import crypto from "node:crypto";
+import type {
+  SourceReplyDeliveryMode,
+  TaskSuggestionDeliveryMode,
+} from "../auto-reply/get-reply-options.types.js";
+import type { InboundEventKind } from "../channels/inbound-event/kind.js";
+
+export type McpLoopbackRequestContext = {
+  sessionKey: string;
+  sessionId?: string;
+  messageProvider?: string;
+  clientCaps?: string[];
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string;
+  currentInboundAudio?: boolean;
+  accountId?: string;
+  inboundEventKind?: InboundEventKind;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  taskSuggestionDeliveryMode?: TaskSuggestionDeliveryMode;
+  requireExplicitMessageTarget?: boolean;
+  senderIsOwner: boolean;
+};
 
 export interface McpAttachGrant {
   /** Opaque bearer presented as `Authorization: Bearer <token>`. */
@@ -11,10 +33,23 @@ export interface McpAttachGrant {
   readonly issuedAtMs: number;
 }
 
+export interface McpLoopbackClientGrant {
+  /** Opaque bearer presented as `Authorization: Bearer <token>`. */
+  readonly token: string;
+  /** Gateway-selected request context; child-process headers cannot widen it. */
+  readonly context: McpLoopbackRequestContext;
+}
+
+type StoredMcpLoopbackClientGrant = McpLoopbackClientGrant & {
+  runtimeOwnerToken: string;
+  activeCaptureKey?: string;
+};
+
 const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1h
 const MAX_TTL_MS = 12 * 60 * 60 * 1000;
 
 const grantsByToken = new Map<string, McpAttachGrant>();
+const clientGrantsByToken = new Map<string, StoredMcpLoopbackClientGrant>();
 
 function clampTtlMs(ttlMs: number | undefined): number {
   if (!Number.isFinite(ttlMs) || (ttlMs as number) <= 0) {
@@ -93,4 +128,105 @@ export function attachGrantStoreSize(): number {
 
 export function resetAttachGrantsForTest(): void {
   grantsByToken.clear();
+}
+
+export function mintMcpLoopbackClientGrant(params: {
+  context: McpLoopbackRequestContext;
+  runtimeOwnerToken: string;
+}): McpLoopbackClientGrant {
+  const sessionKey = params.context.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("mintMcpLoopbackClientGrant: context.sessionKey is required");
+  }
+  const runtimeOwnerToken = params.runtimeOwnerToken.trim();
+  if (!runtimeOwnerToken) {
+    throw new Error("mintMcpLoopbackClientGrant: runtimeOwnerToken is required");
+  }
+  const grant: StoredMcpLoopbackClientGrant = {
+    token: crypto.randomBytes(32).toString("hex"),
+    context: structuredClone({ ...params.context, sessionKey }),
+    runtimeOwnerToken,
+  };
+  clientGrantsByToken.set(grant.token, grant);
+  return structuredClone({
+    token: grant.token,
+    context: grant.context,
+  });
+}
+
+/** Bind the active execution attempt's capture before its child process starts. */
+export function activateMcpLoopbackClientGrantCapture(params: {
+  token: string;
+  runtimeOwnerToken: string;
+  captureKey: string;
+}): boolean {
+  const captureKey = params.captureKey.trim();
+  if (!captureKey) {
+    throw new Error("activateMcpLoopbackClientGrantCapture: captureKey is required");
+  }
+  const grant = clientGrantsByToken.get(params.token);
+  if (!grant || grant.runtimeOwnerToken !== params.runtimeOwnerToken) {
+    return false;
+  }
+  clientGrantsByToken.set(params.token, { ...grant, activeCaptureKey: captureKey });
+  return true;
+}
+
+/** Release only the attempt that still owns this grant's active capture. */
+export function deactivateMcpLoopbackClientGrantCapture(params: {
+  token: string;
+  runtimeOwnerToken: string;
+  captureKey: string;
+}): boolean {
+  const grant = clientGrantsByToken.get(params.token);
+  if (
+    !grant ||
+    grant.runtimeOwnerToken !== params.runtimeOwnerToken ||
+    grant.activeCaptureKey !== params.captureKey
+  ) {
+    return false;
+  }
+  const { activeCaptureKey: _activeCaptureKey, ...inactiveGrant } = grant;
+  clientGrantsByToken.set(params.token, inactiveGrant);
+  return true;
+}
+
+export function resolveMcpLoopbackClientGrant(params: {
+  token: string;
+  runtimeOwnerToken: string;
+  captureKey: string;
+}): { context: McpLoopbackRequestContext; captureKey: string } | undefined {
+  const grant = clientGrantsByToken.get(params.token);
+  if (
+    !grant ||
+    grant.runtimeOwnerToken !== params.runtimeOwnerToken ||
+    !grant.activeCaptureKey ||
+    grant.activeCaptureKey !== params.captureKey
+  ) {
+    return undefined;
+  }
+  return structuredClone({ context: grant.context, captureKey: grant.activeCaptureKey });
+}
+
+export function revokeMcpLoopbackClientGrant(token: string): boolean {
+  return clientGrantsByToken.delete(token);
+}
+
+export function revokeMcpLoopbackClientGrantsForRuntime(runtimeOwnerToken: string): number {
+  let removed = 0;
+  for (const [token, grant] of clientGrantsByToken) {
+    if (grant.runtimeOwnerToken === runtimeOwnerToken) {
+      clientGrantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function mcpLoopbackClientGrantStoreSize(): number {
+  return clientGrantsByToken.size;
+}
+
+export function resetMcpLoopbackClientGrantsForTest(): void {
+  clientGrantsByToken.clear();
 }

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -367,14 +367,6 @@ export function setActiveMcpLoopbackRuntime(runtime: McpLoopbackRuntime): void {
   activeRuntime = { ...runtime };
 }
 
-/** Choose the bearer token matching owner/non-owner caller identity. */
-export function resolveMcpLoopbackBearerToken(
-  runtime: McpLoopbackRuntime,
-  senderIsOwner: boolean,
-): string {
-  return senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken;
-}
-
 /** Clear loopback runtime only when the owning token matches the active runtime. */
 export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): void {
   if (activeRuntime?.ownerToken === ownerToken) {
@@ -386,21 +378,7 @@ const MCP_AUTH_HEADERS = {
   Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
 } as const;
 
-const MCP_CONTEXT_HEADERS = {
-  "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
-  "x-openclaw-session-id": "${OPENCLAW_MCP_SESSION_ID}",
-  "x-openclaw-agent-id": "${OPENCLAW_MCP_AGENT_ID}",
-  "x-openclaw-account-id": "${OPENCLAW_MCP_ACCOUNT_ID}",
-  "x-openclaw-message-channel": "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
-  "x-openclaw-client-caps": "${OPENCLAW_MCP_CLIENT_CAPS}",
-  "x-openclaw-current-channel-id": "${OPENCLAW_MCP_CURRENT_CHANNEL_ID}",
-  "x-openclaw-current-thread-ts": "${OPENCLAW_MCP_CURRENT_THREAD_TS}",
-  "x-openclaw-current-message-id": "${OPENCLAW_MCP_CURRENT_MESSAGE_ID}",
-  "x-openclaw-current-inbound-audio": "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
-  "x-openclaw-inbound-event-kind": "${OPENCLAW_MCP_INBOUND_EVENT_KIND}",
-  "x-openclaw-source-reply-delivery-mode": "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-  "x-openclaw-task-suggestion-delivery-mode": "${OPENCLAW_MCP_TASK_SUGGESTION_DELIVERY_MODE}",
-  "x-openclaw-require-explicit-message-target": "${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}",
+const MCP_CAPTURE_HEADERS = {
   "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
 } as const;
 
@@ -419,7 +397,7 @@ function createMcpServerConfig(port: number, headers: Record<string, string>) {
 
 /** Build the MCP server config injected into agents for loopback tool access. */
 export function createMcpLoopbackServerConfig(port: number) {
-  return createMcpServerConfig(port, { ...MCP_AUTH_HEADERS, ...MCP_CONTEXT_HEADERS });
+  return createMcpServerConfig(port, { ...MCP_AUTH_HEADERS, ...MCP_CAPTURE_HEADERS });
 }
 
 export function createMcpAttachGrantServerConfig(port: number) {

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -13,7 +13,11 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-utils.js";
-import { resolveAttachGrant } from "./mcp-grant-store.js";
+import {
+  resolveAttachGrant,
+  resolveMcpLoopbackClientGrant,
+  type McpLoopbackRequestContext,
+} from "./mcp-grant-store.js";
 import { isLoopbackAddress } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
 
@@ -52,21 +56,13 @@ function logMcpLoopbackHttp(step: string, details: Record<string, unknown>): voi
   console.error(`[mcp-loopback] ${step} ${JSON.stringify(details)}`);
 }
 
-type McpRequestContext = {
-  sessionKey: string;
-  sessionId: string | undefined;
-  messageProvider: string | undefined;
-  clientCaps: string[] | undefined;
-  currentChannelId: string | undefined;
-  currentThreadTs: string | undefined;
-  currentMessageId: string | undefined;
-  currentInboundAudio: boolean | undefined;
-  accountId: string | undefined;
-  inboundEventKind: InboundEventKind | undefined;
-  sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
-  taskSuggestionDeliveryMode: TaskSuggestionDeliveryMode | undefined;
-  requireExplicitMessageTarget: boolean | undefined;
-  senderIsOwner: boolean | undefined;
+type McpRequestContext = McpLoopbackRequestContext;
+
+type McpLoopbackRequestAuth = {
+  senderIsOwner: boolean;
+  boundSessionKey?: string;
+  boundContext?: McpLoopbackRequestContext;
+  boundCaptureKey?: string;
 };
 
 function resolveScopedSessionKey(cfg: OpenClawConfig, rawSessionKey: string | undefined): string {
@@ -124,7 +120,7 @@ function resolveMcpSender(params: {
   req: IncomingMessage;
   ownerToken: string;
   nonOwnerToken: string;
-}): { senderIsOwner: boolean; boundSessionKey?: string } | undefined {
+}): McpLoopbackRequestAuth | undefined {
   const authHeader = getHeader(params.req, "authorization") ?? "";
   const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
   const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
@@ -132,6 +128,22 @@ function resolveMcpSender(params: {
     return { senderIsOwner: ownerTokenMatched };
   }
   const grantToken = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : "";
+  const captureKey = normalizeOptionalString(getHeader(params.req, "x-openclaw-cli-capture-key"));
+  const clientGrant =
+    grantToken && captureKey
+      ? resolveMcpLoopbackClientGrant({
+          token: grantToken,
+          runtimeOwnerToken: params.ownerToken,
+          captureKey,
+        })
+      : undefined;
+  if (clientGrant) {
+    return {
+      senderIsOwner: clientGrant.context.senderIsOwner,
+      boundContext: clientGrant.context,
+      boundCaptureKey: clientGrant.captureKey,
+    };
+  }
   const grant = grantToken ? resolveAttachGrant(grantToken) : undefined;
   if (grant) {
     return { senderIsOwner: false, boundSessionKey: grant.sessionKey };
@@ -145,7 +157,7 @@ export function validateMcpLoopbackRequest(params: {
   ownerToken: string;
   nonOwnerToken: string;
   onSseResponse?: (res: ServerResponse) => void;
-}): { senderIsOwner: boolean; boundSessionKey?: string } | null {
+}): McpLoopbackRequestAuth | null {
   let url: URL;
   try {
     url = new URL(params.req.url ?? "/", `http://${params.req.headers.host ?? "localhost"}`);
@@ -261,7 +273,12 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
-  return { senderIsOwner: sender.senderIsOwner, boundSessionKey: sender.boundSessionKey };
+  return {
+    senderIsOwner: sender.senderIsOwner,
+    boundSessionKey: sender.boundSessionKey,
+    boundContext: sender.boundContext,
+    boundCaptureKey: sender.boundCaptureKey,
+  };
 }
 
 export async function readMcpHttpBody(
@@ -367,7 +384,13 @@ export function resolveMcpHttpBodyTimeoutMs(): number {
   return readPositiveIntEnv("OPENCLAW_MCP_LOOPBACK_BODY_TIMEOUT_MS", DEFAULT_MCP_BODY_TIMEOUT_MS);
 }
 
-export function resolveMcpCliCaptureKey(req: IncomingMessage): string | undefined {
+export function resolveMcpCliCaptureKey(
+  req: IncomingMessage,
+  auth: McpLoopbackRequestAuth,
+): string | undefined {
+  if (auth.boundContext || auth.boundSessionKey) {
+    return auth.boundCaptureKey;
+  }
   return normalizeOptionalString(getHeader(req, "x-openclaw-cli-capture-key"));
 }
 
@@ -381,8 +404,14 @@ function normalizeMcpClientCapsHeader(value: string | undefined): string[] | und
 export function resolveMcpRequestContext(
   req: IncomingMessage,
   cfg: OpenClawConfig,
-  auth: { senderIsOwner: boolean; boundSessionKey?: string },
+  auth: McpLoopbackRequestAuth,
 ): McpRequestContext {
+  if (auth.boundContext) {
+    // Gateway-launched CLI clients receive an immutable context grant. The
+    // child process can replay the token, but cannot scope-shop by rewriting
+    // session, channel, capability, or ownership headers.
+    return structuredClone(auth.boundContext);
+  }
   // Grant-authenticated callers get only their server-bound session; spoofable
   // delivery/action headers stay reserved for the gateway-launched loopback client.
   if (auth.boundSessionKey) {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -132,7 +132,15 @@ vi.mock("./tool-resolution.js", () => ({
     resolveGatewayScopedToolsMock(...args),
 }));
 
-import { resetAttachGrantsForTest, mintAttachGrant } from "./mcp-grant-store.js";
+import {
+  activateMcpLoopbackClientGrantCapture,
+  deactivateMcpLoopbackClientGrantCapture,
+  mintAttachGrant,
+  mintMcpLoopbackClientGrant,
+  resetAttachGrantsForTest,
+  resetMcpLoopbackClientGrantsForTest,
+  revokeMcpLoopbackClientGrant,
+} from "./mcp-grant-store.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   createMcpAttachGrantServerConfig,
@@ -600,6 +608,8 @@ function buildMockMcpToolSchema(tools: MockGatewayTool[]) {
 }
 
 beforeEach(() => {
+  resetAttachGrantsForTest();
+  resetMcpLoopbackClientGrantsForTest();
   clearMcpToolSchemaWarningsForTest();
   logWarnMock.mockClear();
   clearMcpLoopbackToolCallCapturesForTest();
@@ -870,7 +880,6 @@ describe("mcp loopback server", () => {
   });
 
   it("binds an attach grant's session and ignores ALL spoofed context headers (no scope-shop)", async () => {
-    resetAttachGrantsForTest();
     const grant = mintAttachGrant({ sessionKey: "agent:main:attach-host" });
     const port = await getFreePortBlockWithPermissionFallback({
       offsets: [0],
@@ -906,6 +915,133 @@ describe("mcp loopback server", () => {
     expect(call.currentThreadTs).toBeUndefined();
     expect(call.sourceReplyDeliveryMode).toBeUndefined();
     expect(call.inboundEventKind).toBeUndefined();
+  });
+
+  it("binds a CLI grant's complete context and ignores spoofed scope headers", async () => {
+    const { port, runtime } = await startLoopbackServerForTest();
+    const grant = mintMcpLoopbackClientGrant({
+      context: {
+        sessionKey: "agent:main:discord:channel:bound",
+        sessionId: "session-bound",
+        messageProvider: "discord",
+        clientCaps: ["tool-events"],
+        currentChannelId: "discord:bound",
+        currentThreadTs: "bound-thread",
+        currentMessageId: "bound-message",
+        currentInboundAudio: true,
+        accountId: "bound-account",
+        inboundEventKind: "user_request",
+        sourceReplyDeliveryMode: "message_tool_only",
+        taskSuggestionDeliveryMode: "gateway",
+        requireExplicitMessageTarget: true,
+        senderIsOwner: false,
+      },
+      runtimeOwnerToken: runtime.ownerToken,
+    });
+    expect(
+      activateMcpLoopbackClientGrantCapture({
+        token: grant.token,
+        runtimeOwnerToken: runtime.ownerToken,
+        captureKey: "capture-bound",
+      }),
+    ).toBe(true);
+
+    const sendWithCapture = async (captureKey?: string, method: "list" | "call" = "list") =>
+      await sendRaw({
+        port,
+        token: grant.token,
+        headers: jsonHeaders({
+          ...(captureKey ? { "x-openclaw-cli-capture-key": captureKey } : {}),
+          "x-session-key": "agent:main:main",
+          "x-openclaw-session-id": "session-spoofed",
+          "x-openclaw-message-channel": "telegram",
+          "x-openclaw-client-caps": "inline-widgets,admin",
+          "x-openclaw-account-id": "spoofed-account",
+          "x-openclaw-current-channel-id": "telegram:spoofed",
+          "x-openclaw-current-thread-ts": "spoofed-thread",
+          "x-openclaw-current-message-id": "spoofed-message",
+          "x-openclaw-current-inbound-audio": "false",
+          "x-openclaw-inbound-event-kind": "room_event",
+          "x-openclaw-source-reply-delivery-mode": "automatic",
+          "x-openclaw-task-suggestion-delivery-mode": "direct",
+          "x-openclaw-require-explicit-message-target": "false",
+        }),
+        body: method === "call" ? mcpToolCallBody("message") : mcpToolsListBody(),
+      });
+
+    expect((await sendWithCapture()).status).toBe(401);
+    expect((await sendWithCapture("capture-forged")).status).toBe(401);
+    expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+
+    expect((await sendWithCapture("capture-bound")).status).toBe(200);
+    expect((await sendWithCapture("capture-bound", "call")).status).toBe(200);
+    const expectedBoundContext = {
+      sessionKey: "agent:main:discord:channel:bound",
+      sessionId: "session-bound",
+      messageProvider: "discord",
+      clientCaps: ["tool-events"],
+      currentChannelId: "discord:bound",
+      currentThreadTs: "bound-thread",
+      currentMessageId: "bound-message",
+      currentInboundAudio: true,
+      accountId: "bound-account",
+      inboundEventKind: "user_request",
+      sourceReplyDeliveryMode: "message_tool_only",
+      taskSuggestionDeliveryMode: "gateway",
+      requireExplicitMessageTarget: true,
+      senderIsOwner: false,
+      surface: "loopback",
+    };
+    expect(getScopedToolsCall(0)).toMatchObject(expectedBoundContext);
+    expect(getScopedToolsCall(1)).toMatchObject(expectedBoundContext);
+  });
+
+  it("rejects revoked and prior-runtime CLI grants", async () => {
+    const firstServer = await startLoopbackServerForTest();
+    const staleGrant = mintMcpLoopbackClientGrant({
+      context: { sessionKey: "agent:main:stale", senderIsOwner: false },
+      runtimeOwnerToken: firstServer.runtime.ownerToken,
+    });
+    activateMcpLoopbackClientGrantCapture({
+      token: staleGrant.token,
+      runtimeOwnerToken: firstServer.runtime.ownerToken,
+      captureKey: "capture-stale",
+    });
+    await server?.close();
+    server = undefined;
+
+    const successor = await startLoopbackServerForTest();
+    expect(
+      (
+        await sendRaw({
+          port: successor.port,
+          token: staleGrant.token,
+          headers: jsonHeaders({ "x-openclaw-cli-capture-key": "capture-stale" }),
+          body: mcpToolsListBody(),
+        })
+      ).status,
+    ).toBe(401);
+
+    const revokedGrant = mintMcpLoopbackClientGrant({
+      context: { sessionKey: "agent:main:revoked", senderIsOwner: false },
+      runtimeOwnerToken: successor.runtime.ownerToken,
+    });
+    activateMcpLoopbackClientGrantCapture({
+      token: revokedGrant.token,
+      runtimeOwnerToken: successor.runtime.ownerToken,
+      captureKey: "capture-revoked",
+    });
+    expect(revokeMcpLoopbackClientGrant(revokedGrant.token)).toBe(true);
+    expect(
+      (
+        await sendRaw({
+          port: successor.port,
+          token: revokedGrant.token,
+          headers: jsonHeaders({ "x-openclaw-cli-capture-key": "capture-revoked" }),
+          body: mcpToolsListBody(),
+        })
+      ).status,
+    ).toBe(401);
   });
 
   it("routes sessions_yield to the current CLI capture", async () => {
@@ -2240,43 +2376,10 @@ describe("createMcpLoopbackServerConfig", () => {
     };
     expect(config.mcpServers?.openclaw?.url).toBe("http://127.0.0.1:23119/mcp");
     expect(config.mcpServers?.openclaw?.alwaysLoad).toBe(true);
-    expect(config.mcpServers?.openclaw?.headers?.Authorization).toBe(
-      "Bearer ${OPENCLAW_MCP_TOKEN}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-session-id"]).toBe(
-      "${OPENCLAW_MCP_SESSION_ID}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-message-channel"]).toBe(
-      "${OPENCLAW_MCP_MESSAGE_CHANNEL}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-client-caps"]).toBe(
-      "${OPENCLAW_MCP_CLIENT_CAPS}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-current-channel-id"]).toBe(
-      "${OPENCLAW_MCP_CURRENT_CHANNEL_ID}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-current-thread-ts"]).toBe(
-      "${OPENCLAW_MCP_CURRENT_THREAD_TS}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-current-message-id"]).toBe(
-      "${OPENCLAW_MCP_CURRENT_MESSAGE_ID}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-current-inbound-audio"]).toBe(
-      "${OPENCLAW_MCP_CURRENT_INBOUND_AUDIO}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-source-reply-delivery-mode"]).toBe(
-      "${OPENCLAW_MCP_SOURCE_REPLY_DELIVERY_MODE}",
-    );
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-task-suggestion-delivery-mode"]).toBe(
-      "${OPENCLAW_MCP_TASK_SUGGESTION_DELIVERY_MODE}",
-    );
-    expect(
-      config.mcpServers?.openclaw?.headers?.["x-openclaw-require-explicit-message-target"],
-    ).toBe("${OPENCLAW_MCP_REQUIRE_EXPLICIT_MESSAGE_TARGET}");
-    expect(config.mcpServers?.openclaw?.headers?.["x-openclaw-cli-capture-key"]).toBe(
-      "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
-    );
-    expect(config.mcpServers?.openclaw?.headers).not.toHaveProperty("x-openclaw-sender-is-owner");
+    expect(config.mcpServers?.openclaw?.headers).toEqual({
+      Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+      "x-openclaw-cli-capture-key": "${OPENCLAW_MCP_CLI_CAPTURE_KEY}",
+    });
   });
 
   it("builds an attach grant config with only token-backed headers", () => {
@@ -2298,6 +2401,52 @@ describe("createMcpLoopbackServerConfig", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/event-stream");
     await expectInitialSseCommentFrame(res);
+  });
+
+  it("requires an active matching CLI capture on GET and DELETE", async () => {
+    const { port, runtime } = await startLoopbackServerForTest();
+    const grant = mintMcpLoopbackClientGrant({
+      context: { sessionKey: "agent:main:transport", senderIsOwner: false },
+      runtimeOwnerToken: runtime.ownerToken,
+    });
+    const captureKey = "capture-transport";
+    activateMcpLoopbackClientGrantCapture({
+      token: grant.token,
+      runtimeOwnerToken: runtime.ownerToken,
+      captureKey,
+    });
+    const send = async (method: "GET" | "DELETE", requestCaptureKey?: string) =>
+      await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method,
+        headers: {
+          authorization: `Bearer ${grant.token}`,
+          ...(requestCaptureKey ? { "x-openclaw-cli-capture-key": requestCaptureKey } : {}),
+        },
+      });
+
+    for (const method of ["GET", "DELETE"] as const) {
+      for (const requestCaptureKey of [undefined, "capture-forged"]) {
+        const response = await send(method, requestCaptureKey);
+        expect(response.status).toBe(401);
+        await response.body?.cancel();
+      }
+    }
+
+    const getResponse = await send("GET", captureKey);
+    expect(getResponse.status).toBe(200);
+    await expectInitialSseCommentFrame(getResponse);
+    expect((await send("DELETE", captureKey)).status).toBe(200);
+
+    deactivateMcpLoopbackClientGrantCapture({
+      token: grant.token,
+      runtimeOwnerToken: runtime.ownerToken,
+      captureKey,
+    });
+    for (const method of ["GET", "DELETE"] as const) {
+      const response = await send(method, captureKey);
+      expect(response.status).toBe(401);
+      await response.body?.cancel();
+    }
   });
 
   it("closes active GET notification streams during loopback shutdown", async () => {
@@ -2323,6 +2472,108 @@ describe("createMcpLoopbackServerConfig", () => {
     } finally {
       await reader.cancel().catch(() => undefined);
       reader.releaseLock();
+    }
+  });
+
+  it("withdraws a closing runtime before drain without fencing its successor", async () => {
+    const oldServer = await startMcpLoopbackServer(0);
+    const oldRuntime = getActiveMcpLoopbackRuntime();
+    if (!oldRuntime) {
+      throw new Error("expected old MCP loopback runtime");
+    }
+    let stalledRequest: ReturnType<typeof request> | undefined;
+    let resolveSocketReady: () => void = () => {};
+    let rejectSocketReady: (error: Error) => void = () => {};
+    const socketReady = new Promise<void>((resolve, reject) => {
+      resolveSocketReady = resolve;
+      rejectSocketReady = reject;
+    });
+    const responsePromise = new Promise<void>((resolve, reject) => {
+      const req = request(
+        {
+          hostname: "127.0.0.1",
+          port: oldServer.port,
+          path: "/mcp",
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${oldRuntime.ownerToken}`,
+            connection: "close",
+            "content-type": "application/json",
+          },
+        },
+        (res) => {
+          res.resume();
+          res.once("end", resolve);
+        },
+      );
+      req.once("socket", (socket) => {
+        if (!socket.connecting) {
+          resolveSocketReady();
+          return;
+        }
+        socket.once("connect", resolveSocketReady);
+      });
+      req.once("error", (error) => {
+        rejectSocketReady(error);
+        reject(error);
+      });
+      req.write("{");
+      stalledRequest = req;
+    });
+    let stalledRequestEnded = false;
+    const finishStalledRequest = () => {
+      if (stalledRequestEnded) {
+        return;
+      }
+      stalledRequestEnded = true;
+      stalledRequest?.end("}");
+    };
+    let oldClose: Promise<void> | undefined;
+    try {
+      await socketReady;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      let closeSettled = false;
+      oldClose = oldServer.close().finally(() => {
+        closeSettled = true;
+      });
+      expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      expect(closeSettled).toBe(false);
+
+      const successor = await startLoopbackServerForTest();
+      const successorGrant = mintMcpLoopbackClientGrant({
+        context: { sessionKey: "agent:main:successor", senderIsOwner: false },
+        runtimeOwnerToken: successor.runtime.ownerToken,
+      });
+      activateMcpLoopbackClientGrantCapture({
+        token: successorGrant.token,
+        runtimeOwnerToken: successor.runtime.ownerToken,
+        captureKey: "capture-successor",
+      });
+
+      finishStalledRequest();
+      await responsePromise;
+      await oldClose;
+      expect(getActiveMcpLoopbackRuntime()?.ownerToken).toBe(successor.runtime.ownerToken);
+      expect(
+        (
+          await sendRaw({
+            port: successor.port,
+            token: successorGrant.token,
+            headers: jsonHeaders({ "x-openclaw-cli-capture-key": "capture-successor" }),
+            body: mcpToolsListBody(),
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      finishStalledRequest();
+      await responsePromise.catch(() => undefined);
+      await (oldClose ?? oldServer.close()).catch(() => undefined);
     }
   });
 

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -11,6 +11,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";
+import { revokeMcpLoopbackClientGrantsForRuntime } from "./mcp-grant-store.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
@@ -43,7 +44,6 @@ export {
   createMcpAttachGrantServerConfig,
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
-  resolveMcpLoopbackBearerToken,
 } from "./mcp-http.loopback-runtime.js";
 
 type McpLoopbackServer = {
@@ -192,7 +192,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
 
     // Bind the request before body parsing/tool resolution. A CLI may exit while
     // an accepted request is still uploading, and retries must not outrun it.
-    const cliCaptureKey = resolveMcpCliCaptureKey(req);
+    const cliCaptureKey = resolveMcpCliCaptureKey(req, auth);
     const cliRequestCaptureHandle = markMcpLoopbackRequestStarted(cliCaptureKey);
     const requestAbort = createRequestAbortSignal(req, res);
     void (async () => {
@@ -255,7 +255,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           ),
           sessionKey: requestContext.sessionKey,
           inboundEventKind: requestContext.inboundEventKind,
-          senderIsOwner: requestContext.senderIsOwner === true,
+          senderIsOwner: requestContext.senderIsOwner,
           toolCount: scopedTools.toolSchema.length,
           cronVisible: scopedTools.toolSchema.some((tool) => tool.name === "cron"),
         });
@@ -378,11 +378,14 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
 
   const server: McpLoopbackServer = {
     port: address.port,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
+    close: () => {
+      // Stop admitting this runtime's child grants before draining accepted
+      // requests. A delayed old-server close cannot revoke a successor runtime.
+      clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
+      revokeMcpLoopbackClientGrantsForRuntime(ownerToken);
+      return new Promise<void>((resolve, reject) => {
         httpServer.close((error) => {
           if (!error) {
-            clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
             if (activeMcpLoopbackServer === server) {
               activeMcpLoopbackServer = undefined;
             }
@@ -394,7 +397,8 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           resolve();
         });
         closeActiveSseResponses();
-      }),
+      });
+    },
   };
   return server;
 }


### PR DESCRIPTION
Follow-up to #103074.

## What Problem This Solves

Fixes an issue where a bundled CLI MCP child running in a non-main sandbox could rewrite its loopback session/context headers and recover the broader main-session tool set. The loopback bearer selected the sender class, but the child still supplied the session, channel, capability, and delivery context used by sandbox policy.

## Why This Change Was Made

The Gateway now mints an opaque per-run grant containing its own immutable request context, binds that grant to the exact loopback runtime and active execution-attempt capture, and revokes it during prepared-resource cleanup or runtime shutdown. CLI children receive only the opaque token and capture key; stale grants, prior-runtime grants, missing/forged captures, and child-rewritten context headers are rejected or ignored.

The activation boundary remains immediately before process spawn, while deactivation occurs only after accepted MCP work drains. This preserves delivery accounting and fences retries without trusting process-controlled headers.

## User Impact

Bundled CLI backends continue to receive the tools allowed for their actual OpenClaw session and sandbox mode, but cannot widen that scope by changing generated MCP headers. Long-running and retried CLI turns keep working because grants are lifecycle-owned rather than time-expiring mid-run.

AI-assisted implementation; the complete behavior and dependency paths were reviewed before submission.

Release-note context: bind bundled CLI loopback access to the Gateway-selected sandbox scope and active execution attempt, preventing child-rewritten headers or stale grants from widening tool visibility. Follow-up to #103074; thanks @pgondhi987 for the original sandbox-policy fix.

## Evidence

- External Blacksmith Testbox scenario through the generated CLI MCP config and source Gateway:
  - non-main sandbox: only `agents_list`; `sessions_list` denied
  - same child with forged `x-session-key: agent:main:main`: still only `agents_list`; `sessions_list` denied
  - genuine main session in `non-main` mode: main tool set visible
  - genuine main session in `all` mode: sandbox-restricted set remains enforced
- Exact-tree focused tests: 540 passed across `mcp-grant-store`, `mcp-http`, CLI prepare, CLI execution/capture, and CLI spawn suites.
- `corepack pnpm check:changed`: passed production/test typechecks, all core lint shards, import-cycle checks, and repository policy guards.
- `corepack pnpm build`: passed, including runtime post-build, plugin SDK export checks, and Control UI build.
- `corepack pnpm format:docs:check`: passed for all 688 docs files.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
- Dependency contracts checked directly: MCP TypeScript SDK 1.29.0 carries configured headers across GET, POST, and DELETE; current sibling Codex source maps configured MCP environment headers into those requests.
