### PR TITLE
fix(plugins): official ClawHub plugins fail trusted startup

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
@@ -99,6 +100,40 @@ function createPluginCandidate(params: {
     bundledManifest: params.bundledManifest,
     bundledManifestPath: params.bundledManifestPath,
   };
+}
+
+function createMsteamsClawHubInstallRecord(
+  installPath: string,
+  overrides: Partial<PluginInstallRecord> = {},
+): PluginInstallRecord {
+  const record: PluginInstallRecord = {
+    source: "clawhub",
+    spec: "clawhub:@openclaw/msteams",
+    installPath,
+    clawhubUrl: "https://clawhub.ai",
+    clawhubPackage: "@openclaw/msteams",
+    clawhubChannel: "official",
+  };
+  return { ...record, ...overrides };
+}
+
+function resolveMsteamsClawHubTrust(overrides: Partial<PluginInstallRecord> = {}) {
+  const dir = makeTempDir();
+  writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+  const registry = loadPluginManifestRegistry({
+    installRecords: {
+      msteams: createMsteamsClawHubInstallRecord(dir, overrides),
+    },
+    candidates: [
+      createPluginCandidate({
+        idHint: "msteams",
+        rootDir: dir,
+        packageName: "@openclaw/msteams",
+        origin: "global",
+      }),
+    ],
+  });
+  return registry.plugins[0]?.trustedOfficialInstall;
 }
 
 function loadRegistry(candidates: PluginCandidate[]) {
@@ -738,6 +773,196 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
   });
 
+  it.each([
+    { name: "complete records", overrides: {} },
+    {
+      name: "versioned ClawHub specs",
+      overrides: { spec: "clawhub:@openclaw/msteams@2026.6.11" },
+    },
+    {
+      name: "legacy spec-only records",
+      overrides: { clawhubPackage: undefined },
+    },
+    {
+      name: "package-only records",
+      overrides: { spec: undefined },
+    },
+    {
+      name: "matching npm resolved specs",
+      overrides: { resolvedSpec: "@openclaw/msteams@2026.6.11" },
+    },
+    {
+      name: "matching ClawHub resolved specs",
+      overrides: { resolvedSpec: "clawhub:@openclaw/msteams@2026.6.11" },
+    },
+    {
+      name: "matching resolved package names",
+      overrides: { resolvedName: "@openclaw/msteams" },
+    },
+  ] satisfies Array<{ name: string; overrides: Partial<PluginInstallRecord> }>)(
+    "marks official npm-only ClawHub installs with $name as trusted",
+    ({ overrides }) => {
+      expect(resolveMsteamsClawHubTrust(overrides)).toBe(true);
+    },
+  );
+
+  it.each([
+    {
+      name: "community ClawHub channel",
+      overrides: { clawhubChannel: "community" },
+    },
+    {
+      name: "private ClawHub channel",
+      overrides: { clawhubChannel: "private" },
+    },
+    {
+      name: "custom ClawHub URL",
+      overrides: { clawhubUrl: "https://example.invalid" },
+    },
+    {
+      name: "missing ClawHub URL",
+      overrides: { clawhubUrl: undefined },
+    },
+    {
+      name: "conflicting ClawHub package",
+      overrides: { clawhubPackage: "@openclaw/line" },
+    },
+    {
+      name: "conflicting requested spec",
+      overrides: { spec: "clawhub:@openclaw/line" },
+    },
+    {
+      name: "conflicting npm resolved spec",
+      overrides: { resolvedSpec: "@openclaw/line@2026.6.11" },
+    },
+    {
+      name: "conflicting ClawHub resolved spec",
+      overrides: { resolvedSpec: "clawhub:@openclaw/line@2026.6.11" },
+    },
+    {
+      name: "blank ClawHub package",
+      overrides: { clawhubPackage: " " },
+    },
+    {
+      name: "malformed ClawHub package",
+      overrides: { clawhubPackage: "@openclaw/msteams@2026.6.11" },
+    },
+    {
+      name: "malformed requested spec",
+      overrides: { spec: "@openclaw/msteams" },
+    },
+    {
+      name: "malformed resolved spec",
+      overrides: { resolvedSpec: "file:plugin.tgz" },
+    },
+    {
+      name: "conflicting resolved package name",
+      overrides: { resolvedName: "@openclaw/line" },
+    },
+    {
+      name: "malformed resolved package name",
+      overrides: { resolvedName: "@openclaw/msteams@2026.6.11" },
+    },
+    {
+      name: "missing package identities",
+      overrides: {
+        clawhubPackage: undefined,
+        spec: undefined,
+        resolvedSpec: undefined,
+      },
+    },
+    {
+      name: "resolved identity without ClawHub source identity",
+      overrides: {
+        clawhubPackage: undefined,
+        spec: undefined,
+        resolvedSpec: "@openclaw/msteams@2026.6.11",
+      },
+    },
+  ] satisfies Array<{ name: string; overrides: Partial<PluginInstallRecord> }>)(
+    "does not trust npm-only official ClawHub installs from $name",
+    ({ overrides }) => {
+      expect(resolveMsteamsClawHubTrust(overrides)).toBeUndefined();
+    },
+  );
+
+  it("does not trust ClawHub records from a different install path", () => {
+    expect(resolveMsteamsClawHubTrust({ installPath: makeTempDir() })).toBeUndefined();
+  });
+
+  it("does not trust a stale source path after switching to ClawHub", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        msteams: createMsteamsClawHubInstallRecord(makeTempDir(), { sourcePath: dir }),
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "msteams",
+          rootDir: dir,
+          packageName: "@openclaw/msteams",
+          origin: "config",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
+  });
+
+  it("does not trust custom ClawHub sources for catalog entries with a ClawHub spec", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        "diagnostics-otel": {
+          source: "clawhub",
+          spec: "clawhub:@openclaw/diagnostics-otel",
+          installPath: dir,
+          clawhubUrl: "https://example.invalid",
+          clawhubPackage: "@openclaw/diagnostics-otel",
+          clawhubChannel: "official",
+        },
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "diagnostics-otel",
+          rootDir: dir,
+          packageName: "@openclaw/diagnostics-otel",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
+  });
+
+  it("preserves legacy spec-only records for catalog-backed ClawHub installs", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        "diagnostics-otel": {
+          source: "clawhub",
+          spec: "clawhub:@openclaw/diagnostics-otel@2026.5.18",
+          installPath: dir,
+        },
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "diagnostics-otel",
+          rootDir: dir,
+          packageName: "@openclaw/diagnostics-otel",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
+  });
+
   it("marks official diagnostics-otel config paths trusted when the install record matches", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
@@ -817,6 +1042,25 @@ describe("loadPluginManifestRegistry", () => {
           idHint: "diagnostics-prometheus",
           rootDir: dir,
           packageName: "@openclaw/diagnostics-prometheus",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
+  });
+
+  it("does not trust unrecorded npm-only official ClawHub channel globals", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {},
+      candidates: [
+        createPluginCandidate({
+          idHint: "msteams",
+          rootDir: dir,
+          packageName: "@openclaw/msteams",
           origin: "global",
         }),
       ],

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -57,6 +57,7 @@ import {
   normalizeManifestChannelCommandDefaults,
 } from "./manifest.js";
 import { checkMinHostVersion } from "./min-host-version.js";
+import { resolveTrustedSourceLinkedOfficialClawHubInstall } from "./official-external-install-records.js";
 import {
   getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
@@ -764,6 +765,7 @@ function matchesInstalledPluginRecord(params: {
   config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   installRecords: Record<string, PluginInstallRecord>;
+  installPathOnly?: boolean;
 }): boolean {
   if (params.candidate.origin !== "global" && params.candidate.origin !== "config") {
     return false;
@@ -783,7 +785,11 @@ function matchesInstalledPluginRecord(params: {
       const resolved = resolveUserPath(entry, params.env);
       return safeRealpathSync(resolved) ?? resolved;
     });
-  const trackedPaths = [record.installPath, record.sourcePath]
+  // Security decisions must bind to the current install output. sourcePath can
+  // legitimately identify path installs, but it can also survive a source switch.
+  const trackedPaths = (
+    params.installPathOnly ? [record.installPath] : [record.installPath, record.sourcePath]
+  )
     .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
     .map((entry) => {
       const resolved = resolveUserPath(entry, params.env);
@@ -826,6 +832,7 @@ function isTrustedOfficialPluginInstall(params: {
       candidate: params.candidate,
       env: params.env,
       installRecords: params.installRecords,
+      installPathOnly: true,
     })
   ) {
     return false;
@@ -843,6 +850,13 @@ function isTrustedOfficialPluginInstall(params: {
   if (!installRecord) {
     return false;
   }
+  const officialClawHubInstall =
+    installRecord.source === "clawhub"
+      ? resolveTrustedSourceLinkedOfficialClawHubInstall({
+          pluginId: params.pluginId,
+          record: installRecord,
+        })
+      : undefined;
   if (
     installRecord.source === "npm" &&
     officialInstall?.npmSpec === packageName &&
@@ -855,14 +869,7 @@ function isTrustedOfficialPluginInstall(params: {
   ) {
     return true;
   }
-  if (
-    installRecord.source === "clawhub" &&
-    officialInstall?.clawhubSpec &&
-    installRecord.clawhubChannel === "official" &&
-    (installRecord.clawhubPackage === packageName ||
-      installRecord.spec === officialInstall.clawhubSpec ||
-      installRecord.resolvedSpec === officialInstall.clawhubSpec)
-  ) {
+  if (installRecord.source === "clawhub" && officialClawHubInstall) {
     return true;
   }
   return false;

--- a/src/plugins/official-external-install-records.ts
+++ b/src/plugins/official-external-install-records.ts
@@ -16,6 +16,11 @@ function resolveClawHubSpecPackageName(spec: string | undefined): string | undef
   return spec ? parseClawHubPluginSpec(spec)?.name : undefined;
 }
 
+function resolveExactNpmPackageName(value: string): string | undefined {
+  const packageName = resolveNpmSpecPackageName(value);
+  return packageName && value.trim() === packageName ? packageName : undefined;
+}
+
 function resolveOfficialPackageNames(params: {
   entry: OfficialExternalPluginCatalogEntry;
   npmSpec?: string;
@@ -28,17 +33,67 @@ function resolveOfficialPackageNames(params: {
   ].filter((value): value is string => Boolean(value));
 }
 
-function resolveRecordedClawHubPackageNames(record: PluginInstallRecord): string[] {
-  return [record.clawhubPackage, resolveClawHubSpecPackageName(record.spec)].filter(
-    (value): value is string => Boolean(value),
-  );
+function resolveRecordedClawHubPackageNames(record: PluginInstallRecord): string[] | undefined {
+  // Source switches can leave legacy resolution fields in durable records. Treat every
+  // populated identity as corroborating evidence so one conflicting field fails closed.
+  const packageNames: string[] = [];
+  if (record.clawhubPackage !== undefined) {
+    const packageName = resolveExactNpmPackageName(record.clawhubPackage);
+    if (!packageName) {
+      return undefined;
+    }
+    packageNames.push(packageName);
+  }
+  if (record.spec !== undefined) {
+    const packageName = resolveClawHubSpecPackageName(record.spec);
+    if (!packageName) {
+      return undefined;
+    }
+    packageNames.push(packageName);
+  }
+  if (record.resolvedSpec !== undefined) {
+    const packageName =
+      resolveClawHubSpecPackageName(record.resolvedSpec) ??
+      resolveNpmSpecPackageName(record.resolvedSpec);
+    if (!packageName) {
+      return undefined;
+    }
+    packageNames.push(packageName);
+  }
+  if (record.resolvedName !== undefined) {
+    const packageName = resolveExactNpmPackageName(record.resolvedName);
+    if (!packageName) {
+      return undefined;
+    }
+    packageNames.push(packageName);
+  }
+  return packageNames;
 }
 
 function isOfficialClawHubInstallRecord(record: PluginInstallRecord): boolean {
   if (record.source !== "clawhub" || record.clawhubChannel !== "official") {
     return false;
   }
-  return (record.clawhubUrl ?? "").replace(/\/+$/, "") === "https://clawhub.ai";
+  return (record.clawhubUrl ?? "").trim().replace(/\/+$/, "") === "https://clawhub.ai";
+}
+
+function hasTrustedClawHubSourceAuthority(
+  record: PluginInstallRecord,
+  officialClawHubSpec: string | undefined,
+): boolean {
+  const hasAuthorityMetadata =
+    record.clawhubUrl !== undefined || record.clawhubChannel !== undefined;
+  if (hasAuthorityMetadata) {
+    return isOfficialClawHubInstallRecord(record);
+  }
+  // Older official installs persisted only their catalog-backed ClawHub spec.
+  // Preserve that shipped shape, but do not let package-only records claim it.
+  return Boolean(
+    officialClawHubSpec &&
+    record.spec &&
+    resolveClawHubSpecPackageName(record.spec) ===
+      resolveClawHubSpecPackageName(officialClawHubSpec),
+  );
 }
 
 /** Resolves the official npm spec when an install record matches the trusted catalog package. */
@@ -89,6 +144,9 @@ export function resolveTrustedSourceLinkedOfficialClawHubInstall(params: {
   const install = resolveOfficialExternalPluginInstall(entry);
   const officialClawHubSpec = install?.clawhubSpec;
   const officialNpmSpec = install?.npmSpec;
+  if (!officialClawHubSpec && !officialNpmSpec) {
+    return undefined;
+  }
   const officialNames = resolveOfficialPackageNames({
     entry,
     npmSpec: officialNpmSpec,
@@ -97,16 +155,22 @@ export function resolveTrustedSourceLinkedOfficialClawHubInstall(params: {
   if (officialNames.length === 0) {
     return undefined;
   }
-  const recordedPackageNames = resolveRecordedClawHubPackageNames(params.record);
-  const matchesOfficialPackage = recordedPackageNames.some((name) => officialNames.includes(name));
-  if (!matchesOfficialPackage) {
+  // resolvedSpec can survive a source switch, so it may corroborate but cannot establish
+  // ClawHub provenance without either the requested spec or resolved package identity.
+  if (params.record.clawhubPackage === undefined && params.record.spec === undefined) {
     return undefined;
   }
-  if (officialClawHubSpec || isOfficialClawHubInstallRecord(params.record)) {
-    return {
-      ...(officialClawHubSpec ? { clawhubSpec: officialClawHubSpec } : {}),
-      ...(officialNpmSpec ? { npmSpec: officialNpmSpec } : {}),
-    };
+  const recordedPackageNames = resolveRecordedClawHubPackageNames(params.record);
+  if (
+    !hasTrustedClawHubSourceAuthority(params.record, officialClawHubSpec) ||
+    !recordedPackageNames ||
+    recordedPackageNames.length === 0 ||
+    !recordedPackageNames.every((name) => officialNames.includes(name))
+  ) {
+    return undefined;
   }
-  return undefined;
+  return {
+    ...(officialClawHubSpec ? { clawhubSpec: officialClawHubSpec } : {}),
+    ...(officialNpmSpec ? { npmSpec: officialNpmSpec } : {}),
+  };
 }


### PR DESCRIPTION
Closes #92452

Related: #98875

## What Problem This Solves

Fixes an issue where users who install the official Microsoft Teams channel through ClawHub can hit a startup crash loop when the channel opens keyed state. The official external catalog records Teams with an npm package identity, while the existing ClawHub trust path only accepted entries that also declared a ClawHub spec.

## Why This Change Was Made

The official-install owner now recognizes npm-only catalog entries without adding a Teams-specific bypass. Trust remains fail-closed: the current install path must match, every populated package identity (`clawhubPackage`, `spec`, `resolvedSpec`, and `resolvedName`) must parse and agree with the catalog, and populated ClawHub authority metadata must name the official channel and `clawhub.ai`.

The rewrite also rejects stale `sourcePath` matches after install-source changes. It preserves the shipped legacy shape where an explicit catalog-backed ClawHub install stored only its ClawHub spec and install path. Community, private, custom-registry, malformed, split-brain, path-mismatched, and unrecorded installs remain untrusted.

This is a maintainer takeover of #98875 because its organization-owned fork rejected an authenticated maintainer push despite advertising maintainer edits. Jimmy Puckett retains commit co-author credit. The unrelated UI test edit from the contributor branch is not included.

## User Impact

Official Microsoft Teams installs from ClawHub can start and use the trusted plugin state surface. The stricter provenance checks prevent one valid identity field or a stale source path from masking contradictory install metadata.

## Evidence

- The original contributor's before/after Teams startup proof is preserved in #98875: published `2026.6.11` failed at `openKeyedStore`; the candidate became `trustedOfficialInstall: true`, listened on port 3978, and returned the expected unauthenticated HTTP 401 without a restart loop.
- The regression matrix covers npm-only official records, versioned specs, consistent legacy resolution metadata, every conflicting or malformed identity field, custom/missing authority, path mismatch, stale source paths, and explicit-catalog legacy spec-only records.
- Fresh branch autoreview: no accepted or actionable findings.
- `oxfmt` and `git diff --check`: clean.
- Exact-head hosted CI for `b7b74e2dbfa9e96d599d6e27aa211ecf67b88901`: [run 29109138305](https://github.com/openclaw/openclaw/actions/runs/29109138305), 45 successful jobs, 10 scoped skips, no failures.

Known gap: the available proof starts the real Teams plugin and reaches its HTTP listener, but does not send a message through a live Microsoft tenant.
