### PR TITLE
fix(release): reuse evidence for changelog-only candidates

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -24,6 +24,8 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   fails, the parent cancels the remaining child matrix and prints the failed
   job summary. Inspect that first red job instead of waiting for unrelated
   matrix tails.
+- Cross-SHA reuse requires a successful `Release Delta Evidence` artifact.
+  The manifest is read-only evidence, never publish authorization.
 - In a sparse worktree or Testbox source sync, first confirm `package.json`,
   `pnpm-lock.yaml`, and every source path the selected check reads. If any are
   absent, that checkout cannot validate a release dependency or Docker lane:
@@ -61,6 +63,39 @@ ambient env only when it was already intentionally injected for this release.
 The script prints only provider status and HTTP class, never tokens.
 The Anthropic check performs a tiny message completion so exhausted or
 non-billable credentials fail before the expensive release matrix.
+
+## Delta Evidence
+
+The v1 workflow is deliberately limited to beta candidates whose only changed
+path is `CHANGELOG.md`. Use `.github/workflows/release-delta-evidence.yml` only
+with a reviewed policy under `.github/release-delta-policies/`. Pass exact run,
+job, and artifact ids. The workflow verifies:
+
+- the policy source is an ancestor of the exact target branch tip
+- every linear delta commit has valid GitHub signature verification
+- allowed changed paths plus deterministic diff, tree, and filtered-tree hashes
+- source Full Release Validation through the existing strict v3 validator
+- exact Full Release Validation lane-selection inputs and blocking performance
+  controls
+- fresh evidence for impacted gates and direct source evidence only for
+  unaffected gates
+- trusted-main lineage for FRV/generic workflows, release-ref candidate identity
+  for npm gates, and exact successful first-attempt run/job/artifact tuples
+- bounded archives whose complete member inventory matches policy
+
+`CHANGELOG.md` may be excluded from product-tree equivalence, but it ships in
+the root npm tarball. A changelog delta therefore requires a fresh exact-target
+root-package gate even when product, Docker, performance, install, and provider
+evidence remains reusable. The manifest computes `rawRootTarballEqual` for
+audit only. It derives the root and dependency package set from each
+`preflight-manifest.json`, verifies release tag/SHA/version/dist-tag and every
+tarball hash, rejects unlisted `.tgz` members, and requires dependency bytes to
+match between source and target.
+
+The manifest has `publicationPerformed: false`. Publish workflows must not
+accept it as permission to mutate tags, registries, releases, or images. Until
+a consumer is separately reviewed, keep the run-and-attempt-scoped upload as an
+operator evidence artifact.
 
 ## Dispatch
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,8 +64,13 @@
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
 # Release workflow and its supporting release-path checks.
+/.github/release-delta-policies/ @openclaw/openclaw-release-managers
 /.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-release-managers
+/.github/workflows/release-delta-evidence.yml @openclaw/openclaw-release-managers
 /docs/reference/RELEASING.md @openclaw/openclaw-release-managers
+/scripts/lib/canonical-json.mjs @openclaw/openclaw-release-managers
+/scripts/lib/release-delta-evidence.mjs @openclaw/openclaw-release-managers
 /scripts/openclaw-npm-publish.sh @openclaw/openclaw-release-managers
 /scripts/openclaw-npm-release-check.ts @openclaw/openclaw-release-managers
+/scripts/release-delta-evidence.mjs @openclaw/openclaw-release-managers
 /scripts/release-check.ts @openclaw/openclaw-release-managers

--- a/.github/workflows/release-delta-evidence.yml
+++ b/.github/workflows/release-delta-evidence.yml
@@ -1,0 +1,149 @@
+name: Release Delta Evidence
+
+run-name: Release Delta Evidence ${{ inputs.target_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact target branch tip to evaluate
+        required: true
+        type: string
+      policy_path:
+        description: Policy under .github/release-delta-policies/
+        required: true
+        type: string
+      evidence_runs_json:
+        description: Exact gate run, job, and artifact ids as JSON
+        required: true
+        type: string
+
+concurrency:
+  group: release-delta-evidence-${{ inputs.target_sha }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  TARGET_SHA: ${{ inputs.target_sha }}
+  POLICY_PATH: ${{ inputs.policy_path }}
+  WORKFLOW_SHA: ${{ github.workflow_sha }}
+  PRODUCER_ARTIFACT_NAME: release-delta-evidence-${{ inputs.target_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  produce:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Validate inputs
+        env:
+          EVIDENCE_RUNS_JSON: ${{ inputs.evidence_runs_json }}
+          WORKFLOW_REF: ${{ github.ref }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REPOSITORY" == "openclaw/openclaw" ]]
+          [[ "$WORKFLOW_REF" == "refs/heads/main" ]]
+          [[ "$RUN_ATTEMPT" == "1" ]]
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$POLICY_PATH" =~ ^\.github/release-delta-policies/[A-Za-z0-9][A-Za-z0-9._-]*\.json$ ]]
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/release-delta-evidence.yml@refs/heads/main"
+          [[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]
+          producer_workflow_path="${GITHUB_WORKFLOW_REF#${GITHUB_REPOSITORY}/}"
+          producer_workflow_path="${producer_workflow_path%@*}"
+          [[ "$producer_workflow_path" == ".github/workflows/release-delta-evidence.yml" ]]
+          printf 'PRODUCER_WORKFLOW_PATH=%s\n' "$producer_workflow_path" >> "$GITHUB_ENV"
+          node -e 'JSON.parse(process.env.EVIDENCE_RUNS_JSON)'
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.15.0
+
+      - name: Verify trusted workflow checkout
+        run: test "$(git rev-parse HEAD)" = "$WORKFLOW_SHA"
+
+      - name: Fetch target commit
+        run: git fetch --no-tags origin "$TARGET_SHA"
+
+      - name: Write exact evidence bindings
+        env:
+          EVIDENCE_RUNS_JSON: ${{ inputs.evidence_runs_json }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+          const value = JSON.parse(process.env.EVIDENCE_RUNS_JSON);
+          writeFileSync(process.env.RUNNER_TEMP + "/release-delta-runs.json", JSON.stringify(value));
+          NODE
+
+      - name: Create canonical delta manifest
+        id: create
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/release-delta-evidence.mjs create \
+            --repo "$GITHUB_REPOSITORY" \
+            --policy "$POLICY_PATH" \
+            --target-sha "$TARGET_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-workflow-path "$PRODUCER_WORKFLOW_PATH" \
+            --producer-workflow-ref "$GITHUB_REF" \
+            --producer-artifact-name "$PRODUCER_ARTIFACT_NAME" \
+            --evidence-runs "$RUNNER_TEMP/release-delta-runs.json" \
+            --output "$RUNNER_TEMP/release-delta-evidence.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Reverify current GitHub evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/release-delta-evidence.mjs verify \
+            --repo "$GITHUB_REPOSITORY" \
+            --policy "$POLICY_PATH" \
+            --target-sha "$TARGET_SHA" \
+            --workflow-sha "$WORKFLOW_SHA" \
+            --producer-run-id "$GITHUB_RUN_ID" \
+            --producer-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --producer-workflow-path "$PRODUCER_WORKFLOW_PATH" \
+            --producer-workflow-ref "$GITHUB_REF" \
+            --producer-artifact-name "$PRODUCER_ARTIFACT_NAME" \
+            --manifest "$RUNNER_TEMP/release-delta-evidence.json"
+
+      - name: Write manifest digest
+        run: |
+          printf '%s  %s\n' \
+            '${{ steps.create.outputs.manifest_sha256 }}' \
+            'release-delta-evidence.json' \
+            > "$RUNNER_TEMP/release-delta-evidence.sha256"
+
+      - name: Stage read-only delta evidence
+        env:
+          EVIDENCE_ARTIFACT_DIR: ${{ runner.temp }}/release-delta-evidence-artifact
+        run: |
+          set -euo pipefail
+          rm -rf "$EVIDENCE_ARTIFACT_DIR"
+          mkdir -p "$EVIDENCE_ARTIFACT_DIR"
+          cp -- "$RUNNER_TEMP/release-delta-evidence.json" "$EVIDENCE_ARTIFACT_DIR/"
+          cp -- "$RUNNER_TEMP/release-delta-evidence.sha256" "$EVIDENCE_ARTIFACT_DIR/"
+          cp -- "$POLICY_PATH" "$EVIDENCE_ARTIFACT_DIR/release-delta-policy.json"
+
+      - name: Upload read-only delta evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ env.PRODUCER_ARTIFACT_NAME }}
+          archive: true
+          if-no-files-found: error
+          retention-days: 30
+          path: ${{ runner.temp }}/release-delta-evidence-artifact

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -357,6 +357,29 @@ the same `release/*`
 ref and rerun group supersede in-progress ones automatically. Pass
 `reuse_evidence=false` to force a fresh full run.
 
+For reviewed cross-SHA reuse, `Release Delta Evidence` v1 accepts only a beta
+candidate whose exact delta is `CHANGELOG.md`. Dispatch it from trusted `main`
+with the exact target branch tip, a checked-in policy under
+`.github/release-delta-policies/`, and exact run, job, and artifact ids. Its
+canonical manifest records the signed commit chain, changed paths, diff and
+tree hashes, strict source Full Release Validation result and exact
+lane-selection inputs, source/fresh gate decisions, complete bounded artifact
+inventories, and reuse rationale. FRV and generic gates must come from
+trusted-main ancestry; source and target npm gates must execute on the release
+ref at the exact candidate SHA. Immutable artifact reads bind the exact run,
+first attempt, name, digest, size, workflow path, and workflow SHA. The manifest is
+evidence only and always records
+`publicationPerformed: false`; no publish workflow consumes it by default.
+
+A `CHANGELOG.md`-only delta may keep the filtered product tree byte-identical,
+so policy can reuse unaffected product, Docker, performance, install, and live
+provider gates. The root npm package is different because `CHANGELOG.md` is
+packed. Its root-package gate must run fresh on the exact target SHA, the
+manifest computes `rawRootTarballEqual` for audit only, and each npm artifact's
+`preflight-manifest.json` must bind the exact release tag, candidate SHA,
+package version, npm dist-tag, and complete `.tgz` package set. Dependency
+package hashes and sizes must remain identical.
+
 For bounded recovery, pass `rerun_group` to the umbrella. `all` is the real release-candidate run, `ci` runs only the normal CI child, `plugin-prerelease` runs only the release-only plugin child, `release-checks` runs every release box, and the narrower release groups are `install-smoke`, `cross-os`, `live-e2e`, `package`, `qa`, `qa-parity`, `qa-live`, and `npm-telegram`. Focused `npm-telegram` reruns require `release_package_spec` or `npm_telegram_package_spec`; full/all runs use the canonical package Telegram E2E inside Package Acceptance. Focused cross-OS reruns can add `cross_os_suite_filter=windows/packaged-upgrade` or another OS/suite filter. QA release-check failures block normal release validation, including required OpenClaw dynamic tool drift in the standard tier. Tideclaw alpha runs may still treat non-package-safety release-check lanes as advisory. With `release_profile=beta`, the `Run repo/live E2E validation` live-provider suites are advisory (warnings, not blockers); stable and full profiles keep them blocking. When `live_suite_filter` explicitly requests a gated QA live lane such as Discord, WhatsApp, or Slack, the matching `OPENCLAW_RELEASE_QA_*_LIVE_CI_ENABLED` repo variable must be enabled; otherwise input capture fails instead of silently skipping the lane.
 
 ### Vitest

--- a/scripts/lib/canonical-json.mjs
+++ b/scripts/lib/canonical-json.mjs
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+function sortJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, entry]) => [key, sortJson(entry)]),
+    );
+  }
+  return value;
+}
+
+export const canonicalJson = (value) => JSON.stringify(sortJson(value));
+export const canonicalJsonSha256 = (value) =>
+  createHash("sha256").update(canonicalJson(value)).digest("hex");

--- a/scripts/lib/release-delta-evidence.mjs
+++ b/scripts/lib/release-delta-evidence.mjs
@@ -1,0 +1,1312 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { canonicalJson, canonicalJsonSha256 } from "./canonical-json.mjs";
+
+export const RELEASE_DELTA_POLICY_SCHEMA = "openclaw.release-delta-policy/v1";
+export const RELEASE_DELTA_MANIFEST_SCHEMA = "openclaw.release-delta-evidence/v1";
+
+const SHA_RE = /^[0-9a-f]{40}$/u;
+const SHA256_RE = /^[0-9a-f]{64}$/u;
+const DIGEST_RE = /^sha256:([0-9a-f]{64})$/u;
+const POLICY_PATH_RE = /^\.github\/release-delta-policies\/[A-Za-z0-9][A-Za-z0-9._-]*\.json$/u;
+const GIT_BINARY = process.platform === "win32" ? "git.exe" : "/usr/bin/git";
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function exactObject(value, required, optional, label) {
+  assert(value && typeof value === "object" && !Array.isArray(value), `${label} must be an object`);
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    assert(allowed.has(key), `${label}.${key} is not allowed`);
+  }
+  for (const key of required) {
+    assert(Object.hasOwn(value, key), `${label}.${key} is required`);
+  }
+}
+
+function nonEmptyString(value, label) {
+  assert(typeof value === "string" && value.length > 0, `${label} must be a non-empty string`);
+  return value;
+}
+
+function fullSha(value, label) {
+  assert(typeof value === "string" && SHA_RE.test(value), `${label} must be a full lowercase SHA`);
+  return value;
+}
+
+function sha256(value, label) {
+  assert(typeof value === "string" && SHA256_RE.test(value), `${label} must be a SHA-256 hex`);
+  return value;
+}
+
+function positiveInteger(value, label) {
+  assert(Number.isSafeInteger(value) && value > 0, `${label} must be a positive integer`);
+  return value;
+}
+
+function compareStrings(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function containsControlCharacter(value) {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sortedUniqueStrings(value, label, { allowEmpty = false } = {}) {
+  assert(Array.isArray(value), `${label} must be an array`);
+  const result = value.map((entry, index) => nonEmptyString(entry, `${label}[${index}]`));
+  assert(allowEmpty || result.length > 0, `${label} must not be empty`);
+  assert(new Set(result).size === result.length, `${label} must not contain duplicates`);
+  return result.toSorted();
+}
+
+function validateRepositoryPath(value, label) {
+  nonEmptyString(value, label);
+  assert(!containsControlCharacter(value), `${label} must not contain control characters`);
+  assert(value.normalize("NFC") === value, `${label} must use canonical UTF-8 normalization`);
+  assert(!path.posix.isAbsolute(value), `${label} must be repository-relative`);
+  assert(value === value.split("\\").join("/"), `${label} must use POSIX separators`);
+  const normalized = path.posix.normalize(value);
+  assert(normalized === value && !normalized.startsWith("../"), `${label} must be normalized`);
+  return value;
+}
+
+function validateGlob(value, label) {
+  nonEmptyString(value, label);
+  assert(!value.startsWith("!"), `${label} must not be a negated glob`);
+  assert(!value.includes("\\"), `${label} must use POSIX separators`);
+  return value;
+}
+
+function matchesGlob(filePath, pattern) {
+  return path.matchesGlob(filePath, pattern);
+}
+
+function matchesAny(filePath, patterns) {
+  return patterns.some((pattern) => matchesGlob(filePath, pattern));
+}
+
+function decodeUtf8(value, label) {
+  try {
+    return UTF8_DECODER.decode(value);
+  } catch {
+    throw new Error(`${label} is not canonical UTF-8`);
+  }
+}
+
+function parseBinding(value, label) {
+  exactObject(value, ["path", "candidateShaPointer"], [], label);
+  validateRepositoryPath(value.path, `${label}.path`);
+  const candidateShaPointer = nonEmptyString(
+    value.candidateShaPointer,
+    `${label}.candidateShaPointer`,
+  );
+  assert(candidateShaPointer.startsWith("/"), `${label}.candidateShaPointer must be JSON Pointer`);
+  return { path: value.path, candidateShaPointer };
+}
+
+function parsePackageMembers(value, label, requiredMembers, binding) {
+  if (value === undefined) {
+    return undefined;
+  }
+  exactObject(value, ["preflightManifest"], [], label);
+  const preflightManifest = validateRepositoryPath(
+    value.preflightManifest,
+    `${label}.preflightManifest`,
+  );
+  assert(
+    requiredMembers.includes(preflightManifest),
+    `${label}.preflightManifest must be a required member`,
+  );
+  assert(
+    binding.path === preflightManifest && binding.candidateShaPointer === "/releaseSha",
+    `${label} must use /releaseSha from its preflight manifest as the candidate binding`,
+  );
+  return { preflightManifest };
+}
+
+function parseArtifactPolicy(value, label) {
+  exactObject(value, ["key", "name", "requiredMembers", "binding"], ["packageMembers"], label);
+  const requiredMembers = sortedUniqueStrings(
+    value.requiredMembers,
+    `${label}.requiredMembers`,
+  ).map((entry, index) => validateRepositoryPath(entry, `${label}.requiredMembers[${index}]`));
+  const binding = parseBinding(value.binding, `${label}.binding`);
+  const packageMembers = parsePackageMembers(
+    value.packageMembers,
+    `${label}.packageMembers`,
+    requiredMembers,
+    binding,
+  );
+  assert(requiredMembers.includes(binding.path), `${label}.binding.path must be a required member`);
+  return {
+    key: nonEmptyString(value.key, `${label}.key`),
+    name: nonEmptyString(value.name, `${label}.name`),
+    requiredMembers,
+    binding,
+    ...(packageMembers ? { packageMembers } : {}),
+  };
+}
+
+function parseValidationInputs(value, label) {
+  exactObject(
+    value,
+    [
+      "provider",
+      "mode",
+      "liveSuiteFilter",
+      "crossOsSuiteFilter",
+      "releasePackageSpec",
+      "packageAcceptancePackageSpec",
+      "codexPluginSpec",
+    ],
+    [],
+    label,
+  );
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      assert(typeof entry === "string", `${label}.${key} must be a string`);
+      return [key, entry];
+    }),
+  );
+}
+
+function parseGatePolicy(value, index) {
+  const label = `policy.gates[${index}]`;
+  exactObject(
+    value,
+    ["id", "kind", "reuse", "workflowPath", "workflowSha", "jobName", "impactPaths", "artifacts"],
+    ["validationInputs"],
+    label,
+  );
+  assert(
+    ["generic", "source-frv", "source-npm", "root-package"].includes(value.kind),
+    `${label}.kind is invalid`,
+  );
+  assert(["never", "when-unimpacted"].includes(value.reuse), `${label}.reuse is invalid`);
+  const impactPaths = sortedUniqueStrings(value.impactPaths, `${label}.impactPaths`, {
+    allowEmpty: true,
+  }).map((entry, patternIndex) => validateGlob(entry, `${label}.impactPaths[${patternIndex}]`));
+  assert(
+    Array.isArray(value.artifacts) && value.artifacts.length > 0,
+    `${label}.artifacts is empty`,
+  );
+  const artifacts = value.artifacts.map((artifact, artifactIndex) =>
+    parseArtifactPolicy(artifact, `${label}.artifacts[${artifactIndex}]`),
+  );
+  assert(
+    new Set(artifacts.map((artifact) => artifact.key)).size === artifacts.length,
+    `${label}.artifacts keys must be unique`,
+  );
+  assert(
+    new Set(artifacts.map((artifact) => artifact.name)).size === artifacts.length,
+    `${label}.artifacts names must be unique`,
+  );
+  const validationInputs =
+    value.kind === "source-frv"
+      ? parseValidationInputs(value.validationInputs, `${label}.validationInputs`)
+      : undefined;
+  assert(
+    value.kind === "source-frv" || value.validationInputs === undefined,
+    `${label}.validationInputs is only valid for source-frv`,
+  );
+  return {
+    id: nonEmptyString(value.id, `${label}.id`),
+    kind: value.kind,
+    reuse: value.reuse,
+    workflowPath: validateRepositoryPath(value.workflowPath, `${label}.workflowPath`),
+    workflowSha: fullSha(value.workflowSha, `${label}.workflowSha`),
+    jobName: nonEmptyString(value.jobName, `${label}.jobName`),
+    impactPaths,
+    artifacts,
+    ...(validationInputs ? { validationInputs } : {}),
+  };
+}
+
+export function validateReleaseDeltaPolicyPath(policyPath) {
+  assert(
+    POLICY_PATH_RE.test(policyPath),
+    "policy path must name one JSON file under release-delta-policies",
+  );
+  return policyPath;
+}
+
+export function parseReleaseDeltaPolicy(input) {
+  const value =
+    typeof input === "string"
+      ? JSON.parse(input)
+      : Buffer.isBuffer(input)
+        ? JSON.parse(decodeUtf8(input, "release delta policy"))
+        : input;
+  exactObject(
+    value,
+    ["schema", "release", "targetRef", "sourceSha", "allowedPaths", "metadataPaths", "gates"],
+    [],
+    "policy",
+  );
+  assert(value.schema === RELEASE_DELTA_POLICY_SCHEMA, "policy.schema is invalid");
+  exactObject(value.release, ["version", "channel"], [], "policy.release");
+  assert(value.release.channel === "beta", "policy.release.channel must be beta");
+  assert(
+    /^\d{4}\.\d+\.\d+-beta\.[1-9]\d*$/u.test(value.release.version),
+    "policy.release.version must be a beta version",
+  );
+  const stableVersion = value.release.version.replace(/-beta\.[1-9]\d*$/u, "");
+  assert(
+    value.targetRef === `release/${stableVersion}`,
+    "policy.targetRef must match the beta stable version",
+  );
+  const allowedPaths = sortedUniqueStrings(value.allowedPaths, "policy.allowedPaths").map(
+    (entry, index) => validateGlob(entry, `policy.allowedPaths[${index}]`),
+  );
+  const metadataPaths = sortedUniqueStrings(value.metadataPaths, "policy.metadataPaths", {
+    allowEmpty: true,
+  }).map((entry, index) => validateGlob(entry, `policy.metadataPaths[${index}]`));
+  const gates = value.gates.map(parseGatePolicy);
+  assert(
+    new Set(gates.map((gate) => gate.id)).size === gates.length,
+    "policy gate ids must be unique",
+  );
+  assert(
+    canonicalJson(allowedPaths) === canonicalJson(["CHANGELOG.md"]),
+    "v1 policy allows only CHANGELOG.md",
+  );
+  assert(
+    canonicalJson(metadataPaths) === canonicalJson(["CHANGELOG.md"]),
+    "v1 policy metadataPaths must be CHANGELOG.md",
+  );
+  for (const kind of ["source-frv", "source-npm", "root-package"]) {
+    assert(
+      gates.filter((gate) => gate.kind === kind).length === 1,
+      `policy must contain exactly one ${kind} gate`,
+    );
+  }
+  for (const kind of ["source-npm", "root-package"]) {
+    const packageArtifacts = gates
+      .find((gate) => gate.kind === kind)
+      .artifacts.filter((artifact) => artifact.packageMembers);
+    assert(
+      packageArtifacts.length === 1,
+      `${kind} gate must contain exactly one packageMembers artifact`,
+    );
+  }
+  assert(
+    gates.find((gate) => gate.kind === "source-frv").reuse === "when-unimpacted",
+    "source-frv gate must be reusable when unimpacted",
+  );
+  assert(
+    gates.find((gate) => gate.kind === "source-npm").reuse === "when-unimpacted",
+    "source-npm gate must be reusable when unimpacted",
+  );
+  assert(
+    gates.find((gate) => gate.kind === "root-package").reuse === "when-unimpacted",
+    "root-package freshness must derive from the changelog package rule",
+  );
+  return {
+    schema: value.schema,
+    release: {
+      version: value.release.version,
+      channel: "beta",
+    },
+    targetRef: nonEmptyString(value.targetRef, "policy.targetRef"),
+    sourceSha: fullSha(value.sourceSha, "policy.sourceSha"),
+    allowedPaths,
+    metadataPaths,
+    gates,
+  };
+}
+
+function isolatedGitEnvironment() {
+  const environment = { ...process.env };
+  for (const variable of Object.keys(environment)) {
+    if (variable === "GIT_CONFIG" || variable.startsWith("GIT_CONFIG_")) {
+      delete environment[variable];
+    }
+  }
+  for (const variable of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE",
+  ]) {
+    delete environment[variable];
+  }
+  return {
+    ...environment,
+    GIT_ATTR_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: os.devNull,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_SYSTEM: os.devNull,
+    GIT_LITERAL_PATHSPECS: "1",
+    GIT_NO_REPLACE_OBJECTS: "1",
+    GIT_PAGER: "cat",
+    GIT_TERMINAL_PROMPT: "0",
+    LC_ALL: "C",
+    NO_COLOR: "1",
+  };
+}
+
+function gitArgs(args) {
+  return ["-c", "core.fsmonitor=false", "-c", `core.hooksPath=${os.devNull}`, ...args];
+}
+
+function git(cwd, args, encoding = "utf8") {
+  return execFileSync(GIT_BINARY, gitArgs(args), {
+    cwd,
+    encoding,
+    env: isolatedGitEnvironment(),
+    maxBuffer: 128 * 1024 * 1024,
+  });
+}
+
+function gitSucceeds(cwd, args) {
+  return (
+    spawnSync(GIT_BINARY, gitArgs(args), {
+      cwd,
+      env: isolatedGitEnvironment(),
+      stdio: "ignore",
+    }).status === 0
+  );
+}
+
+function hashBytes(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function nulList(value) {
+  return decodeUtf8(value, "git path output").split("\0").filter(Boolean);
+}
+
+function filteredTreeHash(cwd, commitSha, metadataPaths) {
+  const entries = nulList(git(cwd, ["ls-tree", "-r", "-z", "--full-tree", commitSha], "buffer"));
+  const filtered = entries.filter((entry) => {
+    const tab = entry.indexOf("\t");
+    assert(tab > 0, "git ls-tree output is invalid");
+    return !matchesAny(entry.slice(tab + 1), metadataPaths);
+  });
+  return hashBytes(Buffer.from(`${filtered.join("\0")}${filtered.length > 0 ? "\0" : ""}`));
+}
+
+function resolvePointer(document, pointer, label) {
+  if (pointer === "") {
+    return document;
+  }
+  let value = document;
+  for (const token of pointer
+    .slice(1)
+    .split("/")
+    .map((entry) => entry.replaceAll("~1", "/").replaceAll("~0", "~"))) {
+    assert(value !== null && typeof value === "object", `${label} does not resolve`);
+    assert(Object.hasOwn(value, token), `${label} does not resolve`);
+    value = value[token];
+  }
+  return value;
+}
+
+function normalizeCommitVerification(value, sha) {
+  exactObject(value, ["verified", "reason", "verifiedAt"], [], `commit verification ${sha}`);
+  assert(value.verified === true, `delta commit ${sha} is not verified`);
+  assert(value.reason === "valid", `delta commit ${sha} verification reason is not valid`);
+  nonEmptyString(value.verifiedAt, `commit verification ${sha}.verifiedAt`);
+  assert(
+    !Number.isNaN(Date.parse(value.verifiedAt)),
+    `commit verification ${sha}.verifiedAt is invalid`,
+  );
+  return {
+    verified: true,
+    reason: "valid",
+    verifiedAt: value.verifiedAt,
+  };
+}
+
+function gatePlan(policy, changedPaths) {
+  return policy.gates.map((gate) => {
+    const impactedPaths = changedPaths.filter((filePath) => matchesAny(filePath, gate.impactPaths));
+    const changelogForcesFresh =
+      gate.kind === "root-package" && changedPaths.includes("CHANGELOG.md");
+    const mode =
+      gate.reuse === "never" || impactedPaths.length > 0 || changelogForcesFresh
+        ? "fresh"
+        : "reuse";
+    const reason =
+      mode === "reuse"
+        ? "No changed path matches this gate; source evidence is reused directly."
+        : changelogForcesFresh
+          ? "CHANGELOG.md is packed in the root npm artifact, so exact-target package proof is fresh."
+          : gate.reuse === "never"
+            ? "Policy requires exact-target evidence for this gate."
+            : `Changed paths require exact-target evidence: ${impactedPaths.join(", ")}`;
+    return {
+      id: gate.id,
+      mode,
+      impactedPaths,
+      reason,
+    };
+  });
+}
+
+export function computeReleaseDelta(cwd, policyInput, targetShaInput, branchTipShaInput) {
+  const policy = parseReleaseDeltaPolicy(policyInput);
+  const sourceSha = fullSha(policy.sourceSha, "source SHA");
+  const targetSha = fullSha(targetShaInput, "target SHA");
+  const branchTipSha = fullSha(branchTipShaInput, "target branch tip SHA");
+  assert(targetSha === branchTipSha, "target SHA is not the current target branch tip");
+  assert(
+    gitSucceeds(cwd, ["cat-file", "-e", `${sourceSha}^{commit}`]),
+    "source commit is unavailable",
+  );
+  assert(
+    gitSucceeds(cwd, ["cat-file", "-e", `${targetSha}^{commit}`]),
+    "target commit is unavailable",
+  );
+  assert(
+    gitSucceeds(cwd, ["merge-base", "--is-ancestor", sourceSha, targetSha]),
+    "source is not an ancestor of target",
+  );
+
+  const commitShas = git(cwd, ["rev-list", "--reverse", `${sourceSha}..${targetSha}`])
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  assert(commitShas.length > 0, "source and target must differ");
+  const commits = [];
+  let expectedParent = sourceSha;
+  for (const [index, commitSha] of commitShas.entries()) {
+    const [sha, parents, treeSha] = git(cwd, ["show", "-s", "--format=%H%x00%P%x00%T", commitSha])
+      .trimEnd()
+      .split("\0");
+    const parentShas = parents.split(" ").filter(Boolean);
+    assert(sha === commitSha, `delta commit ${index} identity changed`);
+    assert(parentShas.length === 1, `delta commit ${sha} is not linear`);
+    assert(
+      parentShas[0] === expectedParent,
+      `delta commit ${sha} does not follow the prior commit`,
+    );
+    const commitChangedPaths = nulList(
+      git(cwd, ["diff", "--name-only", "-z", "--no-renames", parentShas[0], sha], "buffer"),
+    ).toSorted();
+    assert(commitChangedPaths.length > 0, `delta commit ${sha} changes no paths`);
+    for (const filePath of commitChangedPaths) {
+      validateRepositoryPath(filePath, `delta commit ${sha} path`);
+      assert(
+        matchesAny(filePath, policy.allowedPaths),
+        `delta commit ${sha} changed a path not allowed by policy: ${filePath}`,
+      );
+    }
+    commits.push({
+      sha,
+      parentSha: parentShas[0],
+      treeSha: fullSha(treeSha, `tree ${sha}`),
+      changedPaths: commitChangedPaths,
+    });
+    expectedParent = sha;
+  }
+  assert(expectedParent === targetSha, "delta history does not terminate at target");
+
+  const changedPaths = nulList(
+    git(cwd, ["diff", "--name-only", "-z", "--no-renames", sourceSha, targetSha], "buffer"),
+  ).toSorted();
+  assert(changedPaths.length > 0, "delta contains no changed paths");
+  assert(new Set(changedPaths).size === changedPaths.length, "delta changed paths are duplicated");
+  for (const filePath of changedPaths) {
+    validateRepositoryPath(filePath, `changed path ${filePath}`);
+    assert(
+      matchesAny(filePath, policy.allowedPaths),
+      `changed path is not allowed by policy: ${filePath}`,
+    );
+  }
+  assert(
+    canonicalJson(changedPaths) === canonicalJson(["CHANGELOG.md"]),
+    "v1 supports only a CHANGELOG.md-only delta",
+  );
+
+  const sourceTreeSha = fullSha(
+    git(cwd, ["rev-parse", `${sourceSha}^{tree}`]).trim(),
+    "source tree SHA",
+  );
+  const targetTreeSha = fullSha(
+    git(cwd, ["rev-parse", `${targetSha}^{tree}`]).trim(),
+    "target tree SHA",
+  );
+  const sourceReusableTreeSha256 = filteredTreeHash(cwd, sourceSha, policy.metadataPaths);
+  const targetReusableTreeSha256 = filteredTreeHash(cwd, targetSha, policy.metadataPaths);
+  const gates = gatePlan(policy, changedPaths);
+  if (gates.some((gate) => gate.mode === "reuse")) {
+    assert(
+      sourceReusableTreeSha256 === targetReusableTreeSha256,
+      "reusable tree differs after metadata exclusions",
+    );
+  }
+  if (changedPaths.includes("CHANGELOG.md")) {
+    assert(
+      policy.gates.some((gate) => gate.kind === "root-package"),
+      "CHANGELOG.md changed without a root-package gate",
+    );
+  }
+
+  return {
+    source: {
+      sha: sourceSha,
+      treeSha: sourceTreeSha,
+      reusableTreeSha256: sourceReusableTreeSha256,
+    },
+    target: {
+      ref: policy.targetRef,
+      sha: targetSha,
+      treeSha: targetTreeSha,
+      reusableTreeSha256: targetReusableTreeSha256,
+    },
+    commits,
+    changedPaths,
+    diffSha256: hashBytes(
+      git(
+        cwd,
+        ["diff", "--binary", "--full-index", "--no-renames", "--no-ext-diff", sourceSha, targetSha],
+        "buffer",
+      ),
+    ),
+    metadataPaths: policy.metadataPaths,
+    gates,
+  };
+}
+
+function gateRunExpectation(gate, delta) {
+  if (gate.kind === "source-npm") {
+    return { headBranch: delta.target.ref, headSha: delta.source.sha };
+  }
+  if (gate.kind === "root-package") {
+    return { headBranch: delta.target.ref, headSha: delta.target.sha };
+  }
+  return { headBranch: "main", headSha: gate.workflowSha };
+}
+
+function normalizeRun(value, gate, repository, delta) {
+  exactObject(
+    value,
+    [
+      "id",
+      "runAttempt",
+      "name",
+      "path",
+      "event",
+      "headBranch",
+      "headRepository",
+      "headSha",
+      "url",
+      "status",
+      "conclusion",
+    ],
+    [],
+    `gate ${gate.id} run`,
+  );
+  assert(value.path === gate.workflowPath, `gate ${gate.id} run workflow differs from policy`);
+  assert(value.headRepository === repository, `gate ${gate.id} run head repository differs`);
+  const expected = gateRunExpectation(gate, delta);
+  assert(value.headSha === expected.headSha, `gate ${gate.id} run head SHA differs`);
+  assert(value.event === "workflow_dispatch", `gate ${gate.id} run event is not workflow_dispatch`);
+  assert(value.headBranch === expected.headBranch, `gate ${gate.id} run head branch differs`);
+  assert(
+    value.status === "completed" && value.conclusion === "success",
+    `gate ${gate.id} run is not successful`,
+  );
+  assert(value.runAttempt === 1, `gate ${gate.id} run attempt must be 1`);
+  return {
+    id: positiveInteger(value.id, `gate ${gate.id} run id`),
+    runAttempt: positiveInteger(value.runAttempt, `gate ${gate.id} run attempt`),
+    name: nonEmptyString(value.name, `gate ${gate.id} run name`),
+    path: value.path,
+    event: nonEmptyString(value.event, `gate ${gate.id} run event`),
+    headBranch: nonEmptyString(value.headBranch, `gate ${gate.id} run head branch`),
+    headRepository: value.headRepository,
+    headSha: fullSha(value.headSha, `gate ${gate.id} run head SHA`),
+    url: nonEmptyString(value.url, `gate ${gate.id} run URL`),
+    status: "completed",
+    conclusion: "success",
+  };
+}
+
+function normalizeJob(value, gate, run) {
+  exactObject(
+    value,
+    ["id", "runId", "runAttempt", "name", "headSha", "url", "status", "conclusion"],
+    [],
+    `gate ${gate.id} job`,
+  );
+  assert(
+    value.runId === run.id && value.runAttempt === run.runAttempt,
+    `gate ${gate.id} job run differs`,
+  );
+  assert(value.name === gate.jobName, `gate ${gate.id} job name differs from policy`);
+  assert(value.headSha === run.headSha, `gate ${gate.id} job head SHA differs`);
+  assert(
+    value.status === "completed" && value.conclusion === "success",
+    `gate ${gate.id} job is not successful`,
+  );
+  return {
+    id: positiveInteger(value.id, `gate ${gate.id} job id`),
+    runId: run.id,
+    runAttempt: run.runAttempt,
+    name: value.name,
+    headSha: fullSha(value.headSha, `gate ${gate.id} job head SHA`),
+    url: nonEmptyString(value.url, `gate ${gate.id} job URL`),
+    status: "completed",
+    conclusion: "success",
+  };
+}
+
+function normalizeNpmPreflightManifest(
+  document,
+  artifactPolicy,
+  files,
+  expectedSha,
+  release,
+  gate,
+) {
+  const label = `gate ${gate.id} npm preflight manifest`;
+  exactObject(
+    document,
+    [
+      "version",
+      "releaseTag",
+      "releaseSha",
+      "npmDistTag",
+      "packageName",
+      "packageVersion",
+      "tarballName",
+      "tarballSha256",
+      "dependencyTarballs",
+      "dependencyEvidenceDir",
+      "dependencyEvidenceManifest",
+    ],
+    [],
+    label,
+  );
+  assert(document.version === 1, `${label} version is invalid`);
+  assert(document.releaseTag === `v${release.version}`, `${label} release tag differs`);
+  assert(document.releaseSha === expectedSha, `${label} release SHA differs`);
+  assert(document.npmDistTag === release.channel, `${label} npm dist-tag differs`);
+  assert(document.packageName === "openclaw", `${label} root package name differs`);
+  assert(document.packageVersion === release.version, `${label} root package version differs`);
+  assert(
+    document.dependencyEvidenceDir === "dependency-evidence" &&
+      document.dependencyEvidenceManifest ===
+        "dependency-evidence/dependency-evidence-manifest.json",
+    `${label} dependency evidence paths differ`,
+  );
+  const rootTarballPath = validateRepositoryPath(document.tarballName, `${label}.tarballName`);
+  assert(
+    path.posix.basename(rootTarballPath) === rootTarballPath && rootTarballPath.endsWith(".tgz"),
+    `${label} root tarball name is invalid`,
+  );
+  sha256(document.tarballSha256, `${label}.tarballSha256`);
+  const rootTarballBytes = files.get(rootTarballPath);
+  assert(Buffer.isBuffer(rootTarballBytes), `${label} root tarball is missing`);
+  assert(
+    hashBytes(rootTarballBytes) === document.tarballSha256,
+    `${label} root tarball digest differs`,
+  );
+  assert(
+    Array.isArray(document.dependencyTarballs),
+    `${label}.dependencyTarballs must be an array`,
+  );
+  const dependencyTarballs = document.dependencyTarballs
+    .map((dependency, index) => {
+      const dependencyLabel = `${label}.dependencyTarballs[${index}]`;
+      exactObject(
+        dependency,
+        ["packageName", "packageVersion", "tarballName", "tarballSha256"],
+        [],
+        dependencyLabel,
+      );
+      const packageName = nonEmptyString(dependency.packageName, `${dependencyLabel}.packageName`);
+      assert(
+        packageName.startsWith("@openclaw/"),
+        `${dependencyLabel}.packageName must be an OpenClaw package`,
+      );
+      assert(
+        dependency.packageVersion === release.version,
+        `${dependencyLabel}.packageVersion differs`,
+      );
+      const tarballPath = validateRepositoryPath(
+        dependency.tarballName,
+        `${dependencyLabel}.tarballName`,
+      );
+      assert(
+        path.posix.basename(tarballPath) === tarballPath && tarballPath.endsWith(".tgz"),
+        `${dependencyLabel}.tarballName is invalid`,
+      );
+      sha256(dependency.tarballSha256, `${dependencyLabel}.tarballSha256`);
+      const bytes = files.get(tarballPath);
+      assert(Buffer.isBuffer(bytes), `${dependencyLabel} tarball is missing`);
+      assert(
+        hashBytes(bytes) === dependency.tarballSha256,
+        `${dependencyLabel} tarball digest differs`,
+      );
+      return {
+        packageName,
+        packageVersion: dependency.packageVersion,
+        path: tarballPath,
+        sha256: dependency.tarballSha256,
+        sizeBytes: bytes.byteLength,
+      };
+    })
+    .toSorted((left, right) =>
+      left.packageName < right.packageName ? -1 : left.packageName > right.packageName ? 1 : 0,
+    );
+  assert(
+    new Set(dependencyTarballs.map((entry) => entry.packageName)).size ===
+      dependencyTarballs.length,
+    `${label} dependency package names duplicate`,
+  );
+  assert(
+    new Set(dependencyTarballs.map((entry) => entry.path)).size === dependencyTarballs.length,
+    `${label} dependency tarball names duplicate`,
+  );
+  const declaredTarballPaths = [
+    rootTarballPath,
+    ...dependencyTarballs.map((entry) => entry.path),
+  ].toSorted(compareStrings);
+  const artifactTarballPaths = [...files.keys()]
+    .filter((memberPath) => memberPath.endsWith(".tgz"))
+    .toSorted(compareStrings);
+  assert(
+    canonicalJson(artifactTarballPaths) === canonicalJson(declaredTarballPaths),
+    `${label} does not cover the exact artifact tarball set`,
+  );
+  assert(
+    artifactPolicy.packageMembers.preflightManifest === artifactPolicy.binding.path,
+    `${label} policy binding differs`,
+  );
+  return {
+    version: 1,
+    releaseTag: document.releaseTag,
+    releaseSha: document.releaseSha,
+    npmDistTag: document.npmDistTag,
+    rootTarball: {
+      packageName: document.packageName,
+      packageVersion: document.packageVersion,
+      path: rootTarballPath,
+      sha256: document.tarballSha256,
+      sizeBytes: rootTarballBytes.byteLength,
+    },
+    dependencyTarballs,
+  };
+}
+
+function normalizeArtifact(value, artifactPolicy, gate, run, expectedSha, release) {
+  exactObject(value, ["key", "metadata", "archiveBytes", "files"], [], `gate ${gate.id} artifact`);
+  assert(value.key === artifactPolicy.key, `gate ${gate.id} artifact key differs from policy`);
+  exactObject(
+    value.metadata,
+    ["id", "name", "digest", "sizeBytes", "runId", "workflowSha"],
+    [],
+    `gate ${gate.id} artifact metadata`,
+  );
+  const digestMatch = DIGEST_RE.exec(value.metadata.digest);
+  assert(digestMatch, `gate ${gate.id} artifact digest is invalid`);
+  assert(
+    value.metadata.name === artifactPolicy.name,
+    `gate ${gate.id} artifact name differs from policy`,
+  );
+  assert(value.metadata.runId === run.id, `gate ${gate.id} artifact run differs`);
+  assert(
+    value.metadata.workflowSha === run.headSha,
+    `gate ${gate.id} artifact workflow SHA differs from run`,
+  );
+  assert(Buffer.isBuffer(value.archiveBytes), `gate ${gate.id} artifact archive must be bytes`);
+  const sizeBytes = positiveInteger(value.metadata.sizeBytes, `gate ${gate.id} artifact size`);
+  assert(
+    value.archiveBytes.byteLength === sizeBytes,
+    `gate ${gate.id} artifact archive size differs`,
+  );
+  assert(
+    hashBytes(value.archiveBytes) === digestMatch[1],
+    `gate ${gate.id} artifact digest differs`,
+  );
+  assert(value.files instanceof Map, `gate ${gate.id} artifact files must be a Map`);
+
+  const members = [...value.files.entries()]
+    .map(([memberPath, bytes]) => {
+      validateRepositoryPath(memberPath, `gate ${gate.id} artifact member`);
+      assert(Buffer.isBuffer(bytes), `gate ${gate.id} artifact member ${memberPath} must be bytes`);
+      return { path: memberPath, sizeBytes: bytes.byteLength, sha256: hashBytes(bytes) };
+    })
+    .toSorted((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  assert(members.length > 0, `gate ${gate.id} artifact is empty`);
+  assert(
+    new Set(members.map((member) => member.path)).size === members.length,
+    `gate ${gate.id} artifact members duplicate`,
+  );
+  assert(
+    canonicalJson(members.map((member) => member.path)) ===
+      canonicalJson(artifactPolicy.requiredMembers),
+    `gate ${gate.id} artifact inventory differs from policy`,
+  );
+
+  const bytes = value.files.get(artifactPolicy.binding.path);
+  const decoded = decodeUtf8(bytes, `gate ${gate.id} binding member`);
+  let document;
+  try {
+    document = JSON.parse(decoded);
+  } catch {
+    throw new Error(`gate ${gate.id} binding member is not valid JSON`);
+  }
+  const candidateSha = resolvePointer(
+    document,
+    artifactPolicy.binding.candidateShaPointer,
+    `gate ${gate.id} candidate SHA binding`,
+  );
+  assert(
+    candidateSha === expectedSha,
+    `gate ${gate.id} artifact is bound to the wrong candidate SHA`,
+  );
+  const binding = {
+    path: artifactPolicy.binding.path,
+    candidateSha: {
+      pointer: artifactPolicy.binding.candidateShaPointer,
+      value: candidateSha,
+    },
+    sha256: hashBytes(bytes),
+  };
+  const packageManifest = artifactPolicy.packageMembers
+    ? normalizeNpmPreflightManifest(
+        document,
+        artifactPolicy,
+        value.files,
+        expectedSha,
+        release,
+        gate,
+      )
+    : undefined;
+
+  return {
+    key: artifactPolicy.key,
+    id: positiveInteger(value.metadata.id, `gate ${gate.id} artifact id`),
+    name: value.metadata.name,
+    digest: value.metadata.digest,
+    sizeBytes,
+    workflowSha: fullSha(value.metadata.workflowSha, `gate ${gate.id} artifact workflow SHA`),
+    members,
+    binding,
+    ...(packageManifest ? { packageManifest } : {}),
+  };
+}
+
+function normalizeSourceFrv(value, gate, run, delta, repository, artifacts) {
+  assert(value && typeof value === "object", `gate ${gate.id} source FRV validation is missing`);
+  assert(
+    value.schema === "openclaw.release-validation-evidence/v3" && value.valid === true,
+    `gate ${gate.id} source FRV validation is not strict v3 evidence`,
+  );
+  assert(value.repository === repository, `gate ${gate.id} source FRV repository differs`);
+  assert(
+    value.producerOnTrustedMainLineage === true &&
+      value.directRoot === true &&
+      value.evidenceReuse === null,
+    `gate ${gate.id} source FRV is not a trusted direct root`,
+  );
+  assert(
+    value.rerunGroup === "all" && value.releaseProfile === "full" && value.runReleaseSoak === true,
+    `gate ${gate.id} source FRV coverage is not full`,
+  );
+  assert(
+    canonicalJson(value.validationInputs) === canonicalJson(gate.validationInputs),
+    `gate ${gate.id} source FRV validation inputs differ from policy`,
+  );
+  assert(
+    value.controls?.performanceBlocking === true &&
+      value.controls?.performanceReportPublication === "artifact-only",
+    `gate ${gate.id} source FRV performance controls are not blocking`,
+  );
+  assert(
+    value.conclusions?.current === "success" &&
+      value.conclusions?.root === "success" &&
+      value.conclusions?.allRequiredSucceeded === true,
+    `gate ${gate.id} source FRV conclusions are not successful`,
+  );
+  assert(value.root?.runId === run.id, `gate ${gate.id} source FRV run differs`);
+  assert(value.root?.runAttempt === run.runAttempt, `gate ${gate.id} source FRV attempt differs`);
+  assert(value.root?.targetSha === delta.source.sha, `gate ${gate.id} source FRV target differs`);
+  assert(value.root?.workflowSha === run.headSha, `gate ${gate.id} source FRV workflow differs`);
+  assert(
+    value.root?.status === "completed" && value.root?.conclusion === "success",
+    `gate ${gate.id} source FRV root is not successful`,
+  );
+  const artifact = value.root?.artifact;
+  const digestMatch = DIGEST_RE.exec(artifact?.digest ?? "");
+  assert(digestMatch, `gate ${gate.id} source FRV artifact digest is invalid`);
+  const normalizedArtifact = artifacts.find((entry) => entry.id === Number(artifact.id));
+  assert(
+    normalizedArtifact &&
+      normalizedArtifact.name === artifact.name &&
+      normalizedArtifact.digest === artifact.digest &&
+      normalizedArtifact.sizeBytes === artifact.sizeInBytes,
+    `gate ${gate.id} source FRV artifact differs from the strict validator`,
+  );
+  return {
+    schema: value.schema,
+    sha256: canonicalJsonSha256(value),
+    releaseProfile: value.releaseProfile,
+    runReleaseSoak: value.runReleaseSoak,
+    validationInputs: gate.validationInputs,
+    runId: run.id,
+    targetSha: delta.source.sha,
+    artifact: {
+      id: positiveInteger(Number(artifact.id), `gate ${gate.id} source FRV artifact id`),
+      name: nonEmptyString(artifact.name, `gate ${gate.id} source FRV artifact name`),
+      digest: artifact.digest,
+      sizeBytes: positiveInteger(artifact.sizeInBytes, `gate ${gate.id} source FRV artifact size`),
+    },
+    conclusion: "success",
+  };
+}
+
+function normalizeGateEvidence(gate, plan, value, delta, repository, release) {
+  exactObject(
+    value,
+    ["id", "run", "job", "artifacts"],
+    ["sourceValidation"],
+    `gate ${gate.id} evidence`,
+  );
+  assert(value.id === gate.id, `gate ${gate.id} evidence id differs`);
+  const run = normalizeRun(value.run, gate, repository, delta);
+  const job = normalizeJob(value.job, gate, run);
+  assert(Array.isArray(value.artifacts), `gate ${gate.id} artifacts must be an array`);
+  assert(
+    value.artifacts.length === gate.artifacts.length,
+    `gate ${gate.id} artifact count differs`,
+  );
+  const artifactsByKey = new Map(value.artifacts.map((artifact) => [artifact.key, artifact]));
+  assert(artifactsByKey.size === value.artifacts.length, `gate ${gate.id} artifact keys duplicate`);
+  const expectedSha = plan.mode === "fresh" ? delta.target.sha : delta.source.sha;
+  const artifacts = gate.artifacts.map((artifactPolicy) =>
+    normalizeArtifact(
+      artifactsByKey.get(artifactPolicy.key),
+      artifactPolicy,
+      gate,
+      run,
+      expectedSha,
+      release,
+    ),
+  );
+  const candidateBound = artifacts.every(
+    (artifact) => artifact.binding.candidateSha.value === expectedSha,
+  );
+  assert(candidateBound, `gate ${gate.id} evidence does not bind the ${plan.mode} candidate SHA`);
+  const sourceValidation =
+    gate.kind === "source-frv"
+      ? normalizeSourceFrv(value.sourceValidation, gate, run, delta, repository, artifacts)
+      : undefined;
+  assert(
+    gate.kind === "source-frv" || value.sourceValidation === undefined,
+    `gate ${gate.id} must not include source FRV validation`,
+  );
+  return {
+    id: gate.id,
+    mode: plan.mode,
+    impactedPaths: plan.impactedPaths,
+    rationale: plan.reason,
+    run,
+    job,
+    artifacts,
+    ...(sourceValidation ? { sourceValidation } : {}),
+    conclusion: "success",
+  };
+}
+
+function packageEvidenceForGate(policyGate, manifestGate) {
+  const artifactPolicy = policyGate.artifacts.find((artifact) => artifact.packageMembers);
+  const artifact = manifestGate.artifacts.find((entry) => entry.key === artifactPolicy.key);
+  assert(artifact.packageManifest, `gate ${manifestGate.id} package manifest is missing`);
+  return {
+    gateId: manifestGate.id,
+    mode: manifestGate.mode,
+    artifact: {
+      id: artifact.id,
+      name: artifact.name,
+      digest: artifact.digest,
+    },
+    releaseTag: artifact.packageManifest.releaseTag,
+    releaseSha: artifact.packageManifest.releaseSha,
+    npmDistTag: artifact.packageManifest.npmDistTag,
+    rootTarball: artifact.packageManifest.rootTarball,
+    dependencyTarballs: artifact.packageManifest.dependencyTarballs,
+  };
+}
+
+function buildPackageEvidence(policy, gates) {
+  const gateById = new Map(gates.map((gate) => [gate.id, gate]));
+  const sourcePolicy = policy.gates.find((gate) => gate.kind === "source-npm");
+  const targetPolicy = policy.gates.find((gate) => gate.kind === "root-package");
+  const source = packageEvidenceForGate(sourcePolicy, gateById.get(sourcePolicy.id));
+  const target = packageEvidenceForGate(targetPolicy, gateById.get(targetPolicy.id));
+  assert(source.mode === "reuse", "source npm package gate must reuse source evidence");
+  assert(target.mode === "fresh", "target root package gate must use fresh evidence");
+  assert(
+    source.releaseTag === target.releaseTag && source.npmDistTag === target.npmDistTag,
+    "source and target npm release selectors differ",
+  );
+  assert(
+    source.releaseSha !== target.releaseSha,
+    "source and target npm evidence SHAs must differ",
+  );
+  assert(
+    source.rootTarball.packageName === target.rootTarball.packageName &&
+      source.rootTarball.packageVersion === target.rootTarball.packageVersion &&
+      source.rootTarball.path === target.rootTarball.path,
+    "source and target root tarball identities differ",
+  );
+  assert(
+    source.dependencyTarballs.length === target.dependencyTarballs.length,
+    "source and target dependency tarball counts differ",
+  );
+  const dependencyTarballs = source.dependencyTarballs.map((sourceMember, index) => {
+    const targetMember = target.dependencyTarballs[index];
+    assert(
+      sourceMember.packageName === targetMember.packageName &&
+        sourceMember.packageVersion === targetMember.packageVersion &&
+        sourceMember.path === targetMember.path &&
+        sourceMember.sha256 === targetMember.sha256 &&
+        sourceMember.sizeBytes === targetMember.sizeBytes,
+      `dependency tarball differs across the changelog delta: ${sourceMember.packageName}`,
+    );
+    return {
+      packageName: sourceMember.packageName,
+      packageVersion: sourceMember.packageVersion,
+      path: sourceMember.path,
+      sha256: sourceMember.sha256,
+      sizeBytes: sourceMember.sizeBytes,
+    };
+  });
+  return {
+    releaseTag: source.releaseTag,
+    npmDistTag: source.npmDistTag,
+    sourceReleaseSha: source.releaseSha,
+    targetReleaseSha: target.releaseSha,
+    sourceGate: source.gateId,
+    targetGate: target.gateId,
+    sourceArtifact: source.artifact,
+    targetArtifact: target.artifact,
+    sourceRootTarball: source.rootTarball,
+    targetRootTarball: target.rootTarball,
+    rawRootTarballEqual:
+      source.rootTarball.sha256 === target.rootTarball.sha256 &&
+      source.rootTarball.sizeBytes === target.rootTarball.sizeBytes,
+    dependencyTarballs,
+  };
+}
+
+function normalizeProducer(value, workflowSha, targetSha) {
+  exactObject(
+    value,
+    ["workflowPath", "workflowSha", "workflowRef", "runId", "runAttempt", "artifactName"],
+    [],
+    "producer",
+  );
+  assert(
+    value.workflowPath === ".github/workflows/release-delta-evidence.yml",
+    "producer workflow path is invalid",
+  );
+  assert(value.workflowSha === workflowSha, "producer workflow SHA differs");
+  assert(value.workflowRef === "refs/heads/main", "producer workflow ref must be main");
+  assert(value.runAttempt === 1, "producer must be workflow run attempt 1");
+  const runId = positiveInteger(value.runId, "producer run id");
+  assert(
+    value.artifactName === `release-delta-evidence-${targetSha}-${runId}-1`,
+    "producer artifact name differs",
+  );
+  return {
+    workflowPath: value.workflowPath,
+    workflowSha: fullSha(value.workflowSha, "producer workflow SHA"),
+    workflowRef: value.workflowRef,
+    runId,
+    runAttempt: 1,
+    artifactName: value.artifactName,
+  };
+}
+
+function validateGateWorkflowTrust(cwd, policy, delta, producerWorkflowSha) {
+  assert(
+    gitSucceeds(cwd, ["cat-file", "-e", `${producerWorkflowSha}^{commit}`]),
+    "producer workflow commit is unavailable",
+  );
+  for (const gate of policy.gates) {
+    assert(
+      gitSucceeds(cwd, ["cat-file", "-e", `${gate.workflowSha}^{commit}`]),
+      `gate ${gate.id} workflow commit is unavailable`,
+    );
+    assert(
+      gitSucceeds(cwd, ["cat-file", "-e", `${gate.workflowSha}:${gate.workflowPath}`]),
+      `gate ${gate.id} workflow file is unavailable at its workflow SHA`,
+    );
+    if (gate.kind === "source-npm") {
+      assert(
+        gate.workflowSha === delta.source.sha,
+        `gate ${gate.id} must execute from the source release candidate`,
+      );
+      continue;
+    }
+    if (gate.kind === "root-package") {
+      assert(
+        gate.workflowSha === delta.target.sha,
+        `gate ${gate.id} must execute from the target release candidate`,
+      );
+      continue;
+    }
+    assert(
+      gitSucceeds(cwd, ["merge-base", "--is-ancestor", gate.workflowSha, producerWorkflowSha]),
+      `gate ${gate.id} workflow SHA is not on trusted main lineage`,
+    );
+  }
+}
+
+export function createReleaseDeltaManifest(options) {
+  const policy = parseReleaseDeltaPolicy(options.policy);
+  const repository = nonEmptyString(options.repository, "repository");
+  validateReleaseDeltaPolicyPath(options.policyPath);
+  const policyBytes = Buffer.isBuffer(options.policyBytes)
+    ? options.policyBytes
+    : Buffer.from(options.policyBytes);
+  assert(
+    canonicalJson(parseReleaseDeltaPolicy(policyBytes)) === canonicalJson(policy),
+    "policy input differs from the trusted policy bytes",
+  );
+  const policyBlobBytes = git(
+    options.cwd,
+    ["show", `${fullSha(options.workflowSha, "workflow SHA")}:${options.policyPath}`],
+    "buffer",
+  );
+  assert(
+    policyBlobBytes.equals(policyBytes),
+    "policy bytes differ from the trusted workflow commit",
+  );
+  const policyBlobSha = fullSha(
+    git(options.cwd, ["rev-parse", `${options.workflowSha}:${options.policyPath}`]).trim(),
+    "policy blob SHA",
+  );
+  const delta = computeReleaseDelta(options.cwd, policy, options.targetSha, options.branchTipSha);
+  const producer = normalizeProducer(options.producer, options.workflowSha, delta.target.sha);
+  validateGateWorkflowTrust(options.cwd, policy, delta, producer.workflowSha);
+  const verificationBySha = new Map(
+    options.commitVerifications.map((entry) => [entry.sha, entry.verification]),
+  );
+  assert(
+    verificationBySha.size === options.commitVerifications.length,
+    "commit verifications duplicate",
+  );
+  const commits = delta.commits.map((commit) => ({
+    ...commit,
+    verification: normalizeCommitVerification(verificationBySha.get(commit.sha), commit.sha),
+  }));
+  assert(Array.isArray(options.evidence), "evidence must be an array");
+  const evidenceById = new Map(options.evidence.map((entry) => [entry.id, entry]));
+  assert(evidenceById.size === options.evidence.length, "evidence gate ids duplicate");
+  const planById = new Map(delta.gates.map((entry) => [entry.id, entry]));
+  const gates = policy.gates.map((gate) =>
+    normalizeGateEvidence(
+      gate,
+      planById.get(gate.id),
+      evidenceById.get(gate.id),
+      delta,
+      repository,
+      policy.release,
+    ),
+  );
+  assert(evidenceById.size === gates.length, "evidence includes unknown gates");
+
+  const reused = gates.filter((gate) => gate.mode === "reuse").map((gate) => gate.id);
+  const fresh = gates.filter((gate) => gate.mode === "fresh").map((gate) => gate.id);
+  return {
+    schema: RELEASE_DELTA_MANIFEST_SCHEMA,
+    mode: "changelog-only-v1",
+    repository,
+    release: policy.release,
+    producer,
+    policy: {
+      path: options.policyPath,
+      blobSha: policyBlobSha,
+      sha256: hashBytes(policyBytes),
+      schema: policy.schema,
+    },
+    workflowSha: fullSha(options.workflowSha, "workflow SHA"),
+    source: delta.source,
+    target: delta.target,
+    commits,
+    changedPaths: delta.changedPaths,
+    diffSha256: delta.diffSha256,
+    metadataPaths: delta.metadataPaths,
+    gates,
+    packageEvidence: buildPackageEvidence(policy, gates),
+    coverage: {
+      reused,
+      fresh,
+      changedPathCount: delta.changedPaths.length,
+      gateCount: gates.length,
+    },
+    conclusion: "success",
+    rationale:
+      reused.length > 0
+        ? `Reused ${reused.length} unaffected gate(s); ran ${fresh.length} exact-target gate(s).`
+        : `All ${fresh.length} gate(s) require exact-target evidence.`,
+    publicationPerformed: false,
+  };
+}
+
+export function validateReleaseDeltaManifest(manifest, options) {
+  assert(manifest?.schema === RELEASE_DELTA_MANIFEST_SCHEMA, "manifest schema is invalid");
+  assert(manifest.publicationPerformed === false, "delta evidence must not authorize publication");
+  const expected = createReleaseDeltaManifest(options);
+  assert(
+    canonicalJson(manifest) === canonicalJson(expected),
+    "manifest differs from current evidence",
+  );
+  return {
+    valid: true,
+    manifestSha256: canonicalJsonSha256(manifest),
+    sourceSha: manifest.source.sha,
+    targetSha: manifest.target.sha,
+    conclusion: manifest.conclusion,
+    publicationPerformed: false,
+  };
+}
+
+export function readReleaseDeltaPolicy(policyPath) {
+  validateReleaseDeltaPolicyPath(policyPath);
+  const bytes = readFileSync(policyPath);
+  return { bytes, policy: parseReleaseDeltaPolicy(bytes) };
+}
+
+export function evidenceBindingsFromManifest(manifest) {
+  assert(manifest?.schema === RELEASE_DELTA_MANIFEST_SCHEMA, "manifest schema is invalid");
+  return Object.fromEntries(
+    manifest.gates.map((gate) => [
+      gate.id,
+      {
+        runId: gate.run.id,
+        runAttempt: gate.run.runAttempt,
+        jobId: gate.job.id,
+        artifacts: Object.fromEntries(
+          gate.artifacts.map((artifact) => [artifact.key, artifact.id]),
+        ),
+      },
+    ]),
+  );
+}

--- a/scripts/release-delta-evidence.mjs
+++ b/scripts/release-delta-evidence.mjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { canonicalJson } from "./lib/canonical-json.mjs";
+import { execPlainGh } from "./lib/plain-gh.mjs";
+import {
+  computeReleaseDelta,
+  createReleaseDeltaManifest,
+  evidenceBindingsFromManifest,
+  parseReleaseDeltaPolicy,
+  validateReleaseDeltaManifest,
+} from "./lib/release-delta-evidence.mjs";
+
+const MAX_ARTIFACT_ARCHIVE_BYTES = 256 * 1024 * 1024;
+const MAX_ARTIFACT_EXPANDED_BYTES = 512 * 1024 * 1024;
+const MAX_ARTIFACT_MEMBER_BYTES = 256 * 1024 * 1024;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    fail(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function firstRunAttempt(value, label) {
+  const runAttempt = positiveInteger(value, label);
+  if (runAttempt !== 1) {
+    fail(`${label} must be 1`);
+  }
+  return runAttempt;
+}
+
+function isErrorWithCode(error, code) {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+function parseOptions(argv) {
+  const command = argv.shift();
+  if (!["create", "verify"].includes(command)) {
+    fail("expected create or verify");
+  }
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      repo: { type: "string" },
+      policy: { type: "string" },
+      "target-sha": { type: "string" },
+      "workflow-sha": { type: "string" },
+      "producer-run-id": { type: "string" },
+      "producer-run-attempt": { type: "string" },
+      "producer-workflow-path": { type: "string" },
+      "producer-workflow-ref": { type: "string" },
+      "producer-artifact-name": { type: "string" },
+      "evidence-runs": { type: "string" },
+      manifest: { type: "string" },
+      output: { type: "string" },
+      "github-output": { type: "string" },
+    },
+    strict: true,
+  });
+  for (const key of [
+    "repo",
+    "policy",
+    "target-sha",
+    "workflow-sha",
+    "producer-run-id",
+    "producer-run-attempt",
+    "producer-workflow-path",
+    "producer-workflow-ref",
+    "producer-artifact-name",
+  ]) {
+    if (!values[key]) {
+      fail(`--${key} is required`);
+    }
+  }
+  if (command === "create" && (!values["evidence-runs"] || !values.output)) {
+    fail("create requires --evidence-runs and --output");
+  }
+  if (command === "verify" && !values.manifest) {
+    fail("verify requires --manifest");
+  }
+  return {
+    command,
+    repo: values.repo,
+    policyPath: values.policy,
+    targetSha: values["target-sha"],
+    workflowSha: values["workflow-sha"],
+    producer: {
+      workflowPath: values["producer-workflow-path"],
+      workflowSha: values["workflow-sha"],
+      workflowRef: values["producer-workflow-ref"],
+      runId: positiveInteger(values["producer-run-id"], "producer run id"),
+      runAttempt: positiveInteger(values["producer-run-attempt"], "producer run attempt"),
+      artifactName: values["producer-artifact-name"],
+    },
+    evidenceRunsPath: values["evidence-runs"],
+    manifestPath: values.manifest,
+    outputPath: values.output,
+    githubOutputPath: values["github-output"],
+  };
+}
+
+function githubApi(apiPath) {
+  return JSON.parse(
+    execPlainGh(["api", apiPath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    }),
+  );
+}
+
+function branchTipSha(repo, targetRef, api) {
+  const ref = api(`repos/${repo}/git/ref/heads/${targetRef}`);
+  if (ref?.object?.type !== "commit" || typeof ref.object.sha !== "string") {
+    fail(`target branch ref is invalid: ${targetRef}`);
+  }
+  return ref.object.sha;
+}
+
+function commitVerifications(repo, delta, api) {
+  return delta.commits.map((commit) => {
+    const response = api(`repos/${repo}/commits/${commit.sha}`);
+    if (response?.sha !== commit.sha) {
+      fail(`commit API identity differs for ${commit.sha}`);
+    }
+    const verification = response?.commit?.verification;
+    return {
+      sha: commit.sha,
+      verification: {
+        verified: verification?.verified,
+        reason: verification?.reason,
+        verifiedAt: verification?.verified_at,
+      },
+    };
+  });
+}
+
+function exactKeys(value, required, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const expected = required.toSorted();
+  const actual = Object.keys(value).toSorted();
+  if (canonicalJson(expected) !== canonicalJson(actual)) {
+    fail(`${label} keys must be exactly: ${expected.join(", ")}`);
+  }
+}
+
+function parseEvidenceBindings(input, policy) {
+  const value = typeof input === "string" || Buffer.isBuffer(input) ? JSON.parse(input) : input;
+  exactKeys(
+    value,
+    policy.gates.map((gate) => gate.id),
+    "evidence runs",
+  );
+  return Object.fromEntries(
+    policy.gates.map((gate) => {
+      const binding = value[gate.id];
+      exactKeys(binding, ["runId", "runAttempt", "jobId", "artifacts"], `evidence runs.${gate.id}`);
+      exactKeys(
+        binding.artifacts,
+        gate.artifacts.map((artifact) => artifact.key),
+        `evidence runs.${gate.id}.artifacts`,
+      );
+      return [
+        gate.id,
+        {
+          runId: positiveInteger(binding.runId, `${gate.id} run id`),
+          runAttempt: firstRunAttempt(binding.runAttempt, `${gate.id} run attempt`),
+          jobId: positiveInteger(binding.jobId, `${gate.id} job id`),
+          artifacts: Object.fromEntries(
+            gate.artifacts.map((artifact) => [
+              artifact.key,
+              positiveInteger(
+                binding.artifacts[artifact.key],
+                `${gate.id} ${artifact.key} artifact id`,
+              ),
+            ]),
+          ),
+        },
+      ];
+    }),
+  );
+}
+
+function normalizeRun(response) {
+  return {
+    id: response.id,
+    runAttempt: response.run_attempt,
+    name: response.name,
+    path: response.path,
+    event: response.event,
+    headBranch: response.head_branch,
+    headRepository: response.head_repository?.full_name,
+    headSha: response.head_sha,
+    url: response.html_url,
+    status: response.status,
+    conclusion: response.conclusion,
+  };
+}
+
+function normalizeJob(response) {
+  return {
+    id: response.id,
+    runId: response.run_id,
+    runAttempt: response.run_attempt,
+    name: response.name,
+    headSha: response.head_sha,
+    url: response.html_url,
+    status: response.status,
+    conclusion: response.conclusion,
+  };
+}
+
+function normalizeArtifactMetadata(response) {
+  if (response.expired !== false) {
+    fail("Actions artifact is expired");
+  }
+  return {
+    id: response.id,
+    name: response.name,
+    digest: response.digest,
+    sizeBytes: response.size_in_bytes,
+    runId: response.workflow_run?.id,
+    workflowSha: response.workflow_run?.head_sha,
+  };
+}
+
+function validateSourceFrv({ cwd, repo, runId }) {
+  const script = path.join(
+    cwd,
+    ".agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs",
+  );
+  return JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        script,
+        "--validate-run",
+        String(runId),
+        "--repo",
+        repo,
+        "--trusted-workflow-ref",
+        "main",
+        "--json",
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "inherit"],
+      },
+    ),
+  );
+}
+
+async function loadProductionArtifactReader() {
+  try {
+    const module = await import("./lib/actions-artifact-archive.mjs");
+    if (typeof module.readPublicationArtifactArchive === "function") {
+      return module.readPublicationArtifactArchive;
+    }
+  } catch (/** @type {unknown} */ error) {
+    if (!isErrorWithCode(error, "ERR_MODULE_NOT_FOUND")) {
+      throw error;
+    }
+  }
+  throw new Error(
+    "release delta artifact adapter is pending scripts/lib/actions-artifact-archive.mjs from #103809",
+  );
+}
+
+function gateRunExpectation(gate, delta) {
+  if (gate.kind === "source-npm") {
+    return { headBranch: delta.target.ref, headSha: delta.source.sha };
+  }
+  if (gate.kind === "root-package") {
+    return { headBranch: delta.target.ref, headSha: delta.target.sha };
+  }
+  return { headBranch: "main", headSha: gate.workflowSha };
+}
+
+async function collectGateEvidence({
+  cwd,
+  repo,
+  policy,
+  delta,
+  bindings,
+  api,
+  artifactReader,
+  token,
+  sourceFrvValidator,
+}) {
+  const readArtifact = artifactReader ?? (await loadProductionArtifactReader());
+  if (typeof token !== "string" || token.trim() === "") {
+    fail("GH_TOKEN is required to read immutable Actions artifacts");
+  }
+  const evidence = [];
+  for (const gate of policy.gates) {
+    const binding = bindings[gate.id];
+    const runResponse = await api(`repos/${repo}/actions/runs/${binding.runId}`);
+    if (runResponse.run_attempt !== binding.runAttempt) {
+      fail(`gate ${gate.id} run attempt differs from the requested tuple`);
+    }
+    const jobResponse = await api(`repos/${repo}/actions/jobs/${binding.jobId}`);
+    const run = normalizeRun(runResponse);
+    const job = normalizeJob(jobResponse);
+    const artifacts = [];
+    for (const artifactPolicy of gate.artifacts) {
+      const runExpectation = gateRunExpectation(gate, delta);
+      const artifactId = binding.artifacts[artifactPolicy.key];
+      const artifactResponse = await api(`repos/${repo}/actions/artifacts/${artifactId}`);
+      const metadata = normalizeArtifactMetadata(artifactResponse);
+      const expected = {
+        repository: repo,
+        artifactId,
+        artifactName: artifactPolicy.name,
+        artifactDigest: artifactResponse.digest,
+        artifactSizeBytes: artifactResponse.size_in_bytes,
+        runId: binding.runId,
+        runAttempt: binding.runAttempt,
+        workflowSha: runExpectation.headSha,
+        workflowPath: gate.workflowPath,
+        workflowEvent: "workflow_dispatch",
+        workflowHeadBranch: runExpectation.headBranch,
+        runStatePolicy: "completed-success",
+      };
+      const archive = await readArtifact({
+        token,
+        expected,
+        maxArchiveBytes: MAX_ARTIFACT_ARCHIVE_BYTES,
+        archivePolicy: {
+          expectedEntries: artifactPolicy.requiredMembers,
+          maxArchiveBytes: MAX_ARTIFACT_ARCHIVE_BYTES,
+          maxExpandedBytes: MAX_ARTIFACT_EXPANDED_BYTES,
+          maxCompressedEntryBytes: () => MAX_ARTIFACT_MEMBER_BYTES,
+          maxEntryBytes: () => MAX_ARTIFACT_MEMBER_BYTES,
+        },
+      });
+      if (
+        !Buffer.isBuffer(archive?.archiveBytes) ||
+        !(archive.files instanceof Map) ||
+        canonicalJson(archive.binding) !==
+          canonicalJson({
+            ...expected,
+            workflowStatus: "completed",
+            workflowConclusion: "success",
+          }) ||
+        archive.artifactMetadata?.id !== artifactId ||
+        archive.artifactMetadata?.name !== artifactPolicy.name ||
+        archive.artifactMetadata?.digest !== artifactResponse.digest ||
+        archive.artifactMetadata?.size_in_bytes !== artifactResponse.size_in_bytes ||
+        archive.workflowRun?.id !== binding.runId ||
+        archive.workflowRun?.run_attempt !== binding.runAttempt
+      ) {
+        fail(`artifact reader returned invalid evidence for ${gate.id}/${artifactPolicy.key}`);
+      }
+      artifacts.push({
+        key: artifactPolicy.key,
+        metadata,
+        archiveBytes: archive.archiveBytes,
+        files: archive.files,
+      });
+    }
+    evidence.push({
+      id: gate.id,
+      run,
+      job,
+      artifacts,
+      ...(gate.kind === "source-frv"
+        ? {
+            sourceValidation: await (sourceFrvValidator ?? validateSourceFrv)({
+              cwd,
+              repo,
+              runId: binding.runId,
+            }),
+          }
+        : {}),
+    });
+  }
+  return evidence;
+}
+
+async function assembleInputs(options, overrides, bindings) {
+  const api = overrides.api ?? githubApi;
+  const cwd = overrides.cwd ?? process.cwd();
+  const policyBytes = readFileSync(path.resolve(cwd, options.policyPath));
+  const policy = parseReleaseDeltaPolicy(policyBytes);
+  const tipSha = branchTipSha(options.repo, policy.targetRef, api);
+  const delta = computeReleaseDelta(cwd, policy, options.targetSha, tipSha);
+  const verifications = commitVerifications(options.repo, delta, api);
+  const evidence = await collectGateEvidence({
+    cwd,
+    repo: options.repo,
+    policy,
+    delta,
+    bindings,
+    api,
+    artifactReader: overrides.artifactReader,
+    token: overrides.token ?? process.env.GH_TOKEN,
+    sourceFrvValidator: overrides.sourceFrvValidator,
+  });
+  return {
+    cwd,
+    repository: options.repo,
+    policy,
+    policyBytes,
+    policyPath: options.policyPath,
+    workflowSha: options.workflowSha,
+    producer: options.producer,
+    targetSha: options.targetSha,
+    branchTipSha: tipSha,
+    commitVerifications: verifications,
+    evidence,
+  };
+}
+
+function writeGithubOutput(filePath, result) {
+  if (!filePath) {
+    return;
+  }
+  writeFileSync(
+    filePath,
+    [
+      `manifest_sha256=${result.manifestSha256}`,
+      `source_sha=${result.sourceSha}`,
+      `target_sha=${result.targetSha}`,
+      `conclusion=${result.conclusion}`,
+      "publication_performed=false",
+      "",
+    ].join("\n"),
+    { flag: "a" },
+  );
+}
+
+export async function runReleaseDeltaEvidence(argv, overrides = {}) {
+  const options = parseOptions([...argv]);
+  const cwd = overrides.cwd ?? process.cwd();
+  const policy = parseReleaseDeltaPolicy(readFileSync(path.resolve(cwd, options.policyPath)));
+  if (options.command === "create") {
+    const bindings = parseEvidenceBindings(readFileSync(options.evidenceRunsPath), policy);
+    const inputs = await assembleInputs(options, overrides, bindings);
+    const manifest = createReleaseDeltaManifest(inputs);
+    writeFileSync(options.outputPath, canonicalJson(manifest));
+    const result = validateReleaseDeltaManifest(manifest, inputs);
+    writeGithubOutput(options.githubOutputPath, result);
+    return result;
+  }
+
+  const manifest = JSON.parse(readFileSync(options.manifestPath, "utf8"));
+  const bindings = parseEvidenceBindings(evidenceBindingsFromManifest(manifest), policy);
+  const inputs = await assembleInputs(options, overrides, bindings);
+  const result = validateReleaseDeltaManifest(manifest, inputs);
+  writeGithubOutput(options.githubOutputPath, result);
+  return result;
+}
+
+export async function main(argv = process.argv.slice(2), overrides = {}) {
+  const result = await runReleaseDeltaEvidence(argv, overrides);
+  process.stdout.write(`${canonicalJson(result)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((/** @type {unknown} */ error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/scripts/release-delta-evidence.test.ts
+++ b/test/scripts/release-delta-evidence.test.ts
@@ -1,0 +1,901 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { canonicalJson } from "../../scripts/lib/canonical-json.mjs";
+import {
+  computeReleaseDelta,
+  createReleaseDeltaManifest,
+  parseReleaseDeltaPolicy,
+  validateReleaseDeltaManifest,
+} from "../../scripts/lib/release-delta-evidence.mjs";
+import { runReleaseDeltaEvidence } from "../../scripts/release-delta-evidence.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const POLICY_PATH = ".github/release-delta-policies/test.json";
+const REPOSITORY = "openclaw/openclaw";
+const VERSION = "2026.7.1-beta.3";
+const TARGET_REF = "release/2026.7.1";
+const VALIDATION_INPUTS = {
+  provider: "openai",
+  mode: "both",
+  liveSuiteFilter: "",
+  crossOsSuiteFilter: "",
+  releasePackageSpec: "",
+  packageAcceptancePackageSpec: "",
+  codexPluginSpec: "",
+};
+const roots = useAutoCleanupTempDirTracker(afterEach);
+
+const sha256 = (value: Uint8Array | string) => createHash("sha256").update(value).digest("hex");
+
+type WorkflowStep = {
+  name?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+};
+
+type Workflow = {
+  jobs: {
+    produce: {
+      steps: WorkflowStep[];
+    };
+  };
+};
+
+function git(cwd: string, args: string[]) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function write(root: string, filePath: string, value: string | Buffer) {
+  const destination = path.join(root, filePath);
+  mkdirSync(path.dirname(destination), { recursive: true });
+  writeFileSync(destination, value);
+}
+
+type GateFixture = {
+  id: string;
+  kind: "generic" | "source-frv" | "source-npm" | "root-package";
+  reuse: "never" | "when-unimpacted";
+  workflowPath: string;
+  workflowSha: string;
+  jobName: string;
+  impactPaths: string[];
+  validationInputs?: typeof VALIDATION_INPUTS;
+  artifacts: Array<{
+    key: string;
+    name: string;
+    requiredMembers: string[];
+    binding: { path: string; candidateShaPointer: string };
+    packageMembers?: { preflightManifest: string };
+  }>;
+};
+
+function gate(
+  id: string,
+  kind: GateFixture["kind"],
+  workflowSha: string,
+  overrides: Partial<GateFixture> = {},
+): GateFixture {
+  return {
+    id,
+    kind,
+    reuse: "when-unimpacted",
+    workflowPath: `.github/workflows/${id}.yml`,
+    workflowSha,
+    jobName: `${id} proof`,
+    impactPaths: ["src/**"],
+    artifacts: [
+      {
+        key: "evidence",
+        name: `${id}-evidence`,
+        requiredMembers: ["binding.json"],
+        binding: { path: "binding.json", candidateShaPointer: "/targetSha" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function packageGate(
+  id: string,
+  kind: "source-npm" | "root-package",
+  workflowSha: string,
+): GateFixture {
+  return gate(id, kind, workflowSha, {
+    artifacts: [
+      {
+        key: "package",
+        name: `${id}-package`,
+        requiredMembers: ["openclaw.tgz", "openclaw-ai.tgz", "preflight-manifest.json"],
+        binding: {
+          path: "preflight-manifest.json",
+          candidateShaPointer: "/releaseSha",
+        },
+        packageMembers: {
+          preflightManifest: "preflight-manifest.json",
+        },
+      },
+    ],
+  });
+}
+
+function createFixture() {
+  const root = roots.make("openclaw-release-delta-");
+  git(root, ["init", "-b", "main"]);
+  git(root, ["config", "user.name", "Release Test"]);
+  git(root, ["config", "user.email", "release@example.com"]);
+  write(root, "src/index.ts", "export const value = 1;\n");
+  write(root, "package.json", `${JSON.stringify({ name: "openclaw", version: VERSION })}\n`);
+  write(root, "CHANGELOG.md", "# Changelog\n\n## 2026.7.1\n\n- source\n");
+  for (const workflow of [
+    "full-release-validation.yml",
+    "source-npm.yml",
+    "target-npm.yml",
+    "release-notes.yml",
+  ]) {
+    write(root, `.github/workflows/${workflow}`, `name: ${workflow}\n`);
+  }
+  git(root, ["add", "."]);
+  git(root, ["commit", "-m", "test: source"]);
+  const sourceSha = git(root, ["rev-parse", "HEAD"]);
+  const evidenceWorkflowSha = sourceSha;
+
+  git(root, ["switch", "-c", TARGET_REF]);
+  write(root, "CHANGELOG.md", "# Changelog\n\n## 2026.7.1\n\n- target\n");
+  git(root, ["add", "CHANGELOG.md"]);
+  git(root, ["commit", "-m", "docs: finalize release notes"]);
+  const targetSha = git(root, ["rev-parse", "HEAD"]);
+
+  git(root, ["switch", "main"]);
+  const gates = [
+    gate("source-frv", "source-frv", evidenceWorkflowSha, {
+      workflowPath: ".github/workflows/full-release-validation.yml",
+      jobName: "Verify full validation",
+      validationInputs: VALIDATION_INPUTS,
+    }),
+    packageGate("source-npm", "source-npm", evidenceWorkflowSha),
+    packageGate("target-npm", "root-package", targetSha),
+    gate("release-notes", "generic", evidenceWorkflowSha, {
+      reuse: "never",
+      impactPaths: [],
+    }),
+  ];
+  const policy = {
+    schema: "openclaw.release-delta-policy/v1",
+    release: { version: VERSION, channel: "beta" },
+    targetRef: TARGET_REF,
+    sourceSha,
+    allowedPaths: ["CHANGELOG.md"],
+    metadataPaths: ["CHANGELOG.md"],
+    gates,
+  };
+  write(root, POLICY_PATH, `${canonicalJson(policy)}\n`);
+  git(root, ["add", POLICY_PATH]);
+  git(root, ["commit", "-m", "ci: add delta policy"]);
+  const workflowSha = git(root, ["rev-parse", "HEAD"]);
+
+  return {
+    root,
+    sourceSha,
+    targetSha,
+    evidenceWorkflowSha,
+    workflowSha,
+    policy,
+    gates,
+  };
+}
+
+function archive(
+  id: number,
+  name: string,
+  runId: number,
+  workflowSha: string,
+  files: Map<string, Buffer>,
+) {
+  const archiveBytes = Buffer.from(`artifact-${id}-${name}`);
+  return {
+    key: "",
+    metadata: {
+      id,
+      name,
+      digest: `sha256:${sha256(archiveBytes)}`,
+      sizeBytes: archiveBytes.byteLength,
+      runId,
+      workflowSha,
+    },
+    archiveBytes,
+    files,
+  };
+}
+
+function evidenceFixture(fixture: ReturnType<typeof createFixture>) {
+  let nextId = 100;
+  const evidence = fixture.gates.map((gateFixture) => {
+    const runId = nextId++;
+    const jobId = nextId++;
+    const candidateSha =
+      gateFixture.kind === "source-frv" || gateFixture.kind === "source-npm"
+        ? fixture.sourceSha
+        : fixture.targetSha;
+    const releaseCandidateRun =
+      gateFixture.kind === "source-npm" || gateFixture.kind === "root-package";
+    const runHeadSha = releaseCandidateRun ? candidateSha : fixture.evidenceWorkflowSha;
+    const runHeadBranch = releaseCandidateRun ? TARGET_REF : "main";
+    const artifacts = gateFixture.artifacts.map((artifactPolicy) => {
+      const files = new Map<string, Buffer>();
+      if (artifactPolicy.packageMembers) {
+        const rootBytes = Buffer.from(
+          gateFixture.kind === "source-npm" ? "source-root" : "target-root",
+        );
+        const dependencyBytes = Buffer.from("identical-dependency");
+        files.set("openclaw.tgz", rootBytes);
+        files.set("openclaw-ai.tgz", dependencyBytes);
+        files.set(
+          "preflight-manifest.json",
+          Buffer.from(
+            JSON.stringify({
+              version: 1,
+              releaseTag: `v${VERSION}`,
+              releaseSha: candidateSha,
+              npmDistTag: "beta",
+              packageName: "openclaw",
+              packageVersion: VERSION,
+              tarballName: "openclaw.tgz",
+              tarballSha256: sha256(rootBytes),
+              dependencyTarballs: [
+                {
+                  packageName: "@openclaw/ai",
+                  packageVersion: VERSION,
+                  tarballName: "openclaw-ai.tgz",
+                  tarballSha256: sha256(dependencyBytes),
+                },
+              ],
+              dependencyEvidenceDir: "dependency-evidence",
+              dependencyEvidenceManifest: "dependency-evidence/dependency-evidence-manifest.json",
+            }),
+          ),
+        );
+      } else {
+        files.set("binding.json", Buffer.from(JSON.stringify({ targetSha: candidateSha })));
+      }
+      const value = archive(nextId++, artifactPolicy.name, runId, runHeadSha, files);
+      value.key = artifactPolicy.key;
+      return value;
+    });
+    const run = {
+      id: runId,
+      runAttempt: 1,
+      name: gateFixture.id,
+      path: gateFixture.workflowPath,
+      event: "workflow_dispatch",
+      headBranch: runHeadBranch,
+      headRepository: REPOSITORY,
+      headSha: runHeadSha,
+      url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`,
+      status: "completed",
+      conclusion: "success",
+    };
+    const job = {
+      id: jobId,
+      runId,
+      runAttempt: 1,
+      name: gateFixture.jobName,
+      headSha: runHeadSha,
+      url: `https://github.com/${REPOSITORY}/actions/runs/${runId}/job/${jobId}`,
+      status: "completed",
+      conclusion: "success",
+    };
+    return {
+      id: gateFixture.id,
+      run,
+      job,
+      artifacts,
+      ...(gateFixture.kind === "source-frv"
+        ? {
+            sourceValidation: {
+              schema: "openclaw.release-validation-evidence/v3",
+              valid: true,
+              repository: REPOSITORY,
+              producerOnTrustedMainLineage: true,
+              directRoot: true,
+              evidenceReuse: null,
+              rerunGroup: "all",
+              releaseProfile: "full",
+              runReleaseSoak: true,
+              validationInputs: VALIDATION_INPUTS,
+              controls: {
+                performanceBlocking: true,
+                performanceReportPublication: "artifact-only",
+              },
+              conclusions: {
+                current: "success",
+                root: "success",
+                allRequiredSucceeded: true,
+              },
+              root: {
+                runId,
+                runAttempt: 1,
+                targetSha: fixture.sourceSha,
+                workflowSha: fixture.evidenceWorkflowSha,
+                status: "completed",
+                conclusion: "success",
+                artifact: {
+                  id: String(artifacts[0].metadata.id),
+                  name: artifacts[0].metadata.name,
+                  digest: artifacts[0].metadata.digest,
+                  sizeInBytes: artifacts[0].metadata.sizeBytes,
+                },
+              },
+            },
+          }
+        : {}),
+    };
+  });
+  return evidence;
+}
+
+function rewritePreflightManifest(
+  artifact: ReturnType<typeof evidenceFixture>[number]["artifacts"][number],
+  update: (manifest: any) => void,
+) {
+  const manifest = JSON.parse(artifact.files.get("preflight-manifest.json")!.toString("utf8"));
+  update(manifest);
+  artifact.files.set("preflight-manifest.json", Buffer.from(JSON.stringify(manifest)));
+}
+
+function manifestInputs(
+  fixture: ReturnType<typeof createFixture>,
+  evidence = evidenceFixture(fixture),
+) {
+  return {
+    cwd: fixture.root,
+    repository: REPOSITORY,
+    policy: fixture.policy,
+    policyBytes: readFileSync(path.join(fixture.root, POLICY_PATH)),
+    policyPath: POLICY_PATH,
+    workflowSha: fixture.workflowSha,
+    producer: {
+      workflowPath: ".github/workflows/release-delta-evidence.yml",
+      workflowSha: fixture.workflowSha,
+      workflowRef: "refs/heads/main",
+      runId: 999,
+      runAttempt: 1,
+      artifactName: `release-delta-evidence-${fixture.targetSha}-999-1`,
+    },
+    targetSha: fixture.targetSha,
+    branchTipSha: fixture.targetSha,
+    commitVerifications: [
+      {
+        sha: fixture.targetSha,
+        verification: {
+          verified: true,
+          reason: "valid",
+          verifiedAt: "2026-07-10T00:00:00Z",
+        },
+      },
+    ],
+    evidence,
+  };
+}
+
+describe("release delta evidence v1", () => {
+  it("creates and reverifies read-only changelog evidence", () => {
+    const fixture = createFixture();
+    const inputs = manifestInputs(fixture);
+    const manifest = createReleaseDeltaManifest(inputs);
+
+    expect(manifest.mode).toBe("changelog-only-v1");
+    expect(manifest.release).toEqual({ version: VERSION, channel: "beta" });
+    expect(manifest.changedPaths).toEqual(["CHANGELOG.md"]);
+    expect(manifest.source.reusableTreeSha256).toBe(manifest.target.reusableTreeSha256);
+    expect(manifest.gates.map((gate: any) => [gate.id, gate.mode])).toEqual([
+      ["source-frv", "reuse"],
+      ["source-npm", "reuse"],
+      ["target-npm", "fresh"],
+      ["release-notes", "fresh"],
+    ]);
+    expect(manifest.packageEvidence.rawRootTarballEqual).toBe(false);
+    expect(manifest.packageEvidence.dependencyTarballs).toHaveLength(1);
+    expect(manifest.publicationPerformed).toBe(false);
+    expect(validateReleaseDeltaManifest(manifest, inputs)).toMatchObject({
+      valid: true,
+      sourceSha: fixture.sourceSha,
+      targetSha: fixture.targetSha,
+      publicationPerformed: false,
+    });
+  });
+
+  it("rejects a target that is not the current release branch tip", () => {
+    const fixture = createFixture();
+    expect(() =>
+      computeReleaseDelta(fixture.root, fixture.policy, fixture.targetSha, fixture.sourceSha),
+    ).toThrow("target SHA is not the current target branch tip");
+  });
+
+  it("rejects unsigned delta commits", () => {
+    const fixture = createFixture();
+    const inputs = manifestInputs(fixture);
+    inputs.commitVerifications[0].verification.verified = false;
+    expect(() => createReleaseDeltaManifest(inputs)).toThrow("is not verified");
+  });
+
+  it("rejects any non-changelog path", () => {
+    const fixture = createFixture();
+    git(fixture.root, ["switch", TARGET_REF]);
+    write(fixture.root, "src/index.ts", "export const value = 2;\n");
+    git(fixture.root, ["add", "src/index.ts"]);
+    git(fixture.root, ["commit", "-m", "fix: product change"]);
+    const productTarget = git(fixture.root, ["rev-parse", "HEAD"]);
+    expect(() =>
+      computeReleaseDelta(fixture.root, fixture.policy, productTarget, productTarget),
+    ).toThrow("changed a path not allowed by policy");
+  });
+
+  it("audits every delta commit even when an endpoint path is reverted", () => {
+    const fixture = createFixture();
+    git(fixture.root, ["switch", TARGET_REF]);
+    write(fixture.root, "src/index.ts", "export const value = 2;\n");
+    git(fixture.root, ["add", "src/index.ts"]);
+    git(fixture.root, ["commit", "-m", "test: transient product change"]);
+    write(fixture.root, "src/index.ts", "export const value = 1;\n");
+    git(fixture.root, ["add", "src/index.ts"]);
+    git(fixture.root, ["commit", "-m", "test: revert transient product change"]);
+    const revertedTarget = git(fixture.root, ["rev-parse", "HEAD"]);
+    expect(() =>
+      computeReleaseDelta(fixture.root, fixture.policy, revertedTarget, revertedTarget),
+    ).toThrow("changed a path not allowed by policy");
+  });
+
+  it("rejects dependency tarball drift", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    const changed = Buffer.from("changed-dependency");
+    target.artifacts[0].files.set("openclaw-ai.tgz", changed);
+    rewritePreflightManifest(target.artifacts[0], (manifest) => {
+      manifest.dependencyTarballs[0].tarballSha256 = sha256(changed);
+    });
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "dependency tarball differs",
+    );
+  });
+
+  it("rejects package tarballs omitted from the npm preflight manifest", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    target.artifacts[0].files.set("unlisted.tgz", Buffer.from("unlisted"));
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "artifact inventory differs from policy",
+    );
+  });
+
+  it("records raw root equality without reusing the target package gate", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    const sourceRoot = Buffer.from("source-root");
+    target.artifacts[0].files.set("openclaw.tgz", sourceRoot);
+    rewritePreflightManifest(target.artifacts[0], (manifest) => {
+      manifest.tarballSha256 = sha256(sourceRoot);
+    });
+    const manifest = createReleaseDeltaManifest(manifestInputs(fixture, evidence));
+    expect(manifest.packageEvidence.rawRootTarballEqual).toBe(true);
+    expect(manifest.gates.find((gate: any) => gate.id === "target-npm").mode).toBe("fresh");
+  });
+
+  it("rejects source FRV evidence that bypasses the strict validator contract", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const source = evidence.find((entry) => entry.id === "source-frv")!;
+    source.sourceValidation.directRoot = false;
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "source FRV is not a trusted direct root",
+    );
+  });
+
+  it("rejects source FRV evidence with different lane-selection inputs", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const source = evidence.find((entry) => entry.id === "source-frv")!;
+    source.sourceValidation.validationInputs = {
+      ...VALIDATION_INPUTS,
+      provider: "anthropic",
+    };
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "validation inputs differ from policy",
+    );
+  });
+
+  it("rejects npm preflight metadata for a different package version", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    rewritePreflightManifest(target.artifacts[0], (manifest) => {
+      manifest.packageVersion = "2026.7.1-beta.2";
+    });
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "root package version differs",
+    );
+  });
+
+  it("rejects trusted-main gate workflow SHAs outside producer ancestry", () => {
+    const fixture = createFixture();
+    const releaseNotes = fixture.policy.gates.find((gate) => gate.id === "release-notes")!;
+    releaseNotes.workflowSha = fixture.targetSha;
+    write(fixture.root, POLICY_PATH, `${canonicalJson(fixture.policy)}\n`);
+    git(fixture.root, ["add", POLICY_PATH]);
+    git(fixture.root, ["commit", "-m", "test: move policy"]);
+    fixture.workflowSha = git(fixture.root, ["rev-parse", "HEAD"]);
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture))).toThrow(
+      "workflow SHA is not on trusted main lineage",
+    );
+  });
+
+  it("rejects a manifest that claims publication", () => {
+    const fixture = createFixture();
+    const inputs = manifestInputs(fixture);
+    const manifest = createReleaseDeltaManifest(inputs);
+    manifest.publicationPerformed = true;
+    expect(() => validateReleaseDeltaManifest(manifest, inputs)).toThrow(
+      "must not authorize publication",
+    );
+  });
+
+  it("parses only beta changelog policies", () => {
+    const fixture = createFixture();
+    expect(() =>
+      parseReleaseDeltaPolicy({
+        ...fixture.policy,
+        allowedPaths: ["CHANGELOG.md", "src/**"],
+      }),
+    ).toThrow("v1 policy allows only CHANGELOG.md");
+  });
+
+  it("binds the policy release branch to the beta stable version", () => {
+    const fixture = createFixture();
+    expect(() =>
+      parseReleaseDeltaPolicy({
+        ...fixture.policy,
+        targetRef: "release/2026.7.2",
+      }),
+    ).toThrow("targetRef must match the beta stable version");
+  });
+
+  it("rejects non-dispatch evidence runs", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    evidence[0].run.event = "push";
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "run event is not workflow_dispatch",
+    );
+  });
+
+  it("rejects noncanonical UTF-8 artifact bindings", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    target.artifacts[0].files.set("preflight-manifest.json", Buffer.from([0xff]));
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "binding member is not canonical UTF-8",
+    );
+  });
+
+  it("requires producer attempt one", () => {
+    const fixture = createFixture();
+    const inputs = manifestInputs(fixture);
+    inputs.producer.runAttempt = 2;
+    expect(() => createReleaseDeltaManifest(inputs)).toThrow(
+      "producer must be workflow run attempt 1",
+    );
+  });
+
+  it("rejects evidence from workflow rerun attempts", () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const target = evidence.find((entry) => entry.id === "target-npm")!;
+    target.run.runAttempt = 2;
+    target.job.runAttempt = 2;
+    expect(() => createReleaseDeltaManifest(manifestInputs(fixture, evidence))).toThrow(
+      "gate target-npm run attempt must be 1",
+    );
+  });
+
+  it("rejects rerun attempts in CLI evidence bindings", async () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const bindings = Object.fromEntries(
+      evidence.map((entry) => [
+        entry.id,
+        {
+          runId: entry.run.id,
+          runAttempt: entry.id === "target-npm" ? 2 : 1,
+          jobId: entry.job.id,
+          artifacts: Object.fromEntries(
+            entry.artifacts.map((artifact) => [artifact.key, artifact.metadata.id]),
+          ),
+        },
+      ]),
+    );
+    const evidenceRunsPath = path.join(fixture.root, "rerun-evidence-runs.json");
+    writeFileSync(evidenceRunsPath, JSON.stringify(bindings));
+    await expect(
+      runReleaseDeltaEvidence(
+        [
+          "create",
+          "--repo",
+          REPOSITORY,
+          "--policy",
+          POLICY_PATH,
+          "--target-sha",
+          fixture.targetSha,
+          "--workflow-sha",
+          fixture.workflowSha,
+          "--producer-run-id",
+          "999",
+          "--producer-run-attempt",
+          "1",
+          "--producer-workflow-path",
+          ".github/workflows/release-delta-evidence.yml",
+          "--producer-workflow-ref",
+          "refs/heads/main",
+          "--producer-artifact-name",
+          `release-delta-evidence-${fixture.targetSha}-999-1`,
+          "--evidence-runs",
+          evidenceRunsPath,
+          "--output",
+          path.join(fixture.root, "rerun-manifest.json"),
+        ],
+        { cwd: fixture.root },
+      ),
+    ).rejects.toThrow("target-npm run attempt must be 1");
+  });
+
+  it("runs create and verify through injected GitHub and archive adapters", async () => {
+    const fixture = createFixture();
+    const evidence = evidenceFixture(fixture);
+    const readerRequests: any[] = [];
+    const bindings = Object.fromEntries(
+      evidence.map((entry) => [
+        entry.id,
+        {
+          runId: entry.run.id,
+          runAttempt: entry.run.runAttempt,
+          jobId: entry.job.id,
+          artifacts: Object.fromEntries(
+            entry.artifacts.map((artifact) => [artifact.key, artifact.metadata.id]),
+          ),
+        },
+      ]),
+    );
+    const runById = new Map(evidence.map((entry) => [entry.run.id, entry]));
+    const jobById = new Map(evidence.map((entry) => [entry.job.id, entry.job]));
+    const artifactById = new Map(
+      evidence.flatMap((entry) =>
+        entry.artifacts.map((artifact) => [
+          artifact.metadata.id,
+          {
+            id: artifact.metadata.id,
+            name: artifact.metadata.name,
+            digest: artifact.metadata.digest,
+            size_in_bytes: artifact.metadata.sizeBytes,
+            expired: false,
+            workflow_run: {
+              id: artifact.metadata.runId,
+              head_sha: artifact.metadata.workflowSha,
+            },
+          },
+        ]),
+      ),
+    );
+    const archiveById = new Map(
+      evidence.flatMap((entry) =>
+        entry.artifacts.map((artifact) => [
+          artifact.metadata.id,
+          { archiveBytes: artifact.archiveBytes, files: artifact.files },
+        ]),
+      ),
+    );
+    const sourceValidation = evidence.find((entry) => entry.id === "source-frv")!.sourceValidation;
+    const api = (apiPath: string) => {
+      if (apiPath.includes("/git/ref/heads/")) {
+        return { object: { type: "commit", sha: fixture.targetSha } };
+      }
+      const commitMatch = /\/commits\/([0-9a-f]{40})$/u.exec(apiPath);
+      if (commitMatch) {
+        return {
+          sha: commitMatch[1],
+          commit: {
+            verification: {
+              verified: true,
+              reason: "valid",
+              verified_at: "2026-07-10T00:00:00Z",
+            },
+          },
+        };
+      }
+      const runMatch = /\/actions\/runs\/(\d+)$/u.exec(apiPath);
+      if (runMatch) {
+        const entry = runById.get(Number(runMatch[1]))!;
+        return {
+          id: entry.run.id,
+          run_attempt: entry.run.runAttempt,
+          name: entry.run.name,
+          path: entry.run.path,
+          event: entry.run.event,
+          head_branch: entry.run.headBranch,
+          head_repository: { full_name: entry.run.headRepository },
+          head_sha: entry.run.headSha,
+          html_url: entry.run.url,
+          status: entry.run.status,
+          conclusion: entry.run.conclusion,
+        };
+      }
+      const jobMatch = /\/actions\/jobs\/(\d+)$/u.exec(apiPath);
+      if (jobMatch) {
+        const job = jobById.get(Number(jobMatch[1]))!;
+        return {
+          id: job.id,
+          run_id: job.runId,
+          run_attempt: job.runAttempt,
+          name: job.name,
+          head_sha: job.headSha,
+          html_url: job.url,
+          status: job.status,
+          conclusion: job.conclusion,
+        };
+      }
+      const artifactMatch = /\/actions\/artifacts\/(\d+)$/u.exec(apiPath);
+      if (artifactMatch) {
+        return artifactById.get(Number(artifactMatch[1]));
+      }
+      throw new Error(`unexpected API path: ${apiPath}`);
+    };
+    const evidenceRunsPath = path.join(fixture.root, "evidence-runs.json");
+    const manifestPath = path.join(fixture.root, "delta-manifest.json");
+    writeFileSync(evidenceRunsPath, JSON.stringify(bindings));
+    const common = [
+      "--repo",
+      REPOSITORY,
+      "--policy",
+      POLICY_PATH,
+      "--target-sha",
+      fixture.targetSha,
+      "--workflow-sha",
+      fixture.workflowSha,
+      "--producer-run-id",
+      "999",
+      "--producer-run-attempt",
+      "1",
+      "--producer-workflow-path",
+      ".github/workflows/release-delta-evidence.yml",
+      "--producer-workflow-ref",
+      "refs/heads/main",
+      "--producer-artifact-name",
+      `release-delta-evidence-${fixture.targetSha}-999-1`,
+    ];
+    const overrides = {
+      cwd: fixture.root,
+      api,
+      artifactReader: async (request: any) => {
+        readerRequests.push(request);
+        const runEntry = runById.get(request.expected.runId)!;
+        return {
+          ...archiveById.get(request.expected.artifactId),
+          artifactMetadata: artifactById.get(request.expected.artifactId),
+          binding: {
+            ...request.expected,
+            workflowStatus: "completed",
+            workflowConclusion: "success",
+          },
+          workflowRun: {
+            id: runEntry.run.id,
+            run_attempt: runEntry.run.runAttempt,
+            path: runEntry.run.path,
+            event: runEntry.run.event,
+            head_branch: runEntry.run.headBranch,
+            head_sha: runEntry.run.headSha,
+            status: runEntry.run.status,
+            conclusion: runEntry.run.conclusion,
+            repository: { full_name: runEntry.run.headRepository },
+          },
+        };
+      },
+      sourceFrvValidator: async () => sourceValidation,
+      token: "test-token",
+    };
+
+    const created = await runReleaseDeltaEvidence(
+      ["create", ...common, "--evidence-runs", evidenceRunsPath, "--output", manifestPath],
+      overrides,
+    );
+    expect(sha256(readFileSync(manifestPath))).toBe(created.manifestSha256);
+    const result = await runReleaseDeltaEvidence(
+      ["verify", ...common, "--manifest", manifestPath],
+      overrides,
+    );
+    expect(result).toMatchObject({
+      valid: true,
+      targetSha: fixture.targetSha,
+      publicationPerformed: false,
+    });
+    expect(readerRequests).not.toHaveLength(0);
+    expect(readerRequests[0]).toMatchObject({
+      token: "test-token",
+      maxArchiveBytes: 256 * 1024 * 1024,
+      expected: {
+        repository: REPOSITORY,
+        artifactId: readerRequests[0].expected.artifactId,
+        artifactName: "source-frv-evidence",
+        artifactDigest: readerRequests[0].expected.artifactDigest,
+        artifactSizeBytes: readerRequests[0].expected.artifactSizeBytes,
+        runId: readerRequests[0].expected.runId,
+        runAttempt: 1,
+        workflowSha: fixture.evidenceWorkflowSha,
+        workflowPath: ".github/workflows/full-release-validation.yml",
+        workflowEvent: "workflow_dispatch",
+        workflowHeadBranch: "main",
+        runStatePolicy: "completed-success",
+      },
+    });
+    expect(readerRequests[0].archivePolicy.expectedEntries).toEqual(["binding.json"]);
+    const targetPackageRequest = readerRequests.find(
+      (request) => request.expected.artifactName === "target-npm-package",
+    );
+    expect(targetPackageRequest).toBeDefined();
+    expect(targetPackageRequest!.expected).toMatchObject({
+      repository: REPOSITORY,
+      workflowSha: fixture.targetSha,
+      workflowHeadBranch: TARGET_REF,
+      runStatePolicy: "completed-success",
+    });
+  });
+});
+
+describe("release delta evidence workflow", () => {
+  const workflow = parse(
+    readFileSync(".github/workflows/release-delta-evidence.yml", "utf8"),
+  ) as Workflow;
+  const steps = workflow.jobs.produce.steps;
+  const step = (name: string) => {
+    const result = steps.find((entry) => entry.name === name);
+    if (!result) {
+      throw new Error(`missing workflow step: ${name}`);
+    }
+    return result;
+  };
+
+  it("binds the producer path to the observed workflow ref", () => {
+    const validate = step("Validate inputs");
+    expect(validate.run).toContain('[[ "$GITHUB_WORKFLOW_REF" == "$expected_workflow_ref" ]]');
+    expect(validate.run).toContain(
+      'producer_workflow_path="${GITHUB_WORKFLOW_REF#${GITHUB_REPOSITORY}/}"',
+    );
+    expect(validate.run).toContain(
+      'printf \'PRODUCER_WORKFLOW_PATH=%s\\n\' "$producer_workflow_path" >> "$GITHUB_ENV"',
+    );
+    expect(step("Create canonical delta manifest").run).toContain(
+      '--producer-workflow-path "$PRODUCER_WORKFLOW_PATH"',
+    );
+    expect(step("Reverify current GitHub evidence").run).toContain(
+      '--producer-workflow-path "$PRODUCER_WORKFLOW_PATH"',
+    );
+  });
+
+  it("uploads one staged artifact root with stable member names", () => {
+    const stage = step("Stage read-only delta evidence");
+    expect(stage.env.EVIDENCE_ARTIFACT_DIR).toBe(
+      "${{ runner.temp }}/release-delta-evidence-artifact",
+    );
+    expect(stage.run).toContain(
+      'cp -- "$POLICY_PATH" "$EVIDENCE_ARTIFACT_DIR/release-delta-policy.json"',
+    );
+    expect(step("Upload read-only delta evidence").with.path).toBe(
+      "${{ runner.temp }}/release-delta-evidence-artifact",
+    );
+  });
+});


### PR DESCRIPTION
Closes #103423

Depends on #103809 for the bounded immutable Actions artifact reader. This PR fails closed until that reader lands.

Supersedes #103632 with a focused evidence-only implementation.

## What Problem This Solves

Resolves a release-operations problem where a reviewed `CHANGELOG.md`-only candidate update forced every broad release lane to restart even when exact ancestry, product-tree, package, and artifact evidence proved most prior results remained valid.

## Why This Change Was Made

This adds a trusted-main `Release Delta Evidence` workflow and strict v1 manifest limited to beta candidates whose only changed path is `CHANGELOG.md`. It audits every delta commit, requires valid signatures and exact branch-tip identity, binds source and fresh gates to immutable run/job/artifact tuples, requires a fresh exact-target root npm package, and records reuse rationale without authorizing publication.

The manifest always records `publicationPerformed: false`. No npm, GitHub Release, Docker, tag, image, or ClawHub publish workflow consumes it.

## User Impact

Release operators can retain unaffected product, Docker, performance, install, and live-provider proof for a changelog-only beta update while rerunning the package and release-note gates whose bytes or metadata changed. The resulting canonical artifact records source/target SHAs, changed paths, package hashes, exact run identities, conclusions, and the reason each gate was reused or rerun.

## Evidence

- Exact head: `e19c9be71d9336a00f83d510c4fe2f7c1f1025b9`.
- Testbox run `29115667526`: focused release-delta suite 23/23 passed; `pnpm check:changed` passed with zero lint errors.
- `oxfmt` passed for the changed scripts and test.
- `node --check` passed for all three new `.mjs` files.
- `actionlint .github/workflows/release-delta-evidence.yml` passed.
- `git diff --check` passed.
- Two independent exact-head reviews found no P1/P2 after attempt provenance, producer path, and staged artifact inventory hardening.
- The shared reader from #103809 must land first; this PR remains draft until that dependency is on `main`.

AI-assisted implementation; independently reviewed before landing. Nothing was published or promoted.
