### PR TITLE
fix: preserve messages when Codex steering lacks transcript acknowledgement

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -141,8 +141,12 @@ vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
     sessionId: string,
     prompt: string,
     options: unknown,
-  ) =>
-    state.queueEmbeddedAgentMessageMock(sessionId, prompt, options)
+  ) => {
+    const result = state.queueEmbeddedAgentMessageMock(sessionId, prompt, options);
+    if (typeof result === "object") {
+      return result;
+    }
+    return result
       ? {
           queued: true,
           sessionId,
@@ -156,7 +160,8 @@ vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
           reason: "no_active_run",
           target: "none",
           gatewayHealth: "live",
-        },
+        };
+  },
 }));
 
 vi.mock("./queue.js", () => ({
@@ -351,6 +356,30 @@ describe("runReplyAgent active steering", () => {
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues a follow-up when transcript-backed steering is unsupported", async () => {
+    state.queueEmbeddedAgentMessageMock.mockReturnValueOnce({
+      queued: false,
+      sessionId: "session",
+      reason: "transcript_commit_wait_unsupported",
+      target: "none",
+      gatewayHealth: "live",
+    });
+    const onTurnAdopted = vi.fn();
+    const { run } = createMinimalRun({
+      opts: { onTurnAdopted },
+      isActive: true,
+      isStreaming: true,
+      shouldSteer: true,
+      resolvedQueueMode: "steer",
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(onTurnAdopted).not.toHaveBeenCalled();
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1274,6 +1274,7 @@ export async function runReplyAgent(params: {
     }
   };
 
+  let shouldQueueAfterSteerRejection = false;
   if (effectiveShouldSteer && isActive) {
     const activeReplyOperation =
       providedReplyOperation ?? (sessionKey ? replyRunRegistry.get(sessionKey) : undefined);
@@ -1314,6 +1315,9 @@ export async function runReplyAgent(params: {
       typing.cleanup();
       return undefined;
     }
+    // The active runtime still owns the turn but cannot prove transcript adoption.
+    // Keep the inbound message queued so ingress can finalize after a later run.
+    shouldQueueAfterSteerRejection = steerOutcome.reason === "transcript_commit_wait_unsupported";
     const summary = formatEmbeddedAgentQueueFailureSummary(steerOutcome);
     logVerbose(`queue: active session ${steerSessionId} rejected steering injection: ${summary}`);
   }
@@ -1321,7 +1325,7 @@ export async function runReplyAgent(params: {
   const activeRunQueueAction = resolveActiveRunQueueAction({
     isActive,
     isHeartbeat,
-    shouldFollowup: effectiveShouldFollowup,
+    shouldFollowup: effectiveShouldFollowup || shouldQueueAfterSteerRejection,
     queueMode: activeRunQueueMode,
     resetTriggered: effectiveResetTriggered,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a message arriving during an active Codex app-server turn could receive no response when Telegram required transcript-backed adoption and the runtime could not wait for a transcript commit.

## Why This Change Was Made

When steering fails specifically with `transcript_commit_wait_unsupported`, OpenClaw keeps the inbound message in the follow-up queue until the active run finishes. Other steering rejection reasons retain their existing admission behavior.

## User Impact

Messages are preserved and run after the active turn when Codex cannot provide the transcript acknowledgement required for safe same-turn steering.

## Evidence

- Reproduced the bug with a regression test that returned a competing run payload instead of queueing the inbound message.
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- Result: 91 tests passed.
- Autoreview reported no accepted or actionable findings.

Related: #98236
