### PR TITLE
fix(browser): run the SSRF interaction guard for hover, drag, and scrollIntoView (#103783)

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -690,6 +690,7 @@ export async function hoverViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
   signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
@@ -701,13 +702,24 @@ export async function hoverViaPlaywright(opts: {
   const { abortPromise, cleanup } = createAbortPromise(opts.signal);
   const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await awaitActionWithAbort(
-      locator.hover({
-        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-      }),
-      abortPromise,
-      reconcileRemoteDialog,
-    );
+    // Hover handlers can trigger document navigations; run the same
+    // interaction navigation guard as click so page-influenced automation
+    // cannot reach destinations the SSRF policy denies (#103783).
+    await assertInteractionNavigationCompletedSafely({
+      action: async () =>
+        await awaitActionWithAbort(
+          locator.hover({
+            timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+          }),
+          abortPromise,
+          reconcileRemoteDialog,
+        ),
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl: opts.ssrfPolicy ? page.url() : "",
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toFriendlyInteractionError(err, label);
   } finally {
@@ -724,6 +736,7 @@ export async function dragViaPlaywright(opts: {
   endRef?: string;
   endSelector?: string;
   timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
   signal?: AbortSignal;
 }): Promise<void> {
   const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
@@ -740,13 +753,22 @@ export async function dragViaPlaywright(opts: {
   const { abortPromise, cleanup } = createAbortPromise(opts.signal);
   const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await awaitActionWithAbort(
-      startLocator.dragTo(endLocator, {
-        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-      }),
-      abortPromise,
-      reconcileRemoteDialog,
-    );
+    // Drag/drop handlers can trigger document navigations; guard like click (#103783).
+    await assertInteractionNavigationCompletedSafely({
+      action: async () =>
+        await awaitActionWithAbort(
+          startLocator.dragTo(endLocator, {
+            timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+          }),
+          abortPromise,
+          reconcileRemoteDialog,
+        ),
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl: opts.ssrfPolicy ? page.url() : "",
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toFriendlyInteractionError(err, `${startLabel} -> ${endLabel}`);
   } finally {
@@ -1157,6 +1179,7 @@ export async function scrollIntoViewViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
   signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
@@ -1170,11 +1193,20 @@ export async function scrollIntoViewViaPlaywright(opts: {
   const { abortPromise, cleanup } = createAbortPromise(opts.signal);
   const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await awaitActionWithAbort(
-      locator.scrollIntoViewIfNeeded({ timeout }),
-      abortPromise,
-      reconcileRemoteDialog,
-    );
+    // Scroll handlers can trigger document navigations; guard like click (#103783).
+    await assertInteractionNavigationCompletedSafely({
+      action: async () =>
+        await awaitActionWithAbort(
+          locator.scrollIntoViewIfNeeded({ timeout }),
+          abortPromise,
+          reconcileRemoteDialog,
+        ),
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl: opts.ssrfPolicy ? page.url() : "",
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toFriendlyInteractionError(err, label);
   } finally {
@@ -1586,6 +1618,7 @@ async function executeSingleAction(
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
         signal,
       });
       break;
@@ -1596,6 +1629,7 @@ async function executeSingleAction(
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
         signal,
       });
       break;
@@ -1608,6 +1642,7 @@ async function executeSingleAction(
         endRef: action.endRef,
         endSelector: action.endSelector,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
         signal,
       });
       break;

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -667,6 +667,9 @@ describe("browser control server", () => {
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
       ref: "2",
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
     expect((hoverArgs as { timeoutMs?: number }).timeoutMs).toBeUndefined();
 
@@ -680,6 +683,9 @@ describe("browser control server", () => {
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
       ref: "2",
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
     expect((scrollArgs as { timeoutMs?: number }).timeoutMs).toBeUndefined();
 
@@ -695,6 +701,9 @@ describe("browser control server", () => {
       targetId: "abcd1234",
       startRef: "3",
       endRef: "4",
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
     expect((dragArgs as { timeoutMs?: number }).timeoutMs).toBeUndefined();
   });

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -255,14 +255,17 @@ const passThroughActDispatch: Record<string, PassThroughActDispatch> = {
   hover: {
     mock: pwMocks.hoverViaPlaywright,
     fields: ["ref", "selector", "timeoutMs"],
+    includeSsrf: true,
   },
   scrollIntoView: {
     mock: pwMocks.scrollIntoViewViaPlaywright,
     fields: ["ref", "selector", "timeoutMs"],
+    includeSsrf: true,
   },
   drag: {
     mock: pwMocks.dragViaPlaywright,
     fields: ["startRef", "startSelector", "endRef", "endSelector", "timeoutMs"],
+    includeSsrf: true,
   },
   select: {
     mock: pwMocks.selectOptionViaPlaywright,


### PR DESCRIPTION
## Summary

Fixes #103783.

The managed Playwright `hover`, `drag`, and `scrollIntoView` actions dropped the resolved browser SSRF policy and never ran `assertInteractionNavigationCompletedSafely` — the canonical interaction navigation guard used by their siblings (click, coordinate click, type/submit, press, select, fill, evaluate). A page whose hover/drag/scroll handler performs a document navigation could therefore reach destinations the configured destination policy denies, and the action reported success. The Chrome MCP existing-session path already runs post-interaction checks for these kinds; the omission was Playwright-only (locally managed Chrome, extension-relay, and remote CDP profiles alike).

### Change

`extensions/browser/src/browser/pw-tools-core.interactions.ts`:
- `hoverViaPlaywright`, `dragViaPlaywright`, `scrollIntoViewViaPlaywright` accept `ssrfPolicy` and wrap their action in `assertInteractionNavigationCompletedSafely`, exactly like the guarded siblings. The guard stays a no-op when no policy is resolved (`previousUrl` is only snapshotted when the guard will run, keeping existing lightweight test doubles working).
- The `executeSingleAction` branches pass the already-in-scope `ssrfPolicy` to all three.
- `server.control-server.test-harness.ts`: the contract dispatch table marks the three kinds `includeSsrf: true`, and `server.agent-contract-core.test.ts` now asserts the policy is delivered for each — locking the contract the sibling actions already assert.

## Verification

- `pnpm test extensions/browser/src/browser/server.agent-contract-core.test.ts extensions/browser/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts` — passed (contract assertions confirmed failing before the harness/production change was complete, i.e. the policy was demonstrably absent for these kinds).
- `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, oxfmt — clean.

## Real behavior proof

Behavior addressed: hover/drag/scrollIntoView bypass the browser destination (SSRF) policy when a page handler navigates during the interaction.
Real environment tested: the real `/act` route → Playwright dispatch chain via the browser control server contract harness, asserting the resolved policy now reaches all three helpers alongside the guarded siblings.
Exact steps or command run after this patch: the three test files above.
Evidence after fix: contract assertions show `ssrfPolicy: { dangerouslyAllowPrivateNetwork: true }` delivered to hover/scrollIntoView/drag mocks; before the fix the same assertions receive `undefined`.
Observed result after fix: the three interactions run the identical navigation guard as click; no behavior change when no policy is configured.
What was not tested: a live Chrome run with a hostile hover-navigation page; the guard being exercised is the same production `assertInteractionNavigationCompletedSafely` that click already uses live, per the issue's own analysis.
