### PR TITLE
chore(audit): prove invalid filters stop before Gateway RPC

### DIFF
--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { testApi } from "./audit.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { auditListCommand, testApi } from "./audit.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
+
+const runtime: RuntimeEnv = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
 
 describe("audit command parsing", () => {
   it("parses ISO and millisecond timestamps", () => {
@@ -15,6 +30,23 @@ describe("audit command parsing", () => {
 
   it.each(["--after", "--before"])("rejects impossible calendar dates for %s", (flag) => {
     expect(() => testApi.parseAuditTimestamp("2026-02-30T00:00:00Z", flag)).toThrow(flag);
+  });
+
+  it.each(["--after", "--before"])("rejects parseable non-ISO values for %s", (flag) => {
+    for (const input of ["-1", "July 1, 2026"]) {
+      expect(Number.isNaN(Date.parse(input))).toBe(false);
+      expect(() => testApi.parseAuditTimestamp(input, flag)).toThrow(flag);
+    }
+  });
+
+  it.each([
+    { flag: "--after", options: { after: "2026-02-30T00:00:00Z" } },
+    { flag: "--before", options: { before: "July 1, 2026" } },
+  ])("rejects invalid $flag before calling the Gateway", async ({ flag, options }) => {
+    mocks.callGateway.mockClear();
+
+    await expect(auditListCommand(options, runtime)).rejects.toThrow(flag);
+    expect(mocks.callGateway).not.toHaveBeenCalled();
   });
 
   it("keeps the original local-time result for timezone-less timestamps", () => {


### PR DESCRIPTION
Related: #103433

Supersedes #103819, whose signed sync commit retained stale ancestry after rapid `main` movement and made the landing wrapper conservatively treat unrelated mainline files as part of the PR.

## What Problem This Solves

The audit date-filter fix in #103433 rejected impossible calendar dates, but its regression coverage did not prove that values JavaScript accepts as dates but the CLI does not support are rejected, or that validation finishes before the Gateway RPC boundary.

## Why This Change Was Made

This test-only follow-up covers both `--after` and `--before` with negative-millisecond and free-text inputs that `Date.parse` accepts. It also exercises `auditListCommand` with a mocked Gateway and proves invalid input never reaches `callGateway`.

## User Impact

No runtime behavior changes. The tests protect the strict audit-filter behavior contributed by @qingminglong in #103433 against regressions at the command boundary.

## Evidence

- Negative control on the parent of #103433: the old implementation accepted `-1`, `July 1, 2026`, and `2026-02-30T00:00:00Z`, returning normalized millisecond timestamps.
- Current-main timezone proof for `2026-07-01T00:00:00`: UTC returns `1782864000000`; `America/New_York` returns `1782878400000`, matching `Date.parse` in each process.
- Current-main command proof with a listening loopback port: invalid `--before` returns the CLI validation error with `connections: 0`.
- `oxfmt --check src/commands/audit.test.ts`: passed.
- `oxlint src/commands/audit.test.ts`: passed.
- Fresh exact-commit autoreview: clean, patch correct at 0.99 confidence.
- Exact-head CI [run 29109000166](https://github.com/openclaw/openclaw/actions/runs/29109000166): fully green at `2aaedec4b62f84aeb846d883fb8eae053e49ed09`.
- Exact-head command shard [job 86416581060](https://github.com/openclaw/openclaw/actions/runs/29109000166/job/86416581060): `src/commands/audit.test.ts` passed all 11 tests.
