### PR TITLE
fix(node): approved local commands no longer fail identity validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Node exec approval replay:** preserve the approval requester's stable device identity on approved `host=node` `system.run` replays, preventing local shared-token connections from failing with `APPROVAL_DEVICE_MISMATCH` while leaving ordinary node calls device-less. (#103869)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Node exec approval replay:** preserve the approval requester's stable device identity on approved `host=node` `system.run` replays, preventing local shared-token connections from failing with `APPROVAL_DEVICE_MISMATCH` while leaving ordinary node calls device-less. (#103869)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -319,6 +319,97 @@ describe("gateway tool defaults", () => {
     expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
+  it.each([
+    {
+      name: "approved flag",
+      params: { approved: true, runId: "approval-inline" },
+    },
+    {
+      name: "allow-once decision",
+      params: { approvalDecision: "allow-once", runId: "approval-async" },
+    },
+    {
+      name: "allow-always decision",
+      params: { approvalDecision: "allow-always", runId: "approval-always" },
+    },
+  ])("binds persisted device identity to node system.run with $name", async ({ params }) => {
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "node.invoke",
+      {},
+      { nodeId: "node-1", command: "system.run", params, idempotencyKey: "invoke-1" },
+      { scopes: ["operator.write", "operator.approvals"] },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it.each([
+    {
+      name: "unapproved system.run",
+      command: "system.run",
+      params: { approved: false },
+    },
+    {
+      name: "system.run.prepare",
+      command: "system.run.prepare",
+      params: { approved: true, approvalDecision: "allow-once" },
+    },
+    {
+      name: "unrelated node command",
+      command: "system.info",
+      params: { approved: true, approvalDecision: "allow-always" },
+    },
+  ])("keeps ordinary node.invoke device-less for $name", async ({ command, params }) => {
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command,
+        params,
+        idempotencyKey: "invoke-1",
+      },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call).not.toHaveProperty("deviceIdentity");
+    expect(call).not.toHaveProperty("approvalRuntimeToken");
+  });
+
+  it.each([
+    { name: "missing persisted identity", persistedDeviceIdentity: null },
+    {
+      name: "different persisted identity",
+      persistedDeviceIdentity: {
+        ...mocks.deviceIdentity,
+        deviceId: "other-device",
+      },
+    },
+  ])("fails approved node system.run closed for $name", async ({ persistedDeviceIdentity }) => {
+    mocks.persistedDeviceIdentity = persistedDeviceIdentity;
+
+    await expect(
+      callGatewayTool(
+        "node.invoke",
+        {},
+        {
+          nodeId: "node-1",
+          command: "system.run",
+          params: { approved: true, runId: "approval-id" },
+          idempotencyKey: "invoke-1",
+        },
+        { scopes: ["operator.write", "operator.approvals"] },
+      ),
+    ).rejects.toThrow("approved node gateway calls require a stable device identity");
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
   it("does not mark direct cron helper calls with agent runtime identity", async () => {
     mocks.callGateway.mockResolvedValueOnce({ id: "job-1" });
 

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -382,17 +382,8 @@ describe("gateway tool defaults", () => {
     expect(call).not.toHaveProperty("approvalRuntimeToken");
   });
 
-  it.each([
-    { name: "missing persisted identity", persistedDeviceIdentity: null },
-    {
-      name: "different persisted identity",
-      persistedDeviceIdentity: {
-        ...mocks.deviceIdentity,
-        deviceId: "other-device",
-      },
-    },
-  ])("fails approved node system.run closed for $name", async ({ persistedDeviceIdentity }) => {
-    mocks.persistedDeviceIdentity = persistedDeviceIdentity;
+  it("fails approved node system.run closed without a persisted identity", async () => {
+    mocks.persistedDeviceIdentity = null;
 
     await expect(
       callGatewayTool(
@@ -408,6 +399,25 @@ describe("gateway tool defaults", () => {
       ),
     ).rejects.toThrow("approved node gateway calls require a stable device identity");
     expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing replay identity without trying to create one", async () => {
+    mocks.deviceIdentityError = new Error("must not create identity during replay");
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "system.run",
+        params: { approved: true, runId: "approval-id" },
+        idempotencyKey: "invoke-1",
+      },
+      { scopes: ["operator.write", "operator.approvals"] },
+    );
+
+    expect(capturedGatewayCall().deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
   it("does not mark direct cron helper calls with agent runtime identity", async () => {

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -263,8 +263,17 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
     return undefined;
   }
   try {
+    if (isNodeApprovalReplay) {
+      // Replay must reuse the identity present when the approval was registered.
+      // Creating one here could turn a device-less record into a different identity.
+      const identity = loadDeviceIdentityIfPresent();
+      if (!identity) {
+        throw new Error("device identity is not persisted");
+      }
+      return identity;
+    }
     const identity = loadOrCreateDeviceIdentity();
-    // Approval registration and replay can use separate gateway connections.
+    // Approval registration and wait can use separate gateway connections.
     // Reject loadOrCreate's unpersisted fallback so both sides bind the same id.
     const persistedIdentity = loadDeviceIdentityIfPresent();
     if (persistedIdentity?.deviceId !== identity.deviceId) {
@@ -273,8 +282,6 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
     return identity;
   } catch (error) {
     if (isNodeApprovalReplay) {
-      // Never downgrade node exec replay to the device-less backend bridge.
-      // Repair stable identity first so replay stays bound to the approving device.
       throw new Error(
         [
           "approved node gateway calls require a stable device identity.",

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -273,6 +273,8 @@ function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
     return identity;
   } catch (error) {
     if (isNodeApprovalReplay) {
+      // Never downgrade node exec replay to the device-less backend bridge.
+      // Repair stable identity first so replay stays bound to the approving device.
       throw new Error(
         [
           "approved node gateway calls require a stable device identity.",

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -3,6 +3,7 @@
  *
  * Resolves gateway URL/token overrides, local credentials, and least-privilege operator scopes.
  */
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -240,29 +241,46 @@ function resolveApprovalRuntimeTokenForGatewayTool(params: {
   return getOperatorApprovalRuntimeToken();
 }
 
+function isApprovalReplayNodeSystemRun(method: string, callParams: unknown): boolean {
+  const invoke = method === "node.invoke" ? asNullableRecord(callParams) : null;
+  const run = invoke?.command === "system.run" ? asNullableRecord(invoke.params) : null;
+  const decision = normalizeOptionalString(run?.approvalDecision);
+  return run?.approved === true || decision === "allow-once" || decision === "allow-always";
+}
+
 function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
   method: string;
+  callParams: unknown;
   opts: GatewayCallOptions;
   target: GatewayOverrideTarget;
 }): DeviceIdentity | undefined {
-  if (!APPROVAL_RUNTIME_METHODS.has(params.method)) {
+  const isApprovalRuntimeMethod = APPROVAL_RUNTIME_METHODS.has(params.method);
+  const isNodeApprovalReplay = isApprovalReplayNodeSystemRun(params.method, params.callParams);
+  if (!isApprovalRuntimeMethod && !isNodeApprovalReplay) {
     return undefined;
   }
-  if (trimToUndefined(params.opts.gatewayUrl) !== undefined) {
+  if (isApprovalRuntimeMethod && trimToUndefined(params.opts.gatewayUrl) !== undefined) {
     return undefined;
   }
   try {
     const identity = loadOrCreateDeviceIdentity();
-    // Approval request/wait calls may cross backend processes. Bind them to the
-    // persisted device id so a process-local approval token mismatch cannot hide
-    // the pending record from the matching wait call.
-    // Reject loadOrCreate's unpersisted fallback so another process can see the same id.
+    // Approval registration and replay can use separate gateway connections.
+    // Reject loadOrCreate's unpersisted fallback so both sides bind the same id.
     const persistedIdentity = loadDeviceIdentityIfPresent();
     if (persistedIdentity?.deviceId !== identity.deviceId) {
       throw new Error("device identity is not persisted");
     }
     return identity;
   } catch (error) {
+    if (isNodeApprovalReplay) {
+      throw new Error(
+        [
+          "approved node gateway calls require a stable device identity.",
+          "Fix the OpenClaw state directory permissions and retry the approval.",
+        ].join(" "),
+        { cause: error },
+      );
+    }
     if (params.target === "local") {
       return undefined;
     }
@@ -347,6 +365,7 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   });
   const deviceIdentity = resolveApprovalRequesterDeviceIdentityForGatewayTool({
     method,
+    callParams: params,
     opts,
     target: gateway.target,
   });


### PR DESCRIPTION
Closes #103869

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where users approving an agent exec command on a local `host=node` target would see the approved replay fail with `APPROVAL_DEVICE_MISMATCH` when the Gateway connection authenticated through the shared-token path.

## Why This Change Was Made

Approval-bearing `node.invoke` calls for `system.run` now carry the same already-persisted requester device identity used to register the approval. The change is deliberately narrow: ordinary node invocations remain device-less, `node.invoke` does not receive the local approval-runtime token, and replay fails closed instead of creating or downgrading a missing identity.

## User Impact

Approved local node commands can execute after `allow-once` or `allow-always`. Unapproved node calls are unchanged, and approval replay remains fail-closed when a stable matching identity is unavailable or belongs to another device.

## Evidence

- Before: on Testbox lease `tbx_01kx6hv7nt1d87g5fycgvh2ndq`, the focused gateway-tool regression run failed 5 tests: all approval-bearing replays omitted identity and missing persistence continued to RPC.
- After: 230 focused tests passed across `src/agents/tools/gateway.test.ts`, `src/agents/bash-tools.exec-host-node.test.ts`, `src/gateway/node-invoke-system-run-approval.test.ts`, and `src/gateway/server.node-invoke-approval-bypass.test.ts`. This covers `approved: true`, `allow-once`, `allow-always`, inline and asynchronous caller shapes, no approval-runtime token, ordinary device-less invokes, missing identity, no identity creation during replay, and existing cross-device rejection.
- Changed-file gate: remote `check:changed` passed formatting, core and test typechecking, lint, conflict-marker checks, import-cycle checks, database-first guards, pairing guards, and related repository checks.
- Review: fresh Codex autoreview reported no accepted or actionable findings after the fail-closed identity lifecycle was tightened.
