### PR TITLE
feat: add Codex session MCP profile

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -1,7 +1,8 @@
 ---
-summary: "Expose OpenClaw channel conversations over MCP and manage saved MCP server definitions"
+summary: "Expose OpenClaw sessions and channel conversations over MCP and manage saved MCP server definitions"
 read_when:
   - Connecting Codex, Claude Code, or another MCP client to OpenClaw-backed channels
+  - Showing OpenClaw sessions in a Codex MCP App
   - Running `openclaw mcp serve`
   - Managing OpenClaw-saved MCP server definitions
 title: "MCP"
@@ -23,14 +24,15 @@ Use [`openclaw acp`](/cli/acp) when OpenClaw should host a coding harness sessio
 
 ## Choose the right MCP path
 
-| Goal                                                                | Use                                                                  | Why                                                                                                             |
-| ------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Let an external MCP client read/send OpenClaw channel conversations | `openclaw mcp serve`                                                 | OpenClaw is the MCP server and exposes Gateway-backed conversations over stdio.                                 |
-| Save third-party MCP servers for OpenClaw-managed agent runs        | `openclaw mcp add`, `set`, `configure`, `tools`, `login`             | OpenClaw is the MCP client-side registry and later projects those servers into eligible runtimes.               |
-| Check a saved server without running an agent turn                  | `openclaw mcp status`, `doctor`, `probe`                             | `status` and `doctor` inspect config; `probe` opens a live MCP connection and lists capabilities.               |
-| Edit MCP config from a browser                                      | Control UI `/settings/mcp` (`/mcp` alias)                            | The page shows inventory, enablement, OAuth/filter summaries, command hints, and a scoped `mcp` editor.         |
-| Give Codex app-server a scoped native MCP server                    | `mcp.servers.<name>.codex`                                           | The `codex` block only affects Codex app-server thread projection and is stripped before native config handoff. |
-| Run ACP-hosted harness sessions                                     | [`openclaw acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | ACP bridge mode does not accept per-session MCP server injection; configure gateway/plugin bridges instead.     |
+| Goal                                                               | Use                                                                  | Why                                                                                                             |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Let an external MCP client read/send routed OpenClaw conversations | `openclaw mcp serve`                                                 | OpenClaw is the MCP server and exposes channel-routed conversations over stdio.                                 |
+| Browse and control all Gateway sessions from Codex                 | `openclaw mcp serve --client codex --app-resource <path>`            | The explicit Codex profile adds the session app and its bounded all-session tools.                              |
+| Save third-party MCP servers for OpenClaw-managed agent runs       | `openclaw mcp add`, `set`, `configure`, `tools`, `login`             | OpenClaw is the MCP client-side registry and later projects those servers into eligible runtimes.               |
+| Check a saved server without running an agent turn                 | `openclaw mcp status`, `doctor`, `probe`                             | `status` and `doctor` inspect config; `probe` opens a live MCP connection and lists capabilities.               |
+| Edit MCP config from a browser                                     | Control UI `/settings/mcp` (`/mcp` alias)                            | The page shows inventory, enablement, OAuth/filter summaries, command hints, and a scoped `mcp` editor.         |
+| Give Codex app-server a scoped native MCP server                   | `mcp.servers.<name>.codex`                                           | The `codex` block only affects Codex app-server thread projection and is stripped before native config handoff. |
+| Run ACP-hosted harness sessions                                    | [`openclaw acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | ACP bridge mode does not accept per-session MCP server injection; configure gateway/plugin bridges instead.     |
 
 <Tip>
 If you are not sure which path you need, start with `openclaw mcp status --verbose`. It shows what OpenClaw has saved without starting any MCP servers.
@@ -44,7 +46,8 @@ This is the `openclaw mcp serve` path.
 
 Use `openclaw mcp serve` when:
 
-- Codex, Claude Code, or another MCP client should talk directly to OpenClaw-backed channel conversations
+- Claude Code or another MCP client should work with routed OpenClaw channel conversations
+- Codex should browse and control all Gateway sessions through the explicit Codex app profile
 - you already have a local or remote OpenClaw Gateway with routed sessions
 - you want one MCP server that works across OpenClaw's channel backends instead of running separate per-channel bridges
 
@@ -61,8 +64,8 @@ Use [`openclaw acp`](/cli/acp) instead when OpenClaw should host the coding runt
   <Step title="Bridge connects to Gateway">
     The bridge connects to the OpenClaw Gateway over WebSocket.
   </Step>
-  <Step title="Sessions become MCP conversations">
-    Routed sessions become MCP conversations and transcript/history tools.
+  <Step title="Conversations become MCP tools">
+    The default and Claude profiles expose sessions that already have channel routes. The explicit Codex profile additionally exposes all sessions through opaque ids.
   </Step>
   <Step title="Live events queue">
     Live events are queued in memory while the bridge is connected.
@@ -94,6 +97,9 @@ Use [`openclaw acp`](/cli/acp) instead when OpenClaw should host the coding runt
   <Tab title="Claude Code">
     Standard MCP tools plus the Claude-specific channel adapter. Enable `--claude-channel-mode on` or leave the default `auto`.
   </Tab>
+  <Tab title="Codex MCP App">
+    Add `--client codex --app-resource <path>` to register the OpenClaw session app, global entrypoint, and host-native session collection. The app resource path is resolved under the process working directory and read once at startup.
+  </Tab>
 </Tabs>
 
 <Note>
@@ -102,7 +108,7 @@ Today, `auto` behaves the same as `on`. There is no client capability detection 
 
 ### What serve exposes
 
-The bridge uses existing Gateway session route metadata to expose channel-backed conversations. A conversation appears when OpenClaw already has session state with a known route such as:
+By default, the bridge exposes only channel conversation tools. A channel conversation appears when OpenClaw already has session state with a known route such as:
 
 - `channel`
 - recipient or destination metadata
@@ -116,6 +122,8 @@ This gives MCP clients one place to:
 - wait for new inbound events
 - send a reply back through the same route
 - see approval requests that arrive while the bridge is connected
+
+The explicit `--client codex --app-resource <path>` profile instead exposes a bounded, app-only all-session view for list, transcript, create, send, abort, and organization actions. It does not register the model-visible channel, event, or approval tools. Codex only receives opaque session ids, titles/previews, activity state, and sanitized user/assistant text. Raw Gateway session keys and internal transcript details are not returned. Generic and Claude profiles do not register these all-session tools.
 
 ### Usage
 
@@ -141,9 +149,42 @@ This gives MCP clients one place to:
     openclaw mcp serve --claude-channel-mode off
     ```
   </Tab>
+  <Tab title="Codex plugin">
+    ```bash
+    openclaw mcp serve \
+      --client codex \
+      --app-resource path/to/openclaw-session-app.html
+    ```
+
+    Run this with the plugin directory as the working directory. Both options are required together.
+
+  </Tab>
 </Tabs>
 
 ### Bridge tools
+
+The `openclaw_session*` tools below are registered only by the explicit Codex profile. The remaining conversation, event, message, and approval tools are available to generic and Claude clients.
+
+<AccordionGroup>
+  <Accordion title="openclaw_sessions_list">
+    Lists a bounded mix of active and archived Gateway sessions as opaque sidebar items. Set `archived` to filter either state. `limit` defaults to 50 and is capped at 100; `search` is capped at 200 characters. Bounded agent avatar data or emoji fallbacks are included when available; remote avatar URLs are not exposed to the app, and aggregate icon data is capped at 4 MiB.
+  </Accordion>
+  <Accordion title="openclaw_session_detail">
+    Reads up to 200 recent messages for one id returned by `openclaw_sessions_list`. Results contain user/assistant visible text only, capped at 20,000 characters per message and 200,000 characters total.
+  </Accordion>
+  <Accordion title="openclaw_session_create">
+    Creates a session with an optional agent id, label, or first message. This surface deliberately does not accept a host path or worktree selection, so it stays within `operator.write` scope.
+  </Accordion>
+  <Accordion title="openclaw_session_send">
+    Sends bounded text to a listed session. The bridge prefers `sessions.send` and capability-detects the older `chat.send` fallback.
+  </Accordion>
+  <Accordion title="openclaw_session_abort">
+    Aborts the active or named run for a listed session. The bridge prefers `sessions.abort` and capability-detects the older `chat.abort` fallback.
+  </Accordion>
+  <Accordion title="openclaw_session_update">
+    Updates user-level organization fields only: label, archived state, pinned state, and unread state.
+  </Accordion>
+</AccordionGroup>
 
 <AccordionGroup>
   <Accordion title="conversations_list">
@@ -287,7 +328,13 @@ For most generic MCP clients, start with the standard tool surface and ignore Cl
   Read password from file.
 </ParamField>
 <ParamField path="--claude-channel-mode" type='"auto" | "on" | "off"'>
-  Claude notification mode. Default `auto`.
+  Claude notification mode. Default `auto`; disabled by the Codex profile.
+</ParamField>
+<ParamField path="--client" type='"codex"'>
+  Explicitly enables the Codex MCP App and bounded all-session tool profile. Must be used with `--app-resource`.
+</ParamField>
+<ParamField path="--app-resource" type="string">
+  HTML resource path under the current working directory. The file is root-contained, capped at 1 MiB, and read once at startup. Must be used with `--client codex`.
 </ParamField>
 <ParamField path="-v, --verbose" type="boolean">
   Verbose logs on stderr.
@@ -299,12 +346,15 @@ Prefer `--token-file` or `--password-file` over inline secrets when possible.
 
 ### Security and trust boundary
 
-The bridge does not invent routing. It only exposes conversations that Gateway already knows how to route.
+The generic and Claude profiles do not invent routing. They expose only conversation tools backed by Gateway route metadata. The Codex profile is an explicit broader trust boundary: it replaces those model-visible channel tools with bounded, app-only session discovery and control tools for the local session app.
 
 That means:
 
 - sender allowlists, pairing, and channel-level trust still belong to the underlying OpenClaw channel configuration
 - `messages_send` can only reply through an existing stored route
+- Codex-only session tools request `operator.read` and `operator.write`, never `operator.admin`; Gateway hello capabilities and granted scopes decide which actions the app enables, with an existing `operator.admin` grant honored as the normal read/write superset
+- session ids are HMAC-SHA-256 opaque handles derived with a fresh random key for each bridge process; after a restart, clients refresh the session list before acting
+- transcript results omit system, tool, reasoning, diagnostics, route, provider, and filesystem data
 - approval state is live/in-memory only for the current bridge session
 - bridge auth should use the same Gateway token or password controls you would trust for any other remote Gateway client
 

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -697,7 +697,7 @@ describe("mcp cli", () => {
       const workspaceDir = await createWorkspace();
       const tokenFile = path.join(workspaceDir, "gateway.token");
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-      await fs.writeFile(tokenFile, "secret-token\n", "utf-8");
+      await fs.writeFile(tokenFile, "token\n", "utf-8");
 
       await runMcpCommand([
         "mcp",
@@ -708,16 +708,61 @@ describe("mcp cli", () => {
         tokenFile,
         "--claude-channel-mode",
         "on",
+        "--client",
+        "codex",
+        "--app-resource",
+        "assets/openclaw-session-app.html",
         "--verbose",
       ]);
 
       expect(serveOpenClawChannelMcp).toHaveBeenCalledWith({
         gatewayUrl: "ws://127.0.0.1:18789",
-        gatewayToken: "secret-token",
+        gatewayToken: "token",
         gatewayPassword: undefined,
         claudeChannelMode: "on",
+        client: "codex",
+        appResourcePath: "assets/openclaw-session-app.html",
         verbose: true,
       });
     });
+  });
+
+  it.each([
+    { name: "the default profile", args: [], claudeChannelMode: "auto" },
+    {
+      name: "the Claude channel profile",
+      args: ["--claude-channel-mode", "on"],
+      claudeChannelMode: "on",
+    },
+  ])("keeps Codex session access disabled for $name", async ({ args, claudeChannelMode }) => {
+    await runMcpCommand(["mcp", "serve", ...args]);
+
+    expect(serveOpenClawChannelMcp).toHaveBeenCalledWith({
+      gatewayUrl: undefined,
+      gatewayToken: undefined,
+      gatewayPassword: undefined,
+      claudeChannelMode,
+      client: undefined,
+      appResourcePath: undefined,
+      verbose: false,
+    });
+  });
+
+  it.each([
+    {
+      name: "an unknown client",
+      args: ["--client", "other", "--app-resource", "assets/app.html"],
+    },
+    {
+      name: "a Codex client without an app resource",
+      args: ["--client", "codex"],
+    },
+    {
+      name: "an app resource without a Codex client",
+      args: ["--app-resource", "assets/app.html"],
+    },
+  ])("rejects $name", async ({ args }) => {
+    await expect(runMcpCommand(["mcp", "serve", ...args])).rejects.toThrow("__exit__:1");
+    expect(serveOpenClawChannelMcp).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -584,6 +584,8 @@ export function registerMcpCli(program: Command) {
       "Claude channel notification mode: auto, on, or off",
       "auto",
     )
+    .option("--client <client>", 'MCP host profile (currently "codex")')
+    .option("--app-resource <path>", "MCP App HTML path under the current plugin directory")
     .option("-v, --verbose", "Verbose logging to stderr", false)
     .action(async (opts) => {
       try {
@@ -598,11 +600,23 @@ export function registerMcpCli(program: Command) {
         ) {
           throw new Error('Invalid --claude-channel-mode value. Use "auto", "on", or "off".');
         }
+        const client = normalizeLowercaseStringOrEmpty(
+          normalizeStringifiedOptionalString(opts.client),
+        );
+        if (client && client !== "codex") {
+          throw new Error('Invalid --client value. Use "codex".');
+        }
+        const appResourcePath = normalizeStringifiedOptionalString(opts.appResource);
+        if ((client === "codex") !== Boolean(appResourcePath)) {
+          throw new Error("--client codex and --app-resource must be used together.");
+        }
         await serveOpenClawChannelMcp({
           gatewayUrl: opts.url as string | undefined,
           gatewayToken,
           gatewayPassword,
           claudeChannelMode,
+          client: client === "codex" ? client : undefined,
+          appResourcePath,
           verbose: Boolean(opts.verbose),
         });
       } catch (err) {

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -12,6 +12,10 @@ const APPROVAL_DEFAULT_TTL_MS = 30 * ONE_MINUTE_MS;
 // exercise. Defined as a standalone shape (not an intersection with the class)
 // because mixing public/private constituents collapses to `never` under tsgo.
 type BridgeInternals = {
+  gateway: {
+    request: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+    stopAndWait: () => Promise<void>;
+  } | null;
   queue: QueueEvent[];
   pendingClaudePermissions: Map<string, unknown>;
   pendingApprovals: Map<string, unknown>;
@@ -38,6 +42,10 @@ type BridgeInternals = {
     event: string;
     payload?: Record<string, unknown>;
   }) => Promise<void>;
+  handleHelloOk: (hello: {
+    features: { methods: string[] };
+    auth: { scopes: string[] };
+  }) => Promise<void>;
   handleSessionMessageEvent: (payload: {
     sessionKey: string;
     senderIsOwner?: boolean;
@@ -49,12 +57,39 @@ type BridgeInternals = {
   sendNotification: (notification: { method: string }) => Promise<void>;
 };
 
-function makeBridge(verbose = false): BridgeInternals {
+function makeBridge(verbose = false, client?: "codex"): BridgeInternals {
   return new OpenClawChannelBridge({} as never, {
     claudeChannelMode: "off",
+    client,
     verbose,
   }) as unknown as BridgeInternals;
 }
+
+describe("OpenClawChannelBridge — Codex polling lifecycle", () => {
+  test("does not subscribe to or retain raw Gateway events", async () => {
+    const bridge = makeBridge(false, "codex");
+    const request = vi.fn(async () => ({}));
+    bridge.gateway = { request, stopAndWait: async () => {} };
+    try {
+      await bridge.handleHelloOk({
+        features: { methods: ["sessions.subscribe"] },
+        auth: { scopes: ["operator.read", "operator.write"] },
+      });
+      await bridge.dispatchGatewayEvent({
+        event: "session.message",
+        payload: {
+          sessionKey: "agent:main:dashboard:private",
+          message: { role: "assistant", content: "private transcript payload" },
+        },
+      });
+
+      expect(request).not.toHaveBeenCalledWith("sessions.subscribe", {});
+      expect(bridge.queue).toEqual([]);
+    } finally {
+      await bridge.close();
+    }
+  });
+});
 
 describe("OpenClawChannelBridge — Claude permission authorization", () => {
   test.each([

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
+import type { EventFrame, HelloOk } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayClient } from "../gateway/client.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
@@ -25,6 +25,7 @@ import type {
   WaitFilter,
 } from "./channel-shared.js";
 import { matchEventFilter, normalizeApprovalId, toConversation, toText } from "./channel-shared.js";
+import { OpenClawSessionTools } from "./session-tools.js";
 
 /**
  * Runtime bridge between MCP tools and the OpenClaw Gateway channel APIs.
@@ -61,6 +62,8 @@ const PENDING_SWEEP_INTERVAL_MS = 5 * 60 * 1_000;
 /** Connects the MCP server surface to a Gateway client and queues channel events for polling. */
 export class OpenClawChannelBridge {
   private gateway: GatewayClient | null = null;
+  private readonly gatewayMethods = new Set<string>();
+  private readonly gatewayScopes = new Set<string>();
   private readonly verbose: boolean;
   private readonly claudeChannelMode: ClaudeChannelMode;
   private readonly queue: QueueEvent[] = [];
@@ -78,6 +81,7 @@ export class OpenClawChannelBridge {
   private resolveReady!: () => void;
   private rejectReady!: (error: Error) => void;
   private readySettled = false;
+  readonly sessionTools: OpenClawSessionTools;
 
   constructor(
     private readonly cfg: OpenClawConfig,
@@ -86,6 +90,7 @@ export class OpenClawChannelBridge {
       gatewayToken?: string;
       gatewayPassword?: string;
       claudeChannelMode: ClaudeChannelMode;
+      client?: "codex";
       verbose: boolean;
     },
   ) {
@@ -94,6 +99,16 @@ export class OpenClawChannelBridge {
     this.readyPromise = new Promise<void>((resolve, reject) => {
       this.resolveReady = resolve;
       this.rejectReady = reject;
+    });
+    this.sessionTools = new OpenClawSessionTools({
+      request: async (method, requestParams) => {
+        await this.waitUntilReady();
+        return await this.requestGateway(method, requestParams);
+      },
+      access: () => ({ methods: this.gatewayMethods, scopes: this.gatewayScopes }),
+      ready: async () => {
+        await this.waitUntilReady();
+      },
     });
   }
 
@@ -145,14 +160,18 @@ export class OpenClawChannelBridge {
       clientDisplayName: "OpenClaw MCP",
       clientVersion: VERSION,
       mode: GATEWAY_CLIENT_MODES.CLI,
-      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
+      scopes: getMcpGatewayScopes(this.params.client, {
+        read: READ_SCOPE,
+        write: WRITE_SCOPE,
+        approvals: APPROVALS_SCOPE,
+      }),
       requestTimeoutMs: 180_000,
       onEvent: (event) => {
         void this.dispatchGatewayEvent(event);
       },
-      onHelloOk: () => {
+      onHelloOk: (hello) => {
         this.retryingInitialConnect = false;
-        void this.handleHelloOk();
+        void this.handleHelloOk(hello);
       },
       onConnectError: (error) => {
         const normalizedError = error instanceof Error ? error : new Error(String(error));
@@ -196,6 +215,9 @@ export class OpenClawChannelBridge {
     }
     this.pendingClaudePermissions.clear();
     this.pendingApprovals.clear();
+    this.sessionTools.clear();
+    this.gatewayMethods.clear();
+    this.gatewayScopes.clear();
     for (const waiter of this.pendingWaiters) {
       if (waiter.timeout) {
         clearTimeout(waiter.timeout);
@@ -407,9 +429,19 @@ export class OpenClawChannelBridge {
     }
   }
 
-  private async handleHelloOk(): Promise<void> {
+  private async handleHelloOk(hello: HelloOk): Promise<void> {
+    this.gatewayMethods.clear();
+    this.gatewayScopes.clear();
+    for (const method of hello.features.methods) {
+      this.gatewayMethods.add(method);
+    }
+    for (const scope of hello.auth.scopes) {
+      this.gatewayScopes.add(scope);
+    }
     try {
-      await this.requestGateway("sessions.subscribe", {});
+      if (this.params.client !== "codex" && this.gatewayMethods.has("sessions.subscribe")) {
+        await this.requestGateway("sessions.subscribe", {});
+      }
       this.ready = true;
       this.resolveReadyOnce();
     } catch (error) {
@@ -522,6 +554,9 @@ export class OpenClawChannelBridge {
   }
 
   private async dispatchGatewayEvent(event: EventFrame): Promise<void> {
+    if (this.params.client === "codex") {
+      return;
+    }
     try {
       await this.handleGatewayEvent(event);
     } catch (error) {
@@ -677,4 +712,14 @@ export function shouldRetryInitialMcpGatewayConnect(error: Error): boolean {
     message.includes("gateway request timeout for connect") ||
     message.includes("gateway connect challenge timeout")
   );
+}
+
+/** Keep approval authority out of the Codex app-only session profile. */
+export function getMcpGatewayScopes(
+  client: "codex" | undefined,
+  scopes: { read: string; write: string; approvals: string },
+): string[] {
+  return client === "codex"
+    ? [scopes.read, scopes.write]
+    : [scopes.read, scopes.write, scopes.approvals];
 }

--- a/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
+++ b/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
@@ -81,7 +81,7 @@ vi.mock("./channel-tools.js", () => ({
   registerChannelMcpTools: vi.fn(),
 }));
 
-vi.mock("./session-tools.js", () => ({
+vi.mock("./session-tools-registration.js", () => ({
   registerSessionMcpTools: vi.fn(),
 }));
 

--- a/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
+++ b/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
@@ -81,6 +81,10 @@ vi.mock("./channel-tools.js", () => ({
   registerChannelMcpTools: vi.fn(),
 }));
 
+vi.mock("./session-tools.js", () => ({
+  registerSessionMcpTools: vi.fn(),
+}));
+
 async function waitForTransport(): Promise<{ onclose?: (() => void) | undefined }> {
   await vi.waitFor(() => {
     if (transportState.lastTransport === null) {

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -144,7 +144,7 @@ describe("openclaw channel mcp server", () => {
       );
       expect(codexTools.map((tool) => tool.name)).not.toContain("conversations_list");
       for (const tool of codexTools) {
-        expect(tool._meta).toMatchObject({ ui: { visibility: ["app"] } });
+        expect(tool["_meta"]).toMatchObject({ ui: { visibility: ["app"] } });
       }
       expect(codexMcp.client.getServerCapabilities()?.experimental).toBeUndefined();
     } finally {

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -1,9 +1,12 @@
 // Channel MCP server tests cover channel tool registration and requests.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { shouldRetryInitialMcpGatewayConnect } from "./channel-bridge.js";
+import { getMcpGatewayScopes, shouldRetryInitialMcpGatewayConnect } from "./channel-bridge.js";
 import { createOpenClawChannelMcpServer, OpenClawChannelBridge } from "./channel-server.js";
 import { extractAttachmentsFromMessage } from "./channel-shared.js";
 
@@ -23,9 +26,25 @@ const ClaudePermissionNotificationSchema = z.object({
   }),
 });
 
-async function connectMcpWithoutGateway(params?: { claudeChannelMode?: "auto" | "on" | "off" }) {
+const CODEX_SESSION_TOOLS = [
+  "openclaw",
+  "openclaw_sessions_list",
+  "openclaw_session_detail",
+  "openclaw_session_create",
+  "openclaw_session_send",
+  "openclaw_session_abort",
+  "openclaw_session_update",
+];
+
+async function connectMcpWithoutGateway(params?: {
+  claudeChannelMode?: "auto" | "on" | "off";
+  client?: "codex";
+  appResourcePath?: string;
+}) {
   const serverHarness = await createOpenClawChannelMcpServer({
     claudeChannelMode: params?.claudeChannelMode ?? "auto",
+    client: params?.client,
+    appResourcePath: params?.appResourcePath,
     config: {} as never,
     verbose: false,
   });
@@ -91,12 +110,71 @@ function gatewayRequestError(retryable: boolean): Error {
 }
 
 describe("openclaw channel mcp server", () => {
+  test.each([
+    { profile: "default", claudeChannelMode: "auto" as const },
+    { profile: "Claude", claudeChannelMode: "on" as const },
+  ])(
+    "does not register all-session tools for the $profile profile",
+    async ({ claudeChannelMode }) => {
+      const mcp = await connectMcpWithoutGateway({ claudeChannelMode });
+      try {
+        const tools = (await mcp.client.listTools()).tools.map((tool) => tool.name);
+        expect(tools).toContain("conversations_list");
+        expect(tools.filter((name) => CODEX_SESSION_TOOLS.includes(name))).toEqual([]);
+      } finally {
+        await mcp.close();
+      }
+    },
+  );
+
+  test("registers all-session tools for the explicit Codex profile", async () => {
+    const rawPluginRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mcp-codex-"));
+    const pluginRoot = await fs.realpath(rawPluginRoot);
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(pluginRoot);
+    let codexMcp: Awaited<ReturnType<typeof connectMcpWithoutGateway>> | undefined;
+    try {
+      await fs.writeFile(path.join(pluginRoot, "session-app.html"), "<!doctype html>", "utf8");
+      codexMcp = await connectMcpWithoutGateway({
+        client: "codex",
+        appResourcePath: "session-app.html",
+      });
+      const codexTools = (await codexMcp.client.listTools()).tools;
+      expect(codexTools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(CODEX_SESSION_TOOLS),
+      );
+      expect(codexTools.map((tool) => tool.name)).not.toContain("conversations_list");
+      for (const tool of codexTools) {
+        expect(tool._meta).toMatchObject({ ui: { visibility: ["app"] } });
+      }
+      expect(codexMcp.client.getServerCapabilities()?.experimental).toBeUndefined();
+    } finally {
+      await codexMcp?.close();
+      cwdSpy.mockRestore();
+      await fs.rm(pluginRoot, { recursive: true, force: true });
+    }
+  });
+
   test("keeps initial MCP gateway connection alive through transient connect errors", () => {
     expect(
       shouldRetryInitialMcpGatewayConnect(new Error("gateway request timeout for connect")),
     ).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(true))).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(false))).toBe(false);
+  });
+
+  test("does not request approval scope for the Codex app profile", () => {
+    const scopes = {
+      read: "operator.read",
+      write: "operator.write",
+      approvals: "operator.approvals",
+    };
+
+    expect(getMcpGatewayScopes("codex", scopes)).toEqual(["operator.read", "operator.write"]);
+    expect(getMcpGatewayScopes(undefined, scopes)).toEqual([
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+    ]);
   });
 
   describe("gateway-backed flows", () => {

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -11,7 +11,7 @@ import {
   openClawMcpServerInfo,
   registerOpenClawMcpApp,
 } from "./session-app.js";
-import { registerSessionMcpTools } from "./session-tools.js";
+import { registerSessionMcpTools } from "./session-tools-registration.js";
 
 /**
  * MCP stdio server assembly for OpenClaw channel conversations.

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -2,10 +2,16 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { VERSION } from "../version.js";
 import { OpenClawChannelBridge } from "./channel-bridge.js";
 import { ClaudePermissionRequestSchema, type ClaudeChannelMode } from "./channel-shared.js";
 import { getChannelMcpCapabilities, registerChannelMcpTools } from "./channel-tools.js";
+import {
+  loadOpenClawMcpAppResource,
+  OPENCLAW_SESSION_APP_URI,
+  openClawMcpServerInfo,
+  registerOpenClawMcpApp,
+} from "./session-app.js";
+import { registerSessionMcpTools } from "./session-tools.js";
 
 /**
  * MCP stdio server assembly for OpenClaw channel conversations.
@@ -22,6 +28,8 @@ type OpenClawMcpServeOptions = {
   gatewayPassword?: string;
   config?: OpenClawConfig;
   claudeChannelMode?: ClaudeChannelMode;
+  client?: "codex";
+  appResourcePath?: string;
   verbose?: boolean;
 };
 
@@ -40,31 +48,57 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
   start: () => Promise<void>;
   close: () => Promise<void>;
 }> {
+  if ((opts.client === "codex") !== Boolean(opts.appResourcePath)) {
+    throw new Error("--client codex and --app-resource must be used together");
+  }
+  const isCodex = opts.client === "codex";
+  const appHtml = opts.appResourcePath
+    ? await loadOpenClawMcpAppResource({
+        cwd: process.cwd(),
+        resourcePath: opts.appResourcePath,
+      })
+    : undefined;
   const cfg = await resolveMcpConfig(opts.config);
-  const claudeChannelMode = opts.claudeChannelMode ?? "auto";
+  const claudeChannelMode = isCodex ? "off" : (opts.claudeChannelMode ?? "auto");
+  const { gatewayUrl, gatewayToken, gatewayPassword } = opts;
   const capabilities = getChannelMcpCapabilities(claudeChannelMode);
   const server = new McpServer(
-    { name: "openclaw", version: VERSION },
+    openClawMcpServerInfo(),
     capabilities ? { capabilities } : undefined,
   );
   const bridge = new OpenClawChannelBridge(cfg, {
-    gatewayUrl: opts.gatewayUrl,
-    gatewayToken: opts.gatewayToken,
-    gatewayPassword: opts.gatewayPassword,
+    gatewayUrl,
+    gatewayToken,
+    gatewayPassword,
     claudeChannelMode,
+    client: opts.client,
     verbose: opts.verbose ?? false,
   });
   bridge.setServer(server);
 
-  server.server.setNotificationHandler(ClaudePermissionRequestSchema, async ({ params }) => {
-    await bridge.handleClaudePermissionRequest({
-      requestId: params.request_id,
-      toolName: params.tool_name,
-      description: params.description,
-      inputPreview: params.input_preview,
+  if (!isCodex) {
+    server.server.setNotificationHandler(ClaudePermissionRequestSchema, async ({ params }) => {
+      await bridge.handleClaudePermissionRequest({
+        requestId: params.request_id,
+        toolName: params.tool_name,
+        description: params.description,
+        inputPreview: params.input_preview,
+      });
     });
-  });
-  registerChannelMcpTools(server, bridge);
+  }
+  // The all-session projection is a Codex app capability. Generic and Claude
+  // channel clients must not gain access to unrelated Gateway sessions.
+  if (isCodex && appHtml !== undefined) {
+    registerSessionMcpTools(server, bridge.sessionTools, {
+      appResourceUri: OPENCLAW_SESSION_APP_URI,
+    });
+    registerOpenClawMcpApp(server, {
+      html: appHtml,
+      open: async () => await bridge.sessionTools.open(),
+    });
+  } else {
+    registerChannelMcpTools(server, bridge);
+  }
 
   return {
     server,

--- a/src/mcp/session-app.test.ts
+++ b/src/mcp/session-app.test.ts
@@ -13,7 +13,8 @@ import {
   openClawMcpServerInfo,
   registerOpenClawMcpApp,
 } from "./session-app.js";
-import { OpenClawSessionTools, registerSessionMcpTools } from "./session-tools.js";
+import { OpenClawSessionTools } from "./session-tools.js";
+import { registerSessionMcpTools } from "./session-tools-registration.js";
 
 const tempDirs: string[] = [];
 const openServers: Array<{ client: Client; server: McpServer }> = [];
@@ -108,9 +109,9 @@ describe("OpenClaw MCP app resource", () => {
     const tools = await client.listTools();
     const listTool = tools.tools.find((tool) => tool.name === "openclaw_sessions_list");
     expect(listTool?.annotations?.readOnlyHint).toBe(true);
-    expect(listTool?._meta).toMatchObject({ ui: { visibility: ["app"] } });
+    expect(listTool?.["_meta"]).toMatchObject({ ui: { visibility: ["app"] } });
     const globalTool = tools.tools.find((tool) => tool.name === "openclaw");
-    expect(globalTool?._meta).toEqual({
+    expect(globalTool?.["_meta"]).toEqual({
       "openai/ui": { entrypoints: [{ type: "global" }] },
       ui: { resourceUri: OPENCLAW_SESSION_APP_URI, visibility: ["app"] },
     });
@@ -123,7 +124,7 @@ describe("OpenClaw MCP app resource", () => {
         mode: expect.any(Object),
       },
     });
-    expect(detailTool?._meta).toEqual({
+    expect(detailTool?.["_meta"]).toEqual({
       "openai/ui": {
         entrypoints: [
           {

--- a/src/mcp/session-app.test.ts
+++ b/src/mcp/session-app.test.ts
@@ -1,0 +1,167 @@
+// MCP app tests cover explicit resource loading and Codex-facing metadata.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  loadOpenClawMcpAppResource,
+  OPENCLAW_SESSION_APP_MIME_TYPE,
+  OPENCLAW_SESSION_APP_URI,
+  openClawMcpServerInfo,
+  registerOpenClawMcpApp,
+} from "./session-app.js";
+import { OpenClawSessionTools, registerSessionMcpTools } from "./session-tools.js";
+
+const tempDirs: string[] = [];
+const openServers: Array<{ client: Client; server: McpServer }> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    openServers.splice(0).map(async ({ client, server }) => {
+      await client.close();
+      await server.close();
+    }),
+  );
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function createAppFile(contents = "<!doctype html><title>OpenClaw</title>") {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mcp-app-"));
+  tempDirs.push(cwd);
+  await fs.mkdir(path.join(cwd, "assets"));
+  await fs.writeFile(path.join(cwd, "assets", "session.html"), contents, "utf8");
+  return cwd;
+}
+
+describe("OpenClaw MCP app resource", () => {
+  test("loads one explicit cwd-contained app file with a byte cap", async () => {
+    const cwd = await createAppFile();
+
+    await expect(
+      loadOpenClawMcpAppResource({ cwd, resourcePath: "assets/session.html" }),
+    ).resolves.toBe("<!doctype html><title>OpenClaw</title>");
+
+    const outside = path.join(path.dirname(cwd), "outside-openclaw-app.html");
+    await fs.writeFile(outside, "outside", "utf8");
+    tempDirs.push(outside);
+    await expect(
+      loadOpenClawMcpAppResource({ cwd, resourcePath: "../outside-openclaw-app.html" }),
+    ).rejects.toThrow("must stay within the plugin root");
+
+    const escapedLink = path.join(cwd, "assets", "escaped.html");
+    try {
+      await fs.symlink(outside, escapedLink);
+      await expect(
+        loadOpenClawMcpAppResource({ cwd, resourcePath: "assets/escaped.html" }),
+      ).rejects.toThrow();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+        throw error;
+      }
+    }
+
+    await fs.writeFile(path.join(cwd, "assets", "huge.html"), "x".repeat(1_048_577), "utf8");
+    await expect(
+      loadOpenClawMcpAppResource({ cwd, resourcePath: "assets/huge.html" }),
+    ).rejects.toThrow();
+  });
+
+  test("advertises themed server icons, app resource, and exact Codex entrypoints", async () => {
+    const html = "<!doctype html><title>OpenClaw</title>";
+    const service = new OpenClawSessionTools({
+      request: async () => ({ sessions: [] }),
+      access: () => ({
+        methods: new Set(["sessions.list", "chat.history", "sessions.create"]),
+        scopes: new Set(["operator.read", "operator.write"]),
+      }),
+    });
+    const server = new McpServer(openClawMcpServerInfo());
+    registerOpenClawMcpApp(server, {
+      html,
+      open: async () => await service.open(),
+    });
+    registerSessionMcpTools(server, service, { appResourceUri: OPENCLAW_SESSION_APP_URI });
+    const client = new Client({ name: "openclaw-app-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    openServers.push({ client, server });
+
+    const serverInfo = client.getServerVersion();
+    expect(serverInfo?.title).toBe("OpenClaw");
+    expect(serverInfo?.icons).toEqual([
+      expect.objectContaining({
+        src: expect.stringMatching(/^data:image\/svg\+xml;base64,/),
+        mimeType: "image/svg+xml",
+        theme: "light",
+      }),
+      expect.objectContaining({
+        src: expect.stringMatching(/^data:image\/svg\+xml;base64,/),
+        mimeType: "image/svg+xml",
+        theme: "dark",
+      }),
+    ]);
+
+    const tools = await client.listTools();
+    const listTool = tools.tools.find((tool) => tool.name === "openclaw_sessions_list");
+    expect(listTool?.annotations?.readOnlyHint).toBe(true);
+    expect(listTool?._meta).toMatchObject({ ui: { visibility: ["app"] } });
+    const globalTool = tools.tools.find((tool) => tool.name === "openclaw");
+    expect(globalTool?._meta).toEqual({
+      "openai/ui": { entrypoints: [{ type: "global" }] },
+      ui: { resourceUri: OPENCLAW_SESSION_APP_URI, visibility: ["app"] },
+    });
+    const detailTool = tools.tools.find((tool) => tool.name === "openclaw_session_detail");
+    expect(detailTool?.title).toBe("OpenClaw");
+    expect(detailTool?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        session_id: expect.any(Object),
+        mode: expect.any(Object),
+      },
+    });
+    expect(detailTool?._meta).toEqual({
+      "openai/ui": {
+        entrypoints: [
+          {
+            type: "sidebar-collection",
+            listTool: "openclaw_sessions_list",
+            replacesGlobal: true,
+            create: {
+              title: "New OpenClaw session",
+              toolArguments: { mode: "new", chrome: "detail" },
+            },
+          },
+        ],
+      },
+      ui: { resourceUri: OPENCLAW_SESSION_APP_URI, visibility: ["app"] },
+    });
+
+    const resources = await client.listResources();
+    expect(resources.resources).toEqual([
+      expect.objectContaining({
+        uri: OPENCLAW_SESSION_APP_URI,
+        mimeType: OPENCLAW_SESSION_APP_MIME_TYPE,
+        _meta: { ui: { prefersBorder: false } },
+      }),
+    ]);
+    const resource = await client.readResource({ uri: OPENCLAW_SESSION_APP_URI });
+    expect(resource.contents).toEqual([
+      {
+        uri: OPENCLAW_SESSION_APP_URI,
+        mimeType: OPENCLAW_SESSION_APP_MIME_TYPE,
+        text: html,
+        _meta: { ui: { prefersBorder: false } },
+      },
+    ]);
+
+    const opened = await client.callTool({ name: "openclaw", arguments: {} });
+    expect(opened.structuredContent).toMatchObject({
+      items: [],
+      capabilities: { list: true, read: true, create: true },
+    });
+  });
+});

--- a/src/mcp/session-app.ts
+++ b/src/mcp/session-app.ts
@@ -1,0 +1,152 @@
+// MCP app assembly owns the explicit HTML resource and server presentation metadata.
+import path from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { root } from "../infra/fs-safe.js";
+import { VERSION } from "../version.js";
+import type { SessionCapabilities } from "./session-tools.js";
+
+export const OPENCLAW_SESSION_APP_URI = "ui://openclaw/session";
+export const OPENCLAW_SESSION_APP_MIME_TYPE = "text/html;profile=mcp-app";
+const MAX_APP_RESOURCE_BYTES = 1024 * 1024;
+
+const OPENCLAW_OUTLINE_LIGHT_SVG = `<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#242424" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z"/>
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z"/>
+    <path d="M45 15 Q35 5 30 8" stroke-width="5"/>
+    <path d="M75 15 Q85 5 90 8" stroke-width="5"/>
+  </g>
+  <circle cx="45" cy="35" r="5.5" fill="#242424"/>
+  <circle cx="75" cy="35" r="5.5" fill="#242424"/>
+</svg>`;
+
+const OPENCLAW_OUTLINE_DARK_SVG = `<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#f3f3f3" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z"/>
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z"/>
+    <path d="M45 15 Q35 5 30 8" stroke-width="5"/>
+    <path d="M75 15 Q85 5 90 8" stroke-width="5"/>
+  </g>
+  <circle cx="45" cy="35" r="5.5" fill="#f3f3f3"/>
+  <circle cx="75" cy="35" r="5.5" fill="#f3f3f3"/>
+</svg>`;
+
+/** Build server info without depending on a plugin install directory at runtime. */
+export function openClawMcpServerInfo(): Implementation {
+  return {
+    name: "openclaw",
+    title: "OpenClaw",
+    version: VERSION,
+    websiteUrl: "https://openclaw.ai/",
+    description: "OpenClaw Gateway sessions and channel conversations.",
+    icons: [
+      {
+        src: svgDataUrl(OPENCLAW_OUTLINE_LIGHT_SVG),
+        mimeType: "image/svg+xml",
+        sizes: ["120x120"],
+        theme: "light",
+      },
+      {
+        src: svgDataUrl(OPENCLAW_OUTLINE_DARK_SVG),
+        mimeType: "image/svg+xml",
+        sizes: ["120x120"],
+        theme: "dark",
+      },
+    ],
+  };
+}
+
+/** Read the one explicitly configured app resource under the plugin cwd. */
+export async function loadOpenClawMcpAppResource(params: {
+  cwd: string;
+  resourcePath: string;
+}): Promise<string> {
+  const pluginRoot = path.resolve(params.cwd);
+  const requestedPath = path.resolve(pluginRoot, params.resourcePath);
+  const relativePath = path.relative(pluginRoot, requestedPath);
+  const escapesRoot =
+    !relativePath ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath);
+  if (escapesRoot) {
+    throw new Error("MCP app resource must stay within the plugin root");
+  }
+  const pluginFiles = await root(pluginRoot);
+  const resource = await pluginFiles.read(relativePath, {
+    hardlinks: "reject",
+    maxBytes: MAX_APP_RESOURCE_BYTES,
+    symlinks: "follow-within-root",
+  });
+  return resource.buffer.toString("utf8");
+}
+
+/** Register the fallback global entrypoint and its single MCP App resource. */
+export function registerOpenClawMcpApp(
+  server: McpServer,
+  params: {
+    html: string;
+    open: () => Promise<{
+      items: unknown[];
+      agents: unknown[];
+      capabilities: SessionCapabilities;
+    }>;
+  },
+): void {
+  const resourceMeta = { ui: { prefersBorder: false } };
+  server.registerResource(
+    "OpenClaw session app",
+    OPENCLAW_SESSION_APP_URI,
+    {
+      title: "OpenClaw",
+      description: "OpenClaw session browser and chat interface.",
+      mimeType: OPENCLAW_SESSION_APP_MIME_TYPE,
+      _meta: resourceMeta,
+    },
+    async () => ({
+      contents: [
+        {
+          uri: OPENCLAW_SESSION_APP_URI,
+          mimeType: OPENCLAW_SESSION_APP_MIME_TYPE,
+          text: params.html,
+          _meta: resourceMeta,
+        },
+      ],
+    }),
+  );
+  server.registerTool(
+    "openclaw",
+    {
+      title: "OpenClaw",
+      description: "Open the OpenClaw session browser.",
+      inputSchema: z.object({}).strict(),
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: {
+        "openai/ui": { entrypoints: [{ type: "global" }] },
+        ui: { resourceUri: OPENCLAW_SESSION_APP_URI, visibility: ["app"] },
+      },
+    },
+    async () => {
+      try {
+        return {
+          content: [{ type: "text" as const, text: "OpenClaw" }],
+          structuredContent: await params.open(),
+        };
+      } catch {
+        return {
+          content: [{ type: "text" as const, text: "OpenClaw request unavailable." }],
+          structuredContent: { error: { code: "gateway_unavailable" } },
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function svgDataUrl(svg: string): string {
+  return `data:image/svg+xml;base64,${Buffer.from(svg, "utf8").toString("base64")}`;
+}

--- a/src/mcp/session-tools-actions.test.ts
+++ b/src/mcp/session-tools-actions.test.ts
@@ -1,0 +1,424 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { MAX_HISTORY_CHARS, MAX_MESSAGE_CHARS } from "./session-tools-contract.js";
+import { visibleMessages } from "./session-tools-projection.js";
+import {
+  closeSessionTools,
+  connectSessionTools,
+  predictableSessionId,
+  structuredContent,
+} from "./session-tools.test-support.js";
+
+afterEach(closeSessionTools);
+
+describe("OpenClaw session MCP tools", () => {
+  test("returns only bounded user and assistant text from history", async () => {
+    const sessionKey = "agent:ops:dashboard:secret";
+    const longText = "x".repeat(21_000);
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            {
+              key: sessionKey,
+              label: "Deploy review",
+              updatedAt: 1_767_995_121_286,
+            },
+          ],
+        };
+      }
+      if (method === "agents.list") {
+        return {
+          defaultId: "main",
+          agents: [{ id: "ops", identity: { emoji: "🦞" } }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              id: "user-1",
+              role: "user",
+              content: [
+                { type: "text", text: "Please review the deploy" },
+                { type: "tool_use", name: "shell", input: { path: "/private/repo" } },
+              ],
+            },
+            { id: "assistant-1", role: "assistant", content: "Review complete" },
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: longText },
+                { type: "thinking", text: "private reasoning" },
+              ],
+            },
+            { role: "system", content: "secret system prompt" },
+            { role: "tool", content: "secret tool output" },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list", "chat.history"],
+      scopes: ["operator.read"],
+    });
+    const listed = await client.callTool({ name: "openclaw_sessions_list", arguments: {} });
+    const sessionId = (structuredContent(listed).items as Array<{ id: string }>)[0]?.id;
+
+    const detail = await client.callTool({
+      name: "openclaw_session_detail",
+      arguments: { session_id: sessionId, limit: 100 },
+    });
+
+    const payload = structuredContent(detail);
+    expect(payload.session).toMatchObject({
+      id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+      agentId: "ops",
+      title: "Deploy review",
+    });
+    expect(payload.messages).toEqual([
+      { role: "user", text: "Please review the deploy" },
+      { role: "assistant", text: "Review complete" },
+      { role: "assistant", text: "x".repeat(20_000) },
+    ]);
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey,
+      agentId: "ops",
+      limit: 100,
+      maxChars: 200_000,
+    });
+    const serialized = JSON.stringify(detail);
+    expect(serialized).not.toContain(sessionKey);
+    expect(serialized).not.toContain("private reasoning");
+    expect(serialized).not.toContain("secret system prompt");
+    expect(serialized).not.toContain("secret tool output");
+    expect(serialized).not.toContain("/private/repo");
+  });
+
+  test("preserves the newest turns when the aggregate history budget is full", () => {
+    const messages = Array.from({ length: 12 }, (_, index) => ({
+      role: "assistant",
+      content: `${String(index).padStart(2, "0")}${"x".repeat(MAX_MESSAGE_CHARS - 2)}`,
+    }));
+
+    const visible = visibleMessages(messages);
+
+    expect(visible).toHaveLength(10);
+    expect(visible[0]?.text.startsWith("02")).toBe(true);
+    expect(visible.at(-1)?.text.startsWith("11")).toBe(true);
+    expect(visible.every((message) => message.text.length <= MAX_MESSAGE_CHARS)).toBe(true);
+    expect(visible.reduce((total, message) => total + message.text.length, 0)).toBeLessThanOrEqual(
+      MAX_HISTORY_CHARS,
+    );
+  });
+
+  test("creates, sends, aborts, and updates through least-privilege session methods", async () => {
+    const sessionKey = "agent:ops:dashboard:new-private-key";
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "sessions.create") {
+        return {
+          ok: true,
+          key: sessionKey,
+          runStarted: true,
+          runId: "run-create",
+          entry: { label: params.label, updatedAt: 1_767_995_121_286 },
+        };
+      }
+      if (method === "sessions.send") {
+        return { status: "started", runId: "run-send", key: sessionKey };
+      }
+      if (method === "sessions.abort") {
+        return { ok: true, abortedRunId: "run-send", status: "aborted", key: sessionKey };
+      }
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          key: sessionKey,
+          path: "/private/session-store",
+          entry: {
+            label: params.label,
+            archivedAt: params.archived ? 1_767_995_121_286 : undefined,
+            pinnedAt: params.pinned ? 1_767_995_121_286 : undefined,
+            markedUnreadAt: params.unread ? 1_767_995_121_286 : undefined,
+            updatedAt: 1_767_995_121_286,
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.create", "sessions.send", "sessions.abort", "sessions.patch"],
+      scopes: ["operator.write"],
+    });
+
+    const created = await client.callTool({
+      name: "openclaw_session_create",
+      arguments: { agent_id: "ops", label: "Release prep", message: "Start the review" },
+    });
+    const sessionId = (structuredContent(created).session as { id: string }).id;
+    expect(structuredContent(created)).toMatchObject({
+      session: {
+        id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+        agentId: "ops",
+        title: "Release prep",
+        status: "working",
+      },
+      run_id: "run-create",
+    });
+    expect(request).toHaveBeenCalledWith("sessions.create", {
+      agentId: "ops",
+      label: "Release prep",
+      message: "Start the review",
+    });
+
+    const sent = await client.callTool({
+      name: "openclaw_session_send",
+      arguments: { session_id: sessionId, text: "Continue" },
+    });
+    expect(structuredContent(sent)).toMatchObject({
+      session_id: sessionId,
+      run_id: "run-send",
+      status: "working",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.send",
+      expect.objectContaining({
+        key: sessionKey,
+        agentId: "ops",
+        message: "Continue",
+        idempotencyKey: expect.any(String),
+      }),
+    );
+
+    const aborted = await client.callTool({
+      name: "openclaw_session_abort",
+      arguments: { session_id: sessionId, run_id: "run-send" },
+    });
+    expect(structuredContent(aborted)).toMatchObject({
+      session_id: sessionId,
+      aborted: true,
+      status: "idle",
+    });
+    expect(request).toHaveBeenCalledWith("sessions.abort", {
+      key: sessionKey,
+      agentId: "ops",
+      runId: "run-send",
+    });
+
+    const updated = await client.callTool({
+      name: "openclaw_session_update",
+      arguments: {
+        session_id: sessionId,
+        label: "Release ready",
+        archived: true,
+        pinned: false,
+        unread: true,
+      },
+    });
+    expect(structuredContent(updated)).toMatchObject({
+      session: {
+        id: sessionId,
+        title: "Release ready",
+        archived: true,
+        pinned: false,
+        unread: true,
+      },
+    });
+    expect(JSON.stringify(updated)).not.toContain(sessionKey);
+    expect(JSON.stringify(updated)).not.toContain("/private/session-store");
+  });
+
+  test("returns the created session with a safe initial-message failure signal", async () => {
+    const { client } = await connectSessionTools({
+      request: async () => ({
+        ok: true,
+        key: "agent:main:dashboard:created-without-run",
+        runStarted: false,
+        runError: "private provider failure with credentials",
+        entry: { label: "Created session" },
+      }),
+      methods: ["sessions.create"],
+      scopes: ["operator.write"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_session_create",
+      arguments: { message: "Please keep this draft" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(structuredContent(result)).toMatchObject({
+      session: {
+        id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+        title: "Created session",
+        status: "idle",
+      },
+      initial_message_status: "failed",
+    });
+    expect(JSON.stringify(result)).not.toContain("private provider failure");
+    expect(JSON.stringify(result)).not.toContain("credentials");
+  });
+
+  test("reuses client operation ids across create and send retries", async () => {
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "sessions.create") {
+        return { key: params.key, runStarted: true, runId: "create-run", entry: {} };
+      }
+      if (method === "sessions.send") {
+        return { runId: "send-run" };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.create", "sessions.send"],
+      scopes: ["operator.write"],
+    });
+
+    const firstCreate = await client.callTool({
+      name: "openclaw_session_create",
+      arguments: {
+        agent_id: "ops",
+        message: "Create once",
+        operation_id: "create-operation",
+      },
+    });
+    const secondCreate = await client.callTool({
+      name: "openclaw_session_create",
+      arguments: {
+        agent_id: "ops",
+        message: "Create once",
+        operation_id: "create-operation",
+      },
+    });
+    const sessionId = (structuredContent(firstCreate).session as { id: string }).id;
+    expect((structuredContent(secondCreate).session as { id: string }).id).toBe(sessionId);
+
+    const createCalls = request.mock.calls.filter(([method]) => method === "sessions.create");
+    expect(createCalls[0]?.[1]).toMatchObject({
+      agentId: "ops",
+      key: expect.stringMatching(/^agent:ops:dashboard:codex-/),
+    });
+    expect(createCalls[0]?.[1].message).toBeUndefined();
+    expect(createCalls[0]?.[1]).not.toHaveProperty("idempotencyKey");
+    expect(createCalls[1]?.[1]).toEqual(createCalls[0]?.[1]);
+
+    const initialSendCalls = request.mock.calls.filter(
+      ([method, params]) => method === "sessions.send" && params.message === "Create once",
+    );
+    expect(initialSendCalls).toHaveLength(2);
+    expect(initialSendCalls[0]?.[1]).toMatchObject({
+      idempotencyKey: "create-operation",
+    });
+    expect(initialSendCalls[1]?.[1]).toMatchObject({
+      idempotencyKey: "create-operation",
+    });
+
+    await client.callTool({
+      name: "openclaw_session_send",
+      arguments: {
+        session_id: sessionId,
+        text: "Send once",
+        operation_id: "send-operation",
+      },
+    });
+    await client.callTool({
+      name: "openclaw_session_send",
+      arguments: {
+        session_id: sessionId,
+        text: "Send once",
+        operation_id: "send-operation",
+      },
+    });
+
+    const sendCalls = request.mock.calls.filter(
+      ([method, params]) => method === "sessions.send" && params.message === "Send once",
+    );
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[0]?.[1]).toMatchObject({ idempotencyKey: "send-operation" });
+    expect(sendCalls[1]?.[1]).toMatchObject({ idempotencyKey: "send-operation" });
+  });
+
+  test("bounds configured agent icons when opening the new-session route", async () => {
+    const avatar = `data:image/png;base64,${"A".repeat(250 * 1024)}`;
+    const { client } = await connectSessionTools({
+      request: async () => ({
+        defaultId: "main",
+        agents: Array.from({ length: 40 }, (_, index) => ({
+          id: `agent-${index}`,
+          identity: { avatarUrl: avatar },
+        })),
+      }),
+      methods: ["sessions.create", "agents.list"],
+      scopes: ["operator.write"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_session_detail",
+      arguments: { mode: "new", chrome: "detail" },
+    });
+    const agents = structuredContent(result).agents as Array<{ icon?: { src: string } }>;
+    const iconCount = agents.filter((agent) => agent.icon != null).length;
+
+    expect(agents).toHaveLength(40);
+    expect(iconCount).toBeGreaterThan(0);
+    expect(iconCount).toBeLessThan(40);
+    expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(5 * 1024 * 1024);
+  });
+
+  test("uses advertised chat fallbacks and never guesses an unknown opaque id", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.create") {
+        return { ok: true, key: "agent:main:dashboard:fallback", entry: {} };
+      }
+      if (method === "chat.send") {
+        return { runId: "run-fallback" };
+      }
+      if (method === "chat.abort") {
+        return { aborted: true };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.create", "chat.history", "chat.send", "chat.abort"],
+      scopes: ["operator.write"],
+    });
+    const created = await client.callTool({
+      name: "openclaw_session_create",
+      arguments: {},
+    });
+    const sessionId = (structuredContent(created).session as { id: string }).id;
+
+    await client.callTool({
+      name: "openclaw_session_send",
+      arguments: { session_id: sessionId, text: "fallback send" },
+    });
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "agent:main:dashboard:fallback",
+        message: "fallback send",
+      }),
+    );
+
+    await client.callTool({
+      name: "openclaw_session_abort",
+      arguments: { session_id: sessionId },
+    });
+    expect(request).toHaveBeenCalledWith("chat.abort", {
+      sessionKey: "agent:main:dashboard:fallback",
+      agentId: "main",
+    });
+
+    const missing = await client.callTool({
+      name: "openclaw_session_detail",
+      arguments: { session_id: predictableSessionId("unknown-session") },
+    });
+    expect(missing.isError).toBe(true);
+    expect(structuredContent(missing)).toEqual({ error: { code: "refresh_required" } });
+    expect(JSON.stringify(missing)).not.toContain("Gateway");
+  });
+});

--- a/src/mcp/session-tools-contract.ts
+++ b/src/mcp/session-tools-contract.ts
@@ -1,0 +1,244 @@
+import { z } from "zod";
+
+type GatewayAccess = {
+  methods: ReadonlySet<string>;
+  scopes: ReadonlySet<string>;
+};
+
+export type SessionToolsGateway = {
+  request: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+  access: () => GatewayAccess;
+  ready?: () => Promise<void>;
+};
+
+export type SessionCapabilities = {
+  list: boolean;
+  read: boolean;
+  create: boolean;
+  send: boolean;
+  abort: boolean;
+  update: boolean;
+};
+
+export type SessionStatus = "idle" | "working" | "waiting" | "error";
+
+export type SessionItem = {
+  id: string;
+  agentId: string;
+  title: string;
+  preview?: string;
+  updatedAt?: string;
+  status: SessionStatus;
+  unread: boolean;
+  pinned: boolean;
+  archived: boolean;
+  icons?: Array<{ src: string }>;
+  toolArguments: {
+    session_id: string;
+    chrome: "detail";
+  };
+};
+
+export type SessionAgent = {
+  id: string;
+  title: string;
+  icon?: { src: string; fallback: string };
+};
+
+export type StoredSession = {
+  key: string;
+  agentId: string;
+  item: SessionItem;
+};
+
+export type AgentSummary = {
+  id: string;
+  name?: string;
+  identity?: {
+    name?: string;
+    emoji?: string;
+    avatarUrl?: string;
+  };
+};
+
+export type SessionToolErrorCode =
+  | "gateway_unavailable"
+  | "invalid_response"
+  | "rejected"
+  | "refresh_required"
+  | "unsupported";
+
+export const READ_SCOPE = "operator.read";
+export const WRITE_SCOPE = "operator.write";
+export const ADMIN_SCOPE = "operator.admin";
+export const DEFAULT_LIST_LIMIT = 50;
+export const DEFAULT_HISTORY_LIMIT = 50;
+export const MAX_HISTORY_CHARS = 200_000;
+export const MAX_TITLE_CHARS = 160;
+export const MAX_PREVIEW_CHARS = 500;
+export const MAX_AGENT_EMOJI_CHARS = 16;
+export const MAX_SESSION_MAPPINGS = 1_000;
+export const MAX_DATE_MS = 8_640_000_000_000_000;
+export const MAX_DATA_ICON_CHARS = 256 * 1024;
+export const MAX_LIST_ICON_CHARS = 4 * 1024 * 1024;
+export const SAFE_RASTER_DATA_ICON_PATTERN = /^data:image\/(?:avif|gif|jpe?g|png|webp);base64,/i;
+
+const MAX_LIST_LIMIT = 100;
+const MAX_HISTORY_LIMIT = 200;
+export const MAX_MESSAGE_CHARS = 20_000;
+const OPAQUE_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const opaqueSessionIdSchema = z.string().regex(OPAQUE_SESSION_ID_PATTERN);
+const operationIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
+export const sessionRowSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().optional(),
+  displayName: z.string().optional(),
+  derivedTitle: z.string().optional(),
+  lastMessagePreview: z.string().optional(),
+  updatedAt: z.number().nullable().optional(),
+  status: z.enum(["running", "done", "failed", "killed", "timeout"]).optional(),
+  hasActiveRun: z.boolean().optional(),
+  unread: z.boolean().optional(),
+  pinned: z.boolean().optional(),
+  archived: z.boolean().optional(),
+});
+
+export const sessionsListResultSchema = z.object({
+  sessions: z.array(sessionRowSchema),
+});
+
+export const agentsListResultSchema = z.object({
+  defaultId: z.string().min(1).optional(),
+  agents: z.array(
+    z.object({
+      id: z.string().min(1),
+      name: z.string().optional(),
+      identity: z
+        .object({
+          name: z.string().optional(),
+          emoji: z.string().optional(),
+          avatarUrl: z.string().optional(),
+        })
+        .optional(),
+    }),
+  ),
+});
+
+export const historyResultSchema = z.object({
+  messages: z.array(z.unknown()),
+});
+
+export const createResultSchema = z.object({
+  key: z.string().min(1),
+  runStarted: z.boolean().optional(),
+  runId: z.string().optional(),
+  entry: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const sendResultSchema = z.object({
+  runId: z.string().optional(),
+});
+
+export const abortResultSchema = z.object({
+  abortedRunId: z.string().nullable().optional(),
+  aborted: z.boolean().optional(),
+  status: z.string().optional(),
+});
+
+export const patchResultSchema = z.object({
+  entry: z.record(z.string(), z.unknown()),
+});
+
+export const listInputSchema = z
+  .object({
+    limit: z.number().int().min(1).max(MAX_LIST_LIMIT).optional(),
+    search: z.string().trim().max(200).optional(),
+    archived: z.boolean().optional(),
+  })
+  .strict();
+
+export const detailInputSchema = z
+  .object({
+    session_id: opaqueSessionIdSchema.optional(),
+    mode: z.literal("new").optional(),
+    limit: z.number().int().min(1).max(MAX_HISTORY_LIMIT).optional(),
+    chrome: z.literal("detail").optional(),
+  })
+  .strict()
+  .refine(
+    ({ session_id, mode }) => (session_id !== undefined) !== (mode !== undefined),
+    { message: "exactly one of session_id or mode is required" },
+  )
+  .refine(({ mode, limit }) => mode !== "new" || limit === undefined, {
+    message: "limit is only valid when reading a session",
+    path: ["limit"],
+  });
+
+export const createInputSchema = z
+  .object({
+    agent_id: z.string().trim().min(1).max(100).optional(),
+    label: z.string().trim().min(1).max(MAX_TITLE_CHARS).optional(),
+    message: z.string().trim().min(1).max(MAX_MESSAGE_CHARS).optional(),
+    operation_id: operationIdSchema.optional(),
+  })
+  .strict();
+
+export const sendInputSchema = z
+  .object({
+    session_id: opaqueSessionIdSchema,
+    text: z.string().trim().min(1).max(MAX_MESSAGE_CHARS),
+    operation_id: operationIdSchema.optional(),
+  })
+  .strict();
+
+export const abortInputSchema = z
+  .object({
+    session_id: opaqueSessionIdSchema,
+    run_id: z.string().min(1).max(200).optional(),
+  })
+  .strict();
+
+export const updateInputSchema = z
+  .object({
+    session_id: opaqueSessionIdSchema,
+    label: z.string().trim().min(1).max(MAX_TITLE_CHARS).optional(),
+    archived: z.boolean().optional(),
+    pinned: z.boolean().optional(),
+    unread: z.boolean().optional(),
+  })
+  .strict()
+  .refine(
+    ({ label, archived, pinned, unread }) =>
+      label !== undefined || archived !== undefined || pinned !== undefined || unread !== undefined,
+    { message: "one update field is required" },
+  );
+
+export type SessionRow = z.output<typeof sessionRowSchema>;
+export type AgentsListResult = z.output<typeof agentsListResultSchema>;
+export type SessionListInput = z.output<typeof listInputSchema>;
+export type SessionDetailInput = z.output<typeof detailInputSchema>;
+export type SessionCreateInput = z.output<typeof createInputSchema>;
+export type SessionSendInput = z.output<typeof sendInputSchema>;
+export type SessionAbortInput = z.output<typeof abortInputSchema>;
+export type SessionUpdateInput = z.output<typeof updateInputSchema>;
+
+export class SessionToolError extends Error {
+  constructor(readonly code: SessionToolErrorCode) {
+    super(code);
+    this.name = "SessionToolError";
+  }
+}
+
+export function parseGatewayResult<T>(schema: z.ZodType<T>, value: unknown): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new SessionToolError("invalid_response");
+  }
+  return parsed.data;
+}

--- a/src/mcp/session-tools-errors.test.ts
+++ b/src/mcp/session-tools-errors.test.ts
@@ -1,0 +1,138 @@
+import { GatewayClientRequestError } from "@openclaw/gateway-client";
+import { ErrorCodes } from "@openclaw/gateway-protocol";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  closeSessionTools,
+  connectSessionTools,
+  structuredContent,
+} from "./session-tools.test-support.js";
+
+afterEach(closeSessionTools);
+
+describe("OpenClaw session MCP tools", () => {
+  test("fails closed when hello does not grant or advertise a capability", async () => {
+    const request = vi.fn();
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: [],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(structuredContent(result)).toEqual({ error: { code: "unsupported" } });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    {
+      name: "an invalid Gateway response",
+      request: async () => ({ unexpected: true }),
+      code: "invalid_response",
+    },
+    {
+      name: "a Gateway request failure",
+      request: async () => {
+        throw new Error("private gateway failure detail");
+      },
+      code: "gateway_unavailable",
+    },
+  ])("returns a fixed safe code for $name", async ({ request, code }) => {
+    const mcp = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await mcp.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(structuredContent(result)).toEqual({ error: { code } });
+    expect(JSON.stringify(result)).not.toContain("private gateway failure detail");
+  });
+
+  test.each([
+    ErrorCodes.NOT_LINKED,
+    ErrorCodes.NOT_PAIRED,
+    ErrorCodes.AGENT_TIMEOUT,
+    ErrorCodes.INVALID_REQUEST,
+    ErrorCodes.APPROVAL_NOT_FOUND,
+  ])("maps Gateway rejection %s without leaking its payload", async (gatewayCode) => {
+    const request = async () => {
+      throw new GatewayClientRequestError({
+        code: gatewayCode,
+        message: "private Gateway rejection detail",
+        details: { sessionKey: "agent:main:dashboard:private" },
+      });
+    };
+    const mcp = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await mcp.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(structuredContent(result)).toEqual({ error: { code: "rejected" } });
+    expect(JSON.stringify(result)).not.toContain("private Gateway rejection detail");
+    expect(JSON.stringify(result)).not.toContain("agent:main:dashboard:private");
+  });
+
+  test("keeps Gateway unavailability distinct from request rejection", async () => {
+    const request = async () => {
+      throw new GatewayClientRequestError({
+        code: ErrorCodes.UNAVAILABLE,
+        message: "private Gateway outage detail",
+        details: { endpoint: "wss://private.example" },
+      });
+    };
+    const mcp = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await mcp.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(structuredContent(result)).toEqual({ error: { code: "gateway_unavailable" } });
+    expect(JSON.stringify(result)).not.toContain("private Gateway outage detail");
+    expect(JSON.stringify(result)).not.toContain("wss://private.example");
+  });
+
+  test("rejects malformed opaque ids and unknown arguments before Gateway access", async () => {
+    const request = vi.fn();
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "chat.history"],
+      scopes: ["operator.read"],
+    });
+
+    const malformedId = await client.callTool({
+      name: "openclaw_session_detail",
+      arguments: { session_id: "!".repeat(43) },
+    });
+    const unknownArgument = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { surprise: true },
+    });
+
+    expect(malformedId.isError).toBe(true);
+    expect(unknownArgument.isError).toBe(true);
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/src/mcp/session-tools-listing.test.ts
+++ b/src/mcp/session-tools-listing.test.ts
@@ -1,0 +1,483 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  closeSessionTools,
+  connectSessionTools,
+  predictableSessionId,
+  structuredContent,
+} from "./session-tools.test-support.js";
+
+afterEach(closeSessionTools);
+
+describe("OpenClaw session MCP tools", () => {
+  test("lists all sessions as opaque host-native sidebar items", async () => {
+    const sessionKey = "agent:main:dashboard:private-route";
+    const avatar = "data:image/png;base64,Y2xhdw==";
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          path: "/Users/alice/.openclaw/agents/main/sessions",
+          sessions: [
+            {
+              key: sessionKey,
+              label: "Investigate flaky CI",
+              derivedTitle: "Private derived title",
+              lastMessagePreview: "The Linux shard is still failing",
+              updatedAt: 1_767_995_121_286,
+              hasActiveRun: true,
+              status: "running",
+              unread: true,
+              pinned: true,
+              archived: false,
+              modelProvider: "private-provider",
+            },
+          ],
+        };
+      }
+      if (method === "agents.list") {
+        return {
+          defaultId: "main",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [
+            {
+              id: "main",
+              name: "Claw",
+              identity: { name: "Claw", avatarUrl: avatar },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: [
+        "sessions.list",
+        "agents.list",
+        "chat.history",
+        "sessions.create",
+        "sessions.send",
+        "sessions.abort",
+        "sessions.patch",
+      ],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { limit: 25, search: "flaky", archived: false },
+    });
+
+    const payload = structuredContent(result);
+    expect(payload).toEqual({
+      items: [
+        {
+          id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+          agentId: "main",
+          title: "Investigate flaky CI",
+          preview: "The Linux shard is still failing",
+          updatedAt: "2026-01-09T21:45:21.286Z",
+          status: "working",
+          unread: true,
+          pinned: true,
+          archived: false,
+          icons: [{ src: avatar }],
+          toolArguments: {
+            session_id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+            chrome: "detail",
+          },
+        },
+      ],
+      agents: [
+        {
+          id: "main",
+          title: "Claw",
+          icon: { src: avatar, fallback: "C" },
+        },
+      ],
+      capabilities: {
+        list: true,
+        read: true,
+        create: true,
+        send: true,
+        abort: true,
+        update: true,
+      },
+    });
+    const [item] = payload.items as Array<{
+      id: string;
+      toolArguments: { session_id: string };
+    }>;
+    expect(item?.toolArguments.session_id).toBe(item?.id);
+    expect(item?.id).not.toBe(predictableSessionId(sessionKey));
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({
+        limit: 25,
+        search: "flaky",
+        archived: false,
+        configuredAgentsOnly: true,
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+      }),
+    );
+    expect(request).toHaveBeenCalledWith("agents.list", {});
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(sessionKey);
+    expect(serialized).not.toContain("/Users/alice");
+    expect(serialized).not.toContain("private-provider");
+  });
+
+  test("treats operator.admin as the read and write scope superset", async () => {
+    const { client } = await connectSessionTools({
+      request: async () => ({ sessions: [] }),
+      methods: [
+        "sessions.list",
+        "chat.history",
+        "sessions.create",
+        "sessions.send",
+        "sessions.abort",
+        "sessions.patch",
+      ],
+      scopes: ["operator.admin"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+
+    expect(structuredContent(result).capabilities).toEqual({
+      list: true,
+      read: true,
+      create: true,
+      send: true,
+      abort: true,
+      update: true,
+    });
+  });
+
+  test("includes active and archived sessions in the default native collection", async () => {
+    const activeKey = "agent:main:dashboard:active";
+    const archivedKey = "agent:main:dashboard:archived";
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected gateway method ${method}`);
+      }
+      return {
+        sessions:
+          params.archived === true
+            ? [{ key: archivedKey, label: "Closed investigation", archived: true }]
+            : [{ key: activeKey, label: "Current investigation", archived: false }],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: {},
+    });
+
+    expect(structuredContent(result).items).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+        archived: false,
+      }),
+      expect.objectContaining({
+        id: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+        archived: true,
+      }),
+    ]);
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({ archived: false }),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({ archived: true }),
+    );
+  });
+
+  test("keeps opaque session ids stable only within one bridge process", async () => {
+    const sessionKey = "agent:main:dashboard:guessable-key";
+    const request = vi.fn(async () => ({ sessions: [{ key: sessionKey }] }));
+    const first = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+    const second = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const firstList = await first.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+    const repeatedList = await first.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+    const secondList = await second.client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+    const firstId = (structuredContent(firstList).items as Array<{ id: string }>)[0]?.id;
+    const repeatedId = (structuredContent(repeatedList).items as Array<{ id: string }>)[0]?.id;
+    const secondId = (structuredContent(secondList).items as Array<{ id: string }>)[0]?.id;
+
+    expect(firstId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(repeatedId).toBe(firstId);
+    expect(secondId).not.toBe(firstId);
+    expect(firstId).not.toBe(predictableSessionId(sessionKey));
+  });
+
+  test("returns configured agents even when they have no listed session", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return { sessions: [] };
+      }
+      return {
+        defaultId: "main",
+        agents: [{ id: "ops", name: "Operations", identity: { emoji: "🦞" } }],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+
+    expect(structuredContent(result).agents).toEqual([
+      expect.objectContaining({ id: "ops", title: "Operations" }),
+    ]);
+  });
+
+  test("retains an archived session mapping across an active-list refresh", async () => {
+    const sessionKey = "agent:main:dashboard:archived-private-key";
+    let listCalls = 0;
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return {
+          sessions: listCalls === 1 ? [{ key: sessionKey, label: "Archived", archived: true }] : [],
+        };
+      }
+      if (method === "sessions.patch") {
+        return { entry: { label: "Archived", archivedAt: undefined } };
+      }
+      throw new Error(`unexpected gateway method ${method}`);
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "sessions.patch"],
+    });
+    const archived = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: true },
+    });
+    const sessionId = (structuredContent(archived).items as Array<{ id: string }>)[0]?.id;
+    await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+
+    const restored = await client.callTool({
+      name: "openclaw_session_update",
+      arguments: { session_id: sessionId, archived: false },
+    });
+
+    expect(restored.isError).not.toBe(true);
+    expect(request).toHaveBeenLastCalledWith("sessions.patch", {
+      key: sessionKey,
+      agentId: "main",
+      label: undefined,
+      archived: false,
+      pinned: undefined,
+      unread: undefined,
+    });
+  });
+
+  test("omits out-of-range Gateway timestamps", async () => {
+    const request = vi.fn(async () => ({
+      sessions: [{ key: "agent:main:dashboard:huge-date", updatedAt: 9_000_000_000_000_000 }],
+    }));
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({ name: "openclaw_sessions_list", arguments: {} });
+    const [item] = structuredContent(result).items as Array<Record<string, unknown>>;
+
+    expect(item).not.toHaveProperty("updatedAt");
+  });
+
+  test("drops oversized agent avatar data", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return { sessions: [{ key: "agent:main:dashboard:oversized-icon" }] };
+      }
+      return {
+        defaultId: "main",
+        agents: [
+          {
+            id: "main",
+            identity: { avatarUrl: `data:image/png;base64,${"A".repeat(256 * 1024)}` },
+          },
+        ],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({ name: "openclaw_sessions_list", arguments: {} });
+    const [item] = structuredContent(result).items as Array<Record<string, unknown>>;
+
+    expect(item).not.toHaveProperty("icons");
+    expect(item).not.toHaveProperty("icon");
+  });
+
+  test("keeps bounded data avatars and drops remote avatar URLs", async () => {
+    const boundedAvatar = `data:image/png;base64,${"A".repeat(64 * 1024)}`;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [{ key: "agent:data:dashboard:one" }, { key: "agent:remote:dashboard:two" }],
+        };
+      }
+      return {
+        defaultId: "data",
+        agents: [
+          { id: "data", identity: { avatarUrl: boundedAvatar } },
+          { id: "remote", identity: { avatarUrl: "https://example.com/avatar.png" } },
+        ],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+    const items = structuredContent(result).items as Array<Record<string, unknown>>;
+
+    expect(items[0]).toHaveProperty("icons", [{ src: boundedAvatar }]);
+    expect(items[0]).not.toHaveProperty("icon");
+    expect(items[1]).not.toHaveProperty("icons");
+  });
+
+  test("bounds agent emoji icons and fallbacks", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return { sessions: [{ key: "agent:main:dashboard:emoji-icon" }] };
+      }
+      return {
+        defaultId: "main",
+        agents: [
+          {
+            id: "main",
+            identity: { emoji: "🦞".repeat(1_000) },
+          },
+        ],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false },
+    });
+    const payload = structuredContent(result);
+    const [item] = payload.items as Array<{ icons?: Array<{ src: string }> }>;
+    const [agent] = payload.agents as Array<{
+      icon?: { fallback?: string; src?: string };
+    }>;
+
+    expect(item?.icons?.[0]?.src.length).toBeLessThan(1_024);
+    expect(agent?.icon?.fallback?.length).toBeLessThanOrEqual(16);
+    expect(agent?.icon?.src?.length).toBeLessThan(1_024);
+  });
+
+  test("keeps a 100-session response below the Codex stdio frame limit", async () => {
+    const avatar = `data:image/png;base64,${"A".repeat(64 * 1024)}`;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: Array.from({ length: 100 }, (_, index) => ({
+            key: `agent:main:dashboard:session-${index}`,
+            label: `Session ${index}`,
+          })),
+        };
+      }
+      return {
+        defaultId: "main",
+        agents: [{ id: "main", identity: { avatarUrl: avatar } }],
+      };
+    });
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.list", "agents.list"],
+      scopes: ["operator.read"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_sessions_list",
+      arguments: { archived: false, limit: 100 },
+    });
+    const payload = structuredContent(result);
+    const items = payload.items as Array<{ icons?: Array<{ src: string }> }>;
+    const iconCount = items.filter((item) => item.icons != null).length;
+
+    expect(items).toHaveLength(100);
+    expect(iconCount).toBeGreaterThan(0);
+    expect(iconCount).toBeLessThan(100);
+    expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(5 * 1024 * 1024);
+  });
+
+  test("opens the new-session app route with configured agents and without history", async () => {
+    const request = vi.fn(async () => ({
+      defaultId: "main",
+      agents: [{ id: "ops", name: "Operations" }],
+    }));
+    const { client } = await connectSessionTools({
+      request,
+      methods: ["sessions.create", "agents.list"],
+      scopes: ["operator.write"],
+    });
+
+    const result = await client.callTool({
+      name: "openclaw_session_detail",
+      arguments: { mode: "new", chrome: "detail" },
+    });
+
+    expect(structuredContent(result)).toMatchObject({
+      mode: "new",
+      agents: [{ id: "ops", title: "Operations" }],
+      capabilities: { create: true },
+    });
+    expect(request).toHaveBeenCalledExactlyOnceWith("agents.list", {});
+  });
+});

--- a/src/mcp/session-tools-listing.test.ts
+++ b/src/mcp/session-tools-listing.test.ts
@@ -159,7 +159,7 @@ describe("OpenClaw session MCP tools", () => {
   test("includes active and archived sessions in the default native collection", async () => {
     const activeKey = "agent:main:dashboard:active";
     const archivedKey = "agent:main:dashboard:archived";
-    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    const request = vi.fn(async (method: string, _params: Record<string, unknown>) => {
       if (method !== "sessions.list") {
         throw new Error(`unexpected gateway method ${method}`);
       }

--- a/src/mcp/session-tools-listing.test.ts
+++ b/src/mcp/session-tools-listing.test.ts
@@ -159,7 +159,7 @@ describe("OpenClaw session MCP tools", () => {
   test("includes active and archived sessions in the default native collection", async () => {
     const activeKey = "agent:main:dashboard:active";
     const archivedKey = "agent:main:dashboard:archived";
-    const request = vi.fn(async (method: string, _params: Record<string, unknown>) => {
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
       if (method !== "sessions.list") {
         throw new Error(`unexpected gateway method ${method}`);
       }
@@ -266,7 +266,7 @@ describe("OpenClaw session MCP tools", () => {
   test("retains an archived session mapping across an active-list refresh", async () => {
     const sessionKey = "agent:main:dashboard:archived-private-key";
     let listCalls = 0;
-    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    const request = vi.fn(async (method: string, _params: Record<string, unknown>) => {
       if (method === "sessions.list") {
         listCalls += 1;
         return {

--- a/src/mcp/session-tools-projection.ts
+++ b/src/mcp/session-tools-projection.ts
@@ -1,0 +1,212 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
+import {
+  type AgentSummary,
+  MAX_AGENT_EMOJI_CHARS,
+  MAX_DATA_ICON_CHARS,
+  MAX_DATE_MS,
+  MAX_HISTORY_CHARS,
+  MAX_LIST_ICON_CHARS,
+  MAX_MESSAGE_CHARS,
+  MAX_PREVIEW_CHARS,
+  MAX_TITLE_CHARS,
+  SAFE_RASTER_DATA_ICON_PATTERN,
+  type SessionAgent,
+  type SessionItem,
+  type SessionRow,
+  type SessionStatus,
+} from "./session-tools-contract.js";
+
+export function defaultCollectionRows(
+  activeRows: SessionRow[],
+  archivedRows: SessionRow[],
+  limit: number,
+) {
+  const active = [...new Map(activeRows.map((row) => [row.key, row])).values()];
+  const activeKeys = new Set(active.map((row) => row.key));
+  const archived = [...new Map(archivedRows.map((row) => [row.key, row])).values()].filter(
+    (row) => !activeKeys.has(row.key),
+  );
+  const archivedReserve = limit >= 5 ? Math.min(archived.length, Math.ceil(limit / 5)) : 0;
+  const selectedActive = active.slice(0, limit - archivedReserve);
+  return [...selectedActive, ...archived.slice(0, limit - selectedActive.length)];
+}
+
+export function sessionItem(
+  row: SessionRow,
+  agentId: string,
+  id: string,
+  agent?: AgentSummary,
+): SessionItem {
+  const title =
+    boundedText(row.label, MAX_TITLE_CHARS) ??
+    boundedText(row.derivedTitle, MAX_TITLE_CHARS) ??
+    boundedText(row.displayName, MAX_TITLE_CHARS) ??
+    "New session";
+  const icon = agentIcon(agent);
+  const preview = boundedText(row.lastMessagePreview, MAX_PREVIEW_CHARS);
+  const updatedAt = isoTimestamp(row.updatedAt);
+  return {
+    id,
+    agentId,
+    title,
+    ...(preview ? { preview } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+    status: sessionStatus(row),
+    unread: row.unread === true,
+    pinned: row.pinned === true,
+    archived: row.archived === true,
+    ...(icon ? { icons: [{ src: icon }] } : {}),
+    toolArguments: { session_id: id, chrome: "detail" },
+  };
+}
+
+export function boundedSessionListIcons(
+  items: SessionItem[],
+  agents: SessionAgent[],
+): { items: SessionItem[]; agents: SessionAgent[] } {
+  let remaining = MAX_LIST_ICON_CHARS;
+  const boundedAgents = agents.map((agent) => {
+    const src = agent.icon?.src;
+    if (!src || src.length > remaining) {
+      const { icon: _icon, ...withoutIcon } = agent;
+      return withoutIcon;
+    }
+    remaining -= src.length;
+    return agent;
+  });
+  const boundedItems = items.map((item) => {
+    const src = item.icons?.[0]?.src;
+    if (!src || src.length > remaining) {
+      const { icons: _icons, ...withoutIcons } = item;
+      return withoutIcons;
+    }
+    remaining -= src.length;
+    return item;
+  });
+  return { items: boundedItems, agents: boundedAgents };
+}
+
+export function sessionAgent(agent: AgentSummary): SessionAgent {
+  const icon = agentIcon(agent);
+  return {
+    id: agent.id,
+    title:
+      boundedText(agent.identity?.name, MAX_TITLE_CHARS) ??
+      boundedText(agent.name, MAX_TITLE_CHARS) ??
+      agent.id,
+    ...(icon ? { icon: { src: icon, fallback: agentFallback(agent, agent.id) } } : {}),
+  };
+}
+
+function agentFallback(agent: AgentSummary | undefined, agentId: string): string {
+  return (
+    boundedText(agent?.identity?.emoji, MAX_AGENT_EMOJI_CHARS) ??
+    boundedText(agent?.identity?.name, 1)?.toUpperCase() ??
+    boundedText(agent?.name, 1)?.toUpperCase() ??
+    agentId.slice(0, 1).toUpperCase()
+  );
+}
+
+function sessionStatus(row: SessionRow): SessionStatus {
+  if (row.hasActiveRun === true || row.status === "running") {
+    return "working";
+  }
+  if (row.status === "failed" || row.status === "timeout") {
+    return "error";
+  }
+  return "idle";
+}
+
+function agentIcon(agent: AgentSummary | undefined): string | undefined {
+  const avatarUrl = agent?.identity?.avatarUrl?.trim();
+  if (
+    avatarUrl &&
+    avatarUrl.length <= MAX_DATA_ICON_CHARS &&
+    SAFE_RASTER_DATA_ICON_PATTERN.test(avatarUrl)
+  ) {
+    return avatarUrl;
+  }
+  const emoji = boundedText(agent?.identity?.emoji, MAX_AGENT_EMOJI_CHARS);
+  if (!emoji) {
+    return undefined;
+  }
+  const safeEmoji = emoji
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><text x="16" y="23" text-anchor="middle" font-size="23">${safeEmoji}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+export function visibleMessages(
+  messages: unknown[],
+): Array<{ role: "user" | "assistant"; text: string }> {
+  const visible: Array<{ role: "user" | "assistant"; text: string }> = [];
+  let remaining = MAX_HISTORY_CHARS;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (remaining <= 0 || !message || typeof message !== "object") {
+      continue;
+    }
+    const role = (message as { role?: unknown }).role;
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+    const text =
+      role === "assistant" ? extractAssistantVisibleText(message) : extractUserText(message);
+    if (!text) {
+      continue;
+    }
+    const bounded = truncateUtf16Safe(text.trim(), Math.min(MAX_MESSAGE_CHARS, remaining));
+    if (!bounded) {
+      continue;
+    }
+    visible.push({ role, text: bounded });
+    remaining -= bounded.length;
+  }
+  return visible.reverse();
+}
+
+function extractUserText(message: object): string | undefined {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const parts = content.flatMap((block) => {
+    if (!block || typeof block !== "object") {
+      return [];
+    }
+    const type = (block as { type?: unknown }).type;
+    const text = (block as { text?: unknown }).text;
+    return (type === "text" || type === "input_text") && typeof text === "string" ? [text] : [];
+  });
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+export function boundedText(value: string | undefined, maxChars: number): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? truncateUtf16Safe(trimmed, maxChars) : undefined;
+}
+
+export function isoTimestamp(value: number | null | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > MAX_DATE_MS) {
+    return undefined;
+  }
+  return new Date(value).toISOString();
+}
+
+export function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/mcp/session-tools-projection.ts
+++ b/src/mcp/session-tools-projection.ts
@@ -167,7 +167,7 @@ export function visibleMessages(
     visible.push({ role, text: bounded });
     remaining -= bounded.length;
   }
-  return visible.reverse();
+  return visible.toReversed();
 }
 
 function extractUserText(message: object): string | undefined {

--- a/src/mcp/session-tools-registration.ts
+++ b/src/mcp/session-tools-registration.ts
@@ -1,0 +1,153 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ErrorCodes } from "@openclaw/gateway-protocol";
+import { summarizeResult } from "./channel-shared.js";
+import {
+  abortInputSchema,
+  createInputSchema,
+  detailInputSchema,
+  listInputSchema,
+  sendInputSchema,
+  SessionToolError,
+  type SessionToolErrorCode,
+  updateInputSchema,
+} from "./session-tools-contract.js";
+import type { OpenClawSessionTools } from "./session-tools.js";
+
+/** Register session tools while keeping raw Gateway errors and identifiers out of MCP results. */
+export function registerSessionMcpTools(
+  server: McpServer,
+  service: OpenClawSessionTools,
+  options?: { appResourceUri?: string },
+): void {
+  const appOnlyMeta = { ui: { visibility: ["app"] } };
+  const detailMeta = options?.appResourceUri
+    ? {
+        "openai/ui": {
+          entrypoints: [
+            {
+              type: "sidebar-collection",
+              listTool: "openclaw_sessions_list",
+              replacesGlobal: true,
+              create: {
+                title: "New OpenClaw session",
+                toolArguments: { mode: "new", chrome: "detail" },
+              },
+            },
+          ],
+        },
+        ui: { resourceUri: options.appResourceUri, visibility: ["app"] },
+      }
+    : appOnlyMeta;
+  server.registerTool(
+    "openclaw_sessions_list",
+    {
+      title: "OpenClaw sessions",
+      description:
+        "List active and archived OpenClaw sessions available to this Gateway connection.",
+      inputSchema: listInputSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: appOnlyMeta,
+    },
+    async (args) => sessionToolResult("sessions", () => service.list(args)),
+  );
+  server.registerTool(
+    "openclaw_session_detail",
+    {
+      title: "OpenClaw",
+      description: "Read the visible transcript for one listed OpenClaw session.",
+      inputSchema: detailInputSchema,
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+      _meta: detailMeta,
+    },
+    async (args) => sessionToolResult("messages", () => service.detail(args)),
+  );
+  server.registerTool(
+    "openclaw_session_create",
+    {
+      title: "New OpenClaw session",
+      description: "Create an OpenClaw session without host filesystem selection.",
+      inputSchema: createInputSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: appOnlyMeta,
+    },
+    async (args) => sessionToolResult("session", () => service.create(args)),
+  );
+  server.registerTool(
+    "openclaw_session_send",
+    {
+      title: "Send to OpenClaw session",
+      description: "Send a text message to one listed OpenClaw session.",
+      inputSchema: sendInputSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: appOnlyMeta,
+    },
+    async (args) => sessionToolResult("message", () => service.send(args)),
+  );
+  server.registerTool(
+    "openclaw_session_abort",
+    {
+      title: "Stop OpenClaw session",
+      description: "Abort the active run for one listed OpenClaw session.",
+      inputSchema: abortInputSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: appOnlyMeta,
+    },
+    async (args) => sessionToolResult("session", () => service.abort(args)),
+  );
+  server.registerTool(
+    "openclaw_session_update",
+    {
+      title: "Update OpenClaw session",
+      description: "Rename or organize one listed OpenClaw session.",
+      inputSchema: updateInputSchema,
+      annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+      _meta: appOnlyMeta,
+    },
+    async (args) => sessionToolResult("session", () => service.update(args)),
+  );
+}
+
+async function sessionToolResult(label: string, run: () => Promise<Record<string, unknown>>) {
+  try {
+    const structuredContent = await run();
+    return {
+      ...summarizeResult(
+        label,
+        label === "messages" && Array.isArray(structuredContent.messages)
+          ? structuredContent.messages.length
+          : 1,
+      ),
+      structuredContent,
+    };
+  } catch (error) {
+    const code = sessionToolErrorCode(error);
+    return {
+      content: [{ type: "text" as const, text: "OpenClaw request unavailable." }],
+      structuredContent: { error: { code } },
+      isError: true,
+    };
+  }
+}
+
+function sessionToolErrorCode(error: unknown): SessionToolErrorCode {
+  if (error instanceof SessionToolError) {
+    return error.code;
+  }
+  if (!(error instanceof Error) || error.name !== "GatewayClientRequestError") {
+    return "gateway_unavailable";
+  }
+  const gatewayCode = (error as Error & { gatewayCode?: unknown }).gatewayCode;
+  switch (gatewayCode) {
+    case ErrorCodes.UNAVAILABLE:
+      return "gateway_unavailable";
+    case ErrorCodes.NOT_LINKED:
+    case ErrorCodes.NOT_PAIRED:
+    case ErrorCodes.AGENT_TIMEOUT:
+    case ErrorCodes.INVALID_REQUEST:
+    case ErrorCodes.APPROVAL_NOT_FOUND:
+      // Preserve the Gateway's stable rejection class without exposing its message or details.
+      return "rejected";
+    default:
+      return "gateway_unavailable";
+  }
+}

--- a/src/mcp/session-tools.test-support.ts
+++ b/src/mcp/session-tools.test-support.ts
@@ -1,0 +1,47 @@
+// Session MCP tool tests cover the opaque, sanitized Gateway projection.
+import { createHash } from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { OpenClawSessionTools, registerSessionMcpTools } from "./session-tools.js";
+
+const openServers: Array<{ client: Client; server: McpServer }> = [];
+
+export async function connectSessionTools(params: {
+  request: (method: string, payload: Record<string, unknown>) => Promise<unknown>;
+  methods: string[];
+  scopes?: string[];
+}) {
+  const service = new OpenClawSessionTools({
+    request: params.request,
+    access: () => ({
+      methods: new Set(params.methods),
+      scopes: new Set(params.scopes ?? ["operator.read", "operator.write"]),
+    }),
+  });
+  const server = new McpServer({ name: "openclaw-test", version: "1.0.0" });
+  registerSessionMcpTools(server, service);
+  const client = new Client({ name: "session-tools-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  openServers.push({ client, server });
+  return { client };
+}
+
+export async function closeSessionTools() {
+  await Promise.all(
+    openServers.splice(0).map(async ({ client, server }) => {
+      await client.close();
+      await server.close();
+    }),
+  );
+}
+
+export function predictableSessionId(sessionKey: string): string {
+  return createHash("sha256").update(sessionKey).digest("base64url");
+}
+
+export function structuredContent(result: unknown): Record<string, unknown> {
+  return (result as { structuredContent?: Record<string, unknown> }).structuredContent ?? {};
+}

--- a/src/mcp/session-tools.test-support.ts
+++ b/src/mcp/session-tools.test-support.ts
@@ -3,7 +3,8 @@ import { createHash } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { OpenClawSessionTools, registerSessionMcpTools } from "./session-tools.js";
+import { OpenClawSessionTools } from "./session-tools.js";
+import { registerSessionMcpTools } from "./session-tools-registration.js";
 
 const openServers: Array<{ client: Client; server: McpServer }> = [];
 

--- a/src/mcp/session-tools.ts
+++ b/src/mcp/session-tools.ts
@@ -1,0 +1,396 @@
+// Session MCP tools expose a bounded, opaque view of Gateway-managed sessions.
+import { createHmac, randomBytes, randomUUID } from "node:crypto";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  ADMIN_SCOPE,
+  abortResultSchema,
+  type AgentsListResult,
+  agentsListResultSchema,
+  createResultSchema,
+  DEFAULT_HISTORY_LIMIT,
+  DEFAULT_LIST_LIMIT,
+  historyResultSchema,
+  MAX_HISTORY_CHARS,
+  MAX_SESSION_MAPPINGS,
+  MAX_TITLE_CHARS,
+  parseGatewayResult,
+  patchResultSchema,
+  READ_SCOPE,
+  sendResultSchema,
+  type SessionAbortInput,
+  type SessionAgent,
+  type SessionCapabilities,
+  type SessionCreateInput,
+  type SessionDetailInput,
+  type SessionItem,
+  type SessionListInput,
+  type SessionSendInput,
+  type SessionStatus,
+  SessionToolError,
+  type SessionToolsGateway,
+  type SessionUpdateInput,
+  sessionsListResultSchema,
+  type StoredSession,
+  WRITE_SCOPE,
+} from "./session-tools-contract.js";
+import {
+  boundedText,
+  boundedSessionListIcons,
+  defaultCollectionRows,
+  isoTimestamp,
+  numberField,
+  sessionAgent,
+  sessionItem,
+  stringField,
+  visibleMessages,
+} from "./session-tools-projection.js";
+
+export type { SessionCapabilities } from "./session-tools-contract.js";
+export { registerSessionMcpTools } from "./session-tools-registration.js";
+
+/** Owns opaque session ids and the narrow Gateway projection used by MCP tools. */
+export class OpenClawSessionTools {
+  private readonly opaqueIdKey = randomBytes(32);
+  private readonly sessionsById = new Map<string, StoredSession>();
+
+  constructor(private readonly gateway: SessionToolsGateway) {}
+
+  clear(): void {
+    this.sessionsById.clear();
+  }
+
+  capabilities(): SessionCapabilities {
+    const { methods, scopes } = this.gateway.access();
+    const canWrite = scopes.has(WRITE_SCOPE) || scopes.has(ADMIN_SCOPE);
+    const canRead = scopes.has(READ_SCOPE) || canWrite;
+    return {
+      list: canRead && methods.has("sessions.list"),
+      read: canRead && methods.has("chat.history"),
+      create: canWrite && methods.has("sessions.create"),
+      send: canWrite && (methods.has("sessions.send") || methods.has("chat.send")),
+      abort: canWrite && (methods.has("sessions.abort") || methods.has("chat.abort")),
+      update: canWrite && methods.has("sessions.patch"),
+    };
+  }
+
+  async list(params: SessionListInput): Promise<{
+    items: SessionItem[];
+    agents: SessionAgent[];
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    this.requireCapability("list");
+    const limit = params.limit ?? DEFAULT_LIST_LIMIT;
+    const archivedStates = params.archived == null ? [false, true] : [params.archived];
+    const [sessionResultsRaw, agents] = await Promise.all([
+      Promise.all(
+        archivedStates.map((archived) =>
+          this.gateway.request("sessions.list", {
+            limit,
+            search: params.search,
+            archived,
+            configuredAgentsOnly: true,
+            includeDerivedTitles: true,
+            includeLastMessage: true,
+          }),
+        ),
+      ),
+      this.listAgents(),
+    ]);
+    const sessionResults = sessionResultsRaw.map((result) =>
+      parseGatewayResult(sessionsListResultSchema, result),
+    );
+    const rows =
+      params.archived == null
+        ? defaultCollectionRows(
+            sessionResults[0]?.sessions ?? [],
+            sessionResults[1]?.sessions ?? [],
+            limit,
+          )
+        : (sessionResults[0]?.sessions.slice(0, limit) ?? []);
+    const agentsById = new Map(agents.agents.map((agent) => [agent.id, agent]));
+    const items = rows.map((row) => {
+      const agentId = parseAgentSessionKey(row.key)?.agentId ?? agents.defaultId ?? "main";
+      const item = sessionItem(
+        row,
+        agentId,
+        this.opaqueSessionId(row.key),
+        agentsById.get(agentId),
+      );
+      this.rememberSession({ key: row.key, agentId, item });
+      return item;
+    });
+    return {
+      ...boundedSessionListIcons(items, [...agentsById.values()].map(sessionAgent)),
+      capabilities: this.capabilities(),
+    };
+  }
+
+  async detail(params: SessionDetailInput): Promise<{
+    session?: SessionItem;
+    messages?: Array<{ role: "user" | "assistant"; text: string }>;
+    agents?: SessionAgent[];
+    mode?: "new";
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    if (params.mode === "new") {
+      const agents = await this.listAgents();
+      const projectedAgents = boundedSessionListIcons([], agents.agents.map(sessionAgent)).agents;
+      return {
+        mode: "new",
+        agents: projectedAgents,
+        capabilities: this.capabilities(),
+      };
+    }
+    if (params.session_id === undefined) {
+      throw new SessionToolError("rejected");
+    }
+    this.requireCapability("read");
+    const session = this.requireSession(params.session_id);
+    const raw = await this.gateway.request("chat.history", {
+      sessionKey: session.key,
+      agentId: session.agentId,
+      limit: params.limit ?? DEFAULT_HISTORY_LIMIT,
+      maxChars: MAX_HISTORY_CHARS,
+    });
+    const history = parseGatewayResult(historyResultSchema, raw);
+    return {
+      session: session.item,
+      messages: visibleMessages(history.messages),
+      capabilities: this.capabilities(),
+    };
+  }
+
+  async create(params: SessionCreateInput): Promise<{
+    session: SessionItem;
+    run_id?: string;
+    initial_message_status?: "failed";
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    this.requireCapability("create");
+    const operationSessionKey = params.operation_id
+      ? this.operationSessionKey(params.agent_id, params.operation_id)
+      : undefined;
+    const raw = await this.gateway.request("sessions.create", {
+      key: operationSessionKey,
+      agentId: params.agent_id,
+      label: params.label,
+      message: operationSessionKey ? undefined : params.message,
+    });
+    const created = parseGatewayResult(createResultSchema, raw);
+    const agentId = params.agent_id ?? parseAgentSessionKey(created.key)?.agentId ?? "main";
+    let runId = created.runId;
+    let runStarted = created.runStarted === true;
+    let initialMessageFailed = params.message != null && created.runStarted === false;
+    if (params.operation_id && params.message) {
+      try {
+        const sent = await this.sendGatewayMessage(
+          { key: created.key, agentId },
+          params.message,
+          params.operation_id,
+        );
+        runId = sent.runId;
+        runStarted = true;
+        initialMessageFailed = false;
+      } catch {
+        initialMessageFailed = true;
+      }
+    }
+    const entry = created.entry ?? {};
+    const item = sessionItem(
+      {
+        key: created.key,
+        label: stringField(entry, "label") ?? params.label,
+        updatedAt: numberField(entry, "updatedAt"),
+        hasActiveRun: runStarted,
+      },
+      agentId,
+      this.opaqueSessionId(created.key),
+    );
+    this.rememberSession({ key: created.key, agentId, item });
+    return {
+      session: item,
+      ...(runId ? { run_id: runId } : {}),
+      ...(initialMessageFailed ? { initial_message_status: "failed" as const } : {}),
+      capabilities: this.capabilities(),
+    };
+  }
+
+  async send(params: SessionSendInput): Promise<{
+    session_id: string;
+    run_id?: string;
+    status: SessionStatus;
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    this.requireCapability("send");
+    const session = this.requireSession(params.session_id);
+    const sent = await this.sendGatewayMessage(
+      session,
+      params.text,
+      params.operation_id ?? randomUUID(),
+    );
+    session.item = { ...session.item, status: "working" };
+    return {
+      session_id: session.item.id,
+      ...(sent.runId ? { run_id: sent.runId } : {}),
+      status: "working",
+      capabilities: this.capabilities(),
+    };
+  }
+
+  async abort(params: SessionAbortInput): Promise<{
+    session_id: string;
+    aborted: boolean;
+    status: SessionStatus;
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    this.requireCapability("abort");
+    const session = this.requireSession(params.session_id);
+    const { methods } = this.gateway.access();
+    const method = methods.has("sessions.abort") ? "sessions.abort" : "chat.abort";
+    const runId = params.run_id;
+    const raw = await this.gateway.request(
+      method,
+      method === "sessions.abort"
+        ? {
+            key: session.key,
+            agentId: session.agentId,
+            ...(runId ? { runId } : {}),
+          }
+        : {
+            sessionKey: session.key,
+            agentId: session.agentId,
+            ...(runId ? { runId } : {}),
+          },
+    );
+    const abortedResult = parseGatewayResult(abortResultSchema, raw);
+    const aborted =
+      abortedResult.aborted === true ||
+      abortedResult.status === "aborted" ||
+      typeof abortedResult.abortedRunId === "string";
+    session.item = { ...session.item, status: "idle" };
+    return {
+      session_id: session.item.id,
+      aborted,
+      status: "idle",
+      capabilities: this.capabilities(),
+    };
+  }
+
+  async update(params: SessionUpdateInput): Promise<{
+    session: SessionItem;
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    this.requireCapability("update");
+    const session = this.requireSession(params.session_id);
+    const raw = await this.gateway.request("sessions.patch", {
+      key: session.key,
+      agentId: session.agentId,
+      label: params.label,
+      archived: params.archived,
+      pinned: params.pinned,
+      unread: params.unread,
+    });
+    const patched = parseGatewayResult(patchResultSchema, raw);
+    session.item = {
+      ...session.item,
+      title:
+        boundedText(stringField(patched.entry, "label") ?? params.label, MAX_TITLE_CHARS) ??
+        session.item.title,
+      updatedAt: isoTimestamp(numberField(patched.entry, "updatedAt")) ?? session.item.updatedAt,
+      archived: params.archived ?? session.item.archived,
+      pinned: params.pinned ?? session.item.pinned,
+      unread: params.unread ?? session.item.unread,
+    };
+    return { session: session.item, capabilities: this.capabilities() };
+  }
+
+  async open(): Promise<{
+    items: SessionItem[];
+    agents: SessionAgent[];
+    capabilities: SessionCapabilities;
+  }> {
+    await this.waitUntilReady();
+    if (!this.capabilities().list) {
+      return { items: [], agents: [], capabilities: this.capabilities() };
+    }
+    return await this.list({});
+  }
+
+  private requireCapability(capability: keyof SessionCapabilities): void {
+    if (!this.capabilities()[capability]) {
+      throw new SessionToolError("unsupported");
+    }
+  }
+
+  private async sendGatewayMessage(
+    session: Pick<StoredSession, "key" | "agentId">,
+    text: string,
+    idempotencyKey: string,
+  ) {
+    const { methods } = this.gateway.access();
+    const method = methods.has("sessions.send") ? "sessions.send" : "chat.send";
+    if (!methods.has(method)) {
+      throw new SessionToolError("unsupported");
+    }
+    const raw = await this.gateway.request(
+      method,
+      method === "sessions.send"
+        ? { key: session.key, agentId: session.agentId, message: text, idempotencyKey }
+        : { sessionKey: session.key, agentId: session.agentId, message: text, idempotencyKey },
+    );
+    return parseGatewayResult(sendResultSchema, raw);
+  }
+
+  private operationSessionKey(agentId: string | undefined, operationId: string): string {
+    const normalizedAgentId = normalizeAgentId(agentId ?? "main");
+    const suffix = createHmac("sha256", this.opaqueIdKey)
+      .update(`create\0${normalizedAgentId}\0${operationId}`)
+      .digest("base64url")
+      .slice(0, 32);
+    return `agent:${normalizedAgentId}:dashboard:codex-${suffix}`;
+  }
+
+  private requireSession(id: string): StoredSession {
+    const session = this.sessionsById.get(id);
+    if (!session) {
+      throw new SessionToolError("refresh_required");
+    }
+    return session;
+  }
+
+  private rememberSession(session: StoredSession): void {
+    this.sessionsById.delete(session.item.id);
+    this.sessionsById.set(session.item.id, session);
+    while (this.sessionsById.size > MAX_SESSION_MAPPINGS) {
+      const oldestId = this.sessionsById.keys().next().value;
+      if (typeof oldestId !== "string") {
+        return;
+      }
+      this.sessionsById.delete(oldestId);
+    }
+  }
+
+  private opaqueSessionId(key: string): string {
+    return createHmac("sha256", this.opaqueIdKey).update(key).digest("base64url");
+  }
+
+  private async listAgents(): Promise<AgentsListResult> {
+    if (!this.gateway.access().methods.has("agents.list")) {
+      return { agents: [] };
+    }
+    return parseGatewayResult(
+      agentsListResultSchema,
+      await this.gateway.request("agents.list", {}),
+    );
+  }
+
+  private async waitUntilReady(): Promise<void> {
+    await this.gateway.ready?.();
+  }
+}

--- a/src/mcp/session-tools.ts
+++ b/src/mcp/session-tools.ts
@@ -46,7 +46,6 @@ import {
 } from "./session-tools-projection.js";
 
 export type { SessionCapabilities } from "./session-tools-contract.js";
-export { registerSessionMcpTools } from "./session-tools-registration.js";
 
 /** Owns opaque session ids and the narrow Gateway projection used by MCP tools. */
 export class OpenClawSessionTools {


### PR DESCRIPTION
Related: #103621

AI-assisted: yes, built and reviewed with Codex.

## What Problem This Solves

OpenClaw can expose a Gateway through MCP, but Codex has no bounded, app-oriented way to browse and chat with OpenClaw sessions. Reusing the existing channel bridge would expose unrelated channel and approval tools and would not provide the structured session data a Codex app needs.

## Why This Change Was Made

This adds an explicit `openclaw mcp serve --client codex --app-resource ...` profile with app-only session list, detail, create, send, abort, and update tools. Session keys are projected to process-local opaque IDs, list/transcript/icon payloads are bounded, Gateway methods and scopes drive capabilities, and create/send retries use stable operation IDs. Generic and Claude MCP clients keep their existing channel surface and do not gain access to the all-session tools.

## User Impact

Codex app integrations can present OpenClaw sessions as first-class, chat-like destinations without exposing raw Gateway session identifiers or approval/admin operations. The profile requests only the read/write scopes it needs and retains a global app fallback when a host does not support a native sidebar collection.

This does not grant OpenClaw arbitrary access to Codex tasks; Codex does not currently expose that control surface to plugins.

## Evidence

- Final focused regression run: 5 Vitest shards, 13 files, 302 tests passed.
- MCP detail schema regression proves `tools/list` advertises both existing-session and new-session arguments.
- Structured autoreview completed cleanly after fixes: no accepted/actionable findings, overall confidence 0.86.
- Direct dependency checks covered Codex local marketplace discovery, plugin-relative MCP working directories, app-only tool visibility, UI resource metadata, the 8 MiB stdio ceiling, and the 300-second tool timeout.
- `git diff --check` passed.
- The Docker Codex-profile scenario has static syntax and wiring coverage. A remote Docker run was not available in this checkout, so hosted CI remains the end-to-end execution proof.
