### PR TITLE
fix(telegram): keep DM reply ids out of thread targets

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -918,6 +918,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
       resolveReplyToMode: (account, chatType) => resolveSlackReplyToMode(account, chatType),
     },
     allowExplicitReplyTagsWhenOff: false,
+    replyToPromotesThreadIdWhenTransportThreadMissing: true,
     buildToolContext: (params) => buildSlackThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
       normalizeSlackThreadTsCandidate(replyToId)

--- a/src/agents/embedded-agent-subscribe.tools.extract.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.extract.test.ts
@@ -89,6 +89,7 @@ describe("extractMessagingToolSend", () => {
               },
             },
             threading: {
+              replyToPromotesThreadIdWhenTransportThreadMissing: true,
               resolveAutoThreadId: ({
                 to,
                 toolContext,
@@ -116,6 +117,20 @@ describe("extractMessagingToolSend", () => {
                 }
                 return toolContext.currentThreadTs;
               },
+              resolveReplyTransport: ({ replyToId }: { replyToId?: string | null }) => ({
+                replyToId,
+                threadId: null,
+              }),
+            },
+          },
+          source: "test",
+        },
+        {
+          pluginId: "flat-reply",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "flat-reply" }),
+            messaging: { normalizeTarget: (raw: string) => raw.trim().toLowerCase() },
+            threading: {
               resolveReplyTransport: ({ replyToId }: { replyToId?: string | null }) => ({
                 replyToId,
                 threadId: null,
@@ -227,6 +242,22 @@ describe("extractMessagingToolSend", () => {
     expect(result?.tool).toBe("message");
     expect(result?.provider).toBe("telegram");
     expect(result?.to).toBe("telegram:123");
+  });
+
+  it("keeps Telegram DM replies flat without synthesizing a destination thread", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      provider: "telegram",
+      to: "123",
+      replyTo: "456",
+      content: "done",
+    });
+
+    expect(result).toMatchObject({
+      provider: "telegram",
+      to: "telegram:123",
+    });
+    expect(result?.threadId).toBeUndefined();
   });
 
   it("prefers provider when both provider and channel are set", () => {
@@ -549,6 +580,19 @@ describe("extractMessagingToolSend", () => {
 
     expect(result?.threadImplicit).toBeUndefined();
     expect(result?.threadId).toBe("999.000");
+  });
+
+  it("does not promote flat reply transports into destination threads", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "send",
+      provider: "flat-reply",
+      to: "channel:dm-1",
+      replyTo: "reply-1",
+      content: "done",
+    });
+
+    expect(result?.threadImplicit).toBeUndefined();
+    expect(result?.threadId).toBeUndefined();
   });
 
   it("uses Slack transport precedence when threadId and replyTo are both present", () => {

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -930,6 +930,7 @@ function resolveMessagingToolThreadEvidence(params: {
     : undefined;
   const transportThreadId = normalizeOptionalStringifiedId(replyTransport?.threadId);
   const replyToThreadId =
+    threading?.replyToPromotesThreadIdWhenTransportThreadMissing === true &&
     replyTransport?.threadId === null
       ? normalizeOptionalString(replyTransport.replyToId)
       : undefined;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -439,6 +439,13 @@ export type ChannelThreadingAdapter = {
     to: string;
     threadId?: string | number | null;
   }) => string | undefined;
+  /**
+   * Opt in when resolveReplyTransport({ threadId: null, replyToId }) means the
+   * reply target is also the canonical destination thread/root for tool-send
+   * evidence. Keep this off for flat reply transports like Telegram DMs where
+   * replyToId must stay a reply reference.
+   */
+  replyToPromotesThreadIdWhenTransportThreadMissing?: boolean;
   resolveReplyTransport?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -1246,6 +1246,41 @@ describe("delivery-queue recovery", () => {
     });
   });
 
+  it("keeps Telegram direct replies flat when replaying queued deliveries", async () => {
+    await enqueueDelivery(
+      {
+        channel: "telegram",
+        to: "telegram:123456789",
+        payloads: [{ text: "done" }],
+        replyToId: "456",
+      },
+      tmpDir(),
+    );
+
+    const queuedEntries = await loadPendingDeliveries(tmpDir());
+    expect(queuedEntries).toHaveLength(1);
+    expect(queuedEntries[0]).toMatchObject({
+      channel: "telegram",
+      to: "telegram:123456789",
+      replyToId: "456",
+    });
+    expect(queuedEntries[0]?.threadId).toBeUndefined();
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    await runRecovery({ deliver });
+
+    const deliverInput = mockCallArg(deliver) as {
+      channel?: string;
+      to?: string;
+      replyToId?: string;
+      threadId?: string;
+    };
+    expect(deliverInput.channel).toBe("telegram");
+    expect(deliverInput.to).toBe("telegram:123456789");
+    expect(deliverInput.replyToId).toBe("456");
+    expect(deliverInput.threadId).toBeUndefined();
+  });
+
   it("respects maxRecoveryMs time budget without bumping deferred retries", async () => {
     await enqueueCrashRecoveryEntries();
     await enqueueDelivery(


### PR DESCRIPTION
## What Problem This Solves

Telegram direct-message replies can carry a plain reply message ID. That value is valid as `replyToId`, but it is not necessarily a Telegram topic ID.

The runtime's messaging-tool evidence extraction previously treated a provider transport result of `threadId: null` as an instruction to promote `replyToId` into `threadId`. A durable delivery then persisted that value as queue thread metadata and Telegram outbound replay could emit it as `message_thread_id`, causing Telegram to reject an ordinary DM with `400 Bad Request: message thread not found`.

## Fix

Make reply-to-thread promotion opt-in. Only providers that deliberately use a reply-root as their destination thread opt in; Slack does. Telegram does not, so a Telegram DM reply stays a reply reference unless it has a genuine explicit topic/thread ID.

## Evidence

Regression coverage proves:

- Telegram DM message-tool evidence retains `replyToId` without synthesizing a destination `threadId`.
- A queued Telegram DM delivery retains `replyToId` but no `threadId` through durable recovery/replay.
- Real Telegram topic threads remain eligible to carry explicit thread IDs.
- Slack retains its intentional reply-root threading behavior.

Verification:

```text
pnpm exec vitest run src/agents/embedded-agent-subscribe.tools.extract.test.ts src/infra/outbound/delivery-queue.recovery.test.ts extensions/telegram/src/send.test.ts extensions/slack/src/channel.test.ts
# 640 tests passed
pnpm exec tsc -b --pretty false
# passed
git diff --check
# passed
```

Closes/replaces #103572, whose dedupe-layer patch did not reach the production Telegram evidence-extraction path.
