### PR TITLE
fix(gateway): keep node pending work until work.ack

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1639,6 +1639,34 @@ public struct NodePendingDrainResult: Codable, Sendable {
     }
 }
 
+/// Result of `node.pending.work.ack` for the durable pending-work queue
+/// (distinct from `node.pending.ack` for pending command actions).
+public struct NodePendingWorkAckResult: Codable, Sendable {
+    public let nodeid: String
+    public let revision: Int
+    public let ackedids: [String]
+    public let remainingcount: Int
+
+    public init(
+        nodeid: String,
+        revision: Int,
+        ackedids: [String],
+        remainingcount: Int)
+    {
+        self.nodeid = nodeid
+        self.revision = revision
+        self.ackedids = ackedids
+        self.remainingcount = remainingcount
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case revision
+        case ackedids = "ackedIds"
+        case remainingcount = "remainingCount"
+    }
+}
+
 public struct NodePendingEnqueueParams: Codable, Sendable {
     public let nodeid: String
     public let type: String

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -498,8 +498,8 @@ methods. Treat this as feature discovery, not a full enumeration of
     - `node.invoke` forwards a command to a connected node.
     - `node.invoke.result` returns the result for an invoke request.
     - `node.event` carries node-originated events back into the gateway.
-    - `node.pending.pull` and `node.pending.ack` are the connected-node queue APIs.
-    - `node.pending.enqueue` and `node.pending.drain` manage durable pending work for offline/disconnected nodes.
+    - `node.pending.pull` and `node.pending.ack` are the connected-node queue APIs for pending command actions.
+    - `node.pending.enqueue`, `node.pending.drain`, and `node.pending.work.ack` manage durable pending work for offline/disconnected nodes. Drain is a non-destructive read; nodes must acknowledge returned work ids with `node.pending.work.ack` (separate from action ack).
 
   </Accordion>
 

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -101,6 +101,7 @@ describe("method scope resolution", () => {
 
   it("leaves node-only pending drain outside operator scopes", () => {
     expect(resolveLeastPrivilegeOperatorScopesForMethod("node.pending.drain")).toStrictEqual([]);
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("node.pending.work.ack")).toStrictEqual([]);
   });
 
   it("classifies plugin session actions with a CLI-safe default operator scope", () => {
@@ -555,6 +556,7 @@ describe("plugin approval method registration", () => {
 describe("core gateway method classification", () => {
   it("treats node-role methods as classified even without operator scopes", () => {
     expect(isGatewayMethodClassified("node.pending.drain")).toBe(true);
+    expect(isGatewayMethodClassified("node.pending.work.ack")).toBe(true);
     expect(isGatewayMethodClassified("node.pending.pull")).toBe(true);
     expect(isGatewayMethodClassified("node.pluginSurface.refresh")).toBe(true);
   });

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -210,6 +210,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "node.describe", scope: "operator.read" },
   { name: "node.pluginSurface.refresh", scope: "node" },
   { name: "node.pending.drain", scope: "node" },
+  { name: "node.pending.work.ack", scope: "node" },
   { name: "node.pending.enqueue", scope: "operator.write" },
   { name: "node.invoke", scope: "operator.write" },
   { name: "node.pending.pull", scope: "node" },

--- a/src/gateway/node-pending-work.test.ts
+++ b/src/gateway/node-pending-work.test.ts
@@ -3,6 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ackNodePendingWork,
   drainNodePendingWork,
   enqueueNodePendingWork,
   getNodePendingWorkStateCountForTests,
@@ -25,7 +26,7 @@ describe("node pending work", () => {
     expect(drained.hasMore).toBe(false);
   });
 
-  it("dedupes explicit work by type until the node drains it", () => {
+  it("dedupes explicit work by type until the node acks it", () => {
     const first = enqueueNodePendingWork({ nodeId: "node-2", type: "location.request" });
     const second = enqueueNodePendingWork({ nodeId: "node-2", type: "location.request" });
 
@@ -35,11 +36,40 @@ describe("node pending work", () => {
 
     const drained = drainNodePendingWork("node-2");
     expect(drained.items.map((item) => item.type)).toEqual(["location.request", "status.request"]);
-    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+    // Drain is non-destructive: work stays queued until ack (or expiry).
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
 
     const afterDrain = enqueueNodePendingWork({ nodeId: "node-2", type: "location.request" });
-    expect(afterDrain.deduped).toBe(false);
-    expect(afterDrain.item.id).not.toBe(first.item.id);
+    expect(afterDrain.deduped).toBe(true);
+    expect(afterDrain.item.id).toBe(first.item.id);
+
+    const acked = ackNodePendingWork("node-2", [first.item.id]);
+    expect(acked.ackedIds).toEqual([first.item.id]);
+    expect(acked.remainingCount).toBe(0);
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+
+    const afterAck = enqueueNodePendingWork({ nodeId: "node-2", type: "location.request" });
+    expect(afterAck.deduped).toBe(false);
+    expect(afterAck.item.id).not.toBe(first.item.id);
+  });
+
+  it("redelivers explicit work when a drain response is discarded", () => {
+    const { item } = enqueueNodePendingWork({ nodeId: "node-lost", type: "location.request" });
+
+    const firstDrain = drainNodePendingWork("node-lost");
+    expect(firstDrain.items.map((entry) => entry.id)).toContain(item.id);
+    // Simulate lost res frame: discard payload, do not ack.
+    void firstDrain;
+
+    const secondDrain = drainNodePendingWork("node-lost");
+    expect(secondDrain.items.map((entry) => entry.id)).toContain(item.id);
+    expect(secondDrain.items.find((entry) => entry.id === item.id)?.type).toBe("location.request");
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
+
+    ackNodePendingWork("node-lost", [item.id]);
+    const afterAck = drainNodePendingWork("node-lost");
+    expect(afterAck.items.map((entry) => entry.id)).toEqual(["baseline-status"]);
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
   });
 
   it("keeps hasMore true when the baseline status item is deferred by maxItems", () => {
@@ -49,14 +79,26 @@ describe("node pending work", () => {
 
     expect(drained.items.map((item) => item.type)).toEqual(["location.request"]);
     expect(drained.hasMore).toBe(true);
-    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+    // Unacked work remains; baseline is still deferred until the explicit item is acked.
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
 
     const next = drainNodePendingWork("node-3", { maxItems: 1 });
-    expect(next.items.map((item) => item.id)).toEqual(["baseline-status"]);
-    expect(next.hasMore).toBe(false);
+    expect(next.items.map((item) => item.type)).toEqual(["location.request"]);
+    expect(next.hasMore).toBe(true);
+
+    const locationId = next.items[0]?.id;
+    expect(locationId).toBeTruthy();
+    if (!locationId) {
+      throw new Error("expected location work id");
+    }
+    ackNodePendingWork("node-3", [locationId]);
+
+    const afterAck = drainNodePendingWork("node-3", { maxItems: 1 });
+    expect(afterAck.items.map((item) => item.id)).toEqual(["baseline-status"]);
+    expect(afterAck.hasMore).toBe(false);
   });
 
-  it("keeps explicit work queued when maxItems defers it", () => {
+  it("keeps explicit work queued when maxItems defers it until ack", () => {
     enqueueNodePendingWork({ nodeId: "node-4", type: "status.request", priority: "normal" });
     enqueueNodePendingWork({ nodeId: "node-4", type: "location.request", priority: "high" });
 
@@ -65,10 +107,30 @@ describe("node pending work", () => {
     expect(firstDrain.hasMore).toBe(true);
     expect(getNodePendingWorkStateCountForTests()).toBe(1);
 
+    // Without ack, paging re-returns the highest-priority unacked item.
     const secondDrain = drainNodePendingWork("node-4", { maxItems: 1 });
-    expect(secondDrain.items.map((item) => item.type)).toEqual(["status.request"]);
-    expect(secondDrain.items.map((item) => item.id)).not.toEqual(["baseline-status"]);
-    expect(secondDrain.hasMore).toBe(false);
+    expect(secondDrain.items.map((item) => item.type)).toEqual(["location.request"]);
+    expect(secondDrain.hasMore).toBe(true);
+
+    const locationId = secondDrain.items[0]?.id;
+    expect(locationId).toBeTruthy();
+    if (!locationId) {
+      throw new Error("expected location work id");
+    }
+    ackNodePendingWork("node-4", [locationId]);
+
+    const afterLocationAck = drainNodePendingWork("node-4", { maxItems: 1 });
+    expect(afterLocationAck.items.map((item) => item.type)).toEqual(["status.request"]);
+    expect(afterLocationAck.items.map((item) => item.id)).not.toEqual(["baseline-status"]);
+    expect(afterLocationAck.hasMore).toBe(false);
+    expect(getNodePendingWorkStateCountForTests()).toBe(1);
+
+    const statusId = afterLocationAck.items[0]?.id;
+    expect(statusId).toBeTruthy();
+    if (!statusId) {
+      throw new Error("expected status work id");
+    }
+    ackNodePendingWork("node-4", [statusId]);
     expect(getNodePendingWorkStateCountForTests()).toBe(0);
   });
 
@@ -79,6 +141,16 @@ describe("node pending work", () => {
 
     expect(drained.items.map((item) => item.id)).toEqual(["baseline-status"]);
     expect(getNodePendingWorkStateCountForTests()).toBe(0);
+  });
+
+  it("ignores baseline status ids on ack", () => {
+    const { item } = enqueueNodePendingWork({
+      nodeId: "node-baseline-ack",
+      type: "location.request",
+    });
+    const acked = ackNodePendingWork("node-baseline-ack", ["baseline-status", item.id, "missing"]);
+    expect(acked.ackedIds).toEqual([item.id]);
+    expect(acked.remainingCount).toBe(0);
   });
 
   it("assigns default expiry to queued work without explicit ttl", () => {

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -164,7 +164,13 @@ export function enqueueNodePendingWork(params: {
   return { revision: state.revision, item, deduped: false };
 }
 
-/** Drains pending work for a node, including a baseline status request unless disabled. */
+/**
+ * Reads pending work for a node without deleting it.
+ *
+ * Explicit items stay queued until `ackNodePendingWork` removes them (or they
+ * expire). Deleting on drain used to drop work whenever the drain response
+ * frame was lost after reconnect.
+ */
 export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): DrainResult {
   const normalizedNodeId = nodeId.trim();
   if (!normalizedNodeId) {
@@ -178,7 +184,9 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   }
   const revision = state?.revision ?? 0;
   const maxItems = Math.min(MAX_ITEMS, Math.max(1, Math.trunc(opts.maxItems ?? DEFAULT_MAX_ITEMS)));
-  const explicitItems = state ? sortedItems(state) : [];
+  // Live state may have been pruned empty above; re-read after prune.
+  const liveState = stateByNodeId.get(normalizedNodeId);
+  const explicitItems = liveState ? sortedItems(liveState) : [];
   const items = explicitItems.slice(0, maxItems);
   const hasExplicitStatus = explicitItems.some((item) => item.type === "status.request");
   const includeBaseline = opts.includeDefaultStatus !== false && !hasExplicitStatus;
@@ -187,19 +195,61 @@ export function drainNodePendingWork(nodeId: string, opts: DrainOptions = {}): D
   }
   const explicitReturnedCount = items.filter((item) => item.id !== DEFAULT_STATUS_ITEM_ID).length;
   const baselineIncluded = items.some((item) => item.id === DEFAULT_STATUS_ITEM_ID);
-  if (state && explicitReturnedCount > 0) {
-    for (const item of items) {
-      if (item.id !== DEFAULT_STATUS_ITEM_ID) {
-        state.itemsById.delete(item.id);
-      }
-    }
-    state.revision += 1;
-    pruneStateIfEmpty(normalizedNodeId, state);
-  }
   return {
-    revision: state?.revision ?? revision,
+    revision: liveState?.revision ?? revision,
     items,
     hasMore: explicitItems.length > explicitReturnedCount || (includeBaseline && !baselineIncluded),
+  };
+}
+
+type AckResult = {
+  revision: number;
+  ackedIds: string[];
+  remainingCount: number;
+};
+
+/**
+ * Removes previously drained explicit pending-work items by id.
+ *
+ * Distinct from `node.pending.ack` (pending command actions). Baseline status
+ * ids are ignored so synthetic drain-only items cannot poison the queue.
+ */
+export function ackNodePendingWork(
+  nodeId: string,
+  ids: readonly string[],
+  opts: { nowMs?: number } = {},
+): AckResult {
+  const normalizedNodeId = nodeId.trim();
+  if (!normalizedNodeId) {
+    return { revision: 0, ackedIds: [], remainingCount: 0 };
+  }
+  const nowMs = resolveDateTimestampMs(opts.nowMs ?? Date.now());
+  const state = stateByNodeId.get(normalizedNodeId);
+  if (!state) {
+    return { revision: 0, ackedIds: [], remainingCount: 0 };
+  }
+  pruneExpired(state, nowMs);
+  const ackedIds: string[] = [];
+  let changed = false;
+  for (const rawId of ids) {
+    const id = rawId.trim();
+    if (!id || id === DEFAULT_STATUS_ITEM_ID) {
+      continue;
+    }
+    if (state.itemsById.delete(id)) {
+      ackedIds.push(id);
+      changed = true;
+    }
+  }
+  if (changed) {
+    state.revision += 1;
+  }
+  pruneStateIfEmpty(normalizedNodeId, state);
+  const liveState = stateByNodeId.get(normalizedNodeId);
+  return {
+    revision: liveState?.revision ?? (changed ? state.revision : 0),
+    ackedIds,
+    remainingCount: liveState?.itemsById.size ?? 0,
   };
 }
 

--- a/src/gateway/role-policy.test.ts
+++ b/src/gateway/role-policy.test.ts
@@ -26,10 +26,12 @@ describe("gateway role policy", () => {
     expect(isRoleAuthorizedForMethod("node", "node.event")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "node.pluginSurface.refresh")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "node.pending.drain")).toBe(true);
+    expect(isRoleAuthorizedForMethod("node", "node.pending.work.ack")).toBe(true);
     expect(isRoleAuthorizedForMethod("node", "status")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "status")).toBe(true);
     expect(isRoleAuthorizedForMethod("operator", "node.pluginSurface.refresh")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.pending.drain")).toBe(false);
+    expect(isRoleAuthorizedForMethod("operator", "node.pending.work.ack")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.event")).toBe(false);
   });
 });

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -649,7 +649,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
     loadHandlers: loadNodeHandlers,
   }),
   ...createLazyCoreHandlers({
-    methods: ["node.pending.drain", "node.pending.enqueue"],
+    methods: ["node.pending.drain", "node.pending.work.ack", "node.pending.enqueue"],
     loadHandlers: loadNodePendingHandlers,
   }),
   ...createLazyCoreHandlers({

--- a/src/gateway/server-methods/nodes-pending.test.ts
+++ b/src/gateway/server-methods/nodes-pending.test.ts
@@ -6,6 +6,7 @@ import { nodePendingHandlers } from "./nodes-pending.js";
 
 const mocks = vi.hoisted(() => ({
   drainNodePendingWork: vi.fn(),
+  ackNodePendingWork: vi.fn(),
   enqueueNodePendingWork: vi.fn(),
   maybeWakeNodeWithApns: vi.fn(),
   maybeSendNodeWakeNudge: vi.fn(),
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../node-pending-work.js", () => ({
   drainNodePendingWork: mocks.drainNodePendingWork,
+  ackNodePendingWork: mocks.ackNodePendingWork,
   enqueueNodePendingWork: mocks.enqueueNodePendingWork,
 }));
 
@@ -56,6 +58,7 @@ function respondCall(respond: ReturnType<typeof vi.fn>): RespondCall | undefined
 describe("node.pending handlers", () => {
   beforeEach(() => {
     mocks.drainNodePendingWork.mockReset();
+    mocks.ackNodePendingWork.mockReset();
     mocks.enqueueNodePendingWork.mockReset();
     mocks.maybeWakeNodeWithApns.mockReset();
     mocks.maybeSendNodeWakeNudge.mockReset();
@@ -104,6 +107,57 @@ describe("node.pending handlers", () => {
       client: null,
       context: makeContext() as never,
       req: { type: "req", id: "req-node-pending-drain-missing", method: "node.pending.drain" },
+      isWebchatConnect: () => false,
+    });
+
+    const call = respondCall(respond);
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.message).toContain("connected device identity");
+  });
+
+  it("acks pending work for the connected node identity", async () => {
+    mocks.ackNodePendingWork.mockReturnValue({
+      revision: 5,
+      ackedIds: ["work-1"],
+      remainingCount: 0,
+    });
+    const respond = vi.fn();
+
+    await nodePendingHandlers["node.pending.work.ack"]({
+      params: { ids: ["work-1"] },
+      respond: respond as never,
+      client: { connect: { device: { id: "ios-node-1" } } } as never,
+      context: makeContext() as never,
+      req: { type: "req", id: "req-node-pending-work-ack", method: "node.pending.work.ack" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.ackNodePendingWork).toHaveBeenCalledWith("ios-node-1", ["work-1"]);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        nodeId: "ios-node-1",
+        revision: 5,
+        ackedIds: ["work-1"],
+        remainingCount: 0,
+      },
+      undefined,
+    );
+  });
+
+  it("rejects node.pending.work.ack without a connected device identity", async () => {
+    const respond = vi.fn();
+
+    await nodePendingHandlers["node.pending.work.ack"]({
+      params: { ids: ["work-1"] },
+      respond: respond as never,
+      client: null,
+      context: makeContext() as never,
+      req: {
+        type: "req",
+        id: "req-node-pending-work-ack-missing",
+        method: "node.pending.work.ack",
+      },
       isWebchatConnect: () => false,
     });
 

--- a/src/gateway/server-methods/nodes-pending.ts
+++ b/src/gateway/server-methods/nodes-pending.ts
@@ -3,10 +3,12 @@
 import {
   ErrorCodes,
   errorShape,
+  validateNodePendingAckParams,
   validateNodePendingDrainParams,
   validateNodePendingEnqueueParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import {
+  ackNodePendingWork,
   drainNodePendingWork,
   enqueueNodePendingWork,
   type NodePendingWorkPriority,
@@ -54,11 +56,47 @@ export const nodePendingHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params as { maxItems?: number };
+    // Non-destructive read: items remain until node.pending.work.ack.
     const drained = drainNodePendingWork(nodeId, {
       maxItems: p.maxItems,
       includeDefaultStatus: true,
     });
     respond(true, { nodeId, ...drained }, undefined);
+  },
+  "node.pending.work.ack": async ({ params, respond, client }) => {
+    if (!validateNodePendingAckParams(params)) {
+      respondInvalidParams({
+        respond,
+        method: "node.pending.work.ack",
+        validator: validateNodePendingAckParams,
+      });
+      return;
+    }
+    const nodeId = resolveClientNodeId(client);
+    if (!nodeId) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "node.pending.work.ack requires a connected device identity",
+        ),
+      );
+      return;
+    }
+    const p = params as { ids: string[] };
+    // Work-queue ack only — not the separate node.pending.ack action queue.
+    const acked = ackNodePendingWork(nodeId, p.ids);
+    respond(
+      true,
+      {
+        nodeId,
+        revision: acked.revision,
+        ackedIds: acked.ackedIds,
+        remainingCount: acked.remainingCount,
+      },
+      undefined,
+    );
   },
   "node.pending.enqueue": async ({ params, respond, context }) => {
     if (!validateNodePendingEnqueueParams(params)) {


### PR DESCRIPTION
Closes #103779

## What Problem This Solves

Fixes an issue where operators queueing work for a paired node (for example a location or status request while the node is offline) would permanently lose that work when the node reconnects, drains the queue, and the drain response frame is dropped on the fragile reconnect link. The next drain returned only the baseline status item, with no result and no recovery signal for the requester.

## Why This Change Was Made

`node.pending.drain` used to delete explicit pending-work items in the same synchronous call that built the response, before the fire-and-forget WebSocket `res` frame was delivered. This change makes drain a non-destructive read and adds a work-queue-specific acknowledgement RPC (`node.pending.work.ack`) so items are removed only after the node confirms receipt. That is distinct from the existing `node.pending.ack` path, which owns the separate pending *command actions* queue. Baseline synthetic status items remain drain-only and are ignored on ack. Protocol docs and the shared Swift protocol model document the new ack result shape.

## User Impact

Paired-node pending work (location/status prompts queued for reconnect) survives a lost drain response and can be redelivered on the next drain until the node acknowledges the work ids. Nodes that already drain without ack will now see at-least-once redelivery until they call `node.pending.work.ack` (or the item expires). Operators no longer lose queued node work solely because the post-reconnect response frame dropped.

## Evidence

Verification host: local macOS (Crabbox bypass; Blacksmith Testbox binary not on PATH).

Focused tests:

```text
node scripts/run-vitest.mjs \
  src/gateway/node-pending-work.test.ts \
  src/gateway/server-methods/nodes-pending.test.ts \
  src/gateway/role-policy.test.ts \
  src/gateway/method-scopes.test.ts
# 14 files / 478 tests passed
```

Targeted redelivery case:

```text
node scripts/run-vitest.mjs src/gateway/node-pending-work.test.ts \
  -t "redelivers explicit work when a drain response is discarded"
# 3 passed (gateway-core/server/client shards)
```

Local static checks on touched TS:

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <touched gateway TS>
# 0 warnings, 0 errors
pnpm exec oxfmt --check <touched files>
# format clean
git diff --check
# clean
```

`pnpm check:changed` defaults to Crabbox/Testbox delegation here and could not warm Blacksmith (`blacksmith` missing on PATH); local oxlint/format/focused Vitest cover the touched surface.

## Real behavior proof

- Behavior addressed: destructive `drainNodePendingWork` no longer deletes explicit work before delivery; lost drain responses redeliver the same work; removal requires `ackNodePendingWork` / `node.pending.work.ack`.
- Environment: local macOS openclaw checkout on branch `fix/103779-node-pending-work-ack`, commit `10215ca08`, Node via `node scripts/run-vitest.mjs`.
- Current-main contrast: on main, enqueue `location.request` → `drainNodePendingWork` → discard payload → second drain cannot return the item (queue empty). After this patch, second drain still returns the same work id until ack.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/gateway/node-pending-work.test.ts -t "redelivers explicit work when a drain response is discarded"`
  2. Full focused suite above for handler + role/method classification of `node.pending.work.ack`
- Evidence after fix: redelivery test passes; suite shows drain leaves state until ack; handler test asserts `node.pending.work.ack` calls `ackNodePendingWork` and returns `ackedIds` / `remainingCount`.
- Control check: baseline-only drain still allocates no state; baseline ids are ignored on ack; action-queue `node.pending.ack` is unchanged; operator roles still cannot call the node work ack method.
- Observed result after fix: lost drain responses redeliver explicit work; ack clears it; subsequent drain is baseline-only.
- What was not tested: live iOS/Android node app reconnect over a real WebSocket (no current app caller of `node.pending.drain` in-tree); full `pnpm check:changed` via Blacksmith Testbox (unavailable on this host).

## AI disclosure

This PR was authored with AI assistance (Grok). Human review of protocol consumer impact remains welcome before merge.
