### PR TITLE
fix(ui): stop the worktrees table from always stacking inside settings

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3041,14 +3041,16 @@
   min-width: 180px;
 }
 
-@media (max-width: 1100px) {
+/* Settings caps .settings-workspace at 1120px, so the table container is ~1080px
+   wide; a 1100px stack breakpoint would collapse the grid at every window size. */
+@media (max-width: 900px) {
   .worktrees-table .table-head,
   .worktrees-table .table-row {
     grid-template-columns: 1fr;
   }
 }
 
-@container (max-width: 1100px) {
+@container (max-width: 900px) {
   .worktrees-table .table-head,
   .worktrees-table .table-row {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What Problem This Solves

Settings caps its content column (`.settings-workspace`) at 1120px, while the Worktrees table stacked to a single column at container widths <= 1100px. The table container inside the settings card is ~1080px, so the managed-worktrees table rendered as a stacked field list at every window size — the 7-column grid (Name / Repository / Branch / Owner / Status / Last active / Actions) was unreachable.

## Why This Change Was Made

The stack breakpoint predates the settings width cap (came in with #100535) and was never reachable as a "wide" layout inside Settings. Lowering the media + container breakpoints to 900px lets the grid render in the settings shell while still stacking on genuinely narrow screens. Follow-up polish for the Worktrees page shipped in #103526 (issue #103431).

## User Impact

Settings -> Worktrees shows a proper table again instead of one stacked card per worktree.

## Evidence

Stacked before (any window size):

![worktrees stacked](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sessions-sidebar-redesign-103431/worktrees-before.png)

Grid after (1800px window, mock-gateway harness):

![worktrees grid](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sessions-sidebar-redesign-103431/worktrees-after.png)

CSS-only change; verified in the Control UI e2e mock-gateway harness via Playwright screenshots above.
