### PR TITLE
fix(clawdock): preserve caller response during checkout confirmation

### DIFF
--- a/scripts/clawdock/clawdock-helpers.sh
+++ b/scripts/clawdock/clawdock-helpers.sh
@@ -122,7 +122,7 @@ _clawdock_ensure_dir() {
   fi
 
   # Auto-detect from common paths
-  local candidate found_path=""
+  local candidate found_path="" response
   for candidate in "${CLAWDOCK_COMMON_PATHS[@]}"; do
     if [[ -f "${candidate}/docker-compose.yml" ]]; then
       found_path="$candidate"

--- a/test/scripts/clawdock-helpers.test.ts
+++ b/test/scripts/clawdock-helpers.test.ts
@@ -42,10 +42,12 @@ describe("scripts/clawdock/clawdock-helpers.sh", () => {
               [
                 'path_before="$PATH"',
                 'candidate="caller-value"',
+                'response="caller-response"',
                 "source scripts/clawdock/clawdock-helpers.sh || exit 1",
                 '_clawdock_ensure_dir < "$CLAWDOCK_CONFIRM_FILE" || exit 1',
                 '[[ "$PATH" == "$path_before" ]] || exit 1',
                 '[[ "$candidate" == "caller-value" ]] || exit 1',
+                '[[ "$response" == "caller-response" ]] || exit 1',
                 '[[ "$CLAWDOCK_DIR" == "$HOME/openclaw" ]] || exit 1',
               ].join("\n"),
             ],


### PR DESCRIPTION
Related: #90875
Follow-up to #103805

## What Problem This Solves

Fixes an issue where Bash and zsh users sourcing the ClawDock helper could have an existing `response` shell variable silently replaced when accepting the first-run checkout confirmation. This is the remaining caller-state leak after #103805 fixed zsh `PATH` corruption.

## Why This Change Was Made

Keep the prompt response function-local, alongside the checkout candidate and selected path, so `_clawdock_ensure_dir` mutates only its intentional public output (`CLAWDOCK_DIR`). The existing real-helper regression now seeds and verifies `response` in both supported shells.

## User Impact

ClawDock checkout auto-detection no longer changes an unrelated caller variable in Bash or zsh. The accepted checkout and persisted `~/.clawdock/config` behavior stay unchanged.

Original diagnosis and replacement context: #90875 by @lshgdut. Thanks @lshgdut.

## Evidence

- `git diff --check`
- `oxfmt --check test/scripts/clawdock-helpers.test.ts`
- Fresh exact-head autoreview reported no actionable findings and rated the patch correct at 0.99 confidence.
- Sanitized AWS proof `run_0b44c89b07c8` reproduced the current-main zsh `PATH` failure and proved the installed Bash/zsh first-run workflow, checkout selection, and config persistence that this follow-up extends.
- Exact-head Testbox `tbx_01kx6fftkmyjmjatecbqea4gp8` installed zsh 5.9 and passed all 4 focused Bash/zsh tests: [run 29109359639](https://github.com/openclaw/openclaw/actions/runs/29109359639).
- Hosted PR CI must be green before merge.

Co-authored-by: wenhua <1192527+lshgdut@users.noreply.github.com>
