### PR TITLE
fix(memory-core): keep same-agent session hits in memory recall under tree visibility (#103732)

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b482ccb7d9cc8c9d44e85c534d8ac41f5175d2d872c48bb6b7a5273453fc0eb6  plugin-sdk-api-baseline.json
-3fc939035d0a04a7ddb3aded363286415fac094b14741a4eeb39a3a88ee7bae6  plugin-sdk-api-baseline.jsonl
+a7d56abb81d448ea1527bf58bb5bce79000016036c5c9fa283899bda21e30f88  plugin-sdk-api-baseline.json
+b7aa12349c0a4508823682025ee91208921f174195bfab4a20b1dc02eb34eb34  plugin-sdk-api-baseline.jsonl

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -202,6 +202,62 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     expect(filtered).toEqual([hit]);
   });
 
+  it("keeps same-agent session hits under the default tree visibility (#103732)", async () => {
+    // corpus=sessions recall previously returned 0 hits: the "tree" default
+    // forbade every same-agent transcript that was not spawned by the current
+    // session, even though the keys were already scoped to the agent.
+    combinedSessionStore = {
+      "agent:main:historic": {
+        sessionId: "w1",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/w1.jsonl",
+      },
+    };
+    const hit: MemorySearchResult = {
+      path: "sessions/w1.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    // No tools.sessions.visibility configured: the "tree" default applies.
+    const cfg = asOpenClawConfig({});
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toEqual([hit]);
+  });
+
+  it("keeps the strict guard for sandboxed runs under the default tree visibility", async () => {
+    combinedSessionStore = {
+      "agent:main:historic": {
+        sessionId: "w1",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/w1.jsonl",
+      },
+    };
+    const hit: MemorySearchResult = {
+      path: "sessions/w1.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const cfg = asOpenClawConfig({});
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: true,
+      hits: [hit],
+    });
+    expect(filtered).toStrictEqual([]);
+  });
+
   it("keeps global-scope session hits for non-default agents", async () => {
     combinedSessionStore = {
       global: {

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -232,6 +232,35 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     expect(filtered).toEqual([hit]);
   });
 
+  it("keeps the documented session-tree boundary when tree visibility is explicitly configured", async () => {
+    // An operator who explicitly sets tools.sessions.visibility: "tree" chose
+    // the documented current-session-tree boundary; the recall bypass only
+    // covers the unset default (#103732 review follow-up).
+    combinedSessionStore = {
+      "agent:main:historic": {
+        sessionId: "w1",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/w1.jsonl",
+      },
+    };
+    const hit: MemorySearchResult = {
+      path: "sessions/w1.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "tree" } } });
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toStrictEqual([]);
+  });
+
   it("honors an explicit self visibility over the tree-default recall bypass", async () => {
     combinedSessionStore = {
       "agent:main:historic": {

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -232,6 +232,32 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     expect(filtered).toEqual([hit]);
   });
 
+  it("honors an explicit self visibility over the tree-default recall bypass", async () => {
+    combinedSessionStore = {
+      "agent:main:historic": {
+        sessionId: "w1",
+        updatedAt: 1,
+        sessionFile: "/tmp/sessions/w1.jsonl",
+      },
+    };
+    const hit: MemorySearchResult = {
+      path: "sessions/w1.jsonl",
+      source: "sessions",
+      score: 1,
+      snippet: "x",
+      startLine: 1,
+      endLine: 2,
+    };
+    const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
+    const filtered = await filterMemorySearchHitsBySessionVisibility({
+      cfg,
+      requesterSessionKey: "agent:main:main",
+      sandboxed: false,
+      hits: [hit],
+    });
+    expect(filtered).toStrictEqual([]);
+  });
+
   it("keeps the strict guard for sandboxed runs under the default tree visibility", async () => {
     combinedSessionStore = {
       "agent:main:historic": {

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -110,7 +110,13 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
         continue;
       }
       if (
-        !isMemoryRecallAllowed({ keys, guard, sandboxed: params.sandboxed, authoritative: true })
+        !isMemoryRecallAllowed({
+          keys,
+          guard,
+          sandboxed: params.sandboxed,
+          visibility,
+          authoritative: true,
+        })
       ) {
         continue;
       }
@@ -170,7 +176,15 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     // Slug-fallback key resolution is lossy: a QMD slug can map to the wrong
     // transcript, so those hits must still pass the strict visibility guard.
     const authoritative = liveKeys.length > 0 || !isQmdSessionHit;
-    if (!isMemoryRecallAllowed({ keys, guard, sandboxed: params.sandboxed, authoritative })) {
+    if (
+      !isMemoryRecallAllowed({
+        keys,
+        guard,
+        sandboxed: params.sandboxed,
+        visibility,
+        authoritative,
+      })
+    ) {
       continue;
     }
     next.push(hit);
@@ -188,9 +202,13 @@ function isMemoryRecallAllowed(params: {
   keys: string[];
   guard: { check: (key: string) => { allowed: boolean } };
   sandboxed: boolean;
+  visibility: string;
   authoritative: boolean;
 }): boolean {
-  if (!params.sandboxed && params.authoritative) {
+  // The bypass exists only for the default "tree" subtree semantics, which
+  // made corpus=sessions recall return nothing (#103732). An operator's
+  // explicit stricter mode (e.g. "self") and sandboxed clamps keep the guard.
+  if (!params.sandboxed && params.visibility === "tree" && params.authoritative) {
     return params.keys.length > 0;
   }
   return params.keys.some((key) => params.guard.check(key).allowed);

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -11,6 +11,7 @@ import {
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityGuard,
+  isSessionToolsVisibilityConfigured,
   resolveEffectiveSessionToolsVisibility,
 } from "openclaw/plugin-sdk/session-visibility";
 import { readQmdSessionArtifactIdentity } from "./qmd-session-artifacts.js";
@@ -55,6 +56,7 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     cfg: params.cfg,
     sandboxed: params.sandboxed,
   });
+  const visibilityDefaulted = !isSessionToolsVisibilityConfigured(params.cfg);
   const a2aPolicy = createAgentToAgentPolicy(params.cfg);
   const requesterAgentId = params.requesterSessionKey
     ? resolveSessionAgentId({
@@ -115,6 +117,7 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
           guard,
           sandboxed: params.sandboxed,
           visibility,
+          visibilityDefaulted,
           authoritative: true,
         })
       ) {
@@ -182,6 +185,7 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
         guard,
         sandboxed: params.sandboxed,
         visibility,
+        visibilityDefaulted,
         authoritative,
       })
     ) {
@@ -203,12 +207,19 @@ function isMemoryRecallAllowed(params: {
   guard: { check: (key: string) => { allowed: boolean } };
   sandboxed: boolean;
   visibility: string;
+  visibilityDefaulted: boolean;
   authoritative: boolean;
 }): boolean {
-  // The bypass exists only for the default "tree" subtree semantics, which
-  // made corpus=sessions recall return nothing (#103732). An operator's
-  // explicit stricter mode (e.g. "self") and sandboxed clamps keep the guard.
-  if (!params.sandboxed && params.visibility === "tree" && params.authoritative) {
+  // The bypass exists only for the *defaulted* "tree" subtree semantics,
+  // which made corpus=sessions recall return nothing (#103732). Any explicit
+  // operator choice — including "tree" itself — keeps the documented
+  // session-tree boundary, as do sandboxed clamps.
+  if (
+    !params.sandboxed &&
+    params.visibilityDefaulted &&
+    params.visibility === "tree" &&
+    params.authoritative
+  ) {
     return params.keys.length > 0;
   }
   return params.keys.some((key) => params.guard.check(key).allowed);

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -109,8 +109,9 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
       if (keys.length === 0) {
         continue;
       }
-      const allowed = keys.some((key) => guard.check(key).allowed);
-      if (!allowed) {
+      if (
+        !isMemoryRecallAllowed({ keys, guard, sandboxed: params.sandboxed, authoritative: true })
+      ) {
         continue;
       }
       next.push(hit);
@@ -166,11 +167,31 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     if (keys.length === 0) {
       continue;
     }
-    const allowed = keys.some((key) => guard.check(key).allowed);
-    if (!allowed) {
+    // Slug-fallback key resolution is lossy: a QMD slug can map to the wrong
+    // transcript, so those hits must still pass the strict visibility guard.
+    const authoritative = liveKeys.length > 0 || !isQmdSessionHit;
+    if (!isMemoryRecallAllowed({ keys, guard, sandboxed: params.sandboxed, authoritative })) {
       continue;
     }
     next.push(hit);
   }
   return next;
+}
+
+// Memory recall over the requester's own agent transcripts must not be gated
+// by cross-session "tree" history visibility: every key reaching this check is
+// already scoped to the requester's agent (filterSessionKeysByScopedAgent),
+// and the tree default forbids all non-descendant sessions, which returned 0
+// hits for corpus=sessions (#103732). Sandboxed runs keep the strict guard so
+// the spawned-subtree clamp still holds.
+function isMemoryRecallAllowed(params: {
+  keys: string[];
+  guard: { check: (key: string) => { allowed: boolean } };
+  sandboxed: boolean;
+  authoritative: boolean;
+}): boolean {
+  if (!params.sandboxed && params.authoritative) {
+    return params.keys.length > 0;
+  }
+  return params.keys.some((key) => params.guard.check(key).allowed);
 }

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,12 +195,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10494,
+      10495,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5237,
+      5238,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -84,6 +84,16 @@ export function resolveSessionToolsVisibility(cfg: OpenClawConfig): SessionTools
   return "tree";
 }
 
+// Distinguishes an operator's explicit visibility choice from the "tree"
+// fallback so default-only relaxations (e.g. memory recall over own-agent
+// transcripts) never widen an explicitly configured boundary.
+export function isSessionToolsVisibilityConfigured(cfg: OpenClawConfig): boolean {
+  const raw = (cfg.tools as { sessions?: { visibility?: unknown } } | undefined)?.sessions
+    ?.visibility;
+  const value = normalizeLowercaseStringOrEmpty(raw);
+  return value === "self" || value === "tree" || value === "agent" || value === "all";
+}
+
 /** Resolve visibility after applying sandbox clamps for spawned-session-only agents. */
 export function resolveEffectiveSessionToolsVisibility(params: {
   cfg: OpenClawConfig;


### PR DESCRIPTION
## Summary

Fixes #103732.

`memory_search(corpus=sessions)` returned 0 hits — and unfiltered searches never surfaced session chunks — while `openclaw memory search` returned session results from the same index (reporter: 1133 indexed session chunks).

### Root cause

Only the tool path runs `filterMemorySearchHitsBySessionVisibility` (`extensions/memory-core/src/tools.ts`); the CLI (`cli.runtime.ts`) returns raw `manager.search` results. Inside the filter, every hit's resolved session keys are already scoped to the requester's agent (`filterSessionKeysByScopedAgent`), but each key must then pass a `history`-action visibility guard whose **default `"tree"` visibility forbids every session that is not the requester or its descendant** (`src/plugin-sdk/session-visibility.ts` tree branch). A normal main-agent call (`agent:main:main`) therefore drops every historical `sessions/main/<uuid>` transcript — all of them.

### Change

`extensions/memory-core/src/session-search-visibility.ts`: same-agent hits from **authoritative** key resolutions (QMD artifact identity, exact live-stem matches, plain transcript stems) no longer require the per-key history guard — the agent scoping already applied is the boundary that matters for memory recall. Two protections are preserved deliberately:
- **sandboxed runs** keep the strict guard, so the spawned-subtree clamp still holds;
- **lossy QMD slug-fallback resolutions** keep the strict guard, so a slug cannot authorize the wrong transcript (existing regression `does not authorize QMD archived .md hits through lossy slug fallback` still passes).

## Verification

- New regressions (first one confirmed failing on main): same-agent hit under the default tree visibility is retained; the same hit under `sandboxed: true` is still dropped.
- `pnpm test extensions/memory-core` — full plugin suite passed (including all 728-line visibility suite + the lossy-slug security case).
- `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, oxfmt — clean.

## Real behavior proof

Behavior addressed: memory_search tool returns 0 session hits despite an indexed sessions corpus; CLI works.
Real environment tested: the real `filterMemorySearchHitsBySessionVisibility` production filter through its dedicated test harness with a real combined session store shape (`agent:main:historic` transcript, requester `agent:main:main`, default visibility).
Exact steps or command run after this patch: `pnpm test extensions/memory-core`
Evidence after fix: the same-agent hit that main drops (tree forbid) is retained; sandboxed and lossy-slug paths still deny.
Observed result after fix: corpus=sessions recall returns same-agent transcripts, matching the CLI.
What was not tested: a live gateway with a populated QMD/sqlite index; the divergence is fully reproduced at the filter boundary that separates the tool path from the CLI path.
