### PR TITLE
fix(discord): stop retrying non-idempotent sends on post-connect-ambiguous errors

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -603,6 +603,7 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
             },
           ),
         plannedTarget.surface === "origin" ? "send-approval-channel" : "send-approval",
+        { nonIdempotent: true },
       )) as { id: string; channel_id: string };
       if (!message?.id) {
         if (plannedTarget.surface === "origin") {

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import type { RetryConfig, RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
+import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -14,7 +14,7 @@ import { RequestClient } from "./internal/discord.js";
 import { getGateway } from "./monitor/gateway-registry.js";
 import { resolveDiscordProxyFetchForAccount } from "./proxy-fetch.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
-import { createDiscordRetryRunner } from "./retry.js";
+import { createDiscordRetryRunner, type DiscordRetryRunner } from "./retry.js";
 import type { DiscordRuntimeAccountContext } from "./send.types.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -142,7 +142,7 @@ export function createDiscordRestClient(opts: DiscordClientOpts) {
 export function createDiscordClient(opts: DiscordClientOpts): {
   token: string;
   rest: RequestClient;
-  request: RetryRunner;
+  request: DiscordRetryRunner;
 } {
   const { token, rest, account } = createDiscordRestClient(opts);
   const request = createDiscordRetryRunner({

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -1,7 +1,11 @@
 // Discord tests cover retry plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
-import { createDiscordRetryRunner, isRetryableDiscordTransientError } from "./retry.js";
+import {
+  createDiscordRetryRunner,
+  isRetryableDiscordPreConnectError,
+  isRetryableDiscordTransientError,
+} from "./retry.js";
 
 const ZERO_DELAY_RETRY = { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 };
 
@@ -50,6 +54,70 @@ describe("isRetryableDiscordTransientError", () => {
     ["plain string", "fetch failed"],
   ])("does not retry %s", (_name, err) => {
     expect(isRetryableDiscordTransientError(err)).toBe(false);
+  });
+});
+
+describe("isRetryableDiscordPreConnectError", () => {
+  it.each([
+    ["rate limit", createRateLimitError()],
+    ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
+    ["ECONNREFUSED", Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" })],
+    ["ENOTFOUND", Object.assign(new Error("dns failure"), { code: "ENOTFOUND" })],
+    ["EAI_AGAIN cause", new Error("request failed", { cause: { code: "EAI_AGAIN" } })],
+    [
+      "UND_ERR_CONNECT_TIMEOUT",
+      Object.assign(new Error("connect"), { code: "UND_ERR_CONNECT_TIMEOUT" }),
+    ],
+  ])("retries %s", (_name, err) => {
+    expect(isRetryableDiscordPreConnectError(err)).toBe(true);
+  });
+
+  it.each([
+    ["ECONNRESET", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" })],
+    ["ETIMEDOUT cause", new Error("request failed", { cause: { code: "ETIMEDOUT" } })],
+    ["abort", Object.assign(new Error("aborted"), { name: "AbortError" })],
+    ["headers timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_HEADERS_TIMEOUT" })],
+    ["body timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_BODY_TIMEOUT" })],
+    ["socket", Object.assign(new Error("socket"), { code: "UND_ERR_SOCKET" })],
+    ["502 status", Object.assign(new Error("bad gateway"), { status: 502 })],
+    ["fetch failed", new TypeError("fetch failed")],
+  ])("does not retry %s", (_name, err) => {
+    expect(isRetryableDiscordPreConnectError(err)).toBe(false);
+  });
+});
+
+describe("createDiscordRetryRunner nonIdempotent", () => {
+  it("does not retry post-connect-ambiguous errors for non-idempotent sends", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "text", { nonIdempotent: true })).rejects.toThrow("aborted");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries pre-connect errors for non-idempotent sends", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps retrying the broad transient set for default idempotent calls", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "react")).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -10,7 +10,6 @@ import {
   resolveRetryConfig,
   retryAsync,
   type RetryConfig,
-  type RetryRunner,
 } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { RateLimitError } from "./internal/discord.js";
@@ -39,7 +38,20 @@ const DISCORD_RETRYABLE_ERROR_CODES = new Set([
 ]);
 const DISCORD_TRANSIENT_MESSAGE_RE =
   /\b(?:bad gateway|fetch failed|network error|networkerror|service unavailable|socket hang up|temporarily unavailable|timed out|timeout)\b|connection (?:closed|reset|refused)/i;
+const DISCORD_PRECONNECT_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 const log = createSubsystemLogger("discord/retry");
+
+export type DiscordRetryRunner = <T>(
+  fn: () => Promise<T>,
+  label?: string,
+  options?: { nonIdempotent?: boolean },
+) => Promise<T>;
 
 function readDiscordErrorStatus(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {
@@ -83,6 +95,25 @@ export function isRetryableDiscordTransientError(err: unknown): boolean {
   return false;
 }
 
+export function isRetryableDiscordPreConnectError(err: unknown): boolean {
+  if (err instanceof RateLimitError) {
+    return true;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => [
+    current.cause,
+    current.error,
+  ])) {
+    if (readDiscordErrorStatus(candidate) === 429) {
+      return true;
+    }
+    const code = extractErrorCode(candidate);
+    if (code && DISCORD_PRECONNECT_ERROR_CODES.has(code.toUpperCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isRetryableDiscordGatewayTransportError(err: unknown): boolean {
   if (!isRetryableDiscordTransientError(err) || err instanceof RateLimitError) {
     return false;
@@ -97,7 +128,7 @@ export function createDiscordRetryRunner(params: {
   configRetry?: RetryConfig;
   verbose?: boolean;
   isGatewayDisconnected?: () => boolean;
-}): RetryRunner {
+}): DiscordRetryRunner {
   const retryConfig = resolveRetryConfig(DISCORD_RETRY_DEFAULTS, {
     ...params.configRetry,
     ...params.retry,
@@ -109,7 +140,10 @@ export function createDiscordRetryRunner(params: {
       ? retryConfig.attempts + DISCORD_GATEWAY_RECONNECT_EXTRA_ATTEMPTS
       : retryConfig.attempts;
 
-  return <T>(fn: () => Promise<T>, label?: string) => {
+  return <T>(fn: () => Promise<T>, label?: string, options?: { nonIdempotent?: boolean }) => {
+    const isRetryable = options?.nonIdempotent
+      ? isRetryableDiscordPreConnectError
+      : isRetryableDiscordTransientError;
     let observedGatewayDisconnect = false;
     const runRequest = async () => {
       observedGatewayDisconnect ||= params.isGatewayDisconnected?.() === true;
@@ -125,7 +159,7 @@ export function createDiscordRetryRunner(params: {
       attempts,
       label,
       shouldRetry: (err, attempt) =>
-        isRetryableDiscordTransientError(err) &&
+        isRetryable(err) &&
         (attempt < retryConfig.attempts ||
           (observedGatewayDisconnect && isRetryableDiscordGatewayTransportError(err))),
       retryAfterMs: (err) => (err instanceof RateLimitError ? err.retryAfter * 1000 : undefined),

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -319,6 +319,7 @@ export async function sendDiscordComponentMessage(
           body,
         }),
       "components",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
   } catch (err) {
     throw await buildDiscordSendError(err, {

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -249,6 +249,7 @@ export async function sendMessageDiscord(
             },
           ),
         "forum-thread",
+        { nonIdempotent: true },
       )) as { id: string; message?: { id: string; channel_id: string } };
     } catch (err) {
       throw await buildDiscordSendError(err, {
@@ -444,6 +445,7 @@ export async function sendStickerDiscord(
         },
       }),
     "sticker",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }
@@ -470,6 +472,7 @@ export async function sendPollDiscord(
         },
       }),
     "poll",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -14,7 +14,6 @@ import {
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
-import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { chunkDiscordTextWithMode } from "./chunk.js";
@@ -27,6 +26,7 @@ import {
 } from "./internal/discord.js";
 import { parseAndResolveRecipient } from "./recipient-resolution.js";
 import { resolveDiscordReplyMessageId, type DiscordReplyReference } from "./reply-reference.js";
+import type { DiscordRetryRunner } from "./retry.js";
 import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";
 import { DiscordSendError } from "./send.types.js";
 
@@ -41,7 +41,7 @@ const DISCORD_UPLOAD_TOO_LARGE_STATUS = 413;
 const DISCORD_UPLOAD_TOO_LARGE_NOTICE =
   "Attachment skipped: Discord rejected the file as too large.";
 
-type DiscordRequest = RetryRunner;
+type DiscordRequest = DiscordRetryRunner;
 
 export {
   buildDiscordMessagePayload,
@@ -380,6 +380,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     const result = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "text",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
     return { result, replyToId: chunkReplyTo };
   };
@@ -480,6 +481,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     res = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "media",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
   } catch (err) {
     if (!isDiscordUploadTooLargeError(err)) {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -26,7 +26,6 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
-import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -35,6 +34,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
 import { readDiscordMessage, readRetryAfter } from "./internal/rest-errors.js";
 import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
+import type { DiscordRetryRunner } from "./retry.js";
 
 const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
@@ -406,7 +406,7 @@ export async function sendDiscordVoiceMessage(
   audioBuffer: Buffer,
   metadata: VoiceMessageMetadata,
   replyTo: string | undefined,
-  request: RetryRunner,
+  request: DiscordRetryRunner,
   silent?: boolean,
   token?: string,
 ): Promise<{ id: string; channel_id: string }> {
@@ -482,6 +482,7 @@ export async function sendDiscordVoiceMessage(
         body: messagePayload,
       }) as Promise<{ id: string; channel_id: string }>,
     "voice-message",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
 
   return res;


### PR DESCRIPTION
## What Problem This Solves

Discord's outbound retry runner (`extensions/discord/src/retry.ts`) treated every transient transport error as retryable, including `ECONNRESET`, `ETIMEDOUT`, `AbortError`, and the undici `UND_ERR_HEADERS_TIMEOUT` / `UND_ERR_BODY_TIMEOUT` / `UND_ERR_SOCKET` timeouts. That runner wraps the non-idempotent `createChannelMessage` POST used by `sendDiscordText` / `sendDiscordMedia` (and the sticker, poll, voice, component, forum-thread, and approval sends). None of those errors indicate the request never reached Discord: the REST client aborts the fetch client-side after a fixed timeout (`extensions/discord/src/internal/rest.ts:289`), and a reset or timeout can fire after Discord has already created the message but before the client reads the response. Retrying then creates the same message a second time while the send still reports success, so users see duplicated Discord messages.

`buildDiscordMessageRequest` never sets Discord's optional `nonce` / `enforce_nonce`, so there is no server-side idempotency key to fall back on; the client is solely responsible for not replaying an ambiguous create.

## Why This Change Was Made

The sibling Telegram adapter was already hardened against exactly this failure class (`extensions/telegram/src/network-errors.ts`): it keeps a narrow `PRE_CONNECT_ERROR_CODES` set for non-idempotent sends and deliberately excludes `ECONNRESET` / `ETIMEDOUT` / `AbortError`, because those can fire after delivery and retrying them duplicates messages. Discord's send path had no equivalent carve-out.

Root cause (`extensions/discord/src/retry.ts`, before):

```ts
shouldRetry: (err, attempt) =>
  isRetryableDiscordTransientError(err) &&
  (attempt < retryConfig.attempts ||
    (observedGatewayDisconnect && isRetryableDiscordGatewayTransportError(err))),
```

`isRetryableDiscordTransientError` returns true for `AbortError`, `ECONNRESET`, `ETIMEDOUT`, and the undici timeouts, all of which are post-connect-ambiguous for a create.

Fix (after): a pre-connect-only classifier and a per-call `nonIdempotent` opt-in on the runner.

```ts
export function isRetryableDiscordPreConnectError(err: unknown): boolean {
  if (err instanceof RateLimitError) return true;
  for (const candidate of collectErrorGraphCandidates(err, ...)) {
    if (readDiscordErrorStatus(candidate) === 429) return true;
    const code = extractErrorCode(candidate);
    if (code && DISCORD_PRECONNECT_ERROR_CODES.has(code.toUpperCase())) return true;
  }
  return false;
}

return <T>(fn, label?, options?: { nonIdempotent?: boolean }) => {
  const isRetryable = options?.nonIdempotent
    ? isRetryableDiscordPreConnectError
    : isRetryableDiscordTransientError;
  ...
};
```

`DISCORD_PRECONNECT_ERROR_CODES` is the subset of the existing retryable codes that provably never reached Discord (`EAI_AGAIN`, `ECONNREFUSED`, `ENETUNREACH`, `ENOTFOUND`, `UND_ERR_CONNECT_TIMEOUT`), plus rate-limit rejections (Discord returned 429 before creating anything, safe to retry). The non-idempotent create/thread-create call sites now pass `{ nonIdempotent: true }`; ambiguous post-connect errors on those calls surface to the caller instead of silently double-sending.

## Why this is the right boundary

The classifier lives in the retry module that already owns Discord retry policy, next to `isRetryableDiscordTransientError`. The runner keeps a single implementation and gains one optional per-call flag rather than a second runner threaded through the send stack. Idempotent REST calls keep the broader transient set: reactions (`createOwnMessageReaction`, PUT), message edits (`editChannelMessage`), DM-channel lookup (`createUserDmChannel`, returns the existing DM), and the voice attachment upload-URL request are all unchanged, so genuine transient resilience for those is preserved. The gateway-reconnect extra-attempt path (`isRetryableDiscordGatewayTransportError`, PR #100896) is untouched for idempotent calls; for non-idempotent calls the pre-connect classifier naturally excludes the ambiguous gateway-transport errors it would otherwise replay.

Related but distinct: #100896 (merged) fixes the opposite failure (reconnect sends silently dropped); #45500 (closed) was an LLM-layer retry, not the transport runner. Neither addresses non-idempotent replay of post-connect-ambiguous errors.

## Evidence

- `extensions/discord/src/retry.test.ts` adds coverage: `isRetryableDiscordPreConnectError` retries pre-connect codes and rate limits but not `ECONNRESET` / `ETIMEDOUT` / `AbortError` / undici timeouts / 5xx; the runner with `{ nonIdempotent: true }` does not retry an `AbortError` (1 call) but still retries `ECONNREFUSED` (2 calls); the default runner keeps retrying the broad set. Full file green: 38 passed via `node scripts/run-vitest.mjs extensions/discord/src/retry.test.ts`.
- Scoped `tsgo` over the eight changed files (base source path mappings) reports no errors in the changed files.
- `oxfmt --check` and `oxlint` clean on the changed files.
- The new pre-connect assertions fail against pristine `main` (which retries the ambiguous errors) and pass with the patch.

## Real behavior proof
Behavior addressed: a client-side abort/reset that fires after Discord created the message caused the non-idempotent `createChannelMessage` retry to run again, delivering a duplicate message while reporting success.
Real environment tested: the real production retry runner from `createDiscordRetryRunner` wrapping the real `createChannelMessage` POST exactly as `extensions/discord/src/send.shared.ts:381` invokes it, on pristine `main` (091584b197) and on the patched tree with identical inputs; the only faked element is the REST socket, which counts each server-side create and returns an abort after the first create then succeeds. The retry decision, classifier, and create wrapper are the real code.
Exact steps or command run after this patch: drive `request(() => createChannelMessage(rest, channelId, { body }), "text", { nonIdempotent: true })` where the socket aborts once after recording the create, capturing the server-side create count and the final send outcome.
Evidence after fix:
```
# BEFORE (pristine main 091584b197)
serverSideMessagesCreated=2 | send RESOLVED as success, returned id=discord-msg-2

# AFTER (this patch, identical inputs)
serverSideMessagesCreated=1 | send REJECTED with AbortError (no duplicate delivered)
```
Observed result after fix: the aborted create is no longer replayed, so Discord receives one create instead of two and the ambiguous outcome is surfaced to the caller rather than reported as a successful duplicate send.
What was not tested: no live Discord API request was issued (the REST socket was faked at the transport boundary); the full repository typecheck and build were not run locally, they run in CI.
