### PR TITLE
fix(agents): bind session rewrites to verified snapshots

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2046,6 +2046,41 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects a same-size rewrite racing the byte-identical snapshot", async () => {
+    const sessionFile = await createTempSessionFile();
+    const originalBytes = await fs.readFile(sessionFile);
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.writeFile(sessionFile, originalBytes);
+
+    const realStat = fs.stat.bind(fs);
+    let armedStatCalls = 0;
+    const statSpy = vi.spyOn(fs, "stat").mockImplementation(async (target, options) => {
+      if (target === sessionFile && options?.bigint === true) {
+        armedStatCalls += 1;
+        if (armedStatCalls === 2) {
+          await fs.writeFile(sessionFile, '{"type":"sessioN"}\n', "utf8");
+        }
+      }
+      return await realStat(target, options);
+    });
+
+    try {
+      await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+    } finally {
+      statSpy.mockRestore();
+    }
+    expect(armedStatCalls).toBeGreaterThanOrEqual(2);
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
   it("trusts owned writes after accepting ctime-only fingerprint drift", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
@@ -2094,22 +2129,21 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(3);
   });
 
-  it("allows metadata drift for digest-backed transcript snapshots", async () => {
+  it("allows a byte-identical rewrite for digest-backed transcript snapshots", async () => {
     const sessionFile = await createTempSessionFile();
-    await fs.writeFile(sessionFile, Buffer.alloc(8 * 1024 * 1024 + 1, "x"));
+    const originalBytes = Buffer.alloc(8 * 1024 * 1024 + 1, "x");
+    await fs.writeFile(sessionFile, originalBytes);
     const oldTime = new Date("2020-01-01T00:00:00.000Z");
     await fs.utimes(sessionFile, oldTime, oldTime);
     const before = await fs.stat(sessionFile, { bigint: true });
     const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalDigestDrift = vi.fn(async () => ({ release }));
     const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalDigestDrift,
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
       lockOptions: { ...lockOptions, sessionFile },
     });
 
     await controller.releaseForPrompt();
-    const newTime = new Date("2021-01-01T00:00:00.000Z");
-    await fs.utimes(sessionFile, newTime, newTime);
+    await fs.writeFile(sessionFile, originalBytes);
     const after = await fs.stat(sessionFile, { bigint: true });
 
     expect(after.dev).toBe(before.dev);
@@ -2121,15 +2155,38 @@ describe("embedded attempt session lock lifecycle", () => {
     await controller.dispose();
   });
 
+  it("rejects changed bytes for digest-backed transcript snapshots", async () => {
+    const sessionFile = await createTempSessionFile();
+    const originalBytes = Buffer.alloc(8 * 1024 * 1024 + 1, "x");
+    await fs.writeFile(sessionFile, originalBytes);
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    const file = await fs.open(sessionFile, "r+");
+    try {
+      await file.write(Buffer.from("y"), 0, 1, 0);
+    } finally {
+      await file.close();
+    }
+
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
   it("rejects same-inode, same-size transcript rewrites when one byte changes", async () => {
     const sessionFile = await createTempSessionFile();
     const oldTime = new Date("2020-01-01T00:00:00.000Z");
     await fs.utimes(sessionFile, oldTime, oldTime);
     const before = await fs.stat(sessionFile, { bigint: true });
     const release = vi.fn(async () => {});
-    const acquireSessionWriteLockLocalSameSizeRewrite = vi.fn(async () => ({ release }));
     const controller = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock: acquireSessionWriteLockLocalSameSizeRewrite,
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
       lockOptions: { ...lockOptions, sessionFile },
     });
 
@@ -2144,8 +2201,24 @@ describe("embedded attempt session lock lifecycle", () => {
       EmbeddedAttemptSessionTakeoverError,
     );
     expect(controller.hasSessionTakeover()).toBe(true);
-    expect(acquireSessionWriteLockLocalSameSizeRewrite).toHaveBeenCalledTimes(2);
-    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects truncated transcript rewrites", async () => {
+    const sessionFile = await createTempSessionFile();
+    const before = await fs.stat(sessionFile);
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.truncate(sessionFile, before.size - 1);
+
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
   });
 
   it("fails closed when a metadata-only snapshot is too large to verify", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -2048,6 +2048,9 @@ describe("embedded attempt session lock lifecycle", () => {
 
   it("rejects a same-size rewrite racing the byte-identical snapshot", async () => {
     const sessionFile = await createTempSessionFile();
+    const oldTime = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, oldTime, oldTime);
+    const before = await fs.stat(sessionFile, { bigint: true });
     const originalBytes = await fs.readFile(sessionFile);
     const release = vi.fn(async () => {});
     const controller = await createEmbeddedAttemptSessionLockController({
@@ -2057,6 +2060,16 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await controller.releaseForPrompt();
     await fs.writeFile(sessionFile, originalBytes);
+    // Force the first rewrite past the fingerprint fast path even on filesystems
+    // that coalesce timestamps; the next path stat is snapshot validation.
+    const rewrittenTime = new Date("2021-01-01T00:00:00.000Z");
+    await fs.utimes(sessionFile, rewrittenTime, rewrittenTime);
+    const after = await fs.stat(sessionFile, { bigint: true });
+
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeNs).not.toBe(before.mtimeNs);
 
     const realStat = fs.stat.bind(fs);
     let armedStatCalls = 0;

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -3,7 +3,7 @@
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
-import { createReadStream, readFileSync, statSync } from "node:fs";
+import { type BigIntStats, readFileSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
@@ -140,6 +140,19 @@ type SessionFileFenceSnapshot = {
   bytes?: Buffer;
   digest?: string;
 };
+
+type SessionFileHandle = Awaited<ReturnType<typeof fs.open>>;
+
+function sessionFileFingerprintFromStat(stat: BigIntStats): SessionFileFingerprint {
+  return {
+    exists: true,
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mtimeNs: stat.mtimeNs,
+    ctimeNs: stat.ctimeNs,
+  };
+}
 
 function sameSessionFileFingerprint(
   left: SessionFileFingerprint | undefined,
@@ -606,42 +619,86 @@ async function readSessionFileFenceSnapshot(
   if (!fingerprint.exists) {
     return { fingerprint };
   }
-  if (
-    fingerprint.size <= BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES) &&
-    fingerprint.size <= MAX_SAFE_FILE_OFFSET
-  ) {
-    try {
-      return {
-        fingerprint,
-        bytes: await fs.readFile(sessionFile),
-      };
-    } catch {
-      return { fingerprint };
-    }
-  }
   if (fingerprint.size > BigInt(MAX_BENIGN_SESSION_FENCE_CONTENT_DIGEST_BYTES)) {
     return { fingerprint };
   }
-  return {
-    fingerprint,
-    digest: await readSessionFileDigest(sessionFile),
-  };
+  let file: SessionFileHandle;
+  try {
+    file = await fs.open(sessionFile, "r");
+  } catch {
+    return { fingerprint };
+  }
+  try {
+    const openedFingerprint = sessionFileFingerprintFromStat(await file.stat({ bigint: true }));
+    if (!sameSessionFileIdentityAndSize(fingerprint, openedFingerprint)) {
+      return { fingerprint: await readSessionFileFingerprint(sessionFile) };
+    }
+
+    let bytes: Buffer | undefined;
+    let digest: string | undefined;
+    if (
+      fingerprint.size <= BigInt(MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES) &&
+      fingerprint.size <= MAX_SAFE_FILE_OFFSET
+    ) {
+      bytes = await readSessionFileBytes(file, Number(fingerprint.size));
+    } else if (fingerprint.size <= BigInt(MAX_BENIGN_SESSION_FENCE_CONTENT_DIGEST_BYTES)) {
+      digest = await readSessionFileDigest(file, Number(fingerprint.size));
+    }
+
+    const postReadFingerprint = sessionFileFingerprintFromStat(await file.stat({ bigint: true }));
+    const resolvedFingerprint = await readSessionFileFingerprint(sessionFile);
+    if (
+      !sameSessionFileIdentityAndSize(openedFingerprint, postReadFingerprint) ||
+      !sameSessionFileFingerprint(fingerprint, resolvedFingerprint) ||
+      !sameSessionFileIdentityAndSize(postReadFingerprint, resolvedFingerprint)
+    ) {
+      return { fingerprint: resolvedFingerprint };
+    }
+    return {
+      fingerprint: resolvedFingerprint,
+      ...(bytes !== undefined ? { bytes } : {}),
+      ...(digest !== undefined ? { digest } : {}),
+    };
+  } catch {
+    return { fingerprint: await readSessionFileFingerprint(sessionFile) };
+  } finally {
+    await file.close();
+  }
 }
 
-async function readSessionFileDigest(sessionFile: string): Promise<string | undefined> {
+async function readSessionFileBytes(
+  file: SessionFileHandle,
+  length: number,
+): Promise<Buffer | undefined> {
+  const buffer = Buffer.alloc(length);
+  let offset = 0;
+  while (offset < length) {
+    const { bytesRead } = await file.read(buffer, offset, length - offset, offset);
+    if (bytesRead === 0) {
+      return undefined;
+    }
+    offset += bytesRead;
+  }
+  return buffer;
+}
+
+async function readSessionFileDigest(
+  file: SessionFileHandle,
+  length: number,
+): Promise<string | undefined> {
   const hash = createHash("sha256");
-  return await new Promise<string | undefined>((resolve) => {
-    const stream = createReadStream(sessionFile);
-    stream.on("data", (chunk) => {
-      hash.update(chunk);
-    });
-    stream.on("error", () => {
-      resolve(undefined);
-    });
-    stream.on("end", () => {
-      resolve(hash.digest("hex"));
-    });
-  });
+  const buffer = Buffer.allocUnsafe(Math.min(length, 64 * 1024));
+  let offset = 0;
+  while (offset < length) {
+    const nextLength = Math.min(buffer.length, length - offset);
+    const { bytesRead } = await file.read(buffer, 0, nextLength, offset);
+    if (bytesRead === 0) {
+      return undefined;
+    }
+    hash.update(buffer.subarray(0, bytesRead));
+    offset += bytesRead;
+  }
+  return hash.digest("hex");
 }
 
 async function classifySessionFenceAdvance(params: {
@@ -728,33 +785,31 @@ async function classifyOwnedSessionFileInitialization(params: {
     : resolvedChange;
 }
 
-async function sessionFenceByteIdenticalRewriteIsBenign(params: {
+async function readByteIdenticalSessionFenceSnapshot(params: {
   sessionFile: string;
   previous: SessionFileFenceSnapshot | undefined;
   current: SessionFileFingerprint;
-}): Promise<boolean> {
+}): Promise<SessionFileFenceSnapshot | undefined> {
   const previous = params.previous;
   if (
     previous?.fingerprint.exists !== true ||
     !params.current.exists ||
     !sameSessionFileIdentityAndSize(previous.fingerprint, params.current)
   ) {
-    return false;
+    return undefined;
+  }
+  const verified = await readSessionFileFenceSnapshot(params.sessionFile);
+  if (!sameSessionFileIdentityAndSize(params.current, verified.fingerprint)) {
+    return undefined;
   }
   // Truncate-and-rewrite keeps inode and size while advancing timestamps.
-  // Only exact bytes may make that metadata-only fence drift trustworthy.
-  if (previous.bytes === undefined) {
-    if (previous.digest === undefined) {
-      return false;
-    }
-    const currentDigest = await readSessionFileDigest(params.sessionFile);
-    return currentDigest !== undefined && currentDigest === previous.digest;
+  // Install only the stable snapshot whose exact bytes were compared here.
+  if (previous.bytes !== undefined && verified.bytes !== undefined) {
+    return previous.bytes.equals(verified.bytes) ? verified : undefined;
   }
-  try {
-    return previous.bytes.equals(await fs.readFile(params.sessionFile));
-  } catch {
-    return false;
-  }
+  return previous.digest !== undefined && previous.digest === verified.digest
+    ? verified
+    : undefined;
 }
 
 async function classifySessionFenceRewrite(params: {
@@ -1107,15 +1162,7 @@ function isTrustedSessionFileState(
 
 async function readSessionFileFingerprint(sessionFile: string): Promise<SessionFileFingerprint> {
   try {
-    const stat = await fs.stat(sessionFile, { bigint: true });
-    return {
-      exists: true,
-      dev: stat.dev,
-      ino: stat.ino,
-      size: stat.size,
-      mtimeNs: stat.mtimeNs,
-      ctimeNs: stat.ctimeNs,
-    };
+    return sessionFileFingerprintFromStat(await fs.stat(sessionFile, { bigint: true }));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return { exists: false };
@@ -1126,15 +1173,7 @@ async function readSessionFileFingerprint(sessionFile: string): Promise<SessionF
 
 function readSessionFileFingerprintSync(sessionFile: string): SessionFileFingerprint {
   try {
-    const stat = statSync(sessionFile, { bigint: true });
-    return {
-      exists: true,
-      dev: stat.dev,
-      ino: stat.ino,
-      size: stat.size,
-      mtimeNs: stat.mtimeNs,
-      ctimeNs: stat.ctimeNs,
-    };
+    return sessionFileFingerprintFromStat(statSync(sessionFile, { bigint: true }));
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return { exists: false };
@@ -1492,16 +1531,17 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
 
-    if (
-      await sessionFenceByteIdenticalRewriteIsBenign({
-        sessionFile: params.lockOptions.sessionFile,
-        previous: fenceSnapshot,
-        current,
-      })
-    ) {
-      fenceSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
-      fenceFingerprint = fenceSnapshot.fingerprint;
-      setFenceGeneration(recordTrustedSessionFileState(sessionFileFenceKey, current));
+    const byteIdenticalSnapshot = await readByteIdenticalSessionFenceSnapshot({
+      sessionFile: params.lockOptions.sessionFile,
+      previous: fenceSnapshot,
+      current,
+    });
+    if (byteIdenticalSnapshot) {
+      fenceSnapshot = byteIdenticalSnapshot;
+      fenceFingerprint = byteIdenticalSnapshot.fingerprint;
+      setFenceGeneration(
+        recordTrustedSessionFileState(sessionFileFenceKey, byteIdenticalSnapshot.fingerprint),
+      );
       return;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #91797 and its landed fix in `2e742e3`.

That fix correctly recognizes byte-identical, same-inode session rewrites, but it validates one pathname read and then installs a second independently read snapshot. A same-inode, same-size external rewrite in that gap can therefore be recorded as trusted instead of raising `EmbeddedAttemptSessionTakeoverError`.

## Why This Change Was Made

- Read each bounded fence snapshot through one file handle.
- Bracket the byte or SHA-256 read with stable path fingerprint and handle identity/size checks.
- Return and install the exact snapshot whose content was verified; never re-read an unvalidated replacement into trusted state.
- Keep full bytes through 8 MiB, bounded SHA-256 through 32 MiB, and fail closed above that limit.
- Preserve @gucasbrg's original byte-identical rewrite report and the maintainer repair that established the bounded content-verification design.

The alternative of relaxing the transcript line classifier remains rejected: equal-line rewrites are safe only when the exact bytes match, independent of JSON semantics.

## User Impact

Legitimate in-place rewrites with identical bytes no longer cause false session takeover aborts. Changed bytes, truncation, identity replacement, unstable reads, and oversized unverifiable snapshots remain takeover failures.

## Evidence

- Deterministic race regression mutates one byte between validation and snapshot publication; the landed implementation accepts it, this change rejects it.
- Real temporary-file controller coverage for small and digest-backed identical rewrites, changed same-size bytes, truncation, and the 32 MiB fail-closed boundary.
- `oxfmt` on both changed files: clean.
- Focused `oxlint` with the core TypeScript config: clean.
- Fresh full autoreview on the final incremental branch diff: clean, no actionable findings, confidence 0.92.
- Final reviewed head `cea726c6c093ceb41ddb5bac519fafe676bc162a`, tree `817f639d42ded8737d69745dc3e686f6fe27b1ab`.
- Exact-head hosted CI [run 29111555642](https://github.com/openclaw/openclaw/actions/runs/29111555642): success. The Linux `checks-node-compact-large-whole-1` shard passed the complete 119-test session-lock controller file; build, lint, production types, test types, and all remaining CI fan-out passed.
- Exact-tree Testbox [run 29111120327](https://github.com/openclaw/openclaw/actions/runs/29111120327) checked out production head `4de11bbf8f2b34616e887bf917fc9bf34f613854`, tree `a2537551b6c69f3a161e0ad7ac1536ae6993ada8`, then reproduced the current-`main` race: the promise resolved instead of rejecting (1 failed, 118 passed). An ANSI-sensitive harness marker stopped that lease before its positive suite, so final positive proof comes from the later exact-head hosted CI above; production code did not change between those heads.
- Fresh autoreview after the Linux-stability test correction: clean, no actionable findings, confidence 0.98.

Co-authored-by: gucasbrg <buruguo2000@163.com>
