### PR TITLE
fix(agents): sentinel-ize thinking signatures interrupted before content_block_stop (#103830)

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1885,6 +1885,52 @@ describe("anthropic transport stream", () => {
     });
   });
 
+  it("sentinel-izes a thinking signature interrupted before content_block_stop", async () => {
+    // A truncated signature persisted verbatim permanently poisons the session:
+    // Anthropic rejects every replay with Invalid `signature` in `thinking`
+    // block (#103830). Blocks that never saw content_block_stop must fall back
+    // to the replay-safe reasoning_content sentinel lane.
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "partial reasoning", signature: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "truncated-chun" },
+        },
+        // No content_block_stop for index 0: the stream was cut mid-block.
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 5 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "think" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.content[0]).toMatchObject({
+      type: "thinking",
+      thinkingSignature: "reasoning_content",
+    });
+  });
+
   it("concatenates multiple signature_delta events instead of overwriting", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -1257,6 +1257,25 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         const blocks = output.content;
         const blockIndexes = new Map<number, number>();
         const signatureDeltaIndexes = new Set<number>();
+        // A thinking block that never saw content_block_stop cannot prove its
+        // streamed signature is complete: persisting a truncated signature
+        // permanently poisons the session on replay (Anthropic rejects the
+        // whole request with Invalid `signature` in `thinking` block, #103830).
+        // Route such blocks through the reasoning_content sentinel lane the
+        // replay serializer already treats as replay-safe.
+        const sealInterruptedThinkingSignatures = () => {
+          for (const contentIndex of blockIndexes.values()) {
+            const block = blocks[contentIndex];
+            if (
+              block?.type === "thinking" &&
+              typeof block.thinkingSignature === "string" &&
+              block.thinkingSignature.length > 0 &&
+              block.thinkingSignature !== "reasoning_content"
+            ) {
+              block.thinkingSignature = "reasoning_content";
+            }
+          }
+        };
         const allowReasoningContentReplay = supportsReasoningContentReplay(model);
         const reasoningContentThinkingBlocks = new Map<number, number>();
         const reasoningContentTextBlocks = new Map<number, number>();
@@ -1823,6 +1842,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             flushPendingTextEnds();
           }
         }
+        sealInterruptedThinkingSignatures();
         if (refusalBuffer && !sawMessageStop) {
           throw new Error("Anthropic stream ended before message_stop");
         }


### PR DESCRIPTION
## Summary

Fixes #103830 (write-time poisoning; related: #103587's permanent-replay-failure symptom).

The Anthropic adapter accumulates an extended-thinking block's `signature` from streamed `signature_delta` events (`anthropic-transport-stream.ts`) and persists whatever accumulated with **no completeness check**. When the stream is cut mid-block (abort/reader-cancel/malformed stream — `content_block_stop` never fires for that index), the truncated signature is persisted into session history; every later turn resends it, and Anthropic permanently rejects the whole request (`messages.N.content.M: Invalid "signature" in "thinking" block`, surfaced as "LLM request failed: provider rejected the request schema or tool payload"). Reporter hit this 6 times in ~44h; the only recovery was discarding the session.

### Root cause

The replay serializer already handles two safe shapes: a **missing** signature downgrades the block to plain text, and the `"reasoning_content"` **sentinel** (used for non-Anthropic-origin thinking) routes through a replay-safe lane. A **non-empty truncated** signature matches neither and is replayed verbatim as a real Anthropic signature.

### Change

At stream finalization, any thinking block still registered in the in-flight block index map (i.e. it never received `content_block_stop`, so its signature cannot be known complete) has its accumulated signature replaced with the existing `"reasoning_content"` sentinel. Cleanly stopped blocks are untouched — their signatures replay exactly as before. This runs before the abort/error throws so the shared partial output is sealed on every termination path.

The reactive layer that heals already-poisoned sessions (`wrapAnthropicStreamWithRecovery` → `repairRejectedThinkingReplayInSessionManager`) is unchanged and still covers legacy transcripts; this PR stops new poisoning at write time.

## Verification

- New regression `sentinel-izes a thinking signature interrupted before content_block_stop` — confirmed failing without the fix (truncated `"truncated-chun"` persisted verbatim); with the fix the block carries the sentinel. The existing signature suite (multi-chunk concat, provider-seeded signature preserved, clean-stop replay) all passes.
- `pnpm test src/agents/anthropic-transport-stream.test.ts` — passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt — clean.

## Real behavior proof

Behavior addressed: truncated streamed thinking signatures are persisted and permanently brick session replay.
Real environment tested: the real Anthropic transport stream assembly driven with an SSE fixture reproducing the interruption shape (signature_delta received, `content_block_stop` never arrives) through the suite's existing fetch-mock harness.
Exact steps or command run after this patch: `pnpm test src/agents/anthropic-transport-stream.test.ts`
Evidence after fix: the interrupted block's `thinkingSignature` is `"reasoning_content"` (replay-safe sentinel) instead of the truncated fragment; cleanly stopped blocks keep their full signatures byte-identical.
Observed result after fix: interrupted turns can no longer write a signature Anthropic will reject on every future replay.
What was not tested: a live long-running Anthropic session with a mid-stream network cut; the fixture reproduces the exact stream shape such a cut produces, and the reactive replay-heal path remains as the safety net for live edge shapes.
