### PR TITLE
fix(agents): surface claude-cli logged-out failures as actionable re-auth errors (#103773)

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -120,6 +120,20 @@ describe("oauth refresh failure hints", () => {
     });
   });
 
+  it("classifies structured claude-cli logged-out failures without the provider prefix in the message", () => {
+    const error = new FailoverError("Not logged in \u00b7 Please run /login", {
+      reason: "auth",
+      provider: "claude-cli",
+      model: "claude-sonnet-4-20250514",
+      status: 401,
+    });
+
+    expect(classifyOAuthRefreshFailureError(error)).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+  });
+
   it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {
     // A generic 401 from another provider should NOT be treated as an OAuth
     // refresh failure — it lacks the "claude-cli" provider prefix.

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -75,18 +75,24 @@ function readStructuredClaudeCliAuthFailure(err: unknown): StructuredClaudeCliAu
   return candidate;
 }
 
-function isStructuredClaudeCliExpiredOAuthFailure(err: unknown): boolean {
+function classifyStructuredClaudeCliOAuthFailureReason(
+  err: unknown,
+): OAuthRefreshFailureReason | null {
   const failure = readStructuredClaudeCliAuthFailure(err);
   if (!failure) {
-    return false;
+    return null;
   }
   const rawError = typeof failure.rawError === "string" ? failure.rawError : "";
   const message = err instanceof Error ? err.message : "";
   const combined = `${message}\n${rawError}`;
   const lower = combined.toLowerCase();
-  return (
-    lower.includes("failed to authenticate") || lower.includes("invalid authentication credentials")
-  );
+  if (/\bnot logged in\b\s*·\s*please run \/login\b/i.test(combined)) {
+    return "sign_in_again";
+  }
+  const hasExpiredTokenSignal =
+    lower.includes("failed to authenticate") ||
+    lower.includes("invalid authentication credentials");
+  return hasExpiredTokenSignal ? "revoked" : null;
 }
 
 function isOAuthRefreshFailureMessage(message: string): boolean {
@@ -181,10 +187,11 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
   const seen = new Set<object>();
   let candidate = err;
   while (candidate && typeof candidate === "object") {
-    if (isStructuredClaudeCliExpiredOAuthFailure(candidate)) {
+    const claudeCliReason = classifyStructuredClaudeCliOAuthFailureReason(candidate);
+    if (claudeCliReason) {
       return {
         provider: "claude-cli",
-        reason: "revoked",
+        reason: claudeCliReason,
       };
     }
     if (candidate instanceof OAuthRefreshFailureError) {

--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import {
+  classifyFailoverReason,
   extractFailoverSignalDetails,
   formatAssistantErrorText,
   isLikelyContextOverflowError,
@@ -22,6 +23,16 @@ vi.mock("../../logging/subsystem.js", () => ({
     warn: vi.fn(),
   }),
 }));
+
+describe("Claude CLI logged-out failures", () => {
+  const loggedOutMessage = "Not logged in · Please run /login";
+
+  it("classifies the logged-out response as auth only for claude-cli", () => {
+    expect(classifyFailoverReason(loggedOutMessage, { provider: "claude-cli" })).toBe("auth");
+    expect(classifyFailoverReason(loggedOutMessage, { provider: "openai" })).toBeNull();
+    expect(classifyFailoverReason(loggedOutMessage)).toBeNull();
+  });
+});
 
 describe("formatAssistantErrorText streaming JSON parse classification", () => {
   beforeEach(() => {

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -989,6 +989,15 @@ function isExactUnknownNoDetailsError(raw: string): boolean {
   );
 }
 
+function isClaudeCliLoggedOutError(raw: string, provider?: string): boolean {
+  // This upstream phrase is generic prose. Provider identity must come from
+  // the runner metadata so other providers cannot inherit Claude CLI policy.
+  if (normalizeOptionalLowercaseString(provider)?.trim() !== "claude-cli") {
+    return false;
+  }
+  return /\bnot logged in\b\s*·\s*please run \/login\b/i.test(raw);
+}
+
 function classifyFailoverClassificationFromMessage(
   raw: string,
   provider?: string,
@@ -1053,6 +1062,9 @@ function classifyFailoverClassificationFromMessage(
   // Auth classifiers run before the broad isJsonApiInternalServerError check so that
   // provider errors like {"type":"api_error","message":"invalid api key"} are
   // correctly classified as "auth" rather than "timeout".
+  if (isClaudeCliLoggedOutError(raw, provider)) {
+    return toReasonClassification("auth");
+  }
   const oauthRefreshFailure = classifyOAuthRefreshFailure(raw);
   if (oauthRefreshFailure?.reason) {
     return toReasonClassification("auth_permanent");

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -242,6 +242,27 @@ describe("runAgentTurnWithFallback: authentication failures", () => {
     }
   });
 
+  it("surfaces the claude-cli re-auth hint when the CLI session is logged out", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("Not logged in · Please run /login", {
+        reason: "auth",
+        provider: "claude-cli",
+        model: "claude-sonnet-4-20250514",
+        status: 401,
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(


### PR DESCRIPTION
## What Problem This Solves

Fixes #103773.

Claude CLI emits `Not logged in · Please run /login` when its session is logged out. OpenClaw previously classified that result as an unknown external failure, so users received the generic `/new` guidance even though every new session failed identically.

This repair keeps the Claude-specific phrase out of global auth matchers. The provider-aware classifier recognizes the exact response only when runner metadata identifies `provider === "claude-cli"`, then carries the structured auth failure into the existing Claude CLI `sign_in_again` recovery path.

Users now receive the actionable combined login command:

`claude auth login && openclaw models auth login --provider anthropic --method cli`

Release note: Claude CLI logged-out failures now surface re-login guidance instead of a generic agent failure.

## Evidence

- Positive classifier proof: the logged-out text with provider `claude-cli` maps to `auth`.
- Negative classifier proof: identical text with provider `openai` or with no provider does not map to `auth`.
- Structured recovery proof: the Claude CLI failure maps to `sign_in_again`.
- Execution integration proof lives in the current split suite at `src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts` and asserts the full user-facing recovery text.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/errors.test.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts` — 3 shards, 36 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers/errors.test.ts src/agents/auth-profiles/oauth-refresh-failure.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts` — Blacksmith Testbox exit 0.
- Fresh autoreview after the final rebase: no accepted/actionable findings.

## Real behavior proof

The contributor live-verified Claude Code v2.1.206 on macOS with a scratch `CLAUDE_CONFIG_DIR`: `claude -p 'hi' --output-format json` exited 1 and returned `is_error: true`, `terminal_reason: "api_error"`, and `result: "Not logged in · Please run /login"` on stdout with empty stderr. The repair matches that exact upstream response only inside the Claude CLI provider path.

An independent local rerun was unavailable because the installed `claude` shim reports that its native binary is not installed. The captured live response remains valid and the provider-specific positive/negative paths are covered by the focused and integration tests above.

What was not tested: a Telegram round trip against a live logged-out gateway. The integration test exercises the same agent-runner failure reply path using the live-captured upstream text.
