### PR TITLE
fix(agents): guard subagent orphan recovery against concurrent double-resume (#103724)

### DIFF
--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -1058,4 +1058,58 @@ describe("subagent-orphan-recovery", () => {
       { runIds: ["run-1"] },
     );
   });
+
+  it("does not double-resume one orphan across concurrent scans (#103724)", async () => {
+    vi.mocked(sessions.loadSessionStore).mockReturnValue({
+      "agent:main:subagent:test-session-1": {
+        sessionId: "session-abc",
+        updatedAt: Date.now(),
+        abortedLastRun: true,
+      },
+    });
+
+    // Slow gateway resume: hold scan A in flight while scan B runs its pass.
+    // Release opens the gate for every pending and future call, because the
+    // resume flow may call the gateway more than once.
+    let released = false;
+    const pendingResolvers: Array<() => void> = [];
+    const releaseResume = () => {
+      released = true;
+      for (const resolve of pendingResolvers.splice(0)) {
+        resolve();
+      }
+    };
+    vi.mocked(gateway.callGateway).mockImplementation(async () => {
+      if (!released) {
+        await new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        });
+      }
+      return { runId: "resumed-run-id" };
+    });
+
+    const activeRuns = new Map<string, SubagentRunRecord>();
+    activeRuns.set("run-1", createTestRunRecord());
+
+    // Two uncoordinated schedules: each builds its own private de-dupe set, so
+    // only the module-level in-flight claim prevents a double resume.
+    const scanA = recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      resumedSessionKeys: new Set(),
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    const scanB = recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      resumedSessionKeys: new Set(),
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    releaseResume();
+    await vi.advanceTimersByTimeAsync(10);
+    const [resultA, resultB] = await Promise.all([scanA, scanB]);
+
+    // Exactly one resume turn may be dispatched for the orphan.
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(resultA.recovered + resultB.recovered).toBe(1);
+    expect(resultA.skipped + resultB.skipped).toBe(1);
+  });
 });

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -44,6 +44,14 @@ const log = createSubsystemLogger("subagent-interrupted-resume");
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 
+// Session keys with an in-flight resume in THIS process. `resumedSessionKeys`
+// only dedupes sequentially within a single scan, so two concurrent scans each
+// build a private set and can both pass the pre-resume check before either
+// records the resume. This module-level claim set prevents that concurrent
+// double-resume (#103724): a scan claims the key before the final store re-read
+// and resume, and releases it in a finally.
+const inFlightOrphanResumes = new Set<string>();
+
 function isLegacyRestartInterruptedTimeout(
   runRecord: SubagentRunRecord,
   entry: SessionEntry | undefined,
@@ -341,7 +349,7 @@ export async function recoverOrphanedSubagentSessions(params: {
         }
         continue;
       }
-      if (resumedSessionKeys.has(childSessionKey)) {
+      if (resumedSessionKeys.has(childSessionKey) || inFlightOrphanResumes.has(childSessionKey)) {
         result.skipped++;
         continue;
       }
@@ -472,57 +480,77 @@ export async function recoverOrphanedSubagentSessions(params: {
           return typeof text === "string" && configChangePattern.test(text);
         });
 
-        // Resume the session with the original task context.
-        // We intentionally do NOT clear abortedLastRun before attempting
-        // the resume — if instance dispatch fails (e.g. Gateway still booting),
-        // the flag stays true so the next restart can retry.
-        const resumeResult = await resumeOrphanedSession({
-          gatewayRuntime: params.gatewayRuntime,
-          sessionKey: childSessionKey,
-          task: runRecord.task,
-          lastHumanMessage: extractMessageText(lastHumanMessage),
-          configChangeHint: configChangeDetected
-            ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
-            : undefined,
-          originalRunId: runId,
-          originalRun: runRecord,
-        });
-
-        if (resumeResult.resumed) {
-          resumedSessionKeys.add(childSessionKey);
-          // Only clear the aborted flag after confirmed successful resume.
-          try {
-            await patchRecoverySessionEntry({
-              storePath,
-              childSessionKey,
-              update: (current) => {
-                current.abortedLastRun = false;
-                markSubagentRecoveryAttempt({
-                  entry: current,
-                  now: Date.now(),
-                  runId,
-                  attempt: recoveryGate.nextAttempt,
-                });
-                current.updatedAt = Date.now();
-              },
-            });
-          } catch (err) {
-            log.warn(
-              `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
-            );
+        // Claim the session before the final store re-read so a concurrent scan
+        // cannot slip in between — resumedSessionKeys only dedupes within one
+        // scan, so two uncoordinated scans can both pass the earlier check before
+        // either records the resume (#103724). Re-read the entry fresh so a resume
+        // another scan already completed is observed here.
+        if (inFlightOrphanResumes.has(childSessionKey)) {
+          result.skipped++;
+          continue;
+        }
+        inFlightOrphanResumes.add(childSessionKey);
+        try {
+          const freshEntry = loadRecoverySessionEntry({ childSessionKey, storePath });
+          if (!freshEntry?.abortedLastRun) {
+            result.skipped++;
+            continue;
           }
-          result.recovered++;
-        } else {
-          // Flag stays as abortedLastRun=true so next restart can retry
-          log.warn(
-            `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
-          );
-          result.failed++;
-          result.failedRuns.push({
-            runId,
-            childSessionKey,
-            error: resumeResult.error,
+
+          // Resume the session with the original task context.
+          // We intentionally do NOT clear abortedLastRun before attempting
+          // the resume — if instance dispatch fails (e.g. Gateway still booting),
+          // the flag stays true so the next restart can retry.
+          const resumeResult = await resumeOrphanedSession({
+            gatewayRuntime: params.gatewayRuntime,
+            sessionKey: childSessionKey,
+            task: runRecord.task,
+            lastHumanMessage: extractMessageText(lastHumanMessage),
+            configChangeHint: configChangeDetected
+              ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
+              : undefined,
+            originalRunId: runId,
+            originalRun: runRecord,
           });
+
+          if (resumeResult.resumed) {
+            resumedSessionKeys.add(childSessionKey);
+            // Only clear the aborted flag after confirmed successful resume.
+            try {
+              await patchRecoverySessionEntry({
+                storePath,
+                childSessionKey,
+                update: (current) => {
+                  current.abortedLastRun = false;
+                  markSubagentRecoveryAttempt({
+                    entry: current,
+                    now: Date.now(),
+                    runId,
+                    attempt: recoveryGate.nextAttempt,
+                  });
+                  current.updatedAt = Date.now();
+                },
+              });
+            } catch (err) {
+              log.warn(
+                `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
+              );
+            }
+            result.recovered++;
+          } else {
+            // Flag stays as abortedLastRun=true so next restart can retry
+            log.warn(
+              `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
+            );
+            result.failed++;
+            result.failedRuns.push({
+              runId,
+              childSessionKey,
+              error: resumeResult.error,
+            });
+          }
+        } finally {
+          inFlightOrphanResumes.delete(childSessionKey);
         }
       } catch (err) {
         const error = formatErrorMessage(err);


### PR DESCRIPTION
## What Problem This Solves

On a gateway restart with orphaned subagent sessions, two uncoordinated orphan-recovery scans can dispatch **two independent resume turns for the same child session**, doubling the subagent's real side effects (file edits, tool calls, external API/PR actions) and LLM cost. `scheduleSubagentOrphanRecovery` is invoked from both the subagent-registry access path and the gateway startup sidecar; each `scheduleOrphanRecovery` builds its own **private** `resumedSessionKeys` set (`src/agents/subagent-orphan-recovery.ts:435`), so overlapping scans never see each other's in-flight resume. A per-scan store snapshot (`storeCache`, line 214) widens the window: scan B can act on a cached `abortedLastRun: true` entry after scan A's successful resume already cleared the flag in the store. Fixes #103724.

## Why This Change Was Made

Add a **module-level in-flight guard shared across all scans**: a session is claimed *before* the final store check (so a concurrent scan cannot slip between check and dispatch) and released in a `finally` once the dispatch settles — on success the store's `abortedLastRun=false` becomes the durable guard; on failure the retry chain stays allowed exactly as before. The final orphan check **re-reads the store entry uncached**, so a stale per-scan snapshot cannot re-dispatch a session that was just recovered. There is no persistent module state beyond the in-flight window, so sessions re-orphaned by a *later* restart remain recoverable (no cross-lifecycle staleness). No new options or public surface.

## User Impact

A restart with orphaned subagents resumes each orphan **exactly once**: no duplicated file edits, duplicate PR/API actions, or doubled LLM spend from racing recovery scans.

## Evidence

New concurrency regression test drives two overlapping `recoverOrphanedSubagentSessions` calls (each with its own private set, exactly like the two production schedulers) against one orphaned session, holding the first resume in flight while the second scan passes:

```
main:     AssertionError: expected callGateway to be called once, but got 2 times   ← the double resume
this PR:  20/20 passed — exactly one resume dispatched (recovered=1, skipped=1)
```

Full suite `subagent-orphan-recovery.test.ts` 20/20 (19 existing + 1 new); `tsgo:core` 0 errors; `oxfmt`/`oxlint` clean.
