### PR TITLE
fix(gateway): reconcile config watcher after error recovery

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -640,17 +640,32 @@ describe("resolveGatewayReloadSettings", () => {
 });
 
 type WatcherHandler = () => void;
-type WatcherEvent = "add" | "change" | "unlink" | "error";
+type WatcherEvent = "add" | "change" | "unlink" | "error" | "ready";
 
 function createWatcherMock(effectiveUsePolling?: boolean) {
   const handlers = new Map<WatcherEvent, WatcherHandler[]>();
+  const register = (event: WatcherEvent, handler: WatcherHandler) => {
+    const existing = handlers.get(event) ?? [];
+    existing.push(handler);
+    handlers.set(event, existing);
+  };
   return {
     effectiveUsePolling,
     options: { usePolling: false },
     on(event: WatcherEvent, handler: WatcherHandler) {
-      const existing = handlers.get(event) ?? [];
-      existing.push(handler);
-      handlers.set(event, existing);
+      register(event, handler);
+      return this;
+    },
+    once(event: WatcherEvent, handler: WatcherHandler) {
+      const wrapped: WatcherHandler = () => {
+        const list = handlers.get(event) ?? [];
+        const idx = list.indexOf(wrapped);
+        if (idx >= 0) {
+          list.splice(idx, 1);
+        }
+        handler();
+      };
+      register(event, wrapped);
       return this;
     },
     emit(event: WatcherEvent) {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -443,7 +443,7 @@ export function startGatewayConfigReloader(opts: {
   let degradedToPolling = false;
   let watcherUsesPolling = false;
 
-  const createWatcher = () => {
+  const createWatcher = async () => {
     if (stopped) {
       return;
     }
@@ -462,6 +462,16 @@ export function startGatewayConfigReloader(opts: {
     watcher = next;
     watcherUsesPolling = next.options.usePolling;
     hotReloadStatus = "active";
+
+    // Reconcile against the current on-disk config after watcher recreation.
+    // Without this, any edit made during the watcher-down window (e.g., manual
+    // edit or separate `openclaw doctor --fix` run) would be silently adopted
+    // as the new baseline and never scheduled for reload.
+    // See: https://github.com/openclaw/openclaw/issues/103729
+    if (watcherRecreateRetries > 0 || degradedToPolling) {
+      opts.log.info("config watcher re-created; performing reconciliation read");
+      schedule();
+    }
   };
 
   const handleWatcherError = (source: typeof watcher, err: unknown) => {
@@ -483,9 +493,9 @@ export function startGatewayConfigReloader(opts: {
         opts.log.warn(
           `config watcher native retries exhausted; degrading to polling mode: ${String(err)}`,
         );
-        watcherRecreateTimer = setTimeout(() => {
+        watcherRecreateTimer = setTimeout(async () => {
           watcherRecreateTimer = null;
-          createWatcher();
+          await createWatcher();
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
@@ -504,13 +514,15 @@ export function startGatewayConfigReloader(opts: {
     opts.log.warn(
       `config watcher error; re-creating watcher (attempt ${watcherRecreateRetries}/${WATCHER_RECREATE_MAX_RETRIES} in ${backoff}ms): ${String(err)}`,
     );
-    watcherRecreateTimer = setTimeout(() => {
+    watcherRecreateTimer = setTimeout(async () => {
       watcherRecreateTimer = null;
-      createWatcher();
+      await createWatcher();
     }, backoff);
   };
 
-  createWatcher();
+  // Initial watcher creation (no reconciliation needed on startup since
+  // the config was already read and applied before the first watcher exists).
+  void createWatcher();
 
   return {
     stop: async () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -463,14 +463,17 @@ export function startGatewayConfigReloader(opts: {
     watcherUsesPolling = next.options.usePolling;
     hotReloadStatus = "active";
 
-    // Reconcile against the current on-disk config after watcher recreation.
-    // Without this, any edit made during the watcher-down window (e.g., manual
-    // edit or separate `openclaw doctor --fix` run) would be silently adopted
-    // as the new baseline and never scheduled for reload.
+    // Reconcile against the current on-disk config only after the replacement
+    // watcher emits its one-shot `ready` event. Without waiting for ready, an
+    // edit made after the reconciliation snapshot but before the watcher starts
+    // tracking would become its ignored initial baseline, leaving the gateway
+    // on stale config until the next write.
     // See: https://github.com/openclaw/openclaw/issues/103729
     if (watcherRecreateRetries > 0 || degradedToPolling) {
-      opts.log.info("config watcher re-created; performing reconciliation read");
-      schedule();
+      next.once("ready", () => {
+        opts.log.info("config watcher ready after recreation; performing reconciliation read");
+        schedule();
+      });
     }
   };
 
@@ -493,9 +496,9 @@ export function startGatewayConfigReloader(opts: {
         opts.log.warn(
           `config watcher native retries exhausted; degrading to polling mode: ${String(err)}`,
         );
-        watcherRecreateTimer = setTimeout(async () => {
+        watcherRecreateTimer = setTimeout(() => {
           watcherRecreateTimer = null;
-          await createWatcher();
+          void createWatcher();
         }, WATCHER_RECREATE_BACKOFF_MS[0] ?? 500);
         return;
       }
@@ -514,9 +517,9 @@ export function startGatewayConfigReloader(opts: {
     opts.log.warn(
       `config watcher error; re-creating watcher (attempt ${watcherRecreateRetries}/${WATCHER_RECREATE_MAX_RETRIES} in ${backoff}ms): ${String(err)}`,
     );
-    watcherRecreateTimer = setTimeout(async () => {
+    watcherRecreateTimer = setTimeout(() => {
       watcherRecreateTimer = null;
-      await createWatcher();
+      void createWatcher();
     }, backoff);
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #103729 — When the gateway config watcher hits an error (e.g., EMFILE/ENOSPC inotify exhaustion) and is re-created after backoff, any config edit made during the watcher-down window (e.g., manual edit or separate `openclaw doctor --fix` run) is silently adopted as the new baseline and never scheduled for reload.

## Why This Change Was Made

The chokidar watcher is created with `ignoreInitial: true`, which suppresses the initial `add` event. On first creation this is fine because the config was already read and applied before the watcher exists. However, when the watcher is re-created after an error, there's a window where:

1. The watcher is down during the backoff period
2. An external edit lands on disk
3. The re-created watcher adopts the edited file as its baseline
4. `ignoreInitial: true` suppresses any event for that edit
5. The gateway silently keeps the stale pre-edit config

The fix adds a reconciliation read after watcher recreation that schedules a reload if the watcher was re-created (`watcherRecreateRetries > 0`) or degraded to polling. This ensures external edits made during the watcher-down window are picked up.

## User Impact

Users who experience inotify exhaustion (common on hosts with low `fs.inotify.max_user_watches`) will now have their config edits picked up after the watcher recovers, rather than being silently dropped until some unrelated future write triggers a reload.

## Evidence

- The fix is a minimal change to `src/gateway/config-reload.ts:432-461`:
  - `createWatcher()` is now `async` and calls `schedule()` after recreation
  - The reconciliation only runs when `watcherRecreateRetries > 0 || degradedToPolling`
  - Initial watcher creation still has no reconciliation (correct, since config is already applied)
- All existing tests pass: `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts`
- Code formatting: `pnpm format:check -- src/gateway/config-reload.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
