### PR TITLE
feat(mattermost): add DM voice call support

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -67,6 +67,43 @@ Details: [Plugins](/tools/plugin)
 Self-hosted Mattermost on a private/LAN/tailnet address: outbound Mattermost API requests pass through an SSRF guard that blocks private and internal IPs by default. Opt in with `channels.mattermost.network.dangerouslyAllowPrivateNetwork: true` (per account: `channels.mattermost.accounts.<id>.network.dangerouslyAllowPrivateNetwork`).
 </Note>
 
+## Voice calls
+
+Mattermost direct-message calls can use the same OpenClaw session as typed messages. The bot joins a newly started DM call, uses Mattermost speaking events to delimit each utterance, transcribes it, runs a hidden agent turn, and plays the synthesized reply into the call. Neither the transcript nor the reply is posted to the Mattermost DM.
+
+Requirements:
+
+- Install and enable the Mattermost Calls plugin on the Mattermost server.
+- Configure batch speech-to-text under `tools.media.audio`; see [Audio and voice notes](/nodes/audio).
+- Configure a text-to-speech provider under `messages.tts`; see [Text-to-speech](/tools/tts). `messages.tts.auto` can remain off because call replies explicitly request speech.
+- Keep the same `dmPolicy` and `allowFrom` access controls used for typed DMs. Voice activity from an unauthorized sender is ignored.
+
+Enable calls for the default account:
+
+```json5
+{
+  channels: {
+    mattermost: {
+      voice: {
+        enabled: true,
+      },
+    },
+  },
+}
+```
+
+For a named account, use `channels.mattermost.accounts.<id>.voice.enabled`.
+
+Behavior and current limits:
+
+- Direct-message calls only. Channel and group calls are ignored.
+- One active DM call per Mattermost account. Starting another DM call moves the bot to the new call.
+- The Calls connection stays open across repeated speech turns and keeps about 1.5 seconds of audio pre-roll so the start of an utterance is retained.
+- Bot playback is excluded from capture to prevent self-transcription.
+- A call must start after the voice worker is enabled. If the Gateway starts while a call is already active, end and restart that call.
+- Reply audio is decoded through ffmpeg before WebRTC playback; ensure ffmpeg is available if call playback fails while TTS itself succeeds.
+- Native WebRTC prebuilds are available for macOS (arm64/x64), Linux (arm64/x64), and Windows (x64).
+
 ## Native slash commands
 
 Native slash commands are opt-in. When enabled, OpenClaw registers `oc_*` slash commands on every team the bot is a member of and receives callback POSTs on the gateway HTTP server.

--- a/extensions/mattermost/npm-shrinkwrap.json
+++ b/extensions/mattermost/npm-shrinkwrap.json
@@ -8,6 +8,8 @@
       "name": "@openclaw/mattermost",
       "version": "2026.7.2",
       "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@roamhq/wrtc": "0.10.0",
         "ws": "8.21.0",
         "zod": "4.4.3"
       },
@@ -18,6 +20,117 @@
         "openclaw": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@roamhq/wrtc": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc/-/wrtc-0.10.0.tgz",
+      "integrity": "sha512-yFqQQ0EV1ZUHaphh3tmjoxPi2wzhW2vjmzoAVNRRLUjXYd2e1nvwi9TKfE2w4WNvNws/hBkouvOt23Xo9FkXkQ==",
+      "license": "BSD-2-Clause",
+      "optionalDependencies": {
+        "@roamhq/wrtc-darwin-arm64": "0.10.0",
+        "@roamhq/wrtc-darwin-x64": "0.10.0",
+        "@roamhq/wrtc-linux-arm64": "0.10.0",
+        "@roamhq/wrtc-linux-x64": "0.10.0",
+        "@roamhq/wrtc-win32-x64": "0.10.0",
+        "domexception": "^4.0.0"
+      }
+    },
+    "node_modules/@roamhq/wrtc-darwin-arm64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-darwin-arm64/-/wrtc-darwin-arm64-0.10.0.tgz",
+      "integrity": "sha512-vFdi79jWuPHcnUcnuOjTvyKtmY/RI2xRQo9Y6RsIjIlYePN/7LTy00c+Ivrz4prYAPbp0oHscl7PDV64VUqGTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-darwin-x64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-darwin-x64/-/wrtc-darwin-x64-0.10.0.tgz",
+      "integrity": "sha512-H6852g2xYCuaR+/TrthpdMafs4bMfAUEpvRDhsIguzrK7Dz+MKpNI8MkwdqJN8W65J+7w7k+YqXIkTHe7Fz/cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-linux-arm64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-linux-arm64/-/wrtc-linux-arm64-0.10.0.tgz",
+      "integrity": "sha512-fEuJbNjprxQG6QlFd2iqBW9x028RDSho6izVg7gyt8irdPiXWOxzOxNnYMs/B2fohBTd1wD4Qxfivl07/dCR8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-linux-x64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-linux-x64/-/wrtc-linux-x64-0.10.0.tgz",
+      "integrity": "sha512-H32lK2eFg3sVb/9nkHIX5HIisxFoS82Gpesuea+zqAyRpRzSd5NpFXx28bVy9wQyRrNtj8k0bTUgEzWRzSbYCA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-win32-x64": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-win32-x64/-/wrtc-win32-x64-0.10.0.tgz",
+      "integrity": "sha512-wEVXMvLrBizdLyrd+Zc7zb7zpwUuHUBXwrdIvI69e3i/AA8YsVYI2xo/sxk6GoQ+o8a14ONc4SStDS35TCjg+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ws": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -8,6 +8,8 @@
   },
   "type": "module",
   "dependencies": {
+    "@msgpack/msgpack": "3.1.3",
+    "@roamhq/wrtc": "0.10.0",
     "ws": "8.21.0",
     "zod": "4.4.3"
   },
@@ -70,6 +72,7 @@
       "bundledDist": false
     },
     "release": {
+      "bundleRuntimeDependencies": false,
       "publishToClawHub": true,
       "publishToNpm": true
     }

--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -84,6 +84,13 @@ const MattermostNetworkSchema = z
   .strict()
   .optional();
 
+const MattermostVoiceSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const MattermostStreamingModeSchema = z.enum(["off", "partial", "block", "progress"]);
 const MattermostStreamingProgressSchema = z
   .object({
@@ -154,6 +161,7 @@ const MattermostAccountSchemaBase = z
         reactions: z.boolean().optional(),
       })
       .optional(),
+    voice: MattermostVoiceSchema,
     commands: MattermostSlashCommandsSchema,
     interactions: z
       .object({

--- a/extensions/mattermost/src/config-schema.test.ts
+++ b/extensions/mattermost/src/config-schema.test.ts
@@ -41,6 +41,23 @@ describe("MattermostConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts opt-in voice calling at top-level and per-account", () => {
+    const result = MattermostConfigSchema.safeParse({
+      voice: { enabled: true },
+      accounts: {
+        quiet: { voice: { enabled: false } },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown voice options", () => {
+    const result = MattermostConfigSchema.safeParse({
+      voice: { enabled: true, autoJoinChannels: true },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('rejects dmPolicy="open" without wildcard allowFrom', () => {
     const result = MattermostConfigSchema.safeParse({
       dmPolicy: "open",

--- a/extensions/mattermost/src/config-ui-hints.ts
+++ b/extensions/mattermost/src/config-ui-hints.ts
@@ -12,6 +12,10 @@ export const mattermostChannelConfigUiHints = {
     dmPolicy: { channelKey: "mattermost" },
     implicitMentions: true,
   }),
+  "voice.enabled": {
+    label: "Mattermost Voice Calls",
+    help: "Automatically join direct-message calls and answer through configured speech-to-text and text-to-speech providers (default: false).",
+  },
   streaming: {
     label: "Mattermost Streaming Mode",
     help: 'Unified Mattermost stream preview mode: "off" | "partial" | "block" | "progress". "progress" keeps a single editable progress draft until final delivery.',

--- a/extensions/mattermost/src/mattermost/calls-client.test.ts
+++ b/extensions/mattermost/src/mattermost/calls-client.test.ts
@@ -45,6 +45,31 @@ function mediaMapMessage(mediaMap: Record<string, unknown>): Buffer {
   return Buffer.concat([Buffer.from(encode(9)), Buffer.from(encode(mediaMap))]);
 }
 
+function createCallsFetch(params?: {
+  config?: Record<string, unknown>;
+  turnCredentials?: unknown[];
+}) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const pathname = new URL(String(input)).pathname;
+    if (pathname === "/plugins/com.mattermost.calls/api/v1/config") {
+      return Response.json(
+        params?.config ?? {
+          ICEServersConfigs: [],
+          NeedsTURNCredentials: false,
+        },
+      );
+    }
+    if (pathname === "/plugins/com.mattermost.calls/api/v1/turn-credentials") {
+      return Response.json(params?.turnCredentials ?? []);
+    }
+    return new Response("not found", { status: 404 });
+  });
+}
+
+async function waitForWebSocketListeners(ws: FakeWebSocket): Promise<void> {
+  await vi.waitFor(() => expect(ws.handlers.has("open")).toBe(true));
+}
+
 function createRtc() {
   const peerHandlers = new Map<string, Handler>();
   const dataChannel = {
@@ -86,6 +111,7 @@ function createRtc() {
 
 async function joinCall(params?: {
   abortSignal?: AbortSignal;
+  fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   now?: () => number;
   sleep?: (milliseconds: number) => Promise<void>;
   decodeAudioFile?: (path: string) => Promise<Buffer>;
@@ -95,15 +121,18 @@ async function joinCall(params?: {
   const onAudio = vi.fn();
   const onVoice = vi.fn();
   const pending = connectMattermostCall({
+    baseUrl: "https://mattermost.test",
     botToken: "test-token",
     callbacks: { onAudio, onVoice },
     channelId: "dm-channel",
+    fetchImpl: params?.fetchImpl ?? createCallsFetch(),
     rtc,
     webSocketFactory: () => ws,
     wsUrl: "ws://mattermost.test/api/v4/websocket",
     ...params,
   });
 
+  await waitForWebSocketListeners(ws);
   ws.emit("open");
   await ws.message({ event: "hello", data: { connection_id: "conn-1" } });
   await ws.message({
@@ -111,7 +140,18 @@ async function joinCall(params?: {
     data: { connID: "conn-1" },
   });
   const session = await pending;
-  return { audioSource, dataChannel, onAudio, onVoice, peer, peerHandlers, session, sinks, ws };
+  return {
+    audioSource,
+    dataChannel,
+    onAudio,
+    onVoice,
+    peer,
+    peerHandlers,
+    rtc,
+    session,
+    sinks,
+    ws,
+  };
 }
 
 describe("Mattermost Calls client", () => {
@@ -119,14 +159,17 @@ describe("Mattermost Calls client", () => {
     const ws = new FakeWebSocket();
     const { peer, rtc } = createRtc();
     const pending = connectMattermostCall({
+      baseUrl: "https://mattermost.test",
       botToken: "test-token",
       callbacks: { onAudio: vi.fn(), onVoice: vi.fn() },
       channelId: "dm-channel",
+      fetchImpl: createCallsFetch(),
       rtc,
       webSocketFactory: () => ws,
       wsUrl: "ws://mattermost.test/api/v4/websocket",
     });
 
+    await waitForWebSocketListeners(ws);
     ws.emit("open");
     await ws.message({ event: "hello", data: { connection_id: "conn-1" } });
     await ws.message({
@@ -160,6 +203,67 @@ describe("Mattermost Calls client", () => {
         },
       });
       expect(peer.setRemoteDescription).not.toHaveBeenCalled();
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("configures the peer with Mattermost Calls ICE servers and generated TURN credentials", async () => {
+    const fetchImpl = createCallsFetch({
+      config: {
+        ICEServersConfigs: [{ urls: "stun:stun.example.com:3478" }],
+        NeedsTURNCredentials: true,
+      },
+      turnCredentials: [
+        {
+          credential: "turn-pass",
+          urls: ["turn:turn.example.com:3478"],
+          username: "turn-user",
+        },
+      ],
+    });
+    const { rtc, session } = await joinCall({ fetchImpl });
+    try {
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        1,
+        "https://mattermost.test/plugins/com.mattermost.calls/api/v1/config",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+      expect(fetchImpl).toHaveBeenNthCalledWith(
+        2,
+        "https://mattermost.test/plugins/com.mattermost.calls/api/v1/turn-credentials",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer test-token" },
+        }),
+      );
+      expect(rtc.createPeerConnection).toHaveBeenCalledWith({
+        iceServers: [
+          { urls: "stun:stun.example.com:3478" },
+          {
+            credential: "turn-pass",
+            urls: ["turn:turn.example.com:3478"],
+            username: "turn-user",
+          },
+        ],
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("treats nullable Mattermost Calls ICE config as empty", async () => {
+    const fetchImpl = createCallsFetch({
+      config: {
+        ICEServersConfigs: null,
+        NeedsTURNCredentials: null,
+      },
+    });
+    const { rtc, session } = await joinCall({ fetchImpl });
+    try {
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(rtc.createPeerConnection).toHaveBeenCalledWith({ iceServers: [] });
     } finally {
       await session.close();
     }
@@ -363,7 +467,7 @@ describe("Mattermost Calls client", () => {
   });
 
   it("releases WebRTC resources when the signaling socket disconnects", async () => {
-    const { dataChannel, peer, peerHandlers, sinks, ws } = await joinCall();
+    const { dataChannel, peer, peerHandlers, session, sinks, ws } = await joinCall();
     dataChannel.onmessage?.({
       data: mediaMapMessage({ 3: { type: "voice", sender_id: "speaker-session" } }),
     });
@@ -373,6 +477,8 @@ describe("Mattermost Calls client", () => {
     });
 
     await ws.emit("close", 1006, Buffer.from("network lost"));
+    expect(session.closed).toBeDefined();
+    await session.closed;
 
     expect(peer.close).toHaveBeenCalledTimes(1);
     expect(sinks[0]?.stop).toHaveBeenCalledTimes(1);

--- a/extensions/mattermost/src/mattermost/calls-client.test.ts
+++ b/extensions/mattermost/src/mattermost/calls-client.test.ts
@@ -1,0 +1,393 @@
+import { inflateSync } from "node:zlib";
+import { decode, encode } from "@msgpack/msgpack";
+import { describe, expect, it, vi } from "vitest";
+import {
+  connectMattermostCall,
+  type MattermostCallsPeerConnection,
+  type MattermostCallsRtcFactory,
+  type MattermostCallsWebSocket,
+} from "./calls-client.js";
+
+type Handler = (...args: unknown[]) => unknown;
+
+class FakeWebSocket implements MattermostCallsWebSocket {
+  readonly handlers = new Map<string, Handler>();
+  readonly sent: Array<string | Buffer> = [];
+
+  on(event: string, listener: Handler): void {
+    this.handlers.set(event, listener);
+  }
+
+  send(data: string | Buffer): void {
+    this.sent.push(data);
+  }
+
+  close = vi.fn();
+  terminate = vi.fn();
+  ping = vi.fn();
+
+  emit(event: string, ...args: unknown[]): unknown {
+    return this.handlers.get(event)?.(...args);
+  }
+
+  async message(payload: unknown): Promise<void> {
+    await this.emit("message", Buffer.from(JSON.stringify(payload)));
+  }
+}
+
+function textMessages(ws: FakeWebSocket): Array<Record<string, unknown>> {
+  return ws.sent
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => JSON.parse(entry) as Record<string, unknown>);
+}
+
+function mediaMapMessage(mediaMap: Record<string, unknown>): Buffer {
+  return Buffer.concat([Buffer.from(encode(9)), Buffer.from(encode(mediaMap))]);
+}
+
+function createRtc() {
+  const peerHandlers = new Map<string, Handler>();
+  const dataChannel = {
+    binaryType: "",
+    onmessage: undefined as ((event: { data: unknown }) => void) | undefined,
+  };
+  const audioSource = {
+    createTrack: vi.fn(() => ({ id: "local-audio", stop: vi.fn() })),
+    onData: vi.fn(),
+  };
+  const peer: MattermostCallsPeerConnection = {
+    addIceCandidate: vi.fn(async () => undefined),
+    addTrack: vi.fn(),
+    close: vi.fn(),
+    createAnswer: vi.fn(async () => ({ type: "answer", sdp: "answer-sdp" })),
+    createDataChannel: vi.fn(() => dataChannel),
+    createOffer: vi.fn(async () => ({ type: "offer", sdp: "offer-sdp" })),
+    setLocalDescription: vi.fn(async () => undefined),
+    setRemoteDescription: vi.fn(async () => undefined),
+    get remoteDescription() {
+      return null;
+    },
+    on(event, listener) {
+      peerHandlers.set(event, listener);
+    },
+  };
+  const sinks: Array<{ ondata?: (event: { samples: Int16Array }) => void; stop: () => void }> = [];
+  const rtc: MattermostCallsRtcFactory = {
+    createAudioSink: vi.fn(() => {
+      const sink = { stop: vi.fn() };
+      sinks.push(sink);
+      return sink;
+    }),
+    createAudioSource: vi.fn(() => audioSource),
+    createPeerConnection: vi.fn(() => peer),
+  };
+  return { audioSource, dataChannel, peer, peerHandlers, rtc, sinks };
+}
+
+async function joinCall(params?: {
+  abortSignal?: AbortSignal;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  decodeAudioFile?: (path: string) => Promise<Buffer>;
+}) {
+  const ws = new FakeWebSocket();
+  const { audioSource, dataChannel, peer, peerHandlers, rtc, sinks } = createRtc();
+  const onAudio = vi.fn();
+  const onVoice = vi.fn();
+  const pending = connectMattermostCall({
+    botToken: "test-token",
+    callbacks: { onAudio, onVoice },
+    channelId: "dm-channel",
+    rtc,
+    webSocketFactory: () => ws,
+    wsUrl: "ws://mattermost.test/api/v4/websocket",
+    ...params,
+  });
+
+  ws.emit("open");
+  await ws.message({ event: "hello", data: { connection_id: "conn-1" } });
+  await ws.message({
+    event: "custom_com.mattermost.calls_join",
+    data: { connID: "conn-1" },
+  });
+  const session = await pending;
+  return { audioSource, dataChannel, onAudio, onVoice, peer, peerHandlers, session, sinks, ws };
+}
+
+describe("Mattermost Calls client", () => {
+  it("ignores join and signaling events for other Calls connection ids", async () => {
+    const ws = new FakeWebSocket();
+    const { peer, rtc } = createRtc();
+    const pending = connectMattermostCall({
+      botToken: "test-token",
+      callbacks: { onAudio: vi.fn(), onVoice: vi.fn() },
+      channelId: "dm-channel",
+      rtc,
+      webSocketFactory: () => ws,
+      wsUrl: "ws://mattermost.test/api/v4/websocket",
+    });
+
+    ws.emit("open");
+    await ws.message({ event: "hello", data: { connection_id: "conn-1" } });
+    await ws.message({
+      event: "custom_com.mattermost.calls_join",
+      data: { connID: "conn-2" },
+    });
+    let foreignSession: Awaited<ReturnType<typeof connectMattermostCall>> | undefined;
+    await Promise.race([
+      pending.then((session) => {
+        foreignSession = session;
+      }),
+      Promise.resolve(),
+    ]);
+    try {
+      expect(rtc.createPeerConnection).not.toHaveBeenCalled();
+    } finally {
+      await foreignSession?.close();
+    }
+
+    await ws.message({
+      event: "custom_com.mattermost.calls_join",
+      data: { connID: "conn-1" },
+    });
+    const session = await pending;
+    try {
+      await ws.message({
+        event: "custom_com.mattermost.calls_signal",
+        data: {
+          connID: "conn-2",
+          data: JSON.stringify({ type: "offer", sdp: "foreign-offer" }),
+        },
+      });
+      expect(peer.setRemoteDescription).not.toHaveBeenCalled();
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("authenticates, joins, and forwards voice activity and decoded audio", async () => {
+    const { dataChannel, onAudio, onVoice, peerHandlers, sinks, ws } = await joinCall();
+    const messages = textMessages(ws);
+
+    expect(messages[0]).toMatchObject({
+      action: "authentication_challenge",
+      data: { token: "test-token" },
+    });
+    expect(messages[1]).toMatchObject({
+      action: "custom_com.mattermost.calls_join",
+      data: {
+        av1Support: false,
+        channelID: "dm-channel",
+        dcSignaling: false,
+        jobID: "",
+      },
+    });
+
+    await ws.message({
+      event: "custom_com.mattermost.calls_user_voice_on",
+      data: { session_id: "speaker-session", userID: "human-user" },
+    });
+    await ws.message({
+      event: "custom_com.mattermost.calls_user_voice_off",
+      data: { session_id: "speaker-session", userID: "human-user" },
+    });
+    expect(onVoice).toHaveBeenNthCalledWith(1, {
+      sessionId: "speaker-session",
+      speaking: true,
+      userId: "human-user",
+    });
+    expect(onVoice).toHaveBeenNthCalledWith(2, {
+      sessionId: "speaker-session",
+      speaking: false,
+      userId: "human-user",
+    });
+
+    await ws.message({
+      event: "custom_com.mattermost.calls_signal",
+      data: {
+        data: JSON.stringify({
+          type: "offer",
+          sdp: [
+            "v=0",
+            "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+            "a=mid:3",
+            "a=msid:remote-stream voice_speaker-session_random",
+            "",
+          ].join("\r\n"),
+        }),
+      },
+    });
+    peerHandlers.get("track")?.({
+      track: { id: "random-track-id" },
+      transceiver: { mid: "3" },
+    });
+    dataChannel.onmessage?.({
+      data: mediaMapMessage({ 3: { type: "voice", sender_id: "receiver-session" } }),
+    });
+    sinks[0]?.ondata?.({ samples: new Int16Array([1, 2]) });
+    expect(onAudio).toHaveBeenCalledWith({
+      samples: new Int16Array([1, 1, 2, 2]),
+      sessionId: "speaker-session",
+    });
+  });
+
+  it("uses the media map sender id when SDP and track ids do not expose the voice session", async () => {
+    const { dataChannel, onAudio, peerHandlers, session, sinks } = await joinCall();
+    try {
+      peerHandlers.get("track")?.({
+        track: { id: "ordinary-track-id" },
+        transceiver: { mid: "3" },
+      });
+      dataChannel.onmessage?.({
+        data: mediaMapMessage({ 3: { type: "voice", sender_id: "mapped-session" } }),
+      });
+      sinks[0]?.ondata?.({ samples: new Int16Array([7, 8]) });
+
+      expect(onAudio).toHaveBeenCalledWith({
+        samples: new Int16Array([7, 7, 8, 8]),
+        sessionId: "mapped-session",
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("exchanges WebRTC signaling in the Calls wire format", async () => {
+    const { peer, peerHandlers, ws } = await joinCall();
+
+    await peerHandlers.get("negotiationneeded")?.();
+    const binary = ws.sent.find((entry): entry is Buffer => Buffer.isBuffer(entry));
+    expect(binary).toBeDefined();
+    const envelope = decode(binary ?? Buffer.alloc(0)) as {
+      action: string;
+      data: { data: Uint8Array };
+    };
+    expect(envelope.action).toBe("custom_com.mattermost.calls_sdp");
+    expect(JSON.parse(inflateSync(envelope.data.data).toString())).toEqual({
+      type: "offer",
+      sdp: "offer-sdp",
+    });
+
+    await ws.message({
+      event: "custom_com.mattermost.calls_signal",
+      data: { data: JSON.stringify({ type: "offer", sdp: "remote-offer" }) },
+    });
+    expect(peer.setRemoteDescription).toHaveBeenCalledWith({
+      type: "offer",
+      sdp: "remote-offer",
+    });
+    expect(peer.createAnswer).toHaveBeenCalled();
+
+    peerHandlers.get("icecandidate")?.({
+      candidate: { toJSON: () => ({ candidate: "local-candidate" }) },
+    });
+    expect(textMessages(ws).at(-1)).toMatchObject({
+      action: "custom_com.mattermost.calls_ice",
+      data: { data: JSON.stringify({ candidate: "local-candidate" }) },
+    });
+  });
+
+  it("waits for connection settling, plays PCM, then leaves cleanly", async () => {
+    let currentTime = 1_000;
+    const sleep = vi.fn(async (milliseconds: number) => {
+      currentTime += milliseconds;
+    });
+    const frame = Buffer.alloc(480 * 2 * 2, 1);
+    const { audioSource, peer, session, sinks, ws } = await joinCall({
+      decodeAudioFile: async () => frame,
+      now: () => currentTime,
+      sleep,
+    });
+
+    await session.play({ audioPath: "/tmp/reply.mp3" });
+
+    expect(sleep.mock.calls[0]?.[0]).toBeGreaterThanOrEqual(3_000);
+    expect(audioSource.onData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bitsPerSample: 16,
+        channelCount: 2,
+        numberOfFrames: 480,
+        sampleRate: 48_000,
+      }),
+    );
+    const playbackCalls = vi.mocked(audioSource.onData).mock.calls;
+    const firstSamples = playbackCalls[0]?.[0].samples;
+    const firstAudibleCallIndex = playbackCalls.findIndex((call) =>
+      Array.from(call[0].samples).some((sample) => sample !== 0),
+    );
+    const lastSamples = playbackCalls.at(-1)?.[0].samples;
+    expect(firstSamples && Array.from(firstSamples).every((sample) => sample === 0)).toBe(true);
+    expect(firstAudibleCallIndex).toBeGreaterThan(0);
+    expect(lastSamples && Array.from(lastSamples).every((sample) => sample === 0)).toBe(true);
+    expect(textMessages(ws).map((message) => message.action)).toEqual(
+      expect.arrayContaining([
+        "custom_com.mattermost.calls_unmute",
+        "custom_com.mattermost.calls_mute",
+      ]),
+    );
+
+    await session.close();
+    expect(textMessages(ws).at(-1)).toMatchObject({
+      action: "custom_com.mattermost.calls_leave",
+    });
+    expect(sinks.every((sink) => vi.mocked(sink.stop).mock.calls.length === 1)).toBe(true);
+    expect(peer.close).toHaveBeenCalled();
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it("stops playback when the playback signal is aborted", async () => {
+    let currentTime = 10_000;
+    const sleep = vi.fn(async (milliseconds: number) => {
+      currentTime += milliseconds;
+    });
+    const frameBytes = 480 * 2 * 2;
+    const pcm = Buffer.alloc(frameBytes * 3, 1);
+    const abort = new AbortController();
+    const { audioSource, session, ws } = await joinCall({
+      decodeAudioFile: async () => pcm,
+      now: () => currentTime,
+      sleep,
+    });
+    vi.mocked(audioSource.onData).mockImplementationOnce(() => abort.abort());
+
+    await session.play({ audioPath: "/tmp/reply.mp3" }, { signal: abort.signal });
+
+    expect(audioSource.onData).toHaveBeenCalledTimes(1);
+    expect(textMessages(ws).map((message) => message.action)).toEqual(
+      expect.arrayContaining([
+        "custom_com.mattermost.calls_unmute",
+        "custom_com.mattermost.calls_mute",
+      ]),
+    );
+    await session.close();
+  });
+
+  it("releases WebRTC resources when the signaling socket disconnects", async () => {
+    const { dataChannel, peer, peerHandlers, sinks, ws } = await joinCall();
+    dataChannel.onmessage?.({
+      data: mediaMapMessage({ 3: { type: "voice", sender_id: "speaker-session" } }),
+    });
+    peerHandlers.get("track")?.({
+      track: { id: "voice_speaker-session_random" },
+      transceiver: { mid: "3" },
+    });
+
+    await ws.emit("close", 1006, Buffer.from("network lost"));
+
+    expect(peer.close).toHaveBeenCalledTimes(1);
+    expect(sinks[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the call when the gateway shuts down", async () => {
+    const abort = new AbortController();
+    const { peer, ws } = await joinCall({ abortSignal: abort.signal });
+
+    abort.abort();
+    await vi.waitFor(() => expect(peer.close).toHaveBeenCalledTimes(1));
+
+    expect(textMessages(ws).at(-1)).toMatchObject({
+      action: "custom_com.mattermost.calls_leave",
+    });
+    expect(ws.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/mattermost/src/mattermost/calls-client.ts
+++ b/extensions/mattermost/src/mattermost/calls-client.ts
@@ -1,0 +1,731 @@
+// Mattermost plugin module implements the Calls WebSocket and WebRTC client.
+import { deflateSync } from "node:zlib";
+import { decodeMulti, encode } from "@msgpack/msgpack";
+import wrtc from "@roamhq/wrtc";
+import WebSocket from "ws";
+import { z } from "zod";
+import { decodeAudioFileToStereo48k } from "./voice-audio.js";
+import type { MattermostVoiceCallCallbacks, MattermostVoiceCallSession } from "./voice-worker.js";
+
+const CALLS_PREFIX = "custom_com.mattermost.calls_";
+const AUDIO_SAMPLE_RATE = 48_000;
+const AUDIO_CHANNELS = 2;
+const AUDIO_FRAME_MILLISECONDS = 10;
+const AUDIO_FRAMES_PER_PACKET = (AUDIO_SAMPLE_RATE * AUDIO_FRAME_MILLISECONDS) / 1_000;
+const AUDIO_BYTES_PER_PACKET = AUDIO_FRAMES_PER_PACKET * AUDIO_CHANNELS * 2;
+const CONNECTION_SETTLE_MILLISECONDS = 3_000;
+const UNMUTE_SETTLE_MILLISECONDS = 100;
+const PLAYBACK_LEAD_IN_MILLISECONDS = 500;
+const PLAYBACK_TRAILING_MILLISECONDS = 300;
+const PLAYBACK_LEAD_IN_PACKETS = Math.ceil(
+  PLAYBACK_LEAD_IN_MILLISECONDS / AUDIO_FRAME_MILLISECONDS,
+);
+const PLAYBACK_TRAILING_PACKETS = Math.ceil(
+  PLAYBACK_TRAILING_MILLISECONDS / AUDIO_FRAME_MILLISECONDS,
+);
+const PING_INTERVAL_MILLISECONDS = 30_000;
+
+type CallsHandler = (...args: unknown[]) => unknown;
+const DATA_CHANNEL_MEDIA_MAP_MESSAGE = 9;
+
+const MediaMapSchema = z.record(
+  z.string(),
+  z.object({
+    sender_id: z.string(),
+    type: z.string(),
+  }),
+);
+
+type MattermostCallsMediaMap = z.infer<typeof MediaMapSchema>;
+
+export type MattermostCallsDataChannel = {
+  binaryType: string;
+  onopen?: () => void;
+  onmessage?: (event: { data: unknown }) => void;
+};
+
+export type MattermostCallsWebSocket = {
+  on: (event: string, listener: CallsHandler) => void;
+  send: (data: string | Buffer) => void;
+  close: () => void;
+  terminate: () => void;
+  ping: () => void;
+};
+
+type SessionDescription = {
+  type: string;
+  sdp?: string;
+};
+
+type IceCandidate = {
+  candidate?: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+  usernameFragment?: string | null;
+};
+
+export type MattermostCallsPeerConnection = {
+  readonly remoteDescription: unknown;
+  on: (event: "icecandidate" | "negotiationneeded" | "track", listener: CallsHandler) => void;
+  addTrack: (track: unknown) => unknown;
+  createDataChannel: (label: string) => MattermostCallsDataChannel;
+  createOffer: () => Promise<SessionDescription>;
+  createAnswer: () => Promise<SessionDescription>;
+  setLocalDescription: (description: SessionDescription) => Promise<void>;
+  setRemoteDescription: (description: SessionDescription) => Promise<void>;
+  addIceCandidate: (candidate: IceCandidate) => Promise<void>;
+  close: () => void;
+};
+
+type MattermostCallsAudioData = {
+  samples: Int16Array;
+  sampleRate?: number;
+  channelCount?: number;
+};
+
+type MattermostCallsAudioSink = {
+  ondata?: (event: MattermostCallsAudioData) => void;
+  stop: () => void;
+};
+
+type MattermostCallsAudioSource = {
+  createTrack: () => { stop?: () => void };
+  onData: (data: {
+    samples: Int16Array;
+    sampleRate: number;
+    bitsPerSample: number;
+    channelCount: number;
+    numberOfFrames: number;
+  }) => void;
+};
+
+export type MattermostCallsRtcFactory = {
+  createPeerConnection: () => MattermostCallsPeerConnection;
+  createAudioSource: () => MattermostCallsAudioSource;
+  createAudioSink: (track: unknown) => MattermostCallsAudioSink;
+};
+
+const CallsEventSchema = z
+  .object({
+    event: z.string().optional(),
+    data: z.record(z.string(), z.unknown()).optional(),
+    broadcast: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+type CallsEvent = z.infer<typeof CallsEventSchema>;
+
+function defaultWebSocketFactory(url: string): MattermostCallsWebSocket {
+  return new WebSocket(url) as unknown as MattermostCallsWebSocket;
+}
+
+function defaultRtcFactory(): MattermostCallsRtcFactory {
+  return {
+    createPeerConnection() {
+      const peer = new wrtc.RTCPeerConnection();
+      return {
+        get remoteDescription() {
+          return peer.remoteDescription;
+        },
+        on(event, listener) {
+          peer.addEventListener(event, listener as EventListener);
+        },
+        addTrack: (track) => peer.addTrack(track as MediaStreamTrack),
+        createDataChannel: (label) =>
+          peer.createDataChannel(label) as unknown as MattermostCallsDataChannel,
+        createOffer: async () => await peer.createOffer(),
+        createAnswer: async () => await peer.createAnswer(),
+        setLocalDescription: async (description) => {
+          await peer.setLocalDescription(description as RTCSessionDescriptionInit);
+        },
+        setRemoteDescription: async (description) => {
+          await peer.setRemoteDescription(description as RTCSessionDescriptionInit);
+        },
+        addIceCandidate: async (candidate) => {
+          await peer.addIceCandidate(candidate as RTCIceCandidateInit);
+        },
+        close: () => peer.close(),
+      };
+    },
+    createAudioSource() {
+      return new wrtc.nonstandard.RTCAudioSource();
+    },
+    createAudioSink(track) {
+      return new wrtc.nonstandard.RTCAudioSink(track as MediaStreamTrack);
+    },
+  };
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function readString(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function parseEvent(data: unknown): CallsEvent | undefined {
+  const raw = Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+  try {
+    const result = CallsEventSchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toUint8Array(value: unknown): Uint8Array | undefined {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return undefined;
+}
+
+function parseMediaMapMessage(value: unknown): MattermostCallsMediaMap | undefined {
+  const bytes = toUint8Array(value);
+  if (!bytes) {
+    return undefined;
+  }
+  const values = decodeMulti(bytes);
+  const first = values.next();
+  if (first.done || first.value !== DATA_CHANNEL_MEDIA_MAP_MESSAGE) {
+    return undefined;
+  }
+  const second = values.next();
+  if (second.done) {
+    return undefined;
+  }
+  const parsed = MediaMapSchema.safeParse(second.value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function parseVoiceTrackSessionId(trackId: string): string | undefined {
+  const match = /^voice_([^_]+)_/.exec(trackId);
+  return match?.[1];
+}
+
+function parseVoiceSessionsByMid(sdp: string): Map<string, string> {
+  const sessions = new Map<string, string>();
+  for (const section of sdp.split(/(?=^m=)/m)) {
+    const mid = /^a=mid:([^\r\n]+)$/m.exec(section)?.[1]?.trim();
+    if (!mid) {
+      continue;
+    }
+    for (const line of section.split(/\r?\n/)) {
+      if (!line.includes("msid:")) {
+        continue;
+      }
+      const trackId = line
+        .slice(line.indexOf("msid:") + "msid:".length)
+        .trim()
+        .split(/\s+/)
+        .findLast((field) => field.startsWith("voice_"));
+      const sessionId = trackId ? parseVoiceTrackSessionId(trackId) : undefined;
+      if (sessionId) {
+        sessions.set(mid, sessionId);
+        break;
+      }
+    }
+  }
+  return sessions;
+}
+
+function normalizeAudioData(data: MattermostCallsAudioData): Int16Array | undefined {
+  const sampleRate = data.sampleRate ?? AUDIO_SAMPLE_RATE;
+  const channelCount = data.channelCount ?? 1;
+  if (sampleRate !== AUDIO_SAMPLE_RATE) {
+    return undefined;
+  }
+  if (channelCount === AUDIO_CHANNELS) {
+    return Int16Array.from(data.samples);
+  }
+  if (channelCount !== 1) {
+    return undefined;
+  }
+  const stereo = new Int16Array(data.samples.length * 2);
+  for (let index = 0; index < data.samples.length; index += 1) {
+    const sample = data.samples[index] ?? 0;
+    stereo[index * 2] = sample;
+    stereo[index * 2 + 1] = sample;
+  }
+  return stereo;
+}
+
+function bufferToAudioSamples(frame: Buffer): Int16Array {
+  const sampleCount = Math.floor(frame.length / 2);
+  const samples = new Int16Array(sampleCount);
+  for (let index = 0; index < sampleCount; index += 1) {
+    samples[index] = frame.readInt16LE(index * 2);
+  }
+  return samples;
+}
+
+export async function connectMattermostCall(params: {
+  wsUrl: string;
+  botToken: string;
+  channelId: string;
+  callbacks: MattermostVoiceCallCallbacks;
+  abortSignal?: AbortSignal;
+  webSocketFactory?: (url: string) => MattermostCallsWebSocket;
+  rtc?: MattermostCallsRtcFactory;
+  decodeAudioFile?: (filePath: string) => Promise<Buffer>;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+  onError?: (message: string) => void;
+  onDebug?: (message: string) => void;
+}): Promise<MattermostVoiceCallSession> {
+  const rtc = params.rtc ?? defaultRtcFactory();
+  const now = params.now ?? Date.now;
+  const sleep = params.sleep ?? delay;
+  const decode = params.decodeAudioFile ?? decodeAudioFileToStereo48k;
+  const ws = (params.webSocketFactory ?? defaultWebSocketFactory)(params.wsUrl);
+  const sinksBySession = new Map<string, MattermostCallsAudioSink[]>();
+  const pendingTracksByMid = new Map<string, unknown[]>();
+  const pendingCandidates: IceCandidate[] = [];
+  const voiceSessionsByMid = new Map<string, string>();
+  let mediaMap: MattermostCallsMediaMap = {};
+  let seq = 1;
+  let closed = false;
+  let connectionId: string | undefined;
+  let joinedAt = 0;
+  let peer: MattermostCallsPeerConnection | undefined;
+  let audioSource: MattermostCallsAudioSource | undefined;
+  let audioTrack: { stop?: () => void } | undefined;
+  let remoteDescriptionReady = false;
+  let sessionResolved = false;
+  let pingTimer: ReturnType<typeof setInterval> | undefined;
+  let removeAbortListener = () => undefined;
+
+  let resolveSession: (session: MattermostVoiceCallSession) => void = () => undefined;
+  let rejectSession: (error: Error) => void = () => undefined;
+  const sessionPromise = new Promise<MattermostVoiceCallSession>((resolve, reject) => {
+    resolveSession = resolve;
+    rejectSession = reject;
+  });
+
+  const reportError = (error: unknown) => {
+    params.onError?.(`mattermost calls: ${String(error)}`);
+  };
+  const debug = (message: string) => {
+    params.onDebug?.(`mattermost calls: ${message}`);
+  };
+
+  const send = (action: string, data: unknown, binary = false) => {
+    if (closed) {
+      return;
+    }
+    const envelope = { action, seq: seq++, data };
+    ws.send(binary ? Buffer.from(encode(envelope)) : JSON.stringify(envelope));
+  };
+
+  const sendCalls = (action: string, data: unknown, binary = false) => {
+    send(`${CALLS_PREFIX}${action}`, data, binary);
+  };
+
+  const sendDescription = (description: SessionDescription) => {
+    // Calls requires zlib-compressed SDP inside a binary MessagePack envelope
+    // so larger descriptions remain within its signaling wire contract.
+    sendCalls("sdp", { data: deflateSync(JSON.stringify(description)) }, true);
+  };
+
+  const flushCandidates = async () => {
+    if (!peer || !remoteDescriptionReady) {
+      return;
+    }
+    for (const candidate of pendingCandidates.splice(0)) {
+      await peer.addIceCandidate(candidate);
+    }
+  };
+
+  const handleSignal = async (rawSignal: string) => {
+    if (!peer) {
+      return;
+    }
+    let signal: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawSignal);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return;
+      }
+      signal = parsed as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    const type = readString(signal, "type");
+    if (type === "offer" || type === "answer") {
+      const sdp = readString(signal, "sdp");
+      if (!sdp) {
+        return;
+      }
+      for (const [mid, sessionId] of parseVoiceSessionsByMid(sdp)) {
+        voiceSessionsByMid.set(mid, sessionId);
+      }
+      await peer.setRemoteDescription({ type, sdp });
+      remoteDescriptionReady = true;
+      await flushCandidates();
+      if (type === "offer") {
+        const answer = await peer.createAnswer();
+        await peer.setLocalDescription(answer);
+        sendDescription(answer);
+      }
+      return;
+    }
+    if (type !== "candidate") {
+      return;
+    }
+    const candidateValue = signal.candidate;
+    if (!candidateValue || typeof candidateValue !== "object" || Array.isArray(candidateValue)) {
+      return;
+    }
+    const candidateRecord = candidateValue as Record<string, unknown>;
+    const nestedCandidate = candidateRecord.candidate;
+    const candidate =
+      nestedCandidate && typeof nestedCandidate === "object" && !Array.isArray(nestedCandidate)
+        ? (nestedCandidate as IceCandidate)
+        : (candidateRecord as IceCandidate);
+    if (remoteDescriptionReady) {
+      await peer.addIceCandidate(candidate);
+    } else {
+      pendingCandidates.push(candidate);
+    }
+  };
+
+  const stopSessionSinks = (sessionId: string) => {
+    for (const sink of sinksBySession.get(sessionId) ?? []) {
+      sink.stop();
+    }
+    sinksBySession.delete(sessionId);
+  };
+
+  const closeConnection = async (options: { sendLeave: boolean; closeSocket: boolean }) => {
+    if (closed) {
+      return;
+    }
+    removeAbortListener();
+    if (options.sendLeave) {
+      try {
+        sendCalls("leave", null);
+      } catch (error) {
+        reportError(error);
+      }
+    }
+    closed = true;
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = undefined;
+    }
+    for (const sessionId of [...sinksBySession.keys()]) {
+      stopSessionSinks(sessionId);
+    }
+    pendingTracksByMid.clear();
+    audioTrack?.stop?.();
+    peer?.close();
+    if (options.closeSocket) {
+      ws.close();
+    }
+  };
+
+  const close = async () => {
+    await closeConnection({ sendLeave: true, closeSocket: true });
+  };
+
+  const play = async (audio: { audioPath: string }, options?: { signal?: AbortSignal }) => {
+    if (closed || !audioSource) {
+      throw new Error("Mattermost call is not connected");
+    }
+    const isAborted = () => options?.signal?.aborted ?? false;
+    if (isAborted()) {
+      return;
+    }
+    const settleDelay = Math.max(0, joinedAt + CONNECTION_SETTLE_MILLISECONDS - now());
+    // The SFU can acknowledge join before its outbound audio route is ready.
+    // Holding first playback avoids clipping the beginning of the first reply.
+    if (settleDelay > 0) {
+      await sleep(settleDelay);
+    }
+    if (isAborted()) {
+      return;
+    }
+    const pcm = await decode(audio.audioPath);
+    if (isAborted()) {
+      return;
+    }
+    sendCalls("unmute", null);
+    await sleep(UNMUTE_SETTLE_MILLISECONDS);
+    try {
+      let targetTime = now();
+      let sentPackets = 0;
+      const writePacket = async (frame: Buffer) => {
+        audioSource.onData({
+          samples: bufferToAudioSamples(frame),
+          sampleRate: AUDIO_SAMPLE_RATE,
+          bitsPerSample: 16,
+          channelCount: AUDIO_CHANNELS,
+          numberOfFrames: AUDIO_FRAMES_PER_PACKET,
+        });
+        sentPackets += 1;
+        targetTime += AUDIO_FRAME_MILLISECONDS;
+        const frameDelay = targetTime - now();
+        if (frameDelay > 0) {
+          await sleep(frameDelay);
+        }
+      };
+      const silence = Buffer.alloc(AUDIO_BYTES_PER_PACKET);
+      for (let index = 0; index < PLAYBACK_LEAD_IN_PACKETS; index += 1) {
+        if (isAborted()) {
+          return;
+        }
+        await writePacket(silence);
+      }
+      for (let offset = 0; offset < pcm.length; offset += AUDIO_BYTES_PER_PACKET) {
+        if (isAborted()) {
+          return;
+        }
+        const frame = Buffer.alloc(AUDIO_BYTES_PER_PACKET);
+        pcm.copy(frame, 0, offset, Math.min(offset + AUDIO_BYTES_PER_PACKET, pcm.length));
+        await writePacket(frame);
+      }
+      for (let index = 0; index < PLAYBACK_TRAILING_PACKETS; index += 1) {
+        if (isAborted()) {
+          return;
+        }
+        await writePacket(silence);
+      }
+      debug(`playback sent packets=${sentPackets} audioBytes=${pcm.length}`);
+    } finally {
+      sendCalls("mute", null);
+    }
+  };
+
+  const initializePeer = () => {
+    if (peer) {
+      return;
+    }
+    peer = rtc.createPeerConnection();
+    audioSource = rtc.createAudioSource();
+    audioTrack = audioSource.createTrack();
+
+    peer.on("icecandidate", (event: unknown) => {
+      const candidate = (event as { candidate?: { toJSON?: () => IceCandidate } }).candidate;
+      if (!candidate) {
+        return;
+      }
+      const value = candidate.toJSON?.() ?? (candidate as IceCandidate);
+      sendCalls("ice", { data: JSON.stringify(value) });
+    });
+    peer.on("negotiationneeded", async () => {
+      try {
+        if (!peer) {
+          return;
+        }
+        const offer = await peer.createOffer();
+        await peer.setLocalDescription(offer);
+        sendDescription(offer);
+      } catch (error) {
+        reportError(error);
+      }
+    });
+    const audioStarted = new Set<string>();
+    const attachTrack = (mid: string, track: unknown) => {
+      const trackInfo = mediaMap[mid];
+      if (trackInfo && trackInfo.type !== "voice") {
+        return;
+      }
+      const trackId = (track as { id?: string }).id;
+      const sessionId =
+        voiceSessionsByMid.get(mid) ??
+        (trackId ? parseVoiceTrackSessionId(trackId) : undefined) ??
+        trackInfo?.sender_id;
+      debug(
+        `remote track mid=${mid} type=${trackInfo?.type ?? "unknown"} mapped=${Boolean(sessionId)}`,
+      );
+      if (!sessionId) {
+        if (trackInfo) {
+          return;
+        }
+        const pending = pendingTracksByMid.get(mid) ?? [];
+        pending.push(track);
+        pendingTracksByMid.set(mid, pending);
+        return;
+      }
+      const sink = rtc.createAudioSink(track);
+      const sessionSinks = sinksBySession.get(sessionId) ?? [];
+      sessionSinks.push(sink);
+      sinksBySession.set(sessionId, sessionSinks);
+      sink.ondata = (data) => {
+        const samples = normalizeAudioData(data);
+        if (samples) {
+          if (!audioStarted.has(sessionId)) {
+            audioStarted.add(sessionId);
+            debug(
+              `audio started session=${sessionId} rate=${data.sampleRate ?? AUDIO_SAMPLE_RATE} channels=${data.channelCount ?? 1}`,
+            );
+          }
+          params.callbacks.onAudio({ sessionId, samples });
+        }
+      };
+    };
+
+    peer.on("track", (event: unknown) => {
+      const rtcEvent = event as {
+        track?: unknown;
+        transceiver?: { mid?: string | null };
+      };
+      const mid = rtcEvent.transceiver?.mid;
+      if (!rtcEvent.track || !mid) {
+        return;
+      }
+      attachTrack(mid, rtcEvent.track);
+    });
+
+    peer.addTrack(audioTrack);
+    const dataChannel = peer.createDataChannel("calls-dc");
+    dataChannel.binaryType = "arraybuffer";
+    dataChannel.onopen = () => debug("data channel opened");
+    dataChannel.onmessage = (event) => {
+      try {
+        const nextMediaMap = parseMediaMapMessage(event.data);
+        if (!nextMediaMap) {
+          return;
+        }
+        mediaMap = nextMediaMap;
+        debug(`media map received entries=${Object.keys(mediaMap).length}`);
+        for (const [mid, tracks] of pendingTracksByMid) {
+          if (!mediaMap[mid]) {
+            continue;
+          }
+          pendingTracksByMid.delete(mid);
+          for (const track of tracks) {
+            attachTrack(mid, track);
+          }
+        }
+      } catch (error) {
+        reportError(error);
+      }
+    };
+  };
+
+  const handleEvent = async (event: CallsEvent) => {
+    const eventName = event.event;
+    const eventConnectionId =
+      readString(event.data, "connID") ?? readString(event.data, "connection_id");
+    const isForeignConnectionEvent = Boolean(
+      connectionId && eventConnectionId && eventConnectionId !== connectionId,
+    );
+    if (eventName === "hello") {
+      connectionId = eventConnectionId;
+      sendCalls("join", {
+        channelID: params.channelId,
+        jobID: "",
+        av1Support: false,
+        dcSignaling: false,
+      });
+      return;
+    }
+    if (eventName === `${CALLS_PREFIX}join`) {
+      if (isForeignConnectionEvent) {
+        return;
+      }
+      initializePeer();
+      joinedAt = now();
+      debug("join acknowledged");
+      sessionResolved = true;
+      resolveSession({ play, close });
+      return;
+    }
+    if (eventName === `${CALLS_PREFIX}signal`) {
+      if (isForeignConnectionEvent) {
+        return;
+      }
+      const signal = readString(event.data, "data");
+      if (signal) {
+        await handleSignal(signal);
+      }
+      return;
+    }
+    if (
+      eventName === `${CALLS_PREFIX}user_voice_on` ||
+      eventName === `${CALLS_PREFIX}user_voice_off`
+    ) {
+      const sessionId = readString(event.data, "session_id");
+      const userId = readString(event.data, "userID") ?? readString(event.data, "user_id");
+      if (sessionId && userId) {
+        debug(`voice ${eventName.endsWith("_on") ? "on" : "off"} session=${sessionId}`);
+        params.callbacks.onVoice({
+          sessionId,
+          userId,
+          speaking: eventName.endsWith("_on"),
+        });
+      }
+      return;
+    }
+    if (eventName === `${CALLS_PREFIX}user_left`) {
+      const sessionId = readString(event.data, "session_id");
+      if (sessionId) {
+        stopSessionSinks(sessionId);
+      }
+      return;
+    }
+    if (eventName === `${CALLS_PREFIX}call_end`) {
+      const channelId =
+        readString(event.data, "channelID") ?? readString(event.broadcast, "channel_id");
+      if (channelId === params.channelId) {
+        await close();
+      }
+    }
+  };
+
+  ws.on("open", () => {
+    send("authentication_challenge", { token: params.botToken });
+    pingTimer = setInterval(() => {
+      try {
+        ws.ping();
+      } catch (error) {
+        reportError(error);
+      }
+    }, PING_INTERVAL_MILLISECONDS);
+    pingTimer.unref();
+  });
+  ws.on("message", async (data: unknown) => {
+    const event = parseEvent(data);
+    if (!event) {
+      return;
+    }
+    try {
+      await handleEvent(event);
+    } catch (error) {
+      reportError(error);
+      rejectSession(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+  ws.on("error", (error: unknown) => {
+    reportError(error);
+    rejectSession(error instanceof Error ? error : new Error(String(error)));
+  });
+  ws.on("close", async () => {
+    await closeConnection({ sendLeave: false, closeSocket: false });
+    if (!sessionResolved) {
+      rejectSession(new Error("Mattermost Calls WebSocket closed before joining"));
+    }
+  });
+
+  const onAbort = () => {
+    rejectSession(new Error("Mattermost call stopped during gateway shutdown"));
+    void close();
+  };
+  if (params.abortSignal?.aborted) {
+    onAbort();
+  } else if (params.abortSignal) {
+    params.abortSignal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => params.abortSignal?.removeEventListener("abort", onAbort);
+  }
+
+  return await sessionPromise;
+}

--- a/extensions/mattermost/src/mattermost/calls-client.ts
+++ b/extensions/mattermost/src/mattermost/calls-client.ts
@@ -4,10 +4,12 @@ import { decodeMulti, encode } from "@msgpack/msgpack";
 import wrtc from "@roamhq/wrtc";
 import WebSocket from "ws";
 import { z } from "zod";
+import { normalizeMattermostBaseUrl, readMattermostError, type MattermostFetch } from "./client.js";
 import { decodeAudioFileToStereo48k } from "./voice-audio.js";
 import type { MattermostVoiceCallCallbacks, MattermostVoiceCallSession } from "./voice-worker.js";
 
 const CALLS_PREFIX = "custom_com.mattermost.calls_";
+const CALLS_PLUGIN_API_PREFIX = "/plugins/com.mattermost.calls/api/v1";
 const AUDIO_SAMPLE_RATE = 48_000;
 const AUDIO_CHANNELS = 2;
 const AUDIO_FRAME_MILLISECONDS = 10;
@@ -64,6 +66,26 @@ type IceCandidate = {
   usernameFragment?: string | null;
 };
 
+const IceServerSchema = z
+  .object({
+    urls: z.union([z.string(), z.array(z.string())]),
+    username: z.string().optional(),
+    credential: z.string().optional(),
+    credentialType: z.string().optional(),
+  })
+  .passthrough();
+
+const CallsConfigSchema = z
+  .object({
+    ICEServersConfigs: z.array(IceServerSchema).nullish(),
+    NeedsTURNCredentials: z.boolean().nullish(),
+  })
+  .passthrough();
+
+const TurnCredentialsSchema = z.array(IceServerSchema);
+
+export type MattermostCallsIceServer = z.infer<typeof IceServerSchema>;
+
 export type MattermostCallsPeerConnection = {
   readonly remoteDescription: unknown;
   on: (event: "icecandidate" | "negotiationneeded" | "track", listener: CallsHandler) => void;
@@ -100,7 +122,9 @@ type MattermostCallsAudioSource = {
 };
 
 export type MattermostCallsRtcFactory = {
-  createPeerConnection: () => MattermostCallsPeerConnection;
+  createPeerConnection: (options: {
+    iceServers: MattermostCallsIceServer[];
+  }) => MattermostCallsPeerConnection;
   createAudioSource: () => MattermostCallsAudioSource;
   createAudioSink: (track: unknown) => MattermostCallsAudioSink;
 };
@@ -121,8 +145,10 @@ function defaultWebSocketFactory(url: string): MattermostCallsWebSocket {
 
 function defaultRtcFactory(): MattermostCallsRtcFactory {
   return {
-    createPeerConnection() {
-      const peer = new wrtc.RTCPeerConnection();
+    createPeerConnection(options) {
+      const peer = new wrtc.RTCPeerConnection({
+        iceServers: options.iceServers,
+      } as RTCConfiguration);
       return {
         get remoteDescription() {
           return peer.remoteDescription;
@@ -267,7 +293,53 @@ function bufferToAudioSamples(frame: Buffer): Int16Array {
   return samples;
 }
 
+function buildCallsApiUrl(baseUrl: string, path: "config" | "turn-credentials"): string {
+  const normalized = normalizeMattermostBaseUrl(baseUrl);
+  if (!normalized) {
+    throw new Error("Mattermost baseUrl is required");
+  }
+  return `${normalized}${CALLS_PLUGIN_API_PREFIX}/${path}`;
+}
+
+async function fetchCallsJson(params: {
+  abortSignal?: AbortSignal;
+  baseUrl: string;
+  botToken: string;
+  fetchImpl: MattermostFetch;
+  path: "config" | "turn-credentials";
+}): Promise<unknown> {
+  const url = buildCallsApiUrl(params.baseUrl, params.path);
+  const response = await params.fetchImpl(url, {
+    headers: { Authorization: `Bearer ${params.botToken}` },
+    signal: params.abortSignal,
+  });
+  if (!response.ok) {
+    const detail = await readMattermostError(response);
+    throw new Error(`Mattermost Calls ${params.path} failed (${response.status}): ${detail}`);
+  }
+  return await response.json();
+}
+
+async function resolveCallsIceServers(params: {
+  abortSignal?: AbortSignal;
+  baseUrl: string;
+  botToken: string;
+  fetchImpl: MattermostFetch;
+}): Promise<MattermostCallsIceServer[]> {
+  const config = CallsConfigSchema.parse(await fetchCallsJson({ ...params, path: "config" }));
+  const iceServers = [...(config.ICEServersConfigs ?? [])];
+  if (!config.NeedsTURNCredentials) {
+    return iceServers;
+  }
+  const turnCredentials = TurnCredentialsSchema.parse(
+    await fetchCallsJson({ ...params, path: "turn-credentials" }),
+  );
+  iceServers.push(...turnCredentials);
+  return iceServers;
+}
+
 export async function connectMattermostCall(params: {
+  baseUrl: string;
   wsUrl: string;
   botToken: string;
   channelId: string;
@@ -275,6 +347,7 @@ export async function connectMattermostCall(params: {
   abortSignal?: AbortSignal;
   webSocketFactory?: (url: string) => MattermostCallsWebSocket;
   rtc?: MattermostCallsRtcFactory;
+  fetchImpl?: MattermostFetch;
   decodeAudioFile?: (filePath: string) => Promise<Buffer>;
   now?: () => number;
   sleep?: (milliseconds: number) => Promise<void>;
@@ -285,6 +358,13 @@ export async function connectMattermostCall(params: {
   const now = params.now ?? Date.now;
   const sleep = params.sleep ?? delay;
   const decode = params.decodeAudioFile ?? decodeAudioFileToStereo48k;
+  const fetchImpl = params.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const iceServers = await resolveCallsIceServers({
+    abortSignal: params.abortSignal,
+    baseUrl: params.baseUrl,
+    botToken: params.botToken,
+    fetchImpl,
+  });
   const ws = (params.webSocketFactory ?? defaultWebSocketFactory)(params.wsUrl);
   const sinksBySession = new Map<string, MattermostCallsAudioSink[]>();
   const pendingTracksByMid = new Map<string, unknown[]>();
@@ -301,13 +381,17 @@ export async function connectMattermostCall(params: {
   let remoteDescriptionReady = false;
   let sessionResolved = false;
   let pingTimer: ReturnType<typeof setInterval> | undefined;
-  let removeAbortListener = () => undefined;
+  let removeAbortListener: () => void = () => undefined;
 
   let resolveSession: (session: MattermostVoiceCallSession) => void = () => undefined;
   let rejectSession: (error: Error) => void = () => undefined;
+  let resolveClosed: () => void = () => undefined;
   const sessionPromise = new Promise<MattermostVoiceCallSession>((resolve, reject) => {
     resolveSession = resolve;
     rejectSession = reject;
+  });
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
   });
 
   const reportError = (error: unknown) => {
@@ -430,6 +514,7 @@ export async function connectMattermostCall(params: {
     if (options.closeSocket) {
       ws.close();
     }
+    resolveClosed();
   };
 
   const close = async () => {
@@ -437,7 +522,8 @@ export async function connectMattermostCall(params: {
   };
 
   const play = async (audio: { audioPath: string }, options?: { signal?: AbortSignal }) => {
-    if (closed || !audioSource) {
+    const activeAudioSource = audioSource;
+    if (closed || !activeAudioSource) {
       throw new Error("Mattermost call is not connected");
     }
     const isAborted = () => options?.signal?.aborted ?? false;
@@ -463,7 +549,7 @@ export async function connectMattermostCall(params: {
       let targetTime = now();
       let sentPackets = 0;
       const writePacket = async (frame: Buffer) => {
-        audioSource.onData({
+        activeAudioSource.onData({
           samples: bufferToAudioSamples(frame),
           sampleRate: AUDIO_SAMPLE_RATE,
           bitsPerSample: 16,
@@ -508,7 +594,7 @@ export async function connectMattermostCall(params: {
     if (peer) {
       return;
     }
-    peer = rtc.createPeerConnection();
+    peer = rtc.createPeerConnection({ iceServers });
     audioSource = rtc.createAudioSource();
     audioTrack = audioSource.createTrack();
 
@@ -637,7 +723,7 @@ export async function connectMattermostCall(params: {
       joinedAt = now();
       debug("join acknowledged");
       sessionResolved = true;
-      resolveSession({ play, close });
+      resolveSession({ play, close, closed: closedPromise });
       return;
     }
     if (eventName === `${CALLS_PREFIX}signal`) {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -227,6 +227,43 @@ describe("mattermost websocket monitor", () => {
     expect(countMatching(patches, (patch) => patch.connected === false)).toBe(2);
   });
 
+  it("forwards Calls events before message-specific filtering", async () => {
+    const socket = new FakeWebSocket();
+    const onEvent = vi.fn(async () => undefined);
+    const onPosted = vi.fn(async () => undefined);
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime: testRuntime(),
+      nextSeq: () => 1,
+      onEvent,
+      onPosted,
+      webSocketFactory: () => socket,
+    });
+    const running = connectOnce();
+    socket.emitOpen();
+    socket.emitMessage(
+      Buffer.from(
+        JSON.stringify({
+          event: "custom_com.mattermost.calls_call_start",
+          data: { channelID: "dm-channel", id: "call-1" },
+          broadcast: { channel_id: "dm-channel" },
+        }),
+      ),
+    );
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1));
+
+    expect(onEvent).toHaveBeenCalledWith({
+      event: "custom_com.mattermost.calls_call_start",
+      data: { channelID: "dm-channel", id: "call-1" },
+      broadcast: { channel_id: "dm-channel" },
+    });
+    expect(onPosted).not.toHaveBeenCalled();
+
+    socket.emitClose(1000);
+    await running;
+  });
+
   it("accepts large valid post envelopes and rejects oversized websocket payloads", async () => {
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     await once(server, "listening");

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -23,6 +23,11 @@ export type MattermostEventPayload = {
     channel_type?: string;
     sender_name?: string;
     team_id?: string;
+    channelID?: string;
+    id?: string;
+    userID?: string;
+    user_id?: string;
+    session_id?: string;
   };
   broadcast?: {
     channel_id?: string;
@@ -67,6 +72,11 @@ const MattermostEventPayloadSchema = z.object({
       channel_type: z.string().optional(),
       sender_name: z.string().optional(),
       team_id: z.string().optional(),
+      channelID: z.string().optional(),
+      id: z.string().optional(),
+      userID: z.string().optional(),
+      user_id: z.string().optional(),
+      session_id: z.string().optional(),
     })
     .optional(),
   broadcast: z
@@ -107,6 +117,7 @@ type CreateMattermostConnectOnceOpts = {
   runtime: RuntimeEnv;
   nextSeq: () => number;
   onPosted: (rawEvent: string) => Promise<void>;
+  onEvent?: (payload: MattermostEventPayload) => Promise<void>;
   onReaction?: (payload: MattermostEventPayload) => Promise<void>;
   webSocketFactory?: MattermostWebSocketFactory;
   /**
@@ -342,6 +353,14 @@ export function createMattermostConnectOnce(
           const payload = parseMattermostEventPayload(raw);
           if (!payload) {
             return;
+          }
+
+          if (opts.onEvent) {
+            try {
+              await opts.onEvent(payload);
+            } catch (err) {
+              opts.runtime.error?.(`mattermost event handler failed: ${String(err)}`);
+            }
           }
 
           if (payload.event === "reaction_added" || payload.event === "reaction_removed") {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -1,6 +1,5 @@
 // Mattermost plugin module implements monitor websocket behavior.
 import { randomUUID } from "node:crypto";
-import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import {
   captureWsEvent,
   createDebugProxyWebSocketAgent,
@@ -89,14 +88,25 @@ const MattermostEventPayloadSchema = z.object({
 }) as z.ZodType<MattermostEventPayload>;
 
 export function parseMattermostEventPayload(raw: string): MattermostEventPayload | null {
-  return safeParseJsonWithSchema(MattermostEventPayloadSchema, raw);
+  try {
+    const result = MattermostEventPayloadSchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
 }
 
 export function parseMattermostPost(value: unknown): MattermostPost | null {
+  let candidate = value;
   if (typeof value === "string") {
-    return safeParseJsonWithSchema(MattermostPostSchema, value);
+    try {
+      candidate = JSON.parse(value);
+    } catch {
+      return null;
+    }
   }
-  return safeParseWithSchema(MattermostPostSchema, value);
+  const result = MattermostPostSchema.safeParse(candidate);
+  return result.success ? result.data : null;
 }
 
 class WebSocketClosedBeforeOpenError extends Error {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -130,6 +130,8 @@ import {
   hasMattermostThreadParticipationWithPersistence,
   recordMattermostThreadParticipation,
 } from "./thread-participation.js";
+import { processMattermostVoiceTurn } from "./voice-turn.js";
+import { createMattermostVoiceWorker } from "./voice-worker.js";
 
 type MonitorMattermostOpts = {
   botToken?: string;
@@ -148,6 +150,8 @@ type MattermostReaction = {
   emoji_name?: string;
   create_at?: number;
 };
+const MATTERMOST_VOICE_MAX_TURN_SAMPLES = 48_000 * 2 * 30;
+
 function normalizeInteractionSourceIps(values?: string[]): string[] {
   return normalizeTrimmedStringList(values);
 }
@@ -2030,6 +2034,95 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   });
 
   const wsUrl = buildMattermostWsUrl(baseUrl);
+  const resolveMattermostVoiceAccess = async (params: { channelId: string; userId: string }) => {
+    const [channelInfo, senderInfo] = await Promise.all([
+      resolveChannelInfo(params.channelId),
+      resolveUserInfo(params.userId),
+    ]);
+    if (channelInfo?.type?.toUpperCase() !== "D") {
+      return { allowed: false, channelInfo, reasonCode: "not_direct" };
+    }
+    const senderName = normalizeOptionalString(senderInfo?.username) ?? params.userId;
+    const access = await resolveMattermostMonitorInboundAccess({
+      account,
+      cfg,
+      senderId: params.userId,
+      senderName,
+      channelId: params.channelId,
+      kind: "direct",
+      groupPolicy,
+      readStoreAllowFrom: pairing.readAllowFromStore,
+      allowTextCommands: false,
+      hasControlCommand: false,
+      eventKind: "message",
+      mayPair: false,
+    });
+    return {
+      allowed: access.ingress.decision === "allow",
+      channelInfo,
+      reasonCode: access.senderAccess.reasonCode,
+    };
+  };
+  const voiceWorker = account.config.voice?.enabled
+    ? createMattermostVoiceWorker({
+        authorizeJoin: async ({ channelId, userId }) => {
+          const access = await resolveMattermostVoiceAccess({ channelId, userId });
+          if (!access.allowed) {
+            logVerboseMessage(
+              `mattermost voice: drop join speaker=${userId} channel=${channelId} reason=${access.reasonCode}`,
+            );
+          }
+          return access.allowed;
+        },
+        botUserId,
+        maxSpeechSamples: MATTERMOST_VOICE_MAX_TURN_SAMPLES,
+        preRollFrames: 150,
+        resolveChannelType: async (channelId) =>
+          (await resolveChannelInfo(channelId))?.type ?? undefined,
+        connect: async ({ channelId, callbacks }) => {
+          // Keep the native WebRTC dependency outside the normal Mattermost
+          // startup path when voice calls are disabled.
+          const { connectMattermostCall } = await import("./calls-client.js");
+          return await connectMattermostCall({
+            wsUrl,
+            botToken,
+            channelId,
+            callbacks,
+            abortSignal: opts.abortSignal,
+            onError: (message) => runtime.error?.(message),
+            onDebug: (message) => runtime.log?.(message),
+          });
+        },
+        processTurn: async ({ channelId, userId, samples }) => {
+          const access = await resolveMattermostVoiceAccess({ channelId, userId });
+          if (!access.allowed || !access.channelInfo) {
+            logVerboseMessage(
+              `mattermost voice: drop speaker=${userId} channel=${channelId} reason=${access.reasonCode}`,
+            );
+            return undefined;
+          }
+          const route = core.channel.routing.resolveAgentRoute({
+            cfg,
+            channel: "mattermost",
+            accountId: account.accountId,
+            teamId: access.channelInfo.team_id ?? undefined,
+            peer: { kind: "direct", id: userId },
+          });
+          return await processMattermostVoiceTurn({
+            accountId: account.accountId,
+            agentId: route.agentId,
+            cfg,
+            channelId,
+            runtime,
+            samples,
+            sessionKey: route.sessionKey,
+            userId,
+          });
+        },
+        onDebug: (message) => runtime.log?.(message),
+        onError: (message) => runtime.error?.(message),
+      })
+    : undefined;
   let seq = 1;
   const connectOnce = createMattermostConnectOnce({
     wsUrl,
@@ -2044,6 +2137,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       return me.update_at ?? 0;
     },
     onPosted: ingress.receive,
+    onEvent: voiceWorker ? async (payload) => await voiceWorker.handleEvent(payload) : undefined,
     onReaction: async (payload) => {
       await handleReactionEvent(payload);
     },
@@ -2095,6 +2189,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   } finally {
     await ingress.stop();
     unregisterInteractions?.();
+    await voiceWorker?.close();
   }
 
   const slashShutdownCleanupPromise = slashShutdownCleanup;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -130,10 +130,7 @@ import {
   hasMattermostThreadParticipationWithPersistence,
   recordMattermostThreadParticipation,
 } from "./thread-participation.js";
-import {
-  generateMattermostVoiceReply,
-  transcribeMattermostVoiceTurn,
-} from "./voice-turn.js";
+import { generateMattermostVoiceReply, transcribeMattermostVoiceTurn } from "./voice-turn.js";
 import { createMattermostVoiceWorker } from "./voice-worker.js";
 
 type MonitorMattermostOpts = {
@@ -2087,11 +2084,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           // startup path when voice calls are disabled.
           const { connectMattermostCall } = await import("./calls-client.js");
           return await connectMattermostCall({
+            baseUrl,
             wsUrl,
             botToken,
             channelId,
             callbacks,
             abortSignal: opts.abortSignal,
+            fetchImpl: client.fetchImpl,
             onError: (message) => runtime.error?.(message),
             onDebug: (message) => runtime.log?.(message),
           });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -130,7 +130,10 @@ import {
   hasMattermostThreadParticipationWithPersistence,
   recordMattermostThreadParticipation,
 } from "./thread-participation.js";
-import { processMattermostVoiceTurn } from "./voice-turn.js";
+import {
+  generateMattermostVoiceReply,
+  transcribeMattermostVoiceTurn,
+} from "./voice-turn.js";
 import { createMattermostVoiceWorker } from "./voice-worker.js";
 
 type MonitorMattermostOpts = {
@@ -2093,7 +2096,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             onDebug: (message) => runtime.log?.(message),
           });
         },
-        processTurn: async ({ channelId, userId, samples }) => {
+        transcribeTurn: async ({ channelId, userId, samples }) => {
           const access = await resolveMattermostVoiceAccess({ channelId, userId });
           if (!access.allowed || !access.channelInfo) {
             logVerboseMessage(
@@ -2108,13 +2111,35 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             teamId: access.channelInfo.team_id ?? undefined,
             peer: { kind: "direct", id: userId },
           });
-          return await processMattermostVoiceTurn({
-            accountId: account.accountId,
+          return await transcribeMattermostVoiceTurn({
             agentId: route.agentId,
             cfg,
-            channelId,
-            runtime,
             samples,
+          });
+        },
+        processTurn: async ({ abortSignal, channelId, message, userId }) => {
+          const access = await resolveMattermostVoiceAccess({ channelId, userId });
+          if (!access.allowed || !access.channelInfo) {
+            logVerboseMessage(
+              `mattermost voice: drop speaker=${userId} channel=${channelId} reason=${access.reasonCode}`,
+            );
+            return undefined;
+          }
+          const route = core.channel.routing.resolveAgentRoute({
+            cfg,
+            channel: "mattermost",
+            accountId: account.accountId,
+            teamId: access.channelInfo.team_id ?? undefined,
+            peer: { kind: "direct", id: userId },
+          });
+          return await generateMattermostVoiceReply({
+            accountId: account.accountId,
+            agentId: route.agentId,
+            abortSignal,
+            cfg,
+            channelId,
+            message,
+            runtime,
             sessionKey: route.sessionKey,
             userId,
           });

--- a/extensions/mattermost/src/mattermost/voice-audio-ffmpeg.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-audio-ffmpeg.test.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  resolveFfmpegBin: () => "/mock/ffmpeg",
+}));
+
+describe("Mattermost voice ffmpeg audio decode", () => {
+  it("falls back to ffmpeg for non-PCM-WAV files", async () => {
+    const { decodeAudioFileToStereo48k } = await import("./voice-audio.js");
+    const pcm = Buffer.alloc(48_000 * 2 * 2);
+    spawnMock.mockImplementationOnce((_command: string, _args: string[]) => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough;
+        stderr: PassThrough;
+      };
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      process.nextTick(() => {
+        child.stdout.emit("data", pcm);
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), "mattermost-voice-audio-"));
+    try {
+      const audioPath = join(dir, "reply.mp3");
+      writeFileSync(audioPath, Buffer.from("not a pcm wav"));
+
+      await expect(decodeAudioFileToStereo48k(audioPath)).resolves.toHaveLength(pcm.length);
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "/mock/ffmpeg",
+        expect.arrayContaining(["-f", "s16le", "-ar", "48000", "-ac", "2", "pipe:1"]),
+        expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/mattermost/src/mattermost/voice-audio.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-audio.test.ts
@@ -24,19 +24,6 @@ describe("Mattermost voice audio", () => {
     expect(capture.stop()).toHaveLength(0);
   });
 
-  it("does not capture the bot's own playback", () => {
-    const capture = createVoiceCapture({ maxSpeechSamples: 100, preRollFrames: 2 });
-
-    capture.push(frame(1));
-    capture.setSuppressed(true);
-    capture.start();
-    capture.push(frame(2));
-    capture.setSuppressed(false);
-    capture.push(frame(3));
-
-    expect(Array.from(capture.stop())).toEqual([3, 3]);
-  });
-
   it("keeps the current utterance when speaking-on is repeated", () => {
     const capture = createVoiceCapture({ maxSpeechSamples: 100, preRollFrames: 2 });
 

--- a/extensions/mattermost/src/mattermost/voice-audio.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-audio.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMonoWav,
+  createVoiceCapture,
+  decodePcmWavToStereo48k,
+  downsampleStereo48kToMono16k,
+} from "./voice-audio.js";
+
+function frame(value: number): Int16Array {
+  return new Int16Array([value, value]);
+}
+
+describe("Mattermost voice audio", () => {
+  it("includes bounded pre-roll when speech starts", () => {
+    const capture = createVoiceCapture({ maxSpeechSamples: 100, preRollFrames: 2 });
+
+    capture.push(frame(1));
+    capture.push(frame(2));
+    capture.push(frame(3));
+    capture.start();
+    capture.push(frame(4));
+
+    expect(Array.from(capture.stop())).toEqual([2, 2, 3, 3, 4, 4]);
+    expect(capture.stop()).toHaveLength(0);
+  });
+
+  it("does not capture the bot's own playback", () => {
+    const capture = createVoiceCapture({ maxSpeechSamples: 100, preRollFrames: 2 });
+
+    capture.push(frame(1));
+    capture.setSuppressed(true);
+    capture.start();
+    capture.push(frame(2));
+    capture.setSuppressed(false);
+    capture.push(frame(3));
+
+    expect(Array.from(capture.stop())).toEqual([3, 3]);
+  });
+
+  it("keeps the current utterance when speaking-on is repeated", () => {
+    const capture = createVoiceCapture({ maxSpeechSamples: 100, preRollFrames: 2 });
+
+    capture.push(frame(1));
+    capture.start();
+    capture.push(frame(2));
+    capture.start();
+    capture.push(frame(3));
+
+    expect(Array.from(capture.stop())).toEqual([1, 1, 2, 2, 3, 3]);
+  });
+
+  it("bounds captured speech samples while voice activity remains active", () => {
+    const capture = createVoiceCapture({ maxSpeechSamples: 4, preRollFrames: 1 });
+
+    capture.push(frame(1));
+    capture.start();
+    capture.push(frame(2));
+    capture.push(frame(3));
+
+    expect(Array.from(capture.stop())).toEqual([1, 1, 2, 2]);
+  });
+
+  it("downsamples 48 kHz stereo PCM to 16 kHz mono", () => {
+    const stereo = new Int16Array([
+      900, 1_100, 1_900, 2_100, 2_900, 3_100, 3_900, 4_100, 4_900, 5_100, 5_900, 6_100,
+    ]);
+
+    expect(Array.from(downsampleStereo48kToMono16k(stereo))).toEqual([2_000, 5_000]);
+  });
+
+  it("builds a valid 16-bit mono WAV", () => {
+    const wav = buildMonoWav(new Int16Array([1, -2]), 16_000);
+
+    expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
+    expect(wav.toString("ascii", 8, 12)).toBe("WAVE");
+    expect(wav.readUInt16LE(22)).toBe(1);
+    expect(wav.readUInt32LE(24)).toBe(16_000);
+    expect(wav.readUInt16LE(34)).toBe(16);
+    expect(wav.readUInt32LE(40)).toBe(4);
+    expect(wav.readInt16LE(44)).toBe(1);
+    expect(wav.readInt16LE(46)).toBe(-2);
+  });
+
+  it("decodes and resamples PCM WAV replies for WebRTC playback", () => {
+    const source = new Int16Array(441).fill(1_234);
+    const decoded = decodePcmWavToStereo48k(buildMonoWav(source, 44_100));
+
+    expect(decoded).toHaveLength(480 * 2 * 2);
+    expect(decoded?.readInt16LE(0)).toBe(1_234);
+    expect(decoded?.readInt16LE(2)).toBe(1_234);
+    expect(decoded?.readInt16LE((480 - 1) * 4)).toBe(1_234);
+  });
+});

--- a/extensions/mattermost/src/mattermost/voice-audio.ts
+++ b/extensions/mattermost/src/mattermost/voice-audio.ts
@@ -8,10 +8,10 @@ const AUDIO_CHANNELS = 2;
 const FFMPEG_ERROR_BYTES = 8_192;
 
 type VoiceCapture = {
+  clearInactivePreRoll: () => void;
   push: (frame: Int16Array) => void;
-  start: () => void;
+  start: () => boolean;
   stop: () => Int16Array;
-  setSuppressed: (suppressed: boolean) => void;
 };
 
 function joinFrames(frames: readonly Int16Array[]): Int16Array {
@@ -33,11 +33,15 @@ export function createVoiceCapture(params: {
   let speech: Int16Array[] = [];
   let speechSamples = 0;
   let active = false;
-  let suppressed = false;
 
   return {
+    clearInactivePreRoll() {
+      if (!active) {
+        preRoll.length = 0;
+      }
+    },
     push(frame) {
-      if (suppressed || frame.length === 0) {
+      if (frame.length === 0) {
         return;
       }
       const copy = Int16Array.from(frame);
@@ -58,15 +62,16 @@ export function createVoiceCapture(params: {
     },
     start() {
       if (active) {
-        return;
+        return false;
       }
       active = true;
-      speech = suppressed ? [] : preRoll.splice(0);
+      speech = preRoll.splice(0);
       speechSamples = speech.reduce((total, frame) => total + frame.length, 0);
       while (speechSamples > params.maxSpeechSamples) {
         const removed = speech.shift();
         speechSamples -= removed?.length ?? 0;
       }
+      return true;
     },
     stop() {
       if (!active) {
@@ -77,14 +82,6 @@ export function createVoiceCapture(params: {
       speech = [];
       speechSamples = 0;
       return audio;
-    },
-    setSuppressed(nextSuppressed) {
-      suppressed = nextSuppressed;
-      if (suppressed) {
-        preRoll.length = 0;
-        speech = [];
-        speechSamples = 0;
-      }
     },
   };
 }

--- a/extensions/mattermost/src/mattermost/voice-audio.ts
+++ b/extensions/mattermost/src/mattermost/voice-audio.ts
@@ -1,0 +1,242 @@
+// Mattermost plugin module implements PCM capture and STT audio preparation.
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
+
+const AUDIO_SAMPLE_RATE = 48_000;
+const AUDIO_CHANNELS = 2;
+const FFMPEG_ERROR_BYTES = 8_192;
+
+type VoiceCapture = {
+  push: (frame: Int16Array) => void;
+  start: () => void;
+  stop: () => Int16Array;
+  setSuppressed: (suppressed: boolean) => void;
+};
+
+function joinFrames(frames: readonly Int16Array[]): Int16Array {
+  const length = frames.reduce((total, frame) => total + frame.length, 0);
+  const joined = new Int16Array(length);
+  let offset = 0;
+  for (const frame of frames) {
+    joined.set(frame, offset);
+    offset += frame.length;
+  }
+  return joined;
+}
+
+export function createVoiceCapture(params: {
+  maxSpeechSamples: number;
+  preRollFrames: number;
+}): VoiceCapture {
+  const preRoll: Int16Array[] = [];
+  let speech: Int16Array[] = [];
+  let speechSamples = 0;
+  let active = false;
+  let suppressed = false;
+
+  return {
+    push(frame) {
+      if (suppressed || frame.length === 0) {
+        return;
+      }
+      const copy = Int16Array.from(frame);
+      if (active) {
+        const remainingSamples = params.maxSpeechSamples - speechSamples;
+        if (remainingSamples <= 0) {
+          return;
+        }
+        const bounded = copy.length > remainingSamples ? copy.slice(0, remainingSamples) : copy;
+        speech.push(bounded);
+        speechSamples += bounded.length;
+        return;
+      }
+      preRoll.push(copy);
+      if (preRoll.length > params.preRollFrames) {
+        preRoll.shift();
+      }
+    },
+    start() {
+      if (active) {
+        return;
+      }
+      active = true;
+      speech = suppressed ? [] : preRoll.splice(0);
+      speechSamples = speech.reduce((total, frame) => total + frame.length, 0);
+      while (speechSamples > params.maxSpeechSamples) {
+        const removed = speech.shift();
+        speechSamples -= removed?.length ?? 0;
+      }
+    },
+    stop() {
+      if (!active) {
+        return new Int16Array();
+      }
+      active = false;
+      const audio = joinFrames(speech);
+      speech = [];
+      speechSamples = 0;
+      return audio;
+    },
+    setSuppressed(nextSuppressed) {
+      suppressed = nextSuppressed;
+      if (suppressed) {
+        preRoll.length = 0;
+        speech = [];
+        speechSamples = 0;
+      }
+    },
+  };
+}
+
+export function downsampleStereo48kToMono16k(stereo: Int16Array): Int16Array {
+  const outputFrames = Math.floor(stereo.length / 6);
+  const mono = new Int16Array(outputFrames);
+  for (let outputIndex = 0; outputIndex < outputFrames; outputIndex += 1) {
+    const inputOffset = outputIndex * 6;
+    let sum = 0;
+    for (let sampleIndex = 0; sampleIndex < 6; sampleIndex += 1) {
+      sum += stereo[inputOffset + sampleIndex] ?? 0;
+    }
+    mono[outputIndex] = Math.round(sum / 6);
+  }
+  return mono;
+}
+
+export function buildMonoWav(pcm: Int16Array, sampleRate: number): Buffer {
+  const dataBytes = pcm.length * 2;
+  const wav = Buffer.alloc(44 + dataBytes);
+  wav.write("RIFF", 0);
+  wav.writeUInt32LE(36 + dataBytes, 4);
+  wav.write("WAVE", 8);
+  wav.write("fmt ", 12);
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(sampleRate, 24);
+  wav.writeUInt32LE(sampleRate * 2, 28);
+  wav.writeUInt16LE(2, 32);
+  wav.writeUInt16LE(16, 34);
+  wav.write("data", 36);
+  wav.writeUInt32LE(dataBytes, 40);
+  for (let index = 0; index < pcm.length; index += 1) {
+    wav.writeInt16LE(pcm[index] ?? 0, 44 + index * 2);
+  }
+  return wav;
+}
+
+export function decodePcmWavToStereo48k(wav: Buffer): Buffer | undefined {
+  if (
+    wav.length < 12 ||
+    wav.toString("ascii", 0, 4) !== "RIFF" ||
+    wav.toString("ascii", 8, 12) !== "WAVE"
+  ) {
+    return undefined;
+  }
+
+  let channels: number | undefined;
+  let sampleRate: number | undefined;
+  let bitsPerSample: number | undefined;
+  let audioFormat: number | undefined;
+  let dataStart: number | undefined;
+  let dataBytes: number | undefined;
+  for (let offset = 12; offset + 8 <= wav.length; ) {
+    const chunkId = wav.toString("ascii", offset, offset + 4);
+    const chunkSize = wav.readUInt32LE(offset + 4);
+    const chunkStart = offset + 8;
+    const availableBytes = Math.max(0, Math.min(chunkSize, wav.length - chunkStart));
+    if (chunkId === "fmt " && availableBytes >= 16) {
+      audioFormat = wav.readUInt16LE(chunkStart);
+      channels = wav.readUInt16LE(chunkStart + 2);
+      sampleRate = wav.readUInt32LE(chunkStart + 4);
+      bitsPerSample = wav.readUInt16LE(chunkStart + 14);
+    } else if (chunkId === "data") {
+      dataStart = chunkStart;
+      dataBytes = availableBytes;
+    }
+    offset = chunkStart + chunkSize + (chunkSize % 2);
+  }
+
+  if (
+    audioFormat !== 1 ||
+    bitsPerSample !== 16 ||
+    !channels ||
+    !sampleRate ||
+    dataStart === undefined ||
+    dataBytes === undefined
+  ) {
+    return undefined;
+  }
+  const inputFrames = Math.floor(dataBytes / (channels * 2));
+  if (inputFrames === 0) {
+    return Buffer.alloc(0);
+  }
+
+  const outputFrames = Math.max(1, Math.round((inputFrames * 48_000) / sampleRate));
+  const stereo = Buffer.alloc(outputFrames * 4);
+  const readSample = (frame: number, channel: number) =>
+    wav.readInt16LE(dataStart + (frame * channels + Math.min(channel, channels - 1)) * 2);
+  for (let outputFrame = 0; outputFrame < outputFrames; outputFrame += 1) {
+    const sourcePosition = (outputFrame * sampleRate) / 48_000;
+    const firstFrame = Math.min(Math.floor(sourcePosition), inputFrames - 1);
+    const secondFrame = Math.min(firstFrame + 1, inputFrames - 1);
+    const fraction = sourcePosition - firstFrame;
+    for (let channel = 0; channel < 2; channel += 1) {
+      const first = readSample(firstFrame, channel);
+      const second = readSample(secondFrame, channel);
+      stereo.writeInt16LE(
+        Math.round(first + (second - first) * fraction),
+        outputFrame * 4 + channel * 2,
+      );
+    }
+  }
+  return stereo;
+}
+
+export async function decodeAudioFileToStereo48k(filePath: string): Promise<Buffer> {
+  const wav = decodePcmWavToStereo48k(await readFile(filePath));
+  if (wav) {
+    return wav;
+  }
+  return await new Promise<Buffer>((resolve, reject) => {
+    const child = spawn(
+      resolveFfmpegBin(),
+      [
+        "-i",
+        filePath,
+        "-analyzeduration",
+        "0",
+        "-loglevel",
+        "error",
+        "-vn",
+        "-sn",
+        "-dn",
+        "-f",
+        "s16le",
+        "-ar",
+        String(AUDIO_SAMPLE_RATE),
+        "-ac",
+        String(AUDIO_CHANNELS),
+        "pipe:1",
+      ],
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
+    );
+    const chunks: Buffer[] = [];
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(0, FFMPEG_ERROR_BYTES);
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve(Buffer.concat(chunks));
+        return;
+      }
+      const status = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+      const detail = stderr.trim() ? `: ${stderr.trim()}` : "";
+      reject(new Error(`ffmpeg exited with ${status}${detail}`));
+    });
+  });
+}

--- a/extensions/mattermost/src/mattermost/voice-turn.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-turn.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
 import { buildMonoWav } from "./voice-audio.js";
-import { processMattermostVoiceTurn } from "./voice-turn.js";
+import { generateMattermostVoiceReply, processMattermostVoiceTurn } from "./voice-turn.js";
 
 const cfg = {} as OpenClawConfig;
 const runtime = {} as RuntimeEnv;
@@ -63,6 +63,65 @@ describe("Mattermost voice turn", () => {
       text: "It is half past three.",
     });
     expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("passes abort signals to hidden agent voice turns", async () => {
+    const controller = new AbortController();
+    const runAgent = vi.fn(async () => ({ payloads: [{ text: "Sure." }] }));
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    await generateMattermostVoiceReply(
+      {
+        accountId: "default",
+        agentId: "main",
+        abortSignal: controller.signal,
+        cfg,
+        channelId: "dm-channel",
+        message: "hello",
+        runtime,
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        runAgent,
+        synthesize,
+      },
+    );
+
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: controller.signal,
+        message: "hello",
+      }),
+      runtime,
+    );
+  });
+
+  it("does not synthesize an error reply when the hidden agent voice turn is aborted", async () => {
+    const controller = new AbortController();
+    const synthesize = vi.fn();
+    const result = await generateMattermostVoiceReply(
+      {
+        accountId: "default",
+        agentId: "main",
+        abortSignal: controller.signal,
+        cfg,
+        channelId: "dm-channel",
+        message: "hello",
+        runtime,
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        runAgent: async () => {
+          controller.abort();
+          throw new Error("aborted");
+        },
+        synthesize,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(synthesize).not.toHaveBeenCalled();
   });
 
   it("strips markdown formatting before synthesizing voice replies", async () => {

--- a/extensions/mattermost/src/mattermost/voice-turn.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-turn.test.ts
@@ -1,0 +1,352 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
+import { buildMonoWav } from "./voice-audio.js";
+import { processMattermostVoiceTurn } from "./voice-turn.js";
+
+const cfg = {} as OpenClawConfig;
+const runtime = {} as RuntimeEnv;
+
+describe("Mattermost voice turn", () => {
+  it("runs STT and a hidden agent turn before synthesizing the reply", async () => {
+    const transcribe = vi.fn(async () => "what time is it");
+    const runAgent = vi.fn(async () => ({ payloads: [{ text: "It is half past three." }] }));
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1, 2, 2, 3, 3]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe,
+        runAgent,
+        synthesize,
+      },
+    );
+
+    expect(transcribe).toHaveBeenCalledWith({
+      agentId: "main",
+      cfg,
+      filePath: "/tmp/input.wav",
+    });
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        agentId: "main",
+        allowModelOverride: false,
+        deliver: false,
+        message: "what time is it",
+        messageChannel: "mattermost",
+        messageProvider: "mattermost-voice",
+        sessionKey: "agent:main:main",
+        transcriptMessage: "what time is it",
+        runContext: expect.objectContaining({
+          chatId: "dm-channel",
+          currentChannelId: "dm-channel",
+          currentInboundAudio: true,
+          senderId: "human-user",
+        }),
+      }),
+      runtime,
+    );
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "It is half past three.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("strips markdown formatting before synthesizing voice replies", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "tell me a pineapple fact",
+        runAgent: async () => ({
+          payloads: [
+            {
+              text: [
+                "## Pineapple fact",
+                "",
+                "- **Pineapples** are [berries](https://example.com).",
+                "- They use `CAM` photosynthesis.",
+                "",
+                "> That is *wild*.",
+              ].join("\n"),
+            },
+          ],
+        }),
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "Pineapple fact\nPineapples are berries.\nThey use CAM photosynthesis.\nThat is wild.",
+    });
+  });
+
+  it("stops when STT returns no text", async () => {
+    const runAgent = vi.fn();
+    const synthesize = vi.fn();
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "  ",
+        runAgent,
+        synthesize,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+
+  it("does not synthesize an empty agent response", async () => {
+    const synthesize = vi.fn();
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "hello",
+        runAgent: async () => ({ payloads: [{ text: " " }] }),
+        synthesize,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+
+  it("speaks one fixed error when the agent turn fails before producing content", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "hello",
+        runAgent: async () => ({
+          payloads: [
+            { text: "[assistant turn failed before producing content]" },
+            {
+              text: [
+                "[assistant turn failed before producing content]",
+                "[assistant turn failed before producing content]",
+              ].join("\n"),
+            },
+          ],
+        }),
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "There was an error processing your request. Check the logs for more information.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("speaks one fixed error when the agent result has an error payload", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "hello",
+        runAgent: async () => ({
+          payloads: [{ text: "LLM request failed.", isError: true }],
+        }),
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "There was an error processing your request. Check the logs for more information.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("speaks one fixed error when the agent result has run-level error metadata", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "hello",
+        runAgent: async () => ({
+          payloads: [{ text: "Low level provider error." }],
+          meta: { error: { kind: "provider_failure" } },
+        }),
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "There was an error processing your request. Check the logs for more information.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("speaks one fixed error when the agent turn rejects", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "hello",
+        runAgent: async () => {
+          throw new Error("provider rejected");
+        },
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "There was an error processing your request. Check the logs for more information.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("does not treat successful replies that mention the legacy error marker as failures", async () => {
+    const synthesize = vi.fn(async () => ({ success: true, audioPath: "/tmp/reply.mp3" }));
+    const result = await processMattermostVoiceTurn(
+      {
+        accountId: "default",
+        agentId: "main",
+        cfg,
+        channelId: "dm-channel",
+        runtime,
+        samples: new Int16Array([1, 1]),
+        sessionKey: "agent:main:main",
+        userId: "human-user",
+      },
+      {
+        withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+        transcribe: async () => "what was the error",
+        runAgent: async () => ({
+          payloads: [
+            {
+              text: "The marker [assistant turn failed before producing content] means the previous turn failed.",
+            },
+          ],
+        }),
+        synthesize,
+      },
+    );
+
+    expect(synthesize).toHaveBeenCalledWith({
+      cfg,
+      text: "The marker [assistant turn failed before producing content] means the previous turn failed.",
+    });
+    expect(result).toEqual({ audioPath: "/tmp/reply.mp3" });
+  });
+
+  it("returns synthesized WAV duration for playback timeout budgeting", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mattermost-voice-turn-"));
+    try {
+      const audioPath = join(dir, "reply.wav");
+      writeFileSync(audioPath, buildMonoWav(new Int16Array(16_000), 16_000));
+      const result = await processMattermostVoiceTurn(
+        {
+          accountId: "default",
+          agentId: "main",
+          cfg,
+          channelId: "dm-channel",
+          runtime,
+          samples: new Int16Array([1, 1]),
+          sessionKey: "agent:main:main",
+          userId: "human-user",
+        },
+        {
+          withAudioFile: async (_samples, run) => await run("/tmp/input.wav"),
+          transcribe: async () => "hello",
+          runAgent: async () => ({ payloads: [{ text: "hello back" }] }),
+          synthesize: async () => ({ success: true, audioPath }),
+        },
+      );
+
+      expect(result).toEqual({ audioPath, durationMilliseconds: 1000 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/mattermost/src/mattermost/voice-turn.ts
+++ b/extensions/mattermost/src/mattermost/voice-turn.ts
@@ -1,0 +1,219 @@
+// Mattermost plugin module implements STT, hidden agent turns, and TTS for calls.
+import { agentCommandFromIngress, resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { getMattermostRuntime } from "../runtime.js";
+import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
+import {
+  buildMonoWav,
+  decodeAudioFileToStereo48k,
+  downsampleStereo48kToMono16k,
+} from "./voice-audio.js";
+import type { MattermostVoiceReplyAudio } from "./voice-worker.js";
+
+const MATTERMOST_VOICE_SYSTEM_PROMPT =
+  "This is a live voice conversation. Reply naturally and concisely for spoken playback. Do not mention transcription or send a separate chat message.";
+const MATTERMOST_VOICE_AGENT_ERROR_TEXT =
+  "There was an error processing your request. Check the logs for more information.";
+const ASSISTANT_TURN_FAILED_BEFORE_CONTENT = "[assistant turn failed before producing content]";
+
+type AgentTurnResult = {
+  payloads?: Array<{ text?: string; isError?: boolean }>;
+  meta?: { error?: unknown };
+};
+
+type VoiceTurnDependencies = {
+  withAudioFile: <T>(samples: Int16Array, run: (filePath: string) => Promise<T>) => Promise<T>;
+  transcribe: (params: {
+    agentId: string;
+    cfg: OpenClawConfig;
+    filePath: string;
+  }) => Promise<string | undefined>;
+  runAgent: (
+    options: Parameters<typeof agentCommandFromIngress>[0],
+    runtime: RuntimeEnv,
+  ) => Promise<AgentTurnResult | undefined>;
+  synthesize: (params: {
+    cfg: OpenClawConfig;
+    text: string;
+  }) => Promise<{ success: boolean; audioPath?: string; error?: string }>;
+};
+
+async function withMattermostVoiceAudioFile<T>(
+  samples: Int16Array,
+  run: (filePath: string) => Promise<T>,
+): Promise<T> {
+  const workspace = await tempWorkspace({
+    rootDir: resolvePreferredOpenClawTmpDir(),
+    prefix: "mattermost-voice-",
+  });
+  try {
+    const mono = downsampleStereo48kToMono16k(samples);
+    const filePath = await workspace.write("segment.wav", buildMonoWav(mono, 16_000));
+    return await run(filePath);
+  } finally {
+    await workspace.cleanup();
+  }
+}
+
+function stripMattermostVoiceTtsMarkdown(text: string): string {
+  return stripMarkdown(
+    text
+      .replace(/!\[([^\]]*)]\([^)]+\)/g, "$1")
+      .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+      .replace(/^```[^\n]*\n?/gm, "")
+      .replace(/^```\s*$/gm, ""),
+  )
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+[.)]\s+/gm, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
+function containsOnlyLegacyAssistantFailureText(payloads: Array<{ text?: string }>): boolean {
+  const texts = payloads
+    .map((payload) => normalizeOptionalString(payload.text))
+    .filter((text): text is string => Boolean(text));
+  return (
+    texts.length > 0 &&
+    texts.every((text) =>
+      text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .every((line) => line === ASSISTANT_TURN_FAILED_BEFORE_CONTENT),
+    )
+  );
+}
+
+function selectMattermostVoiceReplyText(result: AgentTurnResult | undefined): string {
+  const payloads = result?.payloads ?? [];
+  if (
+    result?.meta?.error != null ||
+    payloads.some((payload) => payload.isError === true) ||
+    containsOnlyLegacyAssistantFailureText(payloads)
+  ) {
+    return MATTERMOST_VOICE_AGENT_ERROR_TEXT;
+  }
+  return payloads
+    .map((payload) => normalizeOptionalString(payload.text))
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+}
+
+async function resolveMattermostVoiceAudioDurationMilliseconds(
+  audioPath: string,
+): Promise<number | undefined> {
+  try {
+    const pcm = await decodeAudioFileToStereo48k(audioPath);
+    if (pcm.length === 0) {
+      return undefined;
+    }
+    return Math.ceil((pcm.length / 4 / 48_000) * 1_000);
+  } catch {
+    return undefined;
+  }
+}
+
+const defaultDependencies: VoiceTurnDependencies = {
+  withAudioFile: withMattermostVoiceAudioFile,
+  async transcribe({ agentId, cfg, filePath }) {
+    const result = await getMattermostRuntime().mediaUnderstanding.transcribeAudioFile({
+      filePath,
+      cfg,
+      agentDir: resolveAgentDir(cfg, agentId),
+      mime: "audio/wav",
+    });
+    return normalizeOptionalString(result.text);
+  },
+  runAgent: agentCommandFromIngress,
+  async synthesize({ cfg, text }) {
+    return await getMattermostRuntime().tts.textToSpeech({
+      text,
+      cfg,
+      channel: "mattermost",
+    });
+  },
+};
+
+export async function processMattermostVoiceTurn(
+  params: {
+    accountId: string;
+    agentId: string;
+    cfg: OpenClawConfig;
+    channelId: string;
+    runtime: RuntimeEnv;
+    samples: Int16Array;
+    sessionKey: string;
+    userId: string;
+  },
+  dependencies: VoiceTurnDependencies = defaultDependencies,
+): Promise<MattermostVoiceReplyAudio | undefined> {
+  const transcript = await dependencies.withAudioFile(
+    params.samples,
+    async (filePath) =>
+      await dependencies.transcribe({
+        agentId: params.agentId,
+        cfg: params.cfg,
+        filePath,
+      }),
+  );
+  const message = normalizeOptionalString(transcript);
+  if (!message) {
+    return undefined;
+  }
+
+  let result: AgentTurnResult | undefined;
+  try {
+    result = await dependencies.runAgent(
+      {
+        accountId: params.accountId,
+        agentId: params.agentId,
+        allowModelOverride: false,
+        deliver: false,
+        disableMessageTool: true,
+        extraSystemPrompt: MATTERMOST_VOICE_SYSTEM_PROMPT,
+        message,
+        messageChannel: "mattermost",
+        messageProvider: "mattermost-voice",
+        runContext: {
+          accountId: params.accountId,
+          chatId: params.channelId,
+          currentChannelId: params.channelId,
+          currentInboundAudio: true,
+          messageChannel: "mattermost",
+          senderId: params.userId,
+        },
+        sessionKey: params.sessionKey,
+        transcriptMessage: message,
+      },
+      params.runtime,
+    );
+  } catch (error) {
+    params.runtime.error?.(`mattermost voice agent turn failed: ${String(error)}`);
+    result = { meta: { error } };
+  }
+  const replyText = selectMattermostVoiceReplyText(result);
+  if (!replyText) {
+    return undefined;
+  }
+
+  const spokenText = normalizeOptionalString(stripMattermostVoiceTtsMarkdown(replyText));
+  if (!spokenText) {
+    return undefined;
+  }
+
+  const speech = await dependencies.synthesize({ cfg: params.cfg, text: spokenText });
+  if (!speech.success || !speech.audioPath) {
+    throw new Error(`Mattermost voice TTS failed: ${speech.error ?? "no audio returned"}`);
+  }
+  const durationMilliseconds = await resolveMattermostVoiceAudioDurationMilliseconds(
+    speech.audioPath,
+  );
+  return {
+    audioPath: speech.audioPath,
+    ...(durationMilliseconds === undefined ? {} : { durationMilliseconds }),
+  };
+}

--- a/extensions/mattermost/src/mattermost/voice-turn.ts
+++ b/extensions/mattermost/src/mattermost/voice-turn.ts
@@ -145,26 +145,87 @@ export async function processMattermostVoiceTurn(
     cfg: OpenClawConfig;
     channelId: string;
     runtime: RuntimeEnv;
+    abortSignal?: AbortSignal;
+    message?: string;
     samples: Int16Array;
     sessionKey: string;
     userId: string;
   },
   dependencies: VoiceTurnDependencies = defaultDependencies,
 ): Promise<MattermostVoiceReplyAudio | undefined> {
-  const transcript = await dependencies.withAudioFile(
-    params.samples,
-    async (filePath) =>
-      await dependencies.transcribe({
-        agentId: params.agentId,
-        cfg: params.cfg,
-        filePath,
-      }),
+  const message = normalizeOptionalString(
+    params.message ??
+      (await transcribeMattermostVoiceTurn(
+        {
+          agentId: params.agentId,
+          cfg: params.cfg,
+          samples: params.samples,
+        },
+        dependencies,
+      )),
   );
-  const message = normalizeOptionalString(transcript);
   if (!message) {
     return undefined;
   }
 
+  return await generateMattermostVoiceReply(
+    {
+      accountId: params.accountId,
+      agentId: params.agentId,
+      abortSignal: params.abortSignal,
+      cfg: params.cfg,
+      channelId: params.channelId,
+      message,
+      runtime: params.runtime,
+      sessionKey: params.sessionKey,
+      userId: params.userId,
+    },
+    dependencies,
+  );
+}
+
+export async function transcribeMattermostVoiceTurn(
+  params: {
+    agentId: string;
+    cfg: OpenClawConfig;
+    samples: Int16Array;
+  },
+  dependencies: Pick<VoiceTurnDependencies, "withAudioFile" | "transcribe"> = defaultDependencies,
+): Promise<string | undefined> {
+  return normalizeOptionalString(
+    await dependencies.withAudioFile(
+      params.samples,
+      async (filePath) =>
+        await dependencies.transcribe({
+          agentId: params.agentId,
+          cfg: params.cfg,
+          filePath,
+        }),
+    ),
+  );
+}
+
+export async function generateMattermostVoiceReply(
+  params: {
+    accountId: string;
+    agentId: string;
+    abortSignal?: AbortSignal;
+    cfg: OpenClawConfig;
+    channelId: string;
+    message: string;
+    runtime: RuntimeEnv;
+    sessionKey: string;
+    userId: string;
+  },
+  dependencies: Pick<VoiceTurnDependencies, "runAgent" | "synthesize"> = defaultDependencies,
+): Promise<MattermostVoiceReplyAudio | undefined> {
+  const message = normalizeOptionalString(params.message);
+  if (!message) {
+    return undefined;
+  }
+  if (params.abortSignal?.aborted) {
+    return undefined;
+  }
   let result: AgentTurnResult | undefined;
   try {
     result = await dependencies.runAgent(
@@ -172,6 +233,7 @@ export async function processMattermostVoiceTurn(
         accountId: params.accountId,
         agentId: params.agentId,
         allowModelOverride: false,
+        abortSignal: params.abortSignal,
         deliver: false,
         disableMessageTool: true,
         extraSystemPrompt: MATTERMOST_VOICE_SYSTEM_PROMPT,
@@ -192,8 +254,14 @@ export async function processMattermostVoiceTurn(
       params.runtime,
     );
   } catch (error) {
+    if (params.abortSignal?.aborted) {
+      return undefined;
+    }
     params.runtime.error?.(`mattermost voice agent turn failed: ${String(error)}`);
     result = { meta: { error } };
+  }
+  if (params.abortSignal?.aborted) {
+    return undefined;
   }
   const replyText = selectMattermostVoiceReplyText(result);
   if (!replyText) {

--- a/extensions/mattermost/src/mattermost/voice-turn.ts
+++ b/extensions/mattermost/src/mattermost/voice-turn.ts
@@ -66,6 +66,7 @@ function stripMattermostVoiceTtsMarkdown(text: string): string {
       .replace(/^```\s*$/gm, ""),
   )
     .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*[•‣◦]\s+/gm, "")
     .replace(/^\s*\d+[.)]\s+/gm, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{2,}/g, "\n")

--- a/extensions/mattermost/src/mattermost/voice-worker.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMattermostVoiceWorker,
+  type MattermostVoiceCallCallbacks,
+  type MattermostVoiceCallSession,
+} from "./voice-worker.js";
+
+const CALL_START = "custom_com.mattermost.calls_call_start";
+const CALL_END = "custom_com.mattermost.calls_call_end";
+const USER_JOINED = "custom_com.mattermost.calls_user_joined";
+
+function pcm(value: number): Int16Array {
+  return new Int16Array([value, value]);
+}
+
+async function flushVoiceWorkerMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("Mattermost voice worker", () => {
+  it("joins direct calls, handles repeated turns, and leaves on call end", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const connect = vi.fn(async (params: { callbacks: MattermostVoiceCallCallbacks }) => {
+      callbacks = params.callbacks;
+      return session;
+    });
+    const processTurn = vi.fn(async (_params: { samples: Int16Array }) => ({
+      audioPath: "/tmp/reply.wav",
+    }));
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ channelId: "dm-channel" }));
+
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(3) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(Array.from(processTurn.mock.calls[0]?.[0].samples ?? [])).toEqual([1, 1, 2, 2]);
+    expect(Array.from(processTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([3, 3]);
+    expect(session.play).toHaveBeenCalledTimes(2);
+
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "dm-channel" },
+    });
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-direct calls and the bot's own voice activity", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const connect = vi.fn(async (params: { callbacks: MattermostVoiceCallCallbacks }) => {
+      callbacks = params.callbacks;
+      return session;
+    });
+    const processTurn = vi.fn(async () => undefined);
+    const resolveChannelType = vi
+      .fn<(channelId: string) => Promise<string | undefined>>()
+      .mockResolvedValueOnce("O")
+      .mockResolvedValueOnce("D");
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType,
+      connect,
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "public-channel", user_id: "human-user" },
+    });
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+
+    callbacks?.onVoice({ sessionId: "bot-session", userId: "bot-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "bot-session", samples: pcm(5) });
+    callbacks?.onVoice({ sessionId: "bot-session", userId: "bot-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(processTurn).not.toHaveBeenCalled();
+    await worker.close();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins an existing direct call when a human enters it", async () => {
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const connect = vi.fn(async () => session);
+    const onDebug = vi.fn();
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      processTurn: async () => undefined,
+      onDebug,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "bot-user" },
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ channelId: "dm-channel" }));
+    expect(onDebug).toHaveBeenCalledWith(
+      "mattermost voice event=user_joined channel=dm-channel user=human-user",
+    );
+    await worker.close();
+  });
+
+  it("does not join calls for unauthorized users", async () => {
+    const connect = vi.fn(async () => ({
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    }));
+    const authorizeJoin = vi.fn(async () => false);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "untrusted-user" },
+    });
+
+    expect(authorizeJoin).toHaveBeenCalledWith({
+      channelId: "dm-channel",
+      userId: "untrusted-user",
+    });
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("does not let call_start without a user replace the active call", async () => {
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const connect = vi.fn(async () => session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await worker.handleEvent({
+      event: CALL_START,
+      data: { channelID: "other-dm-channel", id: "call-2" },
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(session.close).not.toHaveBeenCalled();
+    await worker.close();
+  });
+
+  it("does not let ignored non-DM joins cancel an in-flight DM join", async () => {
+    let finishConnect: ((session: MattermostVoiceCallSession) => void) | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async (channelId) => (channelId === "dm-channel" ? "D" : "O"),
+      connect: async () =>
+        await new Promise<MattermostVoiceCallSession>((resolve) => {
+          finishConnect = resolve;
+        }),
+      processTurn: async () => undefined,
+    });
+
+    const joiningDm = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(finishConnect).toBeDefined());
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "public-channel", user_id: "human-user" },
+    });
+    finishConnect?.(session);
+    await joiningDm;
+
+    expect(session.close).not.toHaveBeenCalled();
+    await worker.close();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses inbound capture while the bot is playing", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => {
+        callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+        callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(9) });
+        callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      }),
+      close: vi.fn(async () => undefined),
+    };
+    const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(processTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("interrupts playback after sustained human speech and captures the next turn", async () => {
+    vi.useFakeTimers();
+    try {
+      let callbacks: MattermostVoiceCallCallbacks | undefined;
+      let playbackSignal: AbortSignal | undefined;
+      const session: MattermostVoiceCallSession = {
+        play: vi.fn(
+          async (_audio, options?: { signal?: AbortSignal }) =>
+            await new Promise<void>((resolve) => {
+              playbackSignal = options?.signal;
+              options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+            }),
+        ),
+        close: vi.fn(async () => undefined),
+      };
+      const processTurn = vi
+        .fn<(_params: { samples: Int16Array }) => Promise<{ audioPath: string } | undefined>>()
+        .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
+        .mockResolvedValueOnce(undefined);
+      const worker = createMattermostVoiceWorker({
+        authorizeJoin: async () => true,
+        botUserId: "bot-user",
+        maxSpeechSamples: 100,
+        preRollFrames: 2,
+        resolveChannelType: async () => "D",
+        connect: async (params) => {
+          callbacks = params.callbacks;
+          return session;
+        },
+        processTurn,
+      });
+
+      await worker.handleEvent({
+        event: USER_JOINED,
+        data: { channelID: "dm-channel", user_id: "human-user" },
+      });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await flushVoiceWorkerMicrotasks();
+      expect(session.play).toHaveBeenCalledTimes(1);
+
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(playbackSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(playbackSignal?.aborted).toBe(true);
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(3) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await worker.waitForIdle();
+
+      expect(processTurn).toHaveBeenCalledTimes(2);
+      expect(Array.from(processTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([3, 3]);
+      await worker.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out stalled playback and captures the next turn", async () => {
+    vi.useFakeTimers();
+    try {
+      let callbacks: MattermostVoiceCallCallbacks | undefined;
+      let playbackSignal: AbortSignal | undefined;
+      const onError = vi.fn();
+      const session: MattermostVoiceCallSession = {
+        play: vi.fn(
+          async (_audio, options?: { signal?: AbortSignal }) =>
+            await new Promise<void>(() => {
+              playbackSignal = options?.signal;
+            }),
+        ),
+        close: vi.fn(async () => undefined),
+      };
+      const processTurn = vi
+        .fn<(_params: { samples: Int16Array }) => Promise<{ audioPath: string } | undefined>>()
+        .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
+        .mockResolvedValueOnce(undefined);
+      const worker = createMattermostVoiceWorker({
+        authorizeJoin: async () => true,
+        botUserId: "bot-user",
+        maxSpeechSamples: 100,
+        playbackTimeoutMilliseconds: 10,
+        preRollFrames: 2,
+        resolveChannelType: async () => "D",
+        connect: async (params) => {
+          callbacks = params.callbacks;
+          return session;
+        },
+        processTurn,
+        onError,
+      });
+
+      await worker.handleEvent({
+        event: USER_JOINED,
+        data: { channelID: "dm-channel", user_id: "human-user" },
+      });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await flushVoiceWorkerMicrotasks();
+      expect(session.play).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(playbackSignal?.aborted).toBe(true);
+      await flushVoiceWorkerMicrotasks();
+
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await worker.waitForIdle();
+
+      expect(processTurn).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenCalledWith("mattermost voice playback timed out after 10ms");
+      await worker.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bases the default playback timeout on reply audio duration", async () => {
+    vi.useFakeTimers();
+    try {
+      let callbacks: MattermostVoiceCallCallbacks | undefined;
+      let playbackSignal: AbortSignal | undefined;
+      const onError = vi.fn();
+      const session: MattermostVoiceCallSession = {
+        play: vi.fn(
+          async (_audio, options?: { signal?: AbortSignal }) =>
+            await new Promise<void>((resolve) => {
+              playbackSignal = options?.signal;
+              options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+            }),
+        ),
+        close: vi.fn(async () => undefined),
+      };
+      const processTurn = vi.fn(async () => ({
+        audioPath: "/tmp/reply.wav",
+        durationMilliseconds: 60_000,
+      }));
+      const worker = createMattermostVoiceWorker({
+        authorizeJoin: async () => true,
+        botUserId: "bot-user",
+        maxSpeechSamples: 100,
+        preRollFrames: 2,
+        resolveChannelType: async () => "D",
+        connect: async (params) => {
+          callbacks = params.callbacks;
+          return session;
+        },
+        processTurn,
+        onError,
+      });
+
+      await worker.handleEvent({
+        event: USER_JOINED,
+        data: { channelID: "dm-channel", user_id: "human-user" },
+      });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await flushVoiceWorkerMicrotasks();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(playbackSignal?.aborted).toBe(false);
+      expect(onError).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(40_000);
+      expect(playbackSignal?.aborted).toBe(true);
+      expect(onError).toHaveBeenCalledWith("mattermost voice playback timed out after 70000ms");
+      await worker.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retain a connection that finishes after the call ended", async () => {
+    let finishConnect: ((session: MattermostVoiceCallSession) => void) | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async () =>
+        await new Promise<MattermostVoiceCallSession>((resolve) => {
+          finishConnect = resolve;
+        }),
+      processTurn: async () => undefined,
+    });
+
+    const starting = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(finishConnect).toBeDefined());
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "dm-channel" },
+    });
+    finishConnect?.(session);
+    await starting;
+
+    expect(session.close).toHaveBeenCalledTimes(1);
+    await worker.close();
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/mattermost/src/mattermost/voice-worker.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.test.ts
@@ -9,6 +9,10 @@ const CALL_START = "custom_com.mattermost.calls_call_start";
 const CALL_END = "custom_com.mattermost.calls_call_end";
 const USER_JOINED = "custom_com.mattermost.calls_user_joined";
 
+type ProcessTurn = Parameters<typeof createMattermostVoiceWorker>[0]["processTurn"];
+type TranscribeTurn = Parameters<typeof createMattermostVoiceWorker>[0]["transcribeTurn"];
+type ConnectCall = Parameters<typeof createMattermostVoiceWorker>[0]["connect"];
+
 function pcm(value: number): Int16Array {
   return new Int16Array([value, value]);
 }
@@ -20,9 +24,22 @@ async function flushVoiceWorkerMicrotasks(): Promise<void> {
 }
 
 function createTranscribeTurn(text = "hello") {
-  return vi.fn(
-    async (_params: { channelId: string; userId: string; samples: Int16Array }) => text,
-  );
+  return vi.fn<TranscribeTurn>(async () => text);
+}
+
+function createVoiceCallSession() {
+  let resolveClosed: () => void = () => undefined;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const session: MattermostVoiceCallSession = {
+    play: vi.fn(async () => undefined),
+    close: vi.fn(async () => {
+      resolveClosed();
+    }),
+    closed,
+  };
+  return { resolveClosed, session };
 }
 
 describe("Mattermost voice worker", () => {
@@ -37,7 +54,7 @@ describe("Mattermost voice worker", () => {
       return session;
     });
     const transcribeTurn = createTranscribeTurn();
-    const processTurn = vi.fn(async () => ({
+    const processTurn = vi.fn<ProcessTurn>(async () => ({
       audioPath: "/tmp/reply.wav",
     }));
     const worker = createMattermostVoiceWorker({
@@ -95,7 +112,7 @@ describe("Mattermost voice worker", () => {
       callbacks = params.callbacks;
       return session;
     });
-    const processTurn = vi.fn(async () => undefined);
+    const processTurn = vi.fn<ProcessTurn>(async () => undefined);
     const resolveChannelType = vi
       .fn<(channelId: string) => Promise<string | undefined>>()
       .mockResolvedValueOnce("O")
@@ -164,6 +181,507 @@ describe("Mattermost voice worker", () => {
     expect(onDebug).toHaveBeenCalledWith(
       "mattermost voice event=user_joined channel=dm-channel user=human-user",
     );
+    await worker.close();
+  });
+
+  it("rejoins when the active Calls session closes unexpectedly", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const first = createVoiceCallSession();
+    const second = createVoiceCallSession();
+    const connect = vi
+      .fn(async (params: { callbacks: MattermostVoiceCallCallbacks }) => {
+        callbacks = params.callbacks;
+        return first.session;
+      })
+      .mockImplementationOnce(async (params: { callbacks: MattermostVoiceCallCallbacks }) => {
+        callbacks = params.callbacks;
+        return first.session;
+      })
+      .mockImplementationOnce(async (params: { callbacks: MattermostVoiceCallCallbacks }) => {
+        callbacks = params.callbacks;
+        return second.session;
+      });
+    const processTurn = vi.fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }));
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    first.resolveClosed();
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(2));
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(first.session.close).not.toHaveBeenCalled();
+    expect(second.session.play).toHaveBeenCalledTimes(1);
+    expect(processTurn).toHaveBeenCalledTimes(1);
+    await worker.close();
+    expect(second.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries reconnect while the call lifecycle remains current", async () => {
+    const first = createVoiceCallSession();
+    const second = createVoiceCallSession();
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(first.session)
+      .mockRejectedValueOnce(new Error("calls offline"))
+      .mockResolvedValueOnce(second.session);
+    const sleep = vi.fn(async () => undefined);
+    const onError = vi.fn();
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+      reconnectRetryDelaysMs: [25],
+      sleep,
+      onError,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    first.resolveClosed();
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(3));
+
+    expect(sleep).toHaveBeenCalledWith(25);
+    expect(onError).toHaveBeenCalledWith(
+      "mattermost voice reconnect failed channel=dm-channel: Error: calls offline",
+    );
+    await worker.close();
+    expect(second.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops reconnecting after the retry budget is exhausted", async () => {
+    const first = createVoiceCallSession();
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(first.session)
+      .mockRejectedValue(new Error("calls offline"));
+    const sleep = vi.fn(async () => undefined);
+    const onError = vi.fn();
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+      reconnectRetryDelaysMs: [25],
+      sleep,
+      onError,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    first.resolveClosed();
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(3));
+    await flushVoiceWorkerMicrotasks();
+
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith("mattermost voice reconnect exhausted channel=dm-channel");
+    await worker.close();
+  });
+
+  it("does not rejoin when the call ends while reconnect validation is pending", async () => {
+    const first = createVoiceCallSession();
+    let resolveReconnectType: ((value: string | undefined) => void) | undefined;
+    let channelTypeCalls = 0;
+    const resolveChannelType = vi.fn(async () => {
+      channelTypeCalls += 1;
+      if (channelTypeCalls === 1) {
+        return "D";
+      }
+      return await new Promise<string | undefined>((resolve) => {
+        resolveReconnectType = resolve;
+      });
+    });
+    const connect = vi.fn<ConnectCall>().mockResolvedValue(first.session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType,
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    first.resolveClosed();
+    await vi.waitFor(() => expect(resolveReconnectType).toBeDefined());
+
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "dm-channel" },
+    });
+    resolveReconnectType?.("D");
+    await flushVoiceWorkerMicrotasks();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    await worker.close();
+  });
+
+  it("does not join when the call ends while initial join validation is pending", async () => {
+    let resolveChannelType: ((value: string | undefined) => void) | undefined;
+    const connect = vi.fn<ConnectCall>().mockResolvedValue(createVoiceCallSession().session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () =>
+        await new Promise<string | undefined>((resolve) => {
+          resolveChannelType = resolve;
+        }),
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    const joining = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(resolveChannelType).toBeDefined());
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "dm-channel" },
+    });
+    resolveChannelType?.("D");
+    await joining;
+
+    expect(connect).not.toHaveBeenCalled();
+    await worker.close();
+  });
+
+  it("does not close the active call when a different pending join ends", async () => {
+    let resolveSecondType: ((value: string | undefined) => void) | undefined;
+    const firstSession: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const connect = vi.fn<ConnectCall>().mockResolvedValue(firstSession);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async (channelId) => {
+        if (channelId === "first-dm-channel") {
+          return "D";
+        }
+        return await new Promise<string | undefined>((resolve) => {
+          resolveSecondType = resolve;
+        });
+      },
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "first-dm-channel", user_id: "human-user" },
+    });
+    const joiningSecond = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "second-dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(resolveSecondType).toBeDefined());
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "second-dm-channel" },
+    });
+    resolveSecondType?.("D");
+    await joiningSecond;
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(firstSession.close).not.toHaveBeenCalled();
+    await worker.close();
+  });
+
+  it("does not let an old session reconnect replace a different pending join", async () => {
+    let resolveSecondType: ((value: string | undefined) => void) | undefined;
+    const first = createVoiceCallSession();
+    const second = createVoiceCallSession();
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(first.session)
+      .mockResolvedValueOnce(second.session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async (channelId) => {
+        if (channelId === "first-dm-channel") {
+          return "D";
+        }
+        return await new Promise<string | undefined>((resolve) => {
+          resolveSecondType = resolve;
+        });
+      },
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "first-dm-channel", user_id: "human-user" },
+    });
+    const joiningSecond = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "second-dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(resolveSecondType).toBeDefined());
+    first.resolveClosed();
+    await flushVoiceWorkerMicrotasks();
+    resolveSecondType?.("D");
+    await joiningSecond;
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(connect.mock.calls[1]?.[0].channelId).toBe("second-dm-channel");
+    await worker.close();
+  });
+
+  it("clears a closed active session when a competing pending join is rejected", async () => {
+    let resolveSecondType: ((value: string | undefined) => void) | undefined;
+    const first = createVoiceCallSession();
+    const second = createVoiceCallSession();
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(first.session)
+      .mockResolvedValueOnce(second.session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async (channelId) => {
+        if (channelId === "second-dm-channel") {
+          return await new Promise<string | undefined>((resolve) => {
+            resolveSecondType = resolve;
+          });
+        }
+        return "D";
+      },
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "first-dm-channel", user_id: "human-user" },
+    });
+    const joiningSecond = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "second-dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(resolveSecondType).toBeDefined());
+    first.resolveClosed();
+    await flushVoiceWorkerMicrotasks();
+    resolveSecondType?.("O");
+    await joiningSecond;
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "first-dm-channel", user_id: "human-user" },
+    });
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(connect.mock.calls[1]?.[0].channelId).toBe("first-dm-channel");
+    await worker.close();
+  });
+
+  it("does not rejoin when the call ends while the closed session is being cleared", async () => {
+    const first = createVoiceCallSession();
+    const connect = vi.fn(async () => first.session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    first.resolveClosed();
+    await Promise.resolve();
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "dm-channel" },
+    });
+    await flushVoiceWorkerMicrotasks();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    await worker.close();
+  });
+
+  it("waits for initial connect work during shutdown", async () => {
+    let finishConnect: ((session: MattermostVoiceCallSession) => void) | undefined;
+    const session = createVoiceCallSession();
+    const connect = vi.fn<ConnectCall>(
+      async () =>
+        await new Promise<MattermostVoiceCallSession>((resolve) => {
+          finishConnect = resolve;
+        }),
+    );
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    const joining = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(finishConnect).toBeDefined());
+    let closed = false;
+    const closing = worker.close().then(() => {
+      closed = true;
+    });
+    await flushVoiceWorkerMicrotasks();
+    expect(closed).toBe(false);
+    finishConnect?.(session.session);
+    await joining;
+    await closing;
+
+    expect(session.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for reconnect work during shutdown", async () => {
+    const first = createVoiceCallSession();
+    let finishSleep: (() => void) | undefined;
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(first.session)
+      .mockRejectedValue(new Error("calls offline"));
+    const sleep = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishSleep = resolve;
+        }),
+    );
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+      reconnectRetryDelaysMs: [25],
+      sleep,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    first.resolveClosed();
+    await vi.waitFor(() => expect(sleep).toHaveBeenCalledTimes(1));
+
+    let closed = false;
+    const closing = worker.close().then(() => {
+      closed = true;
+    });
+    await flushVoiceWorkerMicrotasks();
+    expect(closed).toBe(false);
+    finishSleep?.();
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("does not connect a stale join after the previous call closes", async () => {
+    let finishPreviousClose: (() => void) | undefined;
+    const firstSession: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            finishPreviousClose = resolve;
+          }),
+      ),
+    };
+    const second = createVoiceCallSession();
+    const connect = vi
+      .fn<ConnectCall>()
+      .mockResolvedValueOnce(firstSession)
+      .mockResolvedValueOnce(second.session);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect,
+      transcribeTurn: createTranscribeTurn(),
+      processTurn: async () => undefined,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "first-dm-channel", user_id: "human-user" },
+    });
+    const joiningSecond = worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "second-dm-channel", user_id: "human-user" },
+    });
+    await vi.waitFor(() => expect(firstSession.close).toHaveBeenCalledTimes(1));
+    await worker.handleEvent({
+      event: CALL_END,
+      data: { channelID: "second-dm-channel" },
+    });
+    finishPreviousClose?.();
+    await joiningSecond;
+
+    expect(connect).toHaveBeenCalledTimes(1);
     await worker.close();
   });
 
@@ -275,7 +793,7 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcribeTurn = createTranscribeTurn();
-    const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+    const processTurn = vi.fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }));
     const worker = createMattermostVoiceWorker({
       authorizeJoin: async () => true,
       botUserId: "bot-user",
@@ -318,7 +836,7 @@ describe("Mattermost voice worker", () => {
         close: vi.fn(async () => undefined),
       };
       const transcribeTurn = createTranscribeTurn();
-      const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+      const processTurn = vi.fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }));
       const worker = createMattermostVoiceWorker({
         authorizeJoin: async () => true,
         botUserId: "bot-user",
@@ -373,7 +891,7 @@ describe("Mattermost voice worker", () => {
     };
     const transcribeTurn = createTranscribeTurn();
     const processTurn = vi
-      .fn(async () => ({ audioPath: "/tmp/reply.wav" }))
+      .fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }))
       .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
       .mockResolvedValueOnce(undefined);
     const worker = createMattermostVoiceWorker({
@@ -430,19 +948,9 @@ describe("Mattermost voice worker", () => {
         close: vi.fn(async () => undefined),
       };
       const transcripts = ["first", "second"];
-      const transcribeTurn = vi.fn(
-        async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-          transcripts.shift(),
-      );
+      const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
       const processTurn = vi
-        .fn<
-          (_params: {
-            abortSignal?: AbortSignal;
-            channelId: string;
-            message: string;
-            userId: string;
-          }) => Promise<{ audioPath: string } | undefined>
-        >()
+        .fn<ProcessTurn>()
         .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
         .mockResolvedValueOnce(undefined);
       const worker = createMattermostVoiceWorker({
@@ -482,9 +990,7 @@ describe("Mattermost voice worker", () => {
       await worker.waitForIdle();
 
       expect(processTurn).toHaveBeenCalledTimes(2);
-      expect(Array.from(transcribeTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([
-        2, 2, 3, 3,
-      ]);
+      expect(Array.from(transcribeTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([2, 2, 3, 3]);
       expect(processTurn.mock.calls[1]?.[0].message).toBe("first\n\nsecond");
       await worker.close();
     } finally {
@@ -499,13 +1005,10 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcripts = ["first", "second"];
-    const transcribeTurn = vi.fn(
-      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-        transcripts.shift(),
-    );
+    const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
     let firstSignal: AbortSignal | undefined;
     let processTurnCount = 0;
-    const processTurn = vi.fn(
+    const processTurn = vi.fn<ProcessTurn>(
       async (params: {
         abortSignal?: AbortSignal;
         channelId: string;
@@ -572,12 +1075,9 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcripts = ["first", "second"];
-    const transcribeTurn = vi.fn(
-      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-        transcripts.shift(),
-    );
+    const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
     let processTurnCount = 0;
-    const processTurn = vi.fn(
+    const processTurn = vi.fn<ProcessTurn>(
       async (params: {
         abortSignal?: AbortSignal;
         channelId: string;
@@ -650,12 +1150,9 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcripts = ["first", "second"];
-    const transcribeTurn = vi.fn(
-      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-        transcripts.shift(),
-    );
+    const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
     let processTurnCount = 0;
-    const processTurn = vi.fn(
+    const processTurn = vi.fn<ProcessTurn>(
       async (_params: {
         abortSignal?: AbortSignal;
         channelId: string;
@@ -713,24 +1210,19 @@ describe("Mattermost voice worker", () => {
       let callbacks: MattermostVoiceCallCallbacks | undefined;
       let playCalls = 0;
       const session: MattermostVoiceCallSession = {
-        play: vi.fn(
-          async (_audio, options?: { signal?: AbortSignal }) => {
-            playCalls += 1;
-            if (playCalls === 1) {
-              await new Promise<void>((resolve) => {
-                options?.signal?.addEventListener("abort", () => resolve(), { once: true });
-              });
-            }
-          },
-        ),
+        play: vi.fn(async (_audio, options?: { signal?: AbortSignal }) => {
+          playCalls += 1;
+          if (playCalls === 1) {
+            await new Promise<void>((resolve) => {
+              options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+            });
+          }
+        }),
         close: vi.fn(async () => undefined),
       };
       const transcripts = ["first", undefined, "next"];
-      const transcribeTurn = vi.fn(
-        async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-          transcripts.shift(),
-      );
-      const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+      const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
+      const processTurn = vi.fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }));
       const worker = createMattermostVoiceWorker({
         authorizeJoin: async () => true,
         botUserId: "bot-user",
@@ -791,11 +1283,8 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcripts = ["first", "second"];
-    const transcribeTurn = vi.fn(
-      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-        transcripts.shift(),
-    );
-    const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+    const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
+    const processTurn = vi.fn<ProcessTurn>(async () => ({ audioPath: "/tmp/reply.wav" }));
     const worker = createMattermostVoiceWorker({
       authorizeJoin: async () => true,
       botUserId: "bot-user",
@@ -828,9 +1317,7 @@ describe("Mattermost voice worker", () => {
     expect(processTurn).toHaveBeenCalledTimes(2);
     expect(processTurn.mock.calls[0]?.[0].message).toBe("first");
     expect(processTurn.mock.calls[1]?.[0].message).toBe("second");
-    expect(onError).toHaveBeenCalledWith(
-      "mattermost voice playback failed: Error: speaker failed",
-    );
+    expect(onError).toHaveBeenCalledWith("mattermost voice playback failed: Error: speaker failed");
     await worker.close();
   });
 
@@ -842,12 +1329,9 @@ describe("Mattermost voice worker", () => {
       close: vi.fn(async () => undefined),
     };
     const transcripts = ["first", "second"];
-    const transcribeTurn = vi.fn(
-      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
-        transcripts.shift(),
-    );
+    const transcribeTurn = vi.fn<TranscribeTurn>(async () => transcripts.shift());
     const processTurn = vi
-      .fn(async () => ({
+      .fn<ProcessTurn>(async () => ({
         audioPath: "/tmp/reply.wav",
         release: async () => {
           throw new Error("cleanup failed");
@@ -914,14 +1398,7 @@ describe("Mattermost voice worker", () => {
         close: vi.fn(async () => undefined),
       };
       const processTurn = vi
-        .fn<
-          (_params: {
-            abortSignal?: AbortSignal;
-            channelId: string;
-            message: string;
-            userId: string;
-          }) => Promise<{ audioPath: string } | undefined>
-        >()
+        .fn<ProcessTurn>()
         .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
         .mockResolvedValueOnce(undefined);
       const worker = createMattermostVoiceWorker({
@@ -983,7 +1460,7 @@ describe("Mattermost voice worker", () => {
         ),
         close: vi.fn(async () => undefined),
       };
-      const processTurn = vi.fn(async () => ({
+      const processTurn = vi.fn<ProcessTurn>(async () => ({
         audioPath: "/tmp/reply.wav",
         durationMilliseconds: 60_000,
       }));

--- a/extensions/mattermost/src/mattermost/voice-worker.test.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.test.ts
@@ -19,6 +19,12 @@ async function flushVoiceWorkerMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+function createTranscribeTurn(text = "hello") {
+  return vi.fn(
+    async (_params: { channelId: string; userId: string; samples: Int16Array }) => text,
+  );
+}
+
 describe("Mattermost voice worker", () => {
   it("joins direct calls, handles repeated turns, and leaves on call end", async () => {
     let callbacks: MattermostVoiceCallCallbacks | undefined;
@@ -30,7 +36,8 @@ describe("Mattermost voice worker", () => {
       callbacks = params.callbacks;
       return session;
     });
-    const processTurn = vi.fn(async (_params: { samples: Int16Array }) => ({
+    const transcribeTurn = createTranscribeTurn();
+    const processTurn = vi.fn(async () => ({
       audioPath: "/tmp/reply.wav",
     }));
     const worker = createMattermostVoiceWorker({
@@ -40,6 +47,7 @@ describe("Mattermost voice worker", () => {
       preRollFrames: 2,
       resolveChannelType: async () => "D",
       connect,
+      transcribeTurn,
       processTurn,
     });
 
@@ -62,9 +70,12 @@ describe("Mattermost voice worker", () => {
     await worker.waitForIdle();
 
     expect(connect).toHaveBeenCalledTimes(1);
+    expect(transcribeTurn).toHaveBeenCalledTimes(2);
+    expect(Array.from(transcribeTurn.mock.calls[0]?.[0].samples ?? [])).toEqual([1, 1, 2, 2]);
+    expect(Array.from(transcribeTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([3, 3]);
     expect(processTurn).toHaveBeenCalledTimes(2);
-    expect(Array.from(processTurn.mock.calls[0]?.[0].samples ?? [])).toEqual([1, 1, 2, 2]);
-    expect(Array.from(processTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([3, 3]);
+    expect(processTurn.mock.calls[0]?.[0].message).toBe("hello");
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("hello");
     expect(session.play).toHaveBeenCalledTimes(2);
 
     await worker.handleEvent({
@@ -96,6 +107,7 @@ describe("Mattermost voice worker", () => {
       preRollFrames: 2,
       resolveChannelType,
       connect,
+      transcribeTurn: createTranscribeTurn(),
       processTurn,
     });
 
@@ -133,6 +145,7 @@ describe("Mattermost voice worker", () => {
       preRollFrames: 2,
       resolveChannelType: async () => "D",
       connect,
+      transcribeTurn: createTranscribeTurn(),
       processTurn: async () => undefined,
       onDebug,
     });
@@ -167,6 +180,7 @@ describe("Mattermost voice worker", () => {
       preRollFrames: 2,
       resolveChannelType: async () => "D",
       connect,
+      transcribeTurn: createTranscribeTurn(),
       processTurn: async () => undefined,
     });
 
@@ -195,6 +209,7 @@ describe("Mattermost voice worker", () => {
       preRollFrames: 2,
       resolveChannelType: async () => "D",
       connect,
+      transcribeTurn: createTranscribeTurn(),
       processTurn: async () => undefined,
     });
 
@@ -228,6 +243,7 @@ describe("Mattermost voice worker", () => {
         await new Promise<MattermostVoiceCallSession>((resolve) => {
           finishConnect = resolve;
         }),
+      transcribeTurn: createTranscribeTurn(),
       processTurn: async () => undefined,
     });
 
@@ -248,7 +264,7 @@ describe("Mattermost voice worker", () => {
     expect(session.close).toHaveBeenCalledTimes(1);
   });
 
-  it("suppresses inbound capture while the bot is playing", async () => {
+  it("discards brief inbound capture while the bot is playing", async () => {
     let callbacks: MattermostVoiceCallCallbacks | undefined;
     const session: MattermostVoiceCallSession = {
       play: vi.fn(async () => {
@@ -258,6 +274,7 @@ describe("Mattermost voice worker", () => {
       }),
       close: vi.fn(async () => undefined),
     };
+    const transcribeTurn = createTranscribeTurn();
     const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
     const worker = createMattermostVoiceWorker({
       authorizeJoin: async () => true,
@@ -269,6 +286,7 @@ describe("Mattermost voice worker", () => {
         callbacks = params.callbacks;
         return session;
       },
+      transcribeTurn,
       processTurn,
     });
 
@@ -281,7 +299,119 @@ describe("Mattermost voice worker", () => {
     callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
     await worker.waitForIdle();
 
+    expect(transcribeTurn).toHaveBeenCalledTimes(1);
     expect(processTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards brief playback capture when playback finishes before speech stops", async () => {
+    vi.useFakeTimers();
+    try {
+      let callbacks: MattermostVoiceCallCallbacks | undefined;
+      let finishPlayback: (() => void) | undefined;
+      const session: MattermostVoiceCallSession = {
+        play: vi.fn(
+          async () =>
+            await new Promise<void>((resolve) => {
+              finishPlayback = resolve;
+            }),
+        ),
+        close: vi.fn(async () => undefined),
+      };
+      const transcribeTurn = createTranscribeTurn();
+      const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+      const worker = createMattermostVoiceWorker({
+        authorizeJoin: async () => true,
+        botUserId: "bot-user",
+        maxSpeechSamples: 100,
+        preRollFrames: 2,
+        resolveChannelType: async () => "D",
+        connect: async (params) => {
+          callbacks = params.callbacks;
+          return session;
+        },
+        transcribeTurn,
+        processTurn,
+      });
+
+      await worker.handleEvent({
+        event: USER_JOINED,
+        data: { channelID: "dm-channel", user_id: "human-user" },
+      });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await flushVoiceWorkerMicrotasks();
+      expect(session.play).toHaveBeenCalledTimes(1);
+
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(9) });
+      finishPlayback?.();
+      await flushVoiceWorkerMicrotasks();
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await worker.waitForIdle();
+
+      expect(transcribeTurn).toHaveBeenCalledTimes(1);
+      expect(processTurn).toHaveBeenCalledTimes(1);
+      await worker.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not prepend inactive playback pre-roll to the next turn", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    let finishPlayback: (() => void) | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            finishPlayback = resolve;
+          }),
+      ),
+      close: vi.fn(async () => undefined),
+    };
+    const transcribeTurn = createTranscribeTurn();
+    const processTurn = vi
+      .fn(async () => ({ audioPath: "/tmp/reply.wav" }))
+      .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
+      .mockResolvedValueOnce(undefined);
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await flushVoiceWorkerMicrotasks();
+    expect(session.play).toHaveBeenCalledTimes(1);
+
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(9) });
+    finishPlayback?.();
+    await worker.waitForIdle();
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(transcribeTurn).toHaveBeenCalledTimes(2);
+    expect(Array.from(transcribeTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([2, 2]);
+    await worker.close();
   });
 
   it("interrupts playback after sustained human speech and captures the next turn", async () => {
@@ -299,8 +429,20 @@ describe("Mattermost voice worker", () => {
         ),
         close: vi.fn(async () => undefined),
       };
+      const transcripts = ["first", "second"];
+      const transcribeTurn = vi.fn(
+        async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+          transcripts.shift(),
+      );
       const processTurn = vi
-        .fn<(_params: { samples: Int16Array }) => Promise<{ audioPath: string } | undefined>>()
+        .fn<
+          (_params: {
+            abortSignal?: AbortSignal;
+            channelId: string;
+            message: string;
+            userId: string;
+          }) => Promise<{ audioPath: string } | undefined>
+        >()
         .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
         .mockResolvedValueOnce(undefined);
       const worker = createMattermostVoiceWorker({
@@ -313,6 +455,293 @@ describe("Mattermost voice worker", () => {
           callbacks = params.callbacks;
           return session;
         },
+        transcribeTurn,
+        processTurn,
+      });
+
+      await worker.handleEvent({
+        event: USER_JOINED,
+        data: { channelID: "dm-channel", user_id: "human-user" },
+      });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await flushVoiceWorkerMicrotasks();
+      expect(session.play).toHaveBeenCalledTimes(1);
+
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(9) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(playbackSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(playbackSignal?.aborted).toBe(true);
+      callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(3) });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await worker.waitForIdle();
+
+      expect(processTurn).toHaveBeenCalledTimes(2);
+      expect(Array.from(transcribeTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([
+        2, 2, 3, 3,
+      ]);
+      expect(processTurn.mock.calls[1]?.[0].message).toBe("first\n\nsecond");
+      await worker.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels active generation and reruns with combined transcripts", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const transcripts = ["first", "second"];
+    const transcribeTurn = vi.fn(
+      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+        transcripts.shift(),
+    );
+    let firstSignal: AbortSignal | undefined;
+    let processTurnCount = 0;
+    const processTurn = vi.fn(
+      async (params: {
+        abortSignal?: AbortSignal;
+        channelId: string;
+        message: string;
+        userId: string;
+      }) => {
+        processTurnCount += 1;
+        if (processTurnCount === 1) {
+          firstSignal = params.abortSignal;
+          await new Promise<void>((resolve) => {
+            params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return undefined;
+        }
+        return { audioPath: "/tmp/combined.wav" };
+      },
+    );
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await vi.waitFor(() => expect(processTurn).toHaveBeenCalledTimes(1));
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(firstSignal?.aborted).toBe(true);
+    expect(transcribeTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn.mock.calls[0]?.[0].message).toBe("first");
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("first\n\nsecond");
+    expect(session.play).toHaveBeenCalledTimes(1);
+    expect(session.play).toHaveBeenCalledWith(
+      expect.objectContaining({ audioPath: "/tmp/combined.wav" }),
+      expect.any(Object),
+    );
+    await worker.close();
+  });
+
+  it("isolates release failures from stale cancelled generations", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const onError = vi.fn();
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const transcripts = ["first", "second"];
+    const transcribeTurn = vi.fn(
+      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+        transcripts.shift(),
+    );
+    let processTurnCount = 0;
+    const processTurn = vi.fn(
+      async (params: {
+        abortSignal?: AbortSignal;
+        channelId: string;
+        message: string;
+        userId: string;
+      }) => {
+        processTurnCount += 1;
+        if (processTurnCount === 1) {
+          await new Promise<void>((resolve) => {
+            params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return {
+            audioPath: "/tmp/stale.wav",
+            release: async () => {
+              throw new Error("stale cleanup failed");
+            },
+          };
+        }
+        return { audioPath: "/tmp/combined.wav" };
+      },
+    );
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+      onError,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await vi.waitFor(() => expect(processTurn).toHaveBeenCalledTimes(1));
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("first\n\nsecond");
+    expect(session.play).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      "mattermost voice playback release failed: Error: stale cleanup failed",
+    );
+    await worker.close();
+  });
+
+  it("processes speech that started before playback began", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    let finishFirstGeneration: ((reply: { audioPath: string }) => void) | undefined;
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(
+        async (_audio, options?: { signal?: AbortSignal }) =>
+          await new Promise<void>((resolve) => {
+            options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+          }),
+      ),
+      close: vi.fn(async () => undefined),
+    };
+    const transcripts = ["first", "second"];
+    const transcribeTurn = vi.fn(
+      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+        transcripts.shift(),
+    );
+    let processTurnCount = 0;
+    const processTurn = vi.fn(
+      async (_params: {
+        abortSignal?: AbortSignal;
+        channelId: string;
+        message: string;
+        userId: string;
+      }) => {
+        processTurnCount += 1;
+        if (processTurnCount === 1) {
+          return await new Promise<{ audioPath: string }>((resolve) => {
+            finishFirstGeneration = resolve;
+          });
+        }
+        return undefined;
+      },
+    );
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await vi.waitFor(() => expect(processTurn).toHaveBeenCalledTimes(1));
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    finishFirstGeneration?.({ audioPath: "/tmp/reply.wav" });
+    await vi.waitFor(() => expect(session.play).toHaveBeenCalledTimes(1));
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("first\n\nsecond");
+    await worker.close();
+  });
+
+  it("clears retained batch when an interrupted utterance transcribes empty", async () => {
+    vi.useFakeTimers();
+    try {
+      let callbacks: MattermostVoiceCallCallbacks | undefined;
+      let playCalls = 0;
+      const session: MattermostVoiceCallSession = {
+        play: vi.fn(
+          async (_audio, options?: { signal?: AbortSignal }) => {
+            playCalls += 1;
+            if (playCalls === 1) {
+              await new Promise<void>((resolve) => {
+                options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+              });
+            }
+          },
+        ),
+        close: vi.fn(async () => undefined),
+      };
+      const transcripts = ["first", undefined, "next"];
+      const transcribeTurn = vi.fn(
+        async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+          transcripts.shift(),
+      );
+      const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+      const worker = createMattermostVoiceWorker({
+        authorizeJoin: async () => true,
+        botUserId: "bot-user",
+        maxSpeechSamples: 100,
+        preRollFrames: 2,
+        resolveChannelType: async () => "D",
+        connect: async (params) => {
+          callbacks = params.callbacks;
+          return session;
+        },
+        transcribeTurn,
         processTurn,
       });
 
@@ -328,21 +757,145 @@ describe("Mattermost voice worker", () => {
 
       callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
       callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
-      await vi.advanceTimersByTimeAsync(1_999);
-      expect(playbackSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(2_000);
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+      await worker.waitForIdle();
+      expect(processTurn).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(1);
-      expect(playbackSignal?.aborted).toBe(true);
+      callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
       callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(3) });
       callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
       await worker.waitForIdle();
 
+      expect(transcribeTurn).toHaveBeenCalledTimes(3);
       expect(processTurn).toHaveBeenCalledTimes(2);
-      expect(Array.from(processTurn.mock.calls[1]?.[0].samples ?? [])).toEqual([3, 3]);
+      expect(processTurn.mock.calls[1]?.[0].message).toBe("next");
       await worker.close();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("clears the transcript batch after terminal playback failure", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    let playCalls = 0;
+    const onError = vi.fn();
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => {
+        playCalls += 1;
+        if (playCalls === 1) {
+          throw new Error("speaker failed");
+        }
+      }),
+      close: vi.fn(async () => undefined),
+    };
+    const transcripts = ["first", "second"];
+    const transcribeTurn = vi.fn(
+      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+        transcripts.shift(),
+    );
+    const processTurn = vi.fn(async () => ({ audioPath: "/tmp/reply.wav" }));
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+      onError,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn.mock.calls[0]?.[0].message).toBe("first");
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("second");
+    expect(onError).toHaveBeenCalledWith(
+      "mattermost voice playback failed: Error: speaker failed",
+    );
+    await worker.close();
+  });
+
+  it("clears the transcript batch when reply release fails after playback", async () => {
+    let callbacks: MattermostVoiceCallCallbacks | undefined;
+    const onError = vi.fn();
+    const session: MattermostVoiceCallSession = {
+      play: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    };
+    const transcripts = ["first", "second"];
+    const transcribeTurn = vi.fn(
+      async (_params: { channelId: string; userId: string; samples: Int16Array }) =>
+        transcripts.shift(),
+    );
+    const processTurn = vi
+      .fn(async () => ({
+        audioPath: "/tmp/reply.wav",
+        release: async () => {
+          throw new Error("cleanup failed");
+        },
+      }))
+      .mockResolvedValueOnce({
+        audioPath: "/tmp/reply.wav",
+        release: async () => {
+          throw new Error("cleanup failed");
+        },
+      })
+      .mockResolvedValueOnce({ audioPath: "/tmp/reply-2.wav" });
+    const worker = createMattermostVoiceWorker({
+      authorizeJoin: async () => true,
+      botUserId: "bot-user",
+      maxSpeechSamples: 100,
+      preRollFrames: 2,
+      resolveChannelType: async () => "D",
+      connect: async (params) => {
+        callbacks = params.callbacks;
+        return session;
+      },
+      transcribeTurn,
+      processTurn,
+      onError,
+    });
+
+    await worker.handleEvent({
+      event: USER_JOINED,
+      data: { channelID: "dm-channel", user_id: "human-user" },
+    });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(1) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: true });
+    callbacks?.onAudio({ sessionId: "speaker-session", samples: pcm(2) });
+    callbacks?.onVoice({ sessionId: "speaker-session", userId: "human-user", speaking: false });
+    await worker.waitForIdle();
+
+    expect(processTurn).toHaveBeenCalledTimes(2);
+    expect(processTurn.mock.calls[0]?.[0].message).toBe("first");
+    expect(processTurn.mock.calls[1]?.[0].message).toBe("second");
+    expect(onError).toHaveBeenCalledWith(
+      "mattermost voice playback release failed: Error: cleanup failed",
+    );
+    await worker.close();
   });
 
   it("times out stalled playback and captures the next turn", async () => {
@@ -361,7 +914,14 @@ describe("Mattermost voice worker", () => {
         close: vi.fn(async () => undefined),
       };
       const processTurn = vi
-        .fn<(_params: { samples: Int16Array }) => Promise<{ audioPath: string } | undefined>>()
+        .fn<
+          (_params: {
+            abortSignal?: AbortSignal;
+            channelId: string;
+            message: string;
+            userId: string;
+          }) => Promise<{ audioPath: string } | undefined>
+        >()
         .mockResolvedValueOnce({ audioPath: "/tmp/reply.wav" })
         .mockResolvedValueOnce(undefined);
       const worker = createMattermostVoiceWorker({
@@ -375,6 +935,7 @@ describe("Mattermost voice worker", () => {
           callbacks = params.callbacks;
           return session;
         },
+        transcribeTurn: createTranscribeTurn(),
         processTurn,
         onError,
       });
@@ -436,6 +997,7 @@ describe("Mattermost voice worker", () => {
           callbacks = params.callbacks;
           return session;
         },
+        transcribeTurn: createTranscribeTurn(),
         processTurn,
         onError,
       });
@@ -478,6 +1040,7 @@ describe("Mattermost voice worker", () => {
         await new Promise<MattermostVoiceCallSession>((resolve) => {
           finishConnect = resolve;
         }),
+      transcribeTurn: createTranscribeTurn(),
       processTurn: async () => undefined,
     });
 

--- a/extensions/mattermost/src/mattermost/voice-worker.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.ts
@@ -1,0 +1,360 @@
+// Mattermost plugin module coordinates persistent voice call sessions and turns.
+import { createVoiceCapture } from "./voice-audio.js";
+
+const CALLS_EVENT_PREFIX = "custom_com.mattermost.calls_";
+const PLAYBACK_INTERRUPT_MILLISECONDS = 2_000;
+const PLAYBACK_STALL_TIMEOUT_MILLISECONDS = 10_000;
+
+export type MattermostVoiceCallCallbacks = {
+  onAudio: (event: { sessionId: string; samples: Int16Array }) => void;
+  onVoice: (event: { sessionId: string; userId: string; speaking: boolean }) => void;
+};
+
+export type MattermostVoiceReplyAudio = {
+  audioPath: string;
+  durationMilliseconds?: number;
+  release?: () => Promise<void> | void;
+};
+
+type MattermostVoicePlaybackOptions = {
+  signal?: AbortSignal;
+};
+
+export type MattermostVoiceCallSession = {
+  play: (
+    audio: MattermostVoiceReplyAudio,
+    options?: MattermostVoicePlaybackOptions,
+  ) => Promise<void>;
+  close: () => Promise<void>;
+};
+
+type MattermostCallsEvent = {
+  event?: string;
+  data?: {
+    channel_id?: string;
+    channelID?: string;
+    id?: string;
+    userID?: string;
+    user_id?: string;
+  };
+  broadcast?: {
+    channel_id?: string;
+  };
+};
+
+type MattermostVoiceWorker = {
+  handleEvent: (event: MattermostCallsEvent) => Promise<void>;
+  waitForIdle: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+type ActiveCall = {
+  channelId: string;
+  session: MattermostVoiceCallSession;
+};
+
+type PlaybackState = {
+  call: ActiveCall;
+  controller: AbortController;
+  interruptSessionId?: string;
+  interruptTimer?: ReturnType<typeof setTimeout>;
+  interruptUserId?: string;
+};
+
+export function createMattermostVoiceWorker(params: {
+  authorizeJoin: (params: { channelId: string; userId: string }) => Promise<boolean>;
+  botUserId: string;
+  maxSpeechSamples: number;
+  playbackTimeoutMilliseconds?: number;
+  preRollFrames: number;
+  resolveChannelType: (channelId: string) => Promise<string | undefined>;
+  connect: (params: {
+    channelId: string;
+    callbacks: MattermostVoiceCallCallbacks;
+  }) => Promise<MattermostVoiceCallSession>;
+  processTurn: (params: {
+    channelId: string;
+    userId: string;
+    samples: Int16Array;
+  }) => Promise<MattermostVoiceReplyAudio | undefined>;
+  onDebug?: (message: string) => void;
+  onError?: (message: string) => void;
+}): MattermostVoiceWorker {
+  const captures = new Map<string, ReturnType<typeof createVoiceCapture>>();
+  let activeCall: ActiveCall | undefined;
+  let pendingChannelId: string | undefined;
+  let lifecycleGeneration = 0;
+  let playback: PlaybackState | undefined;
+  let playing = false;
+  let turnTail = Promise.resolve();
+  const resolvePlaybackTimeoutMilliseconds = (reply: MattermostVoiceReplyAudio) => {
+    if (params.playbackTimeoutMilliseconds !== undefined) {
+      return Math.max(1, params.playbackTimeoutMilliseconds);
+    }
+    const duration = reply.durationMilliseconds;
+    return typeof duration === "number" && Number.isFinite(duration) && duration > 0
+      ? Math.ceil(duration + PLAYBACK_STALL_TIMEOUT_MILLISECONDS)
+      : undefined;
+  };
+
+  const getCapture = (sessionId: string) => {
+    const existing = captures.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+    const capture = createVoiceCapture({
+      maxSpeechSamples: params.maxSpeechSamples,
+      preRollFrames: params.preRollFrames,
+    });
+    captures.set(sessionId, capture);
+    return capture;
+  };
+
+  const setPlaybackSuppressed = (suppressed: boolean) => {
+    playing = suppressed;
+    for (const capture of captures.values()) {
+      capture.setSuppressed(suppressed);
+    }
+  };
+
+  const clearPlaybackInterruptTimer = (state: PlaybackState | undefined) => {
+    if (!state?.interruptTimer) {
+      return;
+    }
+    clearTimeout(state.interruptTimer);
+    state.interruptTimer = undefined;
+    state.interruptSessionId = undefined;
+    state.interruptUserId = undefined;
+  };
+
+  const schedulePlaybackInterrupt = (event: { sessionId: string; userId: string }) => {
+    const state = playback;
+    if (!state || state.controller.signal.aborted) {
+      return;
+    }
+    if (
+      state.interruptTimer &&
+      state.interruptSessionId === event.sessionId &&
+      state.interruptUserId === event.userId
+    ) {
+      return;
+    }
+    clearPlaybackInterruptTimer(state);
+    state.interruptSessionId = event.sessionId;
+    state.interruptUserId = event.userId;
+    state.interruptTimer = setTimeout(() => {
+      if (playback !== state || activeCall !== state.call || state.controller.signal.aborted) {
+        return;
+      }
+      clearPlaybackInterruptTimer(state);
+      state.controller.abort();
+      setPlaybackSuppressed(false);
+      getCapture(event.sessionId).start();
+    }, PLAYBACK_INTERRUPT_MILLISECONDS);
+    state.interruptTimer.unref?.();
+  };
+
+  const clearMatchingPlaybackInterrupt = (event: { sessionId: string; userId: string }) => {
+    const state = playback;
+    if (state?.interruptSessionId === event.sessionId && state.interruptUserId === event.userId) {
+      clearPlaybackInterruptTimer(state);
+    }
+  };
+
+  const callbacks: MattermostVoiceCallCallbacks = {
+    onAudio(event) {
+      if (playing) {
+        return;
+      }
+      getCapture(event.sessionId).push(event.samples);
+    },
+    onVoice(event) {
+      if (event.userId === params.botUserId) {
+        return;
+      }
+      if (playing) {
+        if (event.speaking) {
+          schedulePlaybackInterrupt(event);
+        } else {
+          clearMatchingPlaybackInterrupt(event);
+        }
+        return;
+      }
+      const capture = getCapture(event.sessionId);
+      if (event.speaking) {
+        capture.start();
+        return;
+      }
+      const samples = capture.stop();
+      const call = activeCall;
+      if (!call || samples.length === 0) {
+        return;
+      }
+      turnTail = turnTail
+        .then(async () => {
+          params.onDebug?.(
+            `mattermost voice turn start channel=${call.channelId} speaker=${event.userId} samples=${samples.length}`,
+          );
+          const reply = await params.processTurn({
+            channelId: call.channelId,
+            userId: event.userId,
+            samples,
+          });
+          if (!reply || activeCall !== call) {
+            await reply?.release?.();
+            params.onDebug?.(
+              `mattermost voice turn skipped channel=${call.channelId} speaker=${event.userId} reason=${reply ? "stale-call" : "no-reply"}`,
+            );
+            return;
+          }
+          const controller = new AbortController();
+          const state: PlaybackState = { call, controller };
+          playback = state;
+          setPlaybackSuppressed(true);
+          const playbackTimeoutMilliseconds = resolvePlaybackTimeoutMilliseconds(reply);
+          let playbackTimeout: ReturnType<typeof setTimeout> | undefined;
+          let timedOut = false;
+          const playbackFinished = call.session
+            .play(reply, { signal: controller.signal })
+            .catch((error: unknown) => {
+              if (!timedOut) {
+                throw error;
+              }
+              params.onError?.(`mattermost voice playback failed after timeout: ${String(error)}`);
+            });
+          try {
+            params.onDebug?.(
+              `mattermost voice playback start channel=${call.channelId} speaker=${event.userId}`,
+            );
+            const playbackTimedOut =
+              playbackTimeoutMilliseconds === undefined
+                ? undefined
+                : new Promise<"timeout">((resolve) => {
+                    playbackTimeout = setTimeout(() => {
+                      timedOut = true;
+                      controller.abort();
+                      resolve("timeout");
+                    }, playbackTimeoutMilliseconds);
+                    playbackTimeout.unref?.();
+                  });
+            const outcome = await Promise.race(
+              playbackTimedOut
+                ? [playbackFinished.then(() => "finished" as const), playbackTimedOut]
+                : [playbackFinished.then(() => "finished" as const)],
+            );
+            if (outcome === "timeout") {
+              params.onError?.(
+                `mattermost voice playback timed out after ${playbackTimeoutMilliseconds}ms`,
+              );
+            } else {
+              params.onDebug?.(
+                `mattermost voice playback finished channel=${call.channelId} speaker=${event.userId}`,
+              );
+            }
+          } finally {
+            if (playbackTimeout) {
+              clearTimeout(playbackTimeout);
+            }
+            if (playback === state) {
+              playback = undefined;
+            }
+            clearPlaybackInterruptTimer(state);
+            setPlaybackSuppressed(false);
+            await reply.release?.();
+          }
+        })
+        .catch((error: unknown) => {
+          params.onError?.(`mattermost voice turn failed: ${String(error)}`);
+        });
+    },
+  };
+
+  const closeActiveCall = async () => {
+    const call = activeCall;
+    activeCall = undefined;
+    if (playback) {
+      const state = playback;
+      playback = undefined;
+      clearPlaybackInterruptTimer(state);
+      state.controller.abort();
+    }
+    captures.clear();
+    setPlaybackSuppressed(false);
+    await call?.session.close();
+  };
+
+  return {
+    async handleEvent(event) {
+      if (!event.event?.startsWith(CALLS_EVENT_PREFIX)) {
+        return;
+      }
+      const eventName = event.event.slice(CALLS_EVENT_PREFIX.length);
+      const channelId =
+        event.data?.channelID ?? event.data?.channel_id ?? event.broadcast?.channel_id;
+      if (eventName === "user_joined" || eventName === "call_end") {
+        const userId = event.data?.user_id ?? event.data?.userID;
+        params.onDebug?.(
+          `mattermost voice event=${eventName} channel=${channelId ?? "unknown"} user=${userId ?? "unknown"}`,
+        );
+      }
+      if (!channelId) {
+        return;
+      }
+      if (eventName === "call_end") {
+        if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
+          lifecycleGeneration += 1;
+          pendingChannelId = undefined;
+          await closeActiveCall();
+        }
+        return;
+      }
+      const joinedUserId = event.data?.user_id ?? event.data?.userID;
+      const humanJoined =
+        eventName === "user_joined" && Boolean(joinedUserId) && joinedUserId !== params.botUserId;
+      if (!humanJoined || !joinedUserId) {
+        return;
+      }
+      if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
+        return;
+      }
+      if ((await params.resolveChannelType(channelId))?.toUpperCase() !== "D") {
+        return;
+      }
+      if (!(await params.authorizeJoin({ channelId, userId: joinedUserId }))) {
+        return;
+      }
+      if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
+        return;
+      }
+      const generation = ++lifecycleGeneration;
+      pendingChannelId = channelId;
+      await closeActiveCall();
+      let session: MattermostVoiceCallSession;
+      try {
+        session = await params.connect({ channelId, callbacks });
+      } catch (error) {
+        if (generation === lifecycleGeneration) {
+          pendingChannelId = undefined;
+        }
+        throw error;
+      }
+      // Call end and shutdown can race the async WebRTC join. Never retain a
+      // connection that belongs to an older lifecycle generation.
+      if (generation !== lifecycleGeneration) {
+        await session.close();
+        return;
+      }
+      pendingChannelId = undefined;
+      activeCall = { channelId, session };
+    },
+    async waitForIdle() {
+      await turnTail;
+    },
+    async close() {
+      lifecycleGeneration += 1;
+      pendingChannelId = undefined;
+      await closeActiveCall();
+      await turnTail;
+    },
+  };
+}

--- a/extensions/mattermost/src/mattermost/voice-worker.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.ts
@@ -61,6 +61,26 @@ type PlaybackState = {
   interruptUserId?: string;
 };
 
+type ActiveGeneration = {
+  call: ActiveCall;
+  controller: AbortController;
+  id: number;
+};
+
+type PendingTranscript = {
+  call: ActiveCall;
+  clearBatchIfEmpty?: boolean;
+  transcript?: string;
+  userId: string;
+};
+
+type PlaybackOutcome = "finished" | "timeout" | "aborted" | "failed";
+
+type PlaybackCaptureGuard = {
+  interrupted: boolean;
+  userId: string;
+};
+
 export function createMattermostVoiceWorker(params: {
   authorizeJoin: (params: { channelId: string; userId: string }) => Promise<boolean>;
   botUserId: string;
@@ -73,10 +93,16 @@ export function createMattermostVoiceWorker(params: {
     callbacks: MattermostVoiceCallCallbacks;
   }) => Promise<MattermostVoiceCallSession>;
   processTurn: (params: {
+    abortSignal?: AbortSignal;
+    channelId: string;
+    message: string;
+    userId: string;
+  }) => Promise<MattermostVoiceReplyAudio | undefined>;
+  transcribeTurn: (params: {
     channelId: string;
     userId: string;
     samples: Int16Array;
-  }) => Promise<MattermostVoiceReplyAudio | undefined>;
+  }) => Promise<string | undefined>;
   onDebug?: (message: string) => void;
   onError?: (message: string) => void;
 }): MattermostVoiceWorker {
@@ -85,8 +111,15 @@ export function createMattermostVoiceWorker(params: {
   let pendingChannelId: string | undefined;
   let lifecycleGeneration = 0;
   let playback: PlaybackState | undefined;
+  let activeGeneration: ActiveGeneration | undefined;
   let playing = false;
-  let turnTail = Promise.resolve();
+  let generationId = 0;
+  let nextUtteranceId = 1;
+  let nextTranscriptId = 1;
+  const pendingTasks = new Set<Promise<void>>();
+  const pendingTranscripts = new Map<number, PendingTranscript>();
+  const playbackCaptureGuards = new Map<string, PlaybackCaptureGuard>();
+  let voiceBatch: string[] = [];
   const resolvePlaybackTimeoutMilliseconds = (reply: MattermostVoiceReplyAudio) => {
     if (params.playbackTimeoutMilliseconds !== undefined) {
       return Math.max(1, params.playbackTimeoutMilliseconds);
@@ -110,11 +143,38 @@ export function createMattermostVoiceWorker(params: {
     return capture;
   };
 
-  const setPlaybackSuppressed = (suppressed: boolean) => {
-    playing = suppressed;
-    for (const capture of captures.values()) {
-      capture.setSuppressed(suppressed);
+  const trackTask = (task: Promise<void>) => {
+    pendingTasks.add(task);
+    void task.then(
+      () => pendingTasks.delete(task),
+      () => pendingTasks.delete(task),
+    );
+  };
+
+  const waitForTrackedTasks = async () => {
+    while (pendingTasks.size > 0) {
+      await Promise.all([...pendingTasks]);
     }
+  };
+
+  const setPlaybackActive = (active: boolean) => {
+    playing = active;
+  };
+
+  const clearInactiveCapturePreRoll = () => {
+    for (const capture of captures.values()) {
+      capture.clearInactivePreRoll();
+    }
+  };
+
+  const playbackCaptureKey = (event: { sessionId: string; userId: string }) =>
+    `${event.sessionId}\0${event.userId}`;
+
+  const consumePlaybackCaptureGuard = (event: { sessionId: string; userId: string }) => {
+    const key = playbackCaptureKey(event);
+    const guard = playbackCaptureGuards.get(key);
+    playbackCaptureGuards.delete(key);
+    return guard;
   };
 
   const clearPlaybackInterruptTimer = (state: PlaybackState | undefined) => {
@@ -125,6 +185,18 @@ export function createMattermostVoiceWorker(params: {
     state.interruptTimer = undefined;
     state.interruptSessionId = undefined;
     state.interruptUserId = undefined;
+  };
+
+  const abortPlayback = () => {
+    const state = playback;
+    if (!state) {
+      return;
+    }
+    playback = undefined;
+    clearPlaybackInterruptTimer(state);
+    state.controller.abort();
+    setPlaybackActive(false);
+    clearInactiveCapturePreRoll();
   };
 
   const schedulePlaybackInterrupt = (event: { sessionId: string; userId: string }) => {
@@ -146,10 +218,11 @@ export function createMattermostVoiceWorker(params: {
       if (playback !== state || activeCall !== state.call || state.controller.signal.aborted) {
         return;
       }
-      clearPlaybackInterruptTimer(state);
-      state.controller.abort();
-      setPlaybackSuppressed(false);
-      getCapture(event.sessionId).start();
+      const guard = playbackCaptureGuards.get(playbackCaptureKey(event));
+      if (guard?.userId === event.userId) {
+        guard.interrupted = true;
+      }
+      abortPlayback();
     }, PLAYBACK_INTERRUPT_MILLISECONDS);
     state.interruptTimer.unref?.();
   };
@@ -161,125 +234,274 @@ export function createMattermostVoiceWorker(params: {
     }
   };
 
-  const callbacks: MattermostVoiceCallCallbacks = {
-    onAudio(event) {
-      if (playing) {
+  const playReply = async (paramsForPlayback: {
+    call: ActiveCall;
+    reply: MattermostVoiceReplyAudio;
+    userId: string;
+  }): Promise<PlaybackOutcome> => {
+    const { call, reply, userId } = paramsForPlayback;
+    const controller = new AbortController();
+    const state: PlaybackState = { call, controller };
+    clearInactiveCapturePreRoll();
+    playback = state;
+    setPlaybackActive(true);
+    const playbackTimeoutMilliseconds = resolvePlaybackTimeoutMilliseconds(reply);
+    let playbackTimeout: ReturnType<typeof setTimeout> | undefined;
+    let timedOut = false;
+    const playbackFinished = call.session
+      .play(reply, { signal: controller.signal })
+      .then((): PlaybackOutcome => {
+        if (timedOut) {
+          return "timeout";
+        }
+        return controller.signal.aborted ? "aborted" : "finished";
+      })
+      .catch((error: unknown): PlaybackOutcome => {
+        if (timedOut) {
+          params.onError?.(`mattermost voice playback failed after timeout: ${String(error)}`);
+          return "timeout";
+        }
+        if (controller.signal.aborted) {
+          return "aborted";
+        }
+        params.onError?.(`mattermost voice playback failed: ${String(error)}`);
+        return "failed";
+      });
+    try {
+      params.onDebug?.(`mattermost voice playback start channel=${call.channelId} speaker=${userId}`);
+      const playbackTimedOut =
+        playbackTimeoutMilliseconds === undefined
+          ? undefined
+          : new Promise<"timeout">((resolve) => {
+              playbackTimeout = setTimeout(() => {
+                timedOut = true;
+                controller.abort();
+                resolve("timeout");
+              }, playbackTimeoutMilliseconds);
+              playbackTimeout.unref?.();
+            });
+      const outcome = await Promise.race(
+        playbackTimedOut ? [playbackFinished, playbackTimedOut] : [playbackFinished],
+      );
+      if (outcome === "timeout") {
+        params.onError?.(
+          `mattermost voice playback timed out after ${playbackTimeoutMilliseconds}ms`,
+        );
+      } else if (outcome === "finished") {
+        params.onDebug?.(
+          `mattermost voice playback finished channel=${call.channelId} speaker=${userId}`,
+        );
+      }
+      return outcome;
+    } finally {
+      if (playbackTimeout) {
+        clearTimeout(playbackTimeout);
+      }
+      if (playback === state) {
+        playback = undefined;
+        setPlaybackActive(false);
+        clearInactiveCapturePreRoll();
+      }
+      clearPlaybackInterruptTimer(state);
+      await releaseReply(reply);
+    }
+  };
+
+  const isCurrentGeneration = (generation: ActiveGeneration) =>
+    activeGeneration?.id === generation.id &&
+    activeGeneration.controller === generation.controller &&
+    activeCall === generation.call;
+
+  const releaseReply = async (reply: MattermostVoiceReplyAudio | undefined) => {
+    try {
+      await reply?.release?.();
+    } catch (error) {
+      params.onError?.(`mattermost voice playback release failed: ${String(error)}`);
+    }
+  };
+
+  const runGeneration = async (generation: ActiveGeneration, userId: string, message: string) => {
+    try {
+      params.onDebug?.(
+        `mattermost voice turn start channel=${generation.call.channelId} speaker=${userId} chars=${message.length}`,
+      );
+      let reply: MattermostVoiceReplyAudio | undefined;
+      try {
+        reply = await params.processTurn({
+          abortSignal: generation.controller.signal,
+          channelId: generation.call.channelId,
+          message,
+          userId,
+        });
+      } catch (error) {
+        if (!generation.controller.signal.aborted && isCurrentGeneration(generation)) {
+          voiceBatch = [];
+          params.onError?.(`mattermost voice turn failed: ${String(error)}`);
+        }
         return;
       }
+      if (!isCurrentGeneration(generation) || generation.controller.signal.aborted) {
+        await releaseReply(reply);
+        params.onDebug?.(
+          `mattermost voice turn skipped channel=${generation.call.channelId} speaker=${userId} reason=stale-generation`,
+        );
+        return;
+      }
+      if (!reply) {
+        voiceBatch = [];
+        params.onDebug?.(
+          `mattermost voice turn skipped channel=${generation.call.channelId} speaker=${userId} reason=no-reply`,
+        );
+        return;
+      }
+      const outcome = await playReply({ call: generation.call, reply, userId });
+      if (isCurrentGeneration(generation) && outcome !== "aborted") {
+        voiceBatch = [];
+      }
+    } finally {
+      if (activeGeneration?.id === generation.id) {
+        activeGeneration = undefined;
+      }
+    }
+  };
+
+  const restartGeneration = (call: ActiveCall, userId: string) => {
+    if (activeCall !== call || voiceBatch.length === 0) {
+      return;
+    }
+    activeGeneration?.controller.abort();
+    abortPlayback();
+    const generation: ActiveGeneration = {
+      call,
+      controller: new AbortController(),
+      id: ++generationId,
+    };
+    activeGeneration = generation;
+    const message = voiceBatch.join("\n\n");
+    trackTask(runGeneration(generation, userId, message));
+  };
+
+  const flushReadyTranscripts = () => {
+    let restartFrom: PendingTranscript | undefined;
+    for (;;) {
+      const pending = pendingTranscripts.get(nextTranscriptId);
+      if (!pending) {
+        break;
+      }
+      pendingTranscripts.delete(nextTranscriptId);
+      nextTranscriptId += 1;
+      if (pending.call !== activeCall) {
+        continue;
+      }
+      if (!pending.transcript) {
+        if (pending.clearBatchIfEmpty) {
+          voiceBatch = [];
+        }
+        continue;
+      }
+      voiceBatch.push(pending.transcript);
+      restartFrom = pending;
+    }
+    if (restartFrom) {
+      restartGeneration(restartFrom.call, restartFrom.userId);
+    }
+  };
+
+  const handleCapturedUtterance = async (paramsForUtterance: {
+    call: ActiveCall;
+    clearBatchIfEmpty?: boolean;
+    samples: Int16Array;
+    userId: string;
+    utteranceId: number;
+  }) => {
+    const { call, clearBatchIfEmpty, samples, userId, utteranceId } = paramsForUtterance;
+    let transcript: string | undefined;
+    try {
+      params.onDebug?.(
+        `mattermost voice transcription start channel=${call.channelId} speaker=${userId} samples=${samples.length}`,
+      );
+      transcript = await params.transcribeTurn({
+        channelId: call.channelId,
+        userId,
+        samples,
+      });
+    } catch (error) {
+      params.onError?.(`mattermost voice transcription failed: ${String(error)}`);
+    }
+    if (activeCall !== call) {
+      return;
+    }
+    pendingTranscripts.set(utteranceId, { call, clearBatchIfEmpty, transcript, userId });
+    flushReadyTranscripts();
+  };
+
+  const callbacks: MattermostVoiceCallCallbacks = {
+    onAudio(event) {
       getCapture(event.sessionId).push(event.samples);
     },
     onVoice(event) {
       if (event.userId === params.botUserId) {
         return;
       }
-      if (playing) {
-        if (event.speaking) {
+      const capture = getCapture(event.sessionId);
+      if (event.speaking) {
+        if (playing) {
+          capture.clearInactivePreRoll();
+        }
+        const started = capture.start();
+        if (!playing && started) {
+          playbackCaptureGuards.delete(playbackCaptureKey(event));
+        }
+        if (playing && started) {
+          const key = playbackCaptureKey(event);
+          if (!playbackCaptureGuards.has(key)) {
+            playbackCaptureGuards.set(key, { interrupted: false, userId: event.userId });
+          }
           schedulePlaybackInterrupt(event);
-        } else {
-          clearMatchingPlaybackInterrupt(event);
         }
         return;
       }
-      const capture = getCapture(event.sessionId);
-      if (event.speaking) {
-        capture.start();
+      const samples = capture.stop();
+      const playbackGuard = consumePlaybackCaptureGuard(event);
+      if (playing && playbackGuard) {
+        clearMatchingPlaybackInterrupt(event);
         return;
       }
-      const samples = capture.stop();
+      clearMatchingPlaybackInterrupt(event);
+      if (playbackGuard && !playbackGuard.interrupted) {
+        return;
+      }
       const call = activeCall;
       if (!call || samples.length === 0) {
         return;
       }
-      turnTail = turnTail
-        .then(async () => {
-          params.onDebug?.(
-            `mattermost voice turn start channel=${call.channelId} speaker=${event.userId} samples=${samples.length}`,
-          );
-          const reply = await params.processTurn({
-            channelId: call.channelId,
-            userId: event.userId,
-            samples,
-          });
-          if (!reply || activeCall !== call) {
-            await reply?.release?.();
-            params.onDebug?.(
-              `mattermost voice turn skipped channel=${call.channelId} speaker=${event.userId} reason=${reply ? "stale-call" : "no-reply"}`,
-            );
-            return;
-          }
-          const controller = new AbortController();
-          const state: PlaybackState = { call, controller };
-          playback = state;
-          setPlaybackSuppressed(true);
-          const playbackTimeoutMilliseconds = resolvePlaybackTimeoutMilliseconds(reply);
-          let playbackTimeout: ReturnType<typeof setTimeout> | undefined;
-          let timedOut = false;
-          const playbackFinished = call.session
-            .play(reply, { signal: controller.signal })
-            .catch((error: unknown) => {
-              if (!timedOut) {
-                throw error;
-              }
-              params.onError?.(`mattermost voice playback failed after timeout: ${String(error)}`);
-            });
-          try {
-            params.onDebug?.(
-              `mattermost voice playback start channel=${call.channelId} speaker=${event.userId}`,
-            );
-            const playbackTimedOut =
-              playbackTimeoutMilliseconds === undefined
-                ? undefined
-                : new Promise<"timeout">((resolve) => {
-                    playbackTimeout = setTimeout(() => {
-                      timedOut = true;
-                      controller.abort();
-                      resolve("timeout");
-                    }, playbackTimeoutMilliseconds);
-                    playbackTimeout.unref?.();
-                  });
-            const outcome = await Promise.race(
-              playbackTimedOut
-                ? [playbackFinished.then(() => "finished" as const), playbackTimedOut]
-                : [playbackFinished.then(() => "finished" as const)],
-            );
-            if (outcome === "timeout") {
-              params.onError?.(
-                `mattermost voice playback timed out after ${playbackTimeoutMilliseconds}ms`,
-              );
-            } else {
-              params.onDebug?.(
-                `mattermost voice playback finished channel=${call.channelId} speaker=${event.userId}`,
-              );
-            }
-          } finally {
-            if (playbackTimeout) {
-              clearTimeout(playbackTimeout);
-            }
-            if (playback === state) {
-              playback = undefined;
-            }
-            clearPlaybackInterruptTimer(state);
-            setPlaybackSuppressed(false);
-            await reply.release?.();
-          }
-        })
-        .catch((error: unknown) => {
-          params.onError?.(`mattermost voice turn failed: ${String(error)}`);
-        });
+      const utteranceId = nextUtteranceId;
+      nextUtteranceId += 1;
+      trackTask(
+        handleCapturedUtterance({
+          call,
+          clearBatchIfEmpty: playbackGuard?.interrupted === true,
+          samples,
+          userId: event.userId,
+          utteranceId,
+        }),
+      );
     },
   };
 
   const closeActiveCall = async () => {
     const call = activeCall;
     activeCall = undefined;
-    if (playback) {
-      const state = playback;
-      playback = undefined;
-      clearPlaybackInterruptTimer(state);
-      state.controller.abort();
-    }
+    activeGeneration?.controller.abort();
+    activeGeneration = undefined;
+    abortPlayback();
     captures.clear();
-    setPlaybackSuppressed(false);
+    pendingTranscripts.clear();
+    playbackCaptureGuards.clear();
+    voiceBatch = [];
+    nextUtteranceId = 1;
+    nextTranscriptId = 1;
+    setPlaybackActive(false);
     await call?.session.close();
   };
 
@@ -348,13 +570,13 @@ export function createMattermostVoiceWorker(params: {
       activeCall = { channelId, session };
     },
     async waitForIdle() {
-      await turnTail;
+      await waitForTrackedTasks();
     },
     async close() {
       lifecycleGeneration += 1;
       pendingChannelId = undefined;
       await closeActiveCall();
-      await turnTail;
+      await waitForTrackedTasks();
     },
   };
 }

--- a/extensions/mattermost/src/mattermost/voice-worker.ts
+++ b/extensions/mattermost/src/mattermost/voice-worker.ts
@@ -4,6 +4,7 @@ import { createVoiceCapture } from "./voice-audio.js";
 const CALLS_EVENT_PREFIX = "custom_com.mattermost.calls_";
 const PLAYBACK_INTERRUPT_MILLISECONDS = 2_000;
 const PLAYBACK_STALL_TIMEOUT_MILLISECONDS = 10_000;
+const RECONNECT_RETRY_DELAYS_MILLISECONDS = [1_000, 2_000, 5_000, 10_000] as const;
 
 export type MattermostVoiceCallCallbacks = {
   onAudio: (event: { sessionId: string; samples: Int16Array }) => void;
@@ -26,6 +27,7 @@ export type MattermostVoiceCallSession = {
     options?: MattermostVoicePlaybackOptions,
   ) => Promise<void>;
   close: () => Promise<void>;
+  closed?: Promise<void>;
 };
 
 type MattermostCallsEvent = {
@@ -51,6 +53,7 @@ type MattermostVoiceWorker = {
 type ActiveCall = {
   channelId: string;
   session: MattermostVoiceCallSession;
+  userId: string;
 };
 
 type PlaybackState = {
@@ -81,6 +84,10 @@ type PlaybackCaptureGuard = {
   userId: string;
 };
 
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
 export function createMattermostVoiceWorker(params: {
   authorizeJoin: (params: { channelId: string; userId: string }) => Promise<boolean>;
   botUserId: string;
@@ -103,12 +110,15 @@ export function createMattermostVoiceWorker(params: {
     userId: string;
     samples: Int16Array;
   }) => Promise<string | undefined>;
+  reconnectRetryDelaysMs?: readonly number[];
+  sleep?: (milliseconds: number) => Promise<void>;
   onDebug?: (message: string) => void;
   onError?: (message: string) => void;
 }): MattermostVoiceWorker {
   const captures = new Map<string, ReturnType<typeof createVoiceCapture>>();
   let activeCall: ActiveCall | undefined;
   let pendingChannelId: string | undefined;
+  let pendingOwnerId = 0;
   let lifecycleGeneration = 0;
   let playback: PlaybackState | undefined;
   let activeGeneration: ActiveGeneration | undefined;
@@ -117,9 +127,14 @@ export function createMattermostVoiceWorker(params: {
   let nextUtteranceId = 1;
   let nextTranscriptId = 1;
   const pendingTasks = new Set<Promise<void>>();
+  const pendingLifecycleTasks = new Set<Promise<void>>();
   const pendingTranscripts = new Map<number, PendingTranscript>();
   const playbackCaptureGuards = new Map<string, PlaybackCaptureGuard>();
   let voiceBatch: string[] = [];
+  const sleep = params.sleep ?? delay;
+  const reconnectRetryDelays = params.reconnectRetryDelaysMs?.length
+    ? params.reconnectRetryDelaysMs
+    : RECONNECT_RETRY_DELAYS_MILLISECONDS;
   const resolvePlaybackTimeoutMilliseconds = (reply: MattermostVoiceReplyAudio) => {
     if (params.playbackTimeoutMilliseconds !== undefined) {
       return Math.max(1, params.playbackTimeoutMilliseconds);
@@ -143,6 +158,27 @@ export function createMattermostVoiceWorker(params: {
     return capture;
   };
 
+  const reservePendingChannel = (channelId: string) => {
+    pendingOwnerId += 1;
+    pendingChannelId = channelId;
+    return pendingOwnerId;
+  };
+
+  const clearPendingChannel = (ownerId: number, channelId: string) => {
+    if (pendingOwnerId === ownerId && pendingChannelId === channelId) {
+      pendingChannelId = undefined;
+    }
+  };
+
+  const cancelPendingChannel = (channelId: string) => {
+    if (pendingChannelId !== channelId) {
+      return false;
+    }
+    pendingOwnerId += 1;
+    pendingChannelId = undefined;
+    return true;
+  };
+
   const trackTask = (task: Promise<void>) => {
     pendingTasks.add(task);
     void task.then(
@@ -151,9 +187,23 @@ export function createMattermostVoiceWorker(params: {
     );
   };
 
+  const trackLifecycleTask = (task: Promise<void>) => {
+    pendingLifecycleTasks.add(task);
+    void task.then(
+      () => pendingLifecycleTasks.delete(task),
+      () => pendingLifecycleTasks.delete(task),
+    );
+  };
+
   const waitForTrackedTasks = async () => {
     while (pendingTasks.size > 0) {
       await Promise.all([...pendingTasks]);
+    }
+  };
+
+  const waitForLifecycleTasks = async () => {
+    while (pendingLifecycleTasks.size > 0) {
+      await Promise.all([...pendingLifecycleTasks]);
     }
   };
 
@@ -268,7 +318,9 @@ export function createMattermostVoiceWorker(params: {
         return "failed";
       });
     try {
-      params.onDebug?.(`mattermost voice playback start channel=${call.channelId} speaker=${userId}`);
+      params.onDebug?.(
+        `mattermost voice playback start channel=${call.channelId} speaker=${userId}`,
+      );
       const playbackTimedOut =
         playbackTimeoutMilliseconds === undefined
           ? undefined
@@ -489,7 +541,7 @@ export function createMattermostVoiceWorker(params: {
     },
   };
 
-  const closeActiveCall = async () => {
+  const resetActiveCall = async (options: { closeSession: boolean }) => {
     const call = activeCall;
     activeCall = undefined;
     activeGeneration?.controller.abort();
@@ -502,8 +554,139 @@ export function createMattermostVoiceWorker(params: {
     nextUtteranceId = 1;
     nextTranscriptId = 1;
     setPlaybackActive(false);
-    await call?.session.close();
+    if (options.closeSession) {
+      await call?.session.close();
+    }
   };
+
+  const connectActiveCall = async (paramsForCall: {
+    channelId: string;
+    generation: number;
+    userId: string;
+  }) => {
+    const { channelId, generation, userId } = paramsForCall;
+    const pendingOwner = reservePendingChannel(channelId);
+    await resetActiveCall({ closeSession: true });
+    if (
+      generation !== lifecycleGeneration ||
+      pendingOwnerId !== pendingOwner ||
+      pendingChannelId !== channelId
+    ) {
+      return;
+    }
+    let session: MattermostVoiceCallSession;
+    try {
+      session = await params.connect({ channelId, callbacks });
+    } catch (error) {
+      clearPendingChannel(pendingOwner, channelId);
+      throw error;
+    }
+    // Call end and shutdown can race the async WebRTC join. Never retain a
+    // connection that belongs to an older lifecycle generation.
+    if (
+      generation !== lifecycleGeneration ||
+      pendingOwnerId !== pendingOwner ||
+      pendingChannelId !== channelId
+    ) {
+      await session.close();
+      return;
+    }
+    const call: ActiveCall = { channelId, session, userId };
+    clearPendingChannel(pendingOwner, channelId);
+    activeCall = call;
+    watchSessionClosed(call);
+  };
+
+  const handleSessionClosed = async (call: ActiveCall) => {
+    if (activeCall !== call) {
+      return;
+    }
+    if (pendingChannelId && pendingChannelId !== call.channelId) {
+      await resetActiveCall({ closeSession: false });
+      return;
+    }
+    params.onDebug?.(
+      `mattermost voice call session closed channel=${call.channelId}; reconnecting`,
+    );
+    const generation = ++lifecycleGeneration;
+    let pendingOwner = reservePendingChannel(call.channelId);
+    await resetActiveCall({ closeSession: false });
+    if (
+      generation !== lifecycleGeneration ||
+      pendingOwnerId !== pendingOwner ||
+      pendingChannelId !== call.channelId
+    ) {
+      return;
+    }
+    let attempt = 0;
+    for (;;) {
+      if (
+        generation !== lifecycleGeneration ||
+        pendingOwnerId !== pendingOwner ||
+        pendingChannelId !== call.channelId
+      ) {
+        return;
+      }
+      let retrying = false;
+      try {
+        if ((await params.resolveChannelType(call.channelId))?.toUpperCase() !== "D") {
+          return;
+        }
+        if (
+          generation !== lifecycleGeneration ||
+          pendingOwnerId !== pendingOwner ||
+          pendingChannelId !== call.channelId
+        ) {
+          return;
+        }
+        if (!(await params.authorizeJoin({ channelId: call.channelId, userId: call.userId }))) {
+          return;
+        }
+        if (generation === lifecycleGeneration) {
+          await connectActiveCall({
+            channelId: call.channelId,
+            generation,
+            userId: call.userId,
+          });
+        }
+        return;
+      } catch (error) {
+        if (generation !== lifecycleGeneration) {
+          return;
+        }
+        params.onError?.(
+          `mattermost voice reconnect failed channel=${call.channelId}: ${String(error)}`,
+        );
+        const retryDelay = reconnectRetryDelays[attempt];
+        if (retryDelay === undefined) {
+          params.onError?.(`mattermost voice reconnect exhausted channel=${call.channelId}`);
+          return;
+        }
+        attempt += 1;
+        pendingOwner = reservePendingChannel(call.channelId);
+        await sleep(Math.max(0, retryDelay));
+        retrying = true;
+      } finally {
+        if (!retrying) {
+          clearPendingChannel(pendingOwner, call.channelId);
+        }
+      }
+    }
+  };
+
+  function watchSessionClosed(call: ActiveCall) {
+    if (!call.session.closed) {
+      return;
+    }
+    const task = call.session.closed
+      .then(async () => {
+        await handleSessionClosed(call);
+      })
+      .catch((error: unknown) => {
+        params.onError?.(`mattermost voice call session watcher failed: ${String(error)}`);
+      });
+    trackLifecycleTask(task);
+  }
 
   return {
     async handleEvent(event) {
@@ -523,10 +706,13 @@ export function createMattermostVoiceWorker(params: {
         return;
       }
       if (eventName === "call_end") {
-        if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
-          lifecycleGeneration += 1;
-          pendingChannelId = undefined;
-          await closeActiveCall();
+        const matchesActiveCall = activeCall?.channelId === channelId;
+        const invalidatedPendingJoin = cancelPendingChannel(channelId);
+        if (matchesActiveCall) {
+          if (!pendingChannelId && !invalidatedPendingJoin) {
+            lifecycleGeneration += 1;
+          }
+          await resetActiveCall({ closeSession: true });
         }
         return;
       }
@@ -536,46 +722,43 @@ export function createMattermostVoiceWorker(params: {
       if (!humanJoined || !joinedUserId) {
         return;
       }
-      if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
+      if (activeCall?.channelId === channelId || pendingChannelId !== undefined) {
         return;
       }
-      if ((await params.resolveChannelType(channelId))?.toUpperCase() !== "D") {
-        return;
-      }
-      if (!(await params.authorizeJoin({ channelId, userId: joinedUserId }))) {
-        return;
-      }
-      if (activeCall?.channelId === channelId || pendingChannelId === channelId) {
-        return;
-      }
-      const generation = ++lifecycleGeneration;
-      pendingChannelId = channelId;
-      await closeActiveCall();
-      let session: MattermostVoiceCallSession;
+      const pendingOwner = reservePendingChannel(channelId);
       try {
-        session = await params.connect({ channelId, callbacks });
-      } catch (error) {
-        if (generation === lifecycleGeneration) {
-          pendingChannelId = undefined;
+        if ((await params.resolveChannelType(channelId))?.toUpperCase() !== "D") {
+          return;
         }
-        throw error;
+        if (pendingOwnerId !== pendingOwner || pendingChannelId !== channelId) {
+          return;
+        }
+        if (!(await params.authorizeJoin({ channelId, userId: joinedUserId }))) {
+          return;
+        }
+        if (pendingOwnerId !== pendingOwner || pendingChannelId !== channelId) {
+          return;
+        }
+        if (activeCall?.channelId === channelId || pendingChannelId !== channelId) {
+          return;
+        }
+        const generation = ++lifecycleGeneration;
+        const connectTask = connectActiveCall({ channelId, generation, userId: joinedUserId });
+        trackLifecycleTask(connectTask);
+        await connectTask;
+      } finally {
+        clearPendingChannel(pendingOwner, channelId);
       }
-      // Call end and shutdown can race the async WebRTC join. Never retain a
-      // connection that belongs to an older lifecycle generation.
-      if (generation !== lifecycleGeneration) {
-        await session.close();
-        return;
-      }
-      pendingChannelId = undefined;
-      activeCall = { channelId, session };
     },
     async waitForIdle() {
       await waitForTrackedTasks();
     },
     async close() {
       lifecycleGeneration += 1;
+      pendingOwnerId += 1;
       pendingChannelId = undefined;
-      await closeActiveCall();
+      await resetActiveCall({ closeSession: true });
+      await waitForLifecycleTasks();
       await waitForTrackedTasks();
     },
   };

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -77,6 +77,11 @@ export type MattermostAccountConfig = {
     /** Enable message reaction actions. Default: true. */
     reactions?: boolean;
   };
+  /** Voice call integration. Disabled by default. */
+  voice?: {
+    /** Automatically join direct-message calls and answer with STT/agent/TTS. */
+    enabled?: boolean;
+  };
   /** Native slash command configuration. */
   commands?: {
     /** Enable native slash commands. "auto" resolves to false (opt-in). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1140,6 +1140,12 @@ importers:
 
   extensions/mattermost:
     dependencies:
+      '@msgpack/msgpack':
+        specifier: 3.1.3
+        version: 3.1.3
+      '@roamhq/wrtc':
+        specifier: 0.10.0
+        version: 0.10.0
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -3517,6 +3523,10 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -4310,6 +4320,34 @@ packages:
   '@reflink/reflink@0.1.19':
     resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
     engines: {node: '>= 10'}
+
+  '@roamhq/wrtc-darwin-arm64@0.10.0':
+    resolution: {integrity: sha512-vFdi79jWuPHcnUcnuOjTvyKtmY/RI2xRQo9Y6RsIjIlYePN/7LTy00c+Ivrz4prYAPbp0oHscl7PDV64VUqGTQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@roamhq/wrtc-darwin-x64@0.10.0':
+    resolution: {integrity: sha512-H6852g2xYCuaR+/TrthpdMafs4bMfAUEpvRDhsIguzrK7Dz+MKpNI8MkwdqJN8W65J+7w7k+YqXIkTHe7Fz/cg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@roamhq/wrtc-linux-arm64@0.10.0':
+    resolution: {integrity: sha512-fEuJbNjprxQG6QlFd2iqBW9x028RDSho6izVg7gyt8irdPiXWOxzOxNnYMs/B2fohBTd1wD4Qxfivl07/dCR8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@roamhq/wrtc-linux-x64@0.10.0':
+    resolution: {integrity: sha512-H32lK2eFg3sVb/9nkHIX5HIisxFoS82Gpesuea+zqAyRpRzSd5NpFXx28bVy9wQyRrNtj8k0bTUgEzWRzSbYCA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@roamhq/wrtc-win32-x64@0.10.0':
+    resolution: {integrity: sha512-wEVXMvLrBizdLyrd+Zc7zb7zpwUuHUBXwrdIvI69e3i/AA8YsVYI2xo/sxk6GoQ+o8a14ONc4SStDS35TCjg+w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@roamhq/wrtc@0.10.0':
+    resolution: {integrity: sha512-yFqQQ0EV1ZUHaphh3tmjoxPi2wzhW2vjmzoAVNRRLUjXYd2e1nvwi9TKfE2w4WNvNws/hBkouvOt23Xo9FkXkQ==}
 
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
@@ -5614,6 +5652,11 @@ packages:
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -8210,6 +8253,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -9954,6 +10001,8 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
+  '@msgpack/msgpack@3.1.3': {}
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -10574,6 +10623,30 @@ snapshots:
       '@reflink/reflink-win32-arm64-msvc': 0.1.19
       '@reflink/reflink-win32-x64-msvc': 0.1.19
     optional: true
+
+  '@roamhq/wrtc-darwin-arm64@0.10.0':
+    optional: true
+
+  '@roamhq/wrtc-darwin-x64@0.10.0':
+    optional: true
+
+  '@roamhq/wrtc-linux-arm64@0.10.0':
+    optional: true
+
+  '@roamhq/wrtc-linux-x64@0.10.0':
+    optional: true
+
+  '@roamhq/wrtc-win32-x64@0.10.0':
+    optional: true
+
+  '@roamhq/wrtc@0.10.0':
+    optionalDependencies:
+      '@roamhq/wrtc-darwin-arm64': 0.10.0
+      '@roamhq/wrtc-darwin-x64': 0.10.0
+      '@roamhq/wrtc-linux-arm64': 0.10.0
+      '@roamhq/wrtc-linux-x64': 0.10.0
+      '@roamhq/wrtc-win32-x64': 0.10.0
+      domexception: 4.0.0
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
@@ -11940,6 +12013,11 @@ snapshots:
       entities: 4.5.0
 
   domelementtype@2.3.0: {}
+
+  domexception@4.0.0:
+    dependencies:
+      webidl-conversions: 7.0.0
+    optional: true
 
   domhandler@5.0.3:
     dependencies:
@@ -15010,6 +15088,9 @@ snapshots:
   web-tree-sitter@0.26.10: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0:
+    optional: true
 
   webidl-conversions@8.0.1: {}
 


### PR DESCRIPTION
Related: #103841

## What Problem This Solves

Mattermost users can start DM calls with the bot account, but before this branch OpenClaw had no end-to-end voice-call path for the Mattermost plugin. Typed DMs worked; voice calls did not join the bot to the call, capture spoken user turns, run the routed OpenClaw session, or play spoken assistant replies back into Mattermost.

This PR adds an opt-in Mattermost DM voice-call POC using the Mattermost Calls plugin, configured OpenClaw speech-to-text, the existing Mattermost session routing, configured text-to-speech, and WebRTC playback. Voice transcripts and assistant reply text stay hidden from the Mattermost DM; only audio is exchanged in the call.

## Why This Change Was Made

The implementation keeps the voice path in the Mattermost plugin instead of adding a new core protocol surface. Mattermost already emits call lifecycle and speaking events, while the plugin owns Mattermost auth, DM access policy, routing, and transport-specific behavior.

Branch-level changes:

- Adds an opt-in `voice.enabled` config surface, config UI hint, generated config metadata, and Mattermost docs.
- Adds Mattermost Calls WebSocket/WebRTC support for authentication, join/leave, zlib/msgpack SDP signaling, Mattermost-provided ICE/STUN/TURN configuration, media-map/track mapping, inbound audio sinks, speaking events, keepalive, outbound PCM playback, terminal socket closure detection, and reconnect/rejoin recovery.
- Adds audio helpers for bounded pre-roll capture, stereo 48 kHz PCM handling, 16 kHz mono WAV creation for STT, and ffmpeg-backed reply audio decoding/resampling for playback.
- Wires the Mattermost monitor to forward Calls events before post filtering, authorize only direct-message voice calls, route voice turns to the same agent/session as typed DMs, and clean up on shutdown.
- Adds hidden STT → agent → TTS voice turns with `deliver: false`, `disableMessageTool: true`, a voice-specific system prompt, abort propagation, fixed error speech on failed turns, and markdown stripping before TTS.
- Adds a persistent voice worker for call lifecycle, finite reconnect retries, repeated turns, ordered transcript batching, active generation/playback cancellation, stale reply release, playback timeout budgeting, and cleanup-failure isolation.
- Adds natural barge-in behavior: brief playback-overlap noise is discarded, sustained user speech interrupts playback, and new transcripts during generation rerun the hidden agent turn with the full accumulated spoken batch.
- Adds focused tests for config validation, Calls signaling/audio, ICE/TURN config consumption, socket closure recovery, finite reconnect retry, ffmpeg fallback, voice capture, hidden voice turns, monitor event forwarding, call lifecycle, access gating, batching, cancellation, interruption, timeouts, and cleanup edge cases.

## User Impact

With `channels.mattermost.voice.enabled: true`, an authorized user can start a direct-message Mattermost call with the bot account and speak to the same OpenClaw session they use in the DM. The bot joins the call, listens for Mattermost speaking events, transcribes the captured utterance, generates a hidden assistant reply, strips markdown for spoken output, and plays synthesized audio back into the call.

Current limits are documented: direct-message calls only, one active DM call per Mattermost account, the call should start after the voice worker is enabled, the Mattermost Calls plugin must be installed, STT/TTS must be configured, and playback depends on the native WebRTC dependency plus ffmpeg-compatible audio decoding.

## Evidence

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/calls-client.test.ts extensions/mattermost/src/mattermost/voice-worker.test.ts extensions/mattermost/src/mattermost/voice-turn.test.ts extensions/mattermost/src/mattermost/voice-audio.test.ts extensions/mattermost/src/mattermost/voice-audio-ffmpeg.test.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts extensions/mattermost/src/config-schema.test.ts`
  - 7 files passed, 92 tests passed.
- `node scripts/run-tsgo.mjs -p extensions/mattermost/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/mattermost.tsbuildinfo 2>&1 | rg 'extensions/mattermost/src/mattermost/(calls-client|voice-worker|voice-turn|monitor-websocket)\.ts'`
  - no touched-file type errors in the filtered probe.
- `git diff --check`
  - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local ...`
  - clean: no accepted/actionable findings.
- Live POC smoke after restarting the gateway from this worktree:
  - bot joined a Mattermost DM call and played audible TTS replies;
  - markdown was stripped before TTS;
  - fish → interrupt/correct to shark cancelled stale playback/generation and responded with the corrected turn.

AI-assisted: yes. Implemented and reviewed with Codex.

Proof gap: Testbox/Crabbox proof was not run because the delegated Testbox binary was unavailable in this environment (`blacksmith` was not on PATH). Focused local Codex-worktree fallback plus live local Mattermost POC smoke were used for this Mattermost voice surface. A full plugin/all-extension tsgo run was not claimed because the broader graph still reports unrelated existing SDK/dist/dependency errors; the filtered touched-file probe above was clean.
