### PR TITLE
fix(acp): skip unadvertised thinking/effort config keys instead of throwing

### DIFF
--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -922,4 +922,129 @@ describe("AcpSessionManager runtime config", () => {
       { code: "ACP_INVALID_RUNTIME_OPTION" },
     );
   });
+
+  it("skips unadvertised thinking config key instead of throwing", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: {
+        ...readySessionMeta({ agent: "codex" }),
+        runtimeOptions: {
+          model: "codex/latest",
+          thinking: "high",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-1",
+    });
+
+    // thinking was silently skipped because the backend does not advertise it
+    expectNoMockCallFields(runtimeState.setConfigOption, {
+      key: "thinking",
+    });
+    // model was still applied normally
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "model",
+      value: "codex/latest",
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips unadvertised effort config key instead of throwing", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-2",
+      storeSessionKey: "agent:codex:acp:session-2",
+      acp: {
+        ...readySessionMeta({ agent: "codex" }),
+        runtimeOptions: {
+          model: "codex/latest",
+          effort: "low",
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-2",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-2",
+    });
+
+    expectNoMockCallFields(runtimeState.setConfigOption, {
+      key: "effort",
+    });
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "model",
+      value: "codex/latest",
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still throws for unadvertised keys other than thinking/effort", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_mode", "session/set_config_option", "session/status"],
+      configOptionKeys: ["mode", "model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-3",
+      storeSessionKey: "agent:codex:acp:session-3",
+      acp: {
+        ...readySessionMeta({ agent: "codex" }),
+        runtimeOptions: {
+          model: "codex/latest",
+          backendExtras: {
+            custom_unknown_key: "value",
+          },
+        },
+      },
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-3",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-3",
+      }),
+      {
+        code: "ACP_BACKEND_UNSUPPORTED_CONTROL",
+      },
+    );
+
+    expect(runtimeState.runTurn).not.toHaveBeenCalled();
+  });
 });

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -175,10 +175,18 @@ export async function applyManagerRuntimeControls(params: {
           });
         }
         for (const [key, value] of configOptions) {
+          const normalizedKey = normalizeLowercaseStringOrEmpty(key);
+          // Skip unadvertised optional tuning keys (thinking, effort) instead of throwing.
+          // These are best-effort hints that backends may not support, similar to timeout.
+          // See: https://github.com/openclaw/openclaw/issues/103802
           if (
             advertisedKeys.size > 0 &&
-            !advertisedKeys.has(normalizeLowercaseStringOrEmpty(key))
+            !advertisedKeys.has(normalizedKey) &&
+            (normalizedKey === "thinking" || normalizedKey === "effort")
           ) {
+            continue;
+          }
+          if (advertisedKeys.size > 0 && !advertisedKeys.has(normalizedKey)) {
             throw new AcpRuntimeError(
               "ACP_BACKEND_UNSUPPORTED_CONTROL",
               `ACP backend "${backend}" does not accept config key "${key}".`,


### PR DESCRIPTION
## What Problem This Solves

Fixes #103802 — Every `sessions_spawn(runtime: "acp")` against the embedded **acpx** backend fails at spawn with:

```
AcpRuntimeError: ACP backend "acpx" does not accept config key "thinking".: code=ACP_BACKEND_UNSUPPORTED_CONTROL
```

The gateway's ACP manager computes a default `thinking` level and pushes it via `session/set_config_option`. Because acpx does not advertise `thinking` (or `effort`) as supported config options, the strict advertised-keys check throws and the session dies before its first turn.

## Why This Change Was Made

The fix follows the precedent of PR #81603 which tolerates unsupported timeout config hints. Optional tuning keys (`thinking`, `effort`) that the backend does not advertise should be skipped as best-effort hints instead of causing hard failures.

## Changes

Modified `src/acp/control-plane/manager.runtime-controls.ts:177-194`:
- Added a check to skip unadvertised `thinking` and `effort` keys before the strict advertised-keys validation
- These optional tuning keys are now treated as best-effort hints, similar to how timeout keys are handled

## User Impact

Users can now spawn ACP sessions (e.g., codex/acpx) without failures from force-injected `thinking` config defaults. Explicit `setConfigOption` calls for unsupported keys still throw as before.

## Evidence

- The fix is a minimal 9-line change at a single call site
- All existing tests pass: `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts` (28/28)
- Code formatting: `pnpm format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
