### PR TITLE
fix(ui): preserve Unicode boundaries in config diffs

### DIFF
--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -758,6 +758,32 @@ describe("config view", () => {
     expect(item.querySelector(".config-diff__to")?.textContent?.trim()).toBe('"remote"');
   });
 
+  it("preserves UTF-16 boundaries in pending change summaries", () => {
+    const boundaryValue = `${"A".repeat(35)}😀ZZZZZ`;
+    const adjacentValue = `${"B".repeat(34)}😀YYYYYY`;
+    const { container } = renderConfigView({
+      formValue: {
+        boundary: boundaryValue,
+        adjacent: adjacentValue,
+      },
+      originalValue: {
+        boundary: "before",
+        adjacent: "before",
+      },
+    });
+
+    const items = Array.from(container.querySelectorAll(".config-diff__item"));
+    const values = new Map(
+      items.map((item) => [
+        item.querySelector(".config-diff__path")?.textContent?.trim(),
+        item.querySelector(".config-diff__to")?.textContent?.trim(),
+      ]),
+    );
+
+    expect(values.get("boundary")).toBe(`"${"A".repeat(35)}...`);
+    expect(values.get("adjacent")).toBe(`"${"B".repeat(34)}😀...`);
+  });
+
   it("renders array diff summaries without serializing array values", () => {
     const poison = {
       value: "TOKEN_AFTER",

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1,4 +1,5 @@
 // Control UI view renders config screen content.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import JSON5 from "json5";
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfigUiHints } from "../../api/types.ts";
@@ -779,7 +780,7 @@ function truncateValue(value: unknown, maxLen = 40): string {
   if (str.length <= maxLen) {
     return str;
   }
-  return str.slice(0, maxLen - 3) + "...";
+  return truncateUtf16Safe(str, maxLen - 3) + "...";
 }
 
 function renderDiffValue(path: ConfigDiffPath, value: unknown, _uiHints: ConfigUiHints): string {


### PR DESCRIPTION
## Summary

- Keep Control UI pending config diff summaries on valid UTF-16 boundaries.
- Reuse the browser-safe `truncateUtf16Safe` helper instead of slicing raw UTF-16 code units.
- Add a regression case for both the split-surrogate boundary and the adjacent safe boundary.

## What Problem This Solves

The config page serializes changed values and shortens each pending-change summary to 40 UTF-16 code units. The previous `slice(0, maxLen - 3)` call could stop between an emoji's high and low surrogate, leaving an unpaired surrogate in the rendered diff.

## User Impact

A config value with an emoji at the truncation boundary appeared as the replacement character (`�...`) in **View pending changes**, making the preview look corrupted even though the edited value itself was valid.

## Origin / follow-up

- **Follows:** #102225, which made the shared Control UI `clampText` / `truncateText` helpers surrogate-safe.
- **Gap this fills:** the config pending-diff path had a separate local `truncateValue` implementation that still used raw `String.prototype.slice`.
- **Consistency:** this change reuses the same browser-compatible `@openclaw/normalization-core/utf16-slice` helper pattern.

## Competition / linked PR analysis

No linked issue or open PR targets this config pending-diff boundary. Before submission, the competition scan searched open PRs for `unicode config diff`, `surrogate pending changes`, and `preserve unicode boundaries config` and returned no matches. This is a focused follow-up to the already merged #102225 rather than a competing implementation.

## Merge risk

- **Why it matters / User impact:** Pending config summaries can visibly corrupt emoji at one specific truncation boundary.
- **Risk labels considered:** compatibility.
- **Risk explanation:** The shortened summary can become one UTF-16 code unit shorter when the limit falls inside a surrogate pair.
- **Why acceptable:** The preview remains within the existing maximum, the ellipsis behavior is unchanged, and complete code points are preserved.
- **Maintainer-ready confidence:** High; the patch changes one truncation call, adds one boundary regression, and has real Gateway + browser proof.
- **Patch quality notes:** None; this replaces the failing primitive at the source of the malformed string rather than masking the rendered replacement character.
- **Target test file:** `ui/src/pages/config/view.browser.test.ts`
- **Root cause:** The root cause was `truncateValue` slicing serialized values by raw UTF-16 code-unit offsets, which violated the valid-surrogate-pair invariant at the cutoff.
- **Why this is root-cause fix:** This fixes the invariant at its source: the truncation operation now returns a valid UTF-16 prefix before the projection reaches Lit or the DOM, rather than masking the replacement character after rendering.
- **What did NOT change:** Unchanged and out of scope: config parsing, diff computation, sensitive-value redaction, save/apply behavior, and the 40-code-unit summary limit.
- **Architecture / source-of-truth check:** Source-of-truth boundary: parsed config values and `ConfigDiffEntry` objects are unchanged; only their pending-diff display projection uses the existing dependency-free normalization-core helper intended for browser bundles.
- **Scenario locked in:** A serialized string with 35 ASCII characters followed by an emoji at the summary cutoff, plus an adjacent case where the full emoji fits.
- **Why this is the smallest reliable guardrail:** It changes only the unsafe slice and tests the rendered pending-diff output that users see.

## Real behavior proof

- **Behavior or issue addressed:** Control UI pending config summaries no longer render an unpaired surrogate when an emoji crosses the truncation boundary.
- **Canonical reachability path:** User input in the Raw config editor → JSON5 parser and object validation in `computeRawDiff` → runtime `ConfigDiffEntry` values from `computeDiff` → `renderRawDiffValue` and `truncateValue` → Lit request/render effect in `.config-diff__to` under **View pending changes**.
- **Boundary crossed:** local-runtime; a source Gateway served the real config RPC over WebSocket, a Vite Control UI connected to it, and headless Chrome interacted with the config page and inspected the rendered DOM.
- **Shared helper / provider constraint check:** Reused `truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice`; provider constraints are N/A because this is a local UI rendering path.
- **Real environment tested:** Linux, Node.js 22, source OpenClaw Gateway, Vite Control UI production source, and `/usr/bin/google-chrome` via Playwright.
- **Exact steps or command run after this patch:** Started the source Gateway with an isolated config on `127.0.0.1:18911`, started the Control UI with Vite on `127.0.0.1:5209`, opened `/config`, switched to Advanced → Raw, edited `agents.defaults.workspace`, expanded **View pending changes**, and inspected the UTF-16 units of the rendered `.config-diff__to` text for boundary and adjacent inputs.
- **Evidence after fix:** The same browser session produced the following DOM observations:

```text
boundary input:  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA😀ZZZZZ
rendered summary: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...
unpaired UTF-16 units: []

adjacent input:  BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB😀YYYYYY
rendered summary: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB😀...
unpaired UTF-16 units: []
Gateway status shown in UI: online
```

- **Observed result after fix:** The split-boundary case drops the incomplete emoji instead of emitting `�`, while the adjacent control preserves the complete emoji. Both rendered summaries contain zero unpaired UTF-16 code units.
- **What was not tested:** The edited config was not saved or applied because persistence is outside this rendering bug; no external channel or provider boundary is involved.
- **Fix classification:** Root cause fix.

## Review findings addressed

N/A — new focused follow-up PR with no prior review findings.

## Regression Test Plan

- Confirm the new browser test fails on the previous implementation with `Received: ...�...`.
- Run `ui/src/pages/config/view.browser.test.ts` and confirm all 28 tests pass.
- Run `oxfmt --check` on both changed files.
- Build the Control UI with Vite and confirm the UTF-16 helper is included in the browser bundle.
- Repeat the real Gateway + Chrome boundary and adjacent-control flow described above.

## Risk / Compatibility

Low. The only behavior change occurs when the truncation limit would split a surrogate pair. ASCII, BMP text, arrays, sensitive-value redaction, and values already within the limit retain their previous behavior.

## What was not changed

- No config schema or storage changes.
- No changes to diff detection or path formatting.
- No broad refactor of other truncation helpers.
- No dependency or lockfile changes.

## Root Cause

`truncateValue` shortened serialized config values with `str.slice(0, maxLen - 3)`. JavaScript string indexes are UTF-16 code-unit offsets, so a cutoff between an emoji's surrogate halves returned an invalid prefix that the browser displayed as a replacement character.
