### PR TITLE
[AI-assisted] Make Android chat thinking selection explicit

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 182,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -163,7 +163,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 285,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -171,7 +171,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 299,
+      "line": 301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 648,
+      "line": 649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1511,
+      "line": 1512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1511,
+      "line": 1512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1555,
+      "line": 1556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
@@ -243,7 +243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1555,
+      "line": 1556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
@@ -251,7 +251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3147,
+      "line": 3149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3149,
+      "line": 3151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3151,
+      "line": 3153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5875,7 +5875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 326,
+      "line": 333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5883,7 +5883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5891,7 +5891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 567,
+      "line": 575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 588,
+      "line": 596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 593,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -5915,7 +5915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 608,
+      "line": 616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5923,7 +5923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 611,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5931,7 +5931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 759,
+      "line": 767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5939,7 +5939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 786,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5947,7 +5947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 812,
+      "line": 820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5955,7 +5955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 843,
+      "line": 851,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5963,7 +5963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 844,
+      "line": 852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5971,7 +5971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1028,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -5979,7 +5979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1028,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -5987,7 +5987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1049,
+      "line": 1057,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5995,7 +5995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1051,
+      "line": 1059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6003,7 +6003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1054,
+      "line": 1062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6011,7 +6011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1064,
+      "line": 1072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6019,7 +6019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1065,
+      "line": 1073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6027,7 +6027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1247,
+      "line": 1255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6035,7 +6035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1313,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6043,7 +6043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1379,
+      "line": 1418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6051,7 +6051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1379,
+      "line": 1418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6059,7 +6059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1396,
+      "line": 1435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6067,7 +6067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1458,
+      "line": 1497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6075,7 +6075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1504,
+      "line": 1543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -6083,7 +6083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1504,
+      "line": 1543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -6091,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1564,
+      "line": 1603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6099,7 +6099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1599,
+      "line": 1638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6107,7 +6107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1615,
+      "line": 1654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -6115,7 +6115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1664,
+      "line": 1703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6123,7 +6123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1685,
+      "line": 1724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6131,7 +6131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1693,
+      "line": 1732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -6139,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1752,
+      "line": 1791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6147,7 +6147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1783,
+      "line": 1822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5875,7 +5875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 323,
+      "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5883,7 +5883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 506,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5891,7 +5891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 564,
+      "line": 567,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 585,
+      "line": 588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 590,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -5915,7 +5915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 605,
+      "line": 608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5923,7 +5923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 608,
+      "line": 611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5931,7 +5931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 756,
+      "line": 759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5939,7 +5939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 783,
+      "line": 786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5947,7 +5947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 809,
+      "line": 812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5955,7 +5955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 840,
+      "line": 843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5963,7 +5963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 841,
+      "line": 844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5971,7 +5971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1025,
+      "line": 1028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -5979,7 +5979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1025,
+      "line": 1028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -5987,7 +5987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1046,
+      "line": 1049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5995,7 +5995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1048,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6003,7 +6003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1051,
+      "line": 1054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6011,7 +6011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1061,
+      "line": 1064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6019,7 +6019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1062,
+      "line": 1065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6027,7 +6027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1226,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6035,7 +6035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1292,
+      "line": 1313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6043,7 +6043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1358,
+      "line": 1379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6051,7 +6051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1358,
+      "line": 1379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6059,7 +6059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1375,
+      "line": 1396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6067,15 +6067,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1437,
+      "line": 1458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
       "id": "native.android.8e3e367df24cae4b"
     },
     {
+      "kind": "conditional-branch",
+      "line": 1504,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Close thinking level selector",
+      "surface": "android",
+      "id": "native.android.36ed01582459bc10"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1504,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Open thinking level selector",
+      "surface": "android",
+      "id": "native.android.82d6389036a1e211"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 1537,
+      "line": 1564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6083,7 +6099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1572,
+      "line": 1599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6091,7 +6107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1588,
+      "line": 1615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -6099,7 +6115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1637,
+      "line": 1664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6107,7 +6123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1658,
+      "line": 1685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6115,7 +6131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1666,
+      "line": 1693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -6123,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1725,
+      "line": 1752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6131,7 +6147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1765,
+      "line": 1783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -5,8 +5,10 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.chat.defaultChatThinkingLevelSelection
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayRegistryEntry
 import ai.openclaw.app.gateway.GatewayRegistryEntryKind
@@ -307,6 +309,8 @@ class MainViewModel(
   val chatError: StateFlow<String?> = runtimeState(initial = null) { it.chatError }
   val chatHealthOk: StateFlow<Boolean> = runtimeState(initial = false) { it.chatHealthOk }
   val chatThinkingLevel: StateFlow<String> = runtimeState(initial = "off") { it.chatThinkingLevel }
+  val chatThinkingLevelSelection: StateFlow<ChatThinkingLevelSelection> =
+    runtimeState(initial = defaultChatThinkingLevelSelection) { it.chatThinkingLevelSelection }
   val chatSelectedModelRef: StateFlow<String?> = runtimeState(initial = null) { it.chatSelectedModelRef }
   val chatModelCatalog: StateFlow<List<GatewayModelSummary>> = runtimeState(initial = emptyList()) { it.chatModelCatalog }
   val chatStreamingAssistantText: StateFlow<String?> = runtimeState(initial = null) { it.chatStreamingAssistantText }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
 import ai.openclaw.app.chat.MessageSpeechClient
 import ai.openclaw.app.chat.MessageSpeechController
@@ -1881,6 +1882,7 @@ class NodeRuntime private constructor(
   val chatError: StateFlow<String?> = chat.errorText
   val chatHealthOk: StateFlow<Boolean> = chat.healthOk
   val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
+  val chatThinkingLevelSelection: StateFlow<ChatThinkingLevelSelection> = chat.thinkingLevelSelection
   val chatSelectedModelRef: StateFlow<String?> = chat.selectedModelRef
   val chatModelCatalog: StateFlow<List<GatewayModelSummary>> = chat.modelCatalog
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -2297,9 +2297,11 @@ class ChatController internal constructor(
     val selected = entry.thinkingLevel?.let(::normalizeThinking)
     val currentLevel = normalizeThinking(_thinkingLevel.value)
     val defaultLevel = entry.thinkingDefault?.let(::normalizeThinking)
+    // Lightweight picker metadata can omit a Gateway-validated effective level.
+    // Preserve that send state; only local/default fallbacks require picker membership.
     _thinkingLevel.value =
-      listOfNotNull(selected, currentLevel, defaultLevel)
-        .firstOrNull { candidate -> options.any { it.id == candidate } }
+      selected
+        ?: listOf(currentLevel, defaultLevel).firstOrNull { candidate -> options.any { it.id == candidate } }
         ?: options.first().id
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -110,6 +111,9 @@ class ChatController internal constructor(
 
   private val _thinkingLevel = MutableStateFlow("off")
   val thinkingLevel: StateFlow<String> = _thinkingLevel.asStateFlow()
+
+  private val _thinkingLevelSelection = MutableStateFlow(defaultChatThinkingLevelSelection)
+  val thinkingLevelSelection: StateFlow<ChatThinkingLevelSelection> = _thinkingLevelSelection.asStateFlow()
 
   private val _selectedModelRef = MutableStateFlow<String?>(null)
   val selectedModelRef: StateFlow<String?> = _selectedModelRef.asStateFlow()
@@ -261,6 +265,7 @@ class ChatController internal constructor(
       )
       clearLiveHistoryMarker()
       _sessions.value = emptyList()
+      applyThinkingMetadata(null)
       sessionsListArchived = false
       unreadPatchSessionKey = null
       unreadPatchRequested = false
@@ -588,6 +593,10 @@ class ChatController internal constructor(
   /** Persists the normalized thinking level used for subsequent chat sends. */
   fun setThinkingLevel(thinkingLevel: String) {
     val normalized = normalizeThinking(thinkingLevel)
+    val selection = _thinkingLevelSelection.value
+    if (selection.isGatewayProvided && selection.options.none { it.id == normalized }) {
+      return
+    }
     if (normalized == _thinkingLevel.value) return
     _thinkingLevel.value = normalized
   }
@@ -622,8 +631,10 @@ class ChatController internal constructor(
                 put("key", JsonPrimitive(key))
                 put("model", normalizedModelRef?.let(::JsonPrimitive) ?: JsonNull)
               }
-            requestGateway("sessions.patch", params.toString())
+            val response = requestGateway("sessions.patch", params.toString())
+            val resolution = parseSessionModelPatchResolution(response)
             normalizedModelRef?.let(recordModelRecent)
+            applyAcceptedModelPatch(key = key, modelRef = normalizedModelRef, resolution = resolution)
             if (_sessionKey.value == key) {
               modelSelectionGeneration.incrementAndGet()
               _selectedModelRef.value = normalizedModelRef
@@ -669,6 +680,7 @@ class ChatController internal constructor(
   ): Long {
     val generation = historyLoadGeneration.incrementAndGet()
     _sessionKey.value = key
+    applyThinkingMetadata(_sessions.value.firstOrNull { it.key == key })
     _selectedModelRef.value = null
     lastHandledTerminalRunId = null
     val nextAgentId = resolveAgentIdForSessionKey(key)
@@ -762,7 +774,7 @@ class ChatController internal constructor(
     // Applied at enqueue time too so durable rows never persist a level the selected model
     // rejects; reconnect flushes with a cleared catalog fail open, matching pre-gating behavior.
     val thinking =
-      if (thinkingSupportedForSelection(_selectedModelRef.value, _modelCatalog.value)) {
+      if (thinkingSupportedForCurrentSelection()) {
         normalizeThinking(thinkingLevel)
       } else {
         "off"
@@ -1272,6 +1284,9 @@ class ChatController internal constructor(
           if (requestCacheScope != currentCacheScope()) return
           if (requestSequence != sessionsRequestSequence.get()) return
           _sessions.value = result.sessions
+          result.sessions
+            .firstOrNull { it.key == _sessionKey.value }
+            ?.let(::applyThinkingMetadata)
           sessionsListArchived = archived
           val activeSessionKey = _sessionKey.value
           val activeOutsideLocalWindow =
@@ -1593,8 +1608,7 @@ class ChatController internal constructor(
       // open, preserving the thinking level captured when they were enqueued.
       val thinking =
         if (
-          queuedSessionKey == _sessionKey.value &&
-          !thinkingSupportedForSelection(_selectedModelRef.value, _modelCatalog.value)
+          queuedSessionKey == _sessionKey.value && !thinkingSupportedForCurrentSelection()
         ) {
           "off"
         } else {
@@ -2133,6 +2147,13 @@ class ChatController internal constructor(
     val isTruncated: Boolean,
   )
 
+  private data class SessionModelPatchResolution(
+    val modelProvider: String?,
+    val model: String?,
+    val thinkingLevel: String?,
+    val thinkingLevels: List<ChatThinkingLevelOption>?,
+  )
+
   private fun parseSessions(jsonString: String): SessionListResult {
     val root =
       json.parseToJsonElement(jsonString).asObjectOrNull()
@@ -2181,12 +2202,114 @@ class ChatController internal constructor(
       totalTokensFresh = obj["totalTokensFresh"].asBooleanOrNull(),
       modelProvider = obj["modelProvider"].asStringOrNull()?.trim(),
       model = obj["model"].asStringOrNull()?.trim(),
+      thinkingLevel = obj["thinkingLevel"].asStringOrNull()?.trim(),
+      thinkingLevels = parseThinkingLevels(obj["thinkingLevels"]),
+      thinkingDefault = obj["thinkingDefault"].asStringOrNull()?.trim(),
       contextTokens = obj["contextTokens"].asLongOrNull(),
       hasContextUsageMetadata =
         "totalTokens" in obj ||
           "totalTokensFresh" in obj ||
           "contextTokens" in obj,
     )
+  }
+
+  private fun parseSessionModelPatchResolution(jsonString: String): SessionModelPatchResolution? {
+    val root = json.parseToJsonElement(jsonString).asObjectOrNull() ?: return null
+    val resolved = root["resolved"].asObjectOrNull() ?: return null
+    return SessionModelPatchResolution(
+      modelProvider = resolved["modelProvider"].asStringOrNull()?.trim(),
+      model = resolved["model"].asStringOrNull()?.trim(),
+      thinkingLevel = resolved["thinkingLevel"].asStringOrNull()?.trim(),
+      thinkingLevels = parseThinkingLevels(resolved["thinkingLevels"]),
+    )
+  }
+
+  private fun parseThinkingLevels(element: JsonElement?): List<ChatThinkingLevelOption>? {
+    val array = element.asArrayOrNull() ?: return null
+    return array
+      .mapNotNull { item ->
+        val obj = item.asObjectOrNull() ?: return@mapNotNull null
+        val rawId = obj["id"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+        val id = normalizeThinking(rawId)
+        val label = obj["label"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id
+        ChatThinkingLevelOption(id = id, label = label)
+      }.distinctBy { it.id }
+  }
+
+  private fun applyAcceptedModelPatch(
+    key: String,
+    modelRef: String?,
+    resolution: SessionModelPatchResolution?,
+  ) {
+    val fallbackProvider = modelRef?.substringBefore('/', missingDelimiterValue = "")?.takeIf { it.isNotEmpty() }
+    val fallbackModel =
+      modelRef?.let { ref -> ref.substringAfter('/', missingDelimiterValue = ref) }?.takeIf { it.isNotEmpty() }
+    val current = _sessions.value
+    val index = current.indexOfFirst { it.key == key }
+    val existing = current.getOrNull(index)
+    val applied =
+      (existing ?: ChatSessionEntry(key = key, updatedAtMs = null)).copy(
+        modelProvider = resolution?.modelProvider ?: fallbackProvider ?: existing?.modelProvider,
+        model = resolution?.model ?: fallbackModel ?: existing?.model,
+        thinkingLevel = resolution?.thinkingLevel,
+        thinkingLevels = resolution?.thinkingLevels,
+        thinkingDefault = null,
+      )
+    if (index >= 0) {
+      _sessions.value = current.toMutableList().also { it[index] = applied }
+    }
+    if (_sessionKey.value == key) {
+      applyThinkingMetadata(applied)
+    }
+  }
+
+  private fun applyThinkingMetadata(entry: ChatSessionEntry?) {
+    val advertised = entry?.thinkingLevels
+    if (advertised == null) {
+      _thinkingLevelSelection.value = defaultChatThinkingLevelSelection
+      val requestedLevel =
+        entry
+          ?.thinkingLevel
+          ?.takeIf { it.isNotBlank() }
+          ?.let(::normalizeThinking)
+          ?: normalizeThinking(_thinkingLevel.value)
+      _thinkingLevel.value =
+        requestedLevel.takeIf { candidate ->
+          defaultChatThinkingLevelSelection.options.any { it.id == candidate }
+        } ?: "off"
+      return
+    }
+    val options =
+      advertised
+        .map { option ->
+          val id = normalizeThinking(option.id)
+          ChatThinkingLevelOption(
+            id = id,
+            label = option.label.trim().takeIf { it.isNotEmpty() } ?: id,
+          )
+        }.distinctBy { it.id }
+        .ifEmpty { listOf(ChatThinkingLevelOption(id = "off", label = "off")) }
+    _thinkingLevelSelection.value =
+      ChatThinkingLevelSelection(
+        options = options,
+        isGatewayProvided = true,
+      )
+    val selected = entry.thinkingLevel?.let(::normalizeThinking)
+    val currentLevel = normalizeThinking(_thinkingLevel.value)
+    val defaultLevel = entry.thinkingDefault?.let(::normalizeThinking)
+    _thinkingLevel.value =
+      listOfNotNull(selected, currentLevel, defaultLevel)
+        .firstOrNull { candidate -> options.any { it.id == candidate } }
+        ?: options.first().id
+  }
+
+  private fun thinkingSupportedForCurrentSelection(): Boolean {
+    val selection = _thinkingLevelSelection.value
+    return if (selection.isGatewayProvided) {
+      selection.options.any { it.id != "off" }
+    } else {
+      thinkingSupportedForSelection(_selectedModelRef.value, _modelCatalog.value)
+    }
   }
 
   private fun updateSessionFromHistory(history: ChatHistory) {
@@ -2223,6 +2346,9 @@ class ChatController internal constructor(
       } else {
         listOf(entry) + current
       }
+    if (applied.key == _sessionKey.value) {
+      applyThinkingMetadata(applied)
+    }
     acknowledgeUnreadIfNeeded(applied.key, applied, requireActive = true)
   }
 
@@ -2289,13 +2415,7 @@ class ChatController internal constructor(
     return if (gatewayId == scope.gatewayId) scope else scope.copy(gatewayId = gatewayId)
   }
 
-  private fun normalizeThinking(raw: String): String =
-    when (raw.trim().lowercase()) {
-      "low" -> "low"
-      "medium" -> "medium"
-      "high" -> "high"
-      else -> "off"
-    }
+  private fun normalizeThinking(raw: String): String = raw.trim().lowercase(Locale.US).ifEmpty { "off" }
 }
 
 private enum class ChatMetadataLoadState {
@@ -2670,6 +2790,9 @@ internal fun mergeChatSessionEntry(
       },
     modelProvider = next.modelProvider ?: existing.modelProvider,
     model = next.model ?: existing.model,
+    thinkingLevel = next.thinkingLevel ?: existing.thinkingLevel,
+    thinkingLevels = next.thinkingLevels ?: existing.thinkingLevels,
+    thinkingDefault = next.thinkingDefault ?: existing.thinkingDefault,
     contextTokens =
       when {
         preserveExistingContextUsage -> next.contextTokens ?: existing.contextTokens

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -45,6 +45,30 @@ data class ChatPendingToolCall(
   val isError: Boolean? = null,
 )
 
+/** Gateway-advertised thinking choice for the active provider/model pair. */
+data class ChatThinkingLevelOption(
+  val id: String,
+  val label: String,
+)
+
+/** Thinking choices currently shown by chat, including whether the Gateway supplied them. */
+data class ChatThinkingLevelSelection(
+  val options: List<ChatThinkingLevelOption>,
+  val isGatewayProvided: Boolean,
+)
+
+internal val defaultChatThinkingLevelSelection =
+  ChatThinkingLevelSelection(
+    options =
+      listOf(
+        ChatThinkingLevelOption(id = "off", label = "off"),
+        ChatThinkingLevelOption(id = "low", label = "low"),
+        ChatThinkingLevelOption(id = "medium", label = "medium"),
+        ChatThinkingLevelOption(id = "high", label = "high"),
+      ),
+    isGatewayProvided = false,
+  )
+
 /**
  * Stable session selector row; [key] is the gateway session key used in chat requests.
  */
@@ -63,6 +87,9 @@ data class ChatSessionEntry(
   val totalTokensFresh: Boolean? = null,
   val modelProvider: String? = null,
   val model: String? = null,
+  val thinkingLevel: String? = null,
+  val thinkingLevels: List<ChatThinkingLevelOption>? = null,
+  val thinkingDefault: String? = null,
   val contextTokens: Long? = null,
   val hasContextUsageMetadata: Boolean = totalTokens != null || totalTokensFresh != null || contextTokens != null,
 )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -10,6 +10,8 @@ import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatThinkingLevelOption
+import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.MessageSpeechPhase
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.VoiceNoteRecorderState
@@ -150,6 +152,7 @@ fun ChatScreen(
   val gatewayDefaultAgentId by viewModel.gatewayDefaultAgentId.collectAsState()
   val gatewayAgents by viewModel.gatewayAgents.collectAsState()
   val thinkingLevel by viewModel.chatThinkingLevel.collectAsState()
+  val thinkingLevelSelection by viewModel.chatThinkingLevelSelection.collectAsState()
   val streamingAssistantText by viewModel.chatStreamingAssistantText.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
@@ -172,7 +175,11 @@ fun ChatScreen(
   val micCooldown by viewModel.micCooldown.collectAsState()
   val talkModeEnabled by viewModel.talkModeEnabled.collectAsState()
   val talkModeListening by viewModel.talkModeListening.collectAsState()
-  val thinkingSupported = thinkingSupportedForSelection(selectedModelRef, modelCatalog)
+  val thinkingSupported =
+    chatThinkingSupported(
+      selection = thinkingLevelSelection,
+      fallbackSupported = thinkingSupportedForSelection(selectedModelRef, modelCatalog),
+    )
   val contextUsage = resolveChatContextUsage(sessionKey = sessionKey, mainSessionKey = mainSessionKey, sessions = sessions)
   val gatewayAddress = gatewayDiagnosticsEndpoint(remoteAddress = remoteAddress, manualHost = manualHost, manualPort = manualPort, manualTls = manualTls)
   val gatewayProblemMessage = gatewayConnectionDisplay.problem?.message?.takeIf { it.isNotBlank() }
@@ -357,6 +364,7 @@ fun ChatScreen(
       onValueChange = { input = it },
       attachments = attachments,
       thinkingLevel = thinkingLevel,
+      thinkingOptions = thinkingLevelSelection.options,
       thinkingSupported = thinkingSupported,
       contextUsage = contextUsage,
       selectedModelLabel = selectedModelLabel,
@@ -1099,6 +1107,7 @@ private fun ChatComposer(
   onValueChange: (String) -> Unit,
   attachments: List<PendingAttachment>,
   thinkingLevel: String,
+  thinkingOptions: List<ChatThinkingLevelOption>,
   thinkingSupported: Boolean,
   contextUsage: ChatContextUsage,
   selectedModelLabel: String,
@@ -1170,14 +1179,13 @@ private fun ChatComposer(
     }
 
     if (thinkingSelectorExpanded && thinkingSupported) {
-      ClawSegmentedControl(
-        options = listOf("Off", "Low", "Medium", "High"),
-        selected = contextMeterThinkingLabel(thinkingLevel).replaceFirstChar { it.uppercase() },
-        onSelect = { selected ->
-          onThinkingLevelChange(selected.lowercase(Locale.US))
+      ChatThinkingLevelSelector(
+        options = thinkingOptions,
+        selectedId = thinkingLevel,
+        onSelect = { selectedId ->
+          onThinkingLevelChange(selectedId)
           thinkingSelectorExpanded = false
         },
-        modifier = Modifier.fillMaxWidth(),
       )
     }
 
@@ -1248,6 +1256,37 @@ private fun ChatComposer(
           }
         }
       }
+    }
+  }
+}
+
+@Composable
+private fun ChatThinkingLevelSelector(
+  options: List<ChatThinkingLevelOption>,
+  selectedId: String,
+  onSelect: (String) -> Unit,
+) {
+  val rows = remember(options) { chatThinkingOptionRows(options) }
+  val normalizedSelected = selectedId.trim().lowercase(Locale.US)
+  val selectedLabel =
+    options
+      .firstOrNull { it.id.trim().lowercase(Locale.US) == normalizedSelected }
+      ?.let(::chatThinkingOptionLabel)
+      .orEmpty()
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    rows.forEach { row ->
+      val labels = row.map(::chatThinkingOptionLabel)
+      ClawSegmentedControl(
+        options = labels,
+        selected = selectedLabel,
+        onSelect = { selected ->
+          row.firstOrNull { chatThinkingOptionLabel(it) == selected }?.let { onSelect(it.id) }
+        },
+        modifier = Modifier.fillMaxWidth(),
+      )
     }
   }
 }
@@ -1783,12 +1822,28 @@ internal fun contextMeterLabel(
   return if (thinkingSupported) "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}" else contextLabel
 }
 
-internal fun contextMeterThinkingLabel(value: String): String =
-  when (value.lowercase(Locale.US)) {
-    "low" -> "low"
-    "medium" -> "medium"
-    "high" -> "high"
-    else -> "off"
+internal fun contextMeterThinkingLabel(value: String): String = value.trim().lowercase(Locale.US).ifEmpty { "off" }
+
+internal fun chatThinkingSupported(
+  selection: ChatThinkingLevelSelection,
+  fallbackSupported: Boolean,
+): Boolean =
+  if (selection.isGatewayProvided) {
+    selection.options.any { it.id.trim().lowercase(Locale.US) != "off" }
+  } else {
+    fallbackSupported
   }
+
+internal fun chatThinkingOptionRows(options: List<ChatThinkingLevelOption>): List<List<ChatThinkingLevelOption>> {
+  if (options.isEmpty()) return emptyList()
+  if (options.size <= 4) return listOf(options)
+  return options.chunked((options.size + 1) / 2)
+}
+
+internal fun chatThinkingOptionLabel(option: ChatThinkingLevelOption): String =
+  option.label
+    .trim()
+    .ifEmpty { option.id.trim() }
+    .replaceFirstChar { it.uppercase() }
 
 private fun formatChatTimestamp(timestampMs: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault()).format(Date(timestampMs))

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -20,6 +20,7 @@ import ai.openclaw.app.ui.design.ClawLoadingState
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawSecondaryButton
+import ai.openclaw.app.ui.design.ClawSegmentedControl
 import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTheme
@@ -61,6 +62,8 @@ import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
@@ -1126,6 +1129,11 @@ private fun ChatComposer(
     remember(value, commands) {
       matchingSlashCommands(input = value, commands = commands)
     }
+  var thinkingSelectorExpanded by rememberSaveable { mutableStateOf(false) }
+  LaunchedEffect(thinkingSupported) {
+    if (!thinkingSupported) thinkingSelectorExpanded = false
+  }
+
   val sendEnabled =
     voiceNoteState !is VoiceNoteRecorderState.Recording &&
       voiceNoteState !is VoiceNoteRecorderState.Preparing &&
@@ -1155,8 +1163,21 @@ private fun ChatComposer(
       ChatContextMeter(
         thinkingLevel = thinkingLevel,
         thinkingSupported = thinkingSupported,
+        expanded = thinkingSelectorExpanded,
         contextUsage = contextUsage,
-        onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
+        onClick = { thinkingSelectorExpanded = !thinkingSelectorExpanded },
+      )
+    }
+
+    if (thinkingSelectorExpanded && thinkingSupported) {
+      ClawSegmentedControl(
+        options = listOf("Off", "Low", "Medium", "High"),
+        selected = contextMeterThinkingLabel(thinkingLevel).replaceFirstChar { it.uppercase() },
+        onSelect = { selected ->
+          onThinkingLevelChange(selected.lowercase(Locale.US))
+          thinkingSelectorExpanded = false
+        },
+        modifier = Modifier.fillMaxWidth(),
       )
     }
 
@@ -1454,6 +1475,7 @@ private fun ChatOfflineNotice(
 private fun ChatContextMeter(
   thinkingLevel: String,
   thinkingSupported: Boolean,
+  expanded: Boolean,
   contextUsage: ChatContextUsage,
   onClick: () -> Unit,
 ) {
@@ -1477,7 +1499,12 @@ private fun ChatContextMeter(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
       ) {
         if (thinkingSupported) {
-          Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(13.dp), tint = ClawTheme.colors.textSubtle)
+          Icon(
+            imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+            contentDescription = if (expanded) "Close thinking level selector" else "Open thinking level selector",
+            modifier = Modifier.size(13.dp),
+            tint = ClawTheme.colors.textSubtle,
+          )
         }
         Text(
           text = contextMeterLabel(contextUsage, thinkingLevel, thinkingSupported),
@@ -1739,15 +1766,6 @@ internal fun userFacingChatError(
     else -> error
   }
 }
-
-/** Cycles through context budget presets from the compact composer control. */
-private fun nextThinkingValue(value: String): String =
-  when (value.lowercase(Locale.US)) {
-    "off" -> "low"
-    "low" -> "medium"
-    "medium" -> "high"
-    else -> "off"
-  }
 
 internal fun contextMeterWidth(usage: ChatContextUsage): Float? {
   if (usage.totalTokensFresh == false) return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -45,6 +45,52 @@ class ChatControllerModelSelectionTest {
     }
 
   @Test
+  fun successfulSelectionAppliesGatewayThinkingLevelsAndEffectiveLevel() =
+    runTest {
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { _, _ ->
+            """
+            {
+              "resolved": {
+                "modelProvider": "anthropic",
+                "model": "claude-sonnet-5",
+                "thinkingLevel": "max",
+                "thinkingLevels": [
+                  {"id": "off", "label": "off"},
+                  {"id": "minimal", "label": "minimal"},
+                  {"id": "low", "label": "low"},
+                  {"id": "medium", "label": "medium"},
+                  {"id": "high", "label": "high"},
+                  {"id": "xhigh", "label": "xhigh"},
+                  {"id": "adaptive", "label": "adaptive"},
+                  {"id": "max", "label": "max"}
+                ]
+              }
+            }
+            """.trimIndent()
+          },
+        )
+
+      assertTrue(controller.setSessionModelAwait("main", "anthropic/claude-sonnet-5"))
+
+      assertTrue(controller.thinkingLevelSelection.value.isGatewayProvided)
+      assertEquals(
+        listOf("off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"),
+        controller.thinkingLevelSelection.value.options
+          .map { it.id },
+      )
+      assertEquals("max", controller.thinkingLevel.value)
+
+      controller.setThinkingLevel("ultra")
+      assertEquals("max", controller.thinkingLevel.value)
+      controller.setThinkingLevel("adaptive")
+      assertEquals("adaptive", controller.thinkingLevel.value)
+    }
+
+  @Test
   fun failedSelectionDoesNotRecordRecentOrUpdateSelectedModel() =
     runTest {
       val recents = mutableListOf<String>()
@@ -395,5 +441,73 @@ class ChatControllerModelSelectionTest {
       )
       assertEquals(listOf("off", "high"), sentThinkingLevels)
       assertEquals("high", controller.thinkingLevel.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun advertisedThinkingLevelsOverrideCatalogReasoningFlagForSend() =
+    runTest {
+      val sentThinkingLevels = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            when (method) {
+              "chat.metadata" ->
+                """
+                {
+                  "commands": [],
+                  "models": [
+                    {
+                      "id": "reasoner",
+                      "name": "Reasoner",
+                      "provider": "synthetic",
+                      "available": true,
+                      "input": ["text"],
+                      "reasoning": false
+                    }
+                  ]
+                }
+                """.trimIndent()
+              "chat.history" -> """{"messages":[],"sessionInfo":{"key":"main"}}"""
+              "sessions.list" -> """{"sessions":[]}"""
+              "sessions.patch" ->
+                """
+                {
+                  "resolved": {
+                    "modelProvider": "synthetic",
+                    "model": "reasoner",
+                    "thinkingLevel": "max",
+                    "thinkingLevels": [
+                      {"id": "off", "label": "off"},
+                      {"id": "max", "label": "max"}
+                    ]
+                  }
+                }
+                """.trimIndent()
+              "chat.send" -> {
+                val params = json.parseToJsonElement(paramsJson.orEmpty()) as JsonObject
+                sentThinkingLevels += (params["thinking"] as JsonPrimitive).content
+                """{"runId":"run-ok","status":"ok"}"""
+              }
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+      controller.load("main")
+      advanceUntilIdle()
+
+      assertTrue(controller.setSessionModelAwait("main", "synthetic/reasoner"))
+      assertTrue(
+        controller.sendMessageAwaitAcceptance(
+          message = "use the advertised level",
+          thinkingLevel = controller.thinkingLevel.value,
+          attachments = emptyList(),
+        ),
+      )
+
+      assertEquals(listOf("max"), sentThinkingLevels)
     }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -91,6 +91,69 @@ class ChatControllerModelSelectionTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun existingSessionPreservesEffectiveLevelOmittedFromAdvertisedOptions() =
+    runTest {
+      val sentThinkingLevels = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            when (method) {
+              "sessions.list" ->
+                """
+                {
+                  "sessions": [
+                    {
+                      "key": "main",
+                      "modelProvider": "openai",
+                      "model": "gpt-5.6-luna",
+                      "thinkingLevel": "ultra",
+                      "thinkingLevels": [
+                        {"id": "off", "label": "off"},
+                        {"id": "high", "label": "high"},
+                        {"id": "xhigh", "label": "xhigh"},
+                        {"id": "max", "label": "max"}
+                      ]
+                    }
+                  ]
+                }
+                """.trimIndent()
+              "chat.send" -> {
+                val params = json.parseToJsonElement(paramsJson.orEmpty()) as JsonObject
+                sentThinkingLevels += (params["thinking"] as JsonPrimitive).content
+                """{"runId":"run-ok","status":"ok"}"""
+              }
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.refreshSessions()
+      advanceUntilIdle()
+
+      assertEquals(
+        listOf("off", "high", "xhigh", "max"),
+        controller
+          .thinkingLevelSelection
+          .value
+          .options
+          .map { it.id },
+      )
+      assertEquals("ultra", controller.thinkingLevel.value)
+      controller.handleGatewayEvent("health", null)
+      assertTrue(
+        controller.sendMessageAwaitAcceptance(
+          message = "preserve effective reasoning",
+          thinkingLevel = controller.thinkingLevel.value,
+          attachments = emptyList(),
+        ),
+      )
+      assertEquals(listOf("ultra"), sentThinkingLevels)
+    }
+
+  @Test
   fun failedSelectionDoesNotRecordRecentOrUpdateSelectedModel() =
     runTest {
       val recents = mutableListOf<String>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatContextMeterTest.kt
@@ -1,8 +1,12 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatThinkingLevelOption
+import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatContextMeterTest {
@@ -87,5 +91,54 @@ class ChatContextMeterTest {
     val usage = ChatContextUsage(totalTokens = 2_500L, totalTokensFresh = true, contextTokens = 10_000L)
 
     assertEquals("Context 25%", contextMeterLabel(usage, "high", thinkingSupported = false))
+  }
+
+  @Test
+  fun contextMeterPreservesGatewayThinkingLevelIds() {
+    val usage = ChatContextUsage(totalTokens = null, totalTokensFresh = null, contextTokens = null)
+
+    assertEquals("Context -- · xhigh", contextMeterLabel(usage, "xhigh"))
+    assertEquals("Context -- · adaptive", contextMeterLabel(usage, "adaptive"))
+    assertEquals("Context -- · ultra", contextMeterLabel(usage, "ultra"))
+  }
+
+  @Test
+  fun gatewayThinkingOptionsAreAuthoritativeForSupport() {
+    val offOnly =
+      ChatThinkingLevelSelection(
+        options = listOf(ChatThinkingLevelOption(id = "off", label = "off")),
+        isGatewayProvided = true,
+      )
+    val max =
+      ChatThinkingLevelSelection(
+        options =
+          listOf(
+            ChatThinkingLevelOption(id = "off", label = "off"),
+            ChatThinkingLevelOption(id = "max", label = "max"),
+          ),
+        isGatewayProvided = true,
+      )
+    val fallback =
+      ChatThinkingLevelSelection(
+        options = emptyList(),
+        isGatewayProvided = false,
+      )
+
+    assertFalse(chatThinkingSupported(offOnly, fallbackSupported = true))
+    assertTrue(chatThinkingSupported(max, fallbackSupported = false))
+    assertTrue(chatThinkingSupported(fallback, fallbackSupported = true))
+  }
+
+  @Test
+  fun largeThinkingProfilesSplitIntoBalancedInlineRows() {
+    val options =
+      listOf("off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max")
+        .map { ChatThinkingLevelOption(id = it, label = it) }
+
+    val rows = chatThinkingOptionRows(options)
+
+    assertEquals(listOf(4, 4), rows.map { it.size })
+    assertEquals("Xhigh", chatThinkingOptionLabel(options[5]))
+    assertEquals("Max", chatThinkingOptionLabel(options.last()))
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Android Chat’s inline thinking selector currently assumes a fixed Off, Low, Medium, and High set. Gateway session metadata already reports the exact thinking levels supported by the selected model, so models that expose levels such as Minimal, Xhigh, Adaptive, or Max are shown incomplete choices, while unknown levels can be reduced to Off.

## Why This Change Was Made

This keeps the existing inline segmented-control interaction but makes the available options model-aware. Android now consumes `thinkingLevels`, `thinkingDefault`, and the resolved model metadata returned by the Gateway, propagates them through the chat runtime, and updates the selector after an accepted model change. Gateway-provided metadata is authoritative; the four-level set remains only as a compatibility fallback when that metadata is unavailable.

## User Impact

Android users see the thinking levels supported by their current model instead of a hard-coded subset. Models with an Off-only profile hide the selector, model changes can replace the visible choices, and older Gateways retain the existing Off/Low/Medium/High behavior.

## Evidence

- Focused Android unit tests passed for dynamic Gateway profiles, accepted model changes, unsupported selections, Off-only behavior, fallback behavior, dynamic labels, and the two-row eight-level layout:
  - <code>./gradlew :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.chat.ChatControllerModelSelectionTest --tests ai.openclaw.app.ui.chat.ChatContextMeterTest</code>
- <code>./gradlew :app:ktlintCheck</code> passed.
- <code>node scripts/ensure-cli-startup-build.mjs</code> passed.
- <code>pnpm android:assemble</code> passed.
- <code>pnpm native:i18n:check</code> passed with <code>entries=2917 changed=false</code>.
- <code>pnpm android:i18n:check</code> passed.
- <code>pnpm apple:i18n:check</code> passed.
- <code>git diff --check</code> passed.
- Real behavior was verified on an Android API 36 emulator paired to an isolated online Gateway: App online, Gateway healthy, Nodes 1/1, Approvals 0, device requests 0, and node requests 0.
- The Gateway advertised eight levels for Claude Sonnet 5, and Android rendered all eight inline while preserving High as the active level.

<table>
  <tr>
    <th>Before: fixed four-level selector</th>
    <th>After: Gateway-provided eight-level selector</th>
  </tr>
  <tr>
    <td><img width="360" src="https://github.com/user-attachments/assets/ecc6955d-1d83-468a-b8bc-995518aa5765" alt="Before: Android Chat showing the fixed four-level thinking selector" /></td>
    <td><img width="360" src="https://github.com/user-attachments/assets/a3c227f4-3ea1-4fde-b9b1-325e9dd3253a" alt="After: Android Chat showing eight Gateway-provided thinking levels" /></td>
  </tr>
</table>

Online Android interaction — expanding the selector reveals the eight levels supplied by the current Gateway model profile:

https://github.com/user-attachments/assets/1306d70a-d092-46d7-bce9-22190305fc4c

[AI-assisted]