### PR TITLE
fix(gateway): restore cooperative suspension validation

### DIFF
--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -257,7 +257,6 @@ describe("followup queue drain restart after idle window", () => {
       import.meta.url,
       "./queue/enqueue.js?scope=restart-b",
     );
-    const { clearSessionQueues } = await import("./queue.js");
     const key = `test-idle-window-cross-module-${Date.now()}`;
     const calls: FollowupRun[] = [];
     const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
@@ -522,7 +521,6 @@ describe("followup queue drain restart after idle window", () => {
       setImmediate(resolve);
     });
 
-    const { clearSessionQueues } = await import("./queue.js");
     clearSessionQueues([key]);
 
     enqueueFollowupRun(key, createRun({ prompt: "after-clear" }), settings);

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -11,7 +11,7 @@ import {
 import { NodeRegistry } from "./node-registry.js";
 import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 import { createChatRunEntry, type ChatRunEntry } from "./server-chat-state.js";
-import type { GatewayCronServiceContract } from "./server-cron.js";
+import type { GatewayCronServiceContract } from "./server-cron-contract.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 
 // Embedded/local agent calls need enough GatewayRequestContext to reuse server

--- a/src/gateway/server-cron-contract.ts
+++ b/src/gateway/server-cron-contract.ts
@@ -1,0 +1,11 @@
+// Gateway cron contracts stay separate from the runtime so shared request
+// types do not pull scheduler implementation dependencies into their graph.
+import type { CronServiceContract } from "../cron/service-contract.js";
+
+export type GatewayCronServiceContract = CronServiceContract & {
+  /** Temporarily disarm ticks without running startup recovery on resume. */
+  pauseScheduling(): void;
+  resumeScheduling(): void;
+  /** Scheduler-owned work not represented by active cron run markers. */
+  getSuspensionBlockerCount?(): number;
+};

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -4,7 +4,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayCronServiceContract, GatewayCronState } from "./server-cron.js";
+import type { GatewayCronServiceContract } from "./server-cron-contract.js";
+import type { GatewayCronState } from "./server-cron.js";
 
 const hoisted = vi.hoisted(() => {
   let state: unknown;

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -4,7 +4,8 @@ import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCronJobsStorePath } from "../cron/store.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
-import type { GatewayCronServiceContract, GatewayCronState } from "./server-cron.js";
+import type { GatewayCronServiceContract } from "./server-cron-contract.js";
+import type { GatewayCronState } from "./server-cron.js";
 
 type LazyGatewayCronParams = {
   cfg: OpenClawConfig;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -24,7 +24,6 @@ import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPruneOptions } from "../cron/run-log.js";
-import type { CronServiceContract } from "../cron/service-contract.js";
 import { CronService } from "../cron/service.js";
 import {
   resolveCronDeliverySessionKey,
@@ -59,18 +58,11 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { createCronExitWatchers, type CronExitResult } from "./cron-exit-watchers.js";
+import type { GatewayCronServiceContract } from "./server-cron-contract.js";
 import {
   dispatchGatewayCronFinishedNotifications,
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
-
-export type GatewayCronServiceContract = CronServiceContract & {
-  /** Temporarily disarm ticks without running startup recovery on resume. */
-  pauseScheduling(): void;
-  resumeScheduling(): void;
-  /** Scheduler-owned work not represented by active cron run markers. */
-  getSuspensionBlockerCount?(): number;
-};
 
 export type GatewayCronState = {
   cron: GatewayCronServiceContract;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -27,7 +27,7 @@ import type {
   ChatRunEntry,
   ChatRunRegistration,
 } from "../server-chat-state.js";
-import type { GatewayCronServiceContract } from "../server-cron.js";
+import type { GatewayCronServiceContract } from "../server-cron-contract.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { TerminalLaunchResolution } from "../terminal/launch.js";

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -214,7 +214,9 @@ describe("gateway server chat", () => {
     await withMainSessionStore(async () => {
       let subordinateAdmissionClosed: boolean | undefined;
       dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
         const suspension = tryBeginGatewaySuspendAdmission(() => {});
         expect(suspension).not.toBeNull();
         try {
@@ -796,8 +798,8 @@ describe("gateway server chat", () => {
       });
       const subscribeRes = await rpcReq(ws, "sessions.subscribe", {});
       expect(subscribeRes.ok).toBe(true);
-      const rejectDispatch = createDeferred<void>();
-      const releasePersistence = createDeferred<void>();
+      const rejectDispatch = createDeferred();
+      const releasePersistence = createDeferred();
       let dispatchStarted = false;
       let persistenceEntered = false;
       const persistLifecycleEvent = sessionLifecycleState.persistGatewaySessionLifecycleEvent;


### PR DESCRIPTION
Related: #103618

## What Problem This Solves

Resolves a problem where the cooperative Gateway suspension change left `main`
with a 557-file Madge import cycle and five core lint failures, blocking hosted
CI and downstream PR preparation.

## Why This Change Was Made

The Gateway-only cron suspension contract now lives in a leaf type module, so
shared request context types no longer depend on the full cron runtime graph.
The accompanying test cleanup removes the exact lint violations without
changing the covered behavior.

## User Impact

No runtime behavior changes. Maintainers regain clean architecture and lint
validation for the cooperative suspension feature.

## Evidence

- Failing `main` CI: run `29117924498`, architecture job `86446192773`, lint job
  `86446192688`.
- Blacksmith Testbox `tbx_01kx6srz7emmr8nhqenmfcjser`:
  - `pnpm check:madge-import-cycles`: 0 cycles.
  - `pnpm check:import-cycles`: 0 runtime value cycles.
  - Focused core lint: 0 warnings, 0 errors.
  - Focused tests: 149/149 passed across cron lazy loading, chat/queue retained
    work, suspension admission, and active-work accounting.
  - `pnpm check:changed`: passed `core, coreTests`, including both tsgo lanes,
    changed-file lint, and guards.
- Structured autoreview: no findings; patch correct, confidence 0.86.
