### PR TITLE
fix(discord): stop retrying non-idempotent sends on post-connect-ambiguous errors

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -43,6 +43,36 @@ async function buildExecApprovalPayloadText(commandText: string): Promise<string
 }
 
 describe("discordApprovalNativeRuntime", () => {
+  it("keeps create-only nonce fields out of the shared multi-target payload", async () => {
+    const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "main",
+      context: { token: "discord-token", config: {} as never },
+      request: {
+        id: "approval-1",
+        request: { command: "hostname" },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        phase: "pending",
+        approvalId: "approval-1",
+        title: "Exec Approval Required",
+        commandText: "hostname",
+        commandPreview: null,
+        expiresAtMs: 1_000,
+        metadata: [],
+        actions: [],
+      },
+    });
+
+    expect(pending.body).not.toHaveProperty("nonce");
+    expect(pending.body).not.toHaveProperty("enforce_nonce");
+  });
+
   it("does not split emoji graphemes when truncating exec command previews", async () => {
     const prefix = "a".repeat(999);
 

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -34,7 +34,11 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "./internal/discord.js";
-import { createDiscordClient, stripUndefinedFields } from "./send.shared.js";
+import {
+  createDiscordClient,
+  createDiscordMessageNonce,
+  stripUndefinedFields,
+} from "./send.shared.js";
 import { DiscordUiContainer } from "./ui.js";
 
 type PendingApproval = {
@@ -493,7 +497,11 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
               actionRow,
             });
       return {
-        body: stripUndefinedFields(serializePayload(buildExecApprovalPayload(container))),
+        body: stripUndefinedFields({
+          ...serializePayload(buildExecApprovalPayload(container)),
+          nonce: createDiscordMessageNonce(),
+          enforce_nonce: true,
+        }),
       };
     },
     buildResolvedResult: ({ cfg, accountId, context, view }) => {

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -497,11 +497,7 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
               actionRow,
             });
       return {
-        body: stripUndefinedFields({
-          ...serializePayload(buildExecApprovalPayload(container)),
-          nonce: createDiscordMessageNonce(),
-          enforce_nonce: true,
-        }),
+        body: stripUndefinedFields(serializePayload(buildExecApprovalPayload(container))),
       };
     },
     buildResolvedResult: ({ cfg, accountId, context, view }) => {
@@ -601,13 +597,20 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
         token: resolved.context.token,
         accountId: resolved.accountId,
       });
+      // Each destination is a distinct logical create. Reuse its nonce only across
+      // retries so multi-target approvals cannot deduplicate into the wrong channel.
+      const body = {
+        ...pendingPayload.body,
+        nonce: createDiscordMessageNonce(),
+        enforce_nonce: true,
+      };
       const message = (await discordRequest(
         () =>
           createChannelMessage<{ id: string; channel_id: string }>(
             rest,
             preparedTarget.discordChannelId,
             {
-              body: pendingPayload.body,
+              body,
             },
           ),
         plannedTarget.surface === "origin" ? "send-approval-channel" : "send-approval",

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -603,6 +603,7 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
             },
           ),
         plannedTarget.surface === "origin" ? "send-approval-channel" : "send-approval",
+        { nonIdempotent: true },
       )) as { id: string; channel_id: string };
       if (!message?.id) {
         if (plannedTarget.surface === "origin") {

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -611,7 +611,7 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
             },
           ),
         plannedTarget.surface === "origin" ? "send-approval-channel" : "send-approval",
-        { nonIdempotent: true },
+        { safety: "nonce-protected-create" },
       )) as { id: string; channel_id: string };
       if (!message?.id) {
         if (plannedTarget.surface === "origin") {

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -1,7 +1,7 @@
 // Discord plugin module implements client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import type { RetryConfig, RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
+import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -14,7 +14,7 @@ import { RequestClient } from "./internal/discord.js";
 import { getGateway } from "./monitor/gateway-registry.js";
 import { resolveDiscordProxyFetchForAccount } from "./proxy-fetch.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
-import { createDiscordRetryRunner } from "./retry.js";
+import { createDiscordRetryRunner, type DiscordRetryRunner } from "./retry.js";
 import type { DiscordRuntimeAccountContext } from "./send.types.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -142,7 +142,7 @@ export function createDiscordRestClient(opts: DiscordClientOpts) {
 export function createDiscordClient(opts: DiscordClientOpts): {
   token: string;
   rest: RequestClient;
-  request: RetryRunner;
+  request: DiscordRetryRunner;
 } {
   const { token, rest, account } = createDiscordRestClient(opts);
   const request = createDiscordRetryRunner({

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -1,7 +1,11 @@
 // Discord tests cover retry plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
-import { createDiscordRetryRunner, isRetryableDiscordTransientError } from "./retry.js";
+import {
+  createDiscordRetryRunner,
+  isRetryableDiscordPreConnectError,
+  isRetryableDiscordTransientError,
+} from "./retry.js";
 
 const ZERO_DELAY_RETRY = { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 };
 
@@ -50,6 +54,70 @@ describe("isRetryableDiscordTransientError", () => {
     ["plain string", "fetch failed"],
   ])("does not retry %s", (_name, err) => {
     expect(isRetryableDiscordTransientError(err)).toBe(false);
+  });
+});
+
+describe("isRetryableDiscordPreConnectError", () => {
+  it.each([
+    ["rate limit", createRateLimitError()],
+    ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
+    ["ECONNREFUSED", Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" })],
+    ["ENOTFOUND", Object.assign(new Error("dns failure"), { code: "ENOTFOUND" })],
+    ["EAI_AGAIN cause", new Error("request failed", { cause: { code: "EAI_AGAIN" } })],
+    [
+      "UND_ERR_CONNECT_TIMEOUT",
+      Object.assign(new Error("connect"), { code: "UND_ERR_CONNECT_TIMEOUT" }),
+    ],
+  ])("retries %s", (_name, err) => {
+    expect(isRetryableDiscordPreConnectError(err)).toBe(true);
+  });
+
+  it.each([
+    ["ECONNRESET", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" })],
+    ["ETIMEDOUT cause", new Error("request failed", { cause: { code: "ETIMEDOUT" } })],
+    ["abort", Object.assign(new Error("aborted"), { name: "AbortError" })],
+    ["headers timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_HEADERS_TIMEOUT" })],
+    ["body timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_BODY_TIMEOUT" })],
+    ["socket", Object.assign(new Error("socket"), { code: "UND_ERR_SOCKET" })],
+    ["502 status", Object.assign(new Error("bad gateway"), { status: 502 })],
+    ["fetch failed", new TypeError("fetch failed")],
+  ])("does not retry %s", (_name, err) => {
+    expect(isRetryableDiscordPreConnectError(err)).toBe(false);
+  });
+});
+
+describe("createDiscordRetryRunner nonIdempotent", () => {
+  it("does not retry post-connect-ambiguous errors for non-idempotent sends", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "text", { nonIdempotent: true })).rejects.toThrow("aborted");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still retries pre-connect errors for non-idempotent sends", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps retrying the broad transient set for default idempotent calls", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "react")).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
 import {
   createDiscordRetryRunner,
-  isRetryableDiscordPreConnectError,
+  isRetryableDiscordNonIdempotentError,
   isRetryableDiscordTransientError,
 } from "./retry.js";
 
@@ -57,10 +57,11 @@ describe("isRetryableDiscordTransientError", () => {
   });
 });
 
-describe("isRetryableDiscordPreConnectError", () => {
+describe("isRetryableDiscordNonIdempotentError", () => {
   it.each([
     ["rate limit", createRateLimitError()],
     ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
+    ["502 status", Object.assign(new Error("bad gateway"), { status: 502 })],
     ["ECONNREFUSED", Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" })],
     ["ENOTFOUND", Object.assign(new Error("dns failure"), { code: "ENOTFOUND" })],
     ["EAI_AGAIN cause", new Error("request failed", { cause: { code: "EAI_AGAIN" } })],
@@ -69,7 +70,7 @@ describe("isRetryableDiscordPreConnectError", () => {
       Object.assign(new Error("connect"), { code: "UND_ERR_CONNECT_TIMEOUT" }),
     ],
   ])("retries %s", (_name, err) => {
-    expect(isRetryableDiscordPreConnectError(err)).toBe(true);
+    expect(isRetryableDiscordNonIdempotentError(err)).toBe(true);
   });
 
   it.each([
@@ -79,10 +80,9 @@ describe("isRetryableDiscordPreConnectError", () => {
     ["headers timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_HEADERS_TIMEOUT" })],
     ["body timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_BODY_TIMEOUT" })],
     ["socket", Object.assign(new Error("socket"), { code: "UND_ERR_SOCKET" })],
-    ["502 status", Object.assign(new Error("bad gateway"), { status: 502 })],
     ["fetch failed", new TypeError("fetch failed")],
   ])("does not retry %s", (_name, err) => {
-    expect(isRetryableDiscordPreConnectError(err)).toBe(false);
+    expect(isRetryableDiscordNonIdempotentError(err)).toBe(false);
   });
 });
 
@@ -102,6 +102,17 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a 502 for non-idempotent sends", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
 import {
   createDiscordRetryRunner,
-  isRetryableDiscordNonIdempotentError,
+  isRetryableDiscordNonceProtectedCreateError,
   isRetryableDiscordPreConnectError,
   isRetryableDiscordTransientError,
 } from "./retry.js";
@@ -58,7 +58,7 @@ describe("isRetryableDiscordTransientError", () => {
   });
 });
 
-describe("isRetryableDiscordNonIdempotentError", () => {
+describe("isRetryableDiscordNonceProtectedCreateError", () => {
   it.each([
     ["rate limit", createRateLimitError()],
     ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
@@ -71,7 +71,7 @@ describe("isRetryableDiscordNonIdempotentError", () => {
       Object.assign(new Error("connect"), { code: "UND_ERR_CONNECT_TIMEOUT" }),
     ],
   ])("retries %s", (_name, err) => {
-    expect(isRetryableDiscordNonIdempotentError(err)).toBe(true);
+    expect(isRetryableDiscordNonceProtectedCreateError(err)).toBe(true);
   });
 
   it.each([
@@ -83,7 +83,7 @@ describe("isRetryableDiscordNonIdempotentError", () => {
     ["socket", Object.assign(new Error("socket"), { code: "UND_ERR_SOCKET" })],
     ["fetch failed", new TypeError("fetch failed")],
   ])("does not retry %s", (_name, err) => {
-    expect(isRetryableDiscordNonIdempotentError(err)).toBe(false);
+    expect(isRetryableDiscordNonceProtectedCreateError(err)).toBe(false);
   });
 });
 
@@ -103,7 +103,7 @@ describe("isRetryableDiscordPreConnectError", () => {
   });
 });
 
-describe("createDiscordRetryRunner nonIdempotent", () => {
+describe("createDiscordRetryRunner create safety", () => {
   it("does not retry post-connect-ambiguous errors for non-idempotent sends", async () => {
     const fn = vi
       .fn()
@@ -111,7 +111,9 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 
-    await expect(runner(fn, "text", { nonIdempotent: true })).rejects.toThrow("aborted");
+    await expect(runner(fn, "text", { safety: "nonce-protected-create" })).rejects.toThrow(
+      "aborted",
+    );
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
@@ -122,7 +124,7 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 
-    await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
+    await expect(runner(fn, "text", { safety: "nonce-protected-create" })).resolves.toBe("ok");
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
@@ -133,7 +135,7 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 
-    await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
+    await expect(runner(fn, "text", { safety: "nonce-protected-create" })).resolves.toBe("ok");
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
@@ -144,9 +146,9 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 
-    await expect(
-      runner(fn, "forum-thread", { nonIdempotent: true, retryOn502: false }),
-    ).rejects.toThrow("bad gateway");
+    await expect(runner(fn, "forum-thread", { safety: "non-idempotent-create" })).rejects.toThrow(
+      "bad gateway",
+    );
     expect(fn).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -4,6 +4,7 @@ import { RateLimitError } from "./internal/discord.js";
 import {
   createDiscordRetryRunner,
   isRetryableDiscordNonIdempotentError,
+  isRetryableDiscordPreConnectError,
   isRetryableDiscordTransientError,
 } from "./retry.js";
 
@@ -86,6 +87,22 @@ describe("isRetryableDiscordNonIdempotentError", () => {
   });
 });
 
+describe("isRetryableDiscordPreConnectError", () => {
+  it.each([
+    ["rate limit", createRateLimitError()],
+    ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
+    ["ECONNREFUSED", Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" })],
+  ])("retries %s", (_name, err) => {
+    expect(isRetryableDiscordPreConnectError(err)).toBe(true);
+  });
+
+  it("does not retry 502", () => {
+    expect(
+      isRetryableDiscordPreConnectError(Object.assign(new Error("bad gateway"), { status: 502 })),
+    ).toBe(false);
+  });
+});
+
 describe("createDiscordRetryRunner nonIdempotent", () => {
   it("does not retry post-connect-ambiguous errors for non-idempotent sends", async () => {
     const fn = vi
@@ -118,6 +135,19 @@ describe("createDiscordRetryRunner nonIdempotent", () => {
 
     await expect(runner(fn, "text", { nonIdempotent: true })).resolves.toBe("ok");
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 502 when the endpoint lacks nonce enforcement", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValue("ok");
+    const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
+
+    await expect(
+      runner(fn, "forum-thread", { nonIdempotent: true, retryOn502: false }),
+    ).rejects.toThrow("bad gateway");
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
   it("keeps retrying the broad transient set for default idempotent calls", async () => {

--- a/extensions/discord/src/retry.test.ts
+++ b/extensions/discord/src/retry.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import { RateLimitError } from "./internal/discord.js";
 import {
   createDiscordRetryRunner,
-  isRetryableDiscordNonceProtectedCreateError,
   isRetryableDiscordPreConnectError,
   isRetryableDiscordTransientError,
 } from "./retry.js";
@@ -58,35 +57,6 @@ describe("isRetryableDiscordTransientError", () => {
   });
 });
 
-describe("isRetryableDiscordNonceProtectedCreateError", () => {
-  it.each([
-    ["rate limit", createRateLimitError()],
-    ["429 status", Object.assign(new Error("rate limited"), { status: 429 })],
-    ["502 status", Object.assign(new Error("bad gateway"), { status: 502 })],
-    ["ECONNREFUSED", Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" })],
-    ["ENOTFOUND", Object.assign(new Error("dns failure"), { code: "ENOTFOUND" })],
-    ["EAI_AGAIN cause", new Error("request failed", { cause: { code: "EAI_AGAIN" } })],
-    [
-      "UND_ERR_CONNECT_TIMEOUT",
-      Object.assign(new Error("connect"), { code: "UND_ERR_CONNECT_TIMEOUT" }),
-    ],
-  ])("retries %s", (_name, err) => {
-    expect(isRetryableDiscordNonceProtectedCreateError(err)).toBe(true);
-  });
-
-  it.each([
-    ["ECONNRESET", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" })],
-    ["ETIMEDOUT cause", new Error("request failed", { cause: { code: "ETIMEDOUT" } })],
-    ["abort", Object.assign(new Error("aborted"), { name: "AbortError" })],
-    ["headers timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_HEADERS_TIMEOUT" })],
-    ["body timeout", Object.assign(new Error("timeout"), { code: "UND_ERR_BODY_TIMEOUT" })],
-    ["socket", Object.assign(new Error("socket"), { code: "UND_ERR_SOCKET" })],
-    ["fetch failed", new TypeError("fetch failed")],
-  ])("does not retry %s", (_name, err) => {
-    expect(isRetryableDiscordNonceProtectedCreateError(err)).toBe(false);
-  });
-});
-
 describe("isRetryableDiscordPreConnectError", () => {
   it.each([
     ["rate limit", createRateLimitError()],
@@ -104,20 +74,18 @@ describe("isRetryableDiscordPreConnectError", () => {
 });
 
 describe("createDiscordRetryRunner create safety", () => {
-  it("does not retry post-connect-ambiguous errors for non-idempotent sends", async () => {
+  it("retries post-connect-ambiguous errors for nonce-protected creates", async () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
       .mockResolvedValue("ok");
     const runner = createDiscordRetryRunner({ retry: ZERO_DELAY_RETRY });
 
-    await expect(runner(fn, "text", { safety: "nonce-protected-create" })).rejects.toThrow(
-      "aborted",
-    );
-    expect(fn).toHaveBeenCalledTimes(1);
+    await expect(runner(fn, "text", { safety: "nonce-protected-create" })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it("still retries pre-connect errors for non-idempotent sends", async () => {
+  it("retries pre-connect errors for nonce-protected creates", async () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }))
@@ -128,7 +96,7 @@ describe("createDiscordRetryRunner create safety", () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it("retries a 502 for non-idempotent sends", async () => {
+  it("retries a 502 for nonce-protected creates", async () => {
     const fn = vi
       .fn()
       .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -10,7 +10,6 @@ import {
   resolveRetryConfig,
   retryAsync,
   type RetryConfig,
-  type RetryRunner,
 } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { RateLimitError } from "./internal/discord.js";
@@ -39,7 +38,20 @@ const DISCORD_RETRYABLE_ERROR_CODES = new Set([
 ]);
 const DISCORD_TRANSIENT_MESSAGE_RE =
   /\b(?:bad gateway|fetch failed|network error|networkerror|service unavailable|socket hang up|temporarily unavailable|timed out|timeout)\b|connection (?:closed|reset|refused)/i;
+const DISCORD_PRECONNECT_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
 const log = createSubsystemLogger("discord/retry");
+
+export type DiscordRetryRunner = <T>(
+  fn: () => Promise<T>,
+  label?: string,
+  options?: { nonIdempotent?: boolean },
+) => Promise<T>;
 
 function readDiscordErrorStatus(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {
@@ -83,6 +95,25 @@ export function isRetryableDiscordTransientError(err: unknown): boolean {
   return false;
 }
 
+export function isRetryableDiscordPreConnectError(err: unknown): boolean {
+  if (err instanceof RateLimitError) {
+    return true;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => [
+    current.cause,
+    current.error,
+  ])) {
+    if (readDiscordErrorStatus(candidate) === 429) {
+      return true;
+    }
+    const code = extractErrorCode(candidate);
+    if (code && DISCORD_PRECONNECT_ERROR_CODES.has(code.toUpperCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isRetryableDiscordGatewayTransportError(err: unknown): boolean {
   if (!isRetryableDiscordTransientError(err) || err instanceof RateLimitError) {
     return false;
@@ -97,7 +128,7 @@ export function createDiscordRetryRunner(params: {
   configRetry?: RetryConfig;
   verbose?: boolean;
   isGatewayDisconnected?: () => boolean;
-}): RetryRunner {
+}): DiscordRetryRunner {
   const retryConfig = resolveRetryConfig(DISCORD_RETRY_DEFAULTS, {
     ...params.configRetry,
     ...params.retry,
@@ -109,7 +140,10 @@ export function createDiscordRetryRunner(params: {
       ? retryConfig.attempts + DISCORD_GATEWAY_RECONNECT_EXTRA_ATTEMPTS
       : retryConfig.attempts;
 
-  return <T>(fn: () => Promise<T>, label?: string) => {
+  return <T>(fn: () => Promise<T>, label?: string, options?: { nonIdempotent?: boolean }) => {
+    const isRetryable = options?.nonIdempotent
+      ? isRetryableDiscordPreConnectError
+      : isRetryableDiscordTransientError;
     let observedGatewayDisconnect = false;
     const runRequest = async () => {
       observedGatewayDisconnect ||= params.isGatewayDisconnected?.() === true;
@@ -125,7 +159,7 @@ export function createDiscordRetryRunner(params: {
       attempts,
       label,
       shouldRetry: (err, attempt) =>
-        isRetryableDiscordTransientError(err) &&
+        isRetryable(err) &&
         (attempt < retryConfig.attempts ||
           (observedGatewayDisconnect && isRetryableDiscordGatewayTransportError(err))),
       retryAfterMs: (err) => (err instanceof RateLimitError ? err.retryAfter * 1000 : undefined),

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -116,28 +116,10 @@ export function isRetryableDiscordPreConnectError(err: unknown): boolean {
   return false;
 }
 
-export function isRetryableDiscordNonceProtectedCreateError(err: unknown): boolean {
-  if (
-    collectErrorGraphCandidates(err, (current) => [current.cause, current.error]).some(
-      (candidate) => readDiscordErrorStatus(candidate) === 502,
-    )
-  ) {
-    return true;
-  }
-  return isRetryableDiscordPreConnectError(err);
-}
-
 function resolveDiscordRetryPredicate(safety: DiscordRetrySafety) {
-  switch (safety) {
-    case "idempotent":
-      return isRetryableDiscordTransientError;
-    case "nonce-protected-create":
-      // Discord can deduplicate an ambiguous 502 only for Create Message requests
-      // carrying a stable enforced nonce. Other post-connect failures stay fail-closed.
-      return isRetryableDiscordNonceProtectedCreateError;
-    case "non-idempotent-create":
-      return isRetryableDiscordPreConnectError;
-  }
+  return safety === "non-idempotent-create"
+    ? isRetryableDiscordPreConnectError
+    : isRetryableDiscordTransientError;
 }
 
 function isRetryableDiscordGatewayTransportError(err: unknown): boolean {

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -38,6 +38,7 @@ const DISCORD_RETRYABLE_ERROR_CODES = new Set([
 ]);
 const DISCORD_TRANSIENT_MESSAGE_RE =
   /\b(?:bad gateway|fetch failed|network error|networkerror|service unavailable|socket hang up|temporarily unavailable|timed out|timeout)\b|connection (?:closed|reset|refused)/i;
+const DISCORD_NON_IDEMPOTENT_RETRYABLE_STATUS_CODES = new Set([429, 502]);
 const DISCORD_PRECONNECT_ERROR_CODES = new Set([
   "EAI_AGAIN",
   "ECONNREFUSED",
@@ -95,7 +96,7 @@ export function isRetryableDiscordTransientError(err: unknown): boolean {
   return false;
 }
 
-export function isRetryableDiscordPreConnectError(err: unknown): boolean {
+export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
   if (err instanceof RateLimitError) {
     return true;
   }
@@ -103,7 +104,7 @@ export function isRetryableDiscordPreConnectError(err: unknown): boolean {
     current.cause,
     current.error,
   ])) {
-    if (readDiscordErrorStatus(candidate) === 429) {
+    if (DISCORD_NON_IDEMPOTENT_RETRYABLE_STATUS_CODES.has(readDiscordErrorStatus(candidate) ?? 0)) {
       return true;
     }
     const code = extractErrorCode(candidate);
@@ -142,7 +143,7 @@ export function createDiscordRetryRunner(params: {
 
   return <T>(fn: () => Promise<T>, label?: string, options?: { nonIdempotent?: boolean }) => {
     const isRetryable = options?.nonIdempotent
-      ? isRetryableDiscordPreConnectError
+      ? isRetryableDiscordNonIdempotentError
       : isRetryableDiscordTransientError;
     let observedGatewayDisconnect = false;
     const runRequest = async () => {

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -47,10 +47,12 @@ const DISCORD_PRECONNECT_ERROR_CODES = new Set([
 ]);
 const log = createSubsystemLogger("discord/retry");
 
+export type DiscordRetrySafety = "idempotent" | "nonce-protected-create" | "non-idempotent-create";
+
 export type DiscordRetryRunner = <T>(
   fn: () => Promise<T>,
   label?: string,
-  options?: { nonIdempotent?: boolean; retryOn502?: boolean },
+  options?: { safety: DiscordRetrySafety },
 ) => Promise<T>;
 
 function readDiscordErrorStatus(err: unknown): number | undefined {
@@ -114,7 +116,7 @@ export function isRetryableDiscordPreConnectError(err: unknown): boolean {
   return false;
 }
 
-export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
+export function isRetryableDiscordNonceProtectedCreateError(err: unknown): boolean {
   if (
     collectErrorGraphCandidates(err, (current) => [current.cause, current.error]).some(
       (candidate) => readDiscordErrorStatus(candidate) === 502,
@@ -123,6 +125,19 @@ export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
     return true;
   }
   return isRetryableDiscordPreConnectError(err);
+}
+
+function resolveDiscordRetryPredicate(safety: DiscordRetrySafety) {
+  switch (safety) {
+    case "idempotent":
+      return isRetryableDiscordTransientError;
+    case "nonce-protected-create":
+      // Discord can deduplicate an ambiguous 502 only for Create Message requests
+      // carrying a stable enforced nonce. Other post-connect failures stay fail-closed.
+      return isRetryableDiscordNonceProtectedCreateError;
+    case "non-idempotent-create":
+      return isRetryableDiscordPreConnectError;
+  }
 }
 
 function isRetryableDiscordGatewayTransportError(err: unknown): boolean {
@@ -151,16 +166,8 @@ export function createDiscordRetryRunner(params: {
       ? retryConfig.attempts + DISCORD_GATEWAY_RECONNECT_EXTRA_ATTEMPTS
       : retryConfig.attempts;
 
-  return <T>(
-    fn: () => Promise<T>,
-    label?: string,
-    options?: { nonIdempotent?: boolean; retryOn502?: boolean },
-  ) => {
-    const isRetryable = !options?.nonIdempotent
-      ? isRetryableDiscordTransientError
-      : options.retryOn502 === false
-        ? isRetryableDiscordPreConnectError
-        : isRetryableDiscordNonIdempotentError;
+  return <T>(fn: () => Promise<T>, label?: string, options?: { safety: DiscordRetrySafety }) => {
+    const isRetryable = resolveDiscordRetryPredicate(options?.safety ?? "idempotent");
     let observedGatewayDisconnect = false;
     const runRequest = async () => {
       observedGatewayDisconnect ||= params.isGatewayDisconnected?.() === true;

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -38,7 +38,6 @@ const DISCORD_RETRYABLE_ERROR_CODES = new Set([
 ]);
 const DISCORD_TRANSIENT_MESSAGE_RE =
   /\b(?:bad gateway|fetch failed|network error|networkerror|service unavailable|socket hang up|temporarily unavailable|timed out|timeout)\b|connection (?:closed|reset|refused)/i;
-const DISCORD_NON_IDEMPOTENT_RETRYABLE_STATUS_CODES = new Set([429, 502]);
 const DISCORD_PRECONNECT_ERROR_CODES = new Set([
   "EAI_AGAIN",
   "ECONNREFUSED",
@@ -51,7 +50,7 @@ const log = createSubsystemLogger("discord/retry");
 export type DiscordRetryRunner = <T>(
   fn: () => Promise<T>,
   label?: string,
-  options?: { nonIdempotent?: boolean },
+  options?: { nonIdempotent?: boolean; retryOn502?: boolean },
 ) => Promise<T>;
 
 function readDiscordErrorStatus(err: unknown): number | undefined {
@@ -96,7 +95,7 @@ export function isRetryableDiscordTransientError(err: unknown): boolean {
   return false;
 }
 
-export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
+export function isRetryableDiscordPreConnectError(err: unknown): boolean {
   if (err instanceof RateLimitError) {
     return true;
   }
@@ -104,7 +103,7 @@ export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
     current.cause,
     current.error,
   ])) {
-    if (DISCORD_NON_IDEMPOTENT_RETRYABLE_STATUS_CODES.has(readDiscordErrorStatus(candidate) ?? 0)) {
+    if (readDiscordErrorStatus(candidate) === 429) {
       return true;
     }
     const code = extractErrorCode(candidate);
@@ -113,6 +112,17 @@ export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
     }
   }
   return false;
+}
+
+export function isRetryableDiscordNonIdempotentError(err: unknown): boolean {
+  if (
+    collectErrorGraphCandidates(err, (current) => [current.cause, current.error]).some(
+      (candidate) => readDiscordErrorStatus(candidate) === 502,
+    )
+  ) {
+    return true;
+  }
+  return isRetryableDiscordPreConnectError(err);
 }
 
 function isRetryableDiscordGatewayTransportError(err: unknown): boolean {
@@ -141,10 +151,16 @@ export function createDiscordRetryRunner(params: {
       ? retryConfig.attempts + DISCORD_GATEWAY_RECONNECT_EXTRA_ATTEMPTS
       : retryConfig.attempts;
 
-  return <T>(fn: () => Promise<T>, label?: string, options?: { nonIdempotent?: boolean }) => {
-    const isRetryable = options?.nonIdempotent
-      ? isRetryableDiscordNonIdempotentError
-      : isRetryableDiscordTransientError;
+  return <T>(
+    fn: () => Promise<T>,
+    label?: string,
+    options?: { nonIdempotent?: boolean; retryOn502?: boolean },
+  ) => {
+    const isRetryable = !options?.nonIdempotent
+      ? isRetryableDiscordTransientError
+      : options.retryOn502 === false
+        ? isRetryableDiscordPreConnectError
+        : isRetryableDiscordNonIdempotentError;
     let observedGatewayDisconnect = false;
     const runRequest = async () => {
       observedGatewayDisconnect ||= params.isGatewayDisconnected?.() === true;

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -178,12 +178,21 @@ describe("sendDiscordComponentMessage", () => {
     expect(patchMock).toHaveBeenCalledTimes(1);
     const [patchUrl, patchRequest] = readMockCall(patchMock, 0) as [
       string,
-      { body?: { flags?: unknown; components?: unknown[] } },
+      {
+        body?: {
+          flags?: unknown;
+          components?: unknown[];
+          nonce?: unknown;
+          enforce_nonce?: unknown;
+        };
+      },
     ];
     expect(patchUrl).toContain("/channels/chan-1/messages/msg1");
     expect(patchRequest?.body?.flags).toBe(MessageFlags.IsComponentsV2);
     expect(Array.isArray(patchRequest?.body?.components)).toBe(true);
     expect(patchRequest?.body?.components).toHaveLength(1);
+    expect(patchRequest?.body).not.toHaveProperty("nonce");
+    expect(patchRequest?.body).not.toHaveProperty("enforce_nonce");
     expect(registerMock).toHaveBeenCalledTimes(1);
     const args = readRecordArg(registerMock, 0, 0);
     expect(args.messageId).toBe("msg1");

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -31,6 +31,7 @@ import { createDiscordSendResult } from "./send.receipt.js";
 import {
   buildDiscordSendError,
   createDiscordClient,
+  createDiscordMessageNonce,
   resolveChannelId,
   resolveDiscordChannel,
   stripUndefinedFields,
@@ -258,6 +259,8 @@ async function buildDiscordComponentPayload(params: {
   const body = stripUndefinedFields({
     ...serializePayload(payload),
     ...(messageReference ? { message_reference: messageReference } : {}),
+    nonce: createDiscordMessageNonce(),
+    enforce_nonce: true,
   });
 
   return { body, buildResult };

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -317,6 +317,7 @@ export async function sendDiscordComponentMessage(
           body,
         }),
       "components",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
   } catch (err) {
     throw await buildDiscordSendError(err, {

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -259,8 +259,6 @@ async function buildDiscordComponentPayload(params: {
   const body = stripUndefinedFields({
     ...serializePayload(payload),
     ...(messageReference ? { message_reference: messageReference } : {}),
-    nonce: createDiscordMessageNonce(),
-    enforce_nonce: true,
   });
 
   return { body, buildResult };
@@ -306,11 +304,17 @@ export async function sendDiscordComponentMessage(
     throw new Error("Discord components are not supported in forum-style channels");
   }
 
-  const { body, buildResult } = await buildDiscordComponentPayload({
+  const { body: componentBody, buildResult } = await buildDiscordComponentPayload({
     spec,
     opts,
     accountId: accountInfo.accountId,
   });
+  // Nonce enforcement belongs to Create Message; the shared builder also serves edits.
+  const body = {
+    ...componentBody,
+    nonce: createDiscordMessageNonce(),
+    enforce_nonce: true,
+  };
 
   let result: { id: string; channel_id: string };
   try {
@@ -320,7 +324,7 @@ export async function sendDiscordComponentMessage(
           body,
         }),
       "components",
-      { nonIdempotent: true },
+      { safety: "nonce-protected-create" },
     )) as { id: string; channel_id: string };
   } catch (err) {
     throw await buildDiscordSendError(err, {

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -462,11 +462,13 @@ describe("sendStickerDiscord", () => {
     expect(res.receipt.parts[0]?.platformMessageId).toBe("msg1");
     expect(res.receipt.parts[0]?.kind).toBe("card");
     expect(requestPath(postMock as unknown as MockCallSource)).toBe(Routes.channelMessages("789"));
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
       content: "hiya",
       flags: MessageFlags.SuppressEmbeds,
       sticker_ids: ["123"],
+      enforce_nonce: true,
     });
+    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
   });
 
   it("allows sticker content link embeds when disabled", async () => {
@@ -480,10 +482,12 @@ describe("sendStickerDiscord", () => {
       suppressEmbeds: false,
     });
 
-    expect(requestBody(postMock as unknown as MockCallSource)).toEqual({
+    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
       content: "https://example.com",
       sticker_ids: ["123"],
+      enforce_nonce: true,
     });
+    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
   });
 });
 
@@ -522,6 +526,10 @@ describe("sendPollDiscord", () => {
       allow_multiselect: false,
       layout_type: 1,
     });
+    expect(requestBody(postMock as unknown as MockCallSource)).toMatchObject({
+      enforce_nonce: true,
+    });
+    expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
   });
 
   it("combines silent and suppress-embeds flags for polls", async () => {
@@ -649,23 +657,21 @@ describe("retry rate limits", () => {
     expect(postMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retries transient network errors", async () => {
+  it("does not retry ambiguous network errors", async () => {
     const { rest, postMock } = makeDiscordRest();
     postMock
       .mockRejectedValueOnce(new TypeError("fetch failed"))
       .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
 
-    const result = await sendMessageDiscord("channel:789", "hello", {
-      cfg: DISCORD_TEST_CFG,
-      rest,
-      token: "t",
-      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-    });
-
-    expect(result.messageId).toBe("msg1");
-    expect(result.channelId).toBe("789");
-    expect(result.receipt.platformMessageIds).toEqual(["msg1"]);
-    expect(postMock).toHaveBeenCalledTimes(2);
+    await expect(
+      sendMessageDiscord("channel:789", "hello", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      }),
+    ).rejects.toThrow("fetch failed");
+    expect(postMock).toHaveBeenCalledTimes(1);
   });
 
   it("retries reactions on rate limits", async () => {

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -489,6 +489,25 @@ describe("sendStickerDiscord", () => {
     });
     expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
   });
+
+  it("reuses a single nonce across a retried 502 for stickers", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+    await sendStickerDiscord("channel:789", ["123"], {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      content: "hiya",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstNonce = requestBody(postMock as unknown as MockCallSource, 0).nonce;
+    const secondNonce = requestBody(postMock as unknown as MockCallSource, 1).nonce;
+    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(secondNonce).toBe(firstNonce);
+  });
 });
 
 describe("sendPollDiscord", () => {
@@ -530,6 +549,31 @@ describe("sendPollDiscord", () => {
       enforce_nonce: true,
     });
     expect(requestBody(postMock as unknown as MockCallSource).nonce).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  it("reuses a single nonce across a retried 502 for polls", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
+    await sendPollDiscord(
+      "channel:789",
+      {
+        question: "Lunch?",
+        options: ["Pizza", "Sushi"],
+      },
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      },
+    );
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstNonce = requestBody(postMock as unknown as MockCallSource, 0).nonce;
+    const secondNonce = requestBody(postMock as unknown as MockCallSource, 1).nonce;
+    expect(firstNonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(secondNonce).toBe(firstNonce);
   });
 
   it("combines silent and suppress-embeds flags for polls", async () => {

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -701,21 +701,25 @@ describe("retry rate limits", () => {
     expect(postMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry ambiguous network errors", async () => {
+  it("retries ambiguous network errors with one stable enforced nonce", async () => {
     const { rest, postMock } = makeDiscordRest();
     postMock
       .mockRejectedValueOnce(new TypeError("fetch failed"))
       .mockResolvedValueOnce({ id: "msg1", channel_id: "789" });
 
-    await expect(
-      sendMessageDiscord("channel:789", "hello", {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
-      }),
-    ).rejects.toThrow("fetch failed");
-    expect(postMock).toHaveBeenCalledTimes(1);
+    const result = await sendMessageDiscord("channel:789", "hello", {
+      cfg: DISCORD_TEST_CFG,
+      rest,
+      token: "t",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(result.messageId).toBe("msg1");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    const firstBody = requestBody(postMock as unknown as MockCallSource, 0);
+    const secondBody = requestBody(postMock as unknown as MockCallSource, 1);
+    expect(firstBody.enforce_nonce).toBe(true);
+    expect(secondBody.nonce).toBe(firstBody.nonce);
   });
 
   it("retries reactions on rate limits", async () => {

--- a/extensions/discord/src/send.message-request.test.ts
+++ b/extensions/discord/src/send.message-request.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscordMessageRequest } from "./send.message-request.js";
+
+describe("buildDiscordMessageRequest", () => {
+  it("enforces a supplied nonce across retries", () => {
+    const body = buildDiscordMessageRequest({
+      text: "hello",
+      nonce: "stable-create-nonce",
+    });
+
+    expect(body).toMatchObject({
+      content: "hello",
+      nonce: "stable-create-nonce",
+      enforce_nonce: true,
+    });
+  });
+
+  it("adds a nonce for each logical create", () => {
+    const body = buildDiscordMessageRequest({ text: "hello" });
+
+    expect(body).toMatchObject({
+      content: "hello",
+      enforce_nonce: true,
+    });
+    expect(body.nonce).toMatch(/^[0-9a-f]{24}$/);
+  });
+});

--- a/extensions/discord/src/send.message-request.test.ts
+++ b/extensions/discord/src/send.message-request.test.ts
@@ -4,6 +4,7 @@ import { buildDiscordMessageRequest } from "./send.message-request.js";
 describe("buildDiscordMessageRequest", () => {
   it("enforces a supplied nonce across retries", () => {
     const body = buildDiscordMessageRequest({
+      endpoint: "create-message",
       text: "hello",
       nonce: "stable-create-nonce",
     });
@@ -16,12 +17,18 @@ describe("buildDiscordMessageRequest", () => {
   });
 
   it("adds a nonce for each logical create", () => {
-    const body = buildDiscordMessageRequest({ text: "hello" });
+    const body = buildDiscordMessageRequest({ endpoint: "create-message", text: "hello" });
 
     expect(body).toMatchObject({
       content: "hello",
       enforce_nonce: true,
     });
     expect(body.nonce).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  it("omits create-message nonce fields from forum thread starters", () => {
+    const body = buildDiscordMessageRequest({ endpoint: "forum-thread", text: "hello" });
+
+    expect(body).toEqual({ content: "hello" });
   });
 });

--- a/extensions/discord/src/send.message-request.ts
+++ b/extensions/discord/src/send.message-request.ts
@@ -97,7 +97,7 @@ export function resolveDiscordMessageFlags(params: {
   return flags || undefined;
 }
 
-export function buildDiscordMessageRequest(params: {
+type DiscordMessageRequestParams = {
   text: string;
   components?: TopLevelComponents[];
   embeds?: Embed[];
@@ -105,16 +105,21 @@ export function buildDiscordMessageRequest(params: {
   files?: MessagePayloadFile[];
   flags?: number;
   replyTo?: string;
-  nonce?: string;
-}) {
+} & ({ endpoint: "create-message"; nonce?: string } | { endpoint: "forum-thread"; nonce?: never });
+
+export function buildDiscordMessageRequest(params: DiscordMessageRequestParams) {
   const payload = buildDiscordMessagePayload(params);
+  const nonce =
+    params.endpoint === "create-message"
+      ? (params.nonce ?? createDiscordMessageNonce())
+      : undefined;
   return stripUndefinedFields({
     ...serializePayload(payload),
     ...(params.replyTo
       ? { message_reference: { message_id: params.replyTo, fail_if_not_exists: false } }
       : {}),
-    nonce: params.nonce ?? createDiscordMessageNonce(),
-    enforce_nonce: true,
+    nonce,
+    enforce_nonce: nonce ? true : undefined,
   });
 }
 

--- a/extensions/discord/src/send.message-request.ts
+++ b/extensions/discord/src/send.message-request.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements send.message request behavior.
+import { randomBytes } from "node:crypto";
 import { MessageFlags, type APIAllowedMentions, type APIEmbed } from "discord-api-types/v10";
 import {
   Embed,
@@ -15,6 +16,10 @@ export type DiscordSendComponentFactory = (text: string) => TopLevelComponents[]
 export type DiscordSendComponents = TopLevelComponents[] | DiscordSendComponentFactory;
 export type DiscordSendEmbeds = Array<APIEmbed | Embed>;
 export type DiscordAllowedMentions = APIAllowedMentions;
+
+export function createDiscordMessageNonce(): string {
+  return randomBytes(12).toString("hex");
+}
 
 export function resolveDiscordSendComponents(params: {
   components?: DiscordSendComponents;
@@ -100,6 +105,7 @@ export function buildDiscordMessageRequest(params: {
   files?: MessagePayloadFile[];
   flags?: number;
   replyTo?: string;
+  nonce?: string;
 }) {
   const payload = buildDiscordMessagePayload(params);
   return stripUndefinedFields({
@@ -107,6 +113,8 @@ export function buildDiscordMessageRequest(params: {
     ...(params.replyTo
       ? { message_reference: { message_id: params.replyTo, fail_if_not_exists: false } }
       : {}),
+    nonce: params.nonce ?? createDiscordMessageNonce(),
+    enforce_nonce: true,
   });
 }
 

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -224,6 +224,7 @@ export async function sendMessageDiscord(
       suppressEmbeds: suppressEmbeds && !starterEmbeds?.length,
     });
     const starterBody = buildDiscordMessageRequest({
+      endpoint: "forum-thread",
       text: starterContent,
       components: starterComponents,
       embeds: starterEmbeds,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -249,6 +249,7 @@ export async function sendMessageDiscord(
             },
           ),
         "forum-thread",
+        { nonIdempotent: true },
       )) as { id: string; message?: { id: string; channel_id: string } };
     } catch (err) {
       throw await buildDiscordSendError(err, {
@@ -444,6 +445,7 @@ export async function sendStickerDiscord(
         },
       }),
     "sticker",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }
@@ -470,6 +472,7 @@ export async function sendPollDiscord(
         },
       }),
     "poll",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -436,17 +436,15 @@ export async function sendStickerDiscord(
     await resolveDiscordStructuredSendContext(to, opts);
   const stickers = normalizeStickerIds(stickerIds);
   const flags = resolveDiscordMessageFlags({ suppressEmbeds });
+  const body = {
+    content: rewrittenContent || undefined,
+    sticker_ids: stickers,
+    nonce: createDiscordMessageNonce(),
+    enforce_nonce: true,
+    ...(flags ? { flags } : {}),
+  };
   const res = (await request(
-    () =>
-      createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, {
-        body: {
-          content: rewrittenContent || undefined,
-          sticker_ids: stickers,
-          nonce: createDiscordMessageNonce(),
-          enforce_nonce: true,
-          ...(flags ? { flags } : {}),
-        },
-      }),
+    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "sticker",
     { nonIdempotent: true },
   )) as { id: string; channel_id: string };
@@ -465,17 +463,15 @@ export async function sendPollDiscord(
   }
   const payload = normalizeDiscordPollInput(poll);
   const flags = resolveDiscordMessageFlags({ silent: opts.silent, suppressEmbeds });
+  const body = {
+    content: rewrittenContent || undefined,
+    poll: payload,
+    nonce: createDiscordMessageNonce(),
+    enforce_nonce: true,
+    ...(flags ? { flags } : {}),
+  };
   const res = (await request(
-    () =>
-      createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, {
-        body: {
-          content: rewrittenContent || undefined,
-          poll: payload,
-          nonce: createDiscordMessageNonce(),
-          enforce_nonce: true,
-          ...(flags ? { flags } : {}),
-        },
-      }),
+    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "poll",
     { nonIdempotent: true },
   )) as { id: string; channel_id: string };

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -25,6 +25,7 @@ import {
   buildDiscordSendError,
   buildDiscordTextChunks,
   createDiscordClient,
+  createDiscordMessageNonce,
   normalizeDiscordPollInput,
   normalizeStickerIds,
   resolveDiscordMessageFlags,
@@ -249,7 +250,7 @@ export async function sendMessageDiscord(
             },
           ),
         "forum-thread",
-        { nonIdempotent: true },
+        { nonIdempotent: true, retryOn502: false },
       )) as { id: string; message?: { id: string; channel_id: string } };
     } catch (err) {
       throw await buildDiscordSendError(err, {
@@ -441,6 +442,8 @@ export async function sendStickerDiscord(
         body: {
           content: rewrittenContent || undefined,
           sticker_ids: stickers,
+          nonce: createDiscordMessageNonce(),
+          enforce_nonce: true,
           ...(flags ? { flags } : {}),
         },
       }),
@@ -468,6 +471,8 @@ export async function sendPollDiscord(
         body: {
           content: rewrittenContent || undefined,
           poll: payload,
+          nonce: createDiscordMessageNonce(),
+          enforce_nonce: true,
           ...(flags ? { flags } : {}),
         },
       }),

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -250,7 +250,7 @@ export async function sendMessageDiscord(
             },
           ),
         "forum-thread",
-        { nonIdempotent: true, retryOn502: false },
+        { safety: "non-idempotent-create" },
       )) as { id: string; message?: { id: string; channel_id: string } };
     } catch (err) {
       throw await buildDiscordSendError(err, {
@@ -446,7 +446,7 @@ export async function sendStickerDiscord(
   const res = (await request(
     () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "sticker",
-    { nonIdempotent: true },
+    { safety: "nonce-protected-create" },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }
@@ -473,7 +473,7 @@ export async function sendPollDiscord(
   const res = (await request(
     () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
     "poll",
-    { nonIdempotent: true },
+    { safety: "nonce-protected-create" },
   )) as { id: string; channel_id: string };
   return toDiscordSendResult(res, channelId, { kind: "card" });
 }

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -269,7 +269,13 @@ describe("sendMessageDiscord", () => {
       } as never,
     });
 
-    expect(requireRestBody(postMock)).toEqual({ content: "https://example.com" });
+    const body = requireRestBody(postMock);
+    expect(body).toMatchObject({
+      content: "https://example.com",
+      enforce_nonce: true,
+    });
+    expect(body.nonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(body.flags).toBeUndefined();
   });
 
   it("uses account-level suppressEmbeds overrides", async () => {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -372,7 +372,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     const result = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "text",
-      { nonIdempotent: true },
+      { safety: "nonce-protected-create" },
     )) as { id: string; channel_id: string };
     return { result, replyToId: chunkReplyTo };
   };
@@ -472,7 +472,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     res = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "media",
-      { nonIdempotent: true },
+      { safety: "nonce-protected-create" },
     )) as { id: string; channel_id: string };
   } catch (err) {
     if (!isDiscordUploadTooLargeError(err)) {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -14,7 +14,6 @@ import {
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
-import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { chunkDiscordTextWithMode } from "./chunk.js";
@@ -27,6 +26,7 @@ import {
 } from "./internal/discord.js";
 import { parseAndResolveRecipient } from "./recipient-resolution.js";
 import { resolveDiscordReplyMessageId, type DiscordReplyReference } from "./reply-reference.js";
+import type { DiscordRetryRunner } from "./retry.js";
 import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";
 import { DiscordSendError } from "./send.types.js";
 
@@ -41,7 +41,7 @@ const DISCORD_UPLOAD_TOO_LARGE_STATUS = 413;
 const DISCORD_UPLOAD_TOO_LARGE_NOTICE =
   "Attachment skipped: Discord rejected the file as too large.";
 
-type DiscordRequest = RetryRunner;
+type DiscordRequest = DiscordRetryRunner;
 
 export {
   buildDiscordMessagePayload,
@@ -371,6 +371,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     const result = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "text",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
     return { result, replyToId: chunkReplyTo };
   };
@@ -470,6 +471,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     res = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "media",
+      { nonIdempotent: true },
     )) as { id: string; channel_id: string };
   } catch (err) {
     if (!isDiscordUploadTooLargeError(err)) {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -46,6 +46,7 @@ type DiscordRequest = DiscordRetryRunner;
 export {
   buildDiscordMessagePayload,
   buildDiscordMessageRequest,
+  createDiscordMessageNonce,
   resolveDiscordMessageFlags,
   resolveDiscordSendComponents,
   resolveDiscordSendEmbeds,

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -362,6 +362,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
       suppressEmbeds: suppressEmbeds && !chunkEmbeds?.length,
     });
     const body = buildDiscordMessageRequest({
+      endpoint: "create-message",
       text: chunk,
       components: chunkComponents,
       embeds: chunkEmbeds,
@@ -454,6 +455,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     suppressEmbeds: suppressEmbeds && !captionEmbeds?.length,
   });
   const body = buildDiscordMessageRequest({
+    endpoint: "create-message",
     text: caption,
     components: captionComponents,
     embeds: captionEmbeds,

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -5,6 +5,7 @@ import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RequestClient } from "./internal/discord.js";
 import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
+import type { DiscordRetryRunner } from "./retry.js";
 import type { VoiceMessageMetadata } from "./voice-message.js";
 
 const GUARDED_FETCH_TEST_TIMEOUT_MS = 250;
@@ -348,6 +349,8 @@ describe("sendDiscordVoiceMessage", () => {
     expect(post).toHaveBeenCalledWith("/channels/channel-1/messages", {
       body: {
         flags: 8192,
+        nonce: expect.stringMatching(/^[0-9a-f]{24}$/),
+        enforce_nonce: true,
         attachments: [
           {
             id: "0",
@@ -359,6 +362,62 @@ describe("sendDiscordVoiceMessage", () => {
         ],
       },
     });
+  });
+
+  it("reuses the voice-message nonce across an ambiguous create retry", async () => {
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("bad gateway"), { status: 502 }))
+      .mockResolvedValueOnce({ id: "msg-1", channel_id: "channel-1" });
+    const rest = createRest(post);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = input instanceof Request ? input.method : (init?.method ?? "GET");
+      if (method === "POST" && url.endsWith("/channels/channel-1/attachments")) {
+        return new Response(
+          JSON.stringify({
+            attachments: [
+              {
+                id: 0,
+                upload_url: "https://cdn.test/upload",
+                upload_filename: "uploaded.ogg",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (method === "PUT" && url === "https://cdn.test/upload") {
+        return new Response(null, { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${method} ${url}`);
+    });
+    const request = vi.fn(async <T>(fn: () => Promise<T>, label?: string): Promise<T> => {
+      if (label === "voice-message") {
+        await fn().catch(() => undefined);
+      }
+      return await fn();
+    }) as unknown as DiscordRetryRunner;
+
+    await expect(
+      sendDiscordVoiceMessage(
+        rest,
+        "channel-1",
+        Buffer.from("ogg"),
+        metadata,
+        undefined,
+        request,
+        false,
+        "bot-token",
+      ),
+    ).resolves.toEqual({ id: "msg-1", channel_id: "channel-1" });
+
+    expect(post).toHaveBeenCalledTimes(2);
+    const firstBody = (post.mock.calls[0]?.[1] as { body?: { nonce?: unknown } } | undefined)?.body;
+    const secondBody = (post.mock.calls[1]?.[1] as { body?: { nonce?: unknown } } | undefined)
+      ?.body;
+    expect(firstBody?.nonce).toMatch(/^[0-9a-f]{24}$/);
+    expect(secondBody?.nonce).toBe(firstBody?.nonce);
   });
 
   it("throws typed CDN upload failures", async () => {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -26,7 +26,6 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
-import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -35,6 +34,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
 import { readDiscordMessage, readRetryAfter } from "./internal/rest-errors.js";
 import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
+import type { DiscordRetryRunner } from "./retry.js";
 
 const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
@@ -406,7 +406,7 @@ export async function sendDiscordVoiceMessage(
   audioBuffer: Buffer,
   metadata: VoiceMessageMetadata,
   replyTo: string | undefined,
-  request: RetryRunner,
+  request: DiscordRetryRunner,
   silent?: boolean,
   token?: string,
 ): Promise<{ id: string; channel_id: string }> {
@@ -482,6 +482,7 @@ export async function sendDiscordVoiceMessage(
         body: messagePayload,
       }) as Promise<{ id: string; channel_id: string }>,
     "voice-message",
+    { nonIdempotent: true },
   )) as { id: string; channel_id: string };
 
   return res;

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -35,6 +35,7 @@ import { DiscordError, RateLimitError, type RequestClient } from "./internal/dis
 import { readDiscordMessage, readRetryAfter } from "./internal/rest-errors.js";
 import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
 import type { DiscordRetryRunner } from "./retry.js";
+import { createDiscordMessageNonce } from "./send.message-request.js";
 
 const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
@@ -447,6 +448,8 @@ export async function sendDiscordVoiceMessage(
     : DISCORD_VOICE_MESSAGE_FLAG;
   const messagePayload: {
     flags: number;
+    nonce: string;
+    enforce_nonce: true;
     attachments: Array<{
       id: string;
       filename: string;
@@ -457,6 +460,8 @@ export async function sendDiscordVoiceMessage(
     message_reference?: { message_id: string; fail_if_not_exists: boolean };
   } = {
     flags,
+    nonce: createDiscordMessageNonce(),
+    enforce_nonce: true,
     attachments: [
       {
         id: "0",

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -487,7 +487,7 @@ export async function sendDiscordVoiceMessage(
         body: messagePayload,
       }) as Promise<{ id: string; channel_id: string }>,
     "voice-message",
-    { nonIdempotent: true },
+    { safety: "nonce-protected-create" },
   )) as { id: string; channel_id: string };
 
   return res;


### PR DESCRIPTION
## What Problem This Solves

Discord message creates can complete at Discord while the client receives a transport failure. Retrying the same non-idempotent create without a server deduplication key can deliver a duplicate message.

## Why This Change Was Made

Each direct Discord Create Message now receives a 24-character random nonce with `enforce_nonce: true`. The nonce is built once before the retry runner, so a retry returns the existing message rather than creating another. This covers text, media, components, stickers, polls, approvals, and voice messages.

The nonce-protected Create Message classifier keeps pre-connect failures, rate limits, and HTTP 502 retryable. Forum and media thread creation use the pre-connect-only classifier because Discord documents nonce enforcement only for Create Message, not the endpoint that creates a thread and starter message together.

## Why this is the right boundary

The retry module still owns retry classification. Message construction owns the create nonce, which remains stable for all attempts of one logical create. Forum thread creation selects the narrower retry policy at its endpoint boundary. Idempotent REST operations retain the broad transient retry policy unchanged.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/retry.test.ts extensions/discord/src/send.message-request.test.ts extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/outbound-payload.contract.test.ts extensions/discord/src/client.test.ts extensions/discord/src/outbound-adapter.test.ts` passed with 136 assertions.
- Scoped `tsgo`, `oxlint`, and `oxfmt --check` passed for the changed paths.
- Structured closeout review completed with no actionable findings.

## Real behavior proof
Behavior addressed: a retried HTTP 502 on a sticker or poll create sent a fresh nonce on the second attempt, so Discord could not deduplicate the create and delivered a duplicate message.
Real environment tested: the production `sendStickerDiscord` and `sendPollDiscord` paths driven end to end through `createChannelMessage`, the Discord retry runner, and `createDiscordMessageNonce`, with only the Discord REST `post` boundary substituted to return HTTP 502 then HTTP 200 on identical inputs; run on the pre-fix tree cb1642f798 where the create body is built inside the retry callback, and on this patch head 9a58f89a6f where the create body is built once before the retry runner.
Exact steps or command run after this patch: drive `sendStickerDiscord("channel:789", ["123"], { content: "hiya", retry: { attempts: 2 } })` and `sendPollDiscord("channel:789", { question, options }, { retry: { attempts: 2 } })` where the first Discord POST rejects with status 502 and the second resolves, then read the nonce carried on each recorded POST body.
Evidence after fix:
```
# BEFORE (pre-fix tree cb1642f798, sticker/poll body built inside the retry callback)
sticker create, upstream returns 502 then 200: POST attempts=2 | nonce attempt 1=51b6b881e0d78390c74ee04b | nonce attempt 2=ffd94920965564c647ed9413 | nonce identical across attempts=false
poll create, upstream returns 502 then 200: POST attempts=2 | nonce attempt 1=b5a6300e54a3b414fc1471b7 | nonce attempt 2=978a37c0dfdc8f45460d9e2a | nonce identical across attempts=false

# AFTER (this patch, head 9a58f89a6f, identical 502-then-200 sequence)
sticker create, upstream returns 502 then 200: POST attempts=2 | nonce attempt 1=c15fe9cc6af86ec91672dacc | nonce attempt 2=c15fe9cc6af86ec91672dacc | nonce identical across attempts=true
poll create, upstream returns 502 then 200: POST attempts=2 | nonce attempt 1=6cdf7a07ee99c8e0705e31f9 | nonce attempt 2=6cdf7a07ee99c8e0705e31f9 | nonce identical across attempts=true
```
Observed result after fix: the second attempt carries the exact same nonce as the first for both sticker and poll, so Discord `enforce_nonce` collapses the retried create back to the original message instead of delivering a second one; before the patch each attempt carried a different nonce and the retry created a duplicate.

Live Discord server-side deduplication (real API): the client-side result above establishes that the fix makes a retried create reuse one nonce. The server half was then verified directly against the live Discord REST API (`discord.com/api/v10`) with a real bot in a real guild, sending Create Message with `enforce_nonce: true`. This exercises the actual Discord dedup behavior, not a substituted boundary. Bot, guild, channel, and message ids are masked.
```
# AFTER (fix behavior): retry reuses one nonce -> Discord dedups
same-nonce create x2 (nonce 7b55...ef5): POST #1 -> 200 id 1525...284 | POST #2 -> 200 id 1525...284 (same id: true) | messages delivered = 1

# BEFORE (bug behavior): per-attempt nonce -> Discord treats as two creates
per-attempt-nonce create x2 (nonces a4a4...77f , 3499...3b1): POST #1 -> 200 id 1525...460 | POST #2 -> 200 id 1525...940 (distinct id: true) | messages delivered = 2
```
Observed result (live): sending the identical nonce twice makes Discord return the same message id on both calls and deliver exactly one message; sending a fresh nonce per attempt delivers two messages. This confirms the fix prevents duplicate delivery at the Discord server, and reproduces the duplicate under the pre-fix per-attempt-nonce behavior. Probe messages were deleted after the run.
What was not tested: the forum and media thread pre-connect classifier path was not re-driven in this run; retry-schedule windows longer than Discord's unspecified nonce-retention period were not exercised.

