### PR TITLE
fix(android): require explicit retry after ambiguous sends

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
@@ -23,6 +23,9 @@ internal const val OUTBOX_RETRY_BACKOFF_MS = 2_000L
 /** lastError marker for items expired by [OUTBOX_EXPIRY_MS]; also shown in the UI row. */
 internal const val OUTBOX_EXPIRED_ERROR = "expired"
 
+/** Delivery is ambiguous after dispatch without an acknowledgement; retry needs explicit intent. */
+internal const val OUTBOX_DELIVERY_UNCONFIRMED_ERROR = "delivery unconfirmed; retry manually"
+
 enum class ChatOutboxStatus(
   internal val dbValue: String,
 ) {
@@ -113,8 +116,8 @@ interface ChatCommandOutbox {
   /** Drops every queued command owned by one gateway identity. */
   suspend fun clearGateway(gatewayId: String)
 
-  /** Crash safety: rows stuck in 'sending' from a killed process become 'queued' again. */
-  suspend fun requeueSendingAfterRestart()
+  /** Crash safety: rows stuck in 'sending' after a killed process become visible failed rows. */
+  suspend fun failSendingAfterRestart()
 
   /** Expires queued rows older than [OUTBOX_EXPIRY_MS] to 'failed' instead of sending stale commands. */
   suspend fun expireStale(
@@ -159,10 +162,11 @@ internal interface ChatOutboxDao {
     lastError: String?,
   ): Int
 
-  @Query("UPDATE outbox_commands SET status = :toStatus WHERE status = :fromStatus")
-  suspend fun updateAllWithStatus(
-    fromStatus: String,
-    toStatus: String,
+  @Query("UPDATE outbox_commands SET status = :failedStatus, lastError = :error WHERE status = :sendingStatus")
+  suspend fun failAllSending(
+    sendingStatus: String,
+    failedStatus: String,
+    error: String,
   )
 
   @Query(
@@ -312,11 +316,13 @@ class RoomChatCommandOutbox internal constructor(
     database.outboxDao().deleteGateway(gateway)
   }
 
-  override suspend fun requeueSendingAfterRestart() {
-    // Deliberately unscoped: interrupted sends must recover even before a gateway is resolved.
-    database.outboxDao().updateAllWithStatus(
-      fromStatus = ChatOutboxStatus.Sending.dbValue,
-      toStatus = ChatOutboxStatus.Queued.dbValue,
+  override suspend fun failSendingAfterRestart() {
+    // Deliberately unscoped: recovery happens before a gateway is resolved, but a crash leaves
+    // delivery ambiguous and must not silently replay an already accepted command.
+    database.outboxDao().failAllSending(
+      sendingStatus = ChatOutboxStatus.Sending.dbValue,
+      failedStatus = ChatOutboxStatus.Failed.dbValue,
+      error = OUTBOX_DELIVERY_UNCONFIRMED_ERROR,
     )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.chat
 
 import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.gateway.GatewayRequestDefinitiveFailure
+import ai.openclaw.app.gateway.GatewayRequestNotEnqueued
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
@@ -190,20 +191,22 @@ class ChatController internal constructor(
   val outboxItems: StateFlow<List<ChatOutboxItem>> = _outboxItems.asStateFlow()
 
   private val outboxFlushInFlight = AtomicBoolean(false)
+  private val outboxRecoveryMutex = Mutex()
+  private var outboxRecoveryComplete = false
 
-  init {
-    if (commandOutbox != null) {
+  private val outboxRecoveryJob =
+    commandOutbox?.let { outbox ->
       scope.launch {
-        // Crash safety: a process killed mid-flush leaves rows in 'sending'; requeue them so
-        // they are retried instead of being stuck invisible to the flush loop forever.
-        runCatching { commandOutbox.requeueSendingAfterRestart() }
-        currentCacheScope()?.let { outboxScope ->
-          runCatching { commandOutbox.expireStale(outboxScope.gatewayId, System.currentTimeMillis()) }
+        // A killed process can lose the local delete after the gateway accepted a command.
+        // Keep that delivery ambiguous and user-visible instead of replaying it automatically.
+        if (recoverInterruptedOutboxSends(outbox)) {
+          currentCacheScope()?.let { outboxScope ->
+            runCatching { outbox.expireStale(outboxScope.gatewayId, System.currentTimeMillis()) }
+          }
         }
         publishOutbox()
       }
     }
-  }
 
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
@@ -1465,6 +1468,14 @@ class ChatController internal constructor(
    */
   private suspend fun flushOutbox() {
     val outbox = commandOutbox ?: return
+    // The unscoped recovery sweep must succeed before this process claims a row. A transient
+    // storage failure stays retryable, but never lets younger queued work bypass an ambiguous send.
+    outboxRecoveryJob?.join()
+    if (!recoverInterruptedOutboxSends(outbox)) {
+      _healthOk.value = false
+      publishOutbox()
+      return
+    }
     if (!outboxFlushInFlight.compareAndSet(false, true)) return
     var flushedAny = false
     try {
@@ -1495,7 +1506,7 @@ class ChatController internal constructor(
   }
 
   // Sent: acked and removed. Failed: parked as failed. Skipped: row vanished (user delete).
-  // Stop: flush must halt (offline or gateway scope changed); the row stays queued.
+  // Stop: flush must halt; the row's queued or failed state is already durable.
   private enum class OutboxSendOutcome { Sent, Failed, Skipped, Stop }
 
   private sealed interface OutboxSendResult {
@@ -1506,10 +1517,13 @@ class ChatController internal constructor(
       val error: String,
     ) : OutboxSendResult
 
-    /** Request never got an ack (socket drop, timeout); delivery state is unknown. */
-    data class TransportFailure(
+    /** The request never entered the socket queue, so reconnect may retry it automatically. */
+    data class NotDispatched(
       val error: String,
     ) : OutboxSendResult
+
+    /** Dispatch may have succeeded, so only explicit user intent may retry the command. */
+    data object DeliveryUnconfirmed : OutboxSendResult
   }
 
   private suspend fun sendOutboxItem(
@@ -1532,11 +1546,24 @@ class ChatController internal constructor(
             publishOutbox()
             return OutboxSendOutcome.Sent
           }
-          is OutboxSendResult.TransportFailure -> {
-            // No ack means the gateway is effectively unreachable even if healthOk has not
-            // flipped yet. Keep the row queued without burning attempts and drop health so
-            // the next successful health poll/event re-triggers the flush.
+          is OutboxSendResult.NotDispatched -> {
+            // This frame never entered the socket queue, so reconnect may retry it safely.
             runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Queued, attempts, result.error) }
+            publishOutbox()
+            _healthOk.value = false
+            return OutboxSendOutcome.Stop
+          }
+          OutboxSendResult.DeliveryUnconfirmed -> {
+            // The gateway may have accepted this command. Keep it visible, but never replay it
+            // without explicit user intent; gateway dedupe is process-local and time-bounded.
+            runCatching {
+              outbox.updateStatus(
+                item.id,
+                ChatOutboxStatus.Failed,
+                attempts,
+                OUTBOX_DELIVERY_UNCONFIRMED_ERROR,
+              )
+            }
             publishOutbox()
             _healthOk.value = false
             return OutboxSendOutcome.Stop
@@ -1549,9 +1576,9 @@ class ChatController internal constructor(
         publishOutbox()
         return OutboxSendOutcome.Failed
       }
-      // The row stays 'sending' through the backoff: Sending rows expose no Delete/Retry
-      // actions, so the user cannot delete a row this loop is about to resend.
-      runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Sending, attempts, error) }
+      // A definitive rejection is safe to resume after process death, so persist it as queued
+      // before sleeping. The post-delay re-claim still makes a user deletion win over retry.
+      runCatching { outbox.updateStatus(item.id, ChatOutboxStatus.Queued, attempts, error) }
       publishOutbox()
       // Losing health or the gateway scope mid-flush means this item must not retry now:
       // requeue it for the next reconnect under the right scope. Without the scope check,
@@ -1613,17 +1640,39 @@ class ChatController internal constructor(
           put("idempotencyKey", JsonPrimitive(item.id))
         }
       val ack = parseChatSendAck(json, requestGatewayBound(gatewayId, "chat.send", params.toString()))
-      if (ack.isTerminalFailure) {
-        OutboxSendResult.Rejected("Chat failed before the run started")
-      } else {
-        OutboxSendResult.Accepted
+      when (ack.normalizedStatus) {
+        "ok" -> OutboxSendResult.Accepted
+        "timeout", "error" -> OutboxSendResult.Rejected("Chat failed before the run started")
+        "", "started", "in_flight" ->
+          if (ack.runId.isNullOrBlank()) OutboxSendResult.DeliveryUnconfirmed else OutboxSendResult.Accepted
+        else -> OutboxSendResult.DeliveryUnconfirmed
       }
     } catch (err: CancellationException) {
       // Teardown must not be recorded as a send failure; the row stays 'sending' and the
-      // next startup recovery requeues it.
+      // next startup recovery parks it as delivery-unconfirmed.
       throw err
-    } catch (err: Throwable) {
-      OutboxSendResult.TransportFailure(err.message ?: "send failed")
+    } catch (err: GatewayRequestNotEnqueued) {
+      OutboxSendResult.NotDispatched(err.message ?: "send failed")
+    } catch (err: GatewayRequestDefinitiveFailure) {
+      OutboxSendResult.Rejected(err.message ?: "request rejected")
+    } catch (_: GatewayRequestOutcomeUnknown) {
+      OutboxSendResult.DeliveryUnconfirmed
+    } catch (_: Throwable) {
+      OutboxSendResult.DeliveryUnconfirmed
+    }
+
+  private suspend fun recoverInterruptedOutboxSends(outbox: ChatCommandOutbox): Boolean =
+    outboxRecoveryMutex.withLock {
+      if (outboxRecoveryComplete) return@withLock true
+      try {
+        outbox.failSendingAfterRestart()
+        outboxRecoveryComplete = true
+        true
+      } catch (err: CancellationException) {
+        throw err
+      } catch (_: Throwable) {
+        false
+      }
     }
 
   private fun handleChatEvent(payloadJson: String) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -1,7 +1,14 @@
 package ai.openclaw.app.chat
 
+import ai.openclaw.app.gateway.GatewayRequestNotEnqueued
+import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
+import ai.openclaw.app.gateway.GatewayRequestRejected
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -26,6 +33,8 @@ class ChatControllerOutboxTest {
     val rows = LinkedHashMap<String, ChatOutboxItem>()
     val gatewayIds = mutableMapOf<String, String>()
     val deletedSessions = mutableListOf<String>()
+    var recoveryGate: CompletableDeferred<Unit>? = null
+    var recoveryFailure: Throwable? = null
     private var nextCreatedAt = 0L
 
     fun seed(
@@ -113,10 +122,12 @@ class ChatControllerOutboxTest {
       }
     }
 
-    override suspend fun requeueSendingAfterRestart() {
+    override suspend fun failSendingAfterRestart() {
+      recoveryGate?.await()
+      recoveryFailure?.let { throw it }
       for ((id, item) in rows) {
         if (item.status == ChatOutboxStatus.Sending) {
-          rows[id] = item.copy(status = ChatOutboxStatus.Queued)
+          rows[id] = item.copy(status = ChatOutboxStatus.Failed, lastError = OUTBOX_DELIVERY_UNCONFIRMED_ERROR)
         }
       }
     }
@@ -136,8 +147,9 @@ class ChatControllerOutboxTest {
   /** Toggleable gateway seam: records chat.send idempotency keys and echoes them as run ids. */
   private inner class FakeGateway {
     var online = false
-    var failSendsWithTransportError = false
-    var sendResponse: (idempotencyKey: String) -> String = { key -> """{"runId":"$key"}""" }
+    var sendFailureBeforeDispatch: Throwable? = null
+    var sendFailureAfterDispatch: Throwable? = null
+    var sendResponse: (idempotencyKey: String) -> String = { key -> """{"runId":"$key","status":"started"}""" }
     val sentIdempotencyKeys = mutableListOf<String>()
     val sentMessages = mutableListOf<String>()
     val sentSessionKeys = mutableListOf<String>()
@@ -152,13 +164,14 @@ class ChatControllerOutboxTest {
       if (!online) throw IllegalStateException("offline")
       return when (method) {
         "chat.send" -> {
-          if (failSendsWithTransportError) throw IllegalStateException("socket closed")
+          sendFailureBeforeDispatch?.let { throw it }
           val params = json.parseToJsonElement(paramsJson.orEmpty()) as JsonObject
           val key = (params["idempotencyKey"] as JsonPrimitive).content
           sentIdempotencyKeys += key
           sentMessages += (params["message"] as JsonPrimitive).content
           sentSessionKeys += (params["sessionKey"] as JsonPrimitive).content
           sentThinkingLevels += (params["thinking"] as JsonPrimitive).content
+          sendFailureAfterDispatch?.let { throw it }
           sendResponse(key)
         }
         "chat.history" -> """{"sessionId":"session-1","messages":$historyMessagesJson}"""
@@ -296,12 +309,12 @@ class ChatControllerOutboxTest {
       assertTrue(chat.setSessionModelAwait("main", "openai/plain"))
       // Drop health via a transport failure mid-flush: unlike a disconnect this keeps the
       // hydrated catalog, which is the state where the flush gate has data to act on.
-      gateway.failSendsWithTransportError = true
+      gateway.sendFailureBeforeDispatch = GatewayRequestNotEnqueued("gateway send failed")
       chat.retryOutboxCommand("active")
       advanceUntilIdle()
       assertFalse(chat.healthOk.value)
 
-      gateway.failSendsWithTransportError = false
+      gateway.sendFailureBeforeDispatch = null
       chat.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
@@ -380,7 +393,7 @@ class ChatControllerOutboxTest {
       chat.sendMessageAwaitAcceptance(message = "old gateway text", thinkingLevel = "off", attachments = emptyList())
 
       gateway.online = true
-      gateway.sendResponse = { """{"status":"error"}""" }
+      gateway.sendResponse = { key -> """{"runId":"$key","status":"error"}""" }
       chat.handleGatewayEvent("health", null)
       // Run up to the retry backoff delay, then switch the gateway scope while it is pending.
       runCurrent()
@@ -449,11 +462,11 @@ class ChatControllerOutboxTest {
       val id = queuedRow.id
 
       gateway.online = true
-      gateway.sendResponse = { """{"status":"error"}""" }
+      gateway.sendResponse = { key -> """{"runId":"$key","status":"error"}""" }
       chat.handleGatewayEvent("health", null)
-      // Run up to the retry backoff delay; the row stays 'sending' so the UI offers no actions.
+      // Run up to the retry backoff delay; a definitive rejection remains safe to retry later.
       runCurrent()
-      assertEquals(ChatOutboxStatus.Sending, outbox.rows.getValue(id).status)
+      assertEquals(ChatOutboxStatus.Queued, outbox.rows.getValue(id).status)
       // Simulate the row disappearing through a non-UI path (e.g. session purge) mid-backoff.
       outbox.rows.remove(id)
       advanceUntilIdle()
@@ -475,7 +488,7 @@ class ChatControllerOutboxTest {
       chat.sendMessageAwaitAcceptance(message = "doomed", thinkingLevel = "off", attachments = emptyList())
 
       gateway.online = true
-      gateway.sendResponse = { """{"status":"error"}""" }
+      gateway.sendResponse = { key -> """{"runId":"$key","status":"error"}""" }
       chat.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
@@ -487,7 +500,41 @@ class ChatControllerOutboxTest {
     }
 
   @Test
-  fun transportFailureKeepsRowQueuedForNextReconnectInsteadOfBurningAttempts() =
+  fun definitiveRejectionBackoffSurvivesControllerRestart() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val processJob = SupervisorJob()
+      val processScope = CoroutineScope(coroutineContext + processJob)
+      val first = controller(processScope, gateway, outbox)
+      first.load("main")
+      advanceUntilIdle()
+      first.sendMessageAwaitAcceptance(message = "retry after restart", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { key -> """{"runId":"$key","status":"error"}""" }
+      first.handleGatewayEvent("health", null)
+      runCurrent()
+
+      val retryable = outbox.rows.values.single()
+      assertEquals(ChatOutboxStatus.Queued, retryable.status)
+      assertEquals(1, retryable.retryCount)
+      assertEquals(1, gateway.sentMessages.size)
+      processJob.cancel()
+
+      val restarted = controller(this, gateway, outbox)
+      restarted.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, gateway.sentMessages.size)
+      val failed = restarted.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, failed.status)
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, failed.retryCount)
+      assertEquals("Chat failed before the run started", failed.lastError)
+    }
+
+  @Test
+  fun notDispatchedKeepsRowQueuedForNextReconnectInsteadOfBurningAttempts() =
     runTest {
       val gateway = FakeGateway()
       val outbox = FakeCommandOutbox()
@@ -497,22 +544,184 @@ class ChatControllerOutboxTest {
       chat.sendMessageAwaitAcceptance(message = "survives drops", thinkingLevel = "off", attachments = emptyList())
 
       gateway.online = true
-      gateway.failSendsWithTransportError = true
+      gateway.sendFailureBeforeDispatch = GatewayRequestNotEnqueued("gateway send failed")
       chat.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
-      // No ack means delivery state is unknown: the row must stay queued with attempts intact.
+      // The frame never entered the socket queue, so reconnect may retry it automatically.
       val row = chat.outboxItems.value.single()
       assertEquals(ChatOutboxStatus.Queued, row.status)
       assertEquals(0, row.retryCount)
+      assertTrue(gateway.sentMessages.isEmpty())
       assertFalse(chat.healthOk.value)
 
-      gateway.failSendsWithTransportError = false
+      gateway.sendFailureBeforeDispatch = null
       chat.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
       assertEquals(listOf("survives drops"), gateway.sentMessages)
       assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun droppedAckFailsUnconfirmedAndNeverReplaysUntilExplicitRetry() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val first = controller(this, gateway, outbox)
+      first.load("main")
+      advanceUntilIdle()
+      first.sendMessageAwaitAcceptance(message = "send once", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendFailureAfterDispatch = GatewayRequestOutcomeUnknown("ack lost")
+      first.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      val ambiguous = first.outboxItems.value.single()
+      assertEquals(listOf("send once"), gateway.sentMessages)
+      assertFalse(first.healthOk.value)
+
+      gateway.sendFailureAfterDispatch = null
+      first.handleGatewayEvent("health", null)
+      first.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      // Reconnect must not replay an ambiguous row; only the explicit retry below may dispatch it.
+      assertEquals(1, gateway.sentMessages.size)
+      assertEquals(ChatOutboxStatus.Failed, ambiguous.status)
+      assertEquals(0, ambiguous.retryCount)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, ambiguous.lastError)
+
+      val restarted = controller(this, gateway, outbox)
+      restarted.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(1, gateway.sentMessages.size)
+      assertEquals(
+        ChatOutboxStatus.Failed,
+        restarted.outboxItems.value
+          .single()
+          .status,
+      )
+
+      restarted.retryOutboxCommand(ambiguous.id)
+      advanceUntilIdle()
+      assertEquals(listOf(ambiguous.id, ambiguous.id), gateway.sentIdempotencyKeys)
+      assertTrue(restarted.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun runIdOnlyAckRemainsAcceptedForOlderGateways() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "compatible ack", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { key -> """{"runId":"$key"}""" }
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("compatible ack"), gateway.sentMessages)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun unknownOrMalformedAckFailsUnconfirmed() =
+    runTest {
+      val responses =
+        listOf<(String) -> String>(
+          { key -> """{"runId":"$key","status":"mystery"}""" },
+          { _ -> """{"status":"started"}""" },
+          { _ -> "not-json" },
+        )
+
+      for ((index, response) in responses.withIndex()) {
+        val gateway = FakeGateway()
+        val outbox = FakeCommandOutbox()
+        val chat = controller(this, gateway, outbox)
+        chat.load("main")
+        advanceUntilIdle()
+        chat.sendMessageAwaitAcceptance(message = "unknown-$index", thinkingLevel = "off", attachments = emptyList())
+        gateway.online = true
+        gateway.sendResponse = response
+
+        chat.handleGatewayEvent("health", null)
+        advanceUntilIdle()
+
+        val failed = chat.outboxItems.value.single()
+        assertEquals(ChatOutboxStatus.Failed, failed.status)
+        assertEquals(0, failed.retryCount)
+        assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, failed.lastError)
+        assertEquals(1, gateway.sentMessages.size)
+        assertFalse(chat.healthOk.value)
+      }
+    }
+
+  @Test
+  fun terminalFailureAckWithoutRunIdUsesTheRetryBudget() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "rejected ack", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { _ -> """{"status":"error"}""" }
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, gateway.sentMessages.size)
+      val failed = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, failed.status)
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, failed.retryCount)
+      assertEquals("Chat failed before the run started", failed.lastError)
+    }
+
+  @Test
+  fun terminalSuccessAckWithoutRunIdRemovesTheRow() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "completed ack", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendResponse = { _ -> """{"status":"ok"}""" }
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("completed ack"), gateway.sentMessages)
+      assertTrue(chat.outboxItems.value.isEmpty())
+    }
+
+  @Test
+  fun definitiveGatewayRejectionUsesTheRetryBudget() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val chat = controller(this, gateway, outbox)
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "rejected", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendFailureAfterDispatch =
+        GatewayRequestRejected(GatewaySession.ErrorShape(code = "INVALID_REQUEST", message = "rejected"))
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, gateway.sentMessages.size)
+      val failed = chat.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, failed.status)
+      assertEquals(OUTBOX_MAX_SEND_ATTEMPTS, failed.retryCount)
+      assertTrue(failed.lastError.orEmpty().contains("INVALID_REQUEST"))
     }
 
   @Test
@@ -586,7 +795,7 @@ class ChatControllerOutboxTest {
     }
 
   @Test
-  fun sendingRowsRecoverToQueuedOnControllerStartup() =
+  fun sendingRowsBecomeDeliveryUnconfirmedOnControllerStartup() =
     runTest {
       val gateway = FakeGateway()
       val outbox = FakeCommandOutbox()
@@ -596,7 +805,7 @@ class ChatControllerOutboxTest {
           sessionKey = "main",
           text = "crashed mid-send",
           thinkingLevel = "off",
-          // Recent timestamp: the startup expiry sweep must not expire the recovered row.
+          // Recent timestamp: startup recovery must surface this row before any retry decision.
           createdAtMs = System.currentTimeMillis(),
           status = ChatOutboxStatus.Sending,
           retryCount = 1,
@@ -608,8 +817,153 @@ class ChatControllerOutboxTest {
       advanceUntilIdle()
 
       val recovered = chat.outboxItems.value.single()
-      assertEquals(ChatOutboxStatus.Queued, recovered.status)
+      assertEquals(ChatOutboxStatus.Failed, recovered.status)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, recovered.lastError)
       assertEquals(1, recovered.retryCount)
+    }
+
+  @Test
+  fun startupRecoveryFinishesBeforeAHealthFlushCanClaimQueuedRows() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val recoveryGate = CompletableDeferred<Unit>()
+      outbox.recoveryGate = recoveryGate
+      val now = System.currentTimeMillis()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "interrupted",
+          sessionKey = "main",
+          text = "already dispatched",
+          thinkingLevel = "off",
+          createdAtMs = now,
+          status = ChatOutboxStatus.Sending,
+          retryCount = 1,
+          lastError = null,
+        ),
+      )
+      outbox.seed(
+        ChatOutboxItem(
+          id = "queued",
+          sessionKey = "main",
+          text = "send after recovery",
+          thinkingLevel = "off",
+          createdAtMs = now + 1,
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+        ),
+      )
+
+      val chat = controller(this, gateway, outbox)
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      runCurrent()
+
+      try {
+        assertTrue(gateway.sentMessages.isEmpty())
+        assertEquals(ChatOutboxStatus.Sending, outbox.rows.getValue("interrupted").status)
+        assertEquals(ChatOutboxStatus.Queued, outbox.rows.getValue("queued").status)
+      } finally {
+        // Never strand the controller's child job if a pre-release assertion fails.
+        recoveryGate.complete(Unit)
+      }
+      advanceUntilIdle()
+
+      assertEquals(listOf("send after recovery"), gateway.sentMessages)
+      assertEquals(ChatOutboxStatus.Failed, outbox.rows.getValue("interrupted").status)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, outbox.rows.getValue("interrupted").lastError)
+      assertFalse(outbox.rows.containsKey("queued"))
+    }
+
+  @Test
+  fun startupRecoveryFailureBlocksFlushUntilRecoveryCanBeRetried() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val now = System.currentTimeMillis()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "interrupted",
+          sessionKey = "main",
+          text = "possibly delivered",
+          thinkingLevel = "off",
+          createdAtMs = now,
+          status = ChatOutboxStatus.Sending,
+          retryCount = 0,
+          lastError = null,
+        ),
+      )
+      outbox.seed(
+        ChatOutboxItem(
+          id = "queued",
+          sessionKey = "main",
+          text = "younger queued work",
+          thinkingLevel = "off",
+          createdAtMs = now + 1,
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+        ),
+      )
+      outbox.recoveryFailure = IllegalStateException("database unavailable")
+      val chat = controller(this, gateway, outbox)
+
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertFalse(chat.healthOk.value)
+      assertTrue(gateway.sentMessages.isEmpty())
+      assertEquals(ChatOutboxStatus.Sending, outbox.rows.getValue("interrupted").status)
+      assertEquals(ChatOutboxStatus.Queued, outbox.rows.getValue("queued").status)
+
+      outbox.recoveryFailure = null
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(ChatOutboxStatus.Failed, outbox.rows.getValue("interrupted").status)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, outbox.rows.getValue("interrupted").lastError)
+      assertEquals(listOf("younger queued work"), gateway.sentMessages)
+      assertFalse(outbox.rows.containsKey("queued"))
+    }
+
+  @Test
+  fun cancellationLeavesTheClaimForStartupRecoveryInsteadOfReplaying() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      val processJob = SupervisorJob()
+      val processScope = CoroutineScope(coroutineContext + processJob)
+      val first = controller(processScope, gateway, outbox)
+      first.load("main")
+      advanceUntilIdle()
+      first.sendMessageAwaitAcceptance(message = "interrupted send", thinkingLevel = "off", attachments = emptyList())
+
+      gateway.online = true
+      gateway.sendFailureAfterDispatch = CancellationException("process stopping")
+      first.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("interrupted send"), gateway.sentMessages)
+      assertEquals(
+        ChatOutboxStatus.Sending,
+        outbox.rows.values
+          .single()
+          .status,
+      )
+      processJob.cancel()
+
+      gateway.sendFailureAfterDispatch = null
+      val restarted = controller(this, gateway, outbox)
+      advanceUntilIdle()
+
+      val recovered = restarted.outboxItems.value.single()
+      assertEquals(ChatOutboxStatus.Failed, recovered.status)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, recovered.lastError)
+      restarted.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(1, gateway.sentMessages.size)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
@@ -102,18 +102,19 @@ class RoomChatCommandOutboxTest {
     }
 
   @Test
-  fun requeueSendingAfterRestartRecoversInterruptedRows() =
+  fun failSendingAfterRestartKeepsInterruptedRowsVisibleForExplicitRetry() =
     runTest {
       val interrupted = store.enqueueQueued("interrupted", nowMs = 10)
       store.updateStatus(interrupted.id, ChatOutboxStatus.Sending, retryCount = 1, lastError = "socket closed")
       val failed = store.enqueueQueued("dead", nowMs = 20)
       store.updateStatus(failed.id, ChatOutboxStatus.Failed, retryCount = 3, lastError = "boom")
 
-      store.requeueSendingAfterRestart()
+      store.failSendingAfterRestart()
 
       val byId = store.load("gateway-a").associateBy { it.id }
-      assertEquals(ChatOutboxStatus.Queued, byId.getValue(interrupted.id).status)
-      // Retry bookkeeping survives the restart; only the stuck status is repaired.
+      assertEquals(ChatOutboxStatus.Failed, byId.getValue(interrupted.id).status)
+      assertEquals(OUTBOX_DELIVERY_UNCONFIRMED_ERROR, byId.getValue(interrupted.id).lastError)
+      // Retry bookkeeping survives the restart so an explicit retry retains the original context.
       assertEquals(1, byId.getValue(interrupted.id).retryCount)
       assertEquals(ChatOutboxStatus.Failed, byId.getValue(failed.id).status)
     }


### PR DESCRIPTION
## What Problem This Solves

Android could automatically resend a durable chat command after the request reached the gateway but the acknowledgement was lost, or after the app restarted with the row still marked `sending`. Gateway idempotency state is process-local, so a later replay can repeat an agent run or tool side effect.

Supersedes #103273 after that PR's head was concurrently rewritten into a different six-file design. This replacement preserves only the deeply reviewed and behavior-proven four-file fix, with @NianJiuZst credited as co-author.

## Why This Change Was Made

The final state machine carries the gateway's typed delivery outcome into the Android outbox:

- requests known not to have entered the socket queue remain automatically retryable;
- requests definitively rejected by the gateway use the existing bounded retry budget;
- post-dispatch timeouts/disconnects and process-interrupted `sending` rows become visible as delivery-unconfirmed and require explicit Retry;
- startup recovery is serialized before flush, so a recovery failure cannot let younger queued work bypass an ambiguous row.

ACK handling also preserves legacy run-id-only success, accepts `ok` without a run id, and treats malformed/nonterminal responses without a run id as unconfirmed.

## User Impact

Android no longer silently repeats an ambiguous chat command after a crash, timeout, or disconnect. The affected row remains visible so the user can inspect, delete, or explicitly retry it.

## Evidence

- Replacement commit: `16c514113bfdfba65d82e2231cf7a55a67dc4746`; tree: `15806c225b35b2d9337ee84f68ec6909028c13ca`.
- Stable patch ID `8a82abe1214a902f2b0359fbbe2595f1c15601fd` exactly matches the reviewed four-file head of #103273, so its focused behavior proof applies without source drift.
- Testbox [run 29110337520](https://github.com/openclaw/openclaw/actions/runs/29110337520) independently fetched the reviewed source, asserted exact SHA/tree/clean checkout, and passed 37 focused tests across the controller outbox, Room persistence, and a real MockWebServer disconnect/outcome-unknown path.
- The same Testbox overlaid the dropped-ACK regression on current main; the isolated test failed there as intended because the old path automatically replayed the dispatched command. A harness-only message grep made the delegated job report failure after that expected negative result.
- The reviewed exact head passed both Android test variants, APK build, ktlint, native i18n, preflight, and security checks in [Android CI 29109968978](https://github.com/openclaw/openclaw/actions/runs/29109968978).
- Fresh post-rebase `:app:ktlintCheck` passed on this replacement.
- Fresh full-diff autoreview on this replacement: clean, no actionable findings, correctness confidence 0.91.
- Replacement exact-head hosted CI is required before merge.

AI-assisted: built with Codex.
