### PR TITLE
fix: stop performance model pinning from reading removed Kova files

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -378,16 +378,29 @@ jobs:
           const fs = require("node:fs");
           const path = require("node:path");
           const root = process.env.KOVA_SRC;
+          const sourceModel = "gpt-5.5";
+          const targetModel = process.env.PERFORMANCE_MODEL_ID;
+          if (!targetModel || targetModel === sourceModel) {
+            throw new Error("Kova performance model pin must replace the source model");
+          }
           const files = [
             "support/configure-openclaw-mock-auth.mjs",
             "support/configure-openclaw-live-auth.mjs",
-            "support/mock-openai-server.mjs",
             "states/mock-openai-provider.json"
           ];
-          for (const rel of files) {
+          const rewrites = files.map((rel) => {
             const file = path.join(root, rel);
             const before = fs.readFileSync(file, "utf8");
-            const after = before.replaceAll("gpt-5.5", process.env.PERFORMANCE_MODEL_ID);
+            if (!before.includes(sourceModel)) {
+              throw new Error(`${rel} did not contain the Kova source model`);
+            }
+            const after = before.replaceAll(sourceModel, targetModel);
+            if (after.includes(sourceModel) || !after.includes(targetModel)) {
+              throw new Error(`${rel} did not pin the Kova performance model`);
+            }
+            return { file, after };
+          });
+          for (const { file, after } of rewrites) {
             fs.writeFileSync(file, after, "utf8");
           }
           NODE

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -129,6 +129,26 @@ describe("OpenClaw performance workflow", () => {
     ).toHaveLength(1);
   });
 
+  it("pins the Kova model through exact current source owners and fails closed on drift", () => {
+    const pinModel = findStep("Pin Kova OpenAI model to GPT 5.6");
+    const run = pinModel.run ?? "";
+    const configuredFiles = [...run.matchAll(/^\s*"((?:support|states)\/[^"]+)",?$/gm)].map(
+      (match) => match[1],
+    );
+
+    expect(configuredFiles).toEqual([
+      "support/configure-openclaw-mock-auth.mjs",
+      "support/configure-openclaw-live-auth.mjs",
+      "states/mock-openai-provider.json",
+    ]);
+    expect(run).not.toContain("support/mock-openai-server.mjs");
+    expect(run).toContain("if (!before.includes(sourceModel))");
+    expect(run).toContain("after.includes(sourceModel) || !after.includes(targetModel)");
+    expect(run.indexOf("const rewrites = files.map")).toBeLessThan(
+      run.indexOf("fs.writeFileSync(file, after"),
+    );
+  });
+
   it("fetches the public clawgrit baseline without publisher credentials", () => {
     const workflowText = readFileSync(WORKFLOW, "utf8");
     const baseline = findStep("Fetch previous source performance baseline");


### PR DESCRIPTION
Closes #103831

## What Problem This Solves

Fixes an issue where every expanded release performance producer aborted while pinning GPT-5.6 because the workflow still tried to rewrite a mock-server file removed by the pinned Kova revision.

## Why This Change Was Made

The workflow now names the three exact current model-owning Kova files, requires every file to contain the pinned source model, validates the replacement postconditions, and only writes after all rewrites pass. The retired mock-server path is deleted from the contract; no missing paths are silently skipped and no broad source glob is introduced.

## User Impact

Release operators can progress mock, deep-profile, and live performance lanes beyond model setup. Future Kova model-owner drift fails early with a precise contract error instead of silently leaving mixed model fixtures.

## Evidence

- Before: exact-head [run 29108543012](https://github.com/openclaw/openclaw/actions/runs/29108543012) passed pinned dependency/bin validation, then failed all producers at `Pin Kova OpenAI model to GPT 5.6` with `ENOENT` for removed `support/mock-openai-server.mjs`.
- Exact Kova `24c26969e57d4d49f9d1a5071af85dd3d79daa2d` Testbox proof: all three current source owners rewrote from GPT-5.5 to GPT-5.6 and passed no-source/target-present postconditions.
- Focused Testbox: `test/scripts/openclaw-performance-workflow.test.ts` passed 25/25 on lease `tbx_01kx6d5mvdzhwfz36h5jxr3kq8`.
- Targeted Testbox `check:changed` for the two touched files: tooling lane passed in 1m33s.
- Remote `oxfmt --check`, local actionlint, and diff-check: passed.
- Fresh autoreview: clean; no accepted/actionable findings (0.98 confidence).
