### PR TITLE
fix(agents): prevent duplicate subagent recovery after restart

### DIFF
--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -15,6 +15,7 @@ import { resolveInternalSessionEffectsTarget } from "./internal-session-effects.
 import * as announceDelivery from "./subagent-announce-delivery.js";
 import {
   recoverOrphanedSubagentSessions,
+  resetOrphanRecoveryScheduleForTests,
   scheduleOrphanRecovery,
 } from "./subagent-orphan-recovery.js";
 import * as subagentRegistrySteerRuntime from "./subagent-registry-steer-runtime.js";
@@ -192,6 +193,7 @@ describe("subagent-orphan-recovery", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     resetGatewayWorkAdmission();
+    resetOrphanRecoveryScheduleForTests();
     vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun)
       .mockReset()
       .mockResolvedValue(1);
@@ -833,6 +835,36 @@ describe("subagent-orphan-recovery", () => {
     expect(second.skipped).toBe(1);
     expect(gateway.callGateway).toHaveBeenCalledOnce();
     expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces overlapping scheduled recovery into one follow-up scan", async () => {
+    const store = mockSingleAbortedSession();
+
+    let resolveResume: (result: { runId: string }) => void = () => {};
+    const parkedResume = new Promise<{ runId: string }>((resolve) => {
+      resolveResume = resolve;
+    });
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "unexpected-run" });
+    vi.mocked(gateway.callGateway).mockImplementationOnce(() => parkedResume as never);
+
+    const getActiveRuns = () => createActiveRuns(createTestRunRecord());
+    scheduleOrphanRecovery({ getActiveRuns, delayMs: 1, maxRetries: 0 });
+    // Requests arriving while the first scan is pending or in flight must be
+    // coalesced into exactly one follow-up run, not dropped and not stacked.
+    scheduleOrphanRecovery({ getActiveRuns, delayMs: 1, maxRetries: 0 });
+    scheduleOrphanRecovery({ getActiveRuns, delayMs: 1, maxRetries: 0 });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+
+    resolveResume({ runId: "resumed-run" });
+    await vi.runAllTimersAsync();
+
+    // One scan plus exactly one coalesced follow-up scan, each reading the
+    // session entry once; the orphan is resumed exactly once.
+    expect(sessionAccessor.loadSessionEntry).toHaveBeenCalledTimes(2);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(store["agent:main:subagent:test-session-1"]?.abortedLastRun).toBe(false);
   });
 
   it("finalizes interrupted runs with a readable failure after recovery retries are exhausted", async () => {

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -582,75 +582,115 @@ async function finalizeInterruptedRunWithRetry(params: {
   return false;
 }
 
-/**
- * Schedule orphan recovery after a delay, with retry logic.
- * The delay gives the gateway time to fully bootstrap after restart.
- * If recovery fails (e.g. gateway not yet ready), retries with exponential backoff.
- */
-export function scheduleOrphanRecovery(params: {
+type OrphanRecoveryScheduleParams = {
   getActiveRuns: () => Map<string, SubagentRunRecord>;
   delayMs?: number;
   maxRetries?: number;
-}): void {
-  const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
-  const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
+};
 
+let recoveryScheduleRunning = false;
+let queuedRecoveryParams: OrphanRecoveryScheduleParams | undefined;
+
+/** Test-only: clear the module-level single-flight state between tests. */
+export function resetOrphanRecoveryScheduleForTests(): void {
+  recoveryScheduleRunning = false;
+  queuedRecoveryParams = undefined;
+}
+
+function waitForRecoveryDelay(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
+}
+
+async function runOrphanRecoverySchedule(params: OrphanRecoveryScheduleParams): Promise<void> {
+  const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
   const resumedSessionKeys = new Set<string>();
   const pendingStaleFinalizations = new Map<string, string>();
-  const attemptRecovery = (attempt: number, delay: number) => {
-    setTimeout(() => {
+  let delay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    await waitForRecoveryDelay(delay);
+    try {
       // Every delayed/retry scan owns a fresh root lease. Keep terminal
       // mutation in the same lease so suspension cannot become ready mid-attempt.
-      void runWithGatewayIndependentRootWorkAdmission(async () => {
+      const scan = await runWithGatewayIndependentRootWorkAdmission(async () => {
         const result = await recoverOrphanedSubagentSessions({
           ...params,
           resumedSessionKeys,
           pendingStaleFinalizations,
         });
         if (result.failed > 0 && attempt < maxRetries) {
-          const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
-          log.info(
-            `orphan recovery had ${result.failed} failure(s); retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
-          );
-          attemptRecovery(attempt + 1, nextDelay);
-          return;
+          return { retry: true, failed: result.failed } as const;
         }
-        if (result.failedRuns.length === 0) {
-          return;
-        }
-        const attempts = attempt + 1;
-        const terminalResults = await Promise.all(
-          result.failedRuns.map(async (run) => ({
-            runId: run.runId,
-            completed: await finalizeInterruptedRunWithRetry({
+        if (result.failedRuns.length > 0) {
+          const attempts = attempt + 1;
+          const terminalResults = await Promise.all(
+            result.failedRuns.map(async (run) => ({
               runId: run.runId,
-              error: buildRecoveryFailureMessage({ attempts, error: run.error }),
-              initialDelayMs: delay,
-            }),
-          })),
-        );
-        const incomplete = terminalResults
-          .filter((terminal) => !terminal.completed)
-          .map((terminal) => terminal.runId);
-        if (incomplete.length > 0) {
-          log.warn(
-            `orphan recovery exhausted with ${incomplete.length} interrupted terminal projection(s) incomplete`,
-            { runIds: incomplete },
+              completed: await finalizeInterruptedRunWithRetry({
+                runId: run.runId,
+                error: buildRecoveryFailureMessage({ attempts, error: run.error }),
+                initialDelayMs: delay,
+              }),
+            })),
           );
+          const incomplete = terminalResults
+            .filter((terminal) => !terminal.completed)
+            .map((terminal) => terminal.runId);
+          if (incomplete.length > 0) {
+            log.warn(
+              `orphan recovery exhausted with ${incomplete.length} interrupted terminal projection(s) incomplete`,
+              { runIds: incomplete },
+            );
+          }
         }
-      }).catch((err: unknown) => {
-        if (attempt < maxRetries) {
-          const nextDelay = delay * RETRY_BACKOFF_MULTIPLIER;
-          log.warn(
-            `scheduled orphan recovery failed: ${String(err)}; retrying in ${nextDelay}ms (attempt ${attempt + 1}/${maxRetries})`,
-          );
-          attemptRecovery(attempt + 1, nextDelay);
-        } else {
-          log.warn(`scheduled orphan recovery failed after ${maxRetries} retries: ${String(err)}`);
-        }
+        return { retry: false, failed: result.failed } as const;
       });
-    }, delay).unref?.();
-  };
+      if (!scan.retry) {
+        return;
+      }
+      delay *= RETRY_BACKOFF_MULTIPLIER;
+      log.info(
+        `orphan recovery had ${scan.failed} failure(s); retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+      );
+    } catch (err) {
+      if (attempt >= maxRetries) {
+        log.warn(`scheduled orphan recovery failed after ${maxRetries} retries: ${String(err)}`);
+        return;
+      }
+      delay *= RETRY_BACKOFF_MULTIPLIER;
+      log.warn(
+        `scheduled orphan recovery failed: ${String(err)}; retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+      );
+    }
+  }
+}
 
-  attemptRecovery(0, initialDelay);
+/**
+ * Schedule orphan recovery after a delay, with retry logic.
+ * The delay gives the gateway time to fully bootstrap after restart.
+ * If recovery fails (e.g. gateway not yet ready), retries with exponential backoff.
+ *
+ * Only one recovery schedule runs at a time. Startup, restore, and reactive
+ * triggers share this lifecycle owner: a request arriving while a scan is in
+ * flight is coalesced into exactly one follow-up run rather than dropped, so
+ * work discovered mid-scan is neither lost nor resumed twice.
+ */
+export function scheduleOrphanRecovery(params: OrphanRecoveryScheduleParams): void {
+  if (recoveryScheduleRunning) {
+    queuedRecoveryParams ??= params;
+    return;
+  }
+
+  recoveryScheduleRunning = true;
+  void runOrphanRecoverySchedule(params).finally(() => {
+    recoveryScheduleRunning = false;
+    const queued = queuedRecoveryParams;
+    queuedRecoveryParams = undefined;
+    if (queued) {
+      scheduleOrphanRecovery(queued);
+    }
+  });
 }


### PR DESCRIPTION
Closes #103724

## What Problem This Solves

Fixes an issue where a gateway restart could schedule overlapping orphan-recovery scans and resume the same interrupted subagent twice. Those duplicate turns could repeat tool calls, external side effects, and model spend.

## Why This Change Was Made

The recovery scheduler now owns one retry chain at a time and coalesces overlapping requests into one follow-up scan. This preserves recovery requests raised while a scan is active without allowing independent scans to dispatch the same orphan concurrently.

The regression parks the first gateway resume, schedules a second recovery request, and verifies that only one resume is dispatched before the first completes and that the queued follow-up observes the cleared restart marker.

## User Impact

Interrupted subagents are resumed at most once across overlapping restart-time recovery triggers, avoiding duplicate work and side effects while retaining a follow-up pass for newly discovered orphaned work.

## Evidence

Red-green regression proof — the branch's own test file run on both sides:

**Green (this branch @ `8ff7d0b3d8e`):** `CI=true pnpm test src/agents/subagent-orphan-recovery.test.ts`
```
Test Files  1 passed (1)
Tests  28 passed (28)
```

**Red (`origin/main` @ `e43bd3d57bc`, with only the test file copied over; the test-only `resetOrphanRecoveryScheduleForTests` import shimmed to a no-op so the module loads on main — the test body itself is unchanged):**
```
FAIL  subagent-orphan-recovery > coalesces overlapping scheduled recovery into one follow-up scan
AssertionError: expected "vi.fn()" to be called once, but got 2 times
-> main resumes the same orphaned run twice when recovery schedules overlap; this branch resumes it exactly once and coalesces mid-scan requests into one follow-up.
```

`CI=true pnpm tsgo:core` is clean on the branch. Rebuilt on current main preserving all upstream behavior in the touched files (their pre-existing tests pass unchanged).
