### PR TITLE
fix(qa-matrix): preserve Unicode error previews

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { MatrixVerificationSummary } from "@openclaw/matrix/test-api.js";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createMatrixQaClient } from "../../substrate/client.js";
 import {
   createMatrixQaE2eeScenarioClient,
@@ -2286,7 +2287,7 @@ export async function runMatrixQaE2eeCliEncryptionSetupBootstrapFailureScenario(
     return {
       artifacts: {
         accountId,
-        bootstrapErrorPreview: bootstrapError.slice(0, 240),
+        bootstrapErrorPreview: truncateUtf16Safe(bootstrapError, 240),
         bootstrapSuccess: false,
         cliDeviceId: cliDevice.deviceId,
         faultedEndpoint: faultHits[0]?.path,
@@ -2512,7 +2513,7 @@ export async function runMatrixQaE2eeCliRecoveryKeyInvalidScenario(
     return {
       artifacts: {
         accountId,
-        bootstrapErrorPreview: failure.slice(0, 240),
+        bootstrapErrorPreview: truncateUtf16Safe(failure, 240),
         bootstrapSuccess: false,
         cliDeviceId: cliDevice.deviceId,
         encryptionChanged: payload.encryptionChanged,
@@ -3651,7 +3652,7 @@ export async function runMatrixQaE2eeKeyBootstrapFailureScenario(
   return {
     artifacts: {
       bootstrapActor: "driver",
-      bootstrapErrorPreview: bootstrapError.slice(0, 240),
+      bootstrapErrorPreview: truncateUtf16Safe(bootstrapError, 240),
       bootstrapSuccess: result.success,
       faultedEndpoint: MATRIX_QA_ROOM_KEY_BACKUP_VERSION_ENDPOINT,
       faultHitCount: faultHits.length,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -139,6 +139,10 @@ function requireMatrixQaScenario(id: string): (typeof MATRIX_QA_SCENARIOS)[numbe
   return scenario;
 }
 
+function buildMatrixQaSplitSurrogateError(prefix: string): string {
+  return `${prefix.padEnd(239, "x")}😀tail`;
+}
+
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
     await stat(targetPath);
@@ -5474,6 +5478,9 @@ describe("matrix live qa scenarios", () => {
       path.join(os.tmpdir(), "matrix-cli-encryption-setup-bootstrap-failure-"),
     );
     try {
+      const bootstrapError = buildMatrixQaSplitSurrogateError(
+        "Matrix room key backup is still missing after bootstrap: ",
+      );
       const proxyStop = vi.fn().mockResolvedValue(undefined);
       const hits = vi.fn().mockReturnValue([
         {
@@ -5499,7 +5506,7 @@ describe("matrix live qa scenarios", () => {
         stdout: JSON.stringify({
           accountId: "cli-encryption-failure",
           bootstrap: {
-            error: "Matrix room key backup is still missing after bootstrap",
+            error: bootstrapError,
             success: false,
           },
           encryptionChanged: true,
@@ -5536,6 +5543,7 @@ describe("matrix live qa scenarios", () => {
       });
       const artifacts = result.artifacts as {
         accountId?: unknown;
+        bootstrapErrorPreview?: unknown;
         bootstrapSuccess?: unknown;
         cliDeviceId?: unknown;
         faultedEndpoint?: unknown;
@@ -5543,6 +5551,7 @@ describe("matrix live qa scenarios", () => {
         faultRuleId?: unknown;
       };
       expect(artifacts.accountId).toBe("cli-encryption-failure");
+      expect(artifacts.bootstrapErrorPreview).toBe(bootstrapError.slice(0, 239));
       expect(artifacts.bootstrapSuccess).toBe(false);
       expect(artifacts.cliDeviceId).toBe("CLIFAILUREDEVICE");
       expect(artifacts.faultedEndpoint).toBe("/_matrix/client/v3/room_keys/version");
@@ -5796,6 +5805,9 @@ describe("matrix live qa scenarios", () => {
   it("runs Matrix invalid recovery-key setup through the CLI QA scenario", async () => {
     const outputDir = await mkdtemp(path.join(os.tmpdir(), "matrix-cli-recovery-key-invalid-"));
     try {
+      const bootstrapError = buildMatrixQaSplitSurrogateError(
+        "Matrix recovery key could not unlock secret storage: ",
+      );
       const deleteOwnDevices = vi.fn().mockResolvedValue(undefined);
       const stop = vi.fn().mockResolvedValue(undefined);
       const { loginWithPassword, registerWithToken } = mockMatrixQaCliAccount({
@@ -5830,7 +5842,7 @@ describe("matrix live qa scenarios", () => {
         stdout: JSON.stringify({
           accountId: "cli-invalid-recovery-key",
           bootstrap: {
-            error: "Matrix recovery key could not unlock secret storage",
+            error: bootstrapError,
             success: false,
           },
           encryptionChanged: true,
@@ -5874,6 +5886,7 @@ describe("matrix live qa scenarios", () => {
       });
       const artifacts = result.artifacts as {
         accountId?: unknown;
+        bootstrapErrorPreview?: unknown;
         bootstrapSuccess?: unknown;
         cliDeviceId?: unknown;
         encryptionChanged?: unknown;
@@ -5882,6 +5895,7 @@ describe("matrix live qa scenarios", () => {
         setupSuccess?: unknown;
       };
       expect(artifacts.accountId).toBe("cli-invalid-recovery-key");
+      expect(artifacts.bootstrapErrorPreview).toBe(bootstrapError.slice(0, 239));
       expect(artifacts.bootstrapSuccess).toBe(false);
       expect(artifacts.cliDeviceId).toBe("CLIINVALIDDEVICE");
       expect(artifacts.encryptionChanged).toBe(true);
@@ -6322,6 +6336,9 @@ describe("matrix live qa scenarios", () => {
   });
 
   it("runs Matrix E2EE bootstrap failure through a real faulted homeserver endpoint", async () => {
+    const bootstrapError = buildMatrixQaSplitSurrogateError(
+      "Matrix room key backup is still missing after bootstrap: ",
+    );
     const stop = vi.fn().mockResolvedValue(undefined);
     const hits = vi.fn().mockReturnValue([
       {
@@ -6344,7 +6361,7 @@ describe("matrix live qa scenarios", () => {
         userSigningKeyPublished: true,
       },
       cryptoBootstrap: null,
-      error: "Matrix room key backup is still missing after bootstrap",
+      error: bootstrapError,
       pendingVerifications: 0,
       success: false,
       verification: {
@@ -6400,12 +6417,14 @@ describe("matrix live qa scenarios", () => {
     });
     const artifacts = result.artifacts as {
       bootstrapActor?: unknown;
+      bootstrapErrorPreview?: unknown;
       bootstrapSuccess?: unknown;
       faultedEndpoint?: unknown;
       faultHitCount?: unknown;
       faultRuleId?: unknown;
     };
     expect(artifacts.bootstrapActor).toBe("driver");
+    expect(artifacts.bootstrapErrorPreview).toBe(bootstrapError.slice(0, 239));
     expect(artifacts.bootstrapSuccess).toBe(false);
     expect(artifacts.faultedEndpoint).toBe("/_matrix/client/v3/room_keys/version");
     expect(artifacts.faultHitCount).toBe(1);


### PR DESCRIPTION
Related: #103215

## What Problem This Solves

Fixes an issue where Matrix QA bootstrap-failure artifacts could contain malformed Unicode when a long error placed a surrogate pair across the 240-code-unit preview boundary.

## Why This Change Was Made

All three owning E2EE artifact paths now use the public UTF-16-safe truncation helper. The contributor's standalone proof script was replaced with exact assertions inside the existing CLI bootstrap-failure, invalid recovery-key, and faulted-homeserver scenario tests.

## User Impact

Matrix QA reports keep complete Unicode characters in bounded bootstrap error previews, so downstream JSON and report consumers do not receive lone surrogate halves. Runtime Matrix behavior is unchanged.

## Evidence

- Each regression constructs an emoji whose surrogate pair crosses the 240-code-unit boundary and expects the exact 239-code-unit safe prefix.
- Targeted `oxfmt --check` and `git diff --check` pass.
- Fresh full-branch Codex autoreview reports no actionable findings (correctness confidence 0.98).
- Blacksmith Testbox `tbx_01kx6pynbar8c90w28e6n3pjk0` passed `pnpm test extensions/qa-matrix/src/runners/contract/scenarios.test.ts`: 1 file and 74 tests, exact head, exit 0.
- Exact head `901dcff0c5fbb417ffbb18d12dd68f81e9f9cb0f` passes hosted build, lint, types, guards, and all selected test shards with no relevant failures.

Contributor credit is preserved in commit `901dcff0c5fbb417ffbb18d12dd68f81e9f9cb0f` with `Co-authored-by: lsr911 <liao.shirong@xydigit.com>`.
