### PR TITLE
fix(feishu): prevent duplicate content in streaming cards

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -585,6 +585,7 @@ describe("FeishuStreamingSession", () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_900);
     const replaceBodies: string[] = [];
+    const settingsBodies: string[] = [];
     const previous = "> Thinking one\n\n---\n\nanswer";
     const next = "> Thinking two\n\n---\n\nanswer more";
     let sentTextWhenSettingsClosed: string | undefined;
@@ -603,6 +604,7 @@ describe("FeishuStreamingSession", () => {
         return jsonResponse({ code: 19_002, msg: "replacement rejected" });
       }
       if (url.pathname.includes("/settings")) {
+        settingsBodies.push(body);
         sentTextWhenSettingsClosed = (session as unknown as { state: StreamingSessionState }).state
           .sentText;
       }
@@ -632,7 +634,13 @@ describe("FeishuStreamingSession", () => {
     await expect(session.close()).resolves.toBe(true);
 
     expect(replaceBodies).toHaveLength(1);
+    expect(settingsBodies).toHaveLength(1);
     expect(sentTextWhenSettingsClosed).toBe(previous);
+    const settingsPayload = JSON.parse(settingsBodies[0] ?? "{}") as { settings?: string };
+    const settings = JSON.parse(settingsPayload.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    expect(settings.config?.summary?.content).toBe(previous);
     expect(log).toHaveBeenCalledWith(
       "Final replace failed: Error: Replace card content failed: replacement rejected (code=19002)",
     );

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -589,7 +589,14 @@ describe("FeishuStreamingSession", () => {
     const previous = "> Thinking one\n\n---\n\nanswer";
     const next = "> Thinking two\n\n---\n\nanswer more";
     let sentTextWhenSettingsClosed: string | undefined;
-    let session!: FeishuStreamingSession;
+    const state: StreamingSessionState = {
+      cardId: "card_rejected_pending_reasoning_close",
+      messageId: "om_rejected_pending_reasoning_close",
+      sequence: 1,
+      currentText: previous,
+      sentText: previous,
+      hasNote: false,
+    };
     const deps = createMemoryFetch((url, body) => {
       if (url.pathname.includes("/auth/")) {
         return jsonResponse({
@@ -605,27 +612,19 @@ describe("FeishuStreamingSession", () => {
       }
       if (url.pathname.includes("/settings")) {
         settingsBodies.push(body);
-        sentTextWhenSettingsClosed = (session as unknown as { state: StreamingSessionState }).state
-          .sentText;
+        sentTextWhenSettingsClosed = state.sentText;
       }
       return jsonResponse({ code: 0, msg: "ok" });
     });
     const log = vi.fn();
-    session = new FeishuStreamingSession(
+    const session = new FeishuStreamingSession(
       {} as never,
       { appId: "app_rejected_pending_reasoning_close", appSecret: "secret" },
       log,
       deps,
     );
     setStreamingSessionInternals(session, {
-      state: {
-        cardId: "card_rejected_pending_reasoning_close",
-        messageId: "om_rejected_pending_reasoning_close",
-        sequence: 1,
-        currentText: previous,
-        sentText: previous,
-        hasNote: false,
-      },
+      state,
       lastUpdateTime: 2_900,
     });
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -581,6 +581,115 @@ describe("FeishuStreamingSession", () => {
     expect(JSON.parse(payload.element ?? "{}")).toMatchObject({ content: next });
   });
 
+  it("retains prior visible content when CardKit rejects a divergent close replacement", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_900);
+    const replaceBodies: string[] = [];
+    const previous = "> Thinking one\n\n---\n\nanswer";
+    const next = "> Thinking two\n\n---\n\nanswer more";
+    let sentTextWhenSettingsClosed: string | undefined;
+    let session!: FeishuStreamingSession;
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.endsWith("/elements/content")) {
+        replaceBodies.push(body);
+        return jsonResponse({ code: 19_002, msg: "replacement rejected" });
+      }
+      if (url.pathname.includes("/settings")) {
+        sentTextWhenSettingsClosed = (session as unknown as { state: StreamingSessionState }).state
+          .sentText;
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    const log = vi.fn();
+    session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_rejected_pending_reasoning_close", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_rejected_pending_reasoning_close",
+        messageId: "om_rejected_pending_reasoning_close",
+        sequence: 1,
+        currentText: previous,
+        sentText: previous,
+        hasNote: false,
+      },
+      lastUpdateTime: 2_900,
+    });
+
+    await session.update(next);
+    // close() reports whether any accepted content remains visible, even when the final rewrite fails.
+    await expect(session.close()).resolves.toBe(true);
+
+    expect(replaceBodies).toHaveLength(1);
+    expect(sentTextWhenSettingsClosed).toBe(previous);
+    expect(log).toHaveBeenCalledWith(
+      "Final replace failed: Error: Replace card content failed: replacement rejected (code=19002)",
+    );
+  });
+
+  it("logs CardKit body errors for note updates and streaming close settings", async () => {
+    const noteBodies: string[] = [];
+    const settingsBodies: string[] = [];
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.includes("/elements/note/content")) {
+        noteBodies.push(body);
+        return jsonResponse({ code: 19_003, msg: "note rejected" });
+      }
+      if (url.pathname.includes("/settings")) {
+        settingsBodies.push(body);
+        return jsonResponse({ code: 19_004, msg: "settings rejected" });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    const log = vi.fn();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_rejected_note_and_close", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_rejected_note_and_close",
+        messageId: "om_rejected_note_and_close",
+        sequence: 1,
+        currentText: "visible answer",
+        sentText: "visible answer",
+        hasNote: true,
+      },
+    });
+
+    await expect(session.close(undefined, { note: "model note" })).resolves.toBe(true);
+
+    expect(noteBodies).toHaveLength(1);
+    expect(settingsBodies).toHaveLength(1);
+    expect(log).toHaveBeenCalledWith(
+      "Note update failed: Error: Update card note failed: note rejected (code=19003)",
+    );
+    expect(log).toHaveBeenCalledWith(
+      "Close failed: Error: Close streaming card failed: settings rejected (code=19004)",
+    );
+  });
+
   it("retries cumulative content after a failed streaming update", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_000);

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -639,7 +639,8 @@ describe("FeishuStreamingSession", () => {
     const settings = JSON.parse(settingsPayload.settings ?? "{}") as {
       config?: { summary?: { content?: string } };
     };
-    expect(settings.config?.summary?.content).toBe(previous);
+    expect(settings.config?.summary?.content).toBe(previous.replaceAll("\n", " ").trim());
+    expect(settings.config?.summary?.content).not.toContain("Thinking two");
     expect(log).toHaveBeenCalledWith(
       "Final replace failed: Error: Replace card content failed: replacement rejected (code=19002)",
     );

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -366,7 +366,7 @@ describe("FeishuStreamingSession", () => {
     );
   });
 
-  it("flushes throttled pending text after the throttle window", async () => {
+  it("flushes only the latest authoritative snapshot after the throttle window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const updateBodies: string[] = [];
@@ -386,36 +386,56 @@ describe("FeishuStreamingSession", () => {
         cardId: "card_1",
         messageId: "om_1",
         sequence: 1,
-        currentText: "hello",
-        sentText: "hello",
+        currentText: "visible",
+        sentText: "visible",
         hasNote: false,
       },
       lastUpdateTime: 1_000,
     });
 
-    await session.update("hello small");
+    await session.update("draft one");
+    await session.update("draft two");
     expect(updateBodies).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(160);
 
     expect(updateBodies).toHaveLength(1);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: "hello small",
+      content: "draft two",
       sequence: 2,
       uuid: "s_card_1_2",
     });
   });
 
-  it("handles a rejected scheduled flush update", async () => {
+  it("retries the same throttled snapshot after a CardKit body error", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_500);
     const updateBodies: string[] = [];
-    mockFetches(updateBodies);
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        updateBodies.push(body);
+        return jsonResponse(
+          updateBodies.length === 1
+            ? { code: 19_001, msg: "sequence rejected" }
+            : { code: 0, msg: "ok" },
+        );
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
     const log = vi.fn();
     const session = new FeishuStreamingSession(
       {} as never,
       { appId: "app_rejected_pending_flush", appSecret: "secret" },
       log,
+      deps,
     );
     setStreamingSessionInternals(session, {
       state: {
@@ -430,11 +450,18 @@ describe("FeishuStreamingSession", () => {
     });
 
     await session.update("hello small");
-    vi.spyOn(session, "update").mockRejectedValueOnce(new Error("flush exploded"));
+    await vi.advanceTimersByTimeAsync(160);
+    await session.update("hello small");
     await vi.advanceTimersByTimeAsync(160);
 
-    expect(log).toHaveBeenCalledWith("Scheduled flush update failed: Error: flush exploded");
-    expect(updateBodies).toHaveLength(0);
+    expect(log).toHaveBeenCalledWith(
+      "Update failed: Error: Update card content failed: sequence rejected (code=19001)",
+    );
+    expect(updateBodies).toHaveLength(2);
+    expect(updateBodies.map((body) => JSON.parse(body).content)).toEqual([
+      "hello small",
+      "hello small",
+    ]);
   });
 
   it("pushes natural-boundary updates immediately inside the throttle window", async () => {
@@ -472,6 +499,86 @@ describe("FeishuStreamingSession", () => {
       sequence: 2,
       uuid: "s_card_2_2",
     });
+  });
+
+  it("sends a divergent reasoning snapshot without merging the previous snapshot", async () => {
+    const updateBodies: string[] = [];
+    const deps = await createStreamingFetch(({ url, body, res }) => {
+      if (url.pathname.includes("/auth/")) {
+        writeJson(res, {
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+        return;
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        updateBodies.push(body);
+      }
+      writeJson(res, { code: 0, msg: "ok" });
+    });
+    const previous = "> Thinking one\n\n---\n\nanswer";
+    const next = "> Thinking two\n\n---\n\nanswer!";
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_reasoning_snapshot", appSecret: "secret" },
+      undefined,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_reasoning",
+        messageId: "om_reasoning",
+        sequence: 1,
+        currentText: previous,
+        sentText: previous,
+        hasNote: false,
+      },
+    });
+
+    await session.update(next);
+
+    expect(updateBodies).toHaveLength(1);
+    expect(JSON.parse(updateBodies[0] ?? "{}")).toMatchObject({ content: next });
+  });
+
+  it("closes with a throttled divergent latest snapshot without merging it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_750);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    const deps = mockFetches(updateBodies, new Set<number>(), replaceBodies);
+    const previous = "> Thinking one\n\n---\n\nanswer";
+    const next = "> Thinking two\n\n---\n\nanswer more";
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_pending_reasoning_close", appSecret: "secret" },
+      undefined,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_pending_reasoning_close",
+        messageId: "om_pending_reasoning_close",
+        sequence: 1,
+        currentText: previous,
+        sentText: previous,
+        hasNote: false,
+      },
+      lastUpdateTime: 2_750,
+    });
+
+    await session.update(next);
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(0);
+
+    await session.close();
+
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(1);
+    const payload = JSON.parse(replaceBodies[0] ?? "{}") as { element?: string };
+    expect(JSON.parse(payload.element ?? "{}")).toMatchObject({ content: next });
   });
 
   it("retries cumulative content after a failed streaming update", async () => {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -419,10 +419,21 @@ export class FeishuStreamingSession {
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.update",
       });
-      await release();
-      if (!response.ok) {
-        onError?.(new Error(`Update card content failed with HTTP ${response.status}`));
-        return false;
+      try {
+        if (!response.ok) {
+          throw new Error(`Update card content failed with HTTP ${response.status}`);
+        }
+        const data = await readFeishuJsonResponse<{ code?: number; msg?: string }>(
+          response,
+          "feishu.streaming-card.update",
+        );
+        if (data.code !== 0) {
+          throw new Error(
+            `Update card content failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`,
+          );
+        }
+      } finally {
+        await release();
       }
       return true;
     } catch (error) {
@@ -490,57 +501,60 @@ export class FeishuStreamingSession {
     const delayMs = Math.max(0, this.updateThrottleMs - (Date.now() - this.lastUpdateTime));
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
-      const pending = this.pendingText;
-      if (!pending || this.closed) {
+      if (!this.pendingText || this.closed) {
         return;
       }
-      void this.update(pending).catch((error: unknown) =>
+      this.lastUpdateTime = Date.now();
+      void this.flushPendingUpdate().catch((error: unknown) =>
         this.log?.(`Scheduled flush update failed: ${String(error)}`),
       );
     }, delayMs);
   }
 
+  private async flushPendingUpdate(): Promise<void> {
+    this.queue = this.queue.then(async () => {
+      if (!this.state || this.closed) {
+        return;
+      }
+      const nextText = this.pendingText;
+      if (!nextText) {
+        return;
+      }
+      this.pendingText = null;
+      if (nextText === this.state.sentText) {
+        return;
+      }
+      const sent = await this.updateCardContent(nextText, (e) =>
+        this.log?.(`Update failed: ${String(e)}`),
+      );
+      if (sent && this.state) {
+        this.state.sentText = nextText;
+      } else if (this.state && this.pendingText === null) {
+        // Retain a failed full snapshot for the next update or close retry.
+        this.pendingText = nextText;
+      }
+    });
+    await this.queue;
+  }
+
   async update(text: string): Promise<void> {
-    if (!this.state || this.closed) {
+    if (!this.state || this.closed || !text) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
-    if (!mergedInput || mergedInput === this.state.currentText) {
-      return;
-    }
-    this.pendingText = mergedInput;
+    // The caller supplies the complete current card text. CardKit derives its own
+    // display delta, so merging snapshots here can duplicate divergent reasoning.
+    this.state.currentText = text;
+    this.pendingText = text;
     this.clearFlushTimer();
 
-    const shouldForceUpdate = shouldPushStreamingUpdate(this.state.currentText, mergedInput);
+    const shouldForceUpdate = shouldPushStreamingUpdate(this.state.sentText, text);
     const now = Date.now();
     if (!shouldForceUpdate && now - this.lastUpdateTime < this.updateThrottleMs) {
       this.schedulePendingFlush();
       return;
     }
     this.lastUpdateTime = now;
-
-    this.queue = this.queue.then(async () => {
-      if (!this.state || this.closed) {
-        return;
-      }
-      const nextText = this.pendingText ?? mergedInput;
-      const mergedText = mergeStreamingText(this.state.currentText, nextText);
-      if (!mergedText || mergedText === this.state.currentText) {
-        return;
-      }
-      if (mergedText === this.state.sentText) {
-        return;
-      }
-      this.pendingText = null;
-      this.state.currentText = mergedText;
-      const sent = await this.updateCardContent(mergedText, (e) =>
-        this.log?.(`Update failed: ${String(e)}`),
-      );
-      if (sent && this.state) {
-        this.state.sentText = mergedText;
-      }
-    });
-    await this.queue;
+    await this.flushPendingUpdate();
   }
 
   private async updateNoteContent(note: string): Promise<void> {
@@ -586,8 +600,7 @@ export class FeishuStreamingSession {
     this.clearFlushTimer();
     await this.queue;
 
-    const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
-    const text = finalText ?? pendingMerged;
+    const text = finalText ?? this.pendingText ?? this.state.currentText;
     const apiBase = resolveApiBase(this.creds.domain);
     let visibleContentSent = Boolean(this.state.sentText.trim());
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -529,9 +529,6 @@ export class FeishuStreamingSession {
       );
       if (sent && this.state) {
         this.state.sentText = nextText;
-      } else if (this.state && this.pendingText === null) {
-        // Retain a failed full snapshot for the next update or close retry.
-        this.pendingText = nextText;
       }
     });
     await this.queue;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -645,6 +645,8 @@ export class FeishuStreamingSession {
     }
 
     // Close streaming mode
+    // A rejected final write must not advertise content that CardKit never accepted.
+    const acceptedText = this.state.sentText;
     this.state.sequence += 1;
     await fetchWithSsrFGuard({
       url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
@@ -660,7 +662,7 @@ export class FeishuStreamingSession {
         },
         body: JSON.stringify({
           settings: JSON.stringify({
-            config: { streaming_mode: false, summary: { content: truncateSummary(text) } },
+            config: { streaming_mode: false, summary: { content: truncateSummary(acceptedText) } },
           }),
           sequence: this.state.sequence,
           uuid: `c_${this.state.cardId}_${this.state.sequence}`,

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -35,6 +35,8 @@ type FeishuStreamingDeps = {
   lookupFn?: LookupFn;
 };
 
+type CardKitResponse = { code?: number; msg?: string };
+
 /** Options for customising the initial streaming card appearance. */
 type StreamingCardOptions = {
   /** Optional header with title and color template. */
@@ -100,6 +102,20 @@ function resolveAllowedHostnames(domain?: FeishuDomain): string[] {
     }
   }
   return ["open.feishu.cn"];
+}
+
+async function assertSuccessfulCardKitResponse(
+  response: Response,
+  auditContext: string,
+  action: string,
+): Promise<void> {
+  if (!response.ok) {
+    throw new Error(`${action} failed with HTTP ${response.status}`);
+  }
+  const data = await readFeishuJsonResponse<CardKitResponse>(response, auditContext);
+  if (data.code !== 0) {
+    throw new Error(`${action} failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`);
+  }
 }
 
 async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise<string> {
@@ -420,18 +436,11 @@ export class FeishuStreamingSession {
         auditContext: "feishu.streaming-card.update",
       });
       try {
-        if (!response.ok) {
-          throw new Error(`Update card content failed with HTTP ${response.status}`);
-        }
-        const data = await readFeishuJsonResponse<{ code?: number; msg?: string }>(
+        await assertSuccessfulCardKitResponse(
           response,
           "feishu.streaming-card.update",
+          "Update card content",
         );
-        if (data.code !== 0) {
-          throw new Error(
-            `Update card content failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`,
-          );
-        }
       } finally {
         await release();
       }
@@ -475,10 +484,14 @@ export class FeishuStreamingSession {
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.replace",
       });
-      await release();
-      if (!response.ok) {
-        onError?.(new Error(`Replace card content failed with HTTP ${response.status}`));
-        return false;
+      try {
+        await assertSuccessfulCardKitResponse(
+          response,
+          "feishu.streaming-card.replace",
+          "Replace card content",
+        );
+      } finally {
+        await release();
       }
       return true;
     } catch (error) {
@@ -583,8 +596,16 @@ export class FeishuStreamingSession {
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
     })
-      .then(async ({ release }) => {
-        await release();
+      .then(async ({ response, release }) => {
+        try {
+          await assertSuccessfulCardKitResponse(
+            response,
+            "feishu.streaming-card.note-update",
+            "Update card note",
+          );
+        } finally {
+          await release();
+        }
       })
       .catch((e: unknown) => this.log?.(`Note update failed: ${String(e)}`));
   }
@@ -599,6 +620,8 @@ export class FeishuStreamingSession {
 
     const text = finalText ?? this.pendingText ?? this.state.currentText;
     const apiBase = resolveApiBase(this.creds.domain);
+    // A failed final rewrite does not erase previously accepted visible content.
+    // sentText advances only for an accepted write; the return value reports any visible content.
     let visibleContentSent = Boolean(this.state.sentText.trim());
 
     // Only send final update if content differs from what's already displayed.
@@ -648,8 +671,16 @@ export class FeishuStreamingSession {
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
     })
-      .then(async ({ release }) => {
-        await release();
+      .then(async ({ response, release }) => {
+        try {
+          await assertSuccessfulCardKitResponse(
+            response,
+            "feishu.streaming-card.close",
+            "Close streaming card",
+          );
+        } finally {
+          await release();
+        }
       })
       .catch((e: unknown) => this.log?.(`Close failed: ${String(e)}`));
     const finalState = this.state;


### PR DESCRIPTION
Related: #83868

Original diagnosis and fix direction by Jun Ma (@hpumajun). This maintainer rewrite preserves that contribution in the commit trailer while narrowing the change to the streaming-card owner.

## What Problem This Solves

Fixes an issue where Feishu users streaming cards with changing reasoning snapshots could see old and new full snapshots concatenated, duplicating visible content until the card was finalized.

It also fixes related acceptance holes: Feishu can reject CardKit writes with HTTP 200 and a nonzero business `code`; treating those responses as successful advanced local state, prevented identical retries, and could advertise rejected content in the final card summary.

## Why This Change Was Made

The Feishu reply path supplies complete current card text, and CardKit's element-content update accepts complete content while deriving its own incremental typewriter presentation. The streaming session now treats every input as the authoritative snapshot, keeps current, pending, and successfully sent state distinct, and makes throttling latest-wins.

All direct CardKit write boundaries in the session now validate both HTTP status and Feishu's bounded JSON response `code`. `sentText` advances only after CardKit accepts the snapshot, closeout summaries describe the last accepted content, and auxiliary note/settings rejections are logged. This is intentionally limited to `streaming-card.ts`; the original PR's reply-dispatcher suppression was not needed for the proven invariant.

## User Impact

Feishu streaming cards no longer duplicate divergent reasoning content. Throttled updates flush only the newest full snapshot, closeout uses the latest snapshot, and rejected writes are not silently considered sent. When a final rewrite is rejected, prior accepted visible content and its summary remain consistent.

## Evidence

- Published and freshly reviewed head: `3683becb22472dfef9fc530a0930103aa16650d7`.
- Stable patch ID across the final unrelated-main rebase: `7538b0a7a6a05459530aa6079ea937d157f17877`.
- Blacksmith Testbox focused proof on the identical stable patch: `pnpm test extensions/feishu/src/streaming-card.test.ts` — 25/25 tests passed ([run 29122688887](https://github.com/openclaw/openclaw/actions/runs/29122688887)).
- Blacksmith Testbox changed gate on the identical stable patch: extension production/test tsgo lanes, oxlint (0 warnings, 0 errors), dependency/package guards, database-first guard, and runtime import-cycle check all passed ([run 29122687633](https://github.com/openclaw/openclaw/actions/runs/29122687633)).
- The final rebase changed only the base, had no Feishu overlap, and preserved the full patch ID; fresh exact-head Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted/actionable findings (correctness 0.91).
- Supporting full Feishu suite on the earlier semantic patch: 75 files and 1,033 tests passed.
- Regression coverage proves latest-wins throttling, exact retry after HTTP-200/nonzero CardKit rejection, divergent reasoning snapshots through a real local HTTP server/fetch boundary, closeout with a throttled divergent snapshot, rejected replacement state/summary consistency, and note/settings body-error handling.
- Audited the pinned `@larksuiteoapi/node-sdk@1.68.0` types and runtime: `cardElement.content`, `cardElement.update`, and `card.settings` share the `{code,msg}` envelope; content calls send complete element snapshots while CardKit derives the incremental display.

Proof gap: no live Feishu tenant credential was available, so this was not exercised against a real tenant. The HTTP boundary, application-level response handling, caller contract, and pinned SDK implementation were verified directly.
