### PR TITLE
fix: show actual Mac node exec policy defaults

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -298,7 +298,7 @@ struct ExecApprovalsResolved: Sendable {
     var file: ExecApprovalsFile
 }
 
-struct ExecApprovalsResolvedDefaults: Sendable {
+struct ExecApprovalsResolvedDefaults: Codable, Sendable {
     var security: ExecSecurity
     var ask: ExecAsk
     var askFallback: ExecSecurity

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -699,13 +699,17 @@ enum ExecApprovalsStore {
         return self.resolveFromFile(file, agentId: agentId)
     }
 
-    private static func resolveFromFile(_ file: ExecApprovalsFile, agentId: String?) -> ExecApprovalsResolved {
+    static func resolveDefaults(from file: ExecApprovalsFile) -> ExecApprovalsResolvedDefaults {
         let defaults = file.defaults ?? ExecApprovalsDefaults()
-        let resolvedDefaults = ExecApprovalsResolvedDefaults(
+        return ExecApprovalsResolvedDefaults(
             security: defaults.security ?? self.defaultSecurity,
             ask: defaults.ask ?? self.defaultAsk,
             askFallback: defaults.askFallback ?? self.defaultAskFallback,
             autoAllowSkills: defaults.autoAllowSkills ?? self.defaultAutoAllowSkills)
+    }
+
+    private static func resolveFromFile(_ file: ExecApprovalsFile, agentId: String?) -> ExecApprovalsResolved {
+        let resolvedDefaults = self.resolveDefaults(from: file)
         let key = self.agentKey(agentId)
         let agentEntry = file.agents?[key] ?? ExecApprovalsAgent()
         let wildcardEntry = file.agents?["*"] ?? ExecApprovalsAgent()

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -6,6 +6,14 @@ import OpenClawKit
 actor MacNodeRuntime {
     private static let maxGatewayPayloadBytes = 25 * 1024 * 1024
     private static let maxScreenSnapshotRawBytesBeforeBase64 = (maxGatewayPayloadBytes / 4) * 3
+    private struct ExecApprovalsNodeSnapshot: Encodable {
+        let path: String
+        let exists: Bool
+        let hash: String
+        let file: ExecApprovalsFile
+        let resolvedDefaults: ExecApprovalsResolvedDefaults
+    }
+
     private let cameraCapture = CameraCaptureService()
     private let makeMainActorServices: @Sendable () async -> any MacNodeRuntimeMainActorServices
     private let browserProxyRequest: @Sendable (String?) async throws -> String
@@ -1130,6 +1138,13 @@ extension MacNodeRuntime {
     }
 
     private func handleSystemExecApprovalsGet(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
+        struct GetParams: Decodable {
+            var includeResolvedDefaults: Bool?
+        }
+
+        let params = try req.paramsJSON.map { json in
+            try Self.decodeParams(GetParams.self, from: json)
+        } ?? GetParams(includeResolvedDefaults: nil)
         let snapshot: ExecApprovalsSnapshot
         switch ExecApprovalsStore.ensureSnapshotResult() {
         case let .success(current):
@@ -1140,11 +1155,21 @@ extension MacNodeRuntime {
                 code: .unavailable,
                 message: "UNAVAILABLE: exec approvals store unavailable; retry")
         }
-        let redacted = ExecApprovalsSnapshot(
+        guard params.includeResolvedDefaults == true else {
+            let redacted = ExecApprovalsSnapshot(
+                path: snapshot.path,
+                exists: snapshot.exists,
+                hash: snapshot.hash,
+                file: ExecApprovalsStore.redactForSnapshot(snapshot.file))
+            let payload = try Self.encodePayload(redacted)
+            return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
+        }
+        let redacted = ExecApprovalsNodeSnapshot(
             path: snapshot.path,
             exists: snapshot.exists,
             hash: snapshot.hash,
-            file: ExecApprovalsStore.redactForSnapshot(snapshot.file))
+            file: ExecApprovalsStore.redactForSnapshot(snapshot.file),
+            resolvedDefaults: ExecApprovalsStore.resolveDefaults(from: snapshot.file))
         let payload = try Self.encodePayload(redacted)
         return BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: payload)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -298,6 +298,69 @@ struct MacNodeRuntimeTests {
         #expect(await probe.capturedCommands().isEmpty)
     }
 
+    @Test func `exec approvals snapshot reports resolved host defaults`() async throws {
+        let root = URL(
+            fileURLWithPath: "/tmp/oc-appr-\(UUID().uuidString.prefix(8))",
+            isDirectory: true)
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let stateDir = root.appendingPathComponent("state", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_HOME": home.path,
+            "OPENCLAW_STATE_DIR": stateDir.path,
+        ]) {
+            let runtime = MacNodeRuntime()
+            let legacyResponse = await runtime.handleInvoke(
+                BridgeInvokeRequest(
+                    id: "req-approvals-get-legacy",
+                    command: OpenClawSystemCommand.execApprovalsGet.rawValue))
+            #expect(legacyResponse.ok)
+            let legacyPayloadJSON = try #require(legacyResponse.payloadJSON)
+            let legacyPayload = try #require(
+                JSONSerialization.jsonObject(with: Data(legacyPayloadJSON.utf8)) as? [String: Any])
+            #expect(legacyPayload["resolvedDefaults"] == nil)
+
+            let response = await runtime.handleInvoke(
+                BridgeInvokeRequest(
+                    id: "req-approvals-get-resolved",
+                    command: OpenClawSystemCommand.execApprovalsGet.rawValue,
+                    paramsJSON: #"{"includeResolvedDefaults":true}"#))
+
+            #expect(response.ok)
+            let payloadJSON = try #require(response.payloadJSON)
+            struct Snapshot: Decodable {
+                let resolvedDefaults: ExecApprovalsResolvedDefaults
+            }
+            let snapshot = try JSONDecoder().decode(Snapshot.self, from: Data(payloadJSON.utf8))
+            #expect(snapshot.resolvedDefaults.security == .full)
+            #expect(snapshot.resolvedDefaults.ask == .off)
+            #expect(snapshot.resolvedDefaults.askFallback == .deny)
+            #expect(snapshot.resolvedDefaults.autoAllowSkills == false)
+
+            try ExecApprovalsStore.updateDefaults { defaults in
+                defaults.security = .deny
+                defaults.ask = .onMiss
+                defaults.askFallback = .deny
+                defaults.autoAllowSkills = false
+            }.get()
+            let persistedResponse = await runtime.handleInvoke(
+                BridgeInvokeRequest(
+                    id: "req-approvals-get-persisted",
+                    command: OpenClawSystemCommand.execApprovalsGet.rawValue,
+                    paramsJSON: #"{"includeResolvedDefaults":true}"#))
+            #expect(persistedResponse.ok)
+            let persistedPayloadJSON = try #require(persistedResponse.payloadJSON)
+            let persistedSnapshot = try JSONDecoder().decode(
+                Snapshot.self,
+                from: Data(persistedPayloadJSON.utf8))
+            #expect(persistedSnapshot.resolvedDefaults.security == .deny)
+            #expect(persistedSnapshot.resolvedDefaults.ask == .onMiss)
+            #expect(persistedSnapshot.resolvedDefaults.askFallback == .deny)
+            #expect(persistedSnapshot.resolvedDefaults.autoAllowSkills == false)
+        }
+    }
+
     @Test func `system run denied event preserves gateway run id`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8400,6 +8400,7 @@ public struct ExecApprovalsNodeSnapshot: Codable, Sendable {
     public let exists: Bool?
     public let hash: String?
     public let file: [String: AnyCodable]?
+    public let resolveddefaults: [String: AnyCodable]?
     public let enabled: Bool?
     public let basehash: String?
     public let defaultaction: AnyCodable?
@@ -8412,6 +8413,7 @@ public struct ExecApprovalsNodeSnapshot: Codable, Sendable {
         exists: Bool? = nil,
         hash: String? = nil,
         file: [String: AnyCodable]? = nil,
+        resolveddefaults: [String: AnyCodable]? = nil,
         enabled: Bool? = nil,
         basehash: String? = nil,
         defaultaction: AnyCodable? = nil,
@@ -8423,6 +8425,7 @@ public struct ExecApprovalsNodeSnapshot: Codable, Sendable {
         self.exists = exists
         self.hash = hash
         self.file = file
+        self.resolveddefaults = resolveddefaults
         self.enabled = enabled
         self.basehash = basehash
         self.defaultaction = defaultaction
@@ -8436,6 +8439,7 @@ public struct ExecApprovalsNodeSnapshot: Codable, Sendable {
         case exists
         case hash
         case file
+        case resolveddefaults = "resolvedDefaults"
         case enabled
         case basehash = "baseHash"
         case defaultaction = "defaultAction"

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -48,6 +48,8 @@ openclaw approvals get --gateway
 
 `get` shows the effective exec policy for the target: the requested `tools.exec` policy, the host approvals-file policy, and the merged effective result. Nodes with a host-native policy, such as the Windows companion, show that policy directly instead of applying OpenClaw approvals-file policy math.
 
+For file-backed nodes, the merged view requires a host-resolved policy snapshot. Older nodes show the effective policy as unavailable instead of assuming the Gateway's requested policy also applies on the host.
+
 Precedence:
 
 - The host approvals file is the enforceable source of truth.

--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -75,6 +75,31 @@ describe("exec approvals protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts file-backed node snapshots with host-resolved defaults", () => {
+    expect(
+      validateExecApprovalsNodeSnapshot({
+        path: "/tmp/exec-approvals.json",
+        exists: true,
+        hash: "sha256:file",
+        file: { version: 1 },
+      }),
+    ).toBe(true);
+    expect(
+      validateExecApprovalsNodeSnapshot({
+        path: "/tmp/exec-approvals.json",
+        exists: true,
+        hash: "sha256:file",
+        file: { version: 1 },
+        resolvedDefaults: {
+          security: "deny",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("rejects ambiguous or unsafe host-native approval payloads", () => {
     for (const snapshot of [
       {},
@@ -89,11 +114,45 @@ describe("exec approvals protocol validators", () => {
         defaultAction: "deny",
       },
       {
+        path: "/tmp/exec-approvals.json",
+        exists: true,
+        hash: "sha256:file",
+        file: { version: 1 },
+        resolvedDefaults: {
+          security: "full",
+          ask: "sometimes",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      },
+      {
         enabled: true,
         hash: "sha256:current",
         defaultAction: "deny",
         rules: [],
         message: "mixed state",
+      },
+      {
+        enabled: true,
+        hash: "sha256:current",
+        defaultAction: "deny",
+        rules: [],
+        resolvedDefaults: {
+          security: "deny",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
+      },
+      {
+        enabled: false,
+        message: "No exec policy configured",
+        resolvedDefaults: {
+          security: "deny",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+        },
       },
       { enabled: false, rules: [] },
     ]) {

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -30,6 +30,28 @@ const ExecApprovalsPolicyFields = {
   autoAllowSkills: Type.Optional(Type.Boolean()),
 };
 
+const ExecSecuritySchema = Type.Union([
+  Type.Literal("deny"),
+  Type.Literal("allowlist"),
+  Type.Literal("full"),
+]);
+const ExecAskSchema = Type.Union([
+  Type.Literal("off"),
+  Type.Literal("on-miss"),
+  Type.Literal("always"),
+]);
+
+/** Host-resolved default policy after applying persisted defaults and runtime fallbacks. */
+const ExecApprovalsResolvedDefaultsSchema = Type.Object(
+  {
+    security: ExecSecuritySchema,
+    ask: ExecAskSchema,
+    askFallback: ExecSecuritySchema,
+    autoAllowSkills: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
 /** Default exec approval policy shared by all agents unless overridden. */
 export const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields, {
   additionalProperties: false,
@@ -109,6 +131,7 @@ export const ExecApprovalsNodeSnapshotSchema = Type.Object(
     exists: Type.Optional(Type.Boolean()),
     hash: Type.Optional(Type.String()),
     file: Type.Optional(ExecApprovalsFileSchema),
+    resolvedDefaults: Type.Optional(ExecApprovalsResolvedDefaultsSchema),
     enabled: Type.Optional(Type.Boolean()),
     baseHash: Type.Optional(NonEmptyString),
     defaultAction: Type.Optional(NativeExecApprovalActionSchema),
@@ -140,6 +163,7 @@ export const ExecApprovalsNodeSnapshotSchema = Type.Object(
             { required: ["path"] },
             { required: ["exists"] },
             { required: ["file"] },
+            { required: ["resolvedDefaults"] },
             { required: ["message"] },
           ],
         },
@@ -153,6 +177,7 @@ export const ExecApprovalsNodeSnapshotSchema = Type.Object(
             { required: ["exists"] },
             { required: ["hash"] },
             { required: ["file"] },
+            { required: ["resolvedDefaults"] },
             { required: ["baseHash"] },
             { required: ["defaultAction"] },
             { required: ["rules"] },

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -358,6 +358,12 @@ describe("exec approvals CLI", () => {
               defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
               agents: {},
             },
+            resolvedDefaults: {
+              security: "allowlist",
+              ask: "always",
+              askFallback: "deny",
+              autoAllowSkills: false,
+            },
           };
         }
         return { method, params };
@@ -390,6 +396,82 @@ describe("exec approvals CLI", () => {
         source: "/tmp/node-exec-approvals.json defaults.askFallback",
       },
     );
+  });
+
+  it("uses node-reported defaults for omitted host policy", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          return { config: { tools: { exec: { security: "full", ask: "off" } } } };
+        }
+        if (method === "exec.approvals.node.get") {
+          return {
+            path: "/tmp/node-exec-approvals.json",
+            exists: true,
+            hash: "hash-node-1",
+            file: { version: 1, agents: {} },
+            resolvedDefaults: {
+              security: "deny",
+              ask: "on-miss",
+              askFallback: "deny",
+              autoAllowSkills: false,
+            },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--node", "macbook", "--json"]);
+
+    const scope = scopeByLabel("tools.exec");
+    expectFields(requireRecord(scope.security, "tools.exec security"), "tools.exec security", {
+      requested: "full",
+      host: "deny",
+      hostSource: "node-reported resolved defaults",
+      effective: "deny",
+    });
+    expectFields(requireRecord(scope.ask, "tools.exec ask"), "tools.exec ask", {
+      requested: "off",
+      host: "on-miss",
+      hostSource: "node-reported resolved defaults",
+      effective: "on-miss",
+    });
+  });
+
+  it("does not infer permissive policy for legacy node snapshots", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          return { config: { tools: { exec: { security: "full", ask: "off" } } } };
+        }
+        if (method === "exec.approvals.node.get") {
+          return {
+            path: "/tmp/node-exec-approvals.json",
+            exists: true,
+            hash: "hash-node-1",
+            file: {
+              version: 1,
+              defaults: {
+                security: "full",
+                ask: "off",
+                askFallback: "full",
+                autoAllowSkills: true,
+              },
+              agents: {},
+            },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--node", "macbook", "--json"]);
+
+    expect(effectivePolicy()).toEqual({
+      scopes: [],
+      note: "This node does not expose a complete resolved host policy, so Effective Policy is unavailable.",
+    });
   });
 
   it("shows host-native node approvals without approvals-file policy math", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -20,6 +20,7 @@ import {
   readExecApprovalsSnapshot,
   updateExecApprovals,
   type ExecApprovalsAgent,
+  type ExecApprovalsDefaults,
   type ExecApprovalsFile,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -34,6 +35,7 @@ type FileExecApprovalsSnapshot = {
   exists: boolean;
   hash: string;
   file: ExecApprovalsFile;
+  resolvedDefaults?: Required<ExecApprovalsDefaults>;
 };
 
 type NativeExecApprovalAction = "allow" | "deny" | "prompt";
@@ -372,6 +374,7 @@ function buildEffectivePolicyReport(params: {
   configLoad: ConfigLoadResult;
   source: ApprovalsTargetSource;
   approvals?: ExecApprovalsFile;
+  resolvedDefaults?: Required<ExecApprovalsDefaults>;
   hostPath: string;
   nativePolicy: boolean;
 }): EffectivePolicyReport {
@@ -396,11 +399,19 @@ function buildEffectivePolicyReport(params: {
           "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
       };
     }
+    if (!params.resolvedDefaults) {
+      return {
+        scopes: [],
+        note: "This node does not expose a complete resolved host policy, so Effective Policy is unavailable.",
+      };
+    }
     return {
       scopes: collectExecPolicyScopeSnapshots({
         cfg,
         approvals: params.approvals,
         hostPath: params.hostPath,
+        hostDefaults: params.resolvedDefaults,
+        hostDefaultSource: "node-reported resolved defaults",
       }),
       note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
     };
@@ -746,6 +757,7 @@ export function registerExecApprovalsCli(program: Command) {
           configLoad,
           source,
           approvals: fileSnapshot?.file,
+          resolvedDefaults: fileSnapshot?.resolvedDefaults,
           hostPath: fileSnapshot?.path ?? "",
           nativePolicy,
         });

--- a/src/gateway/server-methods/exec-approvals.test.ts
+++ b/src/gateway/server-methods/exec-approvals.test.ts
@@ -173,6 +173,12 @@ describe("exec approvals gateway methods", () => {
       exists: true,
       hash: "sha256:file",
       file: { version: 1 },
+      resolvedDefaults: {
+        security: "deny",
+        ask: "on-miss",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
     };
     const invoke = vi.fn().mockResolvedValue({ ok: true, payload });
     const respond = vi.fn();
@@ -194,8 +200,10 @@ describe("exec approvals gateway methods", () => {
           get: () => ({
             nodeId: "node-1",
             connId: "conn-1",
-            platform: "windows",
-            deviceFamily: "Windows",
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            platform: "macOS 26.5.2",
+            deviceFamily: "Mac",
             declaredCommands: [command],
             commands: [command],
           }),
@@ -204,7 +212,95 @@ describe("exec approvals gateway methods", () => {
       } as never,
     });
 
-    expect(invoke).toHaveBeenCalledWith({ nodeId: "node-1", command, params: {} });
+    expect(invoke).toHaveBeenCalledWith({
+      nodeId: "node-1",
+      command,
+      params: { includeResolvedDefaults: true },
+    });
+    expect(respond).toHaveBeenCalledWith(true, payload, undefined);
+  });
+
+  it.each([
+    {
+      label: "Windows node",
+      clientId: "node-host",
+      clientMode: "node",
+      platform: "windows",
+      deviceFamily: "Windows",
+    },
+    {
+      label: "macOS CLI node",
+      clientId: "node-host",
+      clientMode: "node",
+      platform: "macos",
+      deviceFamily: "Mac",
+    },
+    {
+      label: "Linux CLI node",
+      clientId: "node-host",
+      clientMode: "node",
+      platform: "linux",
+      deviceFamily: "Linux",
+    },
+    {
+      label: "non-macOS app identity",
+      clientId: "openclaw-macos",
+      clientMode: "node",
+      platform: "linux",
+      deviceFamily: "Linux",
+    },
+    {
+      label: "non-node Mac App identity",
+      clientId: "openclaw-macos",
+      clientMode: "ui",
+      platform: "macOS 26.5.2",
+      deviceFamily: "Mac",
+    },
+  ])("keeps legacy exec-approval get params for $label", async (identity) => {
+    const command = "system.execApprovals.get";
+    const payload = {
+      path: "/tmp/exec-approvals.json",
+      exists: true,
+      hash: "sha256:file",
+      file: { version: 1 },
+    };
+    const invoke = vi.fn().mockResolvedValue({ ok: true, payload });
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.node.get"]({
+      req: {
+        type: "req",
+        id: "req-node-legacy-params",
+        method: "exec.approvals.node.get",
+        params: { nodeId: "node-1" },
+      },
+      params: { nodeId: "node-1" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        getRuntimeConfig: () => ({}),
+        nodeRegistry: {
+          get: () => ({
+            nodeId: "node-1",
+            connId: "conn-1",
+            clientId: identity.clientId,
+            clientMode: identity.clientMode,
+            platform: identity.platform,
+            deviceFamily: identity.deviceFamily,
+            declaredCommands: [command],
+            commands: [command],
+          }),
+          invoke,
+        },
+      } as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith({
+      nodeId: "node-1",
+      command,
+      params: {},
+    });
     expect(respond).toHaveBeenCalledWith(true, payload, undefined);
   });
 
@@ -328,7 +424,11 @@ describe("exec approvals gateway methods", () => {
       } as never,
     });
 
-    expect(invoke).toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith({
+      nodeId: "missing-node",
+      command: "system.execApprovals.get",
+      params: {},
+    });
     expect(respond).toHaveBeenCalledWith(
       false,
       undefined,

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -1,6 +1,10 @@
 // Exec approvals config methods read and write command approval defaults with
 // base-hash protection for admin-edited allowlists.
 import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../packages/gateway-protocol/src/client-info.js";
+import {
   ErrorCodes,
   errorShape,
   validateExecApprovalsGetParams,
@@ -18,6 +22,7 @@ import {
   type ExecApprovalsSnapshot,
 } from "../../infra/exec-approvals.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
+import type { NodeSession } from "../node-registry.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import {
   respondUnavailableOnNodeInvokeError,
@@ -97,6 +102,15 @@ function toExecApprovalsPayload(snapshot: ExecApprovalsSnapshot) {
   };
 }
 
+function isMacAppNode(session: NodeSession | undefined): boolean {
+  const platform = session?.platform?.trim().toLowerCase();
+  return (
+    session?.clientId === GATEWAY_CLIENT_IDS.MACOS_APP &&
+    session.clientMode === GATEWAY_CLIENT_MODES.NODE &&
+    (platform === "macos" || platform?.startsWith("macos ") === true)
+  );
+}
+
 async function respondWithExecApprovalsNodePayload<TParams extends { nodeId: string }>(params: {
   method: string;
   rawParams: unknown;
@@ -104,7 +118,10 @@ async function respondWithExecApprovalsNodePayload<TParams extends { nodeId: str
   context: GatewayRequestContext;
   respond: RespondFn;
   command: "system.execApprovals.get" | "system.execApprovals.set";
-  commandParams: (parsedParams: TParams) => Record<string, unknown>;
+  commandParams: (
+    parsedParams: TParams,
+    nodeSession: NodeSession | undefined,
+  ) => Record<string, unknown>;
   readPayload: (response: { payload?: unknown; payloadJSON?: string | null }) => unknown;
   validatePayload?: (payload: unknown) => boolean;
 }): Promise<void> {
@@ -145,7 +162,7 @@ async function respondWithExecApprovalsNodePayload<TParams extends { nodeId: str
     const res = await params.context.nodeRegistry.invoke({
       nodeId,
       command: params.command,
-      params: params.commandParams(parsedParams),
+      params: params.commandParams(parsedParams, nodeSession),
     });
     if (!respondUnavailableOnNodeInvokeError(params.respond, res)) {
       return;
@@ -213,7 +230,10 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
       context,
       respond,
       command: "system.execApprovals.get",
-      commandParams: () => ({}),
+      // New Mac nodes expand this response only when asked, so older Gateways
+      // continue receiving the strict legacy snapshot shape.
+      commandParams: (_parsedParams, nodeSession) =>
+        isMacAppNode(nodeSession) ? { includeResolvedDefaults: true } : {},
       // Node invocations can return structured payloads or JSON strings
       // depending on the transport; normalize before echoing the RPC response.
       readPayload: (res) => (res.payloadJSON ? safeParseJson(res.payloadJSON) : res.payload),

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -12,6 +12,7 @@ import {
   resolveExecApprovalsFromFile,
   resolveExecModeFromPolicy,
   resolveExecModePolicy,
+  type ExecApprovalsDefaults,
   type ExecApprovalsFile,
   type ExecAsk,
   type ExecMode,
@@ -110,6 +111,10 @@ function formatModeSource(params: { sourcePath: string; configPath: string }): s
 }
 
 type ExecPolicyField = "security" | "ask" | "askFallback";
+export type ExecPolicyHostDefaults = Pick<
+  Required<ExecApprovalsDefaults>,
+  "security" | "ask" | "askFallback"
+>;
 
 function resolveRequestedField<
   // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Field-specific callers narrow the shared requested policy value.
@@ -263,9 +268,13 @@ function formatHostFieldSource(params: {
   hostPath: string;
   field: ExecPolicyField;
   sourceSuffix: string | null;
+  hostDefaultSource?: string;
 }): string {
   if (params.sourceSuffix) {
     return `${params.hostPath} ${params.sourceSuffix}`;
+  }
+  if (params.hostDefaultSource) {
+    return params.hostDefaultSource;
   }
   if (params.field === "askFallback") {
     return `OpenClaw default (${DEFAULT_EXEC_APPROVAL_ASK_FALLBACK})`;
@@ -288,6 +297,8 @@ export function collectExecPolicyScopeSnapshots(params: {
   cfg: OpenClawConfig;
   approvals: ExecApprovalsFile;
   hostPath?: string;
+  hostDefaults?: ExecPolicyHostDefaults;
+  hostDefaultSource?: string;
 }): ExecPolicyScopeSnapshot[] {
   const snapshots = [
     resolveExecPolicyScopeSnapshot({
@@ -295,6 +306,8 @@ export function collectExecPolicyScopeSnapshots(params: {
       scopeExecConfig: params.cfg.tools?.exec,
       configPath: "tools.exec",
       hostPath: params.hostPath,
+      hostDefaults: params.hostDefaults,
+      hostDefaultSource: params.hostDefaultSource,
       scopeLabel: "tools.exec",
     }),
   ];
@@ -317,6 +330,8 @@ export function collectExecPolicyScopeSnapshots(params: {
         globalExecConfig,
         configPath: `agents.list.${agentId}.tools.exec`,
         hostPath: params.hostPath,
+        hostDefaults: params.hostDefaults,
+        hostDefaultSource: params.hostDefaultSource,
         scopeLabel: `agent:${agentId}`,
         agentId,
       }),
@@ -333,6 +348,8 @@ export function resolveExecPolicyScopeSnapshot(params: {
   scopeLabel: string;
   agentId?: string;
   hostPath?: string;
+  hostDefaults?: ExecPolicyHostDefaults;
+  hostDefaultSource?: string;
 }): ExecPolicyScopeSnapshot {
   const requestedHost = resolveRequestedHost({
     scopeExecConfig: params.scopeExecConfig,
@@ -347,8 +364,9 @@ export function resolveExecPolicyScopeSnapshot(params: {
     file: params.approvals,
     agentId: params.agentId,
     overrides: {
-      security: requestedPolicy.security,
-      ask: requestedPolicy.ask,
+      security: params.hostDefaults?.security ?? requestedPolicy.security,
+      ask: params.hostDefaults?.ask ?? requestedPolicy.ask,
+      ...(params.hostDefaults ? { askFallback: params.hostDefaults.askFallback } : {}),
     },
   });
   const hostPath = params.hostPath ?? resolveExecApprovalsDisplayPath();
@@ -390,6 +408,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
         hostPath,
         field: "security",
         sourceSuffix: resolved.agentSources.security,
+        hostDefaultSource: params.hostDefaultSource,
       }),
       effective: effectiveSecurity,
       note:
@@ -405,6 +424,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
         hostPath,
         field: "ask",
         sourceSuffix: resolved.agentSources.ask,
+        hostDefaultSource: params.hostDefaultSource,
       }),
       effective: effectiveAsk,
       note: resolveAskNote({
@@ -419,6 +439,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
         hostPath,
         field: "askFallback",
         sourceSuffix: resolved.agentSources.askFallback,
+        hostDefaultSource: params.hostDefaultSource,
       }),
     },
     allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: effectiveAsk }),

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -782,6 +782,35 @@ describe("exec approvals policy helpers", () => {
     });
   });
 
+  it("uses host-reported defaults instead of requested policy fallbacks", () => {
+    const summary = summarizeExecPolicyScopeSnapshot({
+      approvals: { version: 1, agents: {} },
+      scopeExecConfig: { security: "full", ask: "off" },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+      hostDefaults: {
+        security: "deny",
+        ask: "on-miss",
+        askFallback: "deny",
+      },
+      hostDefaultSource: "node-reported resolved defaults",
+    });
+
+    expectFields(summary.security, {
+      requested: "full",
+      host: "deny",
+      hostSource: "node-reported resolved defaults",
+      effective: "deny",
+    });
+    expectFields(summary.ask, {
+      requested: "off",
+      host: "on-miss",
+      hostSource: "node-reported resolved defaults",
+      effective: "on-miss",
+    });
+    expect(summary.askFallback.source).toBe("node-reported resolved defaults");
+  });
+
   it("collects global, configured-agent, and approvals-only agent scopes", () => {
     const snapshots = collectExecPolicyScopeSnapshots({
       cfg: {


### PR DESCRIPTION
Closes #103902

## What Problem This Solves

Fixes an issue where operators inspecting a Mac App node with omitted exec-approval defaults could see an effective policy inherited from Gateway configuration even when the node host enforced a different policy.

## Why This Change Was Made

The Mac App now returns its resolved, host-owned defaults only when a current Gateway explicitly requests them. Gateway requests that expanded snapshot only from the exact Mac App node identity; legacy Mac Apps, CLI nodes, and host-native Windows nodes retain their existing wire shapes. CLI diagnostics consume attested host defaults and report the effective policy as unavailable when a file-backed node cannot provide them, avoiding permissive inference.

## User Impact

`openclaw approvals get --node <mac> --json` can now describe the policy the Mac host actually applies. Older or non-attesting file-backed nodes show an explicit unavailable result instead of a potentially false effective policy. Runtime enforcement and fail-closed behavior are unchanged.

## Evidence

- Reproduced on a live signed Mac App node: the legacy snapshot omitted defaults while CLI diagnostics inferred Gateway `full/off`; the node host enforced its own omitted-file policy.
- Blacksmith Testbox: [run 29122525413](https://github.com/openclaw/openclaw/actions/runs/29122525413), focused protocol/Gateway/policy/CLI tests, 123 passed.
- Static macOS proof: `swift test --package-path apps/macos --filter MacNodeRuntimeTests`, 34 passed.
- Static macOS compatibility proof: `swift test --package-path apps/macos --filter ExecApprovalsStoreRefactorTests`, 69 passed, including parameterless get, held-lock, malformed-store, CAS, and revocation coverage.
- `node --import tsx scripts/protocol-gen.ts`
- `node --import tsx scripts/protocol-gen-swift.ts`
- `swiftformat ... --lint --config config/swiftformat`
- `xcrun swiftc -frontend -parse` for all changed Swift sources and generated bindings.
- `git diff --check`
- Fresh autoreview after the compatibility fix: no accepted or actionable findings.
