### PR TITLE
fix(tasks): repair legacy delivery statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
 - **Discord thread-title prompts:** truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007.
+- **Task state migration:** canonicalize legacy `not-requested` delivery statuses during sidecar import and existing shared-database open so upgraded task registries and linked TaskFlows recover without manual SQL. (#103946) Thanks @bek91.
 
 ## 2026.7.1
 

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -648,6 +648,35 @@ function appendLegacyCrossAgentTask(taskRunsPath: string): void {
   }
 }
 
+function appendLegacyTaskWithObsoleteDeliveryStatus(taskRunsPath: string): void {
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(taskRunsPath);
+  try {
+    db.prepare(
+      `
+        INSERT INTO task_runs (
+          task_id, runtime, requester_session_key, agent_id, run_id, task,
+          status, delivery_status, notify_policy, created_at, last_event_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      "legacy-not-requested",
+      "cron",
+      "",
+      "ops",
+      "legacy-not-requested-run",
+      "Legacy cancelled task",
+      "cancelled",
+      "not-requested",
+      "silent",
+      150,
+      160,
+    );
+  } finally {
+    db.close();
+  }
+}
+
 async function detectAndRunMigrations(params: {
   root: string;
   cfg: OpenClawConfig;
@@ -3040,6 +3069,36 @@ describe("doctor legacy state migrations", () => {
     await withStateDir(root, async () => {
       expect(loadTaskRegistryStateFromSqlite().tasks.has("legacy-task")).toBe(true);
       expect(loadTaskFlowRegistryStateFromSqlite().flows.has("legacy-flow")).toBe(true);
+    });
+  });
+
+  it("normalizes obsolete task delivery status before archiving the legacy sidecar", async () => {
+    const root = await makeTempRoot();
+    const { taskRunsPath } = writeLegacyTaskStateSidecars(root);
+    appendLegacyTaskWithObsoleteDeliveryStatus(taskRunsPath);
+
+    const result = await autoMigrateLegacyTaskStateSidecars({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 2 task registry sidecar rows → shared SQLite state");
+    expect(fs.existsSync(taskRunsPath)).toBe(false);
+    expect(fs.existsSync(`${taskRunsPath}.migrated`)).toBe(true);
+
+    const shared = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    expect(
+      shared.db
+        .prepare("SELECT delivery_status FROM task_runs WHERE task_id = ?")
+        .get("legacy-not-requested"),
+    ).toEqual({ delivery_status: "not_applicable" });
+
+    await withStateDir(root, async () => {
+      const tasks = loadTaskRegistryStateFromSqlite().tasks;
+      expect(tasks.get("legacy-not-requested")?.deliveryStatus).toBe("not_applicable");
+      expect(tasks.get("legacy-task")?.deliveryStatus).toBe("not_applicable");
     });
   });
 

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -865,6 +865,8 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
         (childAgentId && persistedAgentId !== childAgentId ? persistedAgentId : ""))
       : "");
   const executorAgentId = requesterAgentId ? childAgentId || persistedAgentId : persistedAgentId;
+  const deliveryStatus =
+    row.delivery_status === "not-requested" ? "not_applicable" : row.delivery_status;
   return {
     task_id: taskId,
     runtime,
@@ -882,7 +884,7 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
     label: legacyBindValue(row.label),
     task: legacyBindValue(row.task ?? ""),
     status: legacyBindValue(row.status ?? ""),
-    delivery_status: legacyBindValue(row.delivery_status ?? ""),
+    delivery_status: legacyBindValue(deliveryStatus ?? ""),
     notify_policy: legacyBindValue(row.notify_policy ?? ""),
     created_at: normalizeLegacySqliteInteger(row.created_at as number | bigint | null) ?? 0,
     started_at: normalizeLegacySqliteInteger(row.started_at as number | bigint | null),

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -14,6 +14,8 @@ import {
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
+import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -383,6 +385,68 @@ describe("openclaw state database", () => {
       agent_id: "main",
       requester_agent_id: null,
     });
+  });
+
+  it("normalizes obsolete task delivery statuses in existing state databases", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-state-task-delivery-status-" },
+      async ({ stateDir }) => {
+        const database = openOpenClawStateDatabase({
+          env: { OPENCLAW_STATE_DIR: stateDir },
+        });
+        const insert = database.db.prepare(
+          `INSERT INTO task_runs (
+            task_id, runtime, requester_session_key, owner_key, scope_kind, task, status,
+            delivery_status, notify_policy, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        );
+        for (const [taskId, deliveryStatus] of [
+          ["obsolete", "not-requested"],
+          ["canonical", "not_applicable"],
+          ["pending", "pending"],
+        ] as const) {
+          insert.run(
+            taskId,
+            "cron",
+            "",
+            `system:cron:${taskId}`,
+            "system",
+            `Task ${taskId}`,
+            "cancelled",
+            deliveryStatus,
+            "silent",
+            100,
+          );
+        }
+        closeOpenClawStateDatabaseForTest();
+
+        const readStatuses = () =>
+          openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } })
+            .db.prepare("SELECT task_id, delivery_status FROM task_runs ORDER BY task_id")
+            .all();
+        const expectedStatuses = [
+          { task_id: "canonical", delivery_status: "not_applicable" },
+          { task_id: "obsolete", delivery_status: "not_applicable" },
+          { task_id: "pending", delivery_status: "pending" },
+        ];
+
+        expect(readStatuses()).toEqual(expectedStatuses);
+        expect(
+          [...loadTaskRegistryStateFromSqlite().tasks.values()].map((task) => ({
+            taskId: task.taskId,
+            deliveryStatus: task.deliveryStatus,
+          })),
+        ).toEqual([
+          { taskId: "canonical", deliveryStatus: "not_applicable" },
+          { taskId: "obsolete", deliveryStatus: "not_applicable" },
+          { taskId: "pending", deliveryStatus: "pending" },
+        ]);
+
+        closeOpenClawStateDatabaseForTest();
+        expect(readStatuses()).toEqual(expectedStatuses);
+        closeOpenClawStateDatabaseForTest();
+      },
+    );
   });
 
   it("adds hosted catalog snapshot trust columns to existing state databases", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -192,6 +192,19 @@ function repairLegacyTaskAgentAttribution(db: DatabaseSync): void {
   `);
 }
 
+function repairLegacyTaskDeliveryStatuses(db: DatabaseSync): void {
+  if (!tableExists(db, "task_runs") || !tableHasColumn(db, "task_runs", "delivery_status")) {
+    return;
+  }
+  // Successful sidecar imports archive their source, so database open must
+  // also canonicalize rows already copied by released migrations.
+  db.exec(`
+    UPDATE task_runs
+    SET delivery_status = 'not_applicable'
+    WHERE delivery_status = 'not-requested';
+  `);
+}
+
 function hasCanonicalAgentDatabasesPrimaryKey(db: DatabaseSync): boolean {
   if (!tableExists(db, "agent_databases")) {
     return true;
@@ -926,6 +939,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
     if (addedTaskRequesterAgentId) {
       repairLegacyTaskAgentAttribution(db);
     }
+    repairLegacyTaskDeliveryStatuses(db);
   });
   ensureColumn(db, "subagent_runs", "task_name TEXT");
 }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -151,6 +152,29 @@ describe("task-registry store runtime", () => {
     };
     expect(latestSnapshot.tasks.size).toBe(2);
     expect(latestSnapshot.tasks.get("task-restored")?.task).toBe("Restored task");
+  });
+
+  it("logs restore parser failures and keeps the registry empty", async () => {
+    const warnLogs = createWarnLogCapture("openclaw-task-registry-restore-test");
+    const invalidValue = "not-requested";
+    try {
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () => {
+            throw new Error(
+              `Invalid persisted task delivery status: ${JSON.stringify(invalidValue)}`,
+            );
+          },
+          saveSnapshot: () => {},
+        },
+      });
+
+      expect(findTaskByRunId("run-restored")).toBeUndefined();
+      expect(await warnLogs.findText(invalidValue)).toContain(invalidValue);
+      expect(getTaskById("task-restored")).toBeUndefined();
+    } finally {
+      warnLogs.cleanup();
+    }
   });
 
   it("uses scoped owner lookups for fresh owner task reads", () => {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1232,7 +1232,7 @@ function restoreTaskRegistryOnce() {
       tasks: snapshotTaskRecords(tasks),
     }));
   } catch (error) {
-    log.warn("Failed to restore task registry", { error });
+    log.warn("Failed to restore task registry", { error: formatErrorMessage(error) });
   }
 }
 


### PR DESCRIPTION
Closes #103168

## What Problem This Solves

Fixes an issue where users upgrading task state from legacy sidecars could lose all persisted tasks from the in-memory registry when a migrated row contained the formerly emitted `delivery_status = "not-requested"` value. The sidecar migration accepted and archived that row, but the strict canonical parser later rejected it, so TaskFlow could report blocked dependencies as missing even though their rows were still present in shared SQLite state.

This also repairs installations where the legacy sidecar was already migrated and archived before the fix was installed.

## Why This Change Was Made

The fix covers both affected data boundaries while keeping steady-state runtime validation strict:

- Future legacy sidecar imports normalize only the known obsolete `not-requested` literal to canonical `not_applicable` before conflict comparison and insertion.
- Existing shared databases repair that same exact literal inside the normal database-open migration transaction, before task rows are parsed. This path does not need the archived sidecar and is idempotent across repeated opens.

Import-only normalization is insufficient because successful released migrations already archived their source sidecars. Conversely, parser aliasing, per-row skipping, partial snapshot restoration, or hiding the TaskFlow audit symptom would weaken the canonical storage contract and could conceal unrelated corruption. The canonical `TaskDeliveryStatus` type, strict parser, atomic snapshot restore, and no-throw outer registry boundary remain unchanged; restore failures now include the rejected persisted value in their warning.

This independently verified and completes the recovery shape explored by closed PR #103173. Open PR #103174 covers future imports, but does not repair affected rows already copied into `state/openclaw.sqlite` after their sidecars were archived.

AI-assisted with Codex. I reviewed the implementation, tests, user-path evidence, and autoreview result.

## User Impact

Affected installations self-heal on the next shared-state database open. Persisted tasks become available to the registry again, TaskFlow dependency linkage no longer reports those restored tasks as missing, and no manual SQL or sidecar recovery is required. Valid canonical statuses and unrelated values are left untouched.

## Evidence

Focused regression suite at exact head:

```text
node scripts/run-vitest.mjs \
  src/commands/doctor-state-migrations.test.ts \
  src/state/openclaw-state-db.test.ts \
  src/tasks/task-registry.store.test.ts

3 test files passed
129 tests passed, 1 skipped
```

Canonical changed gate, run locally with the repository's local-child flags:

```text
pnpm check:changed
lanes: core, coreTests
result: passed
```

The changed gate included conflict-marker and dependency guards, core and core-test tsgo checks, changed-file lint, the database-first legacy-store guard, and runtime import-cycle checks.

Synthetic installed-version comparison used an isolated temporary state directory and no legacy sidecar:

```text
installed OpenClaw 2026.6.10 baseline:
  restored tasks: 0
  restore warning with rejected value: visible
  blocked tasks reported missing: 1

fixed source:
  restored tasks: 3
  blocked tasks reported missing: 0
  obsolete row status: not_applicable
  not_applicable control: unchanged
  pending control: unchanged
```

The upgrade/reopen scenario was repeated after the final rebase at exact head `d6d2a8fe806` through the real `tasks list --json` and `tasks audit --json` CLI paths:

```text
first open restored tasks: 3
second open restored tasks: 3
obsolete raw status: not_applicable
not_applicable raw control: unchanged
pending raw control: unchanged
TaskFlow missing_linked_tasks: 0
TaskFlow blocked_task_missing: 0
```

The second database reopen produced the same rows and canonical statuses, proving idempotence. The minimal synthetic terminal rows intentionally omitted cleanup timestamps, so the general task audit also reported three unrelated `missing_cleanup` warnings; TaskFlow linkage remained healthy with zero errors or warnings.

Fresh legacy-sidecar proof, also in an isolated temporary state directory:

```text
restored tasks: 2
obsolete row status: not_applicable
canonical neighbor status: not_applicable
source sidecar archived: yes
migration warnings: none
```

Additional checks:

- `oxfmt` completed on all six touched files.
- `git diff --check` passed.
- Repository autoreview reported no accepted/actionable findings (`patch is correct`, confidence 0.82).
- Exact-head Workflow Sanity and Real behavior proof checks passed on the draft PR.

No Testbox/Crabbox run ID is available: validation was explicitly performed against the local installed OpenClaw and exact-head source. The upgrade proofs use synthetic task rows only; no real user database, task text, credentials, or private state was accessed.
