### PR TITLE
fix(cli): keep owner tools in local agent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Local agent CLI owner tools:** keep configured-local Gateway agent runs owner-authorized without requiring a redundant model override, restoring `nodes`, `gateway`, `cron`, and `computer` while preserving least-privilege configured-remote calls. (#103919)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Local agent CLI owner tools:** keep configured-local Gateway agent runs owner-authorized without requiring a redundant model override, restoring `nodes`, `gateway`, `cron`, and `computer` while preserving least-privilege configured-remote calls. (#103919)
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -234,6 +234,7 @@ let zeroTimeoutGatewayRequestMs: number | undefined;
 
 function resetAgentCliCommandMocksForTest() {
   vi.clearAllMocks();
+  vi.stubEnv("OPENCLAW_GATEWAY_URL", "");
   agentViaGatewayTesting.resetLazyImportsForTests();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests([0, 0, 0, 0]);
   loadAgentSessionModuleMock.mockImplementation(async () => await import("./agent/session.js"));
@@ -247,6 +248,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests();
   loggingState.forceConsoleToStderr = originalForceConsoleToStderr;
 });
@@ -290,7 +292,42 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("uses gateway by default", async () => {
+  it("uses owner authority with the configured local gateway by default", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      expect(request.clientName).toBe("cli");
+      expect(request.mode).toBe("cli");
+      expect(request.scopes).toEqual(["operator.admin"]);
+      expect(request.params).toHaveProperty("cleanupBundleMcpOnRunEnd", true);
+      expect(agentCommand).not.toHaveBeenCalled();
+      expect(agentModuleLoadCount).not.toHaveBeenCalled();
+      expect(runtime.log).toHaveBeenCalledWith("hello");
+    });
+  });
+
+  it.each([
+    {
+      label: "configured remote gateway",
+      overrides: {
+        gateway: {
+          mode: "remote" as const,
+          remote: { url: "wss://gateway.example" },
+        },
+      },
+    },
+    {
+      label: "gateway URL override",
+      gatewayUrl: "wss://gateway-override.example",
+    },
+  ])("keeps ordinary $label runs least-privilege", async ({ gatewayUrl, overrides }) => {
+    if (gatewayUrl) {
+      vi.stubEnv("OPENCLAW_GATEWAY_URL", gatewayUrl);
+    }
     await withTempStore(async () => {
       mockGatewaySuccessReply();
 
@@ -301,11 +338,7 @@ describe("agentCliCommand", () => {
       expect(request.clientName).toBe("cli");
       expect(request.mode).toBe("cli");
       expect(request).not.toHaveProperty("scopes");
-      expect(request.params).toHaveProperty("cleanupBundleMcpOnRunEnd", true);
-      expect(agentCommand).not.toHaveBeenCalled();
-      expect(agentModuleLoadCount).not.toHaveBeenCalled();
-      expect(runtime.log).toHaveBeenCalledWith("hello");
-    });
+    }, overrides);
   });
 
   it("reads a UTF-8 message file for gateway dispatch", async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -739,6 +739,8 @@ async function agentViaGatewayCommand(
   const modelOverride = normalizeOptionalString(opts.model);
   const hasModelOverride = Boolean(modelOverride);
   const needsAdminGatewayIdentity = hasModelOverride || isSessionResetCommand(body);
+  const hasGatewayUrlOverride = Boolean(normalizeOptionalString(process.env.OPENCLAW_GATEWAY_URL));
+  const usesRemoteGateway = cfg.gateway?.mode === "remote" || hasGatewayUrlOverride;
   const gatewayIdentity: AgentGatewayCallIdentity = needsAdminGatewayIdentity
     ? {
         clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
@@ -748,6 +750,9 @@ async function agentViaGatewayCommand(
     : {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
+        // The local CLI is the Gateway owner. Keep owner-only run tools available;
+        // remote clients retain the agent method's least-privilege scope.
+        ...(usesRemoteGateway ? {} : { scopes: [ADMIN_SCOPE] }),
       };
 
   let acceptedRunId: string | undefined = idempotencyKey;


### PR DESCRIPTION
Closes #103919

## What Problem This Solves

Fixes an issue where users running a normal `openclaw agent` turn through their configured local Gateway would lose the owner-only `nodes`, `gateway`, `cron`, and `computer` tools unless they supplied a redundant `--model` override.

The run's system-prompt report still advertised those tools, but the runtime MCP surface omitted them, so agents reported that node operations were unavailable.

## Why This Change Was Made

Ordinary CLI agent dispatch now requests the existing `operator.admin` owner scope only when the resolved target is the configured local Gateway. The client remains a CLI client, server authorization and tool policy are unchanged, and ordinary configured-remote or `OPENCLAW_GATEWAY_URL`-overridden calls retain the existing least-privilege method scope. Model overrides and reset commands keep their existing backend/admin path.

## User Impact

Local operators can ask Gateway-backed agents to inspect and operate nodes without redundantly pinning the session's current model. Remote non-admin CLI clients do not gain owner tools or trigger an admin scope request.

## Evidence

- Live pre-fix A/B on OpenClaw 2026.6.11 (`366d09b`), macOS 26.5.2:
  - ordinary Gateway-backed run completed but omitted exactly `nodes`, `gateway`, `cron`, and `computer` from Claude's MCP surface;
  - the same command plus `--model anthropic/claude-fable-5` invoked `nodes` successfully and returned all six connected nodes;
  - both runs had the same prompt-tool hash, isolating the Gateway identity path.
- `corepack pnpm test src/commands/agent-via-gateway.test.ts`: 72/72 passed on Blacksmith Testbox `tbx_01kx6sb7z90qxedj6ppptckxrd` at exact head `22882a4e`.
- `corepack pnpm check:changed`: passed core/core-test typechecks, changed-file lint, changelog checks, import-cycle checks, and repository guards on the same Testbox lease.
- `corepack pnpm exec oxfmt --check src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts CHANGELOG.md`: passed.
- Fresh Codex autoreview: clean after adding explicit coverage for both configured-remote and environment-overridden Gateway targets.

AI-assisted: yes. The implementation, authorization boundary, tests, and live A/B evidence were reviewed before publication.
