### PR TITLE
fix(i18n): recognize Meta docs glossary terms

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1228,6 +1228,18 @@
     "target": "cohere"
   },
   {
+    "source": "Meta",
+    "target": "Meta"
+  },
+  {
+    "source": "Meta plugin",
+    "target": "Meta 插件"
+  },
+  {
+    "source": "meta",
+    "target": "meta"
+  },
+  {
     "source": "Zalo ClawBot",
     "target": "Zalo ClawBot"
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the documentation glossary validation rejected the Meta plugin reference pages because their title and link terms had no preferred Chinese translations.

## Why This Change Was Made

Adds the three exact Meta terms emitted by the generated provider and plugin reference pages to the canonical Chinese glossary, following the existing Cohere provider pattern.

## User Impact

Documentation validation can complete for the Meta reference pages. No runtime behavior changes.

## Evidence

- `node scripts/check-docs-i18n-glossary.mjs`
- JSON parse validation
- `git diff --check`
