### PR TITLE
fix(qqbot): add timeouts to API response reads

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -15,6 +15,42 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 import { ApiError } from "../types.js";
 import { ApiClient } from "./api-client.js";
 
+type OperationOutcome =
+  | { status: "resolved" }
+  | { status: "rejected"; error: unknown }
+  | { status: "pending" };
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function settleWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<OperationOutcome> {
+  return await Promise.race([
+    promise.then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    ),
+    delay(timeoutMs).then(() => ({ status: "pending" as const })),
+  ]);
+}
+
+async function expectRejectionWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<unknown> {
+  const outcome = await settleWithin(promise, timeoutMs);
+  expect(outcome.status).toBe("rejected");
+  if (outcome.status !== "rejected") {
+    throw new Error(`expected rejection within ${timeoutMs}ms, got ${outcome.status}`);
+  }
+  return outcome.error;
+}
+
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -34,6 +70,38 @@ function cancelTrackedResponse(
   return {
     response: new Response(stream, init),
     wasCanceled: () => canceled,
+  };
+}
+
+function createSignalAbortedBodyResponse(signal: AbortSignal): {
+  response: Response;
+  wasAborted: () => boolean;
+} {
+  let aborted = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const abortBody = () => {
+        aborted = true;
+        const error = new Error("body aborted");
+        error.name = "AbortError";
+        controller.error(error);
+      };
+      if (signal.aborted) {
+        abortBody();
+        return;
+      }
+      signal.addEventListener("abort", abortBody, { once: true });
+    },
+    async pull() {
+      await new Promise<void>(() => {});
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    wasAborted: () => aborted,
   };
 }
 
@@ -117,6 +185,38 @@ describe("ApiClient", () => {
     expect(streamed.getReadCount()).toBeLessThan(32);
     expect(streamed.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the request deadline active while reading a hanging response body", async () => {
+    const release = vi.fn(async () => {});
+    let body: ReturnType<typeof createSignalAbortedBodyResponse> | undefined;
+    fetchWithSsrFGuardMock.mockImplementationOnce(async (request: { init?: RequestInit }) => {
+      const signal = request.init?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("expected ApiClient to pass an AbortSignal");
+      }
+      const responseBody = createSignalAbortedBodyResponse(signal);
+      body = responseBody;
+      return {
+        response: responseBody.response,
+        release,
+      };
+    });
+
+    const client = new ApiClient({
+      baseUrl: "https://qqbot.test",
+      defaultTimeoutMs: 25,
+    });
+
+    const error = await expectRejectionWithin(
+      client.request("token-1", "GET", "/v2/users/@me"),
+      750,
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as Error).message).toBe("Request timeout [/v2/users/@me]: exceeded 25ms");
+    expect(body?.wasAborted()).toBe(true);
     expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -1,11 +1,18 @@
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 // Qqbot tests cover api-client plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const ssrfRuntimeActual = vi.hoisted(() => ({
+  fetchWithSsrFGuard: undefined as
+    | typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard
+    | undefined,
+}));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  ssrfRuntimeActual.fetchWithSsrFGuard = actual.fetchWithSsrFGuard;
   return {
     ...actual,
     fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -14,42 +21,6 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 
 import { ApiError } from "../types.js";
 import { ApiClient } from "./api-client.js";
-
-type OperationOutcome =
-  | { status: "resolved" }
-  | { status: "rejected"; error: unknown }
-  | { status: "pending" };
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function settleWithin(
-  promise: Promise<unknown>,
-  timeoutMs: number,
-): Promise<OperationOutcome> {
-  return await Promise.race([
-    promise.then(
-      () => ({ status: "resolved" as const }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    ),
-    delay(timeoutMs).then(() => ({ status: "pending" as const })),
-  ]);
-}
-
-async function expectRejectionWithin(
-  promise: Promise<unknown>,
-  timeoutMs: number,
-): Promise<unknown> {
-  const outcome = await settleWithin(promise, timeoutMs);
-  expect(outcome.status).toBe("rejected");
-  if (outcome.status !== "rejected") {
-    throw new Error(`expected rejection within ${timeoutMs}ms, got ${outcome.status}`);
-  }
-  return outcome.error;
-}
 
 function cancelTrackedResponse(
   text: string,
@@ -73,40 +44,9 @@ function cancelTrackedResponse(
   };
 }
 
-function createSignalAbortedBodyResponse(signal: AbortSignal): {
-  response: Response;
-  wasAborted: () => boolean;
-} {
-  let aborted = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      const abortBody = () => {
-        aborted = true;
-        const error = new Error("body aborted");
-        error.name = "AbortError";
-        controller.error(error);
-      };
-      if (signal.aborted) {
-        abortBody();
-        return;
-      }
-      signal.addEventListener("abort", abortBody, { once: true });
-    },
-    async pull() {
-      await new Promise<void>(() => {});
-    },
-  });
-  return {
-    response: new Response(stream, {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    }),
-    wasAborted: () => aborted,
-  };
-}
-
 describe("ApiClient", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     fetchWithSsrFGuardMock.mockReset();
   });
@@ -147,13 +87,13 @@ describe("ApiClient", () => {
           "Content-Type": "application/json",
           "User-Agent": "QQBotPlugin/unknown",
         },
-        signal: expect.any(AbortSignal),
       },
       auditContext: "qqbot-api",
       policy: {
         hostnameAllowlist: ["qqbot.test"],
         allowRfc2544BenchmarkRange: true,
       },
+      timeoutMs: 30_000,
     });
   });
 
@@ -188,35 +128,57 @@ describe("ApiClient", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the request deadline active while reading a hanging response body", async () => {
-    const release = vi.fn(async () => {});
-    let body: ReturnType<typeof createSignalAbortedBodyResponse> | undefined;
-    fetchWithSsrFGuardMock.mockImplementationOnce(async (request: { init?: RequestInit }) => {
-      const signal = request.init?.signal;
-      if (!(signal instanceof AbortSignal)) {
-        throw new Error("expected ApiClient to pass an AbortSignal");
+  it.each([0, 25])(
+    "keeps the %dms request deadline active while reading a hanging response body",
+    async (timeoutMs) => {
+      vi.useFakeTimers();
+      const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+      if (!actualGuard) {
+        throw new Error("expected the real SSRF guard implementation");
       }
-      const responseBody = createSignalAbortedBodyResponse(signal);
-      body = responseBody;
-      return {
-        response: responseBody.response,
-        release,
-      };
-    });
+      let requestSignal: AbortSignal | undefined;
+      const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal;
+        if (!(signal instanceof AbortSignal)) {
+          throw new Error("expected the guarded fetch to pass its deadline signal");
+        }
+        requestSignal = signal;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              signal.addEventListener("abort", () => controller.error(signal.reason), {
+                once: true,
+              });
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
+      const lookupFn = vi.fn(async () => [
+        { address: "93.184.216.34", family: 4 },
+      ]) as unknown as LookupFn;
+      fetchWithSsrFGuardMock.mockImplementationOnce(
+        async (request: Parameters<typeof actualGuard>[0]) =>
+          await actualGuard({ ...request, fetchImpl, lookupFn }),
+      );
 
-    const client = new ApiClient({
-      baseUrl: "https://qqbot.test",
-      defaultTimeoutMs: 25,
-    });
+      const client = new ApiClient({
+        baseUrl: "https://qqbot.test",
+        defaultTimeoutMs: timeoutMs,
+      });
 
-    const error = await expectRejectionWithin(
-      client.request("token-1", "GET", "/v2/users/@me"),
-      750,
-    );
+      const rejection = expect(client.request("token-1", "GET", "/v2/users/@me")).rejects.toThrow(
+        `Request timeout [/v2/users/@me]: exceeded ${timeoutMs}ms`,
+      );
+      const guardedTimeoutMs = Math.max(1, timeoutMs);
+      await vi.advanceTimersByTimeAsync(guardedTimeoutMs);
 
-    expect(error).toBeInstanceOf(ApiError);
-    expect((error as Error).message).toBe("Request timeout [/v2/users/@me]: exceeded 25ms");
-    expect(body?.wasAborted()).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
-  });
+      await rejection;
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: guardedTimeoutMs }),
+      );
+      expect(requestSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 });

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -23,6 +23,15 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const FILE_UPLOAD_TIMEOUT_MS = 120_000;
 const QQBOT_API_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    String((err as { name?: unknown }).name) === "AbortError"
+  );
+}
+
 function resolveQqbotApiSsrfPolicy(url: string): SsrFPolicy {
   return {
     hostnameAllowlist: [new URL(url).hostname],
@@ -109,7 +118,11 @@ export class ApiClient {
       options?.timeoutMs ?? (isFileUpload ? this.fileUploadTimeoutMs : this.defaultTimeoutMs);
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeout);
 
     const fetchInit: RequestInit = {
       method,
@@ -136,27 +149,24 @@ export class ApiClient {
     let res: Response;
     let release: (() => Promise<void>) | undefined;
     try {
-      const guarded = await fetchWithSsrFGuard({
-        url,
-        init: fetchInit,
-        auditContext: "qqbot-api",
-        policy: resolveQqbotApiSsrfPolicy(url),
-      });
-      res = guarded.response;
-      release = guarded.release;
-    } catch (err) {
-      clearTimeout(timeoutId);
-      if (err instanceof Error && err.name === "AbortError") {
-        this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
-        throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
+      try {
+        const guarded = await fetchWithSsrFGuard({
+          url,
+          init: fetchInit,
+          auditContext: "qqbot-api",
+          policy: resolveQqbotApiSsrfPolicy(url),
+        });
+        res = guarded.response;
+        release = guarded.release;
+      } catch (err) {
+        if (timedOut && isAbortError(err)) {
+          this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
+          throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
+        }
+        this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
+        throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
       }
-      this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
-      throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
-    } finally {
-      clearTimeout(timeoutId);
-    }
 
-    try {
       // Log response status and trace ID.
       const traceId = res.headers.get("x-tps-trace-id") ?? "";
       this.logger?.info?.(
@@ -169,6 +179,10 @@ export class ApiClient {
             ? await readProviderTextResponse(res, "QQBot API response")
             : await readResponseTextLimited(res, limitBytes);
         } catch (err) {
+          if (timedOut && isAbortError(err)) {
+            this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
+            throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
+          }
           throw new ApiError(
             `Failed to read response [${path}]: ${formatErrorMessage(err)}`,
             res.status,
@@ -238,6 +252,7 @@ export class ApiClient {
         throw new ApiError(`开放平台响应格式异常（${path}），请稍后重试`, res.status, path);
       }
     } finally {
+      clearTimeout(timeoutId);
       await release?.();
     }
   }

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -23,13 +23,8 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const FILE_UPLOAD_TIMEOUT_MS = 120_000;
 const QQBOT_API_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
-function isAbortError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "name" in err &&
-    String((err as { name?: unknown }).name) === "AbortError"
-  );
+function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.name === "TimeoutError";
 }
 
 function resolveQqbotApiSsrfPolicy(url: string): SsrFPolicy {
@@ -116,18 +111,11 @@ export class ApiClient {
       path.includes("/upload_part_finish");
     const timeout =
       options?.timeoutMs ?? (isFileUpload ? this.fileUploadTimeoutMs : this.defaultTimeoutMs);
-
-    const controller = new AbortController();
-    let timedOut = false;
-    const timeoutId = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-    }, timeout);
+    const guardedTimeoutMs = timeout > 0 ? timeout : 1;
 
     const fetchInit: RequestInit = {
       method,
       headers,
-      signal: controller.signal,
     };
 
     if (body) {
@@ -146,27 +134,26 @@ export class ApiClient {
       this.logger.debug(`[qqbot:api] >>> Body: ${JSON.stringify(logBody)}`);
     }
 
-    let res: Response;
-    let release: (() => Promise<void>) | undefined;
+    let guarded: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
     try {
-      try {
-        const guarded = await fetchWithSsrFGuard({
-          url,
-          init: fetchInit,
-          auditContext: "qqbot-api",
-          policy: resolveQqbotApiSsrfPolicy(url),
-        });
-        res = guarded.response;
-        release = guarded.release;
-      } catch (err) {
-        if (timedOut && isAbortError(err)) {
-          this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
-          throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
-        }
-        this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
-        throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
+      guarded = await fetchWithSsrFGuard({
+        url,
+        init: fetchInit,
+        auditContext: "qqbot-api",
+        policy: resolveQqbotApiSsrfPolicy(url),
+        timeoutMs: guardedTimeoutMs,
+      });
+    } catch (err) {
+      if (isTimeoutError(err)) {
+        this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
+        throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
       }
+      this.logger?.error?.(`[qqbot:api] <<< Network error: ${formatErrorMessage(err)}`);
+      throw new ApiError(`Network error [${path}]: ${formatErrorMessage(err)}`, 0, path);
+    }
 
+    const res = guarded.response;
+    try {
       // Log response status and trace ID.
       const traceId = res.headers.get("x-tps-trace-id") ?? "";
       this.logger?.info?.(
@@ -179,7 +166,7 @@ export class ApiClient {
             ? await readProviderTextResponse(res, "QQBot API response")
             : await readResponseTextLimited(res, limitBytes);
         } catch (err) {
-          if (timedOut && isAbortError(err)) {
+          if (isTimeoutError(err)) {
             this.logger?.error?.(`[qqbot:api] <<< Timeout after ${timeout}ms`);
             throw new ApiError(`Request timeout [${path}]: exceeded ${timeout}ms`, 0, path);
           }
@@ -252,8 +239,7 @@ export class ApiClient {
         throw new ApiError(`开放平台响应格式异常（${path}），请稍后重试`, res.status, path);
       }
     } finally {
-      clearTimeout(timeoutId);
-      await release?.();
+      await guarded.release();
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

QQBot API requests could hang after response headers arrived when the response body stopped making progress. The client cleared its request timer as soon as guarded fetch returned headers, leaving both successful and error response reads unbounded.

## Why This Change Was Made

The QQBot client now delegates its request deadline to the existing SSRF-guarded fetch. That guard owns DNS preflight, redirects, header delivery, body consumption, and dispatcher release, so one deadline covers the full request lifecycle. The duplicate client-side abort controller and timer are removed.

Timeout errors keep the existing QQBot `ApiError` shape. Zero-valued deadlines retain their prior immediate-timeout behavior by normalizing the guard delay to one timer tick.

## User Impact

QQBot sends, gateway discovery, interactions, and upload API calls now fail with the configured timeout instead of waiting forever when the provider stalls after headers.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/api-client.test.ts` — 1 file, 4 tests passed.
- Regression coverage invokes the real `fetchWithSsrFGuard` with deterministic DNS, reads a real stalled `Response` body, and proves both 0ms and 25ms deadlines abort the body and release the guard timer.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; patch correct (0.94).

No config, UI, dependency, or capability surface changes.
