### PR TITLE
chore(swift): restore compact conditional bodies

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7011,7 +7011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 560,
+      "line": 558,
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "artifacts repaired",
       "surface": "apple",
@@ -7019,7 +7019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 560,
+      "line": 558,
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "no repair needed",
       "surface": "apple",
@@ -7107,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 190,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instance",
       "surface": "apple",
@@ -7115,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 192,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Device",
       "surface": "apple",
@@ -7123,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 196,
+      "line": 194,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Host",
       "surface": "apple",
@@ -7131,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 198,
+      "line": 196,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "IP",
       "surface": "apple",
@@ -7139,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 198,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Platform",
       "surface": "apple",
@@ -7147,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 200,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Version",
       "surface": "apple",
@@ -7155,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 204,
+      "line": 202,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Mode",
       "surface": "apple",
@@ -7163,7 +7163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 209,
+      "line": 207,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Scopes",
       "surface": "apple",
@@ -7171,7 +7171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 210,
+      "line": 208,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Roles",
       "surface": "apple",
@@ -7179,7 +7179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 211,
+      "line": 209,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Tags",
       "surface": "apple",
@@ -7187,7 +7187,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 240,
+      "line": 238,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Copy \\(title)",
       "surface": "apple",
@@ -7195,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 249,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "None reported.",
       "surface": "apple",
@@ -7299,7 +7299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 45,
+      "line": 43,
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Online",
       "surface": "apple",
@@ -7307,7 +7307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 45,
+      "line": 43,
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Ready",
       "surface": "apple",
@@ -7315,7 +7315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 46,
+      "line": 44,
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Not selected",
       "surface": "apple",
@@ -7323,7 +7323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 46,
+      "line": 44,
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Selected",
       "surface": "apple",
@@ -7523,7 +7523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 593,
+      "line": 579,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading skill status.",
       "surface": "apple",
@@ -7531,7 +7531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 593,
+      "line": 579,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Skill status is available from the gateway.",
       "surface": "apple",
@@ -7539,7 +7539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 615,
+      "line": 601,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Instance presence is available.",
       "surface": "apple",
@@ -7547,7 +7547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 615,
+      "line": 601,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading instance presence.",
       "surface": "apple",
@@ -7555,7 +7555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 634,
+      "line": 620,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "\\(cronStatus.jobs)",
       "surface": "apple",
@@ -7563,7 +7563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 640,
+      "line": 626,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron status is available.",
       "surface": "apple",
@@ -7571,7 +7571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 640,
+      "line": 626,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading cron status.",
       "surface": "apple",
@@ -7579,7 +7579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 645,
+      "line": 631,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler disabled",
       "surface": "apple",
@@ -7587,7 +7587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 645,
+      "line": 631,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler enabled",
       "surface": "apple",
@@ -7595,7 +7595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 670,
+      "line": 656,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading recent usage.",
       "surface": "apple",
@@ -7603,7 +7603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 670,
+      "line": 656,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Recent usage is available.",
       "surface": "apple",
@@ -7611,7 +7611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 689,
+      "line": 675,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Background memory status is available.",
       "surface": "apple",
@@ -7619,7 +7619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 689,
+      "line": 675,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading dreaming status.",
       "surface": "apple",
@@ -7747,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 311,
+      "line": 307,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup: \\(install)",
       "surface": "apple",
@@ -7755,7 +7755,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 330,
+      "line": 326,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Set up \\(skill.displayName)",
       "surface": "apple",
@@ -7763,7 +7763,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 339,
+      "line": 335,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Edit \\(skill.displayName)",
       "surface": "apple",
@@ -7771,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 399,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill unavailable",
       "surface": "apple",
@@ -7779,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
+      "line": 401,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Return to the skills list and choose another skill.",
       "surface": "apple",
@@ -7787,7 +7787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 412,
+      "line": 408,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill",
       "surface": "apple",
@@ -7795,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 447,
+      "line": 443,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Close",
       "surface": "apple",
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 480,
+      "line": 476,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Enabled globally",
       "surface": "apple",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 490,
+      "line": 486,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key",
       "surface": "apple",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 498,
+      "line": 494,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Save key",
       "surface": "apple",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 505,
+      "line": 501,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Get key",
       "surface": "apple",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 559,
+      "line": 555,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Off",
       "surface": "apple",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 559,
+      "line": 555,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "On",
       "surface": "apple",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 565,
+      "line": 561,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup",
       "surface": "apple",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 564,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Missing: \\(missing)",
       "surface": "apple",
@@ -7867,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 572,
+      "line": 568,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "No missing requirements reported.",
       "surface": "apple",
@@ -7875,7 +7875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 595,
+      "line": 591,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Key",
       "surface": "apple",
@@ -7883,7 +7883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 596,
+      "line": 592,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Source",
       "surface": "apple",
@@ -7891,7 +7891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 679,
+      "line": 675,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy reset.",
       "surface": "apple",
@@ -7899,7 +7899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 679,
+      "line": 675,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy saved.",
       "surface": "apple",
@@ -7907,7 +7907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 692,
+      "line": 688,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill disabled.",
       "surface": "apple",
@@ -7915,7 +7915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 692,
+      "line": 688,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill enabled.",
       "surface": "apple",
@@ -7923,7 +7923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 704,
+      "line": 700,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key cleared.",
       "surface": "apple",
@@ -7931,7 +7931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 704,
+      "line": 700,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key saved.",
       "surface": "apple",
@@ -8427,7 +8427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 257,
+      "line": 253,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "New Group",
       "surface": "apple",
@@ -8435,7 +8435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 257,
+      "line": 253,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Rename Session",
       "surface": "apple",
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 261,
+      "line": 257,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Group name",
       "surface": "apple",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 261,
+      "line": 257,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Session name",
       "surface": "apple",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 322,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "View More",
       "surface": "apple",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 747,
+      "line": 743,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Group name",
       "surface": "apple",
@@ -8579,7 +8579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 752,
+      "line": 748,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Create",
       "surface": "apple",
@@ -8587,7 +8587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 752,
+      "line": 748,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Save",
       "surface": "apple",
@@ -8595,7 +8595,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 762,
+      "line": 758,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group?",
       "surface": "apple",
@@ -8603,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 770,
+      "line": 766,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group",
       "surface": "apple",
@@ -8611,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 770,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -8619,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 778,
+      "line": 774,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions in \\u{201C}\\(group)\\u{201D} move back to Ungrouped.",
       "surface": "apple",
@@ -8627,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 786,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions",
       "surface": "apple",
@@ -8635,7 +8635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 804,
+      "line": 800,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions",
       "surface": "apple",
@@ -8643,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 809,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Show Archived",
       "surface": "apple",
@@ -8651,7 +8651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 827,
+      "line": 823,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
@@ -8659,7 +8659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 837,
+      "line": 833,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8667,7 +8667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 864,
+      "line": 860,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading archived sessions",
       "surface": "apple",
@@ -8675,7 +8675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 864,
+      "line": 860,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading recent sessions",
       "surface": "apple",
@@ -8683,7 +8683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 897,
+      "line": 893,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No archived sessions",
       "surface": "apple",
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 897,
+      "line": 893,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No recent sessions",
       "surface": "apple",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 901,
+      "line": 897,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions will appear here.",
       "surface": "apple",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 901,
+      "line": 897,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 931,
+      "line": 927,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group…",
       "surface": "apple",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 934,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group…",
       "surface": "apple",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 944,
+      "line": 940,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group…",
       "surface": "apple",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 950,
+      "line": 946,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group",
       "surface": "apple",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 950,
+      "line": 946,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group",
       "surface": "apple",
@@ -9379,7 +9379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 970,
+      "line": 968,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No \\(IPadWorkboardDefaults.label(for: self.status).lowercased()) cards",
       "surface": "apple",
@@ -9387,7 +9387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 969,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cards moved into this lane appear here.",
       "surface": "apple",
@@ -9395,7 +9395,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1156,
+      "line": 1154,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card Actions",
       "surface": "apple",
@@ -9403,7 +9403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1171,
+      "line": 1169,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open",
       "surface": "apple",
@@ -9411,7 +9411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1202,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Inspect",
       "surface": "apple",
@@ -9419,7 +9419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1211,
+      "line": 1209,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move to \\(IPadWorkboardDefaults.label(for: status))",
       "surface": "apple",
@@ -9427,7 +9427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1258,
+      "line": 1256,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Default agent",
       "surface": "apple",
@@ -9435,7 +9435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1277,
+      "line": 1275,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Title",
       "surface": "apple",
@@ -9443,7 +9443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1278,
+      "line": 1276,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Status",
       "surface": "apple",
@@ -9451,7 +9451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1284,
+      "line": 1282,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card",
       "surface": "apple",
@@ -9459,7 +9459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1293,
+      "line": 1291,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open Session",
       "surface": "apple",
@@ -9467,7 +9467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1307,
+      "line": 1305,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move",
       "surface": "apple",
@@ -9475,7 +9475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1314,
+      "line": 1312,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Archive",
       "surface": "apple",
@@ -9483,7 +9483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1314,
+      "line": 1312,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Unarchive",
       "surface": "apple",
@@ -9491,7 +9491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1319,
+      "line": 1317,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Actions",
       "surface": "apple",
@@ -9499,7 +9499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1330,
+      "line": 1328,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Done",
       "surface": "apple",
@@ -9827,7 +9827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 401,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Stop",
       "surface": "apple",
@@ -9835,7 +9835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 408,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Start",
       "surface": "apple",
@@ -9843,7 +9843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 433,
+      "line": 417,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Logout",
       "surface": "apple",
@@ -9851,7 +9851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 587,
+      "line": 555,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Could not encode channel request.",
       "surface": "apple",
@@ -9859,7 +9859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 572,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connected",
       "surface": "apple",
@@ -9867,7 +9867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 582,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading",
       "surface": "apple",
@@ -9875,7 +9875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 624,
+      "line": 592,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading channel status",
       "surface": "apple",
@@ -9883,7 +9883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 625,
+      "line": 593,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Checking installed channel clients and account state.",
       "surface": "apple",
@@ -9891,7 +9891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 598,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Empty",
       "surface": "apple",
@@ -9899,7 +9899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 632,
+      "line": 600,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Message Routing",
       "surface": "apple",
@@ -9907,7 +9907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 635,
+      "line": 603,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Refresh Channels",
       "surface": "apple",
@@ -9915,7 +9915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 639,
+      "line": 607,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "No channel plugins reported",
       "surface": "apple",
@@ -9923,7 +9923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 640,
+      "line": 608,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Install or enable channel plugins on the gateway, then refresh.",
       "surface": "apple",
@@ -9931,7 +9931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 645,
+      "line": 613,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Error",
       "surface": "apple",
@@ -9939,7 +9939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 648,
+      "line": 616,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Channel status unavailable",
       "surface": "apple",
@@ -9947,7 +9947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 649,
+      "line": 617,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway returned an unexpected channel status response.",
       "surface": "apple",
@@ -9955,7 +9955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 622,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Offline",
       "surface": "apple",
@@ -9963,7 +9963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 657,
+      "line": 625,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway offline",
       "surface": "apple",
@@ -9971,7 +9971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 658,
+      "line": 626,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connect to the gateway to load installed channels, accounts, and routing status.",
       "surface": "apple",
@@ -10227,7 +10227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1080,
+      "line": 1070,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -10235,7 +10235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1080,
+      "line": 1070,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -10243,7 +10243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1159,
+      "line": 1135,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -10251,7 +10251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1159,
+      "line": 1135,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -10259,7 +10259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1207,
+      "line": 1177,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -10267,7 +10267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1207,
+      "line": 1177,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -10275,7 +10275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1212,
+      "line": 1182,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -10283,7 +10283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1212,
+      "line": 1182,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -10291,7 +10291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1214,
+      "line": 1184,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -10299,7 +10299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1214,
+      "line": 1184,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -10307,7 +10307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1247,
+      "line": 1205,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -11451,7 +11451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 444,
+      "line": 430,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected",
       "surface": "apple",
@@ -11459,7 +11459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 446,
+      "line": 432,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Gateway online",
       "surface": "apple",
@@ -11467,7 +11467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 447,
+      "line": 433,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected to openclaw-gateway.tailnet.ts.net.",
       "surface": "apple",
@@ -11475,7 +11475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 443,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Loading",
       "surface": "apple",
@@ -11483,7 +11483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 459,
+      "line": 445,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking gateway",
       "surface": "apple",
@@ -11491,7 +11491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 460,
+      "line": 446,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Refreshing connection, discovery, and device trust state.",
       "surface": "apple",
@@ -11499,7 +11499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 452,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Empty",
       "surface": "apple",
@@ -11507,7 +11507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 468,
+      "line": 454,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "No gateway configured",
       "surface": "apple",
@@ -11515,7 +11515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 469,
+      "line": 455,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan a setup QR code, paste a setup code, or choose a discovered gateway.",
       "surface": "apple",
@@ -11523,7 +11523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 475,
+      "line": 461,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Error",
       "surface": "apple",
@@ -11531,7 +11531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 477,
+      "line": 463,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale warning",
       "surface": "apple",
@@ -11539,7 +11539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 478,
+      "line": 464,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -11547,7 +11547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 513,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Address",
       "surface": "apple",
@@ -11555,7 +11555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 515,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Server",
       "surface": "apple",
@@ -11563,7 +11563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 531,
+      "line": 517,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered",
       "surface": "apple",
@@ -11571,7 +11571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 533,
+      "line": 519,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -11579,7 +11579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 541,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Reconnect",
       "surface": "apple",
@@ -11587,7 +11587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 556,
+      "line": 542,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Diagnose",
       "surface": "apple",
@@ -11595,7 +11595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 565,
+      "line": 551,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -11603,7 +11603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 552,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connect",
       "surface": "apple",
@@ -11611,7 +11611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 554,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "surface": "apple",
@@ -11755,7 +11755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 391,
+      "line": 368,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -11763,7 +11763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 393,
+      "line": 370,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Requesting approval",
       "surface": "apple",
@@ -11771,7 +11771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 395,
+      "line": 372,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -11779,7 +11779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 397,
+      "line": 374,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice API key missing",
       "surface": "apple",
@@ -11787,7 +11787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 399,
+      "line": 376,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice config failed",
       "surface": "apple",
@@ -11795,7 +11795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 466,
+      "line": 421,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Start Talk",
       "surface": "apple",
@@ -11803,7 +11803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 467,
+      "line": 422,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Stop Talk",
       "surface": "apple",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 468,
+      "line": 423,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Enable Talk",
       "surface": "apple",
@@ -11819,7 +11819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 469,
+      "line": 424,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Gateway Settings",
       "surface": "apple",
@@ -11827,7 +11827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 469,
+      "line": 424,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Voice Settings",
       "surface": "apple",
@@ -11835,7 +11835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 470,
+      "line": 425,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Demo Mode Only",
       "surface": "apple",
@@ -11843,7 +11843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 470,
+      "line": 425,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Waiting for Approval",
       "surface": "apple",
@@ -12075,7 +12075,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1266,
+      "line": 1264,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
@@ -12083,7 +12083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1271,
+      "line": 1269,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Check Tailscale or LAN.",
       "surface": "apple",
@@ -12787,7 +12787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3265,
+      "line": 3237,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -12795,7 +12795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3265,
+      "line": 3237,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -12803,7 +12803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3912,
+      "line": 3884,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12811,7 +12811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3912,
+      "line": 3884,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -12819,7 +12819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3916,
+      "line": 3888,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -12827,7 +12827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3916,
+      "line": 3888,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -12835,7 +12835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4235,
+      "line": 4207,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -12843,7 +12843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4235,
+      "line": 4207,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -13259,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 198,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
@@ -13267,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 305,
+      "line": 303,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code",
       "surface": "apple",
@@ -13275,7 +13275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 313,
+      "line": 311,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -13283,7 +13283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 318,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
@@ -13291,7 +13291,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 361,
+      "line": 359,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
@@ -13299,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 369,
+      "line": 367,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
@@ -13307,7 +13307,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 395,
+      "line": 393,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Dismiss Keyboard",
       "surface": "apple",
@@ -13315,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 446,
+      "line": 444,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
@@ -13323,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 447,
+      "line": 445,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -13331,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 449,
+      "line": 447,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
@@ -13339,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 467,
+      "line": 465,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
@@ -13347,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 472,
+      "line": 470,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
@@ -13355,7 +13355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 516,
+      "line": 514,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -13363,7 +13363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 520,
+      "line": 518,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -13371,7 +13371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 531,
+      "line": 529,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -13379,7 +13379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 534,
+      "line": 532,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -13387,7 +13387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 560,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -13395,7 +13395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 564,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
@@ -13403,7 +13403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 578,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -13411,7 +13411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 586,
+      "line": 584,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -13419,7 +13419,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 596,
+      "line": 594,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -13427,7 +13427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 610,
+      "line": 608,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
@@ -13435,7 +13435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 621,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -13443,7 +13443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 652,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
@@ -13451,7 +13451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 670,
+      "line": 668,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
@@ -13459,7 +13459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 688,
+      "line": 686,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -13467,7 +13467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 691,
+      "line": 689,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
@@ -13475,7 +13475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 703,
+      "line": 701,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -13483,7 +13483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 704,
+      "line": 702,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -13491,7 +13491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 707,
+      "line": 705,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -13499,7 +13499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 712,
+      "line": 710,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -13507,7 +13507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 716,
+      "line": 714,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -13515,7 +13515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 746,
+      "line": 744,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -13523,7 +13523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 749,
+      "line": 747,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -13531,7 +13531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 753,
+      "line": 751,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -13539,7 +13539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 823,
+      "line": 821,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -13547,7 +13547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 827,
+      "line": 825,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -14243,7 +14243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 228,
+      "line": 210,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -14251,7 +14251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 230,
+      "line": 212,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
@@ -14259,7 +14259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 232,
+      "line": 214,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
@@ -14267,7 +14267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1284,
+      "line": 1280,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -14275,7 +14275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1284,
+      "line": 1280,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -14283,7 +14283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1468,
+      "line": 1464,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -14291,7 +14291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1468,
+      "line": 1464,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: \\(msg)",
       "surface": "apple",
@@ -14299,7 +14299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1811,
+      "line": 1801,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -14307,7 +14307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1811,
+      "line": 1801,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -14315,7 +14315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3870,
+      "line": 3850,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -14323,7 +14323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3870,
+      "line": 3850,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -14427,7 +14427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 449,
+      "line": 445,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -14435,7 +14435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 449,
+      "line": 445,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
@@ -14443,7 +14443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 307,
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -14451,7 +14451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 307,
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Paused",
       "surface": "apple",
@@ -14699,7 +14699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 404,
+      "line": 402,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Pairing",
       "surface": "apple",
@@ -14707,7 +14707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 404,
+      "line": 402,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Running",
       "surface": "apple",
@@ -14715,7 +14715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 424,
+      "line": 422,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Ready for quick actions",
       "surface": "apple",
@@ -14723,7 +14723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 424,
+      "line": 422,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone sync",
       "surface": "apple",
@@ -14731,7 +14731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 426,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 approval waiting",
       "surface": "apple",
@@ -14739,7 +14739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 426,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount) approvals",
       "surface": "apple",
@@ -14747,7 +14747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 437,
+      "line": 435,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Decide from watch",
       "surface": "apple",
@@ -14755,7 +14755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 437,
+      "line": 435,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals",
       "surface": "apple",
@@ -14763,7 +14763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 491,
+      "line": 489,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 recent message",
       "surface": "apple",
@@ -14771,7 +14771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 491,
+      "line": 489,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount) recent messages",
       "surface": "apple",
@@ -14779,7 +14779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 493,
+      "line": 491,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No messages synced",
       "surface": "apple",
@@ -14787,7 +14787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 527,
+      "line": 521,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Synced",
       "surface": "apple",
@@ -14795,7 +14795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 527,
+      "line": 521,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone",
       "surface": "apple",
@@ -14803,7 +14803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 793,
+      "line": 787,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Inbox",
       "surface": "apple",
@@ -14811,7 +14811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 969,
+      "line": 963,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -14819,7 +14819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1058,
+      "line": 1052,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "You",
       "surface": "apple",
@@ -14827,7 +14827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1060,
+      "line": 1054,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "System",
       "surface": "apple",
@@ -14835,7 +14835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1113,
+      "line": 1107,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -14843,7 +14843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1208,
+      "line": 1202,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chat synced",
       "surface": "apple",
@@ -14851,7 +14851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1215,
+      "line": 1209,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Tap the message pill below to start from your watch.",
       "surface": "apple",
@@ -14859,7 +14859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1263,
+      "line": 1257,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Message OpenClaw",
       "surface": "apple",
@@ -14867,7 +14867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1366,
+      "line": 1360,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -14875,7 +14875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1369,
+      "line": 1363,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Clear",
       "surface": "apple",
@@ -14883,7 +14883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1370,
+      "line": 1364,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals waiting",
       "surface": "apple",
@@ -14891,7 +14891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1430,
+      "line": 1424,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval",
       "surface": "apple",
@@ -14899,7 +14899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1444,
+      "line": 1438,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Sending decision...",
       "surface": "apple",
@@ -14907,7 +14907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1448,
+      "line": 1442,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approve",
       "surface": "apple",
@@ -14915,7 +14915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1457,
+      "line": 1451,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Deny",
       "surface": "apple",
@@ -15115,7 +15115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 36,
+      "line": 34,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(version) is ready.",
       "surface": "apple",
@@ -15123,7 +15123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 38,
+      "line": 36,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway is not installed yet.",
       "surface": "apple",
@@ -15131,7 +15131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 40,
+      "line": 38,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "The OpenClaw Gateway could not be verified. Setup will repair it.",
       "surface": "apple",
@@ -15139,7 +15139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 42,
+      "line": 40,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway \\(found) does not match app \\(required). Setup will update it.",
       "surface": "apple",
@@ -15171,7 +15171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 127,
+      "line": 125,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Unsupported field type.",
       "surface": "apple",
@@ -15179,7 +15179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 267,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No quick settings for this channel.",
       "surface": "apple",
@@ -15187,7 +15187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 269,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Use Config for account, guild, action, and policy details.",
       "surface": "apple",
@@ -15195,7 +15195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 329,
+      "line": 323,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Select…",
       "surface": "apple",
@@ -15203,7 +15203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Extra entries",
       "surface": "apple",
@@ -15211,7 +15211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 506,
+      "line": 492,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No extra entries yet.",
       "surface": "apple",
@@ -15219,7 +15219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 513,
+      "line": 499,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Key",
       "surface": "apple",
@@ -15227,7 +15227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 517,
+      "line": 503,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Remove",
       "surface": "apple",
@@ -15235,7 +15235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 513,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Add",
       "surface": "apple",
@@ -15243,7 +15243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 640,
+      "line": 620,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Loading channel settings",
       "surface": "apple",
@@ -15251,7 +15251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 652,
+      "line": 632,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Configuration",
       "surface": "apple",
@@ -15259,7 +15259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 654,
+      "line": 634,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Schema unavailable",
       "surface": "apple",
@@ -15267,7 +15267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 655,
+      "line": 635,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "OpenClaw could not load editable settings for this channel.",
       "surface": "apple",
@@ -15531,7 +15531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 91,
+      "line": 89,
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "main",
       "surface": "apple",
@@ -15539,7 +15539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 96,
+      "line": 94,
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "000k/000k",
       "surface": "apple",
@@ -15555,7 +15555,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 72,
+      "line": 60,
       "path": "apps/macos/Sources/OpenClaw/ContextUsageBar.swift",
       "source": "Context usage",
       "surface": "apple",
@@ -15627,7 +15627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 97,
+      "line": 95,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Edit cron job",
       "surface": "apple",
@@ -15635,7 +15635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 97,
+      "line": 95,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "New cron job",
       "surface": "apple",
@@ -15643,7 +15643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 110,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Name",
       "surface": "apple",
@@ -15651,7 +15651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 111,
+      "line": 109,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Required (e.g. “Daily summary”)",
       "surface": "apple",
@@ -15659,7 +15659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 116,
+      "line": 114,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Description",
       "surface": "apple",
@@ -15667,7 +15667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 117,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional notes",
       "surface": "apple",
@@ -15675,7 +15675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 122,
+      "line": 120,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Agent ID",
       "surface": "apple",
@@ -15683,7 +15683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 123,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (default agent)",
       "surface": "apple",
@@ -15691,7 +15691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 128,
+      "line": 126,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Enabled",
       "surface": "apple",
@@ -15699,7 +15699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 134,
+      "line": 132,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Session target",
       "surface": "apple",
@@ -15707,7 +15707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 136,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "main",
       "surface": "apple",
@@ -15715,7 +15715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 137,
+      "line": 135,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "isolated",
       "surface": "apple",
@@ -15723,7 +15723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 138,
+      "line": 136,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "current",
       "surface": "apple",
@@ -15731,7 +15731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 145,
+      "line": 143,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Wake mode",
       "surface": "apple",
@@ -15739,7 +15739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 147,
+      "line": 145,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "now",
       "surface": "apple",
@@ -15747,7 +15747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 148,
+      "line": 146,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "next-heartbeat",
       "surface": "apple",
@@ -15755,7 +15755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 169,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "at",
       "surface": "apple",
@@ -15763,7 +15763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "every",
       "surface": "apple",
@@ -15771,7 +15771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 171,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "cron",
       "surface": "apple",
@@ -15779,7 +15779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "At",
       "surface": "apple",
@@ -15787,7 +15787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 199,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Auto-delete",
       "surface": "apple",
@@ -15795,7 +15795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 200,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delete after successful run",
       "surface": "apple",
@@ -15803,7 +15803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Every",
       "surface": "apple",
@@ -15811,7 +15811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "10m, 1h, 1d",
       "surface": "apple",
@@ -15819,7 +15819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 214,
+      "line": 212,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Expression",
       "surface": "apple",
@@ -15827,7 +15827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 215,
+      "line": 213,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "e.g. 0 9 * * 3",
       "surface": "apple",
@@ -15835,7 +15835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 220,
+      "line": 218,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timezone",
       "surface": "apple",
@@ -15843,7 +15843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 221,
+      "line": 219,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. America/Los_Angeles)",
       "surface": "apple",
@@ -15851,7 +15851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 240,
+      "line": 238,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Kind",
       "surface": "apple",
@@ -15859,7 +15859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 240,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "systemEvent",
       "surface": "apple",
@@ -15867,7 +15867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 243,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "agentTurn",
       "surface": "apple",
@@ -15875,7 +15875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 260,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "System event text",
       "surface": "apple",
@@ -15883,7 +15883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 285,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -15891,7 +15891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 295,
+      "line": 293,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Save",
       "surface": "apple",
@@ -15899,7 +15899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 327,
+      "line": 325,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Message",
       "surface": "apple",
@@ -15907,7 +15907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 326,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "What should OpenClaw do?",
       "surface": "apple",
@@ -15915,7 +15915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 332,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -15923,7 +15923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 333,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. low)",
       "surface": "apple",
@@ -15931,7 +15931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 340,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timeout",
       "surface": "apple",
@@ -15939,7 +15939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 341,
+      "line": 339,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Seconds (optional)",
       "surface": "apple",
@@ -15947,7 +15947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delivery",
       "surface": "apple",
@@ -15955,7 +15955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 348,
+      "line": 346,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Announce summary",
       "surface": "apple",
@@ -15963,7 +15963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 347,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "None",
       "surface": "apple",
@@ -15971,7 +15971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 357,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Channel",
       "surface": "apple",
@@ -15979,7 +15979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 370,
+      "line": 368,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "To",
       "surface": "apple",
@@ -15987,7 +15987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 369,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional override (phone number / chat id / Discord channel)",
       "surface": "apple",
@@ -15995,7 +15995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 376,
+      "line": 374,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Best-effort",
       "surface": "apple",
@@ -16003,7 +16003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 377,
+      "line": 375,
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Do not fail the job if announce fails",
       "surface": "apple",
@@ -16019,7 +16019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 46,
+      "line": 44,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -16027,7 +16027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 47,
+      "line": 45,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Delete",
       "surface": "apple",
@@ -16035,7 +16035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 77,
+      "line": 75,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron scheduler is disabled",
       "surface": "apple",
@@ -16043,7 +16043,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 81,
+      "line": 79,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Jobs are saved, but they will not run automatically until `cron.enabled` is set to `true` and the Gateway restarts.",
       "surface": "apple",
@@ -16051,7 +16051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 107,
+      "line": 105,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -16059,7 +16059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 109,
+      "line": 107,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Manage Gateway cron jobs and inspect run history.",
       "surface": "apple",
@@ -16067,7 +16067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 119,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -16075,7 +16075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 129,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "New Job",
       "surface": "apple",
@@ -16083,7 +16083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 142,
+      "line": 140,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Error: \\(err)",
       "surface": "apple",
@@ -16091,7 +16091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 170,
+      "line": 168,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "No cron jobs yet.",
       "surface": "apple",
@@ -16099,7 +16099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 208,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Select a job to inspect details and run history.",
       "surface": "apple",
@@ -16107,7 +16107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 209,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Tip: use ‘New Job’ to add one, or enable cron in your gateway config.",
       "surface": "apple",
@@ -16347,7 +16347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 226,
+      "line": 225,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "think \\(thinking)",
       "surface": "apple",
@@ -16355,7 +16355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 229,
+      "line": 226,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(timeoutSeconds)s",
       "surface": "apple",
@@ -16363,7 +16363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 235,
+      "line": 231,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "announce",
       "surface": "apple",
@@ -16371,7 +16371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 243,
+      "line": 237,
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "no delivery",
       "surface": "apple",
@@ -16651,7 +16651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 323,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check gateway ports",
       "surface": "apple",
@@ -16659,7 +16659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 330,
+      "line": 328,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset SSH tunnel",
       "surface": "apple",
@@ -16667,7 +16667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 349,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check which process owns \\(GatewayEnvironment.gatewayPort()) and suggest fixes.",
       "surface": "apple",
@@ -16675,7 +16675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 357,
+      "line": 355,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port \\(report.port)",
       "surface": "apple",
@@ -16683,7 +16683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 364,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(listener.command) (\\(listener.pid))",
       "surface": "apple",
@@ -16691,7 +16691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 369,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill",
       "surface": "apple",
@@ -16699,7 +16699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 400,
+      "line": 398,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "OpenClaw project root",
       "surface": "apple",
@@ -16707,7 +16707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 401,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path to openclaw repo",
       "surface": "apple",
@@ -16715,7 +16715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 409,
+      "line": 407,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset",
       "surface": "apple",
@@ -16723,7 +16723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 415,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used for pnpm/node fallback and PATH population when launching the gateway.",
       "surface": "apple",
@@ -16731,7 +16731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 426,
+      "line": 424,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session store",
       "surface": "apple",
@@ -16739,7 +16739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 429,
+      "line": 427,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path",
       "surface": "apple",
@@ -16747,7 +16747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 433,
+      "line": 431,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Save",
       "surface": "apple",
@@ -16755,7 +16755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used by the CLI session loader; stored in ~/.openclaw/openclaw.json.",
       "surface": "apple",
@@ -16763,7 +16763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 456,
+      "line": 454,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -16771,7 +16771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 461,
+      "line": 459,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open Agent Events",
       "surface": "apple",
@@ -16779,7 +16779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 472,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send debug voice",
       "surface": "apple",
@@ -16787,7 +16787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 472,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Sending debug voice…",
       "surface": "apple",
@@ -16795,7 +16795,7 @@
     },
     {
       "kind": "ui-call-multiline",
-      "line": 490,
+      "line": 488,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Uses the Voice Wake path: forwards over SSH when configured,\notherwise runs locally via rpc.",
       "surface": "apple",
@@ -16803,7 +16803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 502,
+      "line": 500,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Note: macOS may require restarting OpenClaw after enabling Accessibility or Screen Recording.",
       "surface": "apple",
@@ -16811,7 +16811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 511,
+      "line": 509,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart OpenClaw",
       "surface": "apple",
@@ -16819,7 +16819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 518,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart app",
       "surface": "apple",
@@ -16827,7 +16827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 519,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
@@ -16835,7 +16835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 520,
+      "line": 518,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal app in Finder",
       "surface": "apple",
@@ -16843,7 +16843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 531,
+      "line": 529,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Enable/disable Canvas in General settings.",
       "surface": "apple",
@@ -16851,7 +16851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 536,
+      "line": 534,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session",
       "surface": "apple",
@@ -16859,7 +16859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 538,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Show panel",
       "surface": "apple",
@@ -16867,7 +16867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 544,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Hide panel",
       "surface": "apple",
@@ -16875,7 +16875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 548,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write sample page",
       "surface": "apple",
@@ -16883,7 +16883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 556,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval JS",
       "surface": "apple",
@@ -16891,7 +16891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 560,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval",
       "surface": "apple",
@@ -16899,7 +16899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 564,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Snapshot",
       "surface": "apple",
@@ -16907,7 +16907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 578,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "eval → \\(canvasEvalResult)",
       "surface": "apple",
@@ -16915,7 +16915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 589,
+      "line": 587,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "snapshot → \\(canvasSnapshotPath)",
       "surface": "apple",
@@ -16923,7 +16923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 595,
+      "line": 593,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal",
       "surface": "apple",
@@ -16931,7 +16931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 608,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tip: the session directory is returned by “Show panel”.",
       "surface": "apple",
@@ -16939,7 +16939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 620,
+      "line": 618,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Icon override",
       "surface": "apple",
@@ -16947,7 +16947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 628,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Chat",
       "surface": "apple",
@@ -16955,7 +16955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 631,
+      "line": 629,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Native SwiftUI",
       "surface": "apple",
@@ -16963,7 +16963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 944,
+      "line": 942,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -16971,7 +16971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 945,
+      "line": 943,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Healthy",
       "surface": "apple",
@@ -16979,7 +16979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 946,
+      "line": 944,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Needs Link",
       "surface": "apple",
@@ -16987,7 +16987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 947,
+      "line": 945,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Degraded",
       "surface": "apple",
@@ -16995,7 +16995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1014,
+      "line": 1012,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Test",
       "surface": "apple",
@@ -17179,7 +17179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 30,
+      "line": 28,
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Failed: \\(reason)",
       "surface": "apple",
@@ -17187,7 +17187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 261,
+      "line": 257,
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "not linked",
       "surface": "apple",
@@ -17891,7 +17891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 245,
+      "line": 231,
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded",
       "surface": "apple",
@@ -17899,7 +17899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 245,
+      "line": 231,
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded · status \\(status)",
       "surface": "apple",
@@ -18035,7 +18035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 103,
+      "line": 101,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(device.title) · \\(prettyPlatform)",
       "surface": "apple",
@@ -18043,7 +18043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 126,
+      "line": 122,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(secs)s ago",
       "surface": "apple",
@@ -18051,7 +18051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 137,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Copy Debug Summary",
       "surface": "apple",
@@ -18059,7 +18059,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 175,
+      "line": 171,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Presence updated \\(inst.ageDescription).",
       "surface": "apple",
@@ -18067,7 +18067,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 176,
+      "line": 172,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(status.label) presence",
       "surface": "apple",
@@ -18075,7 +18075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 466,
+      "line": 452,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Android",
       "surface": "apple",
@@ -18083,7 +18083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 467,
+      "line": 453,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Sparkles",
       "surface": "apple",
@@ -18091,7 +18091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 468,
+      "line": 454,
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Plain",
       "surface": "apple",
@@ -18579,7 +18579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 482,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
@@ -18611,7 +18611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1022,
+      "line": 1004,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No",
       "surface": "apple",
@@ -18619,7 +18619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1022,
+      "line": 1004,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Yes",
       "surface": "apple",
@@ -18627,7 +18627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1078,
+      "line": 1060,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update thinking failed",
       "surface": "apple",
@@ -18635,7 +18635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1096,
+      "line": 1078,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update verbose failed",
       "surface": "apple",
@@ -18643,7 +18643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1116,
+      "line": 1098,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset session?",
       "surface": "apple",
@@ -18651,7 +18651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1117,
+      "line": 1099,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Starts a new session id for “\\(key)”.",
       "surface": "apple",
@@ -18659,7 +18659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1125,
+      "line": 1107,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset failed",
       "surface": "apple",
@@ -18667,7 +18667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1135,
+      "line": 1117,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact session log?",
       "surface": "apple",
@@ -18675,7 +18675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1118,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Keeps the last 400 lines; archives the old file.",
       "surface": "apple",
@@ -18683,7 +18683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1144,
+      "line": 1126,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact failed",
       "surface": "apple",
@@ -18691,7 +18691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1154,
+      "line": 1136,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete session?",
       "surface": "apple",
@@ -18699,7 +18699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1155,
+      "line": 1137,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Deletes the “\\(key)” entry and archives its transcript.",
       "surface": "apple",
@@ -18707,7 +18707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1163,
+      "line": 1145,
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete failed",
       "surface": "apple",
@@ -18723,7 +18723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 426,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",
       "surface": "apple",
@@ -18731,7 +18731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 428,
+      "line": 426,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing rejected",
       "surface": "apple",
@@ -18739,7 +18739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/NodesMenu.swift",
       "source": "\\(self.label):",
       "surface": "apple",
@@ -18763,7 +18763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 534,
+      "line": 528,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Looking for AI you already use…",
       "surface": "apple",
@@ -18771,7 +18771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 536,
+      "line": 530,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "surface": "apple",
@@ -18779,7 +18779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 566,
+      "line": 560,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Couldn’t check this Mac for AI accounts",
       "surface": "apple",
@@ -18787,7 +18787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 578,
+      "line": 572,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Couldn’t load the full provider list",
       "surface": "apple",
@@ -18795,7 +18795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 581,
+      "line": 575,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Try again",
       "surface": "apple",
@@ -18803,7 +18803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 589,
+      "line": 583,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "None of the found options worked",
       "surface": "apple",
@@ -18811,7 +18811,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 590,
+      "line": 584,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
       "surface": "apple",
@@ -18819,7 +18819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 611,
+      "line": 605,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Need help? Chat with Crestodian",
       "surface": "apple",
@@ -18827,7 +18827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 619,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Your AI is ready",
       "surface": "apple",
@@ -18835,7 +18835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 642,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "No AI accounts found on this Mac",
       "surface": "apple",
@@ -18843,7 +18843,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 644,
+      "line": 638,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
       "surface": "apple",
@@ -18851,7 +18851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 677,
+      "line": 671,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Recommended",
       "surface": "apple",
@@ -18859,7 +18859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 774,
+      "line": 768,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "No key-based providers are available",
       "surface": "apple",
@@ -18867,7 +18867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 775,
+      "line": 769,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "surface": "apple",
@@ -18875,7 +18875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 777,
+      "line": 771,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Check again",
       "surface": "apple",
@@ -18883,7 +18883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 789,
+      "line": 783,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Connect with an API key or token instead…",
       "surface": "apple",
@@ -18891,7 +18891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 794,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -18899,7 +18899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 803,
+      "line": 797,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Provider",
       "surface": "apple",
@@ -18907,7 +18907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 811,
+      "line": 805,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -18915,7 +18915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 823,
+      "line": 817,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Connect",
       "surface": "apple",
@@ -18923,7 +18923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 836,
+      "line": 830,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -18931,7 +18931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 862,
+      "line": 856,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Crestodian — setup helper",
       "surface": "apple",
@@ -18939,7 +18939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 865,
+      "line": 859,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Done",
       "surface": "apple",
@@ -18947,7 +18947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 926,
+      "line": 920,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -18955,7 +18955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 965,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -18963,7 +18963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 965,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Show details",
       "surface": "apple",
@@ -18971,7 +18971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 979,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetup.swift",
       "source": "Copy error",
       "surface": "apple",
@@ -19531,7 +19531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 825,
+      "line": 817,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Agent workspace",
       "surface": "apple",
@@ -19539,7 +19539,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 827,
+      "line": 819,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
       "surface": "apple",
@@ -19547,7 +19547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
+      "line": 830,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway detected",
       "surface": "apple",
@@ -19555,7 +19555,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 840,
+      "line": 832,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
       "surface": "apple",
@@ -19563,7 +19563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 846,
+      "line": 838,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copied",
       "surface": "apple",
@@ -19571,7 +19571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 846,
+      "line": 838,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copy setup command",
       "surface": "apple",
@@ -19579,7 +19579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 852,
+      "line": 844,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Workspace folder",
       "surface": "apple",
@@ -19587,7 +19587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 866,
+      "line": 858,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create workspace",
       "surface": "apple",
@@ -19595,7 +19595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 872,
+      "line": 864,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open folder",
       "surface": "apple",
@@ -19603,7 +19603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 879,
+      "line": 871,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Save in config",
       "surface": "apple",
@@ -19611,7 +19611,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 900,
+      "line": 892,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
       "surface": "apple",
@@ -19619,7 +19619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 915,
+      "line": 907,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Meet your agent",
       "surface": "apple",
@@ -19627,7 +19627,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 917,
+      "line": 909,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
       "surface": "apple",
@@ -19635,7 +19635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 930,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -19643,7 +19643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 941,
+      "line": 933,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -19651,7 +19651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 949,
+      "line": 941,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -19659,7 +19659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 950,
+      "line": 942,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -19667,7 +19667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 957,
+      "line": 949,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -19675,7 +19675,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 958,
+      "line": 950,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -19683,7 +19683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 967,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -19691,7 +19691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 968,
+      "line": 960,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for quick chat and status.",
       "surface": "apple",
@@ -19699,7 +19699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 963,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -19707,7 +19707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 972,
+      "line": 964,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -19715,7 +19715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 974,
+      "line": 966,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -19723,7 +19723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 979,
+      "line": 971,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -19731,7 +19731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 972,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -19739,7 +19739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 983,
+      "line": 975,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -19747,7 +19747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 984,
+      "line": 976,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel for quick chat; the agent can show previews ",
       "surface": "apple",
@@ -19755,7 +19755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 988,
+      "line": 980,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -19763,7 +19763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 989,
+      "line": 981,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -19771,7 +19771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 991,
+      "line": 983,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -19779,7 +19779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 996,
+      "line": 988,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -19787,7 +19787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1029,
+      "line": 1017,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -19795,7 +19795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1024,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19803,7 +19803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1045,
+      "line": 1033,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -19811,7 +19811,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1048,
+      "line": 1036,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -19819,7 +19819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1054,
+      "line": 1042,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -19827,7 +19827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1060,
+      "line": 1048,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",
@@ -20539,7 +20539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 146,
+      "line": 122,
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Cron",
       "surface": "apple",
@@ -20547,7 +20547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 147,
+      "line": 123,
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Direct",
       "surface": "apple",
@@ -20555,7 +20555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 148,
+      "line": 124,
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Group",
       "surface": "apple",
@@ -20563,7 +20563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 149,
+      "line": 125,
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Global",
       "surface": "apple",
@@ -20571,7 +20571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 150,
+      "line": 126,
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -20627,7 +20627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 165,
+      "line": 163,
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Loading preview…",
       "surface": "apple",
@@ -20635,7 +20635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "No recent messages",
       "surface": "apple",
@@ -21091,7 +21091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 597,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Get your key →",
       "surface": "apple",
@@ -21099,7 +21099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 602,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Saved to openclaw.json under skills.entries.\\(self.editor.skillKey)",
       "surface": "apple",
@@ -21107,7 +21107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 608,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -21115,7 +21115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 610,
+      "line": 608,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Save",
       "surface": "apple",
@@ -21123,7 +21123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 638,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set API Key",
       "surface": "apple",
@@ -21131,7 +21131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 638,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set Environment Variable",
       "surface": "apple",
@@ -21139,7 +21139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 705,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill disabled",
       "surface": "apple",
@@ -21147,7 +21147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 705,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill enabled",
       "surface": "apple",
@@ -21155,7 +21155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 785,
+      "line": 783,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Bundled",
       "surface": "apple",
@@ -21555,7 +21555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 192,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "App Store",
       "surface": "apple",
@@ -21563,7 +21563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Direct Download",
       "surface": "apple",
@@ -21571,7 +21571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 204,
+      "line": 196,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Setup Guide",
       "surface": "apple",
@@ -21579,7 +21579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 212,
+      "line": 204,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure mode",
       "surface": "apple",
@@ -21587,7 +21587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 214,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure",
       "surface": "apple",
@@ -21595,7 +21595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 231,
+      "line": 223,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Dashboard URL:",
       "surface": "apple",
@@ -21603,7 +21603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 243,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale to get your tailnet hostname.",
       "surface": "apple",
@@ -21611,7 +21611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 249,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale",
       "surface": "apple",
@@ -21619,7 +21619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 257,
+      "line": 249,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Require credentials",
       "surface": "apple",
@@ -21627,7 +21627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 254,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Serve uses Tailscale identity headers; no password required.",
       "surface": "apple",
@@ -21635,7 +21635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 263,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Funnel requires authentication.",
       "surface": "apple",
@@ -21643,7 +21643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 272,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Password",
       "surface": "apple",
@@ -21651,7 +21651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 284,
+      "line": 276,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Stored in ~/.openclaw/openclaw.json. Prefer OPENCLAW_GATEWAY_PASSWORD for production.",
       "surface": "apple",
@@ -21659,7 +21659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 279,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Update password",
       "surface": "apple",
@@ -21683,7 +21683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 78,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h",
       "surface": "apple",
@@ -21691,7 +21691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 78,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h \\(mins)m",
       "surface": "apple",
@@ -21931,7 +21931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 466,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "No Sound",
       "surface": "apple",
@@ -21939,7 +21939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 482,
+      "line": 474,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Choose file…",
       "surface": "apple",
@@ -21947,7 +21947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 502,
+      "line": 494,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play",
       "surface": "apple",
@@ -21955,7 +21955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 550,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -21963,7 +21963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 552,
+      "line": 544,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "System default",
       "surface": "apple",
@@ -21971,7 +21971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 565,
+      "line": 557,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
@@ -21979,7 +21979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 584,
+      "line": 576,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Recognition language",
       "surface": "apple",
@@ -21987,7 +21987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 585,
+      "line": 577,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Languages are tried in order. Models may need a first-use download on macOS 26.",
       "surface": "apple",
@@ -21995,7 +21995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 587,
+      "line": 579,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language",
       "surface": "apple",
@@ -22003,7 +22003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 589,
+      "line": 581,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "\\(self.friendlyName(for: current)) (System)",
       "surface": "apple",
@@ -22011,7 +22011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 601,
+      "line": 593,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Additional languages",
       "surface": "apple",
@@ -22019,7 +22019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 644,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add another language",
       "surface": "apple",
@@ -22027,7 +22027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 648,
+      "line": 640,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add",
       "surface": "apple",
@@ -22035,7 +22035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 754,
+      "line": 746,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Live level",
       "surface": "apple",
@@ -22043,7 +22043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 828,
+      "line": 820,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrase",
       "surface": "apple",
@@ -22051,7 +22051,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 845,
+      "line": 837,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove trigger word",
       "surface": "apple",
@@ -22059,7 +22059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 868,
+      "line": 860,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language \\(self.index + 2)",
       "surface": "apple",
@@ -22067,7 +22067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 869,
+      "line": 861,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Fallback recognition language.",
       "surface": "apple",
@@ -22075,7 +22075,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 890,
+      "line": 882,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove language",
       "surface": "apple",
@@ -22083,7 +22083,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 905,
+      "line": 897,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives.",
       "surface": "apple",
@@ -22195,7 +22195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 459,
+      "line": 455,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
@@ -22203,7 +22203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 502,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
@@ -22211,7 +22211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 114,
+      "line": 112,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "</\\(tag)",
       "surface": "apple",
@@ -22219,7 +22219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 114,
+      "line": 112,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "<\\(tag)",
       "surface": "apple",
@@ -22507,7 +22507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 228,
+      "line": 224,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(percent)%",
       "surface": "apple",
@@ -22515,7 +22515,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 235,
+      "line": 231,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Context usage",
       "surface": "apple",
@@ -22539,7 +22539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 604,
+      "line": 600,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
@@ -22547,7 +22547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 604,
+      "line": 600,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -22555,7 +22555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 663,
+      "line": 659,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -22563,7 +22563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 689,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -22571,7 +22571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 692,
+      "line": 688,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -22579,7 +22579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 696,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -22587,7 +22587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 696,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -22595,7 +22595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 724,
+      "line": 720,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued",
       "surface": "apple",
@@ -22603,7 +22603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 726,
+      "line": 722,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending…",
       "surface": "apple",
@@ -22611,7 +22611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 728,
+      "line": 724,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Confirming…",
       "surface": "apple",
@@ -22619,7 +22619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 730,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unknown",
       "surface": "apple",
@@ -22627,7 +22627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 732,
+      "line": 728,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent",
       "surface": "apple",
@@ -22635,7 +22635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 754,
+      "line": 750,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued, sends when reconnected",
       "surface": "apple",
@@ -22643,7 +22643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 756,
+      "line": 752,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending",
       "surface": "apple",
@@ -22651,7 +22651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 758,
+      "line": 754,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sent, waiting for chat history confirmation",
       "surface": "apple",
@@ -22659,7 +22659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 760,
+      "line": 756,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unconfirmed, touch and hold to retry or delete",
       "surface": "apple",
@@ -22667,7 +22667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 762,
+      "line": 758,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent, touch and hold to retry or delete",
       "surface": "apple",
@@ -22675,7 +22675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 857,
+      "line": 853,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
@@ -22683,7 +22683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 865,
+      "line": 861,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.label)",
       "surface": "apple",
@@ -22747,7 +22747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 111,
+      "line": 109,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Session name",
       "surface": "apple",
@@ -22755,7 +22755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 124,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -22763,7 +22763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 155,
+      "line": 153,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No archived sessions",
       "surface": "apple",
@@ -22771,7 +22771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 155,
+      "line": 153,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No sessions found",
       "surface": "apple",
@@ -22779,7 +22779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 196,
+      "line": 194,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -22787,7 +22787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 229,
+      "line": 227,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename",
       "surface": "apple",
@@ -22795,7 +22795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 237,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pin",
       "surface": "apple",
@@ -22803,7 +22803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 237,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unpin",
       "surface": "apple",
@@ -22811,7 +22811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 244,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archive",
       "surface": "apple",
@@ -22819,7 +22819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 244,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unarchive",
       "surface": "apple",
@@ -22931,7 +22931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 679,
+      "line": 673,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22939,7 +22939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 679,
+      "line": 673,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -22947,7 +22947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1184,
+      "line": 1176,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -22955,7 +22955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1240,
+      "line": 1232,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
@@ -23155,7 +23155,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 440,
+      "line": 436,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unread",
       "surface": "apple",
@@ -23163,7 +23163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 450,
+      "line": 446,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pin",
       "surface": "apple",
@@ -23171,7 +23171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 450,
+      "line": 446,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unpin",
       "surface": "apple",
@@ -23179,7 +23179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 457,
+      "line": 453,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Copy Session Key",
       "surface": "apple",
@@ -23187,7 +23187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 468,
+      "line": 464,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Delete Session…",
       "surface": "apple",
@@ -23195,7 +23195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 488,
+      "line": 484,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23203,7 +23203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 488,
+      "line": 484,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -23251,7 +23251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 158,
+      "line": 156,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Another feature is using the microphone.",
       "surface": "apple",
@@ -23259,7 +23259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 165,
+      "line": 163,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Microphone access is required. Enable it in Settings.",
       "surface": "apple",
@@ -23267,7 +23267,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 178,
+      "line": 176,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Could not start recording: \\(error.localizedDescription)",
       "surface": "apple",
@@ -23275,7 +23275,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 270,
+      "line": 266,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Recording was interrupted. Try again.",
       "surface": "apple",

--- a/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
+++ b/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
@@ -88,15 +88,9 @@ struct OpenClawLiveActivity: Widget {
     }
 
     private func dotColor(state: OpenClawActivityAttributes.ContentState) -> Color {
-        if state.isDisconnected {
-            return OpenClawActivityStyle.danger
-        }
-        if state.isConnecting {
-            return OpenClawActivityStyle.info
-        }
-        if state.isIdle {
-            return OpenClawActivityStyle.ok
-        }
+        if state.isDisconnected { return OpenClawActivityStyle.danger }
+        if state.isConnecting { return OpenClawActivityStyle.info }
+        if state.isIdle { return OpenClawActivityStyle.ok }
         return OpenClawActivityStyle.warn
     }
 }

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -352,15 +352,9 @@ final class ShareViewController: UIViewController {
         let text = self.sanitizeDraftFragment(payload.text)
         let url = payload.url?.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        if let title, !title.isEmpty {
-            lines.append(title)
-        }
-        if let text, !text.isEmpty {
-            lines.append(text)
-        }
-        if !url.isEmpty {
-            lines.append(url)
-        }
+        if let title, !title.isEmpty { lines.append(title) }
+        if let text, !text.isEmpty { lines.append(text) }
+        if !url.isEmpty { lines.append(url) }
 
         return lines.joined(separator: "\n\n")
     }
@@ -483,9 +477,7 @@ final class ShareViewController: UIViewController {
             quality -= 0.1
         }
         guard let fallback = image.jpegData(compressionQuality: 0.35) else { return nil }
-        if fallback.count <= maxBytes {
-            return fallback
-        }
+        if fallback.count <= maxBytes { return fallback }
         return nil
     }
 

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -233,24 +233,12 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         unread: Bool? = nil) throws -> String
     {
         var params: [String: Any] = ["key": key]
-        if let agentId {
-            params["agentId"] = agentId
-        }
-        if let label {
-            params["label"] = label ?? NSNull()
-        }
-        if let category {
-            params["category"] = category ?? NSNull()
-        }
-        if let pinned {
-            params["pinned"] = pinned
-        }
-        if let archived {
-            params["archived"] = archived
-        }
-        if let unread {
-            params["unread"] = unread
-        }
+        if let agentId { params["agentId"] = agentId }
+        if let label { params["label"] = label ?? NSNull() }
+        if let category { params["category"] = category ?? NSNull() }
+        if let pinned { params["pinned"] = pinned }
+        if let archived { params["archived"] = archived }
+        if let unread { params["unread"] = unread }
         return try self.encodeJSONObject(params)
     }
 
@@ -806,9 +794,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             let task = Task {
                 let stream = await self.gateway.subscribeServerEvents()
                 for await evt in stream {
-                    if Task.isCancelled {
-                        return
-                    }
+                    if Task.isCancelled { return }
                     if let mapped = Self.mapEventFrame(evt) {
                         continuation.yield(mapped)
                     }

--- a/apps/ios/Sources/Design/AgentProDreamingDestination.swift
+++ b/apps/ios/Sources/Design/AgentProDreamingDestination.swift
@@ -515,9 +515,7 @@ struct AgentProDreamingDestination: View {
     }
 
     private func dreamingPhaseState(_ phase: DreamingPhaseStatusLite) -> String {
-        if phase.enabled == false {
-            return "off"
-        }
+        if phase.enabled == false { return "off" }
         return phase.managedCronPresent == true ? "scheduled" : "setup"
     }
 
@@ -621,15 +619,9 @@ struct AgentProDreamingDestination: View {
         let id = markerDay ?? Self.dayID(title)
         let bodyLines = rawLines.enumerated().compactMap { offset, line -> String? in
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if offset == dateLineIndex {
-                return nil
-            }
-            if trimmed.hasPrefix("<!--") && trimmed.hasSuffix("-->") {
-                return nil
-            }
-            if trimmed == "#" || trimmed == "# Dream Diary" {
-                return nil
-            }
+            if offset == dateLineIndex { return nil }
+            if trimmed.hasPrefix("<!--") && trimmed.hasSuffix("-->") { return nil }
+            if trimmed == "#" || trimmed == "# Dream Diary" { return nil }
             return line
         }
         let body = bodyLines

--- a/apps/ios/Sources/Design/AgentProNodesDestination.swift
+++ b/apps/ios/Sources/Design/AgentProNodesDestination.swift
@@ -124,9 +124,7 @@ struct AgentProNodesDestination: View {
     private var sortedPresenceEntries: [PresenceEntry] {
         (self.overview?.presence ?? [])
             .sorted { lhs, rhs in
-                if lhs.ts != rhs.ts {
-                    return lhs.ts > rhs.ts
-                }
+                if lhs.ts != rhs.ts { return lhs.ts > rhs.ts }
                 return (Self.presenceLabel(lhs) ?? lhs.presenceKey)
                     .localizedCaseInsensitiveCompare(Self.presenceLabel(rhs) ?? rhs.presenceKey) == .orderedAscending
             }
@@ -343,15 +341,9 @@ struct AgentProNodesDestination: View {
 
     private static func presenceIcon(_ entry: PresenceEntry) -> String {
         let family = Self.normalized(entry.devicefamily)?.lowercased()
-        if family?.contains("phone") == true {
-            return "iphone"
-        }
-        if family?.contains("tablet") == true || family?.contains("pad") == true {
-            return "ipad"
-        }
-        if family?.contains("desktop") == true || family?.contains("mac") == true {
-            return "desktopcomputer"
-        }
+        if family?.contains("phone") == true { return "iphone" }
+        if family?.contains("tablet") == true || family?.contains("pad") == true { return "ipad" }
+        if family?.contains("desktop") == true || family?.contains("mac") == true { return "desktopcomputer" }
         return "display"
     }
 

--- a/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
+++ b/apps/ios/Sources/Design/AgentProTab+GatewayData.swift
@@ -23,9 +23,7 @@ extension AgentProTab {
     }
 
     func agentTint(for agent: AgentSummary, state: AgentRosterState) -> Color {
-        if agent.id == self.activeAgentID {
-            return OpenClawBrand.accent
-        }
+        if agent.id == self.activeAgentID { return OpenClawBrand.accent }
         return state.color.opacity(0.62)
     }
 
@@ -49,9 +47,7 @@ extension AgentProTab {
 
     func agentRosterState(for agent: AgentSummary) -> AgentRosterState {
         guard self.gatewayConnected else { return .ready }
-        if agent.id == self.activeAgentID {
-            return .online
-        }
+        if agent.id == self.activeAgentID { return .online }
         return .ready
     }
 
@@ -208,17 +204,11 @@ extension AgentProTab {
 
     static func duration(milliseconds: Int) -> String {
         let seconds = max(0, milliseconds / 1000)
-        if seconds < 60 {
-            return "\(seconds)s"
-        }
+        if seconds < 60 { return "\(seconds)s" }
         let minutes = seconds / 60
-        if minutes < 60 {
-            return "\(minutes)m"
-        }
+        if minutes < 60 { return "\(minutes)m" }
         let hours = minutes / 60
-        if hours < 24 {
-            return "\(hours)h"
-        }
+        if hours < 24 { return "\(hours)h" }
         return "\(hours / 24)d"
     }
 

--- a/apps/ios/Sources/Design/AgentProTab+Overview.swift
+++ b/apps/ios/Sources/Design/AgentProTab+Overview.swift
@@ -491,12 +491,8 @@ extension AgentProTab {
 
     var sortedAgents: [AgentSummary] {
         appModel.gatewayAgents.sorted { lhs, rhs in
-            if lhs.id == self.activeAgentID {
-                return true
-            }
-            if rhs.id == self.activeAgentID {
-                return false
-            }
+            if lhs.id == self.activeAgentID { return true }
+            if rhs.id == self.activeAgentID { return false }
             return self.agentName(for: lhs)
                 .localizedCaseInsensitiveCompare(self.agentName(for: rhs)) == .orderedAscending
         }
@@ -545,28 +541,18 @@ extension AgentProTab {
     }
 
     var emptyAgentsTitle: String {
-        if !self.gatewayConnected {
-            return "Agents unavailable"
-        }
-        if !agentSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return "No matches"
-        }
-        if agentRosterFilter != .all {
-            return "No \(agentRosterFilter.title.lowercased()) agents"
-        }
+        if !self.gatewayConnected { return "Agents unavailable" }
+        if !agentSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return "No matches" }
+        if agentRosterFilter != .all { return "No \(agentRosterFilter.title.lowercased()) agents" }
         return "No agents reported"
     }
 
     var emptyAgentsDetail: String {
-        if !self.gatewayConnected {
-            return "Connect a gateway to load the live agent roster."
-        }
+        if !self.gatewayConnected { return "Connect a gateway to load the live agent roster." }
         if !agentSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return "Try another search or clear the agent filters."
         }
-        if agentRosterFilter != .all {
-            return "Clear the filter to view the full roster."
-        }
+        if agentRosterFilter != .all { return "Clear the filter to view the full roster." }
         return "The connected gateway did not return an agent list."
     }
 

--- a/apps/ios/Sources/Design/AgentProTab+Skills.swift
+++ b/apps/ios/Sources/Design/AgentProTab+Skills.swift
@@ -226,9 +226,7 @@ extension AgentProTab {
     }
 
     var skillPolicySummary: String {
-        if appModel.isAppleReviewDemoModeEnabled {
-            return "Demo mode keeps live skill changes disabled."
-        }
+        if appModel.isAppleReviewDemoModeEnabled { return "Demo mode keeps live skill changes disabled." }
         guard gatewayConnected else { return "Connect a gateway to edit skills." }
         guard let filter = agentSkillFilter else {
             return "All available skills are allowed for this agent."
@@ -282,9 +280,7 @@ extension AgentProTab {
     func sortSkills(_ lhs: SkillStatusEntryLite, _ rhs: SkillStatusEntryLite) -> Bool {
         let lhsEnabled = self.isSkillAllowed(lhs)
         let rhsEnabled = self.isSkillAllowed(rhs)
-        if lhsEnabled != rhsEnabled {
-            return lhsEnabled && !rhsEnabled
-        }
+        if lhsEnabled != rhsEnabled { return lhsEnabled && !rhsEnabled }
         return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
     }
 

--- a/apps/ios/Sources/Design/CommandCenterSupport.swift
+++ b/apps/ios/Sources/Design/CommandCenterSupport.swift
@@ -246,11 +246,7 @@ struct CommandSessionActionsModifier: ViewModifier {
     private var editorBinding: Binding<Bool> {
         Binding(
             get: { self.editor != nil },
-            set: {
-                if !$0 {
-                    self.editor = nil
-                }
-            })
+            set: { if !$0 { self.editor = nil } })
     }
 
     private var editorTitle: String {

--- a/apps/ios/Sources/Design/CommandCenterTab.swift
+++ b/apps/ios/Sources/Design/CommandCenterTab.swift
@@ -626,9 +626,7 @@ struct CommandCenterTab: View {
     nonisolated static func isRecentChatSession(_ key: String, defaultSessionKey: String) -> Bool {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        if trimmed == defaultSessionKey {
-            return false
-        }
+        if trimmed == defaultSessionKey { return false }
         let normalized = trimmed.lowercased()
         let defaultBase = self.sessionBaseKey(defaultSessionKey)
         if !normalized.contains(":"),
@@ -636,9 +634,7 @@ struct CommandCenterTab: View {
         {
             return false
         }
-        if self.isHiddenInternalSession(trimmed) {
-            return false
-        }
+        if self.isHiddenInternalSession(trimmed) { return false }
         return !self.isAgentDeviceSession(trimmed, defaultSessionKey: defaultSessionKey)
     }
 
@@ -953,21 +949,13 @@ struct CommandSessionsScreen: View {
     private var groupEditorBinding: Binding<Bool> {
         Binding(
             get: { self.groupEditor != nil },
-            set: {
-                if !$0 {
-                    self.groupEditor = nil
-                }
-            })
+            set: { if !$0 { self.groupEditor = nil } })
     }
 
     private var groupDeleteBinding: Binding<Bool> {
         Binding(
             get: { self.groupPendingDelete != nil },
-            set: {
-                if !$0 {
-                    self.groupPendingDelete = nil
-                }
-            })
+            set: { if !$0 { self.groupPendingDelete = nil } })
     }
 
     private func commitGroupEditor() {

--- a/apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift
+++ b/apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift
@@ -1223,16 +1223,10 @@ struct IPadSkillProposal: Identifiable {
     var ageLabel: String {
         let diff = max(0, Date().timeIntervalSince1970 * 1000 - self.updatedAtMs)
         let minutes = Int(diff / 60000)
-        if minutes < 1 {
-            return "now"
-        }
-        if minutes < 60 {
-            return "\(minutes)m"
-        }
+        if minutes < 1 { return "now" }
+        if minutes < 60 { return "\(minutes)m" }
         let hours = minutes / 60
-        if hours < 24 {
-            return "\(hours)h"
-        }
+        if hours < 24 { return "\(hours)h" }
         return "\(hours / 24)d"
     }
 

--- a/apps/ios/Sources/Design/IPadWorkboardScreen.swift
+++ b/apps/ios/Sources/Design/IPadWorkboardScreen.swift
@@ -705,9 +705,7 @@ struct IPadWorkboardScreen: View {
             self.errorText = nil
             return
         }
-        if self.isLoading {
-            return
-        }
+        if self.isLoading { return }
 
         self.isLoading = true
         self.errorText = nil

--- a/apps/ios/Sources/Design/SettingsChannelsDestination.swift
+++ b/apps/ios/Sources/Design/SettingsChannelsDestination.swift
@@ -136,9 +136,7 @@ struct SettingsChannelsDestination: View {
     }
 
     private var headerValue: String? {
-        if self.isLoading {
-            return "Loading"
-        }
+        if self.isLoading { return "Loading" }
         guard self.canRead else { return "Offline" }
         return "\(self.channelEntries.count)"
     }
@@ -155,21 +153,15 @@ struct SettingsChannelsDestination: View {
 
     private var summaryValue: String {
         guard self.canRead else { return "offline" }
-        if self.isLoading {
-            return "loading"
-        }
-        if self.errorText != nil {
-            return "error"
-        }
+        if self.isLoading { return "loading" }
+        if self.errorText != nil { return "error" }
         let configured = self.channelEntries.count(where: { $0.configured })
         return "\(configured)/\(self.channelEntries.count)"
     }
 
     private var summaryColor: Color {
         guard self.canRead else { return .secondary }
-        if self.errorText != nil {
-            return OpenClawBrand.warn
-        }
+        if self.errorText != nil { return OpenClawBrand.warn }
         return self.channelEntries.contains(where: { $0.running || $0.connected }) ? OpenClawBrand.ok : OpenClawBrand
             .accent
     }
@@ -241,9 +233,7 @@ struct SettingsChannelsDestination: View {
             self.errorText = nil
             return
         }
-        if self.isLoading {
-            return
-        }
+        if self.isLoading { return }
 
         self.isLoading = true
         self.errorText = nil
@@ -328,16 +318,10 @@ struct SettingsChannelsDestination: View {
     private static func relativeTime(_ milliseconds: Int) -> String {
         let age = max(0, Int(Date().timeIntervalSince1970 * 1000) - milliseconds)
         let minutes = age / 60000
-        if minutes < 1 {
-            return "now"
-        }
-        if minutes < 60 {
-            return "\(minutes)m ago"
-        }
+        if minutes < 1 { return "now" }
+        if minutes < 60 { return "\(minutes)m ago" }
         let hours = minutes / 60
-        if hours < 24 {
-            return "\(hours)h ago"
-        }
+        if hours < 24 { return "\(hours)h ago" }
         return "\(hours / 24)d ago"
     }
 
@@ -475,28 +459,16 @@ private struct SettingsChannelEntry: Identifiable {
     let accounts: [SettingsChannelAccount]
 
     var color: Color {
-        if self.connected || self.running {
-            return OpenClawBrand.ok
-        }
-        if self.lastError != nil {
-            return OpenClawBrand.warn
-        }
+        if self.connected || self.running { return OpenClawBrand.ok }
+        if self.lastError != nil { return OpenClawBrand.warn }
         return self.configured ? OpenClawBrand.accent : .secondary
     }
 
     var statusValue: String {
-        if self.connected {
-            return "connected"
-        }
-        if self.running {
-            return "running"
-        }
-        if self.linked {
-            return "linked"
-        }
-        if self.configured {
-            return "configured"
-        }
+        if self.connected { return "connected" }
+        if self.running { return "running" }
+        if self.linked { return "linked" }
+        if self.configured { return "configured" }
         return "not set"
     }
 
@@ -557,12 +529,8 @@ private struct SettingsChannelAccount: Identifiable {
     }
 
     var color: Color {
-        if self.connected || self.running {
-            return OpenClawBrand.ok
-        }
-        if self.lastError != nil {
-            return OpenClawBrand.warn
-        }
+        if self.connected || self.running { return OpenClawBrand.ok }
+        if self.lastError != nil { return OpenClawBrand.warn }
         return self.configured ? OpenClawBrand.accent : .secondary
     }
 }

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -961,9 +961,7 @@ extension SettingsProTab {
     }
 
     var manualPortIsValid: Bool {
-        if self.manualGatewayPortText.isEmpty {
-            return true
-        }
+        if self.manualGatewayPortText.isEmpty { return true }
         return self.manualGatewayPort >= 1 && self.manualGatewayPort <= 65535
     }
 
@@ -980,24 +978,16 @@ extension SettingsProTab {
         }
         let trimmedSetup = self.setupStatusText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let gatewayStatus = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let friendly = self.friendlyGatewayMessage(from: gatewayStatus) {
-            return friendly
-        }
-        if let friendly = self.friendlyGatewayMessage(from: trimmedSetup) {
-            return friendly
-        }
+        if let friendly = self.friendlyGatewayMessage(from: gatewayStatus) { return friendly }
+        if let friendly = self.friendlyGatewayMessage(from: trimmedSetup) { return friendly }
         if self.isTransientSetupStatus(trimmedSetup),
            !gatewayStatus.isEmpty,
            gatewayStatus != "Offline"
         {
             return gatewayStatus
         }
-        if !trimmedSetup.isEmpty {
-            return trimmedSetup
-        }
-        if gatewayStatus.isEmpty || gatewayStatus == "Offline" {
-            return nil
-        }
+        if !trimmedSetup.isEmpty { return trimmedSetup }
+        if gatewayStatus.isEmpty || gatewayStatus == "Offline" { return nil }
         return gatewayStatus
     }
 
@@ -1084,12 +1074,8 @@ extension SettingsProTab {
         let title = self.appModel.talkMode.gatewayTalkActiveModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let subtitle = (self.appModel.talkMode.gatewayTalkActiveModeSubtitle ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if title.isEmpty {
-            return "Not active"
-        }
-        if subtitle.isEmpty {
-            return title
-        }
+        if title.isEmpty { return "Not active" }
+        if subtitle.isEmpty { return title }
         return "\(title) • \(subtitle)"
     }
 
@@ -1101,12 +1087,8 @@ extension SettingsProTab {
 
     func gatewayDetailLines(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> [String] {
         var lines: [String] = []
-        if let lanHost = gateway.lanHost {
-            lines.append("LAN: \(lanHost)")
-        }
-        if let tailnet = gateway.tailnetDns {
-            lines.append("Tailnet: \(tailnet)")
-        }
+        if let lanHost = gateway.lanHost { lines.append("LAN: \(lanHost)") }
+        if let tailnet = gateway.tailnetDns { lines.append("Tailnet: \(tailnet)") }
         let gw = gateway.gatewayPort.map(String.init)
         let canvas = gateway.canvasPort.map(String.init)
         if gw != nil || canvas != nil {
@@ -1121,23 +1103,17 @@ extension SettingsProTab {
     }
 
     var gatewayStatusDetail: String {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "Apple Review demo mode"
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "Apple Review demo mode" }
         return self.gatewayConnected ? "Connected" : self.appModel.gatewayDisplayStatusText
     }
 
     var gatewayStatusValue: String {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "demo"
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "demo" }
         return self.gatewayConnected ? "online" : "offline"
     }
 
     var gatewayStatusColor: Color {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return OpenClawBrand.accent
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return OpenClawBrand.accent }
         return self.gatewayConnected ? OpenClawBrand.ok : .secondary
     }
 
@@ -1160,23 +1136,17 @@ extension SettingsProTab {
     }
 
     var gatewayTalkConfigDetail: String {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "Demo mode only"
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "Demo mode only" }
         return self.appModel.talkMode.gatewayTalkTransportLabel
     }
 
     var gatewayTalkConfigValue: String {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "demo"
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "demo" }
         return self.appModel.talkMode.gatewayTalkConfigLoaded ? "loaded" : "missing"
     }
 
     var gatewayTalkConfigColor: Color {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return .secondary
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return .secondary }
         return self.appModel.talkMode.gatewayTalkConfigLoaded ? OpenClawBrand.ok : .secondary
     }
 
@@ -1217,28 +1187,16 @@ extension SettingsProTab {
     }
 
     var voiceDetail: String {
-        if self.talkEnabled, self.voiceWakeEnabled {
-            return "Talk + Wake"
-        }
-        if self.talkEnabled {
-            return "Talk on"
-        }
-        if self.voiceWakeEnabled {
-            return "Wake on"
-        }
+        if self.talkEnabled, self.voiceWakeEnabled { return "Talk + Wake" }
+        if self.talkEnabled { return "Talk on" }
+        if self.voiceWakeEnabled { return "Wake on" }
         return "Off"
     }
 
     var diagnosticsHealthValue: String {
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "demo"
-        }
-        if self.gatewayConnected {
-            return "ready"
-        }
-        if self.gatewayController.gateways.isEmpty {
-            return "check"
-        }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "demo" }
+        if self.gatewayConnected { return "ready" }
+        if self.gatewayController.gateways.isEmpty { return "check" }
         return "partial"
     }
 

--- a/apps/ios/Sources/Design/SettingsProTabSupport.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSupport.swift
@@ -343,18 +343,10 @@ enum SettingsDiagnostics {
         notificationsAllowed: Bool) -> [SettingsDiagnosticIssue]
     {
         var issues: [SettingsDiagnosticIssue] = []
-        if !gatewayConnected {
-            issues.append(.gatewayOffline)
-        }
-        if discoveredGatewayCount == 0 {
-            issues.append(.discoveryUnavailable)
-        }
-        if gatewayConnected, !talkConfigLoaded {
-            issues.append(.talkConfigMissing)
-        }
-        if !notificationsAllowed {
-            issues.append(.notificationsUnavailable)
-        }
+        if !gatewayConnected { issues.append(.gatewayOffline) }
+        if discoveredGatewayCount == 0 { issues.append(.discoveryUnavailable) }
+        if gatewayConnected, !talkConfigLoaded { issues.append(.talkConfigMissing) }
+        if !notificationsAllowed { issues.append(.notificationsUnavailable) }
         return issues
     }
 
@@ -387,9 +379,7 @@ extension SettingsProTab {
             let isLoopback = (flags & IFF_LOOPBACK) != 0
             guard let addrPtr = ptr.pointee.ifa_addr else { continue }
             let family = addrPtr.pointee.sa_family
-            if !isUp || isLoopback || family != UInt8(AF_INET) {
-                continue
-            }
+            if !isUp || isLoopback || family != UInt8(AF_INET) { continue }
             var addr = addrPtr.pointee
             var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
             let result = getnameinfo(
@@ -403,18 +393,14 @@ extension SettingsProTab {
             guard result == 0 else { continue }
             let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
             guard let ip = String(bytes: bytes, encoding: .utf8) else { continue }
-            if self.isTailnetIPv4(ip) {
-                return true
-            }
+            if self.isTailnetIPv4(ip) { return true }
         }
         return false
     }
 
     static func isTailnetHostOrIP(_ host: String) -> Bool {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if trimmed.hasSuffix(".ts.net") || trimmed.hasSuffix(".ts.net.") {
-            return true
-        }
+        if trimmed.hasSuffix(".ts.net") || trimmed.hasSuffix(".ts.net.") { return true }
         return self.isTailnetIPv4(trimmed)
     }
 

--- a/apps/ios/Sources/Design/TalkProTab.swift
+++ b/apps/ios/Sources/Design/TalkProTab.swift
@@ -215,36 +215,23 @@ struct TalkProTab: View {
 
     private var heroSubtitle: String {
         if self.state
-            .prefersPermissionCopy
-        {
-            return "Gateway approval is required before this phone can capture voice."
-        }
-        if self.appModel.isAppleReviewDemoModeEnabled {
-            return "Voice is disabled in Apple Review demo mode."
-        }
-        if !self.gatewayConnected {
-            return "Connect to your gateway to start a voice conversation."
-        }
+            .prefersPermissionCopy { return "Gateway approval is required before this phone can capture voice." }
+        if self.appModel.isAppleReviewDemoModeEnabled { return "Voice is disabled in Apple Review demo mode." }
+        if !self.gatewayConnected { return "Connect to your gateway to start a voice conversation." }
         if !self.appModel.talkMode.gatewayTalkConfigLoaded {
             return "Open Voice settings after the gateway loads Talk configuration."
         }
         let subtitle = (appModel.talkMode.gatewayTalkVoiceModeSubtitle ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !subtitle.isEmpty {
-            return subtitle
-        }
+        if !subtitle.isEmpty { return subtitle }
         return "Routes voice to \(self.appModel.chatAgentName)."
     }
 
     private var transportText: String {
         let provider = self.appModel.talkMode.gatewayTalkProviderLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         let transport = self.appModel.talkMode.gatewayTalkTransportLabel.trimmingCharacters(in: .whitespacesAndNewlines)
-        if provider.isEmpty || provider == "Not loaded" {
-            return transport.isEmpty ? "Not loaded" : transport
-        }
-        if transport.isEmpty || transport == "Not loaded" {
-            return provider
-        }
+        if provider.isEmpty || provider == "Not loaded" { return transport.isEmpty ? "Not loaded" : transport }
+        if transport.isEmpty || transport == "Not loaded" { return provider }
         return "\(provider) • \(transport)"
     }
 
@@ -252,12 +239,8 @@ struct TalkProTab: View {
         let title = self.appModel.talkMode.gatewayTalkActiveModeTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let subtitle = (appModel.talkMode.gatewayTalkActiveModeSubtitle ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if title.isEmpty {
-            return "Not active"
-        }
-        if subtitle.isEmpty {
-            return title
-        }
+        if title.isEmpty { return "Not active" }
+        if subtitle.isEmpty { return title }
         return "\(title) • \(subtitle)"
     }
 
@@ -275,9 +258,7 @@ struct TalkProTab: View {
     }
 
     private var speechLocaleText: String {
-        if self.talkSpeechLocale == TalkSpeechLocale.automaticID {
-            return "Automatic"
-        }
+        if self.talkSpeechLocale == TalkSpeechLocale.automaticID { return "Automatic" }
         return self.talkSpeechLocale
     }
 
@@ -381,12 +362,8 @@ struct TalkProState: Equatable {
     }
 
     var title: String {
-        if self.isDemoMode {
-            return "Demo mode only"
-        }
-        if !self.gatewayConnected {
-            return "Gateway offline"
-        }
+        if self.isDemoMode { return "Demo mode only" }
+        if !self.gatewayConnected { return "Gateway offline" }
         switch self.permissionState {
         case .missingScope, .requestFailed:
             return "Gateway permission required"
@@ -401,54 +378,32 @@ struct TalkProState: Equatable {
         default:
             break
         }
-        if !self.isConfigLoaded {
-            return "Voice config unavailable"
-        }
-        if self.isSpeaking {
-            return "Speaking"
-        }
-        if self.isListening {
-            return "Listening"
-        }
-        if self.normalizedStatus.contains("connecting") {
-            return "Connecting"
-        }
-        if self.normalizedStatus.contains("thinking") {
-            return "Asking OpenClaw"
-        }
-        if self.isEnabled {
-            return "Ready to talk"
-        }
+        if !self.isConfigLoaded { return "Voice config unavailable" }
+        if self.isSpeaking { return "Speaking" }
+        if self.isListening { return "Listening" }
+        if self.normalizedStatus.contains("connecting") { return "Connecting" }
+        if self.normalizedStatus.contains("thinking") { return "Asking OpenClaw" }
+        if self.isEnabled { return "Ready to talk" }
         return "Talk is off"
     }
 
     var color: Color {
-        if self.isDemoMode {
-            return .secondary
-        }
-        if !self.gatewayConnected {
-            return .secondary
-        }
+        if self.isDemoMode { return .secondary }
+        if !self.gatewayConnected { return .secondary }
         switch self.permissionState {
         case .requestFailed, .loadFailed:
             return OpenClawBrand.danger
         case .missingScope, .requestingUpgrade, .upgradeRequested, .apiKeyMissing:
             return OpenClawBrand.warn
         default:
-            if !self.isConfigLoaded {
-                return OpenClawBrand.warn
-            }
+            if !self.isConfigLoaded { return OpenClawBrand.warn }
             return self.isEnabled ? OpenClawBrand.ok : OpenClawBrand.accentHot
         }
     }
 
     var primaryAction: TalkProPrimaryAction {
-        if self.isDemoMode {
-            return .waiting
-        }
-        if !self.gatewayConnected {
-            return .openSettings
-        }
+        if self.isDemoMode { return .waiting }
+        if !self.gatewayConnected { return .openSettings }
         switch self.permissionState {
         case .missingScope, .requestFailed:
             return .enablePermission
@@ -491,12 +446,8 @@ struct TalkProState: Equatable {
     }
 
     func waveformPhase(micLevel: Double, playbackLevel: Double?) -> TalkWaveformPhase {
-        if self.isDemoMode {
-            return .idle
-        }
-        if !self.gatewayConnected {
-            return .idle
-        }
+        if self.isDemoMode { return .idle }
+        if !self.gatewayConnected { return .idle }
         switch self.permissionState {
         case .requestingUpgrade, .upgradeRequested:
             return .thinking
@@ -505,15 +456,9 @@ struct TalkProState: Equatable {
         default:
             break
         }
-        if !self.isConfigLoaded {
-            return .idle
-        }
-        if self.isSpeaking {
-            return .speaking(level: playbackLevel)
-        }
-        if self.isListening {
-            return .listening(level: micLevel, speechActive: self.isUserSpeechDetected)
-        }
+        if !self.isConfigLoaded { return .idle }
+        if self.isSpeaking { return .speaking(level: playbackLevel) }
+        if self.isListening { return .listening(level: micLevel, speechActive: self.isUserSpeechDetected) }
         if self.normalizedStatus.contains("connecting") || self.normalizedStatus.contains("thinking") {
             return .thinking
         }

--- a/apps/ios/Sources/Device/NetworkStatusService.swift
+++ b/apps/ios/Sources/Device/NetworkStatusService.swift
@@ -34,18 +34,10 @@ final class NetworkStatusService: @unchecked Sendable {
         }
 
         var interfaces: [OpenClawNetworkInterfaceType] = []
-        if path.usesInterfaceType(.wifi) {
-            interfaces.append(.wifi)
-        }
-        if path.usesInterfaceType(.cellular) {
-            interfaces.append(.cellular)
-        }
-        if path.usesInterfaceType(.wiredEthernet) {
-            interfaces.append(.wired)
-        }
-        if interfaces.isEmpty {
-            interfaces.append(.other)
-        }
+        if path.usesInterfaceType(.wifi) { interfaces.append(.wifi) }
+        if path.usesInterfaceType(.cellular) { interfaces.append(.cellular) }
+        if path.usesInterfaceType(.wiredEthernet) { interfaces.append(.wired) }
+        if interfaces.isEmpty { interfaces.append(.other) }
 
         return OpenClawNetworkStatusPayload(
             status: status,
@@ -70,9 +62,7 @@ private final class NetworkStatusState: @unchecked Sendable {
     func markCompleted() -> Bool {
         self.lock.lock()
         defer { self.lock.unlock() }
-        if self.completed {
-            return false
-        }
+        if self.completed { return false }
         self.completed = true
         return true
     }

--- a/apps/ios/Sources/Gateway/GatewayConnectConfig.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectConfig.swift
@@ -22,9 +22,7 @@ struct GatewayConnectConfig {
     /// If the caller doesn't provide a stableID, fall back to URL identity.
     var effectiveStableID: String {
         let trimmed = self.stableID.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return self.url.absoluteString
-        }
+        if trimmed.isEmpty { return self.url.absoluteString }
         return trimmed
     }
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController+Capabilities.swift
@@ -117,20 +117,14 @@ extension GatewayConnectionController {
             UserDefaults.standard.object(forKey: "camera.enabled") == nil
                 ? true
                 : UserDefaults.standard.bool(forKey: "camera.enabled")
-        if cameraEnabled {
-            caps.append(OpenClawCapability.camera.rawValue)
-        }
+        if cameraEnabled { caps.append(OpenClawCapability.camera.rawValue) }
 
         let voiceWakeEnabled = UserDefaults.standard.bool(forKey: VoiceWakePreferences.enabledKey)
-        if voiceWakeEnabled {
-            caps.append(OpenClawCapability.voiceWake.rawValue)
-        }
+        if voiceWakeEnabled { caps.append(OpenClawCapability.voiceWake.rawValue) }
 
         let locationModeRaw = UserDefaults.standard.string(forKey: "location.enabledMode") ?? "off"
         let locationMode = OpenClawLocationMode(rawValue: locationModeRaw) ?? .off
-        if locationMode != .off {
-            caps.append(OpenClawCapability.location.rawValue)
-        }
+        if locationMode != .off { caps.append(OpenClawCapability.location.rawValue) }
 
         caps.append(OpenClawCapability.device.rawValue)
         caps.append(OpenClawCapability.talk.rawValue)

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -1028,9 +1028,7 @@ extension GatewayConnectionController {
             .max { lhs, rhs in
                 let lhsConnected = lhs.lastConnectedAtMs ?? Int.min
                 let rhsConnected = rhs.lastConnectedAtMs ?? Int.min
-                if lhsConnected != rhsConnected {
-                    return lhsConnected < rhsConnected
-                }
+                if lhsConnected != rhsConnected { return lhsConnected < rhsConnected }
                 return lhs.stableID > rhs.stableID
             }
     }

--- a/apps/ios/Sources/Gateway/GatewayConnectionIssue.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionIssue.swift
@@ -26,9 +26,7 @@ enum GatewayConnectionIssue: Equatable {
     }
 
     var needsPairing: Bool {
-        if case .pairingRequired = self {
-            return true
-        }
+        if case .pairingRequired = self { return true }
         return false
     }
 

--- a/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
@@ -52,9 +52,7 @@ final class GatewayDiscoveryModel {
     }
 
     func start() {
-        if !self.browsers.isEmpty {
-            return
-        }
+        if !self.browsers.isEmpty { return }
         self.appendDebugLog("start()")
 
         for domain in OpenClawBonjour.gatewayServiceDomains {

--- a/apps/ios/Sources/Gateway/GatewayHealthMonitor.swift
+++ b/apps/ios/Sources/Gateway/GatewayHealthMonitor.swift
@@ -44,9 +44,7 @@ final class GatewayHealthMonitor {
                     }
                 }
 
-                if Task.isCancelled {
-                    break
-                }
+                if Task.isCancelled { break }
                 let interval = max(0.0, config.intervalSeconds)
                 let nanos = UInt64(interval * 1_000_000_000)
                 if nanos > 0 {

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -464,9 +464,7 @@ enum GatewaySettingsStore {
             service: self.talkService,
             account: account)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if value?.isEmpty == false {
-            return value
-        }
+        if value?.isEmpty == false { return value }
         return nil
     }
 
@@ -586,9 +584,7 @@ enum GatewaySettingsStore {
             .compactMap(self.normalizedGatewayRegistryEntry)
             .filter { seen.insert($0.stableID).inserted }
             .sorted { lhs, rhs in
-                if lhs.name != rhs.name {
-                    return lhs.name < rhs.name
-                }
+                if lhs.name != rhs.name { return lhs.name < rhs.name }
                 return lhs.stableID < rhs.stableID
             }
         let activeStableID = registry.activeStableID.flatMap { activeID in
@@ -715,9 +711,7 @@ enum GatewaySettingsStore {
         let key = self.clientIdOverrideDefaultsPrefix + trimmedID
         let value = UserDefaults.standard.string(forKey: key)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if value?.isEmpty == false {
-            return value
-        }
+        if value?.isEmpty == false { return value }
         return nil
     }
 
@@ -739,9 +733,7 @@ enum GatewaySettingsStore {
         let key = self.selectedAgentDefaultsPrefix + trimmedID
         let value = UserDefaults.standard.string(forKey: key)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if value?.isEmpty == false {
-            return value
-        }
+        if value?.isEmpty == false { return value }
         return nil
     }
 

--- a/apps/ios/Sources/Gateway/KeychainStore.swift
+++ b/apps/ios/Sources/Gateway/KeychainStore.swift
@@ -28,9 +28,7 @@ enum KeychainStore {
         ]
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
-        if status == errSecItemNotFound {
-            return true
-        }
+        if status == errSecItemNotFound { return true }
         guard status == errSecSuccess else { return false }
         let matches = item as? [[String: Any]] ?? []
         let accounts = matches

--- a/apps/ios/Sources/Gateway/TCPProbe.swift
+++ b/apps/ios/Sources/Gateway/TCPProbe.swift
@@ -15,9 +15,7 @@ enum TCPProbe {
             let finished = OSAllocatedUnfairLock(initialState: false)
             let finish: @Sendable (Bool) -> Void = { ok in
                 let shouldResume = finished.withLock { flag -> Bool in
-                    if flag {
-                        return false
-                    }
+                    if flag { return false }
                     flag = true
                     return true
                 }

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -44,9 +44,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, ConcurrentLoca
             let updated = await self.requestAuthorization(requiresDeterminedStatus: true) {
                 self.manager.requestWhenInUseAuthorization()
             }
-            if mode != .always {
-                return updated
-            }
+            if mode != .always { return updated }
         }
 
         if mode == .always {

--- a/apps/ios/Sources/Model/NodeAppModel+WatchNotifyNormalization.swift
+++ b/apps/ios/Sources/Model/NodeAppModel+WatchNotifyNormalization.swift
@@ -67,9 +67,7 @@ extension NodeAppModel {
         _ risk: OpenClawWatchRisk?,
         priority: OpenClawNotificationPriority?) -> OpenClawWatchRisk?
     {
-        if let risk {
-            return risk
-        }
+        if let risk { return risk }
         switch priority {
         case .passive:
             return .low
@@ -86,9 +84,7 @@ extension NodeAppModel {
         _ priority: OpenClawNotificationPriority?,
         risk: OpenClawWatchRisk?) -> OpenClawNotificationPriority?
     {
-        if let priority {
-            return priority
-        }
+        if let priority { return priority }
         switch risk {
         case .low:
             return .passive

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -237,11 +237,7 @@ final class NodeAppModel {
     // value equality alone cannot tell the UI to re-surface or shake the toast.
     private(set) var gatewayProblemReportCount = 0
     private(set) var lastGatewayProblem: GatewayConnectionProblem? {
-        didSet {
-            if self.lastGatewayProblem != nil {
-                self.gatewayProblemReportCount &+= 1
-            }
-        }
+        didSet { if self.lastGatewayProblem != nil { self.gatewayProblemReportCount &+= 1 } }
     }
 
     private var operatorGatewayProblem: GatewayConnectionProblem?
@@ -366,12 +362,8 @@ final class NodeAppModel {
     }
 
     var localChatFixture: LocalChatFixture? {
-        if self.isScreenshotFixtureModeEnabled {
-            return .appScreenshots
-        }
-        if self.isAppleReviewDemoModeEnabled {
-            return .appleReviewDemo
-        }
+        if self.isScreenshotFixtureModeEnabled { return .appScreenshots }
+        if self.isAppleReviewDemoModeEnabled { return .appleReviewDemo }
         return nil
     }
 
@@ -384,12 +376,8 @@ final class NodeAppModel {
     }
 
     var chatTransportModeID: String {
-        if self.isScreenshotFixtureModeEnabled {
-            return "screenshots"
-        }
-        if self.isAppleReviewDemoModeEnabled {
-            return "apple-review-demo"
-        }
+        if self.isScreenshotFixtureModeEnabled { return "screenshots" }
+        if self.isAppleReviewDemoModeEnabled { return "apple-review-demo" }
         return self.isOperatorGatewayConnected ? "operator" : "offline"
     }
 
@@ -707,9 +695,7 @@ final class NodeAppModel {
     private func handleCanvasA2UIAction(body: [String: Any]) async {
         let userActionAny = body["userAction"] ?? body
         let userAction: [String: Any] = {
-            if let dict = userActionAny as? [String: Any] {
-                return dict
-            }
+            if let dict = userActionAny as? [String: Any] { return dict }
             if let dict = userActionAny as? [AnyHashable: Any] {
                 return dict.reduce(into: [String: Any]()) { acc, pair in
                     guard let key = pair.key as? String else { return }
@@ -1297,9 +1283,7 @@ final class NodeAppModel {
             guard let operatorRoute = await self.operatorGateway.currentRoute(), shouldContinue() else { return }
             let stream = await self.operatorGateway.subscribeServerEvents(bufferingNewest: 200)
             for await evt in stream {
-                if Task.isCancelled || !shouldContinue() {
-                    return
-                }
+                if Task.isCancelled || !shouldContinue() { return }
                 guard evt.payload != nil else { continue }
                 await self.handleOperatorGatewayServerEvent(
                     evt,
@@ -1386,9 +1370,7 @@ final class NodeAppModel {
         self.gatewayHealthMonitor.start(
             check: { [weak self] in
                 guard let self else { return false }
-                if await MainActor.run(body: { self.isGatewayHealthMonitorDisabled() }) {
-                    return true
-                }
+                if await MainActor.run(body: { self.isGatewayHealthMonitorDisabled() }) { return true }
                 do {
                     let data = try await self.operatorGateway.request(
                         method: "health",
@@ -1599,9 +1581,7 @@ final class NodeAppModel {
             let params = try? Self.decodeParams(OpenClawCanvasSnapshotParams.self, from: req.paramsJSON)
             let format = params?.format ?? .jpeg
             let maxWidth: CGFloat? = {
-                if let raw = params?.maxWidth, raw > 0 {
-                    return CGFloat(raw)
-                }
+                if let raw = params?.maxWidth, raw > 0 { return CGFloat(raw) }
                 // Keep default snapshots comfortably below the gateway client's maxPayload.
                 // For full-res, clients should explicitly request a larger maxWidth.
                 return switch format {
@@ -2640,9 +2620,7 @@ extension NodeAppModel {
 
     private func isCameraEnabled() -> Bool {
         // Default-on: if the key doesn't exist yet, treat it as enabled.
-        if UserDefaults.standard.object(forKey: "camera.enabled") == nil {
-            return true
-        }
+        if UserDefaults.standard.object(forKey: "camera.enabled") == nil { return true }
         return UserDefaults.standard.bool(forKey: "camera.enabled")
     }
 
@@ -2702,9 +2680,7 @@ extension NodeAppModel {
         let base = SessionKey.normalizeMainKey(self.mainSessionBaseKey)
         let agentId = (selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let defaultId = (gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) {
-            return base
-        }
+        if agentId.isEmpty || (!defaultId.isEmpty && agentId == defaultId) { return base }
         return SessionKey.makeAgentSessionKey(agentId: agentId, baseKey: base)
     }
 
@@ -2807,9 +2783,7 @@ extension NodeAppModel {
             return sessionAgentId.lowercased()
         }
         let selected = (self.selectedAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if !selected.isEmpty {
-            return selected.lowercased()
-        }
+        if !selected.isEmpty { return selected.lowercased() }
         let defaultId = (self.gatewayDefaultAgentId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return defaultId.isEmpty ? nil : defaultId.lowercased()
     }
@@ -2845,9 +2819,7 @@ extension NodeAppModel {
 
     private func agentDisplayName(for agentId: String, fallback: String) -> String {
         let resolvedId = agentId.trimmingCharacters(in: .whitespacesAndNewlines)
-        if resolvedId.isEmpty {
-            return fallback
-        }
+        if resolvedId.isEmpty { return fallback }
         if let match = gatewayAgents.first(where: { $0.id == resolvedId }) {
             let name = (match.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             return name.isEmpty ? match.id : name
@@ -6432,17 +6404,13 @@ extension NodeAppModel {
            let kind = payload["kind"] as? String
         {
             let trimmed = kind.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         if let payload = userInfo["openclaw"] as? [AnyHashable: Any],
            let kind = payload["kind"] as? String
         {
             let trimmed = kind.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         return "unknown"
     }
@@ -7434,9 +7402,7 @@ extension NodeAppModel {
         let trimmed = (key ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let current = self.mainSessionBaseKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed == current {
-            return
-        }
+        if trimmed == current { return }
         self.mainSessionBaseKey = trimmed
         self.synchronizeTalkSessionKey()
     }

--- a/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
@@ -30,14 +30,10 @@ enum OnboardingStateStore {
         hasSavedGatewayConnection: Bool? = nil)
         -> Bool
     {
-        if defaults.bool(forKey: self.completedDefaultsKey) {
-            return false
-        }
+        if defaults.bool(forKey: self.completedDefaultsKey) { return false }
         let hasSavedGatewayConnection =
             hasSavedGatewayConnection ?? (GatewaySettingsStore.activeGatewayEntry() != nil)
-        if hasSavedGatewayConnection {
-            return false
-        }
+        if hasSavedGatewayConnection { return false }
         return appModel.gatewayServerName == nil
     }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -192,9 +192,7 @@ struct OnboardingWizardView: View {
         .alert("QR Scanner Unavailable", isPresented: Binding(
             get: { self.scannerError != nil },
             set: {
-                if !$0 {
-                    self.scannerError = nil
-                }
+                if !$0 { self.scannerError = nil }
             })) {
                 Button(role: .cancel) {} label: {
                     Text("OK")
@@ -1395,29 +1393,17 @@ extension OnboardingWizardView {
 
         switch mode {
         case .homeNetwork:
-            if hostIsDefaultLike {
-                self.manualHost = "openclaw.local"
-            }
+            if hostIsDefaultLike { self.manualHost = "openclaw.local" }
             self.manualTLS = true
-            if self.manualPort <= 0 || self.manualPort > 65535 {
-                self.manualPort = 18789
-            }
+            if self.manualPort <= 0 || self.manualPort > 65535 { self.manualPort = 18789 }
         case .remoteDomain:
-            if host == "openclaw.local" || host == "localhost" {
-                self.manualHost = ""
-            }
+            if host == "openclaw.local" || host == "localhost" { self.manualHost = "" }
             self.manualTLS = true
-            if self.manualPort <= 0 || self.manualPort > 65535 {
-                self.manualPort = 18789
-            }
+            if self.manualPort <= 0 || self.manualPort > 65535 { self.manualPort = 18789 }
         case .developerLocal:
-            if hostIsDefaultLike {
-                self.manualHost = "localhost"
-            }
+            if hostIsDefaultLike { self.manualHost = "localhost" }
             self.manualTLS = false
-            if self.manualPort <= 0 || self.manualPort > 65535 {
-                self.manualPort = 18789
-            }
+            if self.manualPort <= 0 || self.manualPort > 65535 { self.manualPort = 18789 }
         }
     }
 

--- a/apps/ios/Sources/Onboarding/QRScannerView.swift
+++ b/apps/ios/Sources/Onboarding/QRScannerView.swift
@@ -25,9 +25,7 @@ struct GatewayPendingTargetSuppression {
 
     mutating func take(ifOwnedBy owner: Owner? = nil) -> GatewayConnectionController.AutoConnectSuppressionLease? {
         guard let value = self.value else { return nil }
-        if let owner, value.owner != owner {
-            return nil
-        }
+        if let owner, value.owner != owner { return nil }
         self.value = nil
         return value.lease
     }

--- a/apps/ios/Sources/Push/PushRelayKeychainStore.swift
+++ b/apps/ios/Sources/Push/PushRelayKeychainStore.swift
@@ -96,9 +96,7 @@ enum PushRelayRegistrationStore {
             service: self.service,
             account: self.scopedAccount(self.appAttestKeyIDAccount, scope: scope))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if value?.isEmpty == false {
-            return value
-        }
+        if value?.isEmpty == false { return value }
         return nil
     }
 
@@ -122,9 +120,7 @@ enum PushRelayRegistrationStore {
             service: self.service,
             account: self.scopedAccount(self.appAttestedKeyIDAccount, scope: scope))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if value?.isEmpty == false {
-            return value
-        }
+        if value?.isEmpty == false { return value }
         return nil
     }
 

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -1290,17 +1290,11 @@ extension RootTabs {
     }
 
     private func hasExistingGatewayConfig() -> Bool {
-        if self.appModel.activeGatewayConnectConfig != nil {
-            return true
-        }
-        if GatewaySettingsStore.activeGatewayEntry() != nil {
-            return true
-        }
+        if self.appModel.activeGatewayConnectConfig != nil { return true }
+        if GatewaySettingsStore.activeGatewayEntry() != nil { return true }
 
         let preferredStableID = self.preferredGatewayStableID.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !preferredStableID.isEmpty {
-            return true
-        }
+        if !preferredStableID.isEmpty { return true }
 
         let manualHost = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
         return self.manualGatewayEnabled && !manualHost.isEmpty

--- a/apps/ios/Sources/Screen/ScreenController.swift
+++ b/apps/ios/Sources/Screen/ScreenController.swift
@@ -163,9 +163,7 @@ final class ScreenController {
                 })()
                 """)
                 let trimmed = res.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                if trimmed == "true" || trimmed == "1" {
-                    return true
-                }
+                if trimmed == "true" || trimmed == "1" { return true }
             } catch {
                 // ignore; page likely still loading
             }
@@ -285,9 +283,7 @@ final class ScreenController {
     }
 
     nonisolated static func parseA2UIActionBody(_ body: Any) -> [String: Any]? {
-        if let dict = body as? [String: Any] {
-            return dict.isEmpty ? nil : dict
-        }
+        if let dict = body as? [String: Any] { return dict.isEmpty ? nil : dict }
         if let str = body as? String,
            let data = str.data(using: .utf8),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -317,12 +313,8 @@ final class ScreenController {
 
 extension Double {
     fileprivate func clamped(to range: ClosedRange<Double>) -> Double {
-        if self < range.lowerBound {
-            return range.lowerBound
-        }
-        if self > range.upperBound {
-            return range.upperBound
-        }
+        if self < range.lowerBound { return range.lowerBound }
+        if self > range.upperBound { return range.upperBound }
         return self
     }
 }

--- a/apps/ios/Sources/SessionKey.swift
+++ b/apps/ios/Sources/SessionKey.swift
@@ -9,9 +9,7 @@ enum SessionKey {
     static func makeAgentSessionKey(agentId: String, baseKey: String) -> String {
         let trimmedAgent = agentId.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedBase = baseKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedAgent.isEmpty {
-            return trimmedBase.isEmpty ? "main" : trimmedBase
-        }
+        if trimmedAgent.isEmpty { return trimmedBase.isEmpty ? "main" : trimmedBase }
         let normalizedBase = trimmedBase.isEmpty ? "main" : trimmedBase
         return "agent:\(trimmedAgent):\(normalizedBase)"
     }

--- a/apps/ios/Sources/Status/GatewayStatusBuilder.swift
+++ b/apps/ios/Sources/Status/GatewayStatusBuilder.swift
@@ -22,12 +22,8 @@ enum GatewayStatusBuilder {
         lastGatewayProblem: GatewayConnectionProblem?,
         gatewayStatusText: String) -> GatewayDisplayState
     {
-        if gatewayServerName != nil {
-            return .connected
-        }
-        if let lastGatewayProblem, lastGatewayProblem.pauseReconnect {
-            return .error
-        }
+        if gatewayServerName != nil { return .connected }
+        if let lastGatewayProblem, lastGatewayProblem.pauseReconnect { return .error }
 
         let text = gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.localizedCaseInsensitiveContains("connecting") ||

--- a/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
+++ b/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
@@ -491,7 +491,7 @@ final class RealtimeTalkRelaySession {
             self.startupWaiter = continuation
             Task { [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(max(0, timeoutSeconds)) * 1_000_000_000)
-                await self?.timeoutStartupWaiterIfNeeded(lifecycleGeneration: lifecycleGeneration)
+                self?.timeoutStartupWaiterIfNeeded(lifecycleGeneration: lifecycleGeneration)
             }
         }
     }

--- a/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
+++ b/apps/ios/Sources/Voice/RealtimeTalkRelaySession.swift
@@ -391,9 +391,7 @@ final class RealtimeTalkRelaySession {
         self.eventTask?.cancel()
         self.eventTask = Task { [weak self] in
             for await event in stream {
-                if Task.isCancelled {
-                    return
-                }
+                if Task.isCancelled { return }
                 await self?.handleGatewayEvent(event, lifecycleGeneration: lifecycleGeneration)
             }
         }
@@ -482,15 +480,9 @@ final class RealtimeTalkRelaySession {
         timeoutSeconds: Int,
         lifecycleGeneration: UInt64) async -> StartupWaitResult
     {
-        if self.isClosed {
-            return .cancelled
-        }
-        if self.hasReceivedReady {
-            return .ready
-        }
-        if let startupIssue {
-            return .failed(startupIssue)
-        }
+        if self.isClosed { return .cancelled }
+        if self.hasReceivedReady { return .ready }
+        if let startupIssue { return .failed(startupIssue) }
         return await withCheckedContinuation { continuation in
             if self.isClosed {
                 continuation.resume(returning: .cancelled)

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -39,9 +39,7 @@ struct TalkRuntimeIssue: Equatable {
     }
 
     var displayMessage: String {
-        if !self.message.isEmpty {
-            return self.message
-        }
+        if !self.message.isEmpty { return self.message }
         return "Realtime voice did not start."
     }
 
@@ -66,35 +64,19 @@ struct TalkRuntimeIssue: Equatable {
             "code: \(code.rawValue)",
             "message: \(self.displayMessage)",
         ]
-        if let provider, !provider.isEmpty {
-            lines.append("provider: \(provider)")
-        }
-        if let model, !model.isEmpty {
-            lines.append("model: \(model)")
-        }
-        if let transport, !transport.isEmpty {
-            lines.append("transport: \(transport)")
-        }
-        if let phase, !phase.isEmpty {
-            lines.append("phase: \(phase)")
-        }
+        if let provider, !provider.isEmpty { lines.append("provider: \(provider)") }
+        if let model, !model.isEmpty { lines.append("model: \(model)") }
+        if let transport, !transport.isEmpty { lines.append("transport: \(transport)") }
+        if let phase, !phase.isEmpty { lines.append("phase: \(phase)") }
         return lines.joined(separator: "\n")
     }
 
     var diagnosticSummary: String {
         var parts = [displayMessage]
-        if let provider, !provider.isEmpty {
-            parts.append("provider: \(provider)")
-        }
-        if let model, !model.isEmpty {
-            parts.append("model: \(model)")
-        }
-        if let transport, !transport.isEmpty {
-            parts.append("transport: \(transport)")
-        }
-        if let phase, !phase.isEmpty {
-            parts.append("phase: \(phase)")
-        }
+        if let provider, !provider.isEmpty { parts.append("provider: \(provider)") }
+        if let model, !model.isEmpty { parts.append("model: \(model)") }
+        if let transport, !transport.isEmpty { parts.append("transport: \(transport)") }
+        if let phase, !phase.isEmpty { parts.append("phase: \(phase)") }
         return parts.joined(separator: " • ")
     }
 
@@ -466,9 +448,7 @@ enum TalkModeGatewayConfigParser {
         guard let config else { return nil }
         for key in keys {
             let value = config[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if value?.isEmpty == false {
-                return value
-            }
+            if value?.isEmpty == false { return value }
         }
         return nil
     }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -476,9 +476,7 @@ final class TalkModeManager: NSObject {
     func updateMainSessionKey(_ sessionKey: String?) -> Bool {
         let trimmed = (sessionKey ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        if trimmed == self.mainSessionKey {
-            return false
-        }
+        if trimmed == self.mainSessionKey { return false }
         let shouldRestartTalk = self.isEnabled &&
             (self.hasRealtimeOwnerOrStart || self.hasContinuousTalkOwner)
         if let captureId = self.activePTTCaptureId {
@@ -837,9 +835,7 @@ final class TalkModeManager: NSObject {
     func resumeAfterBackground(wasKeptActive: Bool = false) {
         self.foregroundPushToTalkAllowed = true
         self.foregroundAudioCaptureAllowed = true
-        if wasKeptActive, self.hasContinuousTalkOwner {
-            return
-        }
+        if wasKeptActive, self.hasContinuousTalkOwner { return }
         guard self.isEnabled else { return }
         Task { @MainActor [weak self] in
             await self?.start()
@@ -1486,9 +1482,7 @@ final class TalkModeManager: NSObject {
     private func restartRecognitionAfterError(expectedGeneration: UInt64) async {
         guard self.canRestartNativeRecognition(expectedGeneration: expectedGeneration) else { return }
         // Avoid thrashing the audio engine if it’s already running.
-        if self.recognitionTask != nil, self.audioEngine.isRunning {
-            return
-        }
+        if self.recognitionTask != nil, self.audioEngine.isRunning { return }
         try? await Task.sleep(nanoseconds: 250_000_000)
         guard self.canRestartNativeRecognition(expectedGeneration: expectedGeneration) else { return }
         do {
@@ -1625,9 +1619,7 @@ final class TalkModeManager: NSObject {
             guard !transcript.isEmpty else { return }
             let lastActivity = [lastHeard, lastAudioActivity].compactMap(\.self).max()
             guard let lastActivity else { return }
-            if Date().timeIntervalSince(lastActivity) < self.silenceWindow {
-                return
-            }
+            if Date().timeIntervalSince(lastActivity) < self.silenceWindow { return }
             await self.processTranscript(transcript, restartAfter: true)
             return
         }
@@ -1641,9 +1633,7 @@ final class TalkModeManager: NSObject {
         guard !transcript.isEmpty else { return }
         let lastActivity = [lastHeard, lastAudioActivity].compactMap(\.self).max()
         guard let lastActivity else { return }
-        if Date().timeIntervalSince(lastActivity) < self.silenceWindow {
-            return
-        }
+        if Date().timeIntervalSince(lastActivity) < self.silenceWindow { return }
         if let pttCaptureId {
             _ = self.endPushToTalk(captureId: pttCaptureId)
         } else {
@@ -2416,9 +2406,7 @@ final class TalkModeManager: NSObject {
             guard let content = msg["content"] as? [[String: Any]] else { continue }
             let text = content.compactMap { $0["text"] as? String }.joined(separator: "\n")
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         return nil
     }
@@ -3463,9 +3451,7 @@ extension TalkModeManager {
         let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let normalized = trimmed.lowercased()
-        if let mapped = voiceAliases[normalized] {
-            return mapped
-        }
+        if let mapped = voiceAliases[normalized] { return mapped }
         if self.voiceAliases.values.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
             return trimmed
         }
@@ -3484,14 +3470,10 @@ extension TalkModeManager {
             if Self.isLikelyVoiceId(trimmed) {
                 return trimmed
             }
-            if let resolved = resolveVoiceAlias(trimmed) {
-                return resolved
-            }
+            if let resolved = resolveVoiceAlias(trimmed) { return resolved }
             self.logger.warning("unknown voice alias \(trimmed, privacy: .public)")
         }
-        if let fallbackVoiceId {
-            return fallbackVoiceId
-        }
+        if let fallbackVoiceId { return fallbackVoiceId }
 
         do {
             let voices = try await ElevenLabsTTSClient(apiKey: apiKey).listVoices()
@@ -3527,9 +3509,7 @@ extension TalkModeManager {
         guard !trimmed.isEmpty else { return nil }
         guard trimmed != Self.redactedConfigSentinel else { return nil }
         // Config values may be env placeholders (for example `${ELEVENLABS_API_KEY}`).
-        if trimmed.hasPrefix("${"), trimmed.hasSuffix("}") {
-            return nil
-        }
+        if trimmed.hasPrefix("${"), trimmed.hasSuffix("}") { return nil }
         return trimmed
     }
 
@@ -4128,13 +4108,9 @@ private final class AudioTapDiagnostics: @unchecked Sendable {
         let resolvedRms = Float(TalkAudioLevel.rms(buffer: buffer))
         self.lock.lock()
         self.lastRms = resolvedRms
-        if resolvedRms > self.maxRmsWindow {
-            self.maxRmsWindow = resolvedRms
-        }
+        if resolvedRms > self.maxRmsWindow { self.maxRmsWindow = resolvedRms }
         let maxRms = self.maxRmsWindow
-        if shouldLog {
-            self.maxRmsWindow = 0
-        }
+        if shouldLog { self.maxRmsWindow = 0 }
         self.lock.unlock()
 
         if shouldEmitLevel, let onLevel {

--- a/apps/ios/Sources/Voice/TalkPermissionPromptView.swift
+++ b/apps/ios/Sources/Voice/TalkPermissionPromptView.swift
@@ -168,9 +168,7 @@ struct TalkPermissionPromptView: View {
     private func pollUntilReady() async {
         while !Task.isCancelled {
             try? await Task.sleep(nanoseconds: 3_000_000_000)
-            if Task.isCancelled {
-                return
-            }
+            if Task.isCancelled { return }
             await self.appModel.pollTalkPermissionUpgrade()
             if !self.appModel.talkMode.gatewayTalkPermissionState.requiresTalkPermissionAction {
                 return

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -199,12 +199,8 @@ final class TalkRealtimeWebRTCSession: NSObject {
                     else { continue }
                     // Per the WebRTC stats spec audioLevel is linear 0...1:
                     // media-source is the local mic, inbound-rtp the remote voice.
-                    if stat.type == "media-source" {
-                        input = level.doubleValue
-                    }
-                    if stat.type == "inbound-rtp" {
-                        output = level.doubleValue
-                    }
+                    if stat.type == "media-source" { input = level.doubleValue }
+                    if stat.type == "inbound-rtp" { output = level.doubleValue }
                 }
                 continuation.resume(returning: (input, output))
             }
@@ -514,17 +510,13 @@ final class TalkRealtimeWebRTCSession: NSObject {
                 stream: stream,
                 since: historySince,
                 timeoutSeconds: Self.toolResultTimeoutSeconds)
-            if Task.isCancelled || self.stopped {
-                return
-            }
+            if Task.isCancelled || self.stopped { return }
             self.trace("tool call chat result ready callId=\(callId) runId=\(runId) chars=\(result.count)")
             self.submitToolResult(callId: callId, result: ["result": result])
         } catch is CancellationError {
             return
         } catch {
-            if Task.isCancelled || self.stopped {
-                return
-            }
+            if Task.isCancelled || self.stopped { return }
             Self.logger.error("realtime tool call failed: \(error.localizedDescription, privacy: .public)")
             self.trace("tool call failed callId=\(callId) error=\(error.localizedDescription)")
             if let runId = activeToolRunIds[callId] {
@@ -567,9 +559,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
         } catch is CancellationError {
             return
         } catch {
-            if Task.isCancelled || self.stopped {
-                return
-            }
+            if Task.isCancelled || self.stopped { return }
             Self.logger.error("realtime control tool failed: \(error.localizedDescription, privacy: .public)")
             self.trace("control tool failed callId=\(callId) error=\(error.localizedDescription)")
             self.submitToolResult(callId: callId, result: [
@@ -703,9 +693,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
     private nonisolated static func matchesSessionKey(_ incoming: String, _ current: String) -> Bool {
         let incoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let current = current.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if incoming == current {
-            return true
-        }
+        if incoming == current { return true }
         return (incoming == "agent:main:main" && current == "main") ||
             (incoming == "main" && current == "agent:main:main")
     }

--- a/apps/ios/Sources/Voice/VoiceWakeManager.swift
+++ b/apps/ios/Sources/Voice/VoiceWakeManager.swift
@@ -255,12 +255,8 @@ final class VoiceWakeManager: NSObject {
 
     func start() async {
         guard self.isEnabled else { return }
-        if self.isListening {
-            return
-        }
-        if self.isStarting {
-            return
-        }
+        if self.isListening { return }
+        if self.isStarting { return }
 
         self.isStarting = true
         defer { self.isStarting = false }
@@ -377,9 +373,7 @@ final class VoiceWakeManager: NSObject {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 40_000_000)
                 let drained = queue.drain()
-                if drained.isEmpty {
-                    continue
-                }
+                if drained.isEmpty { continue }
                 for buf in drained {
                     request.append(buf)
                 }
@@ -453,9 +447,7 @@ final class VoiceWakeManager: NSObject {
         guard let transcript else { return }
         guard let cmd = self.extractCommand(from: transcript, segments: segments) else { return }
 
-        if cmd == self.lastDispatched {
-            return
-        }
+        if cmd == self.lastDispatched { return }
         self.lastDispatched = cmd
         self.lastTriggeredCommand = cmd
         self.statusText = "Triggered"

--- a/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
+++ b/apps/ios/WatchApp/Sources/OpenClawWatchApp.swift
@@ -152,9 +152,7 @@ struct OpenClawWatchApp: App {
         self.execApprovalRefreshTask = Task { @MainActor in
             self.inboxStore.beginExecApprovalReviewLoading()
             for attempt in 0..<5 {
-                if Task.isCancelled {
-                    return
-                }
+                if Task.isCancelled { return }
                 await receiver.requestExecApprovalSnapshot()
                 if !self.inboxStore.execApprovals.isEmpty
                     || self.inboxStore.hasCompletedExecApprovalSnapshotRefresh

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -398,9 +398,7 @@ private struct WatchControlSurfaceView: View {
     }
 
     private var primaryLabel: String {
-        if self.store.activeExecApproval != nil {
-            return "Next up"
-        }
+        if self.store.activeExecApproval != nil { return "Next up" }
         return self.store.appSnapshot?.gatewayConnected == true ? "Running" : "Pairing"
     }
 
@@ -505,12 +503,8 @@ private struct WatchControlSurfaceView: View {
             return greetingTextOverride
         }
         let hour = Calendar.current.component(.hour, from: Date())
-        if hour < 12 {
-            return "Good morning"
-        }
-        if hour < 18 {
-            return "Good afternoon"
-        }
+        if hour < 12 { return "Good morning" }
+        if hour < 18 { return "Good afternoon" }
         return "Good evening"
     }
 

--- a/apps/macos/Sources/OpenClaw/AgeFormatting.swift
+++ b/apps/macos/Sources/OpenClaw/AgeFormatting.swift
@@ -7,23 +7,11 @@ func age(from date: Date, now: Date = .init()) -> String {
     let hours = minutes / 60
     let days = hours / 24
 
-    if seconds < 60 {
-        return "just now"
-    }
-    if minutes == 1 {
-        return "1 minute ago"
-    }
-    if minutes < 60 {
-        return "\(minutes)m ago"
-    }
-    if hours == 1 {
-        return "1 hour ago"
-    }
-    if hours < 24 {
-        return "\(hours)h ago"
-    }
-    if days == 1 {
-        return "yesterday"
-    }
+    if seconds < 60 { return "just now" }
+    if minutes == 1 { return "1 minute ago" }
+    if minutes < 60 { return "\(minutes)m ago" }
+    if hours == 1 { return "1 hour ago" }
+    if hours < 24 { return "\(hours)h ago" }
+    if days == 1 { return "yesterday" }
     return "\(days)d ago"
 }

--- a/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
+++ b/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
@@ -30,9 +30,7 @@ enum AgentWorkspace {
     static func displayPath(for url: URL) -> String {
         let home = FileManager().homeDirectoryForCurrentUser.path
         let path = url.path
-        if path == home {
-            return "~"
-        }
+        if path == home { return "~" }
         if path.hasPrefix(home + "/") {
             return "~/" + String(path.dropFirst(home.count + 1))
         }
@@ -41,9 +39,7 @@ enum AgentWorkspace {
 
     static func resolveWorkspaceURL(from userInput: String?) -> URL {
         let trimmed = userInput?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmed.isEmpty {
-            return OpenClawConfigFile.defaultWorkspaceURL()
-        }
+        if trimmed.isEmpty { return OpenClawConfigFile.defaultWorkspaceURL() }
         let expanded = (trimmed as NSString).expandingTildeInPath
         return URL(fileURLWithPath: expanded, isDirectory: true)
     }
@@ -80,9 +76,7 @@ enum AgentWorkspace {
         if !fm.fileExists(atPath: workspaceURL.path, isDirectory: &isDir) {
             return .safe
         }
-        if !isDir.boolValue {
-            return .blocked("Workspace path points to a file.")
-        }
+        if !isDir.boolValue { return .blocked("Workspace path points to a file.") }
         let agentsURL = self.agentsURL(workspaceURL: workspaceURL)
         if fm.fileExists(atPath: agentsURL.path) {
             return .safe

--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -15,9 +15,7 @@ enum CLIInstaller {
         case incompatible(location: String, found: String, required: String)
 
         var isReady: Bool {
-            if case .ready = self {
-                return true
-            }
+            if case .ready = self { return true }
             return false
         }
 

--- a/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
@@ -44,9 +44,7 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
         }
 
         let body: [String: Any] = {
-            if let dict = message.body as? [String: Any] {
-                return dict
-            }
+            if let dict = message.body as? [String: Any] { return dict }
             if let dict = message.body as? [AnyHashable: Any] {
                 return dict.reduce(into: [String: Any]()) { acc, pair in
                     guard let key = pair.key as? String else { return }
@@ -59,9 +57,7 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
 
         let userActionAny = body["userAction"] ?? body
         let userAction: [String: Any] = {
-            if let dict = userActionAny as? [String: Any] {
-                return dict
-            }
+            if let dict = userActionAny as? [String: Any] { return dict }
             if let dict = userActionAny as? [AnyHashable: Any] {
                 return dict.reduce(into: [String: Any]()) { acc, pair in
                     guard let key = pair.key as? String else { return }
@@ -137,24 +133,12 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
 
     private static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
         let (a, b, _, _) = ip
-        if a == 10 {
-            return true
-        }
-        if a == 172, (16...31).contains(Int(b)) {
-            return true
-        }
-        if a == 192, b == 168 {
-            return true
-        }
-        if a == 127 {
-            return true
-        }
-        if a == 169, b == 254 {
-            return true
-        }
-        if a == 100, (64...127).contains(Int(b)) {
-            return true
-        }
+        if a == 10 { return true }
+        if a == 172, (16...31).contains(Int(b)) { return true }
+        if a == 192, b == 168 { return true }
+        if a == 127 { return true }
+        if a == 169, b == 254 { return true }
+        if a == 100, (64...127).contains(Int(b)) { return true }
         return false
     }
     // Formatting helpers live in OpenClawKit (`OpenClawCanvasA2UIAction`).

--- a/apps/macos/Sources/OpenClaw/CanvasChromeContainerView.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasChromeContainerView.swift
@@ -206,15 +206,9 @@ final class HoverChromeContainerView: NSView {
             // When the chrome is hidden, do not intercept any mouse events (let the WKWebView receive them).
             guard self.alphaValue > 0.02 else { return nil }
 
-            if self.closeButton.frame.contains(point) {
-                return self.closeButton
-            }
-            if self.dragHandle.frame.contains(point) {
-                return self.dragHandle
-            }
-            if self.resizeHandle.frame.contains(point) {
-                return self.resizeHandle
-            }
+            if self.closeButton.frame.contains(point) { return self.closeButton }
+            if self.dragHandle.frame.contains(point) { return self.dragHandle }
+            if self.resizeHandle.frame.contains(point) { return self.resizeHandle }
             return nil
         }
 

--- a/apps/macos/Sources/OpenClaw/CanvasManager.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasManager.swift
@@ -255,9 +255,7 @@ final class CanvasManager {
         guard !trimmed.isEmpty else { return nil }
 
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
-            if scheme == "https" || scheme == "http" || scheme == "file" {
-                return url
-            }
+            if scheme == "https" || scheme == "http" || scheme == "file" { return url }
         }
 
         // Convenience: existing absolute *file* paths resolve as local files.
@@ -304,18 +302,14 @@ final class CanvasManager {
         let withoutQuery = trimmed.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false).first
             .map(String.init) ?? trimmed
         var path = withoutQuery
-        if path.hasPrefix("/") {
-            path.removeFirst()
-        }
+        if path.hasPrefix("/") { path.removeFirst() }
         path = path.removingPercentEncoding ?? path
 
         // Root special-case: built-in scaffold page when no index exists.
         if path.isEmpty {
             let a = sessionDir.appendingPathComponent("index.html", isDirectory: false)
             let b = sessionDir.appendingPathComponent("index.htm", isDirectory: false)
-            if fm.fileExists(atPath: a.path) || fm.fileExists(atPath: b.path) {
-                return .ok
-            }
+            if fm.fileExists(atPath: a.path) || fm.fileExists(atPath: b.path) { return .ok }
             return .welcome
         }
 
@@ -343,9 +337,7 @@ final class CanvasManager {
     private static func indexExists(in dir: URL) -> Bool {
         let fm = FileManager()
         let a = dir.appendingPathComponent("index.html", isDirectory: false)
-        if fm.fileExists(atPath: a.path) {
-            return true
-        }
+        if fm.fileExists(atPath: a.path) { return true }
         let b = dir.appendingPathComponent("index.htm", isDirectory: false)
         return fm.fileExists(atPath: b.path)
     }

--- a/apps/macos/Sources/OpenClaw/CanvasSchemeHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasSchemeHandler.swift
@@ -61,12 +61,8 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
 
         // Path mapping: request path maps directly into the session dir.
         var path = url.path
-        if let qIdx = path.firstIndex(of: "?") {
-            path = String(path[..<qIdx])
-        }
-        if path.hasPrefix("/") {
-            path.removeFirst()
-        }
+        if let qIdx = path.firstIndex(of: "?") { path = String(path[..<qIdx]) }
+        if path.hasPrefix("/") { path.removeFirst() }
         path = path.removingPercentEncoding ?? path
 
         // Special-case: welcome page when root index is missing.
@@ -117,9 +113,7 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
         var isDir: ObjCBool = false
         if fm.fileExists(atPath: candidate.path, isDirectory: &isDir) {
             if isDir.boolValue {
-                if let idx = self.resolveIndex(in: candidate) {
-                    return idx
-                }
+                if let idx = self.resolveIndex(in: candidate) { return idx }
                 return nil
             }
             return candidate
@@ -130,9 +124,7 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
         if !requestPath.isEmpty, !requestPath.hasSuffix("/") {
             candidate = sessionRoot.appendingPathComponent(requestPath, isDirectory: true)
             if fm.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
-                if let idx = self.resolveIndex(in: candidate) {
-                    return idx
-                }
+                if let idx = self.resolveIndex(in: candidate) { return idx }
             }
         }
 
@@ -148,13 +140,9 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
     private func resolveIndex(in dir: URL) -> URL? {
         let fm = FileManager()
         let a = dir.appendingPathComponent("index.html", isDirectory: false)
-        if fm.fileExists(atPath: a.path) {
-            return a
-        }
+        if fm.fileExists(atPath: a.path) { return a }
         let b = dir.appendingPathComponent("index.htm", isDirectory: false)
-        if fm.fileExists(atPath: b.path) {
-            return b
-        }
+        if fm.fileExists(atPath: b.path) { return b }
         return nil
     }
 
@@ -229,9 +217,7 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
     private func loadBundledResourceData(relativePath: String) -> Data? {
         let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        if trimmed.contains("..") || trimmed.contains("\\") {
-            return nil
-        }
+        if trimmed.contains("..") || trimmed.contains("\\") { return nil }
 
         let parts = trimmed.split(separator: "/")
         guard let filename = parts.last else { return nil }
@@ -251,9 +237,7 @@ final class CanvasSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func textEncodingName(forMimeType mimeType: String) -> String? {
-        if mimeType.hasPrefix("text/") {
-            return "utf-8"
-        }
+        if mimeType.hasPrefix("text/") { return "utf-8" }
         switch mimeType {
         case "application/javascript", "application/json", "image/svg+xml":
             return "utf-8"

--- a/apps/macos/Sources/OpenClaw/CanvasWindow.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindow.swift
@@ -25,9 +25,7 @@ enum CanvasPresentation {
     case panel(anchorProvider: () -> NSRect?)
 
     var isPanel: Bool {
-        if case .panel = self {
-            return true
-        }
+        if case .panel = self { return true }
         return false
     }
 }

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Helpers.swift
@@ -6,9 +6,7 @@ extension CanvasWindowController {
 
     static func sanitizeSessionKey(_ key: String) -> String {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return "main"
-        }
+        if trimmed.isEmpty { return "main" }
         let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-+")
         let scalars = trimmed.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
         return String(scalars)
@@ -32,9 +30,7 @@ extension CanvasWindowController {
         let key = self.storedFrameDefaultsKey(sessionKey: sessionKey)
         guard let arr = UserDefaults.standard.array(forKey: key) as? [Double], arr.count == 4 else { return nil }
         let rect = NSRect(x: arr[0], y: arr[1], width: arr[2], height: arr[3])
-        if rect.width < CanvasLayout.minPanelSize.width || rect.height < CanvasLayout.minPanelSize.height {
-            return nil
-        }
+        if rect.width < CanvasLayout.minPanelSize.width || rect.height < CanvasLayout.minPanelSize.height { return nil }
         return rect
     }
 

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
@@ -34,24 +34,12 @@ extension CanvasWindowController {
 
     static func _testIsLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
         let (a, b, _, _) = ip
-        if a == 10 {
-            return true
-        }
-        if a == 172, (16...31).contains(Int(b)) {
-            return true
-        }
-        if a == 192, b == 168 {
-            return true
-        }
-        if a == 127 {
-            return true
-        }
-        if a == 169, b == 254 {
-            return true
-        }
-        if a == 100, (64...127).contains(Int(b)) {
-            return true
-        }
+        if a == 10 { return true }
+        if a == 172, (16...31).contains(Int(b)) { return true }
+        if a == 192, b == 168 { return true }
+        if a == 127 { return true }
+        if a == 169, b == 254 { return true }
+        if a == 100, (64...127).contains(Int(b)) { return true }
         return false
     }
 

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Window.swift
@@ -79,18 +79,10 @@ extension CanvasWindowController {
         // - If agent provides width/height, override size.
         // - If agent provides only size, keep the remembered origin.
         if let placement = self.preferredPlacement {
-            if let x = placement.x {
-                frame.origin.x = x
-            }
-            if let y = placement.y {
-                frame.origin.y = y
-            }
-            if let w = placement.width {
-                frame.size.width = max(CanvasLayout.minPanelSize.width, CGFloat(w))
-            }
-            if let h = placement.height {
-                frame.size.height = max(CanvasLayout.minPanelSize.height, CGFloat(h))
-            }
+            if let x = placement.x { frame.origin.x = x }
+            if let y = placement.y { frame.origin.y = y }
+            if let w = placement.width { frame.size.width = max(CanvasLayout.minPanelSize.width, CGFloat(w)) }
+            if let h = placement.height { frame.size.height = max(CanvasLayout.minPanelSize.height, CGFloat(h)) }
         }
 
         self.setPanelFrame(frame, on: targetScreen)
@@ -136,9 +128,7 @@ extension CanvasWindowController {
     }
 
     static func constrainFrame(_ frame: NSRect, toVisibleFrame bounds: NSRect) -> NSRect {
-        if bounds == .zero {
-            return frame
-        }
+        if bounds == .zero { return frame }
 
         var next = frame
         next.size.width = min(max(CanvasLayout.minPanelSize.width, next.size.width), bounds.width)

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -323,12 +323,8 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
     func shouldAutoNavigateToA2UI(lastAutoTarget: String?, candidateTarget: String) -> Bool {
         let current = (self.currentTarget ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let candidate = candidateTarget.trimmingCharacters(in: .whitespacesAndNewlines)
-        if current.isEmpty || current == "/" {
-            return true
-        }
-        if !candidate.isEmpty, current == candidate {
-            return false
-        }
+        if current.isEmpty || current == "/" { return true }
+        if !candidate.isEmpty, current == candidate { return false }
         if let lastAuto = lastAutoTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
            !lastAuto.isEmpty,
            current == lastAuto

--- a/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
@@ -121,9 +121,7 @@ struct ConfigSchemaForm: View {
             }
             return AnyView(
                 VStack(alignment: .leading, spacing: 6) {
-                    if let label {
-                        Text(label).font(.callout.weight(.semibold))
-                    }
+                    if let label { Text(label).font(.callout.weight(.semibold)) }
                     Text("Unsupported field type.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -154,9 +152,7 @@ struct ConfigSchemaForm: View {
         let sortedKeys = properties.keys.sorted { lhs, rhs in
             let orderA = hintForPath(path + [.key(lhs)], hints: store.configUiHints)?.order ?? 0
             let orderB = hintForPath(path + [.key(rhs)], hints: store.configUiHints)?.order ?? 0
-            if orderA != orderB {
-                return orderA < orderB
-            }
+            if orderA != orderB { return orderA < orderB }
             return lhs < rhs
         }
 
@@ -210,9 +206,7 @@ struct ConfigSchemaForm: View {
         value: Any?) -> Bool
     {
         guard schema.allowsAdditionalProperties else { return false }
-        if self.mode != .channelQuick {
-            return true
-        }
+        if self.mode != .channelQuick { return true }
         guard let dict = value as? [String: Any] else { return false }
         let reserved = Set(schema.properties.keys)
         return dict.keys.contains { !reserved.contains($0) }
@@ -341,9 +335,7 @@ struct ConfigSchemaForm: View {
             }
         } else {
             VStack(alignment: .leading, spacing: 6) {
-                if let label {
-                    Text(label).font(.callout.weight(.semibold))
-                }
+                if let label { Text(label).font(.callout.weight(.semibold)) }
                 if let help {
                     Text(help)
                         .font(.caption)
@@ -379,9 +371,7 @@ struct ConfigSchemaForm: View {
             }
         } else {
             VStack(alignment: .leading, spacing: 6) {
-                if let label {
-                    Text(label).font(.callout.weight(.semibold))
-                }
+                if let label { Text(label).font(.callout.weight(.semibold)) }
                 if let help {
                     Text(help)
                         .font(.caption)
@@ -420,9 +410,7 @@ struct ConfigSchemaForm: View {
             }
         } else {
             VStack(alignment: .leading, spacing: 6) {
-                if let label {
-                    Text(label).font(.callout.weight(.semibold))
-                }
+                if let label { Text(label).font(.callout.weight(.semibold)) }
                 if let help {
                     Text(help)
                         .font(.caption)
@@ -450,9 +438,7 @@ struct ConfigSchemaForm: View {
         let items = value as? [Any] ?? []
         let itemSchema = schema.items
         VStack(alignment: .leading, spacing: 10) {
-            if let label {
-                Text(label).font(.callout.weight(.semibold))
-            }
+            if let label { Text(label).font(.callout.weight(.semibold)) }
             if let help {
                 Text(help)
                     .font(.caption)
@@ -544,9 +530,7 @@ struct ConfigSchemaForm: View {
     private func stringBinding(_ path: ConfigPath, defaultValue: String?) -> Binding<String> {
         Binding(
             get: {
-                if let value = store.configValue(at: path) as? String {
-                    return value
-                }
+                if let value = store.configValue(at: path) as? String { return value }
                 return defaultValue ?? ""
             },
             set: { newValue in
@@ -558,9 +542,7 @@ struct ConfigSchemaForm: View {
     private func boolBinding(_ path: ConfigPath, defaultValue: Bool?) -> Binding<Bool> {
         Binding(
             get: {
-                if let value = store.configValue(at: path) as? Bool {
-                    return value
-                }
+                if let value = store.configValue(at: path) as? Bool { return value }
                 return defaultValue ?? false
             },
             set: { newValue in
@@ -575,9 +557,7 @@ struct ConfigSchemaForm: View {
     {
         Binding(
             get: {
-                if let value = store.configValue(at: path) {
-                    return String(describing: value)
-                }
+                if let value = store.configValue(at: path) { return String(describing: value) }
                 guard let defaultValue else { return "" }
                 return isInteger ? String(Int(defaultValue)) : String(defaultValue)
             },

--- a/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelState.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelState.swift
@@ -10,28 +10,16 @@ extension ChannelsSettings {
     }
 
     private func configuredChannelTint(configured: Bool, running: Bool, hasError: Bool, probeOk: Bool?) -> Color {
-        if !configured {
-            return .secondary
-        }
-        if hasError {
-            return .orange
-        }
-        if probeOk == false {
-            return .orange
-        }
-        if running {
-            return .green
-        }
+        if !configured { return .secondary }
+        if hasError { return .orange }
+        if probeOk == false { return .orange }
+        if running { return .green }
         return .orange
     }
 
     private func configuredChannelSummary(configured: Bool, running: Bool) -> String {
-        if !configured {
-            return "Not configured"
-        }
-        if running {
-            return "Running"
-        }
+        if !configured { return "Not configured" }
+        if running { return "Running" }
         return "Configured"
     }
 
@@ -108,21 +96,11 @@ extension ChannelsSettings {
     var whatsAppTint: Color {
         guard let status = self.channelStatus("whatsapp", as: ChannelsStatusSnapshot.WhatsAppStatus.self)
         else { return .secondary }
-        if !status.configured {
-            return .secondary
-        }
-        if !status.linked {
-            return .red
-        }
-        if status.lastError != nil {
-            return .orange
-        }
-        if status.connected {
-            return .green
-        }
-        if status.running {
-            return .orange
-        }
+        if !status.configured { return .secondary }
+        if !status.linked { return .red }
+        if status.lastError != nil { return .orange }
+        if status.connected { return .green }
+        if status.running { return .orange }
         return .orange
     }
 
@@ -179,15 +157,9 @@ extension ChannelsSettings {
     var whatsAppSummary: String {
         guard let status = self.channelStatus("whatsapp", as: ChannelsStatusSnapshot.WhatsAppStatus.self)
         else { return "Checking…" }
-        if !status.linked {
-            return "Not linked"
-        }
-        if status.connected {
-            return "Connected"
-        }
-        if status.running {
-            return "Running"
-        }
+        if !status.linked { return "Not linked" }
+        if status.connected { return "Connected" }
+        if status.running { return "Running" }
         return "Linked"
     }
 
@@ -372,9 +344,7 @@ extension ChannelsSettings {
         return channels.sorted { lhs, rhs in
             let lhsEnabled = self.channelEnabled(lhs)
             let rhsEnabled = self.channelEnabled(rhs)
-            if lhsEnabled != rhsEnabled {
-                return lhsEnabled && !rhsEnabled
-            }
+            if lhsEnabled != rhsEnabled { return lhsEnabled && !rhsEnabled }
             return lhs.sortOrder < rhs.sortOrder
         }
     }
@@ -435,12 +405,8 @@ extension ChannelsSettings {
         case "imessage":
             return self.imessageTint
         default:
-            if self.channelHasError(channel) {
-                return .orange
-            }
-            if self.channelEnabled(channel) {
-                return .green
-            }
+            if self.channelHasError(channel) { return .orange }
+            if self.channelEnabled(channel) { return .green }
             return .secondary
         }
     }
@@ -460,12 +426,8 @@ extension ChannelsSettings {
         case "imessage":
             return self.imessageSummary
         default:
-            if self.channelHasError(channel) {
-                return "Error"
-            }
-            if self.channelEnabled(channel) {
-                return "Active"
-            }
+            if self.channelHasError(channel) { return "Error" }
+            if self.channelEnabled(channel) { return "Active" }
             return "Not configured"
         }
     }
@@ -570,9 +532,7 @@ extension ChannelsSettings {
 
     private func resolveChannelTitle(_ id: String) -> String {
         let label = self.store.resolveChannelLabel(id)
-        if label != id {
-            return label
-        }
+        if label != id { return label }
         return id.prefix(1).uppercased() + id.dropFirst()
     }
 

--- a/apps/macos/Sources/OpenClaw/CoalescingFSEventsWatcher.swift
+++ b/apps/macos/Sources/OpenClaw/CoalescingFSEventsWatcher.swift
@@ -99,9 +99,7 @@ extension CoalescingFSEventsWatcher {
         guard self.shouldNotify(numEvents, eventPaths) else { return }
 
         // Coalesce rapid changes (common during builds/atomic saves).
-        if self.pending {
-            return
-        }
+        if self.pending { return }
         self.pending = true
         self.queue.asyncAfter(deadline: .now() + self.coalesceDelay) { [weak self] in
             guard let self else { return }

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -6,17 +6,11 @@ enum CommandResolver {
 
     static func gatewayEntrypoint(in root: URL) -> String? {
         let distEntry = root.appendingPathComponent("dist/index.js").path
-        if FileManager().isReadableFile(atPath: distEntry) {
-            return distEntry
-        }
+        if FileManager().isReadableFile(atPath: distEntry) { return distEntry }
         let openclawEntry = root.appendingPathComponent("openclaw.mjs").path
-        if FileManager().isReadableFile(atPath: openclawEntry) {
-            return openclawEntry
-        }
+        if FileManager().isReadableFile(atPath: openclawEntry) { return openclawEntry }
         let binEntry = root.appendingPathComponent("bin/openclaw.js").path
-        if FileManager().isReadableFile(atPath: binEntry) {
-            return binEntry
-        }
+        if FileManager().isReadableFile(atPath: binEntry) { return binEntry }
         return nil
     }
 
@@ -207,9 +201,7 @@ enum CommandResolver {
             for i in 0..<maxCount {
                 let ai = i < va.count ? va[i] : 0
                 let bi = i < vb.count ? vb[i] : 0
-                if ai != bi {
-                    return ai > bi
-                }
+                if ai != bi { return ai > bi }
             }
             // If identical numerically, keep stable ordering.
             return a > b
@@ -263,12 +255,8 @@ enum CommandResolver {
     }
 
     static func hasAnyOpenClawInvoker(searchPaths: [String]? = nil) -> Bool {
-        if self.openclawExecutable(searchPaths: searchPaths) != nil {
-            return true
-        }
-        if self.findExecutable(named: "pnpm", searchPaths: searchPaths) != nil {
-            return true
-        }
+        if self.openclawExecutable(searchPaths: searchPaths) != nil { return true }
+        if self.findExecutable(named: "pnpm", searchPaths: searchPaths) != nil { return true }
         if self.findExecutable(named: "node", searchPaths: searchPaths) != nil,
            self.nodeCliPath() != nil
         {
@@ -599,9 +587,7 @@ enum CommandResolver {
     }
 
     private static func shellQuote(_ text: String) -> String {
-        if text.isEmpty {
-            return "''"
-        }
+        if text.isEmpty { return "''" }
         let escaped = text.replacingOccurrences(of: "'", with: "'\\''")
         return "'\(escaped)'"
     }
@@ -625,12 +611,8 @@ enum CommandResolver {
     }
 
     private static func isValidSSHComponent(_ value: String, allowLeadingDash: Bool = false) -> Bool {
-        if value.isEmpty {
-            return false
-        }
-        if !allowLeadingDash, value.hasPrefix("-") {
-            return false
-        }
+        if value.isEmpty { return false }
+        if !allowLeadingDash, value.hasPrefix("-") { return false }
         let invalid = CharacterSet.whitespacesAndNewlines.union(.controlCharacters)
         return value.rangeOfCharacter(from: invalid) == nil
     }

--- a/apps/macos/Sources/OpenClaw/ConfigFileWatcher.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigFileWatcher.swift
@@ -22,15 +22,9 @@ final class ConfigFileWatcher: @unchecked Sendable, SimpleFileWatcherOwner {
                 guard let eventPaths else { return true }
                 let paths = unsafeBitCast(eventPaths, to: NSArray.self)
                 for case let path as String in paths {
-                    if path == targetPath {
-                        return true
-                    }
-                    if path.hasSuffix("/\(targetName)") {
-                        return true
-                    }
-                    if path == watchedDirPath {
-                        return true
-                    }
+                    if path == targetPath { return true }
+                    if path.hasSuffix("/\(targetName)") { return true }
+                    if path == watchedDirPath { return true }
                 }
                 return false
             },

--- a/apps/macos/Sources/OpenClaw/ConfigSchemaSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigSchemaSupport.swift
@@ -64,20 +64,14 @@ struct ConfigSchemaNode {
     }
 
     var typeList: [String] {
-        if let type = self.raw["type"] as? String {
-            return [type]
-        }
-        if let types = self.raw["type"] as? [String] {
-            return types
-        }
+        if let type = self.raw["type"] as? String { return [type] }
+        if let types = self.raw["type"] as? [String] { return types }
         return []
     }
 
     var schemaType: String? {
         let filtered = self.typeList.filter { $0 != "null" }
-        if let first = filtered.first {
-            return first
-        }
+        if let first = filtered.first { return first }
         return self.typeList.first
     }
 
@@ -102,12 +96,8 @@ struct ConfigSchemaNode {
     }
 
     var literalValue: Any? {
-        if let constValue {
-            return constValue
-        }
-        if let enumValues, enumValues.count == 1 {
-            return enumValues[0]
-        }
+        if let constValue { return constValue }
+        if let enumValues, enumValues.count == 1 { return enumValues[0] }
         return nil
     }
 
@@ -129,16 +119,12 @@ struct ConfigSchemaNode {
     }
 
     var allowsAdditionalProperties: Bool {
-        if let allow = self.raw["additionalProperties"] as? Bool {
-            return allow
-        }
+        if let allow = self.raw["additionalProperties"] as? Bool { return allow }
         return self.additionalProperties != nil
     }
 
     var defaultValue: Any {
-        if let value = self.raw["default"] {
-            return value
-        }
+        if let value = self.raw["default"] { return value }
         switch self.schemaType {
         case "object":
             return [String: Any]()
@@ -194,9 +180,7 @@ func decodeUiHints(_ raw: [String: Any]) -> [String: ConfigUiHint] {
 
 func hintForPath(_ path: ConfigPath, hints: [String: ConfigUiHint]) -> ConfigUiHint? {
     let key = pathKey(path)
-    if let direct = hints[key] {
-        return direct
-    }
+    if let direct = hints[key] { return direct }
     let segments = key.split(separator: ".").map(String.init)
     for (hintKey, hint) in hints {
         guard hintKey.contains("*") else { continue }
@@ -210,9 +194,7 @@ func hintForPath(_ path: ConfigPath, hints: [String: ConfigUiHint]) -> ConfigUiH
                 break
             }
         }
-        if match {
-            return hint
-        }
+        if match { return hint }
     }
     return nil
 }

--- a/apps/macos/Sources/OpenClaw/ConfigSettings.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigSettings.swift
@@ -419,9 +419,7 @@ extension ConfigSettings {
     private func sortLookupChildren(_ lhs: ConfigSchemaLookupChild, _ rhs: ConfigSchemaLookupChild) -> Bool {
         let orderA = lhs.hint?.order ?? 0
         let orderB = rhs.hint?.order ?? 0
-        if orderA != orderB {
-            return orderA < orderB
-        }
+        if orderA != orderB { return orderA < orderB }
         return lhs.key < rhs.key
     }
 
@@ -444,9 +442,7 @@ extension ConfigSettings {
     }
 
     private static func shouldRenderFormEditor(for schema: ConfigSchemaNode) -> Bool {
-        if schema.schemaType == "array" {
-            return true
-        }
+        if schema.schemaType == "array" { return true }
         return schema.additionalProperties != nil
     }
 

--- a/apps/macos/Sources/OpenClaw/ContextMenuCardView.swift
+++ b/apps/macos/Sources/OpenClaw/ContextMenuCardView.swift
@@ -49,9 +49,7 @@ struct ContextMenuCardView: View {
 
     private var subtitle: String {
         let count = self.rows.count
-        if count == 1 {
-            return "1 session · 24h"
-        }
+        if count == 1 { return "1 session · 24h" }
         return "\(count) sessions · 24h"
     }
 

--- a/apps/macos/Sources/OpenClaw/ContextUsageBar.swift
+++ b/apps/macos/Sources/OpenClaw/ContextUsageBar.swift
@@ -9,25 +9,19 @@ struct ContextUsageBar: View {
     private static let okGreen: NSColor = .init(name: nil) { appearance in
         let base = NSColor.systemGreen
         let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua {
-            return base
-        }
+        if match == .darkAqua { return base }
         return base.blended(withFraction: 0.24, of: .black) ?? base
     }
 
     private static let trackFill: NSColor = .init(name: nil) { appearance in
         let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua {
-            return NSColor.white.withAlphaComponent(0.14)
-        }
+        if match == .darkAqua { return NSColor.white.withAlphaComponent(0.14) }
         return NSColor.black.withAlphaComponent(0.12)
     }
 
     private static let trackStroke: NSColor = .init(name: nil) { appearance in
         let match = appearance.bestMatch(from: [.aqua, .darkAqua])
-        if match == .darkAqua {
-            return NSColor.white.withAlphaComponent(0.22)
-        }
+        if match == .darkAqua { return NSColor.white.withAlphaComponent(0.22) }
         return NSColor.black.withAlphaComponent(0.2)
     }
 
@@ -43,15 +37,9 @@ struct ContextUsageBar: View {
 
     private var tint: Color {
         guard let pct = self.percentUsed else { return .secondary }
-        if pct >= 95 {
-            return Color(nsColor: .systemRed)
-        }
-        if pct >= 80 {
-            return Color(nsColor: .systemOrange)
-        }
-        if pct >= 60 {
-            return Color(nsColor: .systemYellow)
-        }
+        if pct >= 95 { return Color(nsColor: .systemRed) }
+        if pct >= 80 { return Color(nsColor: .systemOrange) }
+        if pct >= 60 { return Color(nsColor: .systemYellow) }
         return Color(nsColor: Self.okGreen)
     }
 
@@ -74,9 +62,7 @@ struct ContextUsageBar: View {
     }
 
     private var accessibilityValue: String {
-        if self.contextTokens <= 0 {
-            return "Unknown context window"
-        }
+        if self.contextTokens <= 0 { return "Unknown context window" }
         let pct = Int(round(self.clampedFractionUsed * 100))
         return "\(pct) percent used"
     }

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -343,9 +343,7 @@ final class ControlChannel {
 
         let detail = nsError.localizedDescription.isEmpty ? "unknown gateway error" : nsError.localizedDescription
         let trimmed = detail.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.lowercased().hasPrefix("gateway error:") {
-            return trimmed
-        }
+        if trimmed.lowercased().hasPrefix("gateway error:") { return trimmed }
         return "Gateway error: \(trimmed)"
     }
 
@@ -367,9 +365,7 @@ final class ControlChannel {
 
     private func scheduleRecovery(reason: String) {
         let now = Date()
-        if let last = self.lastRecoveryAt, now.timeIntervalSince(last) < 10 {
-            return
-        }
+        if let last = self.lastRecoveryAt, now.timeIntervalSince(last) < 10 { return }
         guard self.recoveryTask == nil else { return }
         self.lastRecoveryAt = now
 

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -99,9 +99,7 @@ extension CritterStatusLabel {
         deadlines: [Date]) -> TimeInterval
     {
         // Working motion needs a steady cadence; idle motion only wakes for its next visible event.
-        if isWorking {
-            return 0.35
-        }
+        if isWorking { return 0.35 }
         guard let nextDeadline = deadlines.min() else { return 1 }
         return max(0.05, nextDeadline.timeIntervalSince(now))
     }
@@ -248,9 +246,7 @@ extension CritterStatusLabel {
     }
 
     private var gatewayNeedsAttention: Bool {
-        if self.isSleeping {
-            return false
-        }
+        if self.isSleeping { return false }
         switch self.gatewayStatus {
         case .failed, .stopped:
             return !self.isPaused

--- a/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
@@ -110,9 +110,7 @@ extension CronJobEditor {
             "payload": payload,
         ]
         self.applyDeleteAfterRun(to: &root)
-        if !description.isEmpty {
-            root["description"] = description
-        }
+        if !description.isEmpty { root["description"] = description }
         if !agentId.isEmpty {
             root["agentId"] = agentId
         } else if self.job?.agentId != nil {
@@ -133,9 +131,7 @@ extension CronJobEditor {
             let trimmed = self.channel.trimmingCharacters(in: .whitespacesAndNewlines)
             delivery["channel"] = trimmed.isEmpty ? "last" : trimmed
             let to = self.to.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !to.isEmpty {
-                delivery["to"] = to
-            }
+            if !to.isEmpty { delivery["to"] = to }
             if self.bestEffortDeliver {
                 delivery["bestEffort"] = true
             } else if self.job?.delivery?.bestEffort == true {
@@ -189,9 +185,7 @@ extension CronJobEditor {
     }
 
     func buildSelectedPayload() throws -> [String: Any] {
-        if self.isIsolatedLikeSessionTarget {
-            return self.buildAgentTurnPayload()
-        }
+        if self.isIsolatedLikeSessionTarget { return self.buildAgentTurnPayload() }
         switch self.payloadKind {
         case .systemEvent:
             let text = self.trimmed(self.systemEventText)
@@ -257,20 +251,14 @@ extension CronJobEditor {
         let msg = self.agentMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         var payload: [String: Any] = ["kind": "agentTurn", "message": msg]
         let thinking = self.thinking.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !thinking.isEmpty {
-            payload["thinking"] = thinking
-        }
-        if let n = Int(self.timeoutSeconds), n > 0 {
-            payload["timeoutSeconds"] = n
-        }
+        if !thinking.isEmpty { payload["thinking"] = thinking }
+        if let n = Int(self.timeoutSeconds), n > 0 { payload["timeoutSeconds"] = n }
         return payload
     }
 
     static func parseDurationMs(_ input: String) -> Int? {
         let raw = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        if raw.isEmpty {
-            return nil
-        }
+        if raw.isEmpty { return nil }
 
         let rx = try? NSRegularExpression(pattern: "^(\\d+(?:\\.\\d+)?)(ms|s|m|h|d)$", options: [.caseInsensitive])
         guard let match = rx?.firstMatch(in: raw, range: NSRange(location: 0, length: raw.utf16.count)) else {
@@ -282,9 +270,7 @@ extension CronJobEditor {
             return String(raw[r])
         }
         let n = Double(group(1)) ?? 0
-        if !n.isFinite || n <= 0 {
-            return nil
-        }
+        if !n.isFinite || n <= 0 { return nil }
         let unit = group(2).lowercased()
         let factor: Double = switch unit {
         case "ms": 1

--- a/apps/macos/Sources/OpenClaw/CronJobEditor.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor.swift
@@ -85,9 +85,7 @@ struct CronJobEditor: View {
     }
 
     func channelLabel(for id: String) -> String {
-        if id == "last" {
-            return "last"
-        }
+        if id == "last" { return "last" }
         return self.channelsStore.resolveChannelLabel(id)
     }
 

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -139,12 +139,8 @@ enum CronSchedule: Codable, Equatable {
 
     static func parseAtDate(_ value: String) -> Date? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
-        if let date = makeIsoFormatter(withFractional: true).date(from: trimmed) {
-            return date
-        }
+        if trimmed.isEmpty { return nil }
+        if let date = makeIsoFormatter(withFractional: true).date(from: trimmed) { return date }
         return self.makeIsoFormatter(withFractional: false).date(from: trimmed)
     }
 

--- a/apps/macos/Sources/OpenClaw/CronSettings+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Helpers.swift
@@ -25,14 +25,10 @@ extension CronSettings {
         case let .every(everyMs, _):
             return "every \(self.formatDuration(ms: everyMs))"
         case let .cron(expr, tz):
-            if let tz, !tz.isEmpty {
-                return "cron \(expr) (\(tz))"
-            }
+            if let tz, !tz.isEmpty { return "cron \(expr) (\(tz))" }
             return "cron \(expr)"
         case let .onExit(command, cwd):
-            if let cwd, !cwd.isEmpty {
-                return "on exit: \(command) (cwd: \(cwd))"
-            }
+            if let cwd, !cwd.isEmpty { return "on exit: \(command) (cwd: \(cwd))" }
             return "on exit: \(command)"
         }
     }
@@ -43,20 +39,12 @@ extension CronSettings {
 
     func nextRunLabel(_ date: Date, now: Date = .init()) -> String {
         let delta = date.timeIntervalSince(now)
-        if delta <= 0 {
-            return "due"
-        }
-        if delta < 60 {
-            return "in <1m"
-        }
+        if delta <= 0 { return "due" }
+        if delta < 60 { return "in <1m" }
         let minutes = Int(round(delta / 60))
-        if minutes < 60 {
-            return "in \(minutes)m"
-        }
+        if minutes < 60 { return "in \(minutes)m" }
         let hours = Int(round(Double(minutes) / 60))
-        if hours < 48 {
-            return "in \(hours)h"
-        }
+        if hours < 48 { return "in \(hours)h" }
         let days = Int(round(Double(hours) / 24))
         return "in \(days)d"
     }

--- a/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
@@ -39,9 +39,7 @@ extension CronSettings {
         .alert("Delete cron job?", isPresented: Binding(
             get: { self.confirmDelete != nil },
             set: {
-                if !$0 {
-                    self.confirmDelete = nil
-                }
+                if !$0 { self.confirmDelete = nil }
             })) {
                 Button("Cancel", role: .cancel) { self.confirmDelete = nil }
                 Button("Delete", role: .destructive) {

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -222,12 +222,8 @@ extension CronSettings {
                         .font(.callout)
                         .textSelection(.enabled)
                     HStack(spacing: 8) {
-                        if let thinking, !thinking.isEmpty {
-                            StatusPill(text: "think \(thinking)", tint: .secondary)
-                        }
-                        if let timeoutSeconds {
-                            StatusPill(text: "\(timeoutSeconds)s", tint: .secondary)
-                        }
+                        if let thinking, !thinking.isEmpty { StatusPill(text: "think \(thinking)", tint: .secondary) }
+                        if let timeoutSeconds { StatusPill(text: "\(timeoutSeconds)s", tint: .secondary) }
                         if job.supportsAnnounceDelivery {
                             let delivery = job.delivery
                             if let delivery {
@@ -236,9 +232,7 @@ extension CronSettings {
                                     if let channel = delivery.channel, !channel.isEmpty {
                                         StatusPill(text: channel, tint: .secondary)
                                     }
-                                    if let to = delivery.to, !to.isEmpty {
-                                        StatusPill(text: to, tint: .secondary)
-                                    }
+                                    if let to = delivery.to, !to.isEmpty { StatusPill(text: to, tint: .secondary) }
                                 } else {
                                     StatusPill(text: "no delivery", tint: .secondary)
                                 }

--- a/apps/macos/Sources/OpenClaw/DebugActions.swift
+++ b/apps/macos/Sources/OpenClaw/DebugActions.swift
@@ -236,13 +236,9 @@ enum DebugActions {
 
     static func killProcess(_ pid: Int) async -> Result<Void, DebugActionError> {
         let primary = await ShellExecutor.run(command: ["kill", "-TERM", "\(pid)"], cwd: nil, env: nil, timeout: 2)
-        if primary.ok {
-            return .success(())
-        }
+        if primary.ok { return .success(()) }
         let force = await ShellExecutor.run(command: ["kill", "-KILL", "\(pid)"], cwd: nil, env: nil, timeout: 2)
-        if force.ok {
-            return .success(())
-        }
+        if force.ok { return .success(()) }
         let detail = force.message ?? primary.message ?? "kill failed"
         return .failure(.message(detail))
     }

--- a/apps/macos/Sources/OpenClaw/DebugSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DebugSettings.swift
@@ -318,9 +318,7 @@ struct DebugSettings: View {
                 HStack(spacing: 8) {
                     Text("Port diagnostics")
                         .font(.caption.weight(.semibold))
-                    if self.portCheckInFlight {
-                        ProgressView().controlSize(.small)
-                    }
+                    if self.portCheckInFlight { ProgressView().controlSize(.small) }
                     Spacer()
                     Button("Check gateway ports") {
                         Task { await self.runPortCheck() }

--- a/apps/macos/Sources/OpenClaw/DeviceModelCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceModelCatalog.swift
@@ -29,9 +29,7 @@ enum DeviceModelCatalog {
             ""
         }
 
-        if title.isEmpty {
-            return nil
-        }
+        if title.isEmpty { return nil }
         return DevicePresentation(title: title, symbol: symbol)
     }
 
@@ -52,54 +50,26 @@ enum DeviceModelCatalog {
         guard !modelIdentifier.isEmpty else { return nil }
 
         let lower = modelIdentifier.lowercased()
-        if lower.hasPrefix("ipad") {
-            return "ipad"
-        }
-        if lower.hasPrefix("iphone") {
-            return "iphone"
-        }
-        if lower.hasPrefix("ipod") {
-            return "iphone"
-        }
-        if lower.hasPrefix("watch") {
-            return "applewatch"
-        }
-        if lower.hasPrefix("appletv") {
-            return "appletv"
-        }
-        if lower.hasPrefix("audio") || lower.hasPrefix("homepod") {
-            return "speaker"
-        }
+        if lower.hasPrefix("ipad") { return "ipad" }
+        if lower.hasPrefix("iphone") { return "iphone" }
+        if lower.hasPrefix("ipod") { return "iphone" }
+        if lower.hasPrefix("watch") { return "applewatch" }
+        if lower.hasPrefix("appletv") { return "appletv" }
+        if lower.hasPrefix("audio") || lower.hasPrefix("homepod") { return "speaker" }
 
         if lower.hasPrefix("macbook") || lower.hasPrefix("macbookpro") || lower.hasPrefix("macbookair") {
             return "laptopcomputer"
         }
-        if lower.hasPrefix("macstudio") {
-            return "macstudio"
-        }
-        if lower.hasPrefix("macmini") {
-            return "macmini"
-        }
-        if lower.hasPrefix("imac") || lower.hasPrefix("macpro") {
-            return "desktopcomputer"
-        }
+        if lower.hasPrefix("macstudio") { return "macstudio" }
+        if lower.hasPrefix("macmini") { return "macmini" }
+        if lower.hasPrefix("imac") || lower.hasPrefix("macpro") { return "desktopcomputer" }
 
         if lower.hasPrefix("mac"), let friendlyNameLower = friendlyName?.lowercased() {
-            if friendlyNameLower.contains("macbook") {
-                return "laptopcomputer"
-            }
-            if friendlyNameLower.contains("imac") {
-                return "desktopcomputer"
-            }
-            if friendlyNameLower.contains("mac mini") {
-                return "macmini"
-            }
-            if friendlyNameLower.contains("mac studio") {
-                return "macstudio"
-            }
-            if friendlyNameLower.contains("mac pro") {
-                return "desktopcomputer"
-            }
+            if friendlyNameLower.contains("macbook") { return "laptopcomputer" }
+            if friendlyNameLower.contains("imac") { return "desktopcomputer" }
+            if friendlyNameLower.contains("mac mini") { return "macmini" }
+            if friendlyNameLower.contains("mac studio") { return "macstudio" }
+            if friendlyNameLower.contains("mac pro") { return "desktopcomputer" }
         }
 
         return nil
@@ -107,9 +77,7 @@ enum DeviceModelCatalog {
 
     private static func fallbackSymbol(for familyRaw: String, modelIdentifier: String) -> String? {
         let family = familyRaw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if family.isEmpty {
-            return nil
-        }
+        if family.isEmpty { return nil }
         switch family.lowercased() {
         case "ipad":
             return "ipad"

--- a/apps/macos/Sources/OpenClaw/DiagnosticsFileLog.swift
+++ b/apps/macos/Sources/OpenClaw/DiagnosticsFileLog.swift
@@ -96,9 +96,7 @@ actor DiagnosticsFileLog {
               let size = attrs[.size] as? NSNumber
         else { return }
 
-        if size.int64Value < self.maxBytes {
-            return
-        }
+        if size.int64Value < self.maxBytes { return }
 
         let fm = FileManager()
 

--- a/apps/macos/Sources/OpenClaw/DurationFormattingSupport.swift
+++ b/apps/macos/Sources/OpenClaw/DurationFormattingSupport.swift
@@ -2,21 +2,13 @@ import Foundation
 
 enum DurationFormattingSupport {
     static func conciseDuration(ms: Int) -> String {
-        if ms < 1000 {
-            return "\(ms)ms"
-        }
+        if ms < 1000 { return "\(ms)ms" }
         let s = Double(ms) / 1000.0
-        if s < 60 {
-            return "\(Int(round(s)))s"
-        }
+        if s < 60 { return "\(Int(round(s)))s" }
         let m = s / 60.0
-        if m < 60 {
-            return "\(Int(round(m)))m"
-        }
+        if m < 60 { return "\(Int(round(m)))m" }
         let h = m / 60.0
-        if h < 48 {
-            return "\(Int(round(h)))h"
-        }
+        if h < 48 { return "\(Int(round(h)))h" }
         let d = h / 24.0
         return "\(Int(round(d)))d"
     }

--- a/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
+++ b/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
@@ -11,9 +11,7 @@ enum ExecAllowlistMatcher {
             case let .valid(pattern):
                 if ExecApprovalHelpers.patternHasPathSelector(pattern) {
                     let target = resolvedPath ?? rawExecutable
-                    if self.matches(pattern: pattern, target: target) {
-                        return entry
-                    }
+                    if self.matches(pattern: pattern, target: target) { return entry }
                 } else if pattern != "*",
                           !ExecApprovalHelpers.patternHasPathSelector(rawExecutable),
                           self.matchesExecutableBasename(pattern: pattern, resolution: resolution)

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -301,9 +301,7 @@ enum ExecApprovalsStore {
 
     private static func isLegacyDefaultSocketPath(_ raw: String, legacyFileURL: URL) -> Bool {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return true
-        }
+        if trimmed.isEmpty { return true }
         let expanded = self.expandPath(trimmed)
         let legacySocket = legacyFileURL.deletingLastPathComponent()
             .appendingPathComponent("exec-approvals.sock", isDirectory: false)
@@ -323,9 +321,7 @@ enum ExecApprovalsStore {
                 }
             }
             let parent = cursor.deletingLastPathComponent()
-            if parent.path == cursor.path {
-                return false
-            }
+            if parent.path == cursor.path { return false }
             cursor = parent
         }
     }
@@ -349,9 +345,7 @@ enum ExecApprovalsStore {
         }
         var closed = false
         defer {
-            if !closed {
-                close(fd)
-            }
+            if !closed { close(fd) }
         }
         do {
             try data.withUnsafeBytes { rawBuffer in
@@ -411,9 +405,7 @@ enum ExecApprovalsStore {
             let rawSocketPath = file.socket?.path?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if self.isLegacyDefaultSocketPath(rawSocketPath, legacyFileURL: legacyURL) {
-                if file.socket == nil {
-                    file.socket = ExecApprovalsSocketConfig(path: nil, token: nil)
-                }
+                if file.socket == nil { file.socket = ExecApprovalsSocketConfig(path: nil, token: nil) }
                 file.socket?.path = self.socketPath()
             }
             let encoder = JSONEncoder()
@@ -423,13 +415,9 @@ enum ExecApprovalsStore {
             try FileManager().createDirectory(
                 at: targetURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true)
-            if FileManager().fileExists(atPath: targetURL.path) {
-                return .notNeeded
-            }
+            if FileManager().fileExists(atPath: targetURL.path) { return .notNeeded }
             let created = try self.writeMigratedFileExclusively(migrated, to: targetURL)
-            if !created {
-                return .notNeeded
-            }
+            if !created { return .notNeeded }
             try? FileManager().setAttributes(
                 [.posixPermissions: 0o600],
                 ofItemAtPath: targetURL.path)
@@ -598,9 +586,7 @@ enum ExecApprovalsStore {
             let loadedHash = self.hashFile(loaded)
 
             var file = self.normalizeIncoming(loaded)
-            if file.socket == nil {
-                file.socket = ExecApprovalsSocketConfig(path: nil, token: nil)
-            }
+            if file.socket == nil { file.socket = ExecApprovalsSocketConfig(path: nil, token: nil) }
             let path = file.socket?.path?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if path.isEmpty {
                 file.socket?.path = self.socketPath()
@@ -609,9 +595,7 @@ enum ExecApprovalsStore {
             if token.isEmpty {
                 file.socket?.token = self.generateToken()
             }
-            if file.agents == nil {
-                file.agents = [:]
-            }
+            if file.agents == nil { file.agents = [:] }
             if !existed || loadedHash != self.hashFile(file) {
                 self.saveFile(file)
             }
@@ -715,9 +699,7 @@ enum ExecApprovalsStore {
             var agents = file.agents ?? [:]
             var entry = agents[key] ?? ExecApprovalsAgent()
             var allowlist = entry.allowlist ?? []
-            if allowlist.contains(where: { $0.pattern == normalizedPattern }) {
-                return
-            }
+            if allowlist.contains(where: { $0.pattern == normalizedPattern }) { return }
             allowlist.append(ExecAllowlistEntry(
                 pattern: normalizedPattern,
                 lastUsedAt: Date().timeIntervalSince1970 * 1000))
@@ -1020,12 +1002,8 @@ enum ExecApprovalHelpers {
         allowlistMatch: ExecAllowlistEntry?,
         skillAllow: Bool) -> Bool
     {
-        if ask == .always {
-            return true
-        }
-        if ask == .onMiss, security == .allowlist, allowlistMatch == nil, !skillAllow {
-            return true
-        }
+        if ask == .always { return true }
+        if ask == .onMiss, security == .allowlist, allowlistMatch == nil, !skillAllow { return true }
         return false
     }
 
@@ -1053,9 +1031,7 @@ struct ExecEventPayload: Codable {
     static func truncateOutput(_ raw: String, maxChars: Int = 20000) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        if trimmed.count <= maxChars {
-            return trimmed
-        }
+        if trimmed.count <= maxChars { return trimmed }
         let suffix = trimmed.suffix(maxChars)
         return "... (truncated) \(suffix)"
     }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -31,9 +31,7 @@ final class ExecApprovalsGatewayPrompter {
     private func run() async {
         let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
         for await push in stream {
-            if Task.isCancelled {
-                return
-            }
+            if Task.isCancelled { return }
             await self.handle(push: push)
         }
     }
@@ -199,9 +197,7 @@ final class ExecApprovalsGatewayPrompter {
     private static func lastInputSeconds() -> Int? {
         let anyEvent = CGEventType(rawValue: UInt32.max) ?? .null
         let seconds = CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: anyEvent)
-        if seconds.isNaN || seconds.isInfinite || seconds < 0 {
-            return nil
-        }
+        if seconds.isNaN || seconds.isInfinite || seconds < 0 { return nil }
         return Int(seconds.rounded())
     }
 }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -169,13 +169,9 @@ private func readLineFromHandle(_ handle: FileHandle, maxBytes: Int) throws -> S
     var buffer = Data()
     while buffer.count < maxBytes {
         let chunk = try handle.read(upToCount: 4096) ?? Data()
-        if chunk.isEmpty {
-            break
-        }
+        if chunk.isEmpty { break }
         buffer.append(chunk)
-        if buffer.contains(0x0A) {
-            break
-        }
+        if buffer.contains(0x0A) { break }
     }
     guard let newlineIndex = buffer.firstIndex(of: 0x0A) else {
         guard !buffer.isEmpty else { return nil }
@@ -619,9 +615,7 @@ private enum ExecHostExecutor {
         guard needsScreenRecording == true else { return nil }
         let authorized = await PermissionManager
             .status([.screenRecording])[.screenRecording] ?? false
-        if authorized {
-            return nil
-        }
+        if authorized { return nil }
         return self.errorResponse(
             code: "UNAVAILABLE",
             message: "PERMISSION_MISSING: screenRecording",
@@ -734,15 +728,9 @@ enum ExecApprovalsSocketPathGuard {
         }
 
         let fileType = status.st_mode & mode_t(S_IFMT)
-        if fileType == mode_t(S_IFDIR) {
-            return .directory
-        }
-        if fileType == mode_t(S_IFSOCK) {
-            return .socket
-        }
-        if fileType == mode_t(S_IFLNK) {
-            return .symlink
-        }
+        if fileType == mode_t(S_IFDIR) { return .directory }
+        if fileType == mode_t(S_IFSOCK) { return .socket }
+        if fileType == mode_t(S_IFLNK) { return .symlink }
         return .other
     }
 
@@ -856,9 +844,7 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
                 }
             }
             if client < 0 {
-                if errno == EINTR {
-                    continue
-                }
+                if errno == EINTR { continue }
                 break
             }
             Task.detached { [weak self] in

--- a/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
+++ b/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
@@ -332,9 +332,7 @@ struct ExecCommandResolution {
             current.append(ch)
         }
 
-        if escaped {
-            current.append("\\")
-        }
+        if escaped { current.append("\\") }
         appendCurrent()
         return tokens
     }
@@ -443,9 +441,7 @@ struct ExecCommandResolution {
             idx += 1
         }
 
-        if escaped || inSingle || inDouble {
-            return nil
-        }
+        if escaped || inSingle || inDouble { return nil }
         guard appendCurrent() else { return nil }
         return segments
     }
@@ -519,9 +515,7 @@ enum ExecCommandFormatter {
             let trimmed = arg.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return "\"\"" }
             let needsQuotes = trimmed.contains { $0.isWhitespace || $0 == "\"" }
-            if !needsQuotes {
-                return trimmed
-            }
+            if !needsQuotes { return trimmed }
             let escaped = trimmed.replacingOccurrences(of: "\"", with: "\\\"")
             return "\"\(escaped)\""
         }.joined(separator: " ")
@@ -529,9 +523,7 @@ enum ExecCommandFormatter {
 
     static func displayString(for argv: [String], rawCommand: String?) -> String {
         let trimmed = rawCommand?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmed.isEmpty {
-            return trimmed
-        }
+        if !trimmed.isEmpty { return trimmed }
         return self.displayString(for: argv)
     }
 }

--- a/apps/macos/Sources/OpenClaw/ExecInlineCommandParser.swift
+++ b/apps/macos/Sources/OpenClaw/ExecInlineCommandParser.swift
@@ -165,9 +165,7 @@ enum ExecInlineCommandParser {
                 idx += 1
                 continue
             }
-            if token == "--" {
-                break
-            }
+            if token == "--" { break }
             let comparableToken = allowCombinedC ? token : token.lowercased()
             if flags.contains(comparableToken) {
                 return Match(tokenIndex: idx, inlineCommand: nil)

--- a/apps/macos/Sources/OpenClaw/ExecShellWrapperParser.swift
+++ b/apps/macos/Sources/OpenClaw/ExecShellWrapperParser.swift
@@ -190,12 +190,8 @@ enum ExecShellWrapperParser {
     private static func extractPowerShellInlineCommand(_ command: [String]) -> String? {
         for idx in 1..<command.count {
             let token = command[idx].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            if token.isEmpty {
-                continue
-            }
-            if token == "--" {
-                break
-            }
+            if token.isEmpty { continue }
+            if token == "--" { break }
             if self.powershellInlineFlags.contains(token) {
                 return ExecInlineCommandParser.extractInlineCommand(
                     command,

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -492,16 +492,12 @@ actor GatewayConnection {
         }
         if let deviceToken = lastSnapshot?.auth["deviceToken"]?.value as? String {
             let trimmed = deviceToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         let identity = DeviceIdentityStore.loadOrCreate()
         if let entry = DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator") {
             let trimmed = entry.token.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         return nil
     }
@@ -880,9 +876,7 @@ extension GatewayConnection {
 
     func healthSnapshot(timeoutMs: Double? = nil) async throws -> HealthSnapshot {
         let data = try await requestRaw(method: .health, timeoutMs: timeoutMs)
-        if let snap = decodeHealthSnapshot(from: data) {
-            return snap
-        }
+        if let snap = decodeHealthSnapshot(from: data) { return snap }
         throw GatewayDecodingError(method: Method.health.rawValue, message: "failed to decode health snapshot")
     }
 
@@ -925,15 +919,9 @@ extension GatewayConnection {
         var params: [String: AnyCodable] = [
             "skillKey": AnyCodable(skillKey),
         ]
-        if let enabled {
-            params["enabled"] = AnyCodable(enabled)
-        }
-        if let apiKey {
-            params["apiKey"] = AnyCodable(apiKey)
-        }
-        if let env, !env.isEmpty {
-            params["env"] = AnyCodable(env)
-        }
+        if let enabled { params["enabled"] = AnyCodable(enabled) }
+        if let apiKey { params["apiKey"] = AnyCodable(apiKey) }
+        if let env, !env.isEmpty { params["env"] = AnyCodable(env) }
         return try await self.requestDecoded(method: .skillsUpdate, params: params)
     }
 
@@ -952,12 +940,8 @@ extension GatewayConnection {
             return OpenClawSessionsPreviewPayload(ts: 0, previews: [])
         }
         var params: [String: AnyCodable] = ["keys": AnyCodable(resolvedKeys)]
-        if let limit {
-            params["limit"] = AnyCodable(limit)
-        }
-        if let maxChars {
-            params["maxChars"] = AnyCodable(maxChars)
-        }
+        if let limit { params["limit"] = AnyCodable(limit) }
+        if let maxChars { params["maxChars"] = AnyCodable(maxChars) }
         let timeout = timeoutMs.map { Double($0) }
         return try await self.requestDecoded(
             method: .sessionsPreview,
@@ -980,12 +964,8 @@ extension GatewayConnection {
         if let agentID = agentID?.trimmingCharacters(in: .whitespacesAndNewlines), !agentID.isEmpty {
             params["agentId"] = AnyCodable(agentID)
         }
-        if let limit {
-            params["limit"] = AnyCodable(limit)
-        }
-        if let maxChars {
-            params["maxChars"] = AnyCodable(maxChars)
-        }
+        if let limit { params["limit"] = AnyCodable(limit) }
+        if let maxChars { params["maxChars"] = AnyCodable(maxChars) }
         let timeout = timeoutMs.map { Double($0) }
         if let route {
             let data = try await request(
@@ -1070,9 +1050,7 @@ extension GatewayConnection {
 
     func talkMode(enabled: Bool, phase: String? = nil) async {
         var params: [String: AnyCodable] = ["enabled": AnyCodable(enabled)]
-        if let phase {
-            params["phase"] = AnyCodable(phase)
-        }
+        if let phase { params["phase"] = AnyCodable(phase) }
         try? await self.requestVoid(method: .talkMode, params: params)
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnectivityCoordinator.swift
@@ -57,9 +57,7 @@ final class GatewayConnectivityCoordinator {
 
     private static func hostLabel(for url: URL) -> String {
         let host = url.host ?? url.absoluteString
-        if let port = url.port {
-            return "\(host):\(port)"
-        }
+        if let port = url.port { return "\(host):\(port)" }
         return host
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -13,12 +13,8 @@ struct Semver: Comparable, CustomStringConvertible {
     }
 
     static func < (lhs: Semver, rhs: Semver) -> Bool {
-        if lhs.major != rhs.major {
-            return lhs.major < rhs.major
-        }
-        if lhs.minor != rhs.minor {
-            return lhs.minor < rhs.minor
-        }
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
         return lhs.patch < rhs.patch
     }
 
@@ -80,9 +76,7 @@ enum GatewayEnvironment {
     static func gatewayPort() -> Int {
         if let raw = ProcessInfo.processInfo.environment["OPENCLAW_GATEWAY_PORT"] {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let parsed = Int(trimmed), parsed > 0 {
-                return parsed
-            }
+            if let parsed = Int(trimmed), parsed > 0 { return parsed }
         }
         if let configPort = OpenClawConfigFile.gatewayPort(), configPort > 0 {
             return configPort

--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -24,9 +24,7 @@ enum GatewayLaunchAgentManager {
     }
 
     static func isLaunchAgentWriteDisabled() -> Bool {
-        if FileManager().fileExists(atPath: self.disableLaunchAgentMarkerURL.path) {
-            return true
-        }
+        if FileManager().fileExists(atPath: self.disableLaunchAgentMarkerURL.path) { return true }
         return false
     }
 
@@ -155,9 +153,7 @@ extension GatewayLaunchAgentManager {
         quiet: Bool = false) async -> String?
     {
         let result = await self.runDaemonCommandResult(args, timeout: timeout, quiet: quiet)
-        if result.success {
-            return nil
-        }
+        if result.success { return nil }
         return result.message ?? "Gateway daemon command failed"
     }
 
@@ -206,9 +202,7 @@ extension GatewayLaunchAgentManager {
     }
 
     private static func withJsonFlag(_ args: [String]) -> [String] {
-        if args.contains("--json") {
-            return args
-        }
+        if args.contains("--json") { return args }
         return args + ["--json"]
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -18,9 +18,7 @@ final class GatewayProcessManager {
             case .stopped: return "Stopped"
             case .starting: return "Starting…"
             case let .running(details):
-                if let details, !details.isEmpty {
-                    return "Running (\(details))"
-                }
+                if let details, !details.isEmpty { return "Running (\(details))" }
                 return "Running"
             case let .attachedExisting(details):
                 if let details, !details.isEmpty {
@@ -151,9 +149,7 @@ final class GatewayProcessManager {
     func refreshEnvironmentStatus(force: Bool = false) {
         let now = Date()
         if !force {
-            if self.environmentRefreshTask != nil {
-                return
-            }
+            if self.environmentRefreshTask != nil { return }
             if let last = self.lastEnvironmentRefresh,
                now.timeIntervalSince(last) < self.environmentRefreshMinInterval
             {
@@ -297,9 +293,7 @@ final class GatewayProcessManager {
             return true
         }
         let ns = error as NSError
-        if ns.domain == "Gateway", ns.code == 1008 {
-            return true
-        }
+        if ns.domain == "Gateway", ns.code == 1008 { return true }
         let lower = ns.localizedDescription.lowercased()
         return lower.contains("unauthorized") || lower.contains("auth")
     }
@@ -342,9 +336,7 @@ final class GatewayProcessManager {
         // Best-effort: wait for the gateway to accept connections.
         let deadline = Date().addingTimeInterval(6)
         while Date() < deadline {
-            if !self.desiredActive {
-                return
-            }
+            if !self.desiredActive { return }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)
                 let instance = await PortGuardian.shared.describe(port: port)
@@ -392,9 +384,7 @@ final class GatewayProcessManager {
     func waitForGatewayReady(timeout: TimeInterval = 6) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if !self.desiredActive {
-                return false
-            }
+            if !self.desiredActive { return false }
             do {
                 _ = try await self.connection.requestRaw(method: .health, timeoutMs: 1500)
                 self.clearLastFailure()
@@ -426,9 +416,7 @@ final class GatewayProcessManager {
         guard FileManager().fileExists(atPath: path) else { return "" }
         guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return "" }
         let text = String(data: data, encoding: .utf8) ?? ""
-        if text.count <= limit {
-            return text
-        }
+        if text.count <= limit { return text }
         return String(text.suffix(limit))
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayPushSubscription.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayPushSubscription.swift
@@ -13,9 +13,7 @@ enum GatewayPushSubscription {
         }
 
         for await push in stream {
-            if Task.isCancelled {
-                return
-            }
+            if Task.isCancelled { return }
             await MainActor.run {
                 onPush(push)
             }

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -248,9 +248,7 @@ enum GatewayRemoteConfig {
     }
 
     static func defaultPort(for url: URL) -> Int? {
-        if let port = url.port {
-            return port
-        }
+        if let port = url.port { return port }
         let scheme = url.scheme?.lowercased() ?? ""
         switch scheme {
         case "wss":

--- a/apps/macos/Sources/OpenClaw/HealthStore.swift
+++ b/apps/macos/Sources/OpenClaw/HealthStore.swift
@@ -129,9 +129,7 @@ final class HealthStore {
                 }
             } else {
                 self.lastError = "health output not JSON"
-                if onDemand {
-                    self.snapshot = nil
-                }
+                if onDemand { self.snapshot = nil }
                 if previousError != self.lastError {
                     Self.logger.warning("health refresh failed: output not JSON")
                 }
@@ -139,9 +137,7 @@ final class HealthStore {
         } catch {
             let desc = error.localizedDescription
             self.lastError = desc
-            if onDemand {
-                self.snapshot = nil
-            }
+            if onDemand { self.snapshot = nil }
             if previousError != desc {
                 Self.logger.error("health refresh failed \(desc, privacy: .public)")
             }
@@ -157,16 +153,12 @@ final class HealthStore {
     private static func describeProbeFailure(_ probe: HealthSnapshot.ChannelSummary.Probe) -> String {
         let elapsed = probe.elapsedMs.map { "\(Int($0))ms" }
         if let error = probe.error, error.lowercased().contains("timeout") || probe.status == nil {
-            if let elapsed {
-                return "Health check timed out (\(elapsed))"
-            }
+            if let elapsed { return "Health check timed out (\(elapsed))" }
             return "Health check timed out"
         }
         let code = probe.status.map { "status \($0)" } ?? "status unknown"
         let reason = probe.error?.isEmpty == false ? probe.error! : "health probe failed"
-        if let elapsed {
-            return "\(reason) (\(code), \(elapsed))"
-        }
+        if let elapsed { return "\(reason) (\(code), \(elapsed))" }
         return "\(reason) (\(code))"
     }
 
@@ -193,9 +185,7 @@ final class HealthStore {
     {
         let order = snap.channelOrder ?? Array(snap.channels.keys)
         for channelId in order {
-            if channelId == id {
-                continue
-            }
+            if channelId == id { continue }
             guard let summary = snap.channels[channelId] else { continue }
             if Self.isChannelHealthy(summary) {
                 return (id: channelId, summary: summary)
@@ -223,12 +213,8 @@ final class HealthStore {
     }
 
     var summaryLine: String {
-        if self.isRefreshing {
-            return "Health check running…"
-        }
-        if let error = self.lastError {
-            return "Health check failed: \(error)"
-        }
+        if self.isRefreshing { return "Health check running…" }
+        if let error = self.lastError { return "Health check failed: \(error)" }
         guard let snap = self.snapshot else { return "Health check pending" }
         guard let link = self.resolveLinkChannel(snap) else { return "Health check pending" }
         if link.summary.linked != true {
@@ -291,16 +277,10 @@ final class HealthStore {
 
 func msToAge(_ ms: Double) -> String {
     let minutes = Int(round(ms / 60000))
-    if minutes < 1 {
-        return "just now"
-    }
-    if minutes < 60 {
-        return "\(minutes)m"
-    }
+    if minutes < 1 { return "just now" }
+    if minutes < 60 { return "\(minutes)m" }
     let hours = Int(round(Double(minutes) / 60))
-    if hours < 48 {
-        return "\(hours)h"
-    }
+    if hours < 48 { return "\(hours)h" }
     let days = Int(round(Double(hours) / 24))
     return "\(days)d"
 }

--- a/apps/macos/Sources/OpenClaw/HeartbeatStore.swift
+++ b/apps/macos/Sources/OpenClaw/HeartbeatStore.swift
@@ -34,8 +34,6 @@ final class HeartbeatStore {
 
     @MainActor
     deinit {
-        if let observer {
-            NotificationCenter.default.removeObserver(observer)
-        }
+        if let observer { NotificationCenter.default.removeObserver(observer) }
     }
 }

--- a/apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSanitizer.swift
@@ -37,23 +37,17 @@ enum HostEnvSanitizer {
     ]
 
     private static func isBlocked(_ upperKey: String) -> Bool {
-        if self.blockedKeys.contains(upperKey) {
-            return true
-        }
+        if self.blockedKeys.contains(upperKey) { return true }
         return self.blockedPrefixes.contains(where: { upperKey.hasPrefix($0) })
     }
 
     private static func isBlockedInherited(_ upperKey: String) -> Bool {
-        if self.blockedInheritedKeys.contains(upperKey) {
-            return true
-        }
+        if self.blockedInheritedKeys.contains(upperKey) { return true }
         return self.blockedInheritedPrefixes.contains(where: { upperKey.hasPrefix($0) })
     }
 
     private static func isBlockedOverride(_ upperKey: String) -> Bool {
-        if self.blockedOverrideKeys.contains(upperKey) {
-            return true
-        }
+        if self.blockedOverrideKeys.contains(upperKey) { return true }
         if upperKey.range(
             of: self.cargoTargetExecutableOverridePattern,
             options: .regularExpression) != nil
@@ -117,9 +111,7 @@ enum HostEnvSanitizer {
 
     private static func sanitizeInheritedGitAllowProtocolValue(_ value: String) -> String {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if normalized.isEmpty {
-            return ""
-        }
+        if normalized.isEmpty { return "" }
         let safeProtocols = normalized
             .split(separator: ":", omittingEmptySubsequences: false)
             .filter { self.gitDefaultAlwaysAllowedProtocols.contains(String($0)) }
@@ -180,9 +172,7 @@ enum HostEnvSanitizer {
                 }
                 continue
             }
-            if self.isBlockedInherited(upper) {
-                continue
-            }
+            if self.isBlockedInherited(upper) { continue }
             merged[key] = value
         }
 
@@ -196,15 +186,9 @@ enum HostEnvSanitizer {
             let upper = key.uppercased()
             // PATH is part of the security boundary (command resolution + safe-bin checks). Never
             // allow request-scoped PATH overrides from agents/gateways.
-            if upper == "PATH" {
-                continue
-            }
-            if self.isBlockedOverride(upper) {
-                continue
-            }
-            if self.isBlocked(upper) {
-                continue
-            }
+            if upper == "PATH" { continue }
+            if self.isBlockedOverride(upper) { continue }
+            if self.isBlocked(upper) { continue }
             merged[key] = value
         }
         return merged

--- a/apps/macos/Sources/OpenClaw/HoverHUD.swift
+++ b/apps/macos/Sources/OpenClaw/HoverHUD.swift
@@ -113,9 +113,7 @@ final class HoverHUDController {
             try? await Task.sleep(nanoseconds: 250_000_000)
             await MainActor.run {
                 guard let self else { return }
-                if self.model.hoveringStatusItem || self.model.hoveringPanel {
-                    return
-                }
+                if self.model.hoveringStatusItem || self.model.hoveringPanel { return }
                 self.dismiss(reason: "hoverExit")
             }
         }
@@ -141,9 +139,7 @@ final class HoverHUDController {
     }
 
     private func ensureWindow() {
-        if self.window != nil {
-            return
-        }
+        if self.window != nil { return }
         let panel = OverlayPanelFactory.makePanel(
             contentRect: NSRect(x: 0, y: 0, width: self.width, height: self.height),
             level: .statusBar,
@@ -180,9 +176,7 @@ final class HoverHUDController {
     }
 
     private func installDismissMonitor() {
-        if ProcessInfo.processInfo.isRunningTests {
-            return
-        }
+        if ProcessInfo.processInfo.isRunningTests { return }
         guard self.dismissMonitor == nil, let window else { return }
         self.dismissMonitor = NSEvent.addGlobalMonitorForEvents(matching: [
             .leftMouseDown,
@@ -207,19 +201,13 @@ private struct HoverHUDView: View {
     private let activityStore = WorkActivityStore.shared
 
     private var statusTitle: String {
-        if self.activityStore.iconState.isWorking {
-            return "Working"
-        }
+        if self.activityStore.iconState.isWorking { return "Working" }
         return "Idle"
     }
 
     private var detail: String {
-        if let current = self.activityStore.current?.label, !current.isEmpty {
-            return current
-        }
-        if let last = self.activityStore.lastToolLabel, !last.isEmpty {
-            return last
-        }
+        if let current = self.activityStore.current?.label, !current.isEmpty { return current }
+        if let last = self.activityStore.lastToolLabel, !last.isEmpty { return last }
         return "No recent activity"
     }
 

--- a/apps/macos/Sources/OpenClaw/InstancesSettings.swift
+++ b/apps/macos/Sources/OpenClaw/InstancesSettings.swift
@@ -84,9 +84,7 @@ struct InstancesSettings: View {
                 HStack(spacing: 8) {
                     Text(inst.host ?? "unknown host").font(.subheadline.bold())
                     self.presenceIndicator(inst)
-                    if let ip = inst.ip {
-                        Text("(") + Text(ip).monospaced() + Text(")")
-                    }
+                    if let ip = inst.ip { Text("(") + Text(ip).monospaced() + Text(")") }
                 }
 
                 HStack(spacing: 8) {
@@ -111,9 +109,7 @@ struct InstancesSettings: View {
                         self.label(icon: self.platformIcon(platform), text: prettyPlatform)
                     }
 
-                    if let mode = inst.mode {
-                        self.label(icon: "network", text: mode)
-                    }
+                    if let mode = inst.mode { self.label(icon: "network", text: mode) }
                 }
                 .layoutPriority(1)
 
@@ -179,12 +175,8 @@ struct InstancesSettings: View {
     private func presenceStatus(for inst: InstanceInfo) -> (label: String, color: Color) {
         let nowMs = Date().timeIntervalSince1970 * 1000
         let ageSeconds = max(0, Int((nowMs - inst.ts) / 1000))
-        if ageSeconds <= 120 {
-            return ("Active", .green)
-        }
-        if ageSeconds <= 300 {
-            return ("Idle", .yellow)
-        }
+        if ageSeconds <= 120 { return ("Active", .green) }
+        if ageSeconds <= 300 { return ("Idle", .yellow) }
         return ("Stale", .gray)
     }
 
@@ -239,19 +231,13 @@ struct InstancesSettings: View {
     }
 
     private func shouldShowUpdateRow(_ inst: InstanceInfo) -> Bool {
-        if inst.lastInputSeconds != nil {
-            return true
-        }
-        if self.updateSummaryText(inst, isGateway: false) != nil {
-            return true
-        }
+        if inst.lastInputSeconds != nil { return true }
+        if self.updateSummaryText(inst, isGateway: false) != nil { return true }
         return false
     }
 
     private func safeSystemSymbol(_ preferred: String, fallback: String) -> String {
-        if self.isSystemSymbolAvailable(preferred) {
-            return preferred
-        }
+        if self.isSystemSymbolAvailable(preferred) { return preferred }
         return fallback
     }
 

--- a/apps/macos/Sources/OpenClaw/InstancesStore.swift
+++ b/apps/macos/Sources/OpenClaw/InstancesStore.swift
@@ -97,9 +97,7 @@ final class InstancesStore {
     }
 
     func refresh() async {
-        if self.isLoading {
-            return
-        }
+        if self.isLoading { return }
         self.statusMessage = nil
         self.isLoading = true
         defer { self.isLoading = false }
@@ -171,9 +169,7 @@ final class InstancesStore {
 
     private func snippet(_ data: Data?, limit: Int = 256) -> String {
         guard let data else { return "<none>" }
-        if data.isEmpty {
-            return "<empty>"
-        }
+        if data.isEmpty { return "<empty>" }
         let prefix = data.prefix(limit)
         if let asString = String(data: prefix, encoding: .utf8) {
             return asString.replacingOccurrences(of: "\n", with: " ")
@@ -186,14 +182,10 @@ final class InstancesStore {
             let data = try await ControlChannel.shared.health(timeout: 8)
             guard let snap = decodeHealthSnapshot(from: data) else { return }
             let linkId = snap.channelOrder?.first(where: {
-                if let summary = snap.channels[$0] {
-                    return summary.linked != nil
-                }
+                if let summary = snap.channels[$0] { return summary.linked != nil }
                 return false
             }) ?? snap.channels.keys.first(where: {
-                if let summary = snap.channels[$0] {
-                    return summary.linked != nil
-                }
+                if let summary = snap.channels[$0] { return summary.linked != nil }
                 return false
             })
             let linked = linkId.flatMap { snap.channels[$0]?.linked } ?? false
@@ -271,19 +263,13 @@ final class InstancesStore {
         for inst in instances {
             guard let reason = inst.reason?.trimmingCharacters(in: .whitespacesAndNewlines) else { continue }
             guard reason == "node-connected" else { continue }
-            if let mode = inst.mode?.lowercased(), mode == "local" {
-                continue
-            }
+            if let mode = inst.mode?.lowercased(), mode == "local" { continue }
 
             let previous = self.lastPresenceById[inst.id]
-            if previous?.reason == "node-connected", previous?.ts == inst.ts {
-                continue
-            }
+            if previous?.reason == "node-connected", previous?.ts == inst.ts { continue }
 
             let lastNotified = self.lastLoginNotifiedAtMs[inst.id] ?? 0
-            if inst.ts <= lastNotified {
-                continue
-            }
+            if inst.ts <= lastNotified { continue }
             self.lastLoginNotifiedAtMs[inst.id] = inst.ts
 
             let name = inst.host?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -468,15 +468,11 @@ struct MenuContent: View {
     }
 
     private var selectedMicLabel: String {
-        if self.state.voiceWakeMicID.isEmpty {
-            return self.defaultMicLabel
-        }
+        if self.state.voiceWakeMicID.isEmpty { return self.defaultMicLabel }
         if let match = self.availableMics.first(where: { $0.uid == self.state.voiceWakeMicID }) {
             return match.name
         }
-        if !self.state.voiceWakeMicName.isEmpty {
-            return self.state.voiceWakeMicName
-        }
+        if !self.state.voiceWakeMicName.isEmpty { return self.state.voiceWakeMicName }
         return "Unavailable"
     }
 
@@ -545,9 +541,7 @@ struct MenuContent: View {
             self.loadingMics = false
             return
         }
-        if !force, !self.availableMics.isEmpty {
-            return
-        }
+        if !force, !self.availableMics.isEmpty { return }
         self.loadingMics = true
         let discovery = AVCaptureDevice.DiscoverySession(
             deviceTypes: [.external, .microphone],

--- a/apps/macos/Sources/OpenClaw/MenuContextCardInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContextCardInjector.swift
@@ -149,20 +149,14 @@ final class MenuContextCardInjector: NSObject, NSMenuDelegate {
         let loaded = snapshot.rows
         let now = Date()
         let current = loaded.filter { row in
-            if row.key == "main" {
-                return true
-            }
+            if row.key == "main" { return true }
             guard let updatedAt = row.updatedAt else { return false }
             return now.timeIntervalSince(updatedAt) <= self.activeWindowSeconds
         }
 
         return current.sorted { lhs, rhs in
-            if lhs.key == "main" {
-                return true
-            }
-            if rhs.key == "main" {
-                return false
-            }
+            if lhs.key == "main" { return true }
+            if rhs.key == "main" { return false }
             return (lhs.updatedAt ?? .distantPast) > (rhs.updatedAt ?? .distantPast)
         }
     }
@@ -183,9 +177,7 @@ final class MenuContextCardInjector: NSObject, NSMenuDelegate {
         }
 
         // Fallback: insert after the first item.
-        if menu.items.count >= 1 {
-            return 1
-        }
+        if menu.items.count >= 1 { return 1 }
         return menu.items.count
     }
 
@@ -201,16 +193,10 @@ final class MenuContextCardInjector: NSObject, NSMenuDelegate {
 
     private func captureMenuWidthIfAvailable(for menu: NSMenu, hosting: NSHostingView<AnyView>) {
         let targetWidth: CGFloat? = {
-            if let contentWidth = hosting.window?.contentView?.bounds.width, contentWidth > 0 {
-                return contentWidth
-            }
-            if let superWidth = hosting.superview?.bounds.width, superWidth > 0 {
-                return superWidth
-            }
+            if let contentWidth = hosting.window?.contentView?.bounds.width, contentWidth > 0 { return contentWidth }
+            if let superWidth = hosting.superview?.bounds.width, superWidth > 0 { return superWidth }
             let minimumWidth = menu.minimumWidth
-            if minimumWidth > 0 {
-                return minimumWidth
-            }
+            if minimumWidth > 0 { return minimumWidth }
             return nil
         }()
 

--- a/apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift
@@ -12,9 +12,7 @@ struct MenuSessionsHeaderView: View {
     }
 
     private var subtitle: String {
-        if self.count == 1 {
-            return "1 session · 24h"
-        }
+        if self.count == 1 { return "1 session · 24h" }
         return "\(self.count) sessions · 24h"
     }
 }

--- a/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift
@@ -394,29 +394,19 @@ extension MenuSessionsInjector {
         let now = Date()
         let mainKey = self.mainSessionKey
         return snapshot.rows.filter { row in
-            if row.key == "main", mainKey != "main" {
-                return false
-            }
-            if row.key == mainKey {
-                return true
-            }
+            if row.key == "main", mainKey != "main" { return false }
+            if row.key == mainKey { return true }
             guard let updatedAt = row.updatedAt else { return false }
             return now.timeIntervalSince(updatedAt) <= self.activeWindowSeconds
         }.sorted { lhs, rhs in
-            if lhs.key == mainKey {
-                return true
-            }
-            if rhs.key == mainKey {
-                return false
-            }
+            if lhs.key == mainKey { return true }
+            if rhs.key == mainKey { return false }
             return (lhs.updatedAt ?? .distantPast) > (rhs.updatedAt ?? .distantPast)
         }
     }
 
     private func sessionsSubtitle(count: Int) -> String {
-        if count == 1 {
-            return "1 session · 24h"
-        }
+        if count == 1 { return "1 session · 24h" }
         return "\(count) sessions · 24h"
     }
 
@@ -537,13 +527,9 @@ extension MenuSessionsInjector {
 
     private var isControlChannelConnected: Bool {
         #if DEBUG
-        if let override = self.testControlChannelConnected {
-            return override
-        }
+        if let override = self.testControlChannelConnected { return override }
         #endif
-        if case .connected = ControlChannel.shared.state {
-            return true
-        }
+        if case .connected = ControlChannel.shared.state { return true }
         return false
     }
 
@@ -821,12 +807,8 @@ extension MenuSessionsInjector {
 
     private func compactUsageError(_ error: Error) -> String {
         let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-        if message.isEmpty {
-            return "Usage unavailable"
-        }
-        if message.count > 90 {
-            return "\(message.prefix(87))…"
-        }
+        if message.isEmpty { return "Usage unavailable" }
+        if message.count > 90 { return "\(message.prefix(87))…" }
         return message
     }
 
@@ -1243,17 +1225,11 @@ extension MenuSessionsInjector {
     private func sortedNodeEntries() -> [NodeInfo] {
         let entries = self.nodesStore.nodes.filter { $0.isConnected || $0.isPaired }
         return entries.sorted { lhs, rhs in
-            if lhs.isConnected != rhs.isConnected {
-                return lhs.isConnected
-            }
-            if lhs.isPaired != rhs.isPaired {
-                return lhs.isPaired
-            }
+            if lhs.isConnected != rhs.isConnected { return lhs.isConnected }
+            if lhs.isPaired != rhs.isPaired { return lhs.isPaired }
             let lhsName = NodeMenuEntryFormatter.primaryName(lhs).lowercased()
             let rhsName = NodeMenuEntryFormatter.primaryName(rhs).lowercased()
-            if lhsName == rhsName {
-                return lhs.nodeId < rhs.nodeId
-            }
+            if lhsName == rhsName { return lhs.nodeId < rhs.nodeId }
             return lhsName < rhsName
         }
     }

--- a/apps/macos/Sources/OpenClaw/MenuUsageHeaderView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuUsageHeaderView.swift
@@ -10,9 +10,7 @@ struct MenuUsageHeaderView: View {
     }
 
     private var subtitle: String {
-        if self.count == 1 {
-            return "1 provider"
-        }
+        if self.count == 1 { return "1 provider" }
         return "\(self.count) providers"
     }
 }

--- a/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
+++ b/apps/macos/Sources/OpenClaw/MicLevelMonitor.swift
@@ -16,9 +16,7 @@ actor MicLevelMonitor {
 
     func start(onLevel: @Sendable @escaping (Double) -> Void) async throws {
         self.update = onLevel
-        if self.running {
-            return
-        }
+        if self.running { return }
         self.logger.info(
             "mic level monitor start (\(AudioInputDeviceObserver.defaultInputDeviceSummary(), privacy: .public))")
         self.lastUpdate = .now
@@ -97,12 +95,8 @@ struct MicLevelBar: View {
 
     private func segmentColor(for idx: Int) -> Color {
         let fraction = Double(idx + 1) / Double(self.segments)
-        if fraction < 0.65 {
-            return .green
-        }
-        if fraction < 0.85 {
-            return .yellow
-        }
+        if fraction < 0.65 { return .green }
+        if fraction < 0.85 { return .yellow }
         return .red
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeBrowserProxy.swift
@@ -203,15 +203,9 @@ actor MacNodeBrowserProxy {
 
     private static func stringValue(for value: Any?) -> String? {
         guard let value else { return nil }
-        if let string = value as? String {
-            return string
-        }
-        if let bool = value as? Bool {
-            return bool ? "true" : "false"
-        }
-        if let number = value as? NSNumber {
-            return number.stringValue
-        }
+        if let string = value as? String { return string }
+        if let bool = value as? Bool { return bool ? "true" : "false" }
+        if let number = value as? NSNumber { return number.stringValue }
         return String(describing: value)
     }
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
@@ -684,9 +684,7 @@ private final class CodexAppServerThreadListSession: @unchecked Sendable {
             if count == 0 {
                 return ReadChunk(data: data, reachedEOF: true)
             }
-            if errno == EINTR {
-                continue
-            }
+            if errno == EINTR { continue }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 return ReadChunk(data: data, reachedEOF: false)
             }
@@ -706,9 +704,7 @@ private final class CodexAppServerThreadListSession: @unchecked Sendable {
             if count == 0 {
                 return true
             }
-            if errno == EINTR {
-                continue
-            }
+            if errno == EINTR { continue }
             if errno == EAGAIN || errno == EWOULDBLOCK {
                 return false
             }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -671,17 +671,13 @@ final class MacNodeModeCoordinator: NSObject {
         if browserControlEnabled, connectionMode == .local {
             caps.append(OpenClawCapability.browser.rawValue)
         }
-        if cameraEnabled {
-            caps.append(OpenClawCapability.camera.rawValue)
-        }
+        if cameraEnabled { caps.append(OpenClawCapability.camera.rawValue) }
         // Advertised only when the operator has enabled Computer Control; the
         // command is dangerous and stays disarmed until allowlisted on the gateway.
         if computerControlEnabled {
             caps.append(OpenClawCapability.computer.rawValue)
         }
-        if locationMode != .off {
-            caps.append(OpenClawCapability.location.rawValue)
-        }
+        if locationMode != .off { caps.append(OpenClawCapability.location.rawValue) }
         if codexThreadCatalogEnabled {
             caps.append(MacNodeCodexThreadCatalogContract.capability)
         }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1140,9 +1140,7 @@ extension MacNodeRuntime {
         guard needsScreenRecording == true else { return nil }
         let authorized = await PermissionManager
             .status([.screenRecording])[.screenRecording] ?? false
-        if authorized {
-            return nil
-        }
+        if authorized { return nil }
         await self.emitExecEvent(
             "exec.denied",
             payload: ExecEventPayload(

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -139,9 +139,7 @@ final class NodePairingApprovalPrompter {
         // pending pairing prompts are still shown on launch.
         var delayMs: UInt64 = 200
         for attempt in 1...8 {
-            if Task.isCancelled {
-                return
-            }
+            if Task.isCancelled { return }
             do {
                 let data = try await GatewayConnection.shared.request(
                     method: "node.pair.list",

--- a/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
+++ b/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
@@ -102,9 +102,7 @@ extension NodeServiceManager {
     }
 
     private static func withJsonFlag(_ args: [String]) -> [String] {
-        if args.contains("--json") {
-            return args
-        }
+        if args.contains("--json") { return args }
         return args + ["--json"]
     }
 

--- a/apps/macos/Sources/OpenClaw/NodesMenu.swift
+++ b/apps/macos/Sources/OpenClaw/NodesMenu.swift
@@ -22,12 +22,8 @@ struct NodeMenuEntryFormatter {
             let role = self.roleText(entry)
             let name = self.primaryName(entry)
             var parts = ["\(name) · \(role)"]
-            if let ip = entry.remoteIp?.nonEmpty {
-                parts.append("host \(ip)")
-            }
-            if let platform = self.platformText(entry) {
-                parts.append(platform)
-            }
+            if let ip = entry.remoteIp?.nonEmpty { parts.append("host \(ip)") }
+            if let platform = self.platformText(entry) { parts.append(platform) }
             return parts.joined(separator: " · ")
         }
         let name = self.primaryName(entry)
@@ -58,9 +54,7 @@ struct NodeMenuEntryFormatter {
 
     static func detailLeft(_ entry: NodeInfo) -> String {
         let role = self.roleText(entry)
-        if let ip = entry.remoteIp?.nonEmpty {
-            return "\(ip) · \(role)"
-        }
+        if let ip = entry.remoteIp?.nonEmpty { return "\(ip) · \(role)" }
         return role
     }
 
@@ -70,9 +64,7 @@ struct NodeMenuEntryFormatter {
 
     static func detailRightVersion(_ entry: NodeInfo) -> String? {
         let labels = self.versionLabels(entry, compact: false)
-        if labels.isEmpty {
-            return nil
-        }
+        if labels.isEmpty { return nil }
         return labels.joined(separator: " · ")
     }
 
@@ -81,18 +73,10 @@ struct NodeMenuEntryFormatter {
             return PlatformLabelFormatter.pretty(raw) ?? raw
         }
         if let family = entry.deviceFamily?.lowercased() {
-            if family.contains("mac") {
-                return "macOS"
-            }
-            if family.contains("iphone") {
-                return "iOS"
-            }
-            if family.contains("ipad") {
-                return "iPadOS"
-            }
-            if family.contains("android") {
-                return "Android"
-            }
+            if family.contains("mac") { return "macOS" }
+            if family.contains("iphone") { return "iOS" }
+            if family.contains("ipad") { return "iPadOS" }
+            if family.contains("android") { return "Android" }
         }
         return nil
     }
@@ -111,12 +95,8 @@ struct NodeMenuEntryFormatter {
 
     private static func shortVersionLabel(_ raw: String) -> String {
         let compact = self.compactVersion(raw)
-        if compact.isEmpty {
-            return compact
-        }
-        if compact.lowercased().hasPrefix("v") {
-            return compact
-        }
+        if compact.isEmpty { return compact }
+        if compact.lowercased().hasPrefix("v") { return compact }
         if let first = compact.unicodeScalars.first, CharacterSet.decimalDigits.contains(first) {
             return "v\(compact)"
         }
@@ -152,9 +132,7 @@ struct NodeMenuEntryFormatter {
 
     private static func isHeadlessPlatform(_ entry: NodeInfo) -> Bool {
         let raw = entry.platform?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
-        if raw == "darwin" || raw == "linux" || raw == "win32" || raw == "windows" {
-            return true
-        }
+        if raw == "darwin" || raw == "linux" || raw == "win32" || raw == "windows" { return true }
         return false
     }
 
@@ -168,40 +146,26 @@ struct NodeMenuEntryFormatter {
             if family.contains("mac") {
                 return self.safeSystemSymbol("laptopcomputer", fallback: "laptopcomputer")
             }
-            if family.contains("iphone") {
-                return self.safeSystemSymbol("iphone", fallback: "iphone")
-            }
-            if family.contains("ipad") {
-                return self.safeSystemSymbol("ipad", fallback: "ipad")
-            }
+            if family.contains("iphone") { return self.safeSystemSymbol("iphone", fallback: "iphone") }
+            if family.contains("ipad") { return self.safeSystemSymbol("ipad", fallback: "ipad") }
         }
         if let platform = entry.platform?.lowercased() {
-            if platform.contains("mac") {
-                return self.safeSystemSymbol("laptopcomputer", fallback: "laptopcomputer")
-            }
-            if platform.contains("ios") {
-                return self.safeSystemSymbol("iphone", fallback: "iphone")
-            }
-            if platform.contains("android") {
-                return self.safeSystemSymbol("cpu", fallback: "cpu")
-            }
+            if platform.contains("mac") { return self.safeSystemSymbol("laptopcomputer", fallback: "laptopcomputer") }
+            if platform.contains("ios") { return self.safeSystemSymbol("iphone", fallback: "iphone") }
+            if platform.contains("android") { return self.safeSystemSymbol("cpu", fallback: "cpu") }
         }
         return "cpu"
     }
 
     static func isAndroid(_ entry: NodeInfo) -> Bool {
         let family = entry.deviceFamily?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if family == "android" {
-            return true
-        }
+        if family == "android" { return true }
         let platform = entry.platform?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return platform?.contains("android") == true
     }
 
     private static func safeSystemSymbol(_ preferred: String, fallback: String) -> String {
-        if NSImage(systemSymbolName: preferred, accessibilityDescription: nil) != nil {
-            return preferred
-        }
+        if NSImage(systemSymbolName: preferred, accessibilityDescription: nil) != nil { return preferred }
         return fallback
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodesStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodesStore.swift
@@ -68,9 +68,7 @@ final class NodesStore {
     }
 
     func refresh() async {
-        if self.isLoading {
-            return
-        }
+        if self.isLoading { return }
         self.statusMessage = nil
         self.isLoading = true
         defer { self.isLoading = false }
@@ -97,16 +95,10 @@ final class NodesStore {
     }
 
     private static func isCancelled(_ error: Error) -> Bool {
-        if error is CancellationError {
-            return true
-        }
-        if let urlError = error as? URLError, urlError.code == .cancelled {
-            return true
-        }
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
         let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
-            return true
-        }
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled { return true }
         return false
     }
 }

--- a/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
@@ -62,9 +62,7 @@ final class NotifyOverlayController {
         self.hostingView?.rootView = NotifyOverlayView(controller: self)
         let target = self.targetFrame()
         let isFirst = !self.model.isVisible
-        if isFirst {
-            self.model.isVisible = true
-        }
+        if isFirst { self.model.isVisible = true }
         OverlayPanelFactory.present(
             window: self.window,
             isFirstPresent: isFirst,
@@ -76,9 +74,7 @@ final class NotifyOverlayController {
     }
 
     private func ensureWindow() {
-        if self.window != nil {
-            return
-        }
+        if self.window != nil { return }
         let panel = OverlayPanelFactory.makePanel(
             contentRect: NSRect(x: 0, y: 0, width: self.width, height: self.minHeight),
             level: .statusBar,

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -251,9 +251,7 @@ final class OnboardingAISetupModel {
     static func activationReconciliationMode(after error: Error) -> ActivationReconciliationMode {
         // Decode failures happen after the side-effectful RPC returned bytes, so check persisted
         // state once. Only transport-unknown outcomes need the bounded polling window.
-        if error is DecodingError {
-            return .immediate
-        }
+        if error is DecodingError { return .immediate }
         if error is GatewayResponseError ||
             error is GatewayConnectAuthError ||
             error is GatewayTLSValidationError
@@ -317,9 +315,7 @@ final class OnboardingAISetupModel {
             case .none:
                 break
             case .immediate:
-                if await self.reconcilePersistedActivation(kind: kind, token: token) {
-                    return
-                }
+                if await self.reconcilePersistedActivation(kind: kind, token: token) { return }
             case .polling:
                 if await self.reconcileActivationAfterTransportDrop(
                     kind: kind,
@@ -356,9 +352,7 @@ final class OnboardingAISetupModel {
             }
             guard token == self.attemptToken else { return false }
             delayMs = min(delayMs * 2, 15000)
-            if await self.reconcilePersistedActivation(kind: kind, token: token) {
-                return true
-            }
+            if await self.reconcilePersistedActivation(kind: kind, token: token) { return true }
             // A healthy detect can race the still-running activation whose socket dropped;
             // keep polling instead of falling through to another provider.
         }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Chat.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Chat.swift
@@ -9,9 +9,7 @@ extension OnboardingView {
 
         Task { @MainActor in
             for _ in 0..<20 {
-                if !self.onboardingChatModel.isLoading {
-                    break
-                }
+                if !self.onboardingChatModel.isLoading { break }
                 try? await Task.sleep(nanoseconds: 200_000_000)
             }
             guard self.onboardingChatModel.messages.isEmpty else { return }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -747,28 +747,20 @@ extension OnboardingView {
     /// Exactly one spinner at a time: the install row finishes before the
     /// service row starts, mirroring the actual runCLIInstall phases.
     private var installStepStateForInstall: InstallStepState {
-        if self.cliInstalled {
-            return .done
-        }
+        if self.cliInstalled { return .done }
         if self.installingCLI {
             return self.cliInstallPhase == .startingService ? .done : .running
         }
-        if self.installFailed {
-            return .failed
-        }
+        if self.installFailed { return .failed }
         return .running // status probe still deciding
     }
 
     private var installStepStateForService: InstallStepState {
-        if self.cliInstalled {
-            return .done
-        }
+        if self.cliInstalled { return .done }
         if self.installingCLI {
             return self.cliInstallPhase == .startingService ? .running : .pending
         }
-        if self.installFailed {
-            return .failed
-        }
+        if self.installFailed { return .failed }
         return .pending
     }
 
@@ -1010,12 +1002,8 @@ extension OnboardingView {
     }
 
     private func maybeLoadOnboardingSkills() async {
-        if self.onboardingSkillsModel.isLoading {
-            return
-        }
-        if self.didLoadOnboardingSkills, self.onboardingSkillsModel.error == nil {
-            return
-        }
+        if self.onboardingSkillsModel.isLoading { return }
+        if self.didLoadOnboardingSkills, self.onboardingSkillsModel.error == nil { return }
         self.didLoadOnboardingSkills = true
         await self.onboardingSkillsModel.refresh()
     }

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -61,9 +61,7 @@ enum OpenClawConfigFile {
     {
         self.withFileLock {
             // Nix mode disables config writes in production, but tests rely on saving temp configs.
-            if ProcessInfo.processInfo.isNixMode, !ProcessInfo.processInfo.isRunningTests {
-                return false
-            }
+            if ProcessInfo.processInfo.isNixMode, !ProcessInfo.processInfo.isRunningTests { return false }
             let url = self.url()
             let previousData = try? Data(contentsOf: url)
             let previousRoot = previousData.flatMap { self.parseConfigData($0) }
@@ -234,14 +232,10 @@ enum OpenClawConfigFile {
         else { return false }
 
         let deny = (plugins["deny"] as? [Any] ?? []).compactMap(self.normalizedPluginConfigId)
-        if deny.contains(pluginId) {
-            return false
-        }
+        if deny.contains(pluginId) { return false }
 
         let allow = (plugins["allow"] as? [Any] ?? []).compactMap(self.normalizedPluginConfigId)
-        if !allow.isEmpty, !allow.contains(pluginId) {
-            return false
-        }
+        if !allow.isEmpty, !allow.contains(pluginId) { return false }
         return true
     }
 
@@ -279,9 +273,7 @@ enum OpenClawConfigFile {
     static func gatewayPort() -> Int? {
         let root = self.loadDict()
         guard let gateway = root["gateway"] as? [String: Any] else { return nil }
-        if let port = gateway["port"] as? Int, port > 0 {
-            return port
-        }
+        if let port = gateway["port"] as? Int, port > 0 { return port }
         if let number = gateway["port"] as? NSNumber, number.intValue > 0 {
             return number.intValue
         }
@@ -548,22 +540,14 @@ enum OpenClawConfigFile {
     }
 
     private static func fileAttributeInt(_ value: Any?) -> Int? {
-        if let number = value as? NSNumber {
-            return number.intValue
-        }
-        if let number = value as? Int {
-            return number
-        }
+        if let number = value as? NSNumber { return number.intValue }
+        if let number = value as? Int { return number }
         return nil
     }
 
     private static func fileSystemNumber(_ value: Any?) -> String? {
-        if let number = value as? NSNumber {
-            return number.stringValue
-        }
-        if let number = value as? Int {
-            return String(number)
-        }
+        if let number = value as? NSNumber { return number.stringValue }
+        if let number = value as? Int { return String(number) }
         return nil
     }
 

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -15,9 +15,7 @@ extension Notification.Name {
 
 enum PermissionManager {
     static func isLocationAuthorized(status: CLAuthorizationStatus, requireAlways: Bool) -> Bool {
-        if requireAlways {
-            return status == .authorizedAlways
-        }
+        if requireAlways { return status == .authorizedAlways }
         switch status {
         case .authorizedAlways, .authorizedWhenInUse:
             return true
@@ -440,9 +438,7 @@ final class PermissionMonitor {
     private func startMonitoring() {
         Task { await self.checkStatus(force: true) }
 
-        if ProcessInfo.processInfo.isRunningTests {
-            return
-        }
+        if ProcessInfo.processInfo.isRunningTests { return }
         self.monitorTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
@@ -458,9 +454,7 @@ final class PermissionMonitor {
     }
 
     private func checkStatus(force: Bool) async {
-        if self.isChecking {
-            return
-        }
+        if self.isChecking { return }
         let now = Date()
         if !force, let lastCheck, now.timeIntervalSince(lastCheck) < self.minimumCheckInterval {
             return

--- a/apps/macos/Sources/OpenClaw/PlatformLabelFormatter.swift
+++ b/apps/macos/Sources/OpenClaw/PlatformLabelFormatter.swift
@@ -3,9 +3,7 @@ import Foundation
 enum PlatformLabelFormatter {
     static func parse(_ raw: String) -> (prefix: String, version: String?) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return ("", nil)
-        }
+        if trimmed.isEmpty { return ("", nil) }
         let parts = trimmed.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
         let prefix = parts.first?.lowercased() ?? ""
         let versionToken = parts.dropFirst().first
@@ -14,9 +12,7 @@ enum PlatformLabelFormatter {
 
     static func pretty(_ raw: String) -> String? {
         let (prefix, version) = self.parse(raw)
-        if prefix.isEmpty {
-            return nil
-        }
+        if prefix.isEmpty { return nil }
         let name: String = switch prefix {
         case "macos": "macOS"
         case "ios": "iOS"

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -230,9 +230,7 @@ actor PortGuardian {
         #if canImport(Darwin)
         guard pid > 0 else { return false }
         _ = Darwin.kill(pid, SIGTERM)
-        if await self.waitForProcessExit(pid: pid) {
-            return true
-        }
+        if await self.waitForProcessExit(pid: pid) { return true }
         _ = Darwin.kill(pid, SIGKILL)
         return await self.waitForProcessExit(pid: pid)
         #else
@@ -286,9 +284,7 @@ actor PortGuardian {
         }
 
         var offenders: [ReportListener] {
-            if case let .interference(_, offenders) = self.status {
-                return offenders
-            }
+            if case let .interference(_, offenders) = self.status { return offenders }
             return []
         }
 
@@ -472,9 +468,7 @@ actor PortGuardian {
             mode == .remote && port == GatewayEnvironment.gatewayPort() && tunnelHealthy == false
         let reportListeners = listeners.map { listener in
             var expected = okPredicate(listener)
-            if tunnelUnhealthy, expected {
-                expected = false
-            }
+            if tunnelUnhealthy, expected { expected = false }
             return ReportListener(
                 pid: listener.pid,
                 command: listener.command,
@@ -531,9 +525,7 @@ actor PortGuardian {
         let full = listener.fullCommand.lowercased()
         switch mode {
         case .remote:
-            if port == GatewayEnvironment.gatewayPort() {
-                return true
-            }
+            if port == GatewayEnvironment.gatewayPort() { return true }
             return false
         case .local:
             // Preserve both the legacy hidden alias and the current service process title.
@@ -542,13 +534,9 @@ actor PortGuardian {
             {
                 return true
             }
-            if self.isNodeOpenClawGatewayCommand(full) {
-                return true
-            }
+            if self.isNodeOpenClawGatewayCommand(full) { return true }
             // If args are unavailable, treat a CLI listener as expected.
-            if cmd.contains("openclaw"), full == cmd {
-                return true
-            }
+            if cmd.contains("openclaw"), full == cmd { return true }
             return false
         case .unconfigured:
             return false

--- a/apps/macos/Sources/OpenClaw/PresenceReporter.swift
+++ b/apps/macos/Sources/OpenClaw/PresenceReporter.swift
@@ -47,12 +47,8 @@ final class PresenceReporter {
             "deviceFamily": AnyHashable("Mac"),
             "reason": AnyHashable(reason),
         ]
-        if let model = InstanceIdentity.modelIdentifier {
-            params["modelIdentifier"] = AnyHashable(model)
-        }
-        if let lastInput {
-            params["lastInputSeconds"] = AnyHashable(lastInput)
-        }
+        if let model = InstanceIdentity.modelIdentifier { params["modelIdentifier"] = AnyHashable(model) }
+        if let lastInput { params["lastInputSeconds"] = AnyHashable(lastInput) }
         do {
             try await ControlChannel.shared.sendSystemEvent(text, params: params)
         } catch {

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -14,18 +14,12 @@ extension ProcessInfo {
         stableSuite: UserDefaults?,
         isAppBundle: Bool) -> Bool
     {
-        if environment["OPENCLAW_NIX_MODE"] == "1" {
-            return true
-        }
-        if standard.bool(forKey: "openclaw.nixMode") {
-            return true
-        }
+        if environment["OPENCLAW_NIX_MODE"] == "1" { return true }
+        if standard.bool(forKey: "openclaw.nixMode") { return true }
 
         // Only consult the stable suite when running as a .app bundle.
         // This avoids local developer machines accidentally influencing unit tests.
-        if isAppBundle, let stableSuite, stableSuite.bool(forKey: "openclaw.nixMode") {
-            return true
-        }
+        if isAppBundle, let stableSuite, stableSuite.bool(forKey: "openclaw.nixMode") { return true }
 
         return false
     }
@@ -43,12 +37,8 @@ extension ProcessInfo {
     var isRunningTests: Bool {
         // SwiftPM tests load one or more `.xctest` bundles. With Swift Testing, `Bundle.main` is not
         // guaranteed to be the `.xctest` bundle, so check all loaded bundles.
-        if Bundle.allBundles.contains(where: { $0.bundleURL.pathExtension == "xctest" }) {
-            return true
-        }
-        if Bundle.main.bundleURL.pathExtension == "xctest" {
-            return true
-        }
+        if Bundle.allBundles.contains(where: { $0.bundleURL.pathExtension == "xctest" }) { return true }
+        if Bundle.main.bundleURL.pathExtension == "xctest" { return true }
 
         // Backwards-compatible fallbacks for runners that still set XCTest env vars.
         return self.environment["XCTestConfigurationFilePath"] != nil

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -255,9 +255,7 @@ final class RemotePortTunnel: @unchecked Sendable {
     }
 
     private static func findPort(preferred: UInt16?, allowRandom: Bool) async throws -> UInt16 {
-        if let preferred, self.portIsFree(preferred) {
-            return preferred
-        }
+        if let preferred, self.portIsFree(preferred) { return preferred }
         if let preferred, !allowRandom {
             throw NSError(
                 domain: "RemotePortTunnel",

--- a/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
@@ -51,9 +51,7 @@ actor RemoteTunnelManager {
             "ensure SSH tunnel target=\(settings.target, privacy: .public) " +
                 "identitySet=\(identitySet, privacy: .public)")
 
-        if let local = await self.controlTunnelPortIfRunning() {
-            return local
-        }
+        if let local = await self.controlTunnelPortIfRunning() { return local }
         if let create = self.createInFlight {
             self.logger.info("control tunnel create in flight; joining")
             let tunnel = try await create.task.value

--- a/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
+++ b/apps/macos/Sources/OpenClaw/RuntimeLocator.swift
@@ -15,12 +15,8 @@ struct RuntimeVersion: Comparable, CustomStringConvertible {
     }
 
     static func < (lhs: RuntimeVersion, rhs: RuntimeVersion) -> Bool {
-        if lhs.major != rhs.major {
-            return lhs.major < rhs.major
-        }
-        if lhs.minor != rhs.minor {
-            return lhs.minor < rhs.minor
-        }
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
         return lhs.patch < rhs.patch
     }
 

--- a/apps/macos/Sources/OpenClaw/ScreenRecordService.swift
+++ b/apps/macos/Sources/OpenClaw/ScreenRecordService.swift
@@ -90,9 +90,7 @@ final class ScreenRecordService {
             try await Task.sleep(nanoseconds: UInt64(durationMs) * 1_000_000)
             try await stream.stopCapture()
         } catch {
-            if started {
-                try? await stream.stopCapture()
-            }
+            if started { try? await stream.stopCapture() }
             throw error
         }
 
@@ -190,9 +188,7 @@ private final class StreamRecorder: NSObject, SCStreamOutput, SCStreamDelegate, 
             self.logger.error("screen record aborting due to prior error: \(msg, privacy: .public)")
             return
         }
-        if self.didFinish {
-            return
-        }
+        if self.didFinish { return }
 
         if !self.started {
             guard self.writer.startWriting() else {
@@ -216,9 +212,7 @@ private final class StreamRecorder: NSObject, SCStreamOutput, SCStreamDelegate, 
             self.logger.error("screen record audio aborting due to prior error: \(msg, privacy: .public)")
             return
         }
-        if self.didFinish || !self.started {
-            return
-        }
+        if self.didFinish || !self.started { return }
         if audioInput.isReadyForMoreMediaData {
             _ = audioInput.append(sampleBuffer)
         }

--- a/apps/macos/Sources/OpenClaw/SelectableRow.swift
+++ b/apps/macos/Sources/OpenClaw/SelectableRow.swift
@@ -32,12 +32,8 @@ extension View {
     }
 
     private func openClawRowBackground(selected: Bool, hovered: Bool) -> Color {
-        if selected {
-            return Color.accentColor.opacity(0.12)
-        }
-        if hovered {
-            return Color.secondary.opacity(0.08)
-        }
+        if selected { return Color.accentColor.opacity(0.12) }
+        if hovered { return Color.secondary.opacity(0.08) }
         return Color.clear
     }
 }

--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -59,9 +59,7 @@ struct SessionTokenStats {
     }
 
     static func formatKTokens(_ value: Int) -> String {
-        if value < 1000 {
-            return "\(value)"
-        }
+        if value < 1000 { return "\(value)" }
         let thousands = Double(value) / 1000
         let decimals = value >= 10000 ? 0 : 1
         return String(format: "%.\(decimals)fk", thousands)
@@ -96,18 +94,10 @@ struct SessionRow: Identifiable {
 
     var flagLabels: [String] {
         var flags: [String] = []
-        if let thinkingLevel {
-            flags.append("think \(thinkingLevel)")
-        }
-        if let verboseLevel {
-            flags.append("verbose \(verboseLevel)")
-        }
-        if self.systemSent {
-            flags.append("system sent")
-        }
-        if self.abortedLastRun {
-            flags.append("aborted")
-        }
+        if let thinkingLevel { flags.append("think \(thinkingLevel)") }
+        if let verboseLevel { flags.append("verbose \(verboseLevel)") }
+        if self.systemSent { flags.append("system sent") }
+        if self.abortedLastRun { flags.append("aborted") }
         return flags
     }
 }
@@ -116,28 +106,14 @@ enum SessionKind {
     case cron, direct, group, global, unknown
 
     static func from(key: String) -> SessionKind {
-        if key == "global" {
-            return .global
-        }
+        if key == "global" { return .global }
         let parts = key.lowercased().split(separator: ":").filter { !$0.isEmpty }
-        if parts.first == "cron" {
-            return .cron
-        }
-        if parts.count >= 3, parts[0] == "agent", parts[2] == "cron" {
-            return .cron
-        }
-        if key.hasPrefix("group:") {
-            return .group
-        }
-        if key.contains(":group:") {
-            return .group
-        }
-        if key.contains(":channel:") {
-            return .group
-        }
-        if key == "unknown" {
-            return .unknown
-        }
+        if parts.first == "cron" { return .cron }
+        if parts.count >= 3, parts[0] == "agent", parts[2] == "cron" { return .cron }
+        if key.hasPrefix("group:") { return .group }
+        if key.contains(":group:") { return .group }
+        if key.contains(":channel:") { return .group }
+        if key == "unknown" { return .unknown }
         return .direct
     }
 
@@ -281,12 +257,8 @@ enum SessionLoader {
             "includeGlobal": AnyHashable(includeGlobal),
             "includeUnknown": AnyHashable(includeUnknown),
         ]
-        if let activeMinutes {
-            params["activeMinutes"] = AnyHashable(activeMinutes)
-        }
-        if let limit {
-            params["limit"] = AnyHashable(limit)
-        }
+        if let activeMinutes { params["activeMinutes"] = AnyHashable(activeMinutes) }
+        if let limit { params["limit"] = AnyHashable(limit) }
 
         let data: Data
         do {
@@ -357,17 +329,11 @@ enum SessionLoader {
 func relativeAge(from date: Date?) -> String {
     guard let date else { return "unknown" }
     let delta = Date().timeIntervalSince(date)
-    if delta < 60 {
-        return "just now"
-    }
+    if delta < 60 { return "just now" }
     let minutes = Int(round(delta / 60))
-    if minutes < 60 {
-        return "\(minutes)m ago"
-    }
+    if minutes < 60 { return "\(minutes)m ago" }
     let hours = Int(round(Double(minutes) / 60))
-    if hours < 48 {
-        return "\(hours)h ago"
-    }
+    if hours < 48 { return "\(hours)h ago" }
     let days = Int(round(Double(hours) / 24))
     return "\(days)d ago"
 }

--- a/apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift
@@ -70,9 +70,7 @@ actor SessionPreviewLimiter {
     func withPermit<T>(_ operation: () async throws -> T) async throws -> T {
         await self.acquire()
         defer { self.release() }
-        if Task.isCancelled {
-            throw CancellationError()
-        }
+        if Task.isCancelled { throw CancellationError() }
         return try await operation()
     }
 
@@ -203,9 +201,7 @@ struct SessionMenuPreviewView: View {
     }
 
     private func roleColor(_ role: PreviewRole) -> Color {
-        if self.isHighlighted {
-            return Color(nsColor: .selectedMenuItemTextColor).opacity(0.9)
-        }
+        if self.isHighlighted { return Color(nsColor: .selectedMenuItemTextColor).opacity(0.9) }
         switch role {
         case .user: return .accentColor
         case .assistant: return .secondary
@@ -241,9 +237,7 @@ enum SessionMenuPreviewLoader {
             let payload = try await self.requestPreview(keys: keys, maxItems: maxItems)
             await self.cache(payload: payload, maxItems: maxItems)
         } catch {
-            if self.isUnknownMethodError(error) {
-                return
-            }
+            if self.isUnknownMethodError(error) { return }
             let errorDescription = String(describing: error)
             Self.logger.debug(
                 "Session preview prewarm failed count=\(keys.count, privacy: .public) " +
@@ -413,9 +407,7 @@ enum SessionMenuPreviewLoader {
     }
 
     private static func previewRole(_ raw: String, isTool: Bool) -> PreviewRole {
-        if isTool {
-            return .tool
-        }
+        if isTool { return .tool }
         return self.previewRoleFromRaw(raw)
     }
 
@@ -432,18 +424,14 @@ enum SessionMenuPreviewLoader {
     private static func previewText(for message: OpenClawChatMessage) -> String? {
         let text = message.content.compactMap(\.text).joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !text.isEmpty {
-            return text
-        }
+        if !text.isEmpty { return text }
 
         let toolNames = self.toolNames(for: message)
         if !toolNames.isEmpty {
             let shown = toolNames.prefix(2)
             let overflow = toolNames.count - shown.count
             var label = "call \(shown.joined(separator: ", "))"
-            if overflow > 0 {
-                label += " +\(overflow)"
-            }
+            if overflow > 0 { label += " +\(overflow)" }
             return label
         }
 
@@ -455,9 +443,7 @@ enum SessionMenuPreviewLoader {
     }
 
     private static func isToolCall(_ message: OpenClawChatMessage) -> Bool {
-        if message.toolName?.nonEmpty != nil {
-            return true
-        }
+        if message.toolName?.nonEmpty != nil { return true }
         return message.content.contains { $0.name?.nonEmpty != nil || $0.type?.lowercased() == "toolcall" }
     }
 
@@ -478,9 +464,7 @@ enum SessionMenuPreviewLoader {
         let types = message.content.compactMap { content -> String? in
             let raw = content.type?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             guard let raw, !raw.isEmpty else { return nil }
-            if raw == "text" || raw == "toolcall" {
-                return nil
-            }
+            if raw == "text" || raw == "toolcall" { return nil }
             return raw
         }
         guard let first = types.first else { return nil }

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -64,12 +64,8 @@ enum ShellExecutor {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = command
-        if let cwd {
-            process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-        }
-        if let env {
-            process.environment = env
-        }
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        if let env { process.environment = env }
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -509,9 +509,7 @@ private struct SkillRow: View {
         guard !self.missingBins.isEmpty else { return [] }
         let missing = Set(self.missingBins)
         return self.skill.install.filter { option in
-            if option.bins.isEmpty {
-                return true
-            }
+            if option.bins.isEmpty { return true }
             return !missing.isDisjoint(with: option.bins)
         }
     }

--- a/apps/macos/Sources/OpenClaw/SoundEffects.swift
+++ b/apps/macos/Sources/OpenClaw/SoundEffects.swift
@@ -96,11 +96,7 @@ enum SoundEffectPlayer {
         else { return nil }
 
         let scoped = url.startAccessingSecurityScopedResource()
-        defer {
-            if scoped {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
         return NSSound(contentsOf: url, byReference: false)
     }
 

--- a/apps/macos/Sources/OpenClaw/SystemPresenceInfo.swift
+++ b/apps/macos/Sources/OpenClaw/SystemPresenceInfo.swift
@@ -6,9 +6,7 @@ enum SystemPresenceInfo {
     static func lastInputSeconds() -> Int? {
         let anyEvent = CGEventType(rawValue: UInt32.max) ?? .null
         let seconds = CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: anyEvent)
-        if seconds.isNaN || seconds.isInfinite || seconds < 0 {
-            return nil
-        }
+        if seconds.isNaN || seconds.isInfinite || seconds < 0 { return nil }
         return Int(seconds.rounded())
     }
 

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -454,9 +454,7 @@ final class ExecApprovalsSettingsModel {
     }
 
     func label(for id: String) -> String {
-        if id == Self.defaultsScopeId {
-            return "Defaults"
-        }
+        if id == Self.defaultsScopeId { return "Defaults" }
         return id
     }
 
@@ -477,9 +475,7 @@ final class ExecApprovalsSettingsModel {
             guard let raw = entry["id"] as? String else { continue }
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            if !seen.insert(trimmed).inserted {
-                continue
-            }
+            if !seen.insert(trimmed).inserted { continue }
             ids.append(trimmed)
             if (entry["default"] as? Bool) == true, defaultId == nil {
                 defaultId = trimmed

--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -176,22 +176,14 @@ struct TailscaleIntegrationSection: View {
     }
 
     private var statusColor: Color {
-        if !self.effectiveService.isInstalled {
-            return .yellow
-        }
-        if self.effectiveService.isRunning {
-            return .green
-        }
+        if !self.effectiveService.isInstalled { return .yellow }
+        if self.effectiveService.isRunning { return .green }
         return .orange
     }
 
     private var statusText: String {
-        if !self.effectiveService.isInstalled {
-            return "Tailscale is not installed"
-        }
-        if self.effectiveService.isRunning {
-            return "Tailscale is installed and running"
-        }
+        if !self.effectiveService.isInstalled { return "Tailscale is not installed" }
+        if self.effectiveService.isRunning { return "Tailscale is installed and running" }
         return "Tailscale is installed but not running"
     }
 
@@ -520,9 +512,7 @@ struct TailscaleIntegrationSection: View {
 
     private func startStatusTimer() {
         self.stopStatusTimer()
-        if ProcessInfo.processInfo.isRunningTests {
-            return
-        }
+        if ProcessInfo.processInfo.isRunningTests { return }
         self.statusTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
             Task { await self.effectiveService.checkTailscaleStatus() }
         }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -273,9 +273,7 @@ actor TalkModeRuntime {
         self.rmsTask = Task { [weak self, meter] in
             while let self {
                 try? await Task.sleep(nanoseconds: 50_000_000)
-                if Task.isCancelled {
-                    return
-                }
+                if Task.isCancelled { return }
                 await self.noteAudioLevel(rms: meter.get())
             }
         }
@@ -479,9 +477,7 @@ extension TalkModeRuntime {
             group.addTask { [runId, sessionKey] in
                 var latestText: String?
                 for await push in stream {
-                    if Task.isCancelled {
-                        return latestText
-                    }
+                    if Task.isCancelled { return latestText }
                     guard case let .event(evt) = push else { continue }
                     guard evt.event == "chat", let payload = evt.payload else { continue }
                     guard let chatEvent = try? GatewayPayloadDecoding.decode(
@@ -539,9 +535,7 @@ extension TalkModeRuntime {
     private static func matchesSessionKey(_ incoming: String, _ current: String) -> Bool {
         let incoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let current = current.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if incoming == current {
-            return true
-        }
+        if incoming == current { return true }
         return (incoming == "agent:main:main" && current == "main") ||
             (incoming == "main" && current == "agent:main:main")
     }
@@ -961,14 +955,10 @@ extension TalkModeRuntime {
     private func resolveVoiceId(preferred: String?, apiKey: String) async -> String? {
         let trimmed = preferred?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmed.isEmpty {
-            if let resolved = self.resolveVoiceAlias(trimmed) {
-                return resolved
-            }
+            if let resolved = self.resolveVoiceAlias(trimmed) { return resolved }
             self.ttsLogger.warning("talk unknown voice alias \(trimmed, privacy: .public)")
         }
-        if let fallbackVoiceId {
-            return fallbackVoiceId
-        }
+        if let fallbackVoiceId { return fallbackVoiceId }
 
         do {
             let voices = try await ElevenLabsTTSClient(apiKey: apiKey).listVoices()
@@ -997,9 +987,7 @@ extension TalkModeRuntime {
         let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let normalized = trimmed.lowercased()
-        if let mapped = self.voiceAliases[normalized] {
-            return mapped
-        }
+        if let mapped = self.voiceAliases[normalized] { return mapped }
         if self.voiceAliases.values.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
             return trimmed
         }
@@ -1250,9 +1238,7 @@ extension TalkModeRuntime {
     // MARK: - Audio level handling
 
     private func noteAudioLevel(rms: Double) async {
-        if self.phase != .listening, self.phase != .speaking {
-            return
-        }
+        if self.phase != .listening, self.phase != .speaking { return }
         let alpha: Double = rms < self.noiseFloorRMS ? 0.08 : 0.01
         self.noiseFloorRMS = max(1e-7, self.noiseFloorRMS + (rms - self.noiseFloorRMS) * alpha)
 
@@ -1272,9 +1258,7 @@ extension TalkModeRuntime {
     private func shouldInterrupt(transcript: String, hasConfidence: Bool) async -> Bool {
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count >= 3 else { return false }
-        if self.isLikelyEcho(of: trimmed) {
-            return false
-        }
+        if self.isLikelyEcho(of: trimmed) { return false }
         let now = Date()
         if let lastSpeechEnergyAt, now.timeIntervalSince(lastSpeechEnergyAt) > 0.35 {
             return false

--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -31,9 +31,7 @@ final class TalkOverlayController {
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
         let isFirst = !self.model.isVisible
-        if isFirst {
-            self.model.isVisible = true
-        }
+        if isFirst { self.model.isVisible = true }
         OverlayPanelFactory.present(
             window: self.window,
             isFirstPresent: isFirst,
@@ -87,9 +85,7 @@ final class TalkOverlayController {
     // MARK: - Private
 
     private func ensureWindow() {
-        if self.window != nil {
-            return
-        }
+        if self.window != nil { return }
         let panel = OverlayPanelFactory.makePanel(
             contentRect: NSRect(x: 0, y: 0, width: Self.overlaySize, height: Self.overlaySize),
             level: NSWindow.Level(rawValue: NSWindow.Level.popUpMenu.rawValue - 4),

--- a/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlayView.swift
@@ -111,9 +111,7 @@ private final class OrbInteractionNSView: NSView {
         if !self.didDrag {
             let dx = event.locationInWindow.x - startEvent.locationInWindow.x
             let dy = event.locationInWindow.y - startEvent.locationInWindow.y
-            if abs(dx) + abs(dy) < 2 {
-                return
-            }
+            if abs(dx) + abs(dy) < 2 { return }
             self.didDrag = true
             self.onDragStart?()
             self.window?.performDrag(with: startEvent)

--- a/apps/macos/Sources/OpenClaw/UsageCostData.swift
+++ b/apps/macos/Sources/OpenClaw/UsageCostData.swift
@@ -110,21 +110,15 @@ struct GatewayCostUsageSummary: Codable {
 enum CostUsageFormatting {
     static func formatUsd(_ value: Double?) -> String? {
         guard let value, value.isFinite else { return nil }
-        if value >= 1 {
-            return String(format: "$%.2f", value)
-        }
-        if value >= 0.01 {
-            return String(format: "$%.2f", value)
-        }
+        if value >= 1 { return String(format: "$%.2f", value) }
+        if value >= 0.01 { return String(format: "$%.2f", value) }
         return String(format: "$%.4f", value)
     }
 
     static func formatTokenCount(_ value: Int?) -> String? {
         guard let value else { return nil }
         let safe = max(0, value)
-        if safe >= 1_000_000 {
-            return String(format: "%.1fm", Double(safe) / 1_000_000.0)
-        }
+        if safe >= 1_000_000 { return String(format: "%.1fm", Double(safe) / 1_000_000.0) }
         if safe >= 1000 {
             return safe >= 10000
                 ? String(format: "%.0fk", Double(safe) / 1000.0)

--- a/apps/macos/Sources/OpenClaw/UsageData.swift
+++ b/apps/macos/Sources/OpenClaw/UsageData.swift
@@ -30,16 +30,12 @@ struct UsageRow: Identifiable {
     let error: String?
 
     var hasError: Bool {
-        if let error, !error.isEmpty {
-            return true
-        }
+        if let error, !error.isEmpty { return true }
         return false
     }
 
     var titleText: String {
-        if let plan, !plan.isEmpty {
-            return "\(self.displayName) (\(plan))"
-        }
+        if let plan, !plan.isEmpty { return "\(self.displayName) (\(plan))" }
         return self.displayName
     }
 
@@ -51,36 +47,24 @@ struct UsageRow: Identifiable {
     func detailText(now: Date = .init()) -> String {
         guard let remaining = self.remainingPercent else { return "No data" }
         var parts = ["\(remaining)% left"]
-        if let windowLabel, !windowLabel.isEmpty {
-            parts.append(windowLabel)
-        }
+        if let windowLabel, !windowLabel.isEmpty { parts.append(windowLabel) }
         if let resetAt {
             let reset = UsageRow.formatResetRemaining(target: resetAt, now: now)
-            if let reset {
-                parts.append("⏱\(reset)")
-            }
+            if let reset { parts.append("⏱\(reset)") }
         }
         return parts.joined(separator: " · ")
     }
 
     private static func formatResetRemaining(target: Date, now: Date) -> String? {
         let diff = target.timeIntervalSince(now)
-        if diff <= 0 {
-            return "now"
-        }
+        if diff <= 0 { return "now" }
         let minutes = Int(floor(diff / 60))
-        if minutes < 60 {
-            return "\(minutes)m"
-        }
+        if minutes < 60 { return "\(minutes)m" }
         let hours = minutes / 60
         let mins = minutes % 60
-        if hours < 24 {
-            return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
-        }
+        if hours < 24 { return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h" }
         let days = hours / 24
-        if days < 7 {
-            return "\(days)d \(hours % 24)h"
-        }
+        if days < 7 { return "\(days)d \(hours % 24)h" }
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d"
         return formatter.string(from: target)

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -25,9 +25,7 @@ final class VoicePushToTalkHotkey: @unchecked Sendable {
     }
 
     func setEnabled(_ enabled: Bool) {
-        if ProcessInfo.processInfo.isRunningTests {
-            return
-        }
+        if ProcessInfo.processInfo.isRunningTests { return }
         self.withMainThread { [weak self] in
             guard let self else { return }
             if enabled {
@@ -317,9 +315,7 @@ actor VoicePushToTalk {
     }
 
     private func finalize(transcriptOverride: String?, reason: String, sessionID: UUID?) async {
-        if self.finalized {
-            return
-        }
+        if self.finalized { return }
         if let sessionID, sessionID != self.sessionID {
             self.logger.debug("push-to-talk drop finalize for stale session")
             return
@@ -409,12 +405,8 @@ actor VoicePushToTalk {
     }
 
     private static func join(_ prefix: String, _ suffix: String) -> String {
-        if prefix.isEmpty {
-            return suffix
-        }
-        if suffix.isEmpty {
-            return prefix
-        }
+        if prefix.isEmpty { return suffix }
+        if suffix.isEmpty { return prefix }
         return "\(prefix) \(suffix)"
     }
 }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift
@@ -140,9 +140,7 @@ enum VoiceWakeForwarder {
 
     static func checkConnection() async -> Result<Void, VoiceWakeForwardError> {
         let status = await GatewayConnection.shared.status()
-        if status.ok {
-            return .success(())
-        }
+        if status.ok { return .success(()) }
         return .failure(.rpcFailed(status.error ?? "agent rpc unreachable"))
     }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeGlobalSettingsSync.swift
@@ -27,9 +27,7 @@ final class VoiceWakeGlobalSettingsSync {
 
                 let stream = await GatewayConnection.shared.subscribe(bufferingNewest: 200)
                 for await push in stream {
-                    if Task.isCancelled {
-                        return
-                    }
+                    if Task.isCancelled { return }
                     await self.handle(push: push)
                 }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Session.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Session.swift
@@ -131,9 +131,7 @@ extension VoiceWakeOverlayController {
         textLen=\(self.model.text.count)
         """
         self.logger.log(level: .info, "\(message)")
-        if self.model.isSending {
-            return
-        }
+        if self.model.isSending { return }
         self.model.isEditing = false
 
         if sendChime != .none {
@@ -249,9 +247,7 @@ extension VoiceWakeOverlayController {
 
     nonisolated static func evaluateToken(active: UUID?, incoming: UUID?) -> GuardOutcome {
         guard let active else { return .dropNoActive }
-        if let incoming, incoming != active {
-            return .dropMismatch
-        }
+        if let incoming, incoming != active { return .dropMismatch }
         return .accept
     }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -14,9 +14,7 @@ extension VoiceWakeOverlayController {
         self.hostingView?.rootView = VoiceWakeOverlayView(controller: self)
         let target = self.targetFrame()
         let isFirst = !self.model.isVisible
-        if isFirst {
-            self.model.isVisible = true
-        }
+        if isFirst { self.model.isVisible = true }
         OverlayPanelFactory.present(
             window: self.window,
             isFirstPresent: isFirst,
@@ -35,9 +33,7 @@ extension VoiceWakeOverlayController {
     }
 
     private func ensureWindow() {
-        if self.window != nil {
-            return
-        }
+        if self.window != nil { return }
         let borderPad = self.closeOverflow
         let panel = OverlayPanelFactory.makePanel(
             contentRect: NSRect(x: 0, y: 0, width: self.width + borderPad * 2, height: 60 + borderPad * 2),

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -121,9 +121,7 @@ actor VoiceWakeRuntime {
 
         let config = snapshot.1
 
-        if self.isStarting {
-            return
-        }
+        if self.isStarting { return }
 
         if self.scheduledRestartTask != nil, config == self.currentConfig, self.recognitionTask == nil {
             return
@@ -143,9 +141,7 @@ actor VoiceWakeRuntime {
     }
 
     private func start(with config: RuntimeConfig) async {
-        if self.isStarting {
-            return
-        }
+        if self.isStarting { return }
         self.isStarting = true
         defer { self.isStarting = false }
         do {
@@ -338,9 +334,7 @@ actor VoiceWakeRuntime {
             }
         }
 
-        if self.isCapturing {
-            return
-        }
+        if self.isCapturing { return }
 
         let gateConfig = WakeWordGateConfig(triggers: config.triggers)
         var usedFallback = false
@@ -739,9 +733,7 @@ actor VoiceWakeRuntime {
     }
 
     private func restartRecognizerIfIdleAndOverlayHidden() async {
-        if self.isCapturing {
-            return
-        }
+        if self.isCapturing { return }
         self.restartRecognizer()
     }
 

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -425,18 +425,10 @@ struct VoiceWakeSettings: View {
                     onUpdate: { newState in
                         DispatchQueue.main.async { [self] in
                             self.testState = newState
-                            if case .detected = newState {
-                                self.isTesting = false
-                            }
-                            if case .failed = newState {
-                                self.isTesting = false
-                            }
-                            if case .detected = newState {
-                                self.testTimeoutTask?.cancel()
-                            }
-                            if case .failed = newState {
-                                self.testTimeoutTask?.cancel()
-                            }
+                            if case .detected = newState { self.isTesting = false }
+                            if case .failed = newState { self.isTesting = false }
+                            if case .detected = newState { self.testTimeoutTask?.cancel() }
+                            if case .failed = newState { self.testTimeoutTask?.cancel() }
                         }
                     })
                 self.testTimeoutTask?.cancel()

--- a/apps/macos/Sources/OpenClaw/VoiceWakeTester.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeTester.swift
@@ -191,9 +191,7 @@ final class VoiceWakeTester {
     }
 
     private func stop(force: Bool) {
-        if force {
-            self.isStopping = true
-        }
+        if force { self.isStopping = true }
         self.isFinalizing = false
         self.recognitionRequest?.endAudio()
         self.recognitionTask?.cancel()
@@ -325,9 +323,7 @@ final class VoiceWakeTester {
             guard count > 0, tokens.count > count else { continue }
             for i in 0...(tokens.count - count - 1) {
                 let matched = (0..<count).allSatisfy { tokens[i + $0].normalized == trigger.tokens[$0] }
-                if !matched {
-                    continue
-                }
+                if !matched { continue }
                 let triggerEnd = tokens[i + count - 1].end
                 let nextToken = tokens[i + count]
                 let gap = nextToken.start - triggerEnd
@@ -355,9 +351,7 @@ final class VoiceWakeTester {
                 .split(whereSeparator: { $0.isWhitespace })
                 .map { VoiceWakeTextUtils.normalizeToken(String($0)) }
                 .filter { !$0.isEmpty }
-            if tokens.isEmpty {
-                continue
-            }
+            if tokens.isEmpty { continue }
             output.append(DebugTriggerTokens(tokens: tokens))
         }
         return output

--- a/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
@@ -87,9 +87,7 @@ enum VoiceWakeTextUtils {
                 else { continue }
 
                 if let bestMatch {
-                    if range.lowerBound > bestMatch.range.lowerBound {
-                        continue
-                    }
+                    if range.lowerBound > bestMatch.range.lowerBound { continue }
                     if range.lowerBound == bestMatch.range.lowerBound,
                        tokenCount <= bestMatch.tokenCount
                     {

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -17,9 +17,7 @@ enum WebChatPresentation {
     case panel(anchorProvider: () -> NSRect?)
 
     var isPanel: Bool {
-        if case .panel = self {
-            return true
-        }
+        if case .panel = self { return true }
         return false
     }
 }
@@ -116,9 +114,7 @@ final class WebChatManager {
     }
 
     func preferredSessionKey() async -> String {
-        if let cachedPreferredSessionKey {
-            return cachedPreferredSessionKey
-        }
+        if let cachedPreferredSessionKey { return cachedPreferredSessionKey }
         let key = await GatewayConnection.shared.mainSessionKey()
         self.cachedPreferredSessionKey = key
         return key

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -130,9 +130,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             "includeGlobal": AnyCodable(true),
             "includeUnknown": AnyCodable(false),
         ]
-        if let limit {
-            params["limit"] = AnyCodable(limit)
-        }
+        if let limit { params["limit"] = AnyCodable(limit) }
         let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let normalizedSearch, !normalizedSearch.isEmpty {
             params["search"] = AnyCodable(normalizedSearch)
@@ -433,9 +431,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
                 let stream = await GatewayConnection.shared.subscribe()
                 for await push in stream {
-                    if Task.isCancelled {
-                        return
-                    }
+                    if Task.isCancelled { return }
                     if let evt = Self.mapPushToTransportEvent(push) {
                         continuation.yield(evt)
                     }
@@ -755,9 +751,7 @@ final class WebChatSwiftUIWindowController {
     }
 
     private func installDismissMonitor() {
-        if ProcessInfo.processInfo.isRunningTests {
-            return
-        }
+        if ProcessInfo.processInfo.isRunningTests { return }
         guard self.dismissMonitor == nil, self.window != nil else { return }
         self.dismissMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown])

--- a/apps/macos/Sources/OpenClaw/WindowPlacement.swift
+++ b/apps/macos/Sources/OpenClaw/WindowPlacement.swift
@@ -75,9 +75,7 @@ enum WindowPlacement {
             frame.intersects(screen.visibleFrame.insetBy(dx: 12, dy: 12))
         }
 
-        if isVisibleSomewhere {
-            return
-        }
+        if isVisibleSomewhere { return }
 
         let screen = NSScreen.main ?? targetScreens.first
         let next = fallback?(screen) ?? self.centeredFrame(size: defaultSize, on: screen)

--- a/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
@@ -97,9 +97,7 @@ public final class GatewayDiscoveryModel {
     }
 
     public func start() {
-        if !self.browsers.isEmpty {
-            return
-        }
+        if !self.browsers.isEmpty { return }
 
         for domain in OpenClawBonjour.gatewayServiceDomains {
             let browser = GatewayDiscoveryBrowserSupport.makeBrowser(
@@ -313,9 +311,7 @@ public final class GatewayDiscoveryModel {
 
     private func scheduleWideAreaFallback() {
         guard let domain = OpenClawBonjour.wideAreaGatewayServiceDomain else { return }
-        if Self.isRunningTests {
-            return
-        }
+        if Self.isRunningTests { return }
         guard self.wideAreaFallbackTask == nil else { return }
         self.wideAreaFallbackTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
@@ -325,9 +321,7 @@ public final class GatewayDiscoveryModel {
                 let hasResults = await MainActor.run {
                     self.hasUsableWideAreaResults
                 }
-                if hasResults {
-                    return
-                }
+                if hasResults { return }
 
                 // Wide-area discovery can be racy (Tailscale not yet up, DNS zone not
                 // published yet). Retry with a short backoff while onboarding is open.
@@ -349,9 +343,7 @@ public final class GatewayDiscoveryModel {
     }
 
     private func scheduleTailscaleServeFallback() {
-        if Self.isRunningTests {
-            return
-        }
+        if Self.isRunningTests { return }
         guard self.tailscaleServeFallbackTask == nil else { return }
         self.tailscaleServeFallbackTask = Task.detached(priority: .utility) { [weak self] in
             guard let self else { return }
@@ -363,9 +355,7 @@ public final class GatewayDiscoveryModel {
                         currentGateways: self.gateways,
                         tailscaleServeGateways: self.tailscaleServeFallbackGateways)
                 }
-                if !shouldContinue {
-                    return
-                }
+                if !shouldContinue { return }
 
                 let beacons = await TailscaleServeGatewayDiscovery.discover(timeoutSeconds: 2.4)
                 if !beacons.isEmpty {
@@ -396,9 +386,7 @@ public final class GatewayDiscoveryModel {
     private var hasUsableWideAreaResults: Bool {
         guard let domain = OpenClawBonjour.wideAreaGatewayServiceDomain else { return false }
         guard let gateways = self.gatewaysByDomain[domain], !gateways.isEmpty else { return false }
-        if !self.filterLocalGateways {
-            return true
-        }
+        if !self.filterLocalGateways { return true }
         return gateways.contains(where: { !$0.isLocal })
     }
 
@@ -419,9 +407,7 @@ public final class GatewayDiscoveryModel {
         var seen = Set<String>()
         let deduped = gateways.filter { gateway in
             let key = Self.dedupeKey(for: gateway)
-            if seen.contains(key) {
-                return false
-            }
+            if seen.contains(key) { return false }
             seen.insert(key)
             return true
         }
@@ -432,9 +418,7 @@ public final class GatewayDiscoveryModel {
 
     private nonisolated static var isRunningTests: Bool {
         // Keep discovery background work from running forever during SwiftPM test runs.
-        if Bundle.allBundles.contains(where: { $0.bundleURL.pathExtension == "xctest" }) {
-            return true
-        }
+        if Bundle.allBundles.contains(where: { $0.bundleURL.pathExtension == "xctest" }) { return true }
 
         let env = ProcessInfo.processInfo.environment
         return env["XCTestConfigurationFilePath"] != nil
@@ -692,9 +676,7 @@ public final class GatewayDiscoveryModel {
     private nonisolated static func normalizeHostToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
+        if trimmed.isEmpty { return nil }
         let lower = trimmed.lowercased()
         let strippedTrailingDot = lower.hasSuffix(".")
             ? String(lower.dropLast())
@@ -711,9 +693,7 @@ public final class GatewayDiscoveryModel {
         guard let raw else { return nil }
         let prettified = Self.prettifyInstanceName(raw)
         let trimmed = prettified.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
+        if trimmed.isEmpty { return nil }
         return trimmed.lowercased()
     }
 

--- a/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
@@ -36,9 +36,7 @@ enum TailscaleServeGatewayDiscovery {
         }
 
         let candidates = self.collectCandidates(status: status)
-        if candidates.isEmpty {
-            return []
-        }
+        if candidates.isEmpty { return [] }
 
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         let perProbeTimeout = min(self.defaultProbeTimeoutSeconds, max(0.5, timeoutSeconds * 0.45))
@@ -127,9 +125,7 @@ enum TailscaleServeGatewayDiscovery {
     private static func displayName(hostName: String?, dnsName: String) -> String {
         if let hostName {
             let trimmed = hostName.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
+            if !trimmed.isEmpty { return trimmed }
         }
         return dnsName
             .split(separator: ".")
@@ -140,9 +136,7 @@ enum TailscaleServeGatewayDiscovery {
     private static func normalizeDnsName(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
+        if trimmed.isEmpty { return nil }
         let withoutDot = trimmed.hasSuffix(".") ? String(trimmed.dropLast()) : trimmed
         let lower = withoutDot.lowercased()
         return lower.isEmpty ? nil : lower
@@ -183,9 +177,7 @@ enum TailscaleServeGatewayDiscovery {
         let entries = pathRaw.split(separator: ":").map(String.init)
         for entry in entries {
             let dir = entry.trimmingCharacters(in: .whitespacesAndNewlines)
-            if dir.isEmpty {
-                continue
-            }
+            if dir.isEmpty { continue }
             let fullPath = URL(fileURLWithPath: dir)
                 .appendingPathComponent(trimmed)
                 .path

--- a/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/WideAreaGatewayDiscovery.swift
@@ -56,9 +56,7 @@ enum WideAreaGatewayDiscovery {
         var beacons: [WideAreaGatewayBeacon] = []
         for raw in ptrLines {
             let ptr = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if ptr.isEmpty {
-                continue
-            }
+            if ptr.isEmpty { continue }
             let ptrName = ptr.hasSuffix(".") ? String(ptr.dropLast()) : ptr
             let suffix = "._openclaw-gw._tcp.\(domainTrimmed)"
             let rawInstanceName = ptrName.hasSuffix(suffix)
@@ -115,9 +113,7 @@ enum WideAreaGatewayDiscovery {
         var seen = Set<String>()
         return ips.filter { value in
             guard self.isTailnetIPv4(value) else { return false }
-            if seen.contains(value) {
-                return false
-            }
+            if seen.contains(value) { return false }
             seen.insert(value)
             return true
         }
@@ -155,9 +151,7 @@ enum WideAreaGatewayDiscovery {
         let domainTrimmed = domain.trimmingCharacters(in: CharacterSet(charactersIn: "."))
         let probeName = "_openclaw-gw._tcp.\(domainTrimmed)"
         let budget = max(0, remaining())
-        if budget <= 0 {
-            return nil
-        }
+        if budget <= 0 { return nil }
 
         guard let stdout = dig(
             ["+short", "+time=1", "+tries=1", "@\(self.tailscaleDNSResolver)", probeName, "PTR"],
@@ -221,9 +215,7 @@ enum WideAreaGatewayDiscovery {
         var tokens: [String] = []
         for raw in lines {
             let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty {
-                continue
-            }
+            if line.isEmpty { continue }
             let matches = line.matches(of: /"([^"]*)"/)
             for match in matches {
                 tokens.append(self.unescapeTxt(String(match.1)))
@@ -247,9 +239,7 @@ enum WideAreaGatewayDiscovery {
             let rawValue = String(token[token.index(after: idx)...])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let value = self.decodeDnsSdEscapes(rawValue)
-            if !key.isEmpty {
-                out[key] = value
-            }
+            if !key.isEmpty { out[key] = value }
         }
         return out
     }
@@ -268,13 +258,9 @@ enum WideAreaGatewayDiscovery {
 
     private static func isTailnetIPv4(_ value: String) -> Bool {
         let parts = value.split(separator: ".")
-        if parts.count != 4 {
-            return false
-        }
+        if parts.count != 4 { return false }
         let octets = parts.compactMap { Int($0) }
-        if octets.count != 4 {
-            return false
-        }
+        if octets.count != 4 { return false }
         let a = octets[0]
         let b = octets[1]
         return a == 100 && b >= 64 && b <= 127
@@ -310,9 +296,7 @@ enum WideAreaGatewayDiscovery {
         }
         flushPending()
 
-        if bytes.isEmpty {
-            return value
-        }
+        if bytes.isEmpty { return value }
         if let decoded = String(bytes: bytes, encoding: .utf8) {
             return decoded
         }

--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -293,9 +293,7 @@ private func normalizeDirectURL(_ raw: String) -> URL? {
 }
 
 private func defaultPort(for url: URL) -> Int? {
-    if let port = url.port {
-        return port
-    }
+    if let port = url.port { return port }
     switch url.scheme?.lowercased() {
     case "wss":
         return 443
@@ -427,9 +425,7 @@ private func normalizedSSHHostKeyPolicy(_ raw: String?) -> String? {
 }
 
 private func isValidSSHTarget(_ raw: String) -> Bool {
-    if raw.isEmpty || raw.hasPrefix("-") {
-        return false
-    }
+    if raw.isEmpty || raw.hasPrefix("-") { return false }
     if raw.rangeOfCharacter(from: CharacterSet.whitespacesAndNewlines.union(.controlCharacters)) != nil {
         return false
     }

--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -325,9 +325,7 @@ private func gatewayEndpoint(
 }
 
 private func resolvedToken(opts: ConnectOptions, mode: String, config: GatewayConfig) -> String? {
-    if let token = opts.token, !token.isEmpty {
-        return token
-    }
+    if let token = opts.token, !token.isEmpty { return token }
     if mode == "remote" {
         return config.remoteToken
     }
@@ -335,9 +333,7 @@ private func resolvedToken(opts: ConnectOptions, mode: String, config: GatewayCo
 }
 
 private func resolvedPassword(opts: ConnectOptions, mode: String, config: GatewayConfig) -> String? {
-    if let password = opts.password, !password.isEmpty {
-        return password
-    }
+    if let password = opts.password, !password.isEmpty { return password }
     if mode == "remote" {
         return config.remotePassword
     }

--- a/apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift
@@ -130,9 +130,7 @@ func runDiscover(_ args: [String]) async {
     print("Gateway Discovery (macOS NWBrowser)")
     print("Status: \(status)")
     print("Found \(gateways.count) gateway(s)\(opts.includeLocal ? "" : " (local filtered)")")
-    if gateways.isEmpty {
-        return
-    }
+    if gateways.isEmpty { return }
 
     for gateway in gateways {
         let hosts = [gateway.tailnetDns, gateway.lanHost]

--- a/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
@@ -139,9 +139,7 @@ private func resolveWizardGatewayEndpoint(opts: WizardCliOptions, config: Gatewa
 }
 
 private func resolvedToken(opts: WizardCliOptions, config: GatewayConfig) -> String? {
-    if let token = opts.token, !token.isEmpty {
-        return token
-    }
+    if let token = opts.token, !token.isEmpty { return token }
     if (config.mode ?? "local").lowercased() == "remote" {
         return config.remoteToken
     }
@@ -149,9 +147,7 @@ private func resolvedToken(opts: WizardCliOptions, config: GatewayConfig) -> Str
 }
 
 private func resolvedPassword(opts: WizardCliOptions, config: GatewayConfig) -> String? {
-    if let password = opts.password, !password.isEmpty {
-        return password
-    }
+    if let password = opts.password, !password.isEmpty { return password }
     if (config.mode ?? "local").lowercased() == "remote" {
         return config.remotePassword
     }
@@ -463,9 +459,7 @@ private func promptAnswer(for step: WizardStep) throws -> Any {
         let initial = anyCodableBool(step.initialvalue)
         let value = try readLineWithPrompt("Confirm? (y/n) [\(initial ? "y" : "n")]")
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if trimmed.isEmpty {
-            return initial
-        }
+        if trimmed.isEmpty { return initial }
         return trimmed == "y" || trimmed == "yes" || trimmed == "true"
     case "select":
         return try promptSelect(step)
@@ -492,9 +486,7 @@ private func promptSelect(_ step: WizardStep) throws -> Any {
         if trimmed.isEmpty, let initialIndex {
             return options[initialIndex].value?.value ?? options[initialIndex].label
         }
-        if trimmed.lowercased() == "q" {
-            throw WizardCliError.cancelled
-        }
+        if trimmed.lowercased() == "q" { throw WizardCliError.cancelled }
         if let number = Int(trimmed), (1...options.count).contains(number) {
             let option = options[number - 1]
             return option.value?.value ?? option.label
@@ -521,9 +513,7 @@ private func promptMultiSelect(_ step: WizardStep) throws -> [Any] {
         if trimmed.isEmpty {
             return initialIndices.map { options[$0 - 1].value?.value ?? options[$0 - 1].label }
         }
-        if trimmed.lowercased() == "q" {
-            throw WizardCliError.cancelled
-        }
+        if trimmed.lowercased() == "q" { throw WizardCliError.cancelled }
         let parts = trimmed.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         let indices = parts.compactMap { Int($0) }.filter { (1...options.count).contains($0) }
         if indices.isEmpty {

--- a/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
@@ -57,9 +57,7 @@ private actor CancellationIgnoringOperation {
     }
 
     func waitUntilFinished() async {
-        if self.didFinish {
-            return
-        }
+        if self.didFinish { return }
         await withCheckedContinuation { continuation in
             self.finishWaiters.append(continuation)
         }
@@ -85,9 +83,7 @@ private actor AsyncTimeoutTestGate {
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
-        if self.isOpen {
-            return
-        }
+        if self.isOpen { return }
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift
@@ -37,9 +37,7 @@ enum AssistantTextParser {
 
             let isSelfClosing = self.isSelfClosingTag(in: raw, tagEnd: tagEnd)
             cursor = tagEnd.upperBound
-            if isSelfClosing {
-                continue
-            }
+            if isSelfClosing { continue }
 
             if match.closing {
                 currentKind = .response
@@ -135,9 +133,7 @@ enum AssistantTextParser {
         while cursor > text.startIndex {
             cursor = text.index(before: cursor)
             let char = text[cursor]
-            if char.isWhitespace {
-                continue
-            }
+            if char.isWhitespace { continue }
             return char == "/"
         }
         return false

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCodeHighlighter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCodeHighlighter.swift
@@ -196,9 +196,7 @@ enum ChatCodeHighlighter {
             } else if self.matches(chars, at: end, block.close) {
                 depth -= 1
                 end += block.close.count
-                if depth == 0 {
-                    break
-                }
+                if depth == 0 { break }
             } else {
                 end += 1
             }
@@ -244,9 +242,7 @@ enum ChatCodeHighlighter {
                 end += delimiter.count
                 break
             }
-            if !multiline, chars[end] == "\n" {
-                break
-            }
+            if !multiline, chars[end] == "\n" { break }
             end += 1
         }
         end = min(end, chars.count)
@@ -373,9 +369,7 @@ public enum ChatCodeHighlightCache {
             return AttributedString(code)
         }
         let key = "\(languageId ?? "")\u{0}\(code)"
-        if let hit = self.cache[key] {
-            return hit
-        }
+        if let hit = self.cache[key] { return hit }
         let value = ChatCodeHighlighter.attributedCode(code, languageId: languageId)
         if self.cache.count >= self.capacity {
             self.cache.removeAll(keepingCapacity: true)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1346,9 +1346,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
         // coordinator never reported is programmatic (send-clear, slash
         // completion) and must reach the view even mid-edit.
         let isEcho = context.coordinator.lastReportedText == self.text
-        if isEditing, isEcho {
-            return
-        }
+        if isEditing, isEcho { return }
 
         if textView.string != self.text {
             context.coordinator.isProgrammaticUpdate = true

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -172,12 +172,8 @@ struct ChatMessageUsagePresentation: Equatable {
 
     private static func pressure(for percent: Int?) -> Pressure {
         guard let percent else { return .normal }
-        if percent >= 90 {
-            return .danger
-        }
-        if percent >= 75 {
-            return .warning
-        }
+        if percent >= 90 { return .danger }
+        if percent >= 75 { return .warning }
         return .normal
     }
 
@@ -238,12 +234,8 @@ struct ChatContextUsageIndicator: View {
 
     private var tint: Color {
         guard let percent = usage.percentUsed else { return .secondary }
-        if percent >= 90 {
-            return Color(nsColor: .systemRed)
-        }
-        if percent >= 75 {
-            return Color(nsColor: .systemOrange)
-        }
+        if percent >= 90 { return Color(nsColor: .systemRed) }
+        if percent >= 75 { return Color(nsColor: .systemOrange) }
         return Color(nsColor: .systemGreen)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
@@ -62,9 +62,7 @@ public enum OpenClawChatEventText {
     }
 
     private static func stringValue(_ value: Any?) -> String? {
-        if let string = value as? String {
-            return string
-        }
+        if let string = value as? String { return string }
         if let wrapped = value as? AnyCodable {
             return self.stringValue(wrapped.value)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -344,9 +344,7 @@ enum ChatMarkdownBlockSegmenter {
         guard header.count == columnCount else { return nil }
         let rows = bodyLines.map { lineIndex in
             let cells = source.tableCells(at: lineIndex)
-            if cells.count >= columnCount {
-                return Array(cells.prefix(columnCount))
-            }
+            if cells.count >= columnCount { return Array(cells.prefix(columnCount)) }
             return cells + Array(repeating: "", count: columnCount - cells.count)
         }
         let alignments = table.columnAlignments.map { alignment in
@@ -418,9 +416,7 @@ enum ChatMarkdownBlockSegmenter {
             var escaped = false
             for character in line {
                 if escaped {
-                    if character != "|" {
-                        current.append("\\")
-                    }
+                    if character != "|" { current.append("\\") }
                     current.append(character)
                     escaped = false
                 } else if character == "\\" {
@@ -432,19 +428,13 @@ enum ChatMarkdownBlockSegmenter {
                     current.append(character)
                 }
             }
-            if escaped {
-                current.append("\\")
-            }
+            if escaped { current.append("\\") }
             cells.append(current)
 
             var trimmed = cells.map { $0.trimmingCharacters(in: .whitespaces) }
             let trimmedLine = line.trimmingCharacters(in: .whitespaces)
-            if trimmedLine.hasPrefix("|"), trimmed.first?.isEmpty == true {
-                trimmed.removeFirst()
-            }
-            if trimmedLine.hasSuffix("|"), trimmed.last?.isEmpty == true {
-                trimmed.removeLast()
-            }
+            if trimmedLine.hasPrefix("|"), trimmed.first?.isEmpty == true { trimmed.removeFirst() }
+            if trimmedLine.hasSuffix("|"), trimmed.last?.isEmpty == true { trimmed.removeLast() }
             return trimmed
         }
 
@@ -462,12 +452,8 @@ enum ChatMarkdownBlockSegmenter {
             let trimmedLine = line.trimmingCharacters(in: .whitespaces)
             var cells = trimmedLine.split(separator: "|", omittingEmptySubsequences: false)
                 .map { $0.trimmingCharacters(in: .whitespaces) }
-            if trimmedLine.hasPrefix("|"), cells.first?.isEmpty == true {
-                cells.removeFirst()
-            }
-            if trimmedLine.hasSuffix("|"), cells.last?.isEmpty == true {
-                cells.removeLast()
-            }
+            if trimmedLine.hasPrefix("|"), cells.first?.isEmpty == true { cells.removeFirst() }
+            if trimmedLine.hasSuffix("|"), cells.last?.isEmpty == true { cells.removeLast() }
             return cells.count == columnCount && cells.allSatisfy {
                 $0.range(of: #"^:?-+:?$"#, options: .regularExpression) != nil
             }
@@ -492,9 +478,7 @@ enum ChatMarkdownBlockSegmenter {
             }
             guard count >= 3 else { return nil }
             let info = line[cursor...].trimmingCharacters(in: .whitespaces)
-            if character == "`", info.contains("`") {
-                return nil
-            }
+            if character == "`", info.contains("`") { return nil }
             return FenceOpener(character: character, count: count)
         }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -56,9 +56,7 @@ enum ChatMarkdownPreprocessor {
         let matches = re.matches(
             in: withoutTimestamps,
             range: NSRange(location: 0, length: ns.length))
-        if matches.isEmpty {
-            return Result(cleaned: self.normalize(withoutTimestamps), images: [])
-        }
+        if matches.isEmpty { return Result(cleaned: self.normalize(withoutTimestamps), images: []) }
 
         var images: [InlineImage] = []
         let cleaned = NSMutableString(string: withoutTimestamps)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -464,12 +464,8 @@ private struct ChatMessageBody: View {
     }
 
     private var bubbleBorderWidth: CGFloat {
-        if self.isUser {
-            return 0.5
-        }
-        if self.style == .onboarding {
-            return 0.8
-        }
+        if self.isUser { return 0.5 }
+        if self.style == .onboarding { return 0.8 }
         return 1
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -108,9 +108,7 @@ enum ChatSessionSidebarModel {
         }
         let agent = String(parts[1])
         let session = String(parts[2])
-        if session.isEmpty {
-            return trimmed
-        }
+        if session.isEmpty { return trimmed }
         return agent == "main" || agent.isEmpty ? session : "\(session) (\(agent))"
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -104,9 +104,7 @@ struct ChatSessionsSheet: View {
                 isPresented: Binding(
                     get: { self.renameTarget != nil },
                     set: {
-                        if !$0 {
-                            self.renameTarget = nil
-                        }
+                        if !$0 { self.renameTarget = nil }
                     })) {
                 TextField("Session name", text: self.$renameText)
                     .font(OpenClawChatTypography.body)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -574,9 +574,7 @@ extension OpenClawChatSQLiteTranscriptCache {
     @discardableResult
     public func recoverInterruptedSends() async -> Bool {
         guard !self.isRetired else { return false }
-        if self.hasRecoveredInterruptedSends {
-            return true
-        }
+        if self.hasRecoveredInterruptedSends { return true }
         guard let db = await handle() else { return false }
         let recovered = self.execute(
             db,
@@ -1039,12 +1037,8 @@ extension OpenClawChatSQLiteTranscriptCache {
 
     private func handle() async -> OpaquePointer? {
         guard !self.isRetired else { return nil }
-        if let db {
-            return db.raw
-        }
-        if self.isBroken {
-            return nil
-        }
+        if let db { return db.raw }
+        if self.isBroken { return nil }
         #if os(iOS)
         // Complete protection intentionally makes the cache unavailable while
         // locked. Treat that as a temporary miss, never as corruption.
@@ -1375,9 +1369,7 @@ extension OpenClawChatSQLiteTranscriptCache {
         defer { sqlite3_finalize(statement) }
         while sqlite3_step(statement) == SQLITE_ROW {
             guard let name = sqlite3_column_text(statement, 1) else { continue }
-            if String(cString: name) == columnName {
-                return true
-            }
+            if String(cString: name) == columnName { return true }
         }
         return false
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
@@ -652,9 +652,7 @@ extension OpenClawChatViewModel {
                 result.append(message)
                 continue
             }
-            if seen.contains(key) {
-                continue
-            }
+            if seen.contains(key) { continue }
             seen.insert(key)
             result.append(message)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -12,9 +12,7 @@ public enum OpenClawChatOutboxMessageState: Equatable, Sendable {
     case failed(reason: String?)
 
     public var isFailed: Bool {
-        if case .failed = self {
-            return true
-        }
+        if case .failed = self { return true }
         return false
     }
 
@@ -200,9 +198,7 @@ extension OpenClawChatViewModel {
             self.errorText = "Offline queue is full. Delete a queued message or reconnect to send."
             return
         }
-        if self.input == draftInput {
-            self.input = ""
-        }
+        if self.input == draftInput { self.input = "" }
         let capturedAttachmentIDs = Set(draftAttachments.map(\.id))
         self.attachments.removeAll { capturedAttachmentIDs.contains($0.id) }
         self.errorText = nil
@@ -379,9 +375,7 @@ extension OpenClawChatViewModel {
         guard !commands.isEmpty else { return }
         var next = self.messages
         for command in commands.sorted(by: { $0.createdAt < $1.createdAt }) {
-            if self.cancelingOutboxCommandIDs.contains(command.id) {
-                continue
-            }
+            if self.cancelingOutboxCommandIDs.contains(command.id) { continue }
             let key = Self.outboxUserIdempotencyKey(command.id)
             if let existing = next.first(where: { $0.idempotencyKey == key }) {
                 self.mapOutboxCommand(command, to: existing.id)
@@ -452,14 +446,10 @@ extension OpenClawChatViewModel {
         self.lastHealthPollAt = Date()
         do {
             let ok = try await self.transport.requestHealth(timeoutMs: 5000)
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
-                return
-            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             self.applyTransportHealth(ok, refreshSessionsOnReconnect: refreshSessionsOnReconnect)
         } catch {
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
-                return
-            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             self.applyTransportHealth(false)
         }
     }
@@ -882,17 +872,11 @@ extension OpenClawChatViewModel {
         let raw = session.key.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !raw.isEmpty else { return nil }
         guard self.transport.outboxRequiresSessionRoutingContract else { return raw }
-        if raw.lowercased() == "unknown" {
-            return raw
-        }
+        if raw.lowercased() == "unknown" { return raw }
         guard let agentID else { return nil }
         let normalized = raw.lowercased()
-        if normalized == "global" {
-            return "global"
-        }
-        if Self.agentID(fromSessionKey: raw) != nil {
-            return raw
-        }
+        if normalized == "global" { return "global" }
+        if Self.agentID(fromSessionKey: raw) != nil { return raw }
         // A malformed ownership prefix must fail closed, not become a nested
         // key such as agent:<id>:agent::main.
         guard !normalized.hasPrefix("agent:") else { return nil }
@@ -908,9 +892,7 @@ extension OpenClawChatViewModel {
         guard command.sessionKey == session.key else { return false }
         // Failed rows never auto-send. Keep them reachable on their original
         // presentation alias after an owner change for explicit retry/delete.
-        if command.status == .failed {
-            return true
-        }
+        if command.status == .failed { return true }
         // Migrated v2 aliases have no owner and are parked as failed. Show
         // them so explicit retry can adopt the currently selected agent.
         guard let commandAgentID = command.agentID else { return true }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -249,23 +249,17 @@ extension OpenClawChatViewModel {
 
     private func handleLocalSlashCommandIfNeeded(_ command: String, draftInput: String) async -> Bool {
         if command == "/new" {
-            if self.input == draftInput {
-                self.input = ""
-            }
+            if self.input == draftInput { self.input = "" }
             await self.performStartNewSession(worktree: false)
             return true
         }
         if Self.resetTriggers.contains(command) {
-            if self.input == draftInput {
-                self.input = ""
-            }
+            if self.input == draftInput { self.input = "" }
             await self.performReset()
             return true
         }
         if Self.compactTriggers.contains(command) {
-            if self.input == draftInput {
-                self.input = ""
-            }
+            if self.input == draftInput { self.input = "" }
             await self.performCompact()
             return true
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -354,9 +354,7 @@ public final class OpenClawChatViewModel {
         self.eventTask = Task { [weak self, transport] in
             let stream = transport.events()
             for await evt in stream {
-                if Task.isCancelled {
-                    return
-                }
+                if Task.isCancelled { return }
                 await MainActor.run { [weak self] in
                     self?.handleTransportEvent(evt)
                 }
@@ -1085,9 +1083,7 @@ extension OpenClawChatViewModel {
         var preservesOverlappingModelPatch = false
         while true {
             await self.waitForPendingModelPatches(for: target)
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
-                return
-            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             let metadataGeneration = self.sessionMetadataGeneration
             let modelPatchRevision = self.modelPatchRevisionsByTarget[target, default: 0]
             let res: OpenClawChatSessionsListResponse
@@ -1099,9 +1095,7 @@ extension OpenClawChatViewModel {
                 }
                 return
             }
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
-                return
-            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             guard sessionsFetchRequestID > self.latestAppliedSessionsFetchRequestID else { return }
             // A list that straddles a patch or reconnect is stale. Retry in this
             // owner so bootstrap cannot discard its only authoritative refresh.
@@ -1156,9 +1150,7 @@ extension OpenClawChatViewModel {
     private func fetchModels(sessionSnapshot: SessionSnapshot? = nil) async {
         do {
             let modelChoices = try await transport.listModels()
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
-                return
-            }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             self.modelChoices = modelChoices
             self.syncSelectedModel()
             syncThinkingLevelOptions()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -395,11 +395,7 @@ private struct ChatSessionSidebar: View {
     private var isPresentingDeleteDialog: Binding<Bool> {
         Binding(
             get: { self.sessionPendingDeletion != nil },
-            set: {
-                if !$0 {
-                    self.sessionPendingDeletion = nil
-                }
-            })
+            set: { if !$0 { self.sessionPendingDeletion = nil } })
     }
 
     private var selectionBinding: Binding<String?> {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -26,9 +26,7 @@ enum ToolResultTextFormatter {
             return self.renderDictionary(dict, toolName: toolName)
         }
         if let array = json as? [Any] {
-            if array.isEmpty {
-                return "No items."
-            }
+            if array.isEmpty { return "No items." }
             return "\(array.count) item\(array.count == 1 ? "" : "s")."
         }
         return ""
@@ -66,9 +64,7 @@ enum ToolResultTextFormatter {
 
     private static func renderNodesSummary(_ dict: [String: Any]) -> String? {
         if let nodes = dict["nodes"] as? [[String: Any]] {
-            if nodes.isEmpty {
-                return "No nodes found."
-            }
+            if nodes.isEmpty { return "No nodes found." }
             var lines: [String] = []
             lines.append("\(nodes.count) node\(nodes.count == 1 ? "" : "s") found.")
 
@@ -108,9 +104,7 @@ enum ToolResultTextFormatter {
         }
 
         if let pending = dict["pending"] as? [Any] {
-            if pending.isEmpty {
-                return "No pending pairing requests."
-            }
+            if pending.isEmpty { return "No pending pairing requests." }
             return "\(pending.count) pending pairing request\(pending.count == 1 ? "" : "s")."
         }
 
@@ -134,9 +128,7 @@ enum ToolResultTextFormatter {
         for key in keys {
             if let value = dict[key] as? String {
                 let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    return trimmed
-                }
+                if !trimmed.isEmpty { return trimmed }
             }
         }
         return nil

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
@@ -100,9 +100,7 @@ public final class OpenClawVoiceNoteRecorder {
     }
 
     public var isRecording: Bool {
-        if case .recording = self.state {
-            return true
-        }
+        if case .recording = self.state { return true }
         return false
     }
 
@@ -203,9 +201,7 @@ public final class OpenClawVoiceNoteRecorder {
     /// Cancels permission or capture and removes any temporary audio file.
     public func cancel() {
         // The chat view model owns the file after claiming the handoff.
-        if case .staging = self.state {
-            return
-        }
+        if case .staging = self.state { return }
         let fileURL: URL? = switch self.state {
         case let .recording(_, fileURL):
             fileURL

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/BonjourTypes.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/BonjourTypes.swift
@@ -19,9 +19,7 @@ public enum OpenClawBonjour {
 
     private static func resolveWideAreaDomain(_ raw: String?) -> String? {
         let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
+        if trimmed.isEmpty { return nil }
         let normalized = self.normalizeServiceDomain(trimmed)
         return normalized == self.gatewayServiceDomain ? nil : normalized
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CanvasA2UIAction.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CanvasA2UIAction.swift
@@ -42,9 +42,7 @@ public enum OpenClawCanvasA2UIAction: Sendable {
         for key in keys {
             if let raw = userAction[key] as? String {
                 let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    return trimmed
-                }
+                if !trimmed.isEmpty { return trimmed }
             }
         }
         return nil

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CanvasA2UIJSONL.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CanvasA2UIJSONL.swift
@@ -17,9 +17,7 @@ public enum OpenClawCanvasA2UIJSONL: Sendable {
         for rawLine in text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
             lineNumber += 1
             let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
-            if line.isEmpty {
-                continue
-            }
+            if line.isEmpty { continue }
             let data = Data(line.utf8)
 
             let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -254,12 +254,8 @@ public actor GatewayChannelActor {
         while self.shouldReconnect {
             guard await self.sleepUnlessCancelled(nanoseconds: 30 * 1_000_000_000) else { return } // 30s cadence
             guard self.shouldReconnect else { return }
-            if self.reconnectPausedForAuthFailure {
-                continue
-            }
-            if self.connected {
-                continue
-            }
+            if self.reconnectPausedForAuthFailure { continue }
+            if self.connected { continue }
             do {
                 try await self.connect()
             } catch {
@@ -367,9 +363,7 @@ public actor GatewayChannelActor {
         guard self.shouldReconnect else { throw CancellationError() }
         guard !self.disconnectNotificationInProgress else { throw CancellationError() }
         if self.connected {
-            if self.task?.state == .running {
-                return
-            }
+            if self.task?.state == .running { return }
             let staleGeneration = self.connectionGeneration
             let staleError = NSError(
                 domain: "Gateway",
@@ -1148,9 +1142,7 @@ extension GatewayChannelActor {
                 waiter.resume(returning: .res(res))
             }
         case let .event(evt):
-            if evt.event == "connect.challenge" {
-                return
-            }
+            if evt.event == "connect.challenge" { return }
             if let seq = evt.seq {
                 if let last = lastSeq, seq > last + 1 {
                     await self.pushHandler?(
@@ -1163,9 +1155,7 @@ extension GatewayChannelActor {
                 }
                 self.lastSeq = seq
             }
-            if evt.event == "tick" {
-                self.lastTick = Date()
-            }
+            if evt.event == "tick" { self.lastTick = Date() }
             await self.pushHandler?(.event(evt), connectionGeneration)
         default:
             break

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift
@@ -8,9 +8,7 @@ public enum GatewayDiscoveryStatusText {
         }
 
         if let failed = states.first(where: { state in
-            if case .failed = state {
-                return true
-            }
+            if case .failed = state { return true }
             return false
         }) {
             if case let .failed(err) = failed {
@@ -19,9 +17,7 @@ public enum GatewayDiscoveryStatusText {
         }
 
         if let waiting = states.first(where: { state in
-            if case .waiting = state {
-                return true
-            }
+            if case .waiting = state { return true }
             return false
         }) {
             if case let .waiting(err) = waiting {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -219,9 +219,7 @@ public struct GatewayResponseError: LocalizedError, @unchecked Sendable {
     }
 
     public var errorDescription: String? {
-        if self.code == "GATEWAY_ERROR" {
-            return "\(self.method): \(self.message)"
-        }
+        if self.code == "GATEWAY_ERROR" { return "\(self.method): \(self.message)" }
         return "\(self.method): [\(self.code)] \(self.message)"
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -97,9 +97,7 @@ public enum GatewayTLSStore {
         self.migrateFromUserDefaultsIfNeeded(stableID: stableID)
         let raw = GenericPasswordKeychainStore.loadString(service: self.keychainService, account: stableID)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if raw?.isEmpty == false {
-            return raw
-        }
+        if raw?.isEmpty == false { return raw }
         return nil
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
@@ -140,9 +140,7 @@ public struct JPEGTranscoder: Sendable {
                 if candidate.data.count <= maxBytes {
                     return candidate
                 }
-                if q <= minQuality {
-                    break
-                }
+                if q <= minQuality { break }
                 q = max(minQuality, q * 0.75)
             }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
@@ -43,12 +43,8 @@ public enum LoopbackHost {
     public static func isLocalNetworkHost(_ rawHost: String) -> Bool {
         let host = self.normalizedHost(rawHost)
         guard !host.isEmpty else { return false }
-        if self.isLoopbackHost(host) {
-            return true
-        }
-        if host.hasSuffix(".local") {
-            return true
-        }
+        if self.isLoopbackHost(host) { return true }
+        if host.hasSuffix(".local") { return true }
         if let ipv4 = self.parseIPv4(host) {
             return self.isLocalNetworkIPv4(ipv4)
         }
@@ -84,25 +80,15 @@ public enum LoopbackHost {
     static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
         let (a, b, _, _) = ip
         // 10.0.0.0/8
-        if a == 10 {
-            return true
-        }
+        if a == 10 { return true }
         // 172.16.0.0/12
-        if a == 172, (16...31).contains(Int(b)) {
-            return true
-        }
+        if a == 172, (16...31).contains(Int(b)) { return true }
         // 192.168.0.0/16
-        if a == 192, b == 168 {
-            return true
-        }
+        if a == 192, b == 168 { return true }
         // 127.0.0.0/8
-        if a == 127 {
-            return true
-        }
+        if a == 127 { return true }
         // 169.254.0.0/16 (link-local)
-        if a == 169, b == 254 {
-            return true
-        }
+        if a == 169, b == 254 { return true }
         return false
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaceIPv4.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaceIPv4.swift
@@ -18,9 +18,7 @@ public enum NetworkInterfaceIPv4 {
             let isUp = (flags & IFF_UP) != 0
             let isLoopback = (flags & IFF_LOOPBACK) != 0
             let family = ptr.pointee.ifa_addr.pointee.sa_family
-            if !isUp || isLoopback || family != UInt8(AF_INET) {
-                continue
-            }
+            if !isUp || isLoopback || family != UInt8(AF_INET) { continue }
 
             var addr = ptr.pointee.ifa_addr.pointee
             var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaces.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaces.swift
@@ -9,9 +9,7 @@ public enum NetworkInterfaces {
                 en0 = entry.ip
                 break
             }
-            if fallback == nil {
-                fallback = entry.ip
-            }
+            if fallback == nil { fallback = entry.ip }
         }
 
         return en0 ?? fallback

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
@@ -163,9 +163,7 @@ public enum TalkDirectiveParser {
         for key in keys {
             if let value = dict[key] as? String {
                 let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty {
-                    return trimmed
-                }
+                if !trimmed.isEmpty { return trimmed }
             }
         }
         return nil
@@ -173,47 +171,29 @@ public enum TalkDirectiveParser {
 
     private static func doubleValue(_ dict: [String: Any], keys: [String]) -> Double? {
         for key in keys {
-            if let value = dict[key] as? Double {
-                return value
-            }
-            if let value = dict[key] as? Int {
-                return Double(value)
-            }
-            if let value = dict[key] as? String, let parsed = Double(value) {
-                return parsed
-            }
+            if let value = dict[key] as? Double { return value }
+            if let value = dict[key] as? Int { return Double(value) }
+            if let value = dict[key] as? String, let parsed = Double(value) { return parsed }
         }
         return nil
     }
 
     private static func intValue(_ dict: [String: Any], keys: [String]) -> Int? {
         for key in keys {
-            if let value = dict[key] as? Int {
-                return value
-            }
-            if let value = dict[key] as? Double {
-                return Int(value)
-            }
-            if let value = dict[key] as? String, let parsed = Int(value) {
-                return parsed
-            }
+            if let value = dict[key] as? Int { return value }
+            if let value = dict[key] as? Double { return Int(value) }
+            if let value = dict[key] as? String, let parsed = Int(value) { return parsed }
         }
         return nil
     }
 
     private static func boolValue(_ dict: [String: Any], keys: [String]) -> Bool? {
         for key in keys {
-            if let value = dict[key] as? Bool {
-                return value
-            }
+            if let value = dict[key] as? Bool { return value }
             if let value = dict[key] as? String {
                 let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                if ["true", "yes", "1"].contains(trimmed) {
-                    return true
-                }
-                if ["false", "no", "0"].contains(trimmed) {
-                    return false
-                }
+                if ["true", "yes", "1"].contains(trimmed) { return true }
+                if ["false", "no", "0"].contains(trimmed) { return false }
             }
         }
         return nil

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -60,9 +60,7 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
         self.watchdog = Task { @MainActor [weak self] in
             guard let self else { return }
             try? await Task.sleep(nanoseconds: UInt64(watchdogTimeout * 1_000_000_000))
-            if Task.isCancelled {
-                return
-            }
+            if Task.isCancelled { return }
             guard self.currentToken == token else { return }
             if self.synth.isSpeaking {
                 self.synth.stopSpeaking(at: .immediate)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ToolDisplay.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ToolDisplay.swift
@@ -10,12 +10,8 @@ public struct ToolDisplaySummary: Sendable, Equatable {
 
     public var detailLine: String? {
         var parts: [String] = []
-        if let verb, !verb.isEmpty {
-            parts.append(verb)
-        }
-        if let detail, !detail.isEmpty {
-            parts.append(detail)
-        }
+        if let verb, !verb.isEmpty { parts.append(verb) }
+        if let detail, !detail.isEmpty { parts.append(detail) }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
@@ -144,9 +140,7 @@ public enum ToolDisplayRegistry {
             .split(separator: " ")
             .map { part in
                 let upper = part.uppercased()
-                if part.count <= 2, part == upper {
-                    return String(part)
-                }
+                if part.count <= 2, part == upper { return String(part) }
                 return String(upper.prefix(1)) + String(part.lowercased().dropFirst())
             }
             .joined(separator: " ")
@@ -191,20 +185,12 @@ public enum ToolDisplayRegistry {
             let trimmed = str.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
             let first = trimmed.split(whereSeparator: \.isNewline).first.map(String.init) ?? trimmed
-            if first.count > 160 {
-                return String(first.prefix(157)) + "…"
-            }
+            if first.count > 160 { return String(first.prefix(157)) + "…" }
             return first
         }
-        if let num = value as? Int {
-            return String(num)
-        }
-        if let num = value as? Double {
-            return String(num)
-        }
-        if let bool = value as? Bool {
-            return bool ? "true" : "false"
-        }
+        if let num = value as? Int { return String(num) }
+        if let num = value as? Double { return String(num) }
+        if let bool = value as? Bool { return bool ? "true" : "false" }
         if let array = value as? [Any] {
             let items = array.compactMap { self.renderValue($0) }
             guard !items.isEmpty else { return nil }
@@ -212,12 +198,8 @@ public enum ToolDisplayRegistry {
             return items.count > 3 ? "\(preview)…" : preview
         }
         if let dict = value as? [String: Any] {
-            if let label = dict["name"].flatMap({ renderValue($0) }) {
-                return label
-            }
-            if let label = dict["id"].flatMap({ renderValue($0) }) {
-                return label
-            }
+            if let label = dict["name"].flatMap({ renderValue($0) }) { return label }
+            if let label = dict["id"].flatMap({ renderValue($0) }) { return label }
         }
         return nil
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
@@ -13,9 +13,7 @@ func waitUntil(
 {
     let deadline = Date().addingTimeInterval(timeoutSeconds)
     while Date() < deadline {
-        if await condition() {
-            return
-        }
+        if await condition() { return }
         try await Task.sleep(nanoseconds: pollMs * 1_000_000)
     }
     throw AsyncWaitTimeoutError(label: label)

--- a/apps/swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/apps/swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -112,9 +112,7 @@ public enum WakeWordGate {
         commandWords.reserveCapacity(segments.count)
         for segment in segments where segment.start >= threshold {
             let normalized = normalizeToken(segment.text)
-            if normalized.isEmpty {
-                continue
-            }
+            if normalized.isEmpty { continue }
             commandWords.append(segment.text)
         }
         return commandWords.joined(separator: " ").trimmingCharacters(in: Self.whitespaceAndPunctuation)
@@ -125,12 +123,8 @@ public enum WakeWordGate {
         let normalized = text.lowercased()
         for trigger in triggers {
             let token = trigger.trimmingCharacters(in: self.whitespaceAndPunctuation).lowercased()
-            if token.isEmpty {
-                continue
-            }
-            if normalized.contains(token) {
-                return true
-            }
+            if token.isEmpty { continue }
+            if normalized.contains(token) { return true }
         }
         return false
     }
@@ -152,9 +146,7 @@ public enum WakeWordGate {
                 .split(whereSeparator: { $0.isWhitespace })
                 .map { self.normalizeToken(String($0)) }
                 .filter { !$0.isEmpty }
-            if tokens.isEmpty {
-                continue
-            }
+            if tokens.isEmpty { continue }
             output.append(TriggerTokens(source: tokens.joined(separator: " "), tokens: tokens))
         }
         return output

--- a/apps/swabble/Sources/swabble/Commands/DoctorCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/DoctorCommand.swift
@@ -14,9 +14,7 @@ struct DoctorCommand: ParsableCommand {
     init() {}
     init(parsed: ParsedValues) {
         self.init()
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/MicCommands.swift
+++ b/apps/swabble/Sources/swabble/Commands/MicCommands.swift
@@ -50,12 +50,8 @@ struct MicSet: ParsableCommand {
     init() {}
     init(parsed: ParsedValues) {
         self.init()
-        if let value = parsed.positional.first, let intVal = Int(value) {
-            self.index = intVal
-        }
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if let value = parsed.positional.first, let intVal = Int(value) { self.index = intVal }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/ServeCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/ServeCommand.swift
@@ -19,12 +19,8 @@ struct ServeCommand: ParsableCommand {
 
     init(parsed: ParsedValues) {
         self.init()
-        if parsed.flags.contains("noWake") {
-            self.noWake = true
-        }
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if parsed.flags.contains("noWake") { self.noWake = true }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/SetupCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/SetupCommand.swift
@@ -13,9 +13,7 @@ struct SetupCommand: ParsableCommand {
     init() {}
     init(parsed: ParsedValues) {
         self.init()
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/StatusCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/StatusCommand.swift
@@ -13,9 +13,7 @@ struct StatusCommand: ParsableCommand {
     init() {}
     init(parsed: ParsedValues) {
         self.init()
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/TestHookCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/TestHookCommand.swift
@@ -15,12 +15,8 @@ struct TestHookCommand: ParsableCommand {
 
     init(parsed: ParsedValues) {
         self.init()
-        if let positional = parsed.positional.first {
-            self.text = positional
-        }
-        if let cfg = parsed.options["config"]?.last {
-            self.configPath = cfg
-        }
+        if let positional = parsed.positional.first { self.text = positional }
+        if let cfg = parsed.options["config"]?.last { self.configPath = cfg }
     }
 
     mutating func run() async throws {

--- a/apps/swabble/Sources/swabble/Commands/TranscribeCommand.swift
+++ b/apps/swabble/Sources/swabble/Commands/TranscribeCommand.swift
@@ -25,24 +25,12 @@ struct TranscribeCommand: ParsableCommand {
 
     init(parsed: ParsedValues) {
         self.init()
-        if let positional = parsed.positional.first {
-            self.inputFile = positional
-        }
-        if let loc = parsed.options["locale"]?.last {
-            self.locale = loc
-        }
-        if parsed.flags.contains("censor") {
-            self.censor = true
-        }
-        if let out = parsed.options["output"]?.last {
-            self.outputFile = out
-        }
-        if let fmt = parsed.options["format"]?.last {
-            self.format = fmt
-        }
-        if let len = parsed.options["maxLength"]?.last, let intVal = Int(len) {
-            self.maxLength = intVal
-        }
+        if let positional = parsed.positional.first { self.inputFile = positional }
+        if let loc = parsed.options["locale"]?.last { self.locale = loc }
+        if parsed.flags.contains("censor") { self.censor = true }
+        if let out = parsed.options["output"]?.last { self.outputFile = out }
+        if let fmt = parsed.options["format"]?.last { self.format = fmt }
+        if let len = parsed.options["maxLength"]?.last, let intVal = Int(len) { self.maxLength = intVal }
     }
 
     mutating func run() async throws {

--- a/config/swiftformat
+++ b/config/swiftformat
@@ -36,6 +36,9 @@
 --wrapcollections before-first
 --closingparen same-line
 
+# Preserve the established compact style for single-statement if bodies.
+--disable wrapIfStatementBodies
+
 # Organization
 --organizetypes class,struct,enum,extension
 --extensionmark "MARK: - %t + %p"


### PR DESCRIPTION
Related: #103313

## What Problem This Solves

SwiftFormat 0.62.1's newly default-enabled `wrapIfStatementBodies` rule expanded OpenClaw's established compact single-statement conditionals across the native Swift codebase. The result was much harder to scan despite the stronger lint cleanup in #103313 being otherwise valuable.

## Why This Change Was Made

This explicitly disables only `wrapIfStatementBodies` and mechanically restores true single-statement `if` bodies. It keeps `wrapIfExpressionBodies`, `redundantSwiftUIGroup`, `--semicolons never`, pinned SwiftFormat 0.62.1 tooling, recursive source coverage, and the rest of the stricter cleanup from #103313. Multi-statement bodies and `if` expressions remain multiline.

The final iOS build also exposed one redundant `await` in the startup timeout task. Removing it preserves `@MainActor` isolation and the awaited timeout sleep while eliminating the compiler warning.

The native i18n source inventory is regenerated so its source locations follow the compact layout; all 2916 entry identities and contents are unchanged.

## User Impact

No runtime behavior change. The repo keeps compact early returns and simple one-statement conditionals while remaining SwiftFormat-, SwiftLint-, and compiler-warning-free.

## Evidence

- `./scripts/check-swift-tools.sh`
- `./scripts/format-swift.sh macos` — 0/265 files require formatting; Swabble 0/23
- `./scripts/lint-swift.sh macos` — 0 violations in 265 macOS files and 22 Swabble files
- `./scripts/format-swift.sh ios` — 0/278 files require formatting
- `./scripts/lint-swift.sh ios` — 0 violations in 278 files
- `pnpm native:i18n:check` — 2916 entries, `changed=false`
- `pnpm ios:build` — build succeeded with no compiler `warning:` or `error:` diagnostics
- `git diff --check origin/main...HEAD`
- Fresh autoreview: no actionable findings
