### PR TITLE
fix(nodes): stop advertising a disabled browser proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Node browser capability declarations:** stop advertising `browser` and `browser.proxy` from headless nodes when browser control or the node browser proxy is disabled, while retaining invocation-time fail-closed checks. (#103885)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Node browser capability declarations:** stop advertising `browser` and `browser.proxy` from headless nodes when browser control or the node browser proxy is disabled, while retaining invocation-time fail-closed checks. (#103885)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -144,6 +144,11 @@ export default definePluginEntry({
 - `configSchema` can be a function for lazy evaluation. OpenClaw resolves and
   memoizes the schema on first access, so expensive schema builders only run
   once.
+- A `nodeHostCommands` descriptor can define `isAvailable({ config, env })`.
+  Returning `false` omits that command and its capability from the headless
+  node's Gateway declaration. OpenClaw evaluates it against the node-local
+  startup config; command handlers should still validate availability when
+  invoked.
 
 ## `defineChannelPluginEntry`
 

--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -115,6 +115,19 @@ describe("browser plugin", () => {
     expect(browserPluginNodeHostCommands).toHaveLength(1);
     expect(browserPluginNodeHostCommands[0]?.command).toBe("browser.proxy");
     expect(browserPluginNodeHostCommands[0]?.cap).toBe("browser");
+    expect(browserPluginNodeHostCommands[0]?.isAvailable?.({ config: {}, env: {} })).toBe(true);
+    expect(
+      browserPluginNodeHostCommands[0]?.isAvailable?.({
+        config: { browser: { enabled: false } },
+        env: {},
+      }),
+    ).toBe(false);
+    expect(
+      browserPluginNodeHostCommands[0]?.isAvailable?.({
+        config: { nodeHost: { browserProxy: { enabled: false } } },
+        env: {},
+      }),
+    ).toBe(false);
     expect(typeof browserPluginNodeHostCommands[0]?.handle).toBe("function");
     expect(browserSecurityAuditCollectors).toHaveLength(1);
   });

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -142,6 +142,8 @@ export const browserPluginNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
   {
     command: "browser.proxy",
     cap: "browser",
+    isAvailable: ({ config }) =>
+      config.browser?.enabled !== false && config.nodeHost?.browserProxy?.enabled !== false,
     handle: async (paramsJSON) => {
       const { runBrowserProxyCommand } = await loadBrowserRegistrationRuntimeModule();
       return await runBrowserProxyCommand(paramsJSON);

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,7 +195,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10490,
+      10492,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/node-host/plugin-node-host.test.ts
+++ b/src/node-host/plugin-node-host.test.ts
@@ -7,6 +7,8 @@ import {
   listRegisteredNodeHostCapsAndCommands,
 } from "./plugin-node-host.js";
 
+const availabilityContext = { config: {}, env: {} };
+
 afterEach(() => {
   resetPluginRuntimeStateForTest();
 });
@@ -48,9 +50,47 @@ describe("plugin node-host registry", () => {
     ];
     setActivePluginRegistry(registry);
 
-    expect(listRegisteredNodeHostCapsAndCommands()).toEqual({
+    expect(listRegisteredNodeHostCapsAndCommands(availabilityContext)).toEqual({
       caps: ["browser", "photos"],
       commands: ["browser.inspect", "browser.proxy", "photos.proxy"],
+    });
+  });
+
+  it("omits commands and capabilities unavailable in the node-local config", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.nodeHostCommands = [
+      {
+        pluginId: "browser",
+        pluginName: "Browser",
+        command: {
+          command: "browser.proxy",
+          cap: "browser",
+          isAvailable: ({ config }) => config.browser?.enabled !== false,
+          handle: vi.fn(async () => "{}"),
+        },
+        source: "test",
+      },
+      {
+        pluginId: "photos",
+        pluginName: "Photos",
+        command: {
+          command: "photos.proxy",
+          cap: "photos",
+          handle: vi.fn(async () => "{}"),
+        },
+        source: "test",
+      },
+    ];
+    setActivePluginRegistry(registry);
+
+    expect(
+      listRegisteredNodeHostCapsAndCommands({
+        config: { browser: { enabled: false } },
+        env: {},
+      }),
+    ).toEqual({
+      caps: ["photos"],
+      commands: ["photos.proxy"],
     });
   });
 

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -6,6 +6,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import type { OpenClawPluginNodeHostCommandAvailabilityContext } from "../plugins/types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 
 const loadPluginRegistryLoaderModule = createLazyRuntimeModule(
@@ -26,7 +27,9 @@ export async function ensureNodeHostPluginRegistry(params: {
 }
 
 /** List registered node-host capabilities and command ids in deterministic order. */
-export function listRegisteredNodeHostCapsAndCommands(): {
+export function listRegisteredNodeHostCapsAndCommands(
+  context: OpenClawPluginNodeHostCommandAvailabilityContext,
+): {
   caps: string[];
   commands: string[];
 } {
@@ -34,6 +37,11 @@ export function listRegisteredNodeHostCapsAndCommands(): {
   const caps = new Set<string>();
   const commands = new Set<string>();
   for (const entry of registry?.nodeHostCommands ?? []) {
+    // Availability belongs to the node-local plugin. Gateway policy still keeps
+    // the command registered so a differently configured remote node can expose it.
+    if (entry.command.isAvailable?.(context) === false) {
+      continue;
+    }
     if (entry.command.cap) {
       caps.add(entry.command.cap);
     }

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -255,7 +255,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
 
   const cfg = getRuntimeConfig();
   await ensureNodeHostPluginRegistry({ config: cfg, env: process.env });
-  const pluginNodeHost = listRegisteredNodeHostCapsAndCommands();
+  const pluginNodeHost = listRegisteredNodeHostCapsAndCommands({ config: cfg, env: process.env });
   const { token, password } = await resolveNodeHostGatewayCredentials({
     config: cfg,
     env: process.env,

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -27,6 +27,8 @@ export type OpenClawPluginHttpRouteHandler =
   import("../plugins/types.js").OpenClawPluginHttpRouteHandler;
 export type OpenClawPluginNodeHostCommand =
   import("../plugins/types.js").OpenClawPluginNodeHostCommand;
+export type OpenClawPluginNodeHostCommandAvailabilityContext =
+  import("../plugins/types.js").OpenClawPluginNodeHostCommandAvailabilityContext;
 export type OpenClawPluginNodeInvokePolicy =
   import("../plugins/types.js").OpenClawPluginNodeInvokePolicy;
 export type OpenClawPluginNodeInvokePolicyContext =

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2223,10 +2223,19 @@ export type OpenClawPluginReloadRegistration = {
   noopPrefixes?: string[];
 };
 
+export type OpenClawPluginNodeHostCommandAvailabilityContext = {
+  /** Node-local configuration used to build this host's Gateway declaration. */
+  config: OpenClawConfig;
+  /** Node-host process environment. */
+  env: NodeJS.ProcessEnv;
+};
+
 export type OpenClawPluginNodeHostCommand = {
   command: string;
   cap?: string;
   dangerous?: boolean;
+  /** Return false to omit this command and capability from the node declaration. */
+  isAvailable?: (context: OpenClawPluginNodeHostCommandAvailabilityContext) => boolean;
   handle: (paramsJSON?: string | null) => Promise<string>;
 };
 


### PR DESCRIPTION
Closes #103885

## What Problem This Solves

Fixes an issue where a headless node advertised the `browser` capability and `browser.proxy` command when browser control or the node browser proxy was disabled. Gateway routing could then select that node for browser work even though invocation would fail closed.

## Why This Change Was Made

Plugin node-host commands can now declare node-local startup availability. The headless node filters unavailable commands and their capabilities from its Gateway declaration while retaining the command in Gateway policy for differently configured remote nodes. Browser invocation still validates both config gates when called.

## User Impact

Operators who disable browser control or the node browser proxy no longer see that node claim unusable browser capability. Plugin authors can use the same node-local availability predicate for other conditional node-host commands.

## Evidence

- Blacksmith Testbox `tbx_01kx6kgpn05h1nzpkt3fssp6z9`: `corepack pnpm test src/node-host/plugin-node-host.test.ts extensions/browser/index.test.ts` — 17 tests passed.
- Same Testbox: `corepack pnpm test test/scripts/plugin-sdk-surface-report.test.ts` — 9 tests passed.
- Same Testbox: `corepack pnpm check:changed` — all selected core, extension, test, docs, type, lint, and policy lanes passed in 13m21s.
- `node_modules/.bin/oxfmt --check docs/plugins/sdk-entrypoints.md extensions/browser/index.test.ts extensions/browser/plugin-registration.ts scripts/plugin-sdk-surface-report.mjs src/node-host/plugin-node-host.test.ts src/node-host/plugin-node-host.ts src/node-host/runner.ts src/plugin-sdk/plugin-entry.ts src/plugins/types.ts`
- `git diff --check origin/main...HEAD`
- Fresh autoreview: no findings; final SDK budget ratchet correct with 0.99 confidence.

AI-assisted: Codex implemented and tested this change; maintainer review and repository-native landing gates remain authoritative.
