### PR TITLE
docs(pairing): correct setup-code expiry payload

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -141,7 +141,7 @@ The setup code is a base64-encoded JSON payload that contains:
 
 - `url`: the Gateway WebSocket URL (`ws://...` or `wss://...`)
 - `urls`: when available, the ordered LAN/Tailnet routes the mobile app can try
-- `bootstrapToken`: a single-use bootstrap token for the initial pairing handshake (expires after 10 minutes; `expiresAtMs` is included in the payload)
+- `bootstrapToken`: a single-use bootstrap token for the initial pairing handshake; the Gateway expires it after 10 minutes
 
 Run `/pair cleanup` to invalidate unused setup codes once pairing finishes.
 


### PR DESCRIPTION
Closes #103942

## What Problem This Solves

Fixes an issue where implementers reading the setup-code documentation could require an `expiresAtMs` field that official setup-code payloads never contain.

## Why This Change Was Made

The docs now retain the real 10-minute lifetime while making clear that expiry is enforced by the Gateway. The payload contract itself remains unchanged.

## User Impact

Mobile and Windows Node implementers can parse the documented payload shape without rejecting valid setup codes for a nonexistent field.

## Evidence

- `PairingSetupPayload` contains `url`, optional `urls`, and `bootstrapToken`; `resolvePairingSetupFromConfig` serializes only the issued token.
- `DEVICE_BOOTSTRAP_TOKEN_TTL_MS` remains 10 minutes and is enforced by Gateway token state.
- `node scripts/check-docs-mdx.mjs docs/channels/pairing.md` — passed (1 file).
- `node scripts/docs-link-audit.mjs` — 5,803 internal links checked, 0 broken.
- `git diff --check` — passed.
