### PR TITLE
fix(macos): duplicate launches open SSH tunnels before handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS duplicate launches:** defer remote Gateway connectivity until after singleton admission so Finder and login-item relaunches cannot open or orphan SSH tunnels before handing off to the existing app. (#103876)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS duplicate launches:** defer remote Gateway connectivity until after singleton admission so Finder and login-item relaunches cannot open or orphan SSH tunnels before handing off to the existing app. (#103876)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18147,7 +18147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 103,
+      "line": 102,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
@@ -18155,7 +18155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 122,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -18163,7 +18163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 122,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -18171,7 +18171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 317,
+      "line": 316,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -18179,7 +18179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 317,
+      "line": 316,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -38,6 +38,7 @@ actor GatewayEndpointStore {
         let localPort: @Sendable () -> Int
         let localHost: @Sendable () async -> String
         let remotePortIfRunning: @Sendable () async -> UInt16?
+        let canStartRemoteTunnel: @Sendable () -> Bool
         let ensureRemoteTunnel: @Sendable () async throws -> UInt16
 
         static let live = Deps(
@@ -75,7 +76,14 @@ actor GatewayEndpointStore {
                     tailscaleIP: tailscaleIP)
             },
             remotePortIfRunning: { await RemoteTunnelManager.shared.controlTunnelPortIfRunning() },
+            canStartRemoteTunnel: { GatewayEndpointStore.primaryAppLaunchAdmitted.withValue { $0 } },
             ensureRemoteTunnel: { try await RemoteTunnelManager.shared.ensureControlTunnel() })
+    }
+
+    private static let primaryAppLaunchAdmitted = LockIsolated(false)
+
+    static func admitPrimaryAppLaunch() {
+        self.primaryAppLaunchAdmitted.withValue { $0 = true }
     }
 
     private static func resolveGatewayPassword(
@@ -461,10 +469,15 @@ actor GatewayEndpointStore {
         self.remoteEnsure = nil
     }
 
-    private func kickRemoteEnsureIfNeeded(detail: String) {
+    @discardableResult
+    private func kickRemoteEnsureIfNeeded(detail: String) -> Bool {
+        guard self.deps.canStartRemoteTunnel() else {
+            self.setState(.connecting(mode: .remote, detail: detail))
+            return false
+        }
         if self.remoteEnsure != nil {
             self.setState(.connecting(mode: .remote, detail: detail))
-            return
+            return true
         }
 
         let deps = self.deps
@@ -472,6 +485,7 @@ actor GatewayEndpointStore {
         let task = Task.detached(priority: .utility) { try await deps.ensureRemoteTunnel() }
         self.remoteEnsure = (token: token, task: task)
         self.setState(.connecting(mode: .remote, detail: detail))
+        return true
     }
 
     private func ensureRemoteConfig(detail: String) async throws -> GatewayConnection.Config {
@@ -485,7 +499,9 @@ actor GatewayEndpointStore {
             return (url, token, password)
         }
 
-        self.kickRemoteEnsureIfNeeded(detail: detail)
+        guard self.kickRemoteEnsureIfNeeded(detail: detail) else {
+            throw CancellationError()
+        }
         guard let ensure = self.remoteEnsure else {
             throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [NSLocalizedDescriptionKey: "Connecting…"])
         }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -33,7 +33,6 @@ struct OpenClawApp: App {
 
     init() {
         OpenClawLogging.bootstrapIfNeeded()
-        GatewayConnectivityCoordinator.shared.start()
 
         Self.applyAttachOnlyOverrideIfNeeded()
         _state = State(initialValue: AppStateStore.shared)
@@ -379,6 +378,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.terminate(nil)
             return
         }
+        // Remote startup can spawn an SSH child. Admit tunnel work only after the
+        // singleton check so a short-lived handoff process cannot orphan that child.
+        GatewayEndpointStore.admitPrimaryAppLaunch()
+        GatewayConnectivityCoordinator.shared.start()
         self.state = AppStateStore.shared
         if let state {
             MacNodeModeCoordinator.prepareNodeIdentityProfile(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -1,8 +1,34 @@
+import ConcurrencyExtras
 import Foundation
 import Testing
 @testable import OpenClaw
 
 struct GatewayEndpointStoreTests {
+    @Test func `remote tunnel waits for primary app launch admission`() async throws {
+        let admitted = LockIsolated(false)
+        let tunnelStarts = LockIsolated(0)
+        let deps = GatewayEndpointStore.Deps(
+            mode: { .remote },
+            token: { nil },
+            password: { nil },
+            localPort: { 18789 },
+            localHost: { "127.0.0.1" },
+            remotePortIfRunning: { nil },
+            canStartRemoteTunnel: { admitted.withValue { $0 } },
+            ensureRemoteTunnel: {
+                tunnelStarts.withValue { $0 += 1 }
+                return 18789
+            })
+        let store = GatewayEndpointStore(deps: deps)
+
+        await store.setMode(.remote)
+        #expect(tunnelStarts.withValue { $0 } == 0)
+
+        admitted.withValue { $0 = true }
+        #expect(try await store.ensureRemoteControlTunnel() == 18789)
+        #expect(tunnelStarts.withValue { $0 } == 1)
+    }
+
     private func makeLaunchAgentSnapshot(
         env: [String: String],
         token: String?,


### PR DESCRIPTION
Closes #103876

## What Problem This Solves

Fixes an issue where launching the macOS app while another instance is already running could start a remote Gateway SSH tunnel before the new process handed off to the existing app. The rejected process could then leave an SSH forward behind and add avoidable connection pressure to the Gateway.

A copied login-item plist with `KeepAlive=true` amplified the live reproduction to 58 rejected launches and five lingering forwards. OpenClaw's generated login item correctly omits `KeepAlive`, but ordinary Finder and login-item overlap could still hit the same startup race once.

## Why This Change Was Made

Remote tunnel startup now remains closed until `AppDelegate` passes the existing singleton check. The gate lives at `GatewayEndpointStore`, the owner of explicit tunnel creation, so it also covers pre-launch endpoint refreshes triggered while SwiftUI initializes `TailscaleService`; direct remote URLs continue to resolve without SSH.

## User Impact

Opening OpenClaw again hands off to the existing macOS app without spawning or orphaning another remote Gateway SSH tunnel. Normal primary-app remote connections and direct transports continue to start as before.

## Evidence

Exact reviewed head: `b830e4d5844547cb91d8efea3888b05449833779`

- `swift test --package-path apps/macos --filter GatewayEndpointStoreTests` — 43 passed
- `swift test --package-path apps/macos --filter MenuContentSmokeTests` — 14 passed
- `swift test --package-path apps/macos --filter LaunchAgentManagerTests` — 7 passed, including the no-`KeepAlive` login-item contract
- `swiftformat --lint ... --config config/swiftformat` — 0/3 files require formatting
- `swiftlint lint --strict --config config/swiftlint.yml ...` — 0 violations
- `corepack pnpm native:i18n:check` — clean on Testbox-through-Crabbox `tbx_01kx6n2084ztgbzg4yddp3v8q9`
- `git diff --check origin/main...HEAD` — clean
- Fresh whole-branch Codex autoreview — no findings; patch correct at 0.94 confidence

AI-assisted: Codex performed the source audit, implementation, focused macOS validation, and fresh review. I reviewed the resulting behavior, ownership boundary, and proof.
