### PR TITLE
fix(ios): resize oversized shared images

### DIFF
--- a/apps/ios/Resources/Localizable.xcstrings
+++ b/apps/ios/Resources/Localizable.xcstrings
@@ -5713,6 +5713,142 @@
         }
       }
     },
+    "The shared image could not be prepared.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The shared image could not be prepared."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法准备共享的图像。"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法準備共享的影像。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível preparar a imagem compartilhada."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das geteilte Bild konnte nicht vorbereitet werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo preparar la imagen compartida."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有画像を準備できませんでした。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유 이미지를 준비할 수 없습니다."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de préparer l’image partagée."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "साझा की गई इमेज तैयार नहीं की जा सकी।"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر تجهيز الصورة المشتركة."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile preparare l’immagine condivisa."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paylaşılan görüntü hazırlanamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося підготувати зображення, яким поділилися."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gambar yang dibagikan tidak dapat disiapkan."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się przygotować udostępnionego obrazu."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่สามารถเตรียมรูปภาพที่แชร์ได้"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể chuẩn bị hình ảnh được chia sẻ."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "De gedeelde afbeelding kon niet worden voorbereid."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آماده‌سازی تصویر هم‌رسانی‌شده ممکن نبود."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось подготовить отправленное изображение."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Det gick inte att förbereda den delade bilden."
+          }
+        }
+      }
+    },
     "Trust and connect": {
       "localizations": {
         "en": {

--- a/apps/ios/ShareExtension/ShareComposeState.swift
+++ b/apps/ios/ShareExtension/ShareComposeState.swift
@@ -7,6 +7,7 @@ enum ShareComposeStatus: Equatable {
     case ready
     case sending
     case sent
+    case blocked(String)
     case failed(String)
 }
 
@@ -25,6 +26,8 @@ struct ShareComposeControlState: Equatable {
             Self(isSendEnabled: false, isCancelEnabled: true, isEditable: false)
         case .ready, .failed:
             Self(isSendEnabled: hasDraftText, isCancelEnabled: true, isEditable: true)
+        case .blocked:
+            Self(isSendEnabled: false, isCancelEnabled: true, isEditable: true)
         case .sending, .sent:
             Self(isSendEnabled: false, isCancelEnabled: false, isEditable: false)
         }

--- a/apps/ios/ShareExtension/ShareComposeView.swift
+++ b/apps/ios/ShareExtension/ShareComposeView.swift
@@ -100,7 +100,7 @@ final class ShareComposeView: UIView, UITextViewDelegate {
                 text: NSLocalizedString("Sent to OpenClaw.", comment: "Share extension success status"),
                 icon: (name: "checkmark.circle.fill", tint: .systemGreen),
                 spinning: false)
-        case let .failed(message):
+        case let .blocked(message), let .failed(message):
             self.showFooter(
                 text: message,
                 icon: (name: "exclamationmark.triangle.fill", tint: .systemOrange),

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -22,7 +22,7 @@ final class ShareViewController: UIViewController {
     private struct ExtractedShareContent {
         var payload: SharedContentPayload
         var attachments: [LoadedAttachment]
-        var attachmentError: String?
+        var attachmentError: ShareImageProcessor.ProcessError?
     }
 
     private let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "ShareExtension")
@@ -30,7 +30,7 @@ final class ShareViewController: UIViewController {
     private var didPrepareDraft = false
     private var isSending = false
     private var pendingAttachments: [ShareAttachment] = []
-    private var attachmentError: String?
+    private var attachmentError: ShareImageProcessor.ProcessError?
 
     override func loadView() {
         self.view = self.composeView
@@ -71,8 +71,8 @@ final class ShareViewController: UIViewController {
         self.composeView.setAttachmentPreviews(extracted.attachments.map(\.preview))
         self.composeView.focusDraft()
         if let attachmentError = extracted.attachmentError {
-            ShareGatewayRelaySettings.saveLastEvent("Share blocked: \(attachmentError)")
-            self.composeView.apply(.failed(attachmentError))
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
+            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
         } else if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: waiting for message input.")
@@ -89,7 +89,7 @@ final class ShareViewController: UIViewController {
 
     private func sendCurrentDraft() async {
         if let attachmentError = self.attachmentError {
-            self.composeView.apply(.failed(attachmentError))
+            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
             return
         }
         let trimmed = self.composeView.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -317,8 +317,10 @@ final class ShareViewController: UIViewController {
                                 from: provider,
                                 index: attachments.count)
                             attachments.append(attachment)
+                        } catch let error as ShareImageProcessor.ProcessError {
+                            attachmentError = error
                         } catch {
-                            attachmentError = error.localizedDescription
+                            attachmentError = .encodeFailed
                         }
                     }
                 }
@@ -357,6 +359,12 @@ final class ShareViewController: UIViewController {
                 fileName: "shared-image-\(index + 1).jpg",
                 content: data.base64EncodedString()),
             preview: self.boundedPreview(from: image))
+    }
+
+    private func imageProcessingErrorMessage(_: ShareImageProcessor.ProcessError) -> String {
+        NSLocalizedString(
+            "The shared image could not be prepared.",
+            comment: "Share extension image processing failure")
     }
 
     /// Previews are retained for the sheet's lifetime; keep them bounded so

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -290,7 +290,7 @@ final class ShareViewController: UIViewController {
         var sharedText: String?
         var attributedContentText: String?
         var attachments: [LoadedAttachment] = []
-        var attachmentError: String?
+        var attachmentError: ShareImageProcessor.ProcessError?
         let maxImageAttachments = 3
 
         for item in items {

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -22,6 +22,7 @@ final class ShareViewController: UIViewController {
     private struct ExtractedShareContent {
         var payload: SharedContentPayload
         var attachments: [LoadedAttachment]
+        var attachmentError: String?
     }
 
     private let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "ShareExtension")
@@ -29,6 +30,7 @@ final class ShareViewController: UIViewController {
     private var didPrepareDraft = false
     private var isSending = false
     private var pendingAttachments: [ShareAttachment] = []
+    private var attachmentError: String?
 
     override func loadView() {
         self.view = self.composeView
@@ -58,6 +60,7 @@ final class ShareViewController: UIViewController {
         let extracted = await self.extractSharedContent()
         let payload = extracted.payload
         self.pendingAttachments = extracted.attachments.map(\.payload)
+        self.attachmentError = extracted.attachmentError
         self.logger.info("share payload trace=\(traceId, privacy: .public)")
         self.logger.info(
             "share payload title=\(payload.title?.count ?? 0) text=\(payload.text?.count ?? 0)")
@@ -66,11 +69,15 @@ final class ShareViewController: UIViewController {
         let message = ShareDraftComposer.compose(from: payload)
         self.composeView.setDraft(message)
         self.composeView.setAttachmentPreviews(extracted.attachments.map(\.preview))
-        self.composeView.apply(.ready)
         self.composeView.focusDraft()
-        if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let attachmentError = extracted.attachmentError {
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: \(attachmentError)")
+            self.composeView.apply(.failed(attachmentError))
+        } else if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: waiting for message input.")
         } else {
+            self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: draft prepared.")
         }
     }
@@ -81,6 +88,10 @@ final class ShareViewController: UIViewController {
     }
 
     private func sendCurrentDraft() async {
+        if let attachmentError = self.attachmentError {
+            self.composeView.apply(.failed(attachmentError))
+            return
+        }
         let trimmed = self.composeView.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             ShareGatewayRelaySettings.saveLastEvent("Share blocked: message is empty.")
@@ -270,7 +281,8 @@ final class ShareViewController: UIViewController {
         guard let items = self.extensionContext?.inputItems as? [NSExtensionItem] else {
             return ExtractedShareContent(
                 payload: SharedContentPayload(title: nil, url: nil, text: nil),
-                attachments: [])
+                attachments: [],
+                attachmentError: nil)
         }
 
         var title: String?
@@ -278,6 +290,7 @@ final class ShareViewController: UIViewController {
         var sharedText: String?
         var attributedContentText: String?
         var attachments: [LoadedAttachment] = []
+        var attachmentError: String?
         let maxImageAttachments = 3
 
         for item in items {
@@ -297,11 +310,16 @@ final class ShareViewController: UIViewController {
                     sharedText = await self.loadText(from: provider)
                 }
 
-                if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier),
-                   attachments.count < maxImageAttachments,
-                   let attachment = await self.loadImageAttachment(from: provider, index: attachments.count)
-                {
-                    attachments.append(attachment)
+                if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                    if attachments.count < maxImageAttachments, attachmentError == nil {
+                        do {
+                            attachments.append(try await self.loadImageAttachment(
+                                from: provider,
+                                index: attachments.count))
+                        } catch {
+                            attachmentError = error.localizedDescription
+                        }
+                    }
                 }
             }
         }
@@ -314,20 +332,21 @@ final class ShareViewController: UIViewController {
             sharedURL: sharedURL)
         return ExtractedShareContent(
             payload: SharedContentPayload(title: title ?? supplementalTitle, url: sharedURL, text: sharedText),
-            attachments: attachments)
+            attachments: attachments,
+            attachmentError: attachmentError)
     }
 
-    private func loadImageAttachment(from provider: NSItemProvider, index: Int) async -> LoadedAttachment? {
+    private func loadImageAttachment(from provider: NSItemProvider, index: Int) async throws -> LoadedAttachment {
         let imageUTI = self.preferredImageTypeIdentifier(from: provider) ?? UTType.image.identifier
         guard let rawData = await self.loadDataValue(from: provider, typeIdentifier: imageUTI) else {
-            return nil
+            throw ShareImageProcessor.ProcessError.invalidImage
         }
 
-        let maxBytes = 5_000_000
-        guard let image = UIImage(data: rawData),
-              let data = self.normalizedJPEGData(from: image, maxBytes: maxBytes)
-        else {
-            return nil
+        let data = try await Task.detached(priority: .userInitiated) {
+            try ShareImageProcessor.processForUpload(data: rawData)
+        }.value
+        guard let image = UIImage(data: data) else {
+            throw ShareImageProcessor.ProcessError.invalidImage
         }
 
         return await LoadedAttachment(
@@ -366,19 +385,6 @@ final class ShareViewController: UIViewController {
                 return identifier
             }
         }
-        return nil
-    }
-
-    private func normalizedJPEGData(from image: UIImage, maxBytes: Int) -> Data? {
-        var quality: CGFloat = 0.9
-        while quality >= 0.4 {
-            if let data = image.jpegData(compressionQuality: quality), data.count <= maxBytes {
-                return data
-            }
-            quality -= 0.1
-        }
-        guard let fallback = image.jpegData(compressionQuality: 0.35) else { return nil }
-        if fallback.count <= maxBytes { return fallback }
         return nil
     }
 

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -313,9 +313,10 @@ final class ShareViewController: UIViewController {
                 if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
                     if attachments.count < maxImageAttachments, attachmentError == nil {
                         do {
-                            attachments.append(try await self.loadImageAttachment(
+                            let attachment = try await self.loadImageAttachment(
                                 from: provider,
-                                index: attachments.count))
+                                index: attachments.count)
+                            attachments.append(attachment)
                         } catch {
                             attachmentError = error.localizedDescription
                         }

--- a/apps/ios/Tests/Logic/ShareComposeStateTests.swift
+++ b/apps/ios/Tests/Logic/ShareComposeStateTests.swift
@@ -25,4 +25,9 @@ struct ShareComposeStateTests {
         let controls = ShareComposeControlState.resolve(status: .failed("offline"), hasDraftText: true)
         #expect(controls == ShareComposeControlState(isSendEnabled: true, isCancelEnabled: true, isEditable: true))
     }
+
+    @Test func `keeps send blocked when an attachment cannot be prepared`() {
+        let controls = ShareComposeControlState.resolve(status: .blocked("invalid image"), hasDraftText: true)
+        #expect(controls == ShareComposeControlState(isSendEnabled: false, isCancelEnabled: true, isEditable: true))
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Share Extension image policy built on the shared, orientation-normalizing JPEG transcoder.
+public enum ShareImageProcessor {
+    public static let maxLongEdgePx = 2560
+    public static let jpegQuality = 0.9
+    public static let maxPayloadBytes = 5_000_000
+
+    public enum ProcessError: Error, LocalizedError, Sendable {
+        case invalidImage
+        case encodeFailed
+        case sizeLimitExceeded
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidImage:
+                "The shared image could not be read."
+            case .encodeFailed:
+                "The shared image could not be converted to JPEG."
+            case .sizeLimitExceeded:
+                "The shared image could not be resized to fit the 5 MB attachment limit."
+            }
+        }
+    }
+
+    public static func processForUpload(data: Data) throws -> Data {
+        do {
+            return try JPEGTranscoder.transcodeToJPEG(
+                imageData: data,
+                maxLongEdgePx: self.maxLongEdgePx,
+                quality: self.jpegQuality,
+                maxBytes: self.maxPayloadBytes).data
+        } catch JPEGTranscodeError.decodeFailed, JPEGTranscodeError.propertiesMissing {
+            throw ProcessError.invalidImage
+        } catch JPEGTranscodeError.sizeLimitExceeded {
+            throw ProcessError.sizeLimitExceeded
+        } catch {
+            throw ProcessError.encodeFailed
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ShareImageProcessor.swift
@@ -6,21 +6,10 @@ public enum ShareImageProcessor {
     public static let jpegQuality = 0.9
     public static let maxPayloadBytes = 5_000_000
 
-    public enum ProcessError: Error, LocalizedError, Sendable {
+    public enum ProcessError: Error, Equatable, Sendable {
         case invalidImage
         case encodeFailed
         case sizeLimitExceeded
-
-        public var errorDescription: String? {
-            switch self {
-            case .invalidImage:
-                "The shared image could not be read."
-            case .encodeFailed:
-                "The shared image could not be converted to JPEG."
-            case .sizeLimitExceeded:
-                "The shared image could not be resized to fit the 5 MB attachment limit."
-            }
-        }
     }
 
     public static func processForUpload(data: Data) throws -> Data {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/JPEGTranscoderTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/JPEGTranscoderTests.swift
@@ -126,4 +126,22 @@ import UniformTypeIdentifiers
             maxBytes: 180_000)
         #expect(out.data.count <= 180_000)
     }
+
+    @Test func explicitlyFailsWhenSizeLimitCannotBeMet() throws {
+        let input = try makeSolidJPEG(width: 800, height: 600)
+
+        do {
+            _ = try JPEGTranscoder.transcodeToJPEG(
+                imageData: input,
+                maxWidthPx: 800,
+                quality: 0.9,
+                maxBytes: 1)
+            Issue.record("Expected a size-limit error")
+        } catch JPEGTranscodeError.sizeLimitExceeded(let maxBytes, let actualBytes) {
+            #expect(maxBytes == 1)
+            #expect(actualBytes > maxBytes)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
@@ -5,8 +5,8 @@ import OpenClawKit
 import Testing
 import UniformTypeIdentifiers
 
-@Suite struct ShareImageProcessorTests {
-    @Test func downscalesImageLargerThanFiveMegabytesAndNormalizesOrientation() throws {
+struct ShareImageProcessorTests {
+    @Test func `downscales image larger than five megabytes and normalizes orientation`() throws {
         let input = try self.makeNoiseJPEG(width: 3000, height: 2500, orientation: 6)
         #expect(input.count > ShareImageProcessor.maxPayloadBytes)
 
@@ -25,9 +25,14 @@ import UniformTypeIdentifiers
         #expect(orientation == 1)
     }
 
-    @Test func reportsInvalidImage() {
-        #expect(throws: ShareImageProcessor.ProcessError.self) {
+    @Test func `reports invalid image`() {
+        do {
             _ = try ShareImageProcessor.processForUpload(data: Data("not an image".utf8))
+            Issue.record("Expected invalid-image error")
+        } catch let error as ShareImageProcessor.ProcessError {
+            #expect(error == .invalidImage)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ShareImageProcessorTests.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import OpenClawKit
+import Testing
+import UniformTypeIdentifiers
+
+@Suite struct ShareImageProcessorTests {
+    @Test func downscalesImageLargerThanFiveMegabytesAndNormalizesOrientation() throws {
+        let input = try self.makeNoiseJPEG(width: 3000, height: 2500, orientation: 6)
+        #expect(input.count > ShareImageProcessor.maxPayloadBytes)
+
+        let output = try ShareImageProcessor.processForUpload(data: input)
+        #expect(output.count <= ShareImageProcessor.maxPayloadBytes)
+
+        let source = try #require(CGImageSourceCreateWithData(output as CFData, nil))
+        let properties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+        let width = try #require((properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue)
+        let height = try #require((properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue)
+        let orientation = (properties[kCGImagePropertyOrientation] as? NSNumber)?.intValue ?? 1
+
+        #expect(max(width, height) <= ShareImageProcessor.maxLongEdgePx)
+        #expect(height > width)
+        #expect(orientation == 1)
+    }
+
+    @Test func reportsInvalidImage() {
+        #expect(throws: ShareImageProcessor.ProcessError.self) {
+            _ = try ShareImageProcessor.processForUpload(data: Data("not an image".utf8))
+        }
+    }
+
+    private func makeNoiseJPEG(width: Int, height: Int, orientation: Int) throws -> Data {
+        let bytesPerPixel = 4
+        let byteCount = width * height * bytesPerPixel
+        var pixels = Data(count: byteCount)
+
+        return try pixels.withUnsafeMutableBytes { buffer -> Data in
+            let bytes = try #require(buffer.baseAddress?.assumingMemoryBound(to: UInt8.self))
+            var state: UInt64 = 0x1234_5678_9ABC_DEF0
+            for index in 0..<byteCount {
+                state = state &* 6_364_136_223_846_793_005 &+ 1
+                bytes[index] = UInt8(truncatingIfNeeded: state >> 32)
+            }
+
+            let context = try #require(CGContext(
+                data: bytes,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * bytesPerPixel,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+            let image = try #require(context.makeImage())
+            let output = NSMutableData()
+            let destination = try #require(CGImageDestinationCreateWithData(
+                output,
+                UTType.jpeg.identifier as CFString,
+                1,
+                nil))
+            let properties: [CFString: Any] = [
+                kCGImageDestinationLossyCompressionQuality: 1.0,
+                kCGImagePropertyOrientation: orientation,
+            ]
+            CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+            #expect(CGImageDestinationFinalize(destination))
+            return output as Data
+        }
+    }
+}

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -46,6 +46,7 @@ const CATALOGS: readonly AppleCatalogSpec[] = [
         "Message is empty.",
         "OpenClaw is not connected to a gateway yet.",
         "Send failed: %@",
+        "The shared image could not be prepared.",
       ],
       "apps/ios/Sources/Design/SettingsChannelsDestination.swift": ["Logout"],
       "apps/ios/Sources/Design/ChatProTab.swift": [


### PR DESCRIPTION
## Summary

- replace the Share Extension's quality-only JPEG loop with the shared ImageIO transcoder
- downscale oversized shared images to a bounded 2560 px long edge and 5 MB payload
- surface image-processing failures instead of silently dropping an attachment and reporting success
- keep CPU-heavy transcoding off the Share Extension's main actor
- satisfy SwiftFormat's `hoistAwait` / `hoistTry` rules in the attachment-loading call site

## Issue / Motivation

Fixes #103362.

The Share Extension previously retried JPEG quality down to 0.35 without changing dimensions. High-resolution images could remain above 5 MB, be omitted from the outgoing attachments, and still leave the UI able to report a successful send.

## Changes

- add a small `ShareImageProcessor` policy on top of the existing orientation-normalizing `JPEGTranscoder`
- enforce both a 2560 px oriented long-edge limit and the existing 5,000,000-byte attachment limit
- run the synchronous ImageIO work in a user-initiated detached task
- disable Send and show a concrete error if a selected image cannot be read or fitted
- add deterministic regression coverage for a >5 MB oriented JPEG, invalid input, and an impossible byte budget
- extract the awaited attachment before appending it, fixing the exact CI formatter failure reported at the previous head

## Testing

Current head `26f1c48d94c977e5cc2a2475f7f696a5ca9209d0`:

- `corepack pnpm ios:filelist:gen` — passed; generated file list includes `ShareImageProcessor.swift`
- `corepack pnpm ios:build` — signing/version/file-list preparation passed; blocked on this Linux host at `xcodegen: command not found`
- `git diff --check origin/main` — passed
- `gitleaks git --no-banner --no-color --log-opts='origin/main..HEAD' --redact` — 2 commits scanned, no leaks found
- `gitleaks protect --no-banner --no-color --staged --source . --redact` — no leaks found before the formatter-fix commit
- SwiftFormat, SwiftLint, Swift package tests, Xcode build, and simulator/device behavior proof are not runnable on this Linux host because the Apple/Swift toolchain is unavailable

Previous head `22666dfb1f1468de92a97ee201a5de1aa461c4e2`:

- `macos-swift` passed, including the focused shared-package test surface
- `ios-build` and `Scan iOS dead code` both stopped at the same SwiftFormat `hoistAwait` / `hoistTry` finding in `ShareViewController.swift`; no independent dead-code finding was produced
- the current head extracts `try await self.loadImageAttachment(...)` into a local value before `attachments.append(...)`, directly removing that shared blocker

## What Problem This Solves

Large iOS Share Extension images no longer disappear when quality-only recompression cannot get them under 5 MB. The extension now reduces image dimensions through the shared transcoder and blocks the send with a visible explanation if the bounded conversion still fails.

## Evidence

- Regression fixture creates a deterministic 3000×2500 JPEG larger than 5 MB with EXIF orientation 6.
- The processor test asserts output is at most 5,000,000 bytes, the oriented long edge is at most 2560 px, portrait orientation is preserved in pixels, and the output orientation tag is normalized to 1.
- The transcoder test asserts an impossible one-byte budget specifically raises `JPEGTranscodeError.sizeLimitExceeded`.
- Direct upstream Codex dependency is not involved; this reuses OpenClaw's existing `JPEGTranscoder` and its established chat-image policy pattern.
- Duplicate gate rechecked after remediation: issue #103362 remains open, and PR #103860 is the only PR returned for the exact issue reference.

Live simulator/device proof is unavailable from this Linux host. No macOS/Xcode or native runtime proof is claimed for the current head; CI/macOS validation is required.
