### PR TITLE
fix: restore validation after suspension coverage

### DIFF
--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -257,7 +257,6 @@ describe("followup queue drain restart after idle window", () => {
       import.meta.url,
       "./queue/enqueue.js?scope=restart-b",
     );
-    const { clearSessionQueues } = await import("./queue.js");
     const key = `test-idle-window-cross-module-${Date.now()}`;
     const calls: FollowupRun[] = [];
     const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
@@ -522,7 +521,6 @@ describe("followup queue drain restart after idle window", () => {
       setImmediate(resolve);
     });
 
-    const { clearSessionQueues } = await import("./queue.js");
     clearSessionQueues([key]);
 
     enqueueFollowupRun(key, createRun({ prompt: "after-clear" }), settings);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -214,7 +214,9 @@ describe("gateway server chat", () => {
     await withMainSessionStore(async () => {
       let subordinateAdmissionClosed: boolean | undefined;
       dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
         const suspension = tryBeginGatewaySuspendAdmission(() => {});
         expect(suspension).not.toBeNull();
         try {
@@ -796,8 +798,8 @@ describe("gateway server chat", () => {
       });
       const subscribeRes = await rpcReq(ws, "sessions.subscribe", {});
       expect(subscribeRes.ok).toBe(true);
-      const rejectDispatch = createDeferred<void>();
-      const releasePersistence = createDeferred<void>();
+      const rejectDispatch = createDeferred();
+      const releasePersistence = createDeferred();
       let dispatchStarted = false;
       let persistenceEntered = false;
       const persistLifecycleEvent = sessionLifecycleState.persistGatewaySessionLifecycleEvent;


### PR DESCRIPTION
Related: #103618

## What Problem This Solves

Fixes a newly introduced current-main validation regression where the suspension coverage added by #103618 made Oxlint report five errors across the queue-drain and Gateway chat test files. The errors block `check:changed` for otherwise unrelated work that includes these current-main files.

## Why This Change Was Made

The tests now use the existing module-level queue cleanup binding, a block-bodied timer executor, and the deferred helper's default `void` type. These are behavior-preserving cleanups that satisfy the repository's current lint rules without weakening or restructuring the suspension coverage.

## User Impact

No runtime behavior changes. Maintainer and CI validation can run cleanly on current main again.

## Evidence

- Before: exact main `72e6fcab8ad943c4033bb59d981f87668feb18ce` reproduced all five errors with the focused core Oxlint command on [Blacksmith Testbox run 29120058168](https://github.com/openclaw/openclaw/actions/runs/29120058168).
- After: the same focused core Oxlint command reports 0 warnings and 0 errors.
- Focused tests: 95 tests passed across the Gateway and auto-reply Vitest project executions.
- Full changed gate: `corepack pnpm check:changed` passed on Blacksmith Testbox `tbx_01kx6t06kph2zndvr37jadkyvr`.
- Fresh structured autoreview: no findings; patch correct at 0.99 confidence.
- Commit: `2dda0c0a966ef18b4b957f27dabd50af21fa8389`; tree: `7bb1c3fb8ccb5b8cd61bbc5e1cdf00db06f6a683`.

AI-assisted: yes.
