### PR TITLE
fix: preserve current Node for node.exe env wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Windows env-wrapper Node pinning:** keep bare case-insensitive `node` and `node.exe` commands on the wrapper's active Node runtime instead of resolving a different executable from `PATH`, while preserving explicit executable paths. (#103907) Thanks @soldforaloss.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Windows env-wrapper Node pinning:** keep bare case-insensitive `node` and `node.exe` commands on the wrapper's active Node runtime instead of resolving a different executable from `PATH`, while preserving explicit executable paths. (#103907) Thanks @soldforaloss.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/scripts/run-with-env.mjs
+++ b/scripts/run-with-env.mjs
@@ -51,7 +51,7 @@ export function parseRunWithEnvArgs(argv) {
  * Resolves node to the current executable so wrapper and child use the same runtime.
  */
 export function resolveSpawnCommand(command, args, execPath = process.execPath) {
-  if (command === "node") {
+  if (command === "node" || command.toLowerCase() === "node.exe") {
     return {
       command: execPath,
       args,

--- a/scripts/run-with-env.mjs
+++ b/scripts/run-with-env.mjs
@@ -48,10 +48,19 @@ export function parseRunWithEnvArgs(argv) {
 }
 
 /**
- * Resolves node to the current executable so wrapper and child use the same runtime.
+ * Resolves bare Node command names to the current executable so wrapper and child use the same
+ * runtime. Windows command lookup is case-insensitive; explicit paths remain caller-owned.
  */
-export function resolveSpawnCommand(command, args, execPath = process.execPath) {
-  if (command === "node" || command.toLowerCase() === "node.exe") {
+export function resolveSpawnCommand(
+  command,
+  args,
+  execPath = process.execPath,
+  platform = process.platform,
+) {
+  const normalizedCommand = platform === "win32" ? command.toLowerCase() : command;
+  const isNodeCommand =
+    normalizedCommand === "node" || (platform === "win32" && normalizedCommand === "node.exe");
+  if (isNodeCommand) {
     return {
       command: execPath,
       args,

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -143,16 +143,33 @@ describe("run-with-env", () => {
     expect(result.stderr).toContain("invalid environment assignment");
   });
 
-  it("uses the current Node executable for node commands", () => {
-    expect(resolveSpawnCommand("node", ["scripts/run-vitest.mjs"], "node.exe")).toEqual({
-      command: "node.exe",
-      args: ["scripts/run-vitest.mjs"],
+  it("uses the current Node executable for bare Node command names", () => {
+    const args = ["scripts/run-vitest.mjs"];
+    expect(resolveSpawnCommand("node", args, "/usr/bin/node", "linux")).toEqual({
+      command: "/usr/bin/node",
+      args,
     });
+    for (const command of ["node", "NODE", "node.exe", "Node.Exe"]) {
+      expect(resolveSpawnCommand(command, args, "C:\\Node24\\node.exe", "win32")).toEqual({
+        command: "C:\\Node24\\node.exe",
+        args,
+      });
+    }
+  });
+
+  it("preserves platform-specific and explicitly pathed commands", () => {
+    const args = ["scripts/run-vitest.mjs"];
+    for (const command of ["NODE", "node.exe", "C:\\Tools\\node.exe"]) {
+      expect(resolveSpawnCommand(command, args, "/usr/bin/node", "linux")).toEqual({
+        command,
+        args,
+      });
+    }
     expect(
-      resolveSpawnCommand("node.exe", ["scripts/run-vitest.mjs"], "C:\\Node24\\node.exe"),
+      resolveSpawnCommand("C:\\Tools\\node.exe", args, "C:\\Node24\\node.exe", "win32"),
     ).toEqual({
-      command: "C:\\Node24\\node.exe",
-      args: ["scripts/run-vitest.mjs"],
+      command: "C:\\Tools\\node.exe",
+      args,
     });
   });
 

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -148,6 +148,12 @@ describe("run-with-env", () => {
       command: "node.exe",
       args: ["scripts/run-vitest.mjs"],
     });
+    expect(
+      resolveSpawnCommand("node.exe", ["scripts/run-vitest.mjs"], "C:\\Node24\\node.exe"),
+    ).toEqual({
+      command: "C:\\Node24\\node.exe",
+      args: ["scripts/run-vitest.mjs"],
+    });
   });
 
   it("rejects malformed force-kill grace configuration before spawning", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running `scripts/run-with-env.mjs` with a bare Windows `node.exe` command could lose the wrapper's runtime pinning and resolve a different Node from `PATH`.

AI-assisted: yes.

## Why This Change Was Made

The env wrapper already replaces bare `node` with `process.execPath` so the wrapped command uses the same Node runtime as the wrapper. This applies that contract to Windows' case-insensitive bare `node` and `node.exe` spellings while preserving explicit executable paths and Unix case-sensitive command names.

## User Impact

Windows contributors and tooling can invoke bare `node`, `NODE`, `node.exe`, or mixed-case `.exe` variants through `run-with-env` and keep the wrapper's active Node runtime. Explicit paths still select the caller's requested executable.

## Evidence

- Rebased onto `origin/main` `b1e688c6577f2b12a3f3a77563a8cc5b4ed9fca4`; exact PR head is `8518151632f4c9f936a02da031c6634adc4a1f74`.
- Windows behavior proof with a different `node.exe` path first on `PATH`:

```text
wrapper_execPath=C:\Program Files\nodejs\node.exe
path_node=%TEMP%\openclaw-node-proof-...\node.exe
child_execPath=C:\Program Files\nodejs\node.exe
```

- Sanitized public-network AWS Crabbox `cbx_67131b70c251`, run `run_337ef3876df6`: exact-head `pnpm test test/scripts/run-with-env.test.ts` -> 1 file passed, 17 tests passed.
- `oxfmt --write scripts/run-with-env.mjs test/scripts/run-with-env.test.ts CHANGELOG.md` -> passed.
- `oxlint scripts/run-with-env.mjs test/scripts/run-with-env.test.ts` -> passed.
- `git diff --check` -> passed.
- Maintainer Codex autoreview -> clean, no actionable findings; correctness confidence 0.98.
