### PR TITLE
fix(slack): reply controls fail to start agent turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Slack reply controls:** dispatch persisted button and select clicks as durable inbound reply turns keyed by Slack's per-action timestamp, preserve source-message thread delivery and session-conflict retry, and keep unsupported ephemeral controls private with visible guidance instead of relying on heartbeat wakes. (#102380) Thanks @rodja.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/extensions/slack/src/monitor/events.ts
+++ b/extensions/slack/src/monitor/events.ts
@@ -30,6 +30,10 @@ export function registerSlackMonitorEvents(params: {
   registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackHomeEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
-  registerSlackInteractionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackInteractionEvents({
+    ctx: params.ctx,
+    handleSlackMessage: params.handleSlackMessage,
+    trackEvent: params.trackEvent,
+  });
   registerSlackAssistantEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
 }

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -23,6 +23,7 @@ import {
   SLACK_REPLY_SELECT_ACTION_ID,
 } from "../../reply-action-ids.js";
 import { truncateSlackText } from "../../truncate.js";
+import type { SlackMessageEvent } from "../../types.js";
 import {
   authorizeSlackSystemEventSender,
   resolveSlackCommandIngress,
@@ -35,6 +36,7 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "../conversation.runtime.js";
+import type { SlackMessageHandler } from "../message-handler.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
 
 type InteractionMessageBlock = {
@@ -99,7 +101,12 @@ type SlackBlockActionBody = {
   trigger_id?: string;
   response_url?: string;
   channel?: { id?: string };
-  container?: { channel_id?: string; message_ts?: string; thread_ts?: string };
+  container?: {
+    channel_id?: string;
+    message_ts?: string;
+    thread_ts?: string;
+    is_ephemeral?: boolean;
+  };
   message?: { ts?: string; thread_ts?: string; text?: string; blocks?: unknown[] };
 };
 
@@ -115,11 +122,13 @@ type ParsedSlackBlockAction = {
     text?: { text?: string };
   };
   actionId: string;
+  actionTs?: string;
   blockId?: string;
   userId: string;
   channelId?: string;
   messageTs?: string;
   threadTs?: string;
+  sourceMessageIsEphemeral: boolean;
   actionSummary: SlackActionSummary;
 };
 
@@ -430,6 +439,7 @@ function parseSlackBlockAction(params: {
   }
   const typedActionWithText = typedAction as {
     action_id?: string;
+    action_ts?: string;
     block_id?: string;
     type?: string;
     text?: { text?: string };
@@ -440,12 +450,53 @@ function parseSlackBlockAction(params: {
     typedActionWithText,
     actionId:
       typeof typedActionWithText.action_id === "string" ? typedActionWithText.action_id : "unknown",
+    actionTs: normalizeOptionalString(typedActionWithText.action_ts),
     blockId: typedActionWithText.block_id,
     userId: typedBody.user?.id ?? "unknown",
     channelId: typedBody.channel?.id ?? typedBody.container?.channel_id,
     messageTs: typedBody.message?.ts ?? typedBody.container?.message_ts,
     threadTs: typedBody.container?.thread_ts ?? typedBody.message?.thread_ts,
+    sourceMessageIsEphemeral: typedBody.container?.is_ephemeral === true,
     actionSummary: summarizeAction(typedAction),
+  };
+}
+
+const SLACK_REPLY_ACTION_TEXT_MAX_CHARS = 2400;
+
+function formatSlackReplyActionText(parsed: ParsedSlackBlockAction): string {
+  const label = formatInteractionSelectionLabel({
+    actionId: parsed.actionId,
+    summary: parsed.actionSummary,
+    buttonText: parsed.typedActionWithText.text?.text,
+  });
+  const value =
+    parsed.actionSummary.selectedValues?.join(", ") ??
+    normalizeOptionalString(parsed.actionSummary.value);
+  const selection = value && value !== label ? `${label} (${value})` : label;
+  return truncateSlackText(`User selected: ${selection}`, SLACK_REPLY_ACTION_TEXT_MAX_CHARS);
+}
+
+function buildSlackReplyActionMessage(params: {
+  ctx: SlackMonitorContext;
+  parsed: ParsedSlackBlockAction;
+  channelType?: "im" | "mpim" | "channel" | "group";
+}): (SlackMessageEvent & { event_ts: string; ts: string }) | null {
+  const { parsed } = params;
+  if (!parsed.actionTs || !parsed.channelId || !parsed.messageTs) {
+    params.ctx.runtime.log?.(
+      `slack:interaction drop reply action=${parsed.actionId} user=${parsed.userId} reason=missing-action-context`,
+    );
+    return null;
+  }
+  return {
+    type: "message" as const,
+    channel: parsed.channelId,
+    channel_type: params.channelType,
+    user: parsed.userId,
+    text: formatSlackReplyActionText(parsed),
+    ts: parsed.messageTs,
+    event_ts: parsed.actionTs,
+    thread_ts: parsed.threadTs,
   };
 }
 
@@ -463,6 +514,32 @@ async function respondEphemeral(
     });
   } catch {
     // Best-effort feedback only.
+  }
+}
+
+async function rejectEphemeralSlackReplyAction(params: {
+  parsed: ParsedSlackBlockAction;
+  respond?: SlackBlockActionRespond;
+}): Promise<void> {
+  if (!params.respond) {
+    return;
+  }
+  const originalText = normalizeOptionalString(params.parsed.typedBody.message?.text);
+  const text = [
+    originalText,
+    formatSlackReplyActionText(params.parsed),
+    "Reply controls in ephemeral Slack messages cannot start an agent turn. Send the selection as a message instead.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  try {
+    await params.respond({
+      replace_original: true,
+      response_type: "ephemeral",
+      text,
+    });
+  } catch {
+    // The response URL is best-effort and may have expired.
   }
 }
 
@@ -880,16 +957,25 @@ async function updateSlackLegacyBlockAction(params: {
   ) {
     return;
   }
+  const blocks = buildSlackConfirmationBlocks({
+    parsed: params.parsed,
+    originalBlocks,
+  });
   try {
+    if (params.parsed.sourceMessageIsEphemeral && params.respond) {
+      await params.respond({
+        replace_original: true,
+        text: params.parsed.typedBody.message?.text ?? "",
+        blocks,
+      });
+      return;
+    }
     await updateSlackInteractionMessage({
       ctx: params.ctx,
       channelId: params.parsed.channelId,
       messageTs: params.parsed.messageTs,
       text: params.parsed.typedBody.message?.text ?? "",
-      blocks: buildSlackConfirmationBlocks({
-        parsed: params.parsed,
-        originalBlocks,
-      }),
+      blocks,
     });
   } catch {
     await respondEphemeral(params.respond, `Button "${params.parsed.actionId}" clicked!`);
@@ -898,6 +984,7 @@ async function updateSlackLegacyBlockAction(params: {
 
 async function handleSlackBlockAction(params: {
   ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
   trackEvent?: () => void;
   args: SlackActionMiddlewareArgs;
   formatSystemEvent: (payload: Record<string, unknown>) => string;
@@ -973,6 +1060,42 @@ async function handleSlackBlockAction(params: {
       return;
     }
   }
+  // Approvals and plugin-owned callbacks returned above. Remaining reply controls are user turns;
+  // keeping them on the generic heartbeat path can consume the click without a visible reply.
+  if (isSlackReplyActionId(parsed.actionId)) {
+    if (parsed.sourceMessageIsEphemeral) {
+      params.ctx.runtime.log?.(
+        `slack:interaction reject ephemeral reply action=${parsed.actionId} user=${parsed.userId}`,
+      );
+      await rejectEphemeralSlackReplyAction({ parsed, respond });
+      return;
+    }
+    const message = buildSlackReplyActionMessage({
+      ctx: params.ctx,
+      parsed,
+      channelType: auth.channelType,
+    });
+    if (!message) {
+      return;
+    }
+    const dispatchPromise = params.handleSlackMessage(message, {
+      interactionAuthorization: {
+        kind: "verified-block-action",
+        senderId: parsed.userId,
+        sourceMessageId: message.ts,
+      },
+      messageIdOverride: message.event_ts,
+      source: "interaction",
+      wasMentioned: true,
+    });
+    const updatePromise = updateSlackLegacyBlockAction({
+      ctx: params.ctx,
+      parsed,
+      respond,
+    });
+    await Promise.all([dispatchPromise, updatePromise]);
+    return;
+  }
   enqueueSlackBlockActionEvent({
     ctx: params.ctx,
     parsed,
@@ -988,6 +1111,7 @@ async function handleSlackBlockAction(params: {
 
 export function registerSlackBlockActionHandler(params: {
   ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
   trackEvent?: () => void;
   formatSystemEvent: (payload: Record<string, unknown>) => string;
 }): void {
@@ -997,6 +1121,7 @@ export function registerSlackBlockActionHandler(params: {
   params.ctx.app.action(/.+/, async (args: SlackActionMiddlewareArgs) => {
     await handleSlackBlockAction({
       ctx: params.ctx,
+      handleSlackMessage: params.handleSlackMessage,
       trackEvent: params.trackEvent,
       args,
       formatSystemEvent: params.formatSystemEvent,

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 const requestHeartbeatMock = vi.hoisted(() => vi.fn());
+const handleSlackMessageMock = vi.hoisted(() => vi.fn(async () => undefined));
 type DispatchPluginInteractiveHandlerResult = {
   matched: boolean;
   handled: boolean;
@@ -23,7 +24,16 @@ const resolveApprovalOverGatewayMock = vi.hoisted(() =>
   vi.fn<(arg: unknown) => Promise<void>>(async () => undefined),
 );
 
-let registerSlackInteractionEvents: typeof import("./interactions.js").registerSlackInteractionEvents;
+let registerSlackInteractionEventsImpl: typeof import("./interactions.js").registerSlackInteractionEvents;
+
+function registerSlackInteractionEvents(
+  params: Omit<Parameters<typeof registerSlackInteractionEventsImpl>[0], "handleSlackMessage">,
+) {
+  return registerSlackInteractionEventsImpl({
+    ...params,
+    handleSlackMessage: handleSlackMessageMock,
+  });
+}
 
 vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/system-event-runtime")>();
@@ -398,13 +408,15 @@ function inputByActionId(
 
 describe("registerSlackInteractionEvents", () => {
   beforeAll(async () => {
-    ({ registerSlackInteractionEvents } = await import("./interactions.js"));
+    ({ registerSlackInteractionEvents: registerSlackInteractionEventsImpl } =
+      await import("./interactions.js"));
   });
 
   beforeEach(() => {
     enqueueSystemEventMock.mockReset();
     enqueueSystemEventMock.mockReturnValue(true);
     requestHeartbeatMock.mockClear();
+    handleSlackMessageMock.mockClear();
     dispatchPluginInteractiveHandlerMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockResolvedValue({ status: "expired" });
@@ -894,7 +906,7 @@ describe("registerSlackInteractionEvents", () => {
     expect(requireRecord(registrationCtx.auth, "registration auth").isAuthorizedSender).toBe(true);
   });
 
-  it("treats Slack reply buttons as plain interaction events instead of plugin dispatch", async () => {
+  it("dispatches Slack reply buttons as inbound turns instead of heartbeat events", async () => {
     const { ctx, app, getHandler, resolveSessionKey } = createContext();
     registerSlackInteractionEvents({ ctx: ctx as never });
 
@@ -922,6 +934,7 @@ describe("registerSlackInteractionEvents", () => {
       action: {
         type: "button",
         action_id: "openclaw:reply_button",
+        action_ts: "100.300",
         block_id: "reply_actions",
         value: "codex",
         text: { type: "plain_text", text: "codex" },
@@ -930,38 +943,137 @@ describe("registerSlackInteractionEvents", () => {
 
     expect(ack).toHaveBeenCalled();
     expect(dispatchPluginInteractiveHandlerMock).not.toHaveBeenCalled();
-    const eventText = mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent");
-    expect(eventText).toContain('"actionId":"openclaw:reply_button"');
-    expectRecordFields(
-      requireRecord(
-        mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1),
-        "event options",
-      ),
+    expect(handleSlackMessageMock).toHaveBeenCalledWith(
       {
-        contextKey: "slack:interaction:C1:100.200:openclaw:reply_button",
-        deliveryContext: {
-          accountId: "default",
-          channel: "slack",
-          threadId: "100.100",
-          to: "channel:C1",
+        type: "message",
+        channel: "C1",
+        channel_type: "channel",
+        user: "U123",
+        text: "User selected: codex",
+        ts: "100.200",
+        event_ts: "100.300",
+        thread_ts: "100.100",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U123",
+          sourceMessageId: "100.200",
         },
-        sessionKey: "agent:ops:slack:channel:C1",
+        messageIdOverride: "100.300",
+        source: "interaction",
+        wasMentioned: true,
       },
     );
-    expect(resolveSessionKey).toHaveBeenCalledWith({
-      channelId: "C1",
-      channelType: "channel",
-      senderId: "U123",
-      threadTs: "100.100",
-    });
-    expect(requestHeartbeatMock).toHaveBeenCalledWith({
-      source: "hook",
-      intent: "immediate",
-      reason: "hook:slack-interaction",
-      sessionKey: "agent:ops:slack:channel:C1",
-      heartbeat: { target: "last" },
-    });
+    expect(resolveSessionKey).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves select labels and values and anchors top-level controls to their message", async () => {
+    const { ctx, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    await getHandler()({
+      ack: vi.fn().mockResolvedValue(undefined),
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200" },
+        message: { ts: "100.200", text: "fallback", blocks: [] },
+      },
+      action: {
+        type: "static_select",
+        action_id: "openclaw:reply_select",
+        action_ts: "100.301",
+        block_id: "reply_actions",
+        selected_option: {
+          text: { type: "plain_text", text: "Use Codex" },
+          value: "codex",
+        },
+      },
+    });
+
+    expect(handleSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "User selected: Use Codex (codex)",
+        ts: "100.200",
+        event_ts: "100.301",
+        thread_ts: undefined,
+      }),
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U123",
+          sourceMessageId: "100.200",
+        },
+        messageIdOverride: "100.301",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps default-ephemeral slash reply controls from becoming public turns", async () => {
+    const { ctx, app, getHandler } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const respond = vi.fn(async () => undefined);
+
+    await getHandler()({
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+      // Slack sends container.is_ephemeral, but Bolt 4.7.3 omits it from this payload type.
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        container: {
+          channel_id: "C1",
+          message_ts: "100.400",
+          is_ephemeral: true,
+        },
+        message: {
+          ts: "100.400",
+          text: "Choose",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "reply_actions",
+              elements: [
+                {
+                  type: "button",
+                  action_id: "openclaw:reply_button",
+                  text: { type: "plain_text", text: "Continue" },
+                  value: "continue",
+                },
+              ],
+            },
+          ],
+        },
+      } as never,
+      action: {
+        type: "button",
+        action_id: "openclaw:reply_button",
+        action_ts: "100.401",
+        block_id: "reply_actions",
+        text: { type: "plain_text", text: "Continue" },
+        value: "continue",
+      },
+    });
+
+    expect(handleSlackMessageMock).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replace_original: true,
+        response_type: "ephemeral",
+        text: expect.stringContaining(
+          "Reply controls in ephemeral Slack messages cannot start an agent turn",
+        ),
+      }),
+    );
+    expect(app.client.chat.update).not.toHaveBeenCalled();
   });
 
   it("uses unique interaction ids for repeated Slack actions on the same message", async () => {
@@ -1110,6 +1222,7 @@ describe("registerSlackInteractionEvents", () => {
       text: "Binding updated.",
       response_type: "ephemeral",
     });
+    expect(handleSlackMessageMock).not.toHaveBeenCalled();
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
   });
 
@@ -1173,6 +1286,7 @@ describe("registerSlackInteractionEvents", () => {
     });
     expect(resolvePluginConversationBindingApprovalMock).not.toHaveBeenCalled();
     expect(dispatchPluginInteractiveHandlerMock).not.toHaveBeenCalled();
+    expect(handleSlackMessageMock).not.toHaveBeenCalled();
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expectRecordFields(chatUpdateCall(app), {
       channel: "C1",
@@ -2080,6 +2194,7 @@ describe("registerSlackInteractionEvents", () => {
       action: {
         type: "button",
         action_id: "openclaw:reply_button",
+        action_ts: "333.555",
         block_id: "reply_actions",
         value: "continue",
         text: { type: "plain_text", text: "Continue" },
@@ -2087,28 +2202,28 @@ describe("registerSlackInteractionEvents", () => {
     });
 
     expect(ack).toHaveBeenCalled();
-    expect(resolveSessionKey).toHaveBeenCalledWith({
-      channelId: "C333",
-      channelType: "channel",
-      senderId: "U333",
-      threadTs: "333.111",
-    });
-    expectRecordFields(slackInteractionPayload(), {
-      channelId: "C333",
-      messageTs: "333.444",
-      threadTs: "333.111",
-      teamId: "T333",
-    });
-    const eventOptions = requireRecord(
-      mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1),
-      "event options",
+    expect(handleSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C333",
+        text: "User selected: Continue (continue)",
+        ts: "333.444",
+        event_ts: "333.555",
+        thread_ts: "333.111",
+      }),
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U333",
+          sourceMessageId: "333.444",
+        },
+        messageIdOverride: "333.555",
+        source: "interaction",
+        wasMentioned: true,
+      },
     );
-    expectRecordFields(requireRecord(eventOptions.deliveryContext, "delivery context"), {
-      channel: "slack",
-      to: "channel:C333",
-      accountId: "default",
-      threadId: "333.111",
-    });
+    expect(resolveSessionKey).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
   });
 
   it("summarizes multi-select confirmations in updated message rows", async () => {

--- a/extensions/slack/src/monitor/events/interactions.ts
+++ b/extensions/slack/src/monitor/events/interactions.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements interactions behavior.
 import { truncateSlackText } from "../../truncate.js";
 import type { SlackMonitorContext } from "../context.js";
+import type { SlackMessageHandler } from "../message-handler.js";
 import { registerSlackBlockActionHandler, summarizeAction } from "./interactions.block-actions.js";
 import {
   registerModalLifecycleHandler,
@@ -184,11 +185,13 @@ function summarizeViewState(values: unknown): ModalInputSummary[] {
 
 export function registerSlackInteractionEvents(params: {
   ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
   trackEvent?: () => void;
 }) {
-  const { ctx, trackEvent } = params;
+  const { ctx, handleSlackMessage, trackEvent } = params;
   registerSlackBlockActionHandler({
     ctx,
+    handleSlackMessage,
     trackEvent,
     formatSystemEvent: formatSlackInteractionSystemEvent,
   });

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const enqueueMock = vi.fn(async (_entry: unknown) => {});
 const flushKeyMock = vi.fn(async (_key: string) => {});
 const onFlushCallbacks: Array<(entries: Array<Record<string, unknown>>) => Promise<void>> = [];
+const shouldDebounceCallbacks: Array<(entry: Record<string, unknown>) => boolean> = [];
 const prepareSlackMessageMock = vi.fn(async () => ({ ctxPayload: {} }));
 const dispatchPreparedSlackMessageMock = vi.fn(async () => {});
 const hasSlackInboundMessageDeliveryMock = vi.fn(async () => false);
@@ -21,8 +22,10 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
     ...actual,
     createChannelInboundDebouncer: (params: {
       onFlush: (entries: Array<Record<string, unknown>>) => Promise<void>;
+      shouldDebounce: (entry: Record<string, unknown>) => boolean;
     }) => {
       onFlushCallbacks.push(params.onFlush);
+      shouldDebounceCallbacks.push(params.shouldDebounce);
       return {
         debounceMs: 10,
         debouncer: {
@@ -113,6 +116,7 @@ describe("createSlackMessageHandler", () => {
     enqueueMock.mockClear();
     flushKeyMock.mockClear();
     onFlushCallbacks.length = 0;
+    shouldDebounceCallbacks.length = 0;
     prepareSlackMessageMock.mockClear();
     dispatchPreparedSlackMessageMock.mockClear();
     hasSlackInboundMessageDeliveryMock.mockReset();
@@ -163,6 +167,67 @@ describe("createSlackMessageHandler", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches interaction turns immediately", async () => {
+    const { handler, trackEvent } = createHandlerWithTracker();
+
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        channel_type: "channel",
+        user: "U111",
+        ts: "1709000000.000150",
+        event_ts: "1709000000.000200",
+        thread_ts: "1709000000.000100",
+        text: "User selected: Continue (continue)",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U111",
+          sourceMessageId: "1709000000.000150",
+        },
+        messageIdOverride: "1709000000.000200",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(shouldDebounceCallbacks[0]?.(entry)).toBe(false);
+    expect(entry).toMatchObject({
+      message: { ts: "1709000000.000150" },
+      opts: {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U111",
+          sourceMessageId: "1709000000.000150",
+        },
+        messageIdOverride: "1709000000.000200",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    });
+    expect(hasSlackInboundMessageDeliveryMock).toHaveBeenCalledWith({
+      accountId: "default",
+      channelId: "C111",
+      ts: "1709000000.000200",
+    });
+
+    await onFlushCallbacks[0]?.([entry]);
+    expect(prepareSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ ts: "1709000000.000150" }),
+        opts: expect.objectContaining({ messageIdOverride: "1709000000.000200" }),
+      }),
+    );
+    expect(recordSlackInboundMessageDeliveriesMock).toHaveBeenCalledWith({
+      accountId: "default",
+      messages: [expect.objectContaining({ ts: "1709000000.000200" })],
+    });
   });
 
   it("records explicit channel type before the first delivery-state await", async () => {
@@ -269,6 +334,48 @@ describe("createSlackMessageHandler", () => {
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 
+  it("flushes pending top-level messages before a control interaction", async () => {
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000100",
+        text: "first buffered text",
+      },
+      { source: "message" },
+    );
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000150",
+        event_ts: "1709000000.000200",
+        text: "User selected: Continue (continue)",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U111",
+          sourceMessageId: "1709000000.000150",
+        },
+        messageIdOverride: "1709000000.000200",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+  });
+
   it("waits for debounced dispatch completion when requested by relay delivery", async () => {
     const { handler } = createHandlerWithTracker();
     const handled = handler(
@@ -354,6 +461,65 @@ describe("createSlackMessageHandler", () => {
         },
       });
       expect(enqueueMock.mock.calls[1]?.[0]).not.toHaveProperty("opts.dispatchCompletion");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries interaction conflicts with the action timestamp identity", async () => {
+    const releaseSeenMessage = vi.fn();
+    dispatchPreparedSlackMessageMock.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:slack:channel:c111"),
+    );
+    const { handler } = createHandlerWithTracker({ releaseSeenMessage });
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000700",
+        event_ts: "1709000000.000701",
+        text: "User selected: Continue (continue)",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U111",
+          sourceMessageId: "1709000000.000700",
+        },
+        messageIdOverride: "1709000000.000701",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    const entry = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    vi.useFakeTimers();
+    try {
+      await expect(onFlushCallbacks[0]?.([entry])).rejects.toThrow(
+        "reply session initialization conflicted",
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(releaseSeenMessage).toHaveBeenCalledWith("C111", "1709000000.000701");
+      expect(recordSlackInboundMessageDeliveriesMock).not.toHaveBeenCalled();
+      expect(hasSlackInboundMessageDeliveryMock).toHaveBeenLastCalledWith({
+        accountId: "default",
+        channelId: "C111",
+        ts: "1709000000.000701",
+      });
+      expect(enqueueMock.mock.calls[1]?.[0]).toMatchObject({
+        opts: {
+          interactionAuthorization: {
+            kind: "verified-block-action",
+            senderId: "U111",
+            sourceMessageId: "1709000000.000700",
+          },
+          messageIdOverride: "1709000000.000701",
+          retryAttempt: 1,
+          source: "interaction",
+        },
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -11,7 +11,11 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackSendIdentity } from "../send.js";
-import type { SlackMessageEvent } from "../types.js";
+import type {
+  SlackMessageEvent,
+  SlackMessageSource,
+  SlackVerifiedInteractionAuthorization,
+} from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackEventScope } from "./event-scope.js";
@@ -29,17 +33,33 @@ const loadSlackMessagePipeline = createLazyRuntimeModule(
   () => import("./message-handler/pipeline.runtime.js"),
 );
 
+type SlackMessageHandlerOptionsBase = {
+  wasMentioned?: boolean;
+  relayIdentity?: SlackSendIdentity;
+  /** Non-serializable listener scope for a validated enterprise event. */
+  eventScope?: SlackEventScope;
+  /** Unique turn id when the source message and inbound event have different Slack timestamps. */
+  messageIdOverride?: string;
+  /** Wait until any inbound debounce flush and dispatch has completed. */
+  awaitDispatch?: boolean;
+};
+
+export type SlackMessageHandlerOptions = SlackMessageHandlerOptionsBase &
+  (
+    | {
+        source: Exclude<SlackMessageSource, "interaction">;
+        interactionAuthorization?: never;
+      }
+    | {
+        source: "interaction";
+        messageIdOverride: string;
+        interactionAuthorization: SlackVerifiedInteractionAuthorization;
+      }
+  );
+
 export type SlackMessageHandler = (
   message: SlackMessageEvent,
-  opts: {
-    source: "message" | "app_mention";
-    wasMentioned?: boolean;
-    relayIdentity?: SlackSendIdentity;
-    /** Non-serializable listener scope for a validated enterprise event. */
-    eventScope?: SlackEventScope;
-    /** Wait until any inbound debounce flush and dispatch has completed. */
-    awaitDispatch?: boolean;
-  },
+  opts: SlackMessageHandlerOptions,
 ) => Promise<void>;
 
 type SlackDispatchCompletion = {
@@ -87,7 +107,15 @@ function isRetryableSlackInboundError(error: unknown): boolean {
   );
 }
 
-function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonitorContext["cfg"]) {
+function shouldDebounceSlackMessage(
+  message: SlackMessageEvent,
+  cfg: SlackMonitorContext["cfg"],
+  source: SlackMessageSource,
+) {
+  // Each interaction has its own action_ts identity; merging clicks would lose that boundary.
+  if (source === "interaction") {
+    return false;
+  }
   const text = message.text ?? "";
   const textForCommandDetection = stripSlackMentionsForCommandDetection(text);
   return shouldDebounceTextInbound({
@@ -108,6 +136,21 @@ function buildSeenMessageKey(
   return `${teamId ? `${teamId}:` : ""}${channelId}:${ts}`;
 }
 
+function resolveSlackInboundMessageId(
+  message: SlackMessageEvent,
+  opts: Pick<IngressSlackMessageOptions, "messageIdOverride">,
+): string | undefined {
+  return opts.messageIdOverride ?? message.ts;
+}
+
+function toSlackDeliveryStateMessage(
+  message: SlackMessageEvent,
+  opts: Pick<IngressSlackMessageOptions, "messageIdOverride">,
+): SlackMessageEvent {
+  const messageId = resolveSlackInboundMessageId(message, opts);
+  return messageId === message.ts ? message : { ...message, ts: messageId };
+}
+
 export function createSlackMessageHandler(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
@@ -124,7 +167,8 @@ export function createSlackMessageHandler(params: {
     buildKey: (entry) =>
       buildSlackDebounceKey(entry.message, ctx.accountId, entry.opts.eventScope?.teamId),
     shouldDebounce: (entry) =>
-      !entry.opts.eventScope && shouldDebounceSlackMessage(entry.message, ctx.cfg),
+      !entry.opts.eventScope &&
+      shouldDebounceSlackMessage(entry.message, ctx.cfg, entry.opts.source),
     onFlush: async (entries) => {
       const retryEntries = (sourceError: unknown): boolean => {
         if (
@@ -208,7 +252,7 @@ export function createSlackMessageHandler(params: {
           };
           const seenMessageKey = buildSeenMessageKey(
             last.message.channel,
-            last.message.ts,
+            resolveSlackInboundMessageId(last.message, last.opts),
             last.opts.eventScope?.teamId,
           );
           try {
@@ -272,7 +316,9 @@ export function createSlackMessageHandler(params: {
               return;
             }
             if (entries.length > 1) {
-              const ids = entries.map((entry) => entry.message.ts).filter(Boolean) as string[];
+              const ids = entries
+                .map((entry) => resolveSlackInboundMessageId(entry.message, entry.opts))
+                .filter(Boolean) as string[];
               if (ids.length > 0) {
                 prepared.ctxPayload.MessageSids = ids;
                 prepared.ctxPayload.MessageSidFirst = ids[0];
@@ -284,14 +330,18 @@ export function createSlackMessageHandler(params: {
               await recordSlackInboundMessageDeliveries({
                 accountId: ctx.accountId,
                 ...(last.opts.eventScope ? { teamId: last.opts.eventScope.teamId } : {}),
-                messages: entries.map((entry) => entry.message),
+                messages: entries.map((entry) =>
+                  toSlackDeliveryStateMessage(entry.message, entry.opts),
+                ),
               });
             } catch (error) {
               if (!isRetryableSlackInboundError(error)) {
                 await recordSlackInboundMessageDeliveries({
                   accountId: ctx.accountId,
                   ...(last.opts.eventScope ? { teamId: last.opts.eventScope.teamId } : {}),
-                  messages: entries.map((entry) => entry.message),
+                  messages: entries.map((entry) =>
+                    toSlackDeliveryStateMessage(entry.message, entry.opts),
+                  ),
                 });
               }
               throw error;
@@ -303,7 +353,7 @@ export function createSlackMessageHandler(params: {
               for (const entry of entries) {
                 const entrySeenKey = buildSeenMessageKey(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundMessageId(entry.message, entry.opts),
                   entry.opts.eventScope?.teamId,
                 );
                 if (entrySeenKey) {
@@ -311,7 +361,7 @@ export function createSlackMessageHandler(params: {
                 }
                 ctx.releaseSeenMessage(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundMessageId(entry.message, entry.opts),
                   entry.opts.eventScope,
                 );
               }
@@ -408,7 +458,7 @@ export function createSlackMessageHandler(params: {
     ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     const seenMessageKey = buildSeenMessageKey(
       message.channel,
-      message.ts,
+      resolveSlackInboundMessageId(message, opts),
       opts.eventScope?.teamId,
     );
     if (
@@ -416,14 +466,18 @@ export function createSlackMessageHandler(params: {
       (await hasSlackInboundMessageDelivery({
         accountId: ctx.accountId,
         channelId: message.channel,
-        ts: message.ts,
+        ts: resolveSlackInboundMessageId(message, opts),
         ...(opts.eventScope ? { teamId: opts.eventScope.teamId } : {}),
       }))
     ) {
       return undefined;
     }
     const wasSeen = seenMessageKey
-      ? ctx.markMessageSeen(message.channel, message.ts, opts.eventScope)
+      ? ctx.markMessageSeen(
+          message.channel,
+          resolveSlackInboundMessageId(message, opts),
+          opts.eventScope,
+        )
       : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
       // Prime exactly one fallback app_mention allowance immediately so a near-simultaneous
@@ -451,7 +505,9 @@ export function createSlackMessageHandler(params: {
       teamId,
     );
     const canDebounce =
-      !opts.eventScope && debounceMs > 0 && shouldDebounceSlackMessage(resolvedMessage, ctx.cfg);
+      !opts.eventScope &&
+      debounceMs > 0 &&
+      shouldDebounceSlackMessage(resolvedMessage, ctx.cfg, opts.source);
     if (!canDebounce && conversationKey) {
       const pendingKeys = pendingTopLevelDebounceKeys.get(conversationKey);
       if (pendingKeys && pendingKeys.size > 0) {

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -20,6 +20,7 @@ export function createInboundSlackTestContext(params: {
   channelsConfig?: SlackChannelConfigEntries;
   threadRequireExplicitMention?: boolean;
   dmHistoryLimit?: number;
+  historyLimit?: number;
   groupDmEnabled?: boolean;
   channelRuntime?: ChannelRuntimeSurface;
 }) {
@@ -34,7 +35,7 @@ export function createInboundSlackTestContext(params: {
     botId: "B1",
     teamId: "T1",
     apiAppId: "A1",
-    historyLimit: 0,
+    historyLimit: params.historyLimit ?? 0,
     dmHistoryLimit: params.dmHistoryLimit,
     sessionScope: "per-sender",
     mainKey: "main",

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -209,12 +209,13 @@ describe("slack prepareSlackMessage inbound contract", () => {
     ctx: SlackMonitorContext,
     account: ResolvedSlackAccount,
     message: SlackMessageEvent,
+    opts: Parameters<typeof prepareSlackMessage>[0]["opts"] = { source: "message" },
   ) {
     return prepareSlackMessage({
       ctx,
       account,
       message,
-      opts: { source: "message" },
+      opts,
     });
   }
 
@@ -886,6 +887,251 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
     expect(prepared?.ackReactionMessageTs).toBeUndefined();
     expect(prepared?.ackReactionPromise).toBeNull();
+  });
+
+  it("does not react to synthetic interaction timestamps", async () => {
+    const addReaction = vi.fn().mockResolvedValue({ ok: true });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        agents: { defaults: { envelopeTimezone: "utc" } },
+        messages: {
+          ackReaction: "eyes",
+          ackReactionScope: "all",
+          statusReactions: { enabled: true },
+        },
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      appClient: { reactions: { add: addReaction } } as unknown as App["client"],
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      {
+        channel: "D123",
+        channel_type: "im",
+        user: "U1",
+        text: "User selected: Continue (continue)",
+        ts: "1.500",
+        event_ts: "2.000",
+        thread_ts: "1.000",
+      } as SlackMessageEvent,
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U1",
+          sourceMessageId: "1.500",
+        },
+        messageIdOverride: "2.000",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.MessageSid).toBe("2.000");
+    expect(prepared.ctxPayload.MessageSidFull).toBeUndefined();
+    expect(prepared.ctxPayload.CurrentMessageId).toBe("1.500");
+    expect(prepared.ctxPayload.Timestamp).toBe(2000);
+    expect(prepared.ctxPayload.Body).toContain("1970-01-01T00:00:02Z");
+    expect(prepared.ctxPayload.Body).not.toContain("1970-01-01T00:00:01Z");
+    expect(prepared.ctxPayload.BodyForAgent).toContain("User selected: Continue (continue)");
+    expect(prepared.ackReactionMessageTs).toBeUndefined();
+    expect(prepared.ackReactionPromise).toBeNull();
+    expect(addReaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { replyToMode: "off" as const, expectedThreadId: undefined },
+    { replyToMode: "first" as const, expectedThreadId: undefined },
+    { replyToMode: "all" as const, expectedThreadId: "10.000" },
+  ])(
+    "keeps top-level interaction routing on the channel session with replyToMode=$replyToMode",
+    async ({ replyToMode, expectedThreadId }) => {
+      const slackCtx = createInboundSlackCtx({
+        cfg: {
+          channels: { slack: { enabled: true, groupPolicy: "open", replyToMode } },
+        } as OpenClawConfig,
+        defaultRequireMention: false,
+        historyLimit: 10,
+        replyToMode,
+      });
+      slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+      slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+      const prepared = await prepareMessageWith(
+        slackCtx,
+        createSlackAccount({ replyToMode }),
+        {
+          type: "message",
+          channel: "C123",
+          channel_type: "channel",
+          user: "U1",
+          text: "User selected: Continue (continue)",
+          ts: "10.000",
+          event_ts: "20.000",
+        },
+        {
+          interactionAuthorization: {
+            kind: "verified-block-action",
+            senderId: "U1",
+            sourceMessageId: "10.000",
+          },
+          messageIdOverride: "20.000",
+          source: "interaction",
+          wasMentioned: true,
+        },
+      );
+
+      assertPrepared(prepared);
+      expect(prepared.ctxPayload.SessionKey).toBe("agent:main:slack:channel:c123");
+      expect(prepared.ctxPayload.MessageThreadId).toBe(expectedThreadId);
+      expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
+      expect(prepared.ctxPayload.MessageSid).toBe("20.000");
+      expect(prepared.ctxPayload.MessageSidFull).toBeUndefined();
+      expect(prepared.ctxPayload.CurrentMessageId).toBe("10.000");
+      expect(prepared.replyToMode).toBe(replyToMode);
+      expect(Array.from(slackCtx.channelHistories.values()).flat()).toMatchObject([
+        { messageId: "20.000", timestamp: 20_000 },
+      ]);
+    },
+  );
+
+  it("keeps interaction turns in their existing Slack thread", async () => {
+    const replies = vi.fn().mockResolvedValue({ messages: [], response_metadata: {} });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, groupPolicy: "open", replyToMode: "off" } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as unknown as App["client"],
+      defaultRequireMention: true,
+      replyToMode: "off",
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "off" }),
+      {
+        type: "message",
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "User selected: Continue (continue)",
+        ts: "10.200",
+        event_ts: "20.000",
+        thread_ts: "10.000",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U1",
+          sourceMessageId: "10.200",
+        },
+        messageIdOverride: "20.000",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:slack:channel:c123:thread:10.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("10.000");
+    expect(prepared.ctxPayload.ReplyToId).toBe("10.000");
+    expect(prepared.ctxPayload.MessageSid).toBe("20.000");
+    expect(prepared.ctxPayload.MessageSidFull).toBeUndefined();
+    expect(prepared.ctxPayload.CurrentMessageId).toBe("10.200");
+  });
+
+  it("preserves verified interactive owner authorization across channel user gates", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true, groupPolicy: "open" } } } as OpenClawConfig,
+      channelsConfig: { C123: { requireMention: true, users: ["U_MEMBER"] } },
+      defaultRequireMention: true,
+    });
+    slackCtx.allowFrom = ["U_OWNER"];
+    slackCtx.resolveUserName = async () => ({ name: "Owner" }) as any;
+    slackCtx.resolveChannelName = async () => ({ name: "ops", type: "channel" });
+    const message = {
+      type: "message",
+      channel: "C123",
+      channel_type: "channel",
+      user: "U_OWNER",
+      text: "User selected: Continue (continue)",
+      ts: "10.200",
+      event_ts: "20.000",
+    } satisfies SlackMessageEvent;
+
+    const ordinary = await prepareMessageWith(slackCtx, createSlackAccount(), message, {
+      source: "message",
+      wasMentioned: true,
+    });
+    const interaction = await prepareMessageWith(slackCtx, createSlackAccount(), message, {
+      interactionAuthorization: {
+        kind: "verified-block-action",
+        senderId: "U_OWNER",
+        sourceMessageId: "10.200",
+      },
+      messageIdOverride: "20.000",
+      source: "interaction",
+      wasMentioned: true,
+    });
+    const mismatched = await prepareMessageWith(slackCtx, createSlackAccount(), message, {
+      interactionAuthorization: {
+        kind: "verified-block-action",
+        senderId: "U_OTHER",
+        sourceMessageId: "10.200",
+      },
+      messageIdOverride: "20.001",
+      source: "interaction",
+      wasMentioned: true,
+    });
+
+    expect(ordinary).toBeNull();
+    assertPrepared(interaction);
+    expect(interaction.ctxPayload.MessageSid).toBe("20.000");
+    expect(interaction.ctxPayload.CurrentMessageId).toBe("10.200");
+    expect(mismatched).toBeNull();
+  });
+
+  it("rechecks DM pairing policy for verified interactions", async () => {
+    const postMessage = vi.fn().mockResolvedValue({ ok: true, ts: "30.000" });
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      appClient: { chat: { postMessage } } as unknown as App["client"],
+    });
+    slackCtx.allowFrom = [];
+    slackCtx.dmPolicy = "pairing";
+    slackCtx.resolveUserName = async () => ({ name: "Unpaired" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      {
+        type: "message",
+        channel: "D123",
+        channel_type: "im",
+        user: "U_UNPAIRED",
+        text: "User selected: Continue (continue)",
+        ts: "10.300",
+        event_ts: "20.300",
+      },
+      {
+        interactionAuthorization: {
+          kind: "verified-block-action",
+          senderId: "U_UNPAIRED",
+          sourceMessageId: "10.300",
+        },
+        messageIdOverride: "20.300",
+        source: "interaction",
+        wasMentioned: true,
+      },
+    );
+
+    expect(prepared).toBeNull();
+    expect(postMessage).toHaveBeenCalledOnce();
   });
 
   it("does not coerce malformed Slack timestamps into inbound event times", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -44,7 +44,13 @@ import { formatSlackError } from "../../errors.js";
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackSendIdentity } from "../../send.js";
 import { hasSlackThreadParticipationWithPersistence } from "../../sent-thread-cache.js";
-import type { SlackAttachment, SlackFile, SlackMessageEvent } from "../../types.js";
+import type {
+  SlackAttachment,
+  SlackFile,
+  SlackMessageEvent,
+  SlackMessageSource,
+  SlackVerifiedInteractionAuthorization,
+} from "../../types.js";
 import { normalizeAllowListLower, normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import {
   authorizeSlackBotRoomMessage,
@@ -356,6 +362,7 @@ type SlackConversationContext = {
 type SlackAuthorizationContext = {
   senderId: string;
   allowFromLower: string[];
+  verifiedInteraction: boolean;
 };
 
 type SlackMentionMetadata = {
@@ -407,7 +414,7 @@ async function resolveSlackExplicitMentionState(params: {
   messageText: string;
   mentionedUserIds: readonly string[];
   hasSubteamMention: boolean;
-  source: "message" | "app_mention";
+  source: SlackMessageSource;
   eventScope?: SlackEventScope;
 }): Promise<SlackExplicitMentionState> {
   const normalizedBotUserId = normalizeSlackId(params.ctx.botUserId);
@@ -553,6 +560,7 @@ async function authorizeSlackInboundMessage(params: {
   account: ResolvedSlackAccount;
   message: SlackMessageEvent;
   conversation: SlackConversationContext;
+  interactionAuthorization?: SlackVerifiedInteractionAuthorization;
   eventScope?: SlackEventScope;
 }): Promise<SlackAuthorizationContext | null> {
   const { ctx, account, message, conversation } = params;
@@ -594,6 +602,14 @@ async function authorizeSlackInboundMessage(params: {
   const allowFromLower = await resolveSlackEffectiveAllowFrom(ctx, {
     includePairingStore: isDirectMessage,
   });
+  const verifiedInteraction =
+    params.interactionAuthorization?.kind === "verified-block-action" &&
+    params.interactionAuthorization.senderId === senderId &&
+    params.interactionAuthorization.sourceMessageId === message.ts;
+  if (params.interactionAuthorization && !verifiedInteraction) {
+    logVerbose("slack: drop interaction message (verified sender mismatch)");
+    return null;
+  }
 
   if (isDirectMessage) {
     const directUserId = message.user;
@@ -633,6 +649,7 @@ async function authorizeSlackInboundMessage(params: {
   return {
     senderId,
     allowFromLower,
+    verifiedInteraction,
   };
 }
 
@@ -641,10 +658,12 @@ export async function prepareSlackMessage(params: {
   account: ResolvedSlackAccount;
   message: SlackMessageEvent;
   opts: {
-    source: "message" | "app_mention";
+    source: SlackMessageSource;
     wasMentioned?: boolean;
     relayIdentity?: SlackSendIdentity;
     eventScope?: SlackEventScope;
+    messageIdOverride?: string;
+    interactionAuthorization?: SlackVerifiedInteractionAuthorization;
     /** Handler-owned race check for suppressing a duplicate dropped-history record. */
     shouldRecordDroppedHistory?: () => boolean;
   };
@@ -677,12 +696,14 @@ export async function prepareSlackMessage(params: {
     account,
     message,
     conversation,
+    interactionAuthorization:
+      opts.source === "interaction" ? opts.interactionAuthorization : undefined,
     eventScope: opts.eventScope,
   });
   if (!authorization) {
     return null;
   }
-  const { senderId, allowFromLower } = authorization;
+  const { senderId, allowFromLower, verifiedInteraction } = authorization;
   const messageText = message.text ?? "";
   let resolvedSenderName = normalizeOptionalString(message.username);
   const resolveSenderName = async (): Promise<string> => {
@@ -762,11 +783,15 @@ export async function prepareSlackMessage(params: {
     channelConfig?.replyToMode ?? resolveSlackReplyToMode(account, channelChatType);
   const willImplicitlyThreadReply =
     isRoom && !channelRequireMention && channelReplyToMode !== "off";
+  // A control click uses wasMentioned to pass room policy, but its source message already owns
+  // routing. Seeding from that flag would manufacture a new thread session for top-level clicks.
+  const canSeedTopLevelRoomThread = opts.source !== "interaction";
   const seedTopLevelRoomThreadBySource =
-    opts.source === "app_mention" ||
-    opts.wasMentioned === true ||
-    explicitlyMentioned ||
-    willImplicitlyThreadReply;
+    canSeedTopLevelRoomThread &&
+    (opts.source === "app_mention" ||
+      opts.wasMentioned === true ||
+      explicitlyMentioned ||
+      willImplicitlyThreadReply);
   let routing = resolveSlackRoutingContext({
     ctx,
     account,
@@ -1041,7 +1066,7 @@ export async function prepareSlackMessage(params: {
     },
   });
   const senderGate = messageIngress.senderAccess.gate;
-  if (isRoom && senderGate?.allowed === false) {
+  if (isRoom && senderGate?.allowed === false && !verifiedInteraction) {
     logVerbose(`Blocked unauthorized slack sender ${senderId} (not in channel users)`);
     return null;
   }
@@ -1087,7 +1112,11 @@ export async function prepareSlackMessage(params: {
   }
 
   const canSeedMentionedRoomThread =
-    !seedTopLevelRoomThreadBySource && isRoom && !routing.isThreadReply && !hasBoundSession;
+    canSeedTopLevelRoomThread &&
+    !seedTopLevelRoomThreadBySource &&
+    isRoom &&
+    !routing.isThreadReply &&
+    !hasBoundSession;
   let seededMentionRouting: typeof routing | undefined;
   const getSeededMentionRouting = () => {
     seededMentionRouting ??= resolveSlackRoutingContext({
@@ -1306,7 +1335,8 @@ export async function prepareSlackMessage(params: {
       }),
     );
 
-  const ackReactionMessageTs = message.ts;
+  // Interaction timestamps identify the click, not a Slack message that can receive reactions.
+  const ackReactionMessageTs = opts.source === "interaction" ? undefined : message.ts;
   const allowToolOnlyStatusReaction =
     statusReactionsExplicitlyEnabled && (effectiveWasMentioned || shouldBypassMention);
   const shouldSendConfiguredAck = shouldAckReaction();
@@ -1364,6 +1394,7 @@ export async function prepareSlackMessage(params: {
     isThreadReply && threadTs
       ? ` thread_ts: ${threadTs}${message.parent_user_id ? ` parent_user_id: ${message.parent_user_id}` : ""}`
       : "";
+  const inboundMessageId = opts.messageIdOverride ?? threadContext.messageTs;
   const textWithId = `${bodyForAgent}\n[slack message id: ${message.ts} channel: ${message.channel}${threadInfo}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
@@ -1373,6 +1404,9 @@ export async function prepareSlackMessage(params: {
     storePath,
     sessionKey,
   });
+  const inboundTimestamp = resolveSlackTimestampMs(
+    opts.source === "interaction" ? message.event_ts : message.ts,
+  );
   if (opts.source === "app_mention" && !ctx.botUserId && message.ts) {
     // The Slack message event can arrive first and queue the same timestamp as dropped history.
     // Remove only this route's copy before the trusted app_mention builds prompt context.
@@ -1395,7 +1429,7 @@ export async function prepareSlackMessage(params: {
   const body = formatInboundEnvelope({
     channel: "Slack",
     from: envelopeFrom,
-    timestamp: resolveSlackTimestampMs(message.ts),
+    timestamp: inboundTimestamp,
     body: textWithId,
     chatType,
     sender: { name: senderName, id: senderId },
@@ -1493,8 +1527,9 @@ export async function prepareSlackMessage(params: {
   const ctxPayload = buildChannelInboundEventContext({
     channel: "slack",
     accountId: route.accountId,
-    messageId: threadContext.messageTs,
-    timestamp: resolveSlackTimestampMs(message.ts),
+    messageId: inboundMessageId,
+    currentMessageId: opts.messageIdOverride ? threadContext.messageTs : undefined,
+    timestamp: inboundTimestamp,
     from: slackFrom,
     sender: {
       id: senderId,
@@ -1594,8 +1629,8 @@ export async function prepareSlackMessage(params: {
       entry: {
         sender: senderName,
         body: rawBody,
-        timestamp: resolveSlackTimestampMs(message.ts),
-        messageId: message.ts,
+        timestamp: inboundTimestamp,
+        messageId: inboundMessageId,
       },
     });
   }

--- a/extensions/slack/src/monitor/thread-resolution.ts
+++ b/extensions/slack/src/monitor/thread-resolution.ts
@@ -8,7 +8,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../errors.js";
-import type { SlackMessageEvent } from "../types.js";
+import type { SlackMessageEvent, SlackMessageSource } from "../types.js";
 
 type ThreadTsCacheEntry = {
   threadTs: string | null;
@@ -102,7 +102,7 @@ export function createSlackThreadTsResolver(params: {
   return {
     resolve: async (request: {
       message: SlackMessageEvent;
-      source: "message" | "app_mention";
+      source: SlackMessageSource;
     }): Promise<SlackMessageEvent> => {
       const { message } = request;
       if (!message.parent_user_id || message.thread_ts || !message.ts) {

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -56,6 +56,15 @@ export type SlackMessageEvent = {
   _ambiguousThreadReply?: boolean;
 };
 
+export type SlackMessageSource = "message" | "app_mention" | "interaction";
+
+/** Proof that the interaction actor passed Slack's signed block-action authorization path. */
+export type SlackVerifiedInteractionAuthorization = {
+  kind: "verified-block-action";
+  senderId: string;
+  sourceMessageId: string;
+};
+
 export type SlackAppMentionEvent = {
   type: "app_mention";
   user?: string;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1623,7 +1623,10 @@ async function runAgentTurnWithFallbackInternal(
       logVerbose(`execution phase typing signal failed: ${String(err)}`);
     });
   };
-  const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
+  const currentMessageId =
+    params.sessionCtx.CurrentMessageId ??
+    params.sessionCtx.MessageSidFull ??
+    params.sessionCtx.MessageSid;
   const notifyUserAboutCompaction = shouldNotifyUserAboutCompaction(runtimeConfig);
   const deliverCompactionNoticePayload = async (noticePayload: ReplyPayload, label: string) => {
     const deliver = params.opts?.onBlockReply ?? params.onCompactionNoticePayload;
@@ -1838,7 +1841,10 @@ async function runAgentTurnWithFallbackInternal(
       const blockReplyHandler = params.opts?.onBlockReply
         ? createBlockReplyDeliveryHandler({
             onBlockReply: params.opts.onBlockReply,
-            currentMessageId: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+            currentMessageId:
+              params.sessionCtx.CurrentMessageId ??
+              params.sessionCtx.MessageSidFull ??
+              params.sessionCtx.MessageSid,
             replyThreading: params.replyThreading,
             normalizeStreamingText,
             applyReplyToMode: params.applyReplyToMode,
@@ -2041,7 +2047,9 @@ async function runAgentTurnWithFallbackInternal(
                 params.sessionCtx.InputProvenance.sourceTool === "restart-sentinel";
               const cliCurrentMessageId = isRestartSentinelContinuation
                 ? params.sessionCtx.ReplyToId
-                : (params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid);
+                : (params.sessionCtx.CurrentMessageId ??
+                  params.sessionCtx.MessageSidFull ??
+                  params.sessionCtx.MessageSid);
               const cliToolSummaryTracker = createCliToolSummaryTracker({
                 detailMode: params.toolProgressDetail,
                 shouldEmitToolResult: params.shouldEmitToolResult,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -445,6 +445,22 @@ describe("agent-runner-utils", () => {
     expect(context.currentMessageId).toBe("msg-9");
   });
 
+  it("prefers an explicit native current message over the inbound event id", () => {
+    const context = buildThreadingToolContext({
+      sessionCtx: {
+        Provider: "slack",
+        To: "channel:C123",
+        MessageSid: "action-ts",
+        MessageSidFull: "action-ts-full",
+        CurrentMessageId: "control-message-ts",
+      },
+      config: {},
+      hasRepliedRef: undefined,
+    });
+
+    expect(context.currentMessageId).toBe("control-message-ts");
+  });
+
   it("does not expose restart-sentinel synthetic ids as message-tool reply targets", () => {
     hoisted.getChannelPluginMock.mockReturnValue({
       threading: {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -124,7 +124,7 @@ export function buildThreadingToolContext(params: {
     sessionCtx.InputProvenance.sourceTool === "restart-sentinel";
   const currentMessageId = isRestartSentinelContinuation
     ? sessionCtx.ReplyToId
-    : (sessionCtx.MessageSidFull ?? sessionCtx.MessageSid);
+    : (sessionCtx.CurrentMessageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid);
   const originProvider = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Provider,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1415,7 +1415,8 @@ export async function runReplyAgent(params: {
     requesterSenderUsername: followupRun.run.senderUsername,
     requesterSenderE164: followupRun.run.senderE164,
   });
-  const compactionNoticeMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  const compactionNoticeMessageId =
+    sessionCtx.CurrentMessageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   const sendDirectCompactionNotice = shouldNotifyUserAboutCompaction(cfg)
     ? async (phase: CompactionNoticePhase) => {
         if (!opts?.onBlockReply) {
@@ -2070,7 +2071,8 @@ export async function runReplyAgent(params: {
     if (opts?.sourceReplyDeliveryMode === "message_tool_only" && committedSourceReplyDelivery) {
       await opts.onObservedReplyDelivery?.();
     }
-    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    const currentMessageId =
+      sessionCtx.CurrentMessageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
     // A terminal fallback is built separately after normal payload filtering.
     // Share this state across deliverable lanes so replyToMode=first still threads
     // at most one visible payload without hidden reasoning/commentary consuming it.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1427,6 +1427,39 @@ describe("dispatchReplyFromConfig", () => {
     });
   });
 
+  it("keeps repeated controls on one Slack message distinct in transcript mirroring", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    installThreadingTestPlugin({ id: "slack" });
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    for (const actionId of ["action-ts-1", "action-ts-2"]) {
+      const dispatcher = createDispatcher();
+      await dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "slack",
+          Surface: "slack",
+          OriginatingChannel: "slack",
+          OriginatingTo: "channel:C123",
+          ChatType: "group",
+          SessionKey: "agent:main:slack:channel:C123",
+          MessageSid: actionId,
+          CurrentMessageId: "control-message-ts",
+        }),
+        cfg: emptyConfig,
+        dispatcher,
+        replyResolver: async () => ({ text: `Reply for ${actionId}` }),
+      });
+      await settleReplyDispatcher({ dispatcher });
+    }
+
+    expect(
+      transcriptMocks.appendAssistantMessageToSessionTranscript.mock.calls.map(
+        ([call]) => (call as { idempotencyKey?: string }).idempotencyKey,
+      ),
+    ).toEqual(["channel-final:action-ts-1:0", "channel-final:action-ts-2:0"]);
+  });
+
   it("mirrors reset acknowledgements into the canonically prepared Slack session", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockReturnValue(false);
@@ -6988,6 +7021,7 @@ describe("dispatchReplyFromConfig", () => {
       RawBody: "raw text",
       Body: "body text",
       Timestamp: 1710000000000,
+      CurrentMessageId: "control-message-ts",
       MessageSidFull: "sid-full",
       SenderId: "user-1",
       SenderName: "Alice",

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -78,6 +78,25 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toEqual([{ text: "", mediaUrl: "/tmp/image.png" }]);
   });
 
+  it.each([
+    { replyToMode: "off" as const, expectedReplyToId: undefined },
+    { replyToMode: "first" as const, expectedReplyToId: "control-message-ts" },
+    { replyToMode: "all" as const, expectedReplyToId: "control-message-ts" },
+  ])(
+    "uses the native current message for queued replyToMode=$replyToMode delivery",
+    ({ replyToMode, expectedReplyToId }) => {
+      const [resolved] = resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [{ text: "queued reply" }],
+        currentMessageId: "control-message-ts",
+        originatingChannel: "slack",
+        originatingReplyToMode: replyToMode,
+      });
+
+      expect(resolved?.replyToId).toBe(expectedReplyToId);
+    },
+  );
+
   it("preserves transcript ownership when stripping heartbeat text", () => {
     const payload = setReplyPayloadMetadata(
       { text: "HEARTBEAT_OK still working" },

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -32,6 +32,7 @@ export function resolveFollowupDeliveryPayloads(params: {
   originatingAccountId?: string;
   originatingChannel?: string;
   originatingChatType?: string | null;
+  currentMessageId?: string;
   originatingReplyToMode?: ReplyToMode;
   originatingTo?: string;
   originatingThreadId?: string | number;
@@ -89,6 +90,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     payloads: sanitizedPayloads,
     replyToMode,
     replyToChannel,
+    currentMessageId: params.currentMessageId,
   }).map((payload) =>
     setReplyPayloadMetadata(payload, {
       replyDelivery,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -741,6 +741,38 @@ describe("createFollowupRunner reply-lane admission", () => {
     expect(call.clientCaps).toEqual(["tool-events", "inline-widgets"]);
   });
 
+  it("passes the native current message to queued embedded runs", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    const storePath = "/tmp/openclaw-followup-current-message.json";
+    const sessionEntry: SessionEntry = { sessionId: "session-current-message", updatedAt: 1 };
+    registerFollowupTestSessionStore(storePath, { main: sessionEntry });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath,
+      defaultModel: "anthropic/claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        messageId: "action-ts",
+        currentMessageId: "control-message-ts",
+        run: {
+          sessionId: "session-current-message",
+          sessionKey: "main",
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+
+    const call = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
+    expect(call.currentMessageId).toBe("control-message-ts");
+  });
+
   it("awaits queued-owner admission before model execution", async () => {
     const events: string[] = [];
     let releaseAdmission!: () => void;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -781,7 +781,7 @@ export function createFollowupRunner(params: {
         run.inputProvenance?.kind === "internal_system" &&
         run.inputProvenance.sourceTool === "restart-sentinel"
           ? queued.originatingReplyToId
-          : queued.messageId;
+          : (queued.currentMessageId ?? queued.messageId);
       const compactionNoticeReplyToId = resolveFollowupCurrentMessageId();
       const sendCompactionNoticePayload = async (
         payload: ReplyPayload,
@@ -801,6 +801,7 @@ export function createFollowupRunner(params: {
           originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
           originatingChannel: queued.originatingChannel,
           originatingChatType: queued.originatingChatType,
+          currentMessageId: resolveFollowupCurrentMessageId(),
           originatingReplyToMode: queued.originatingReplyToMode,
           originatingTo: queued.originatingTo,
           reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
@@ -1815,6 +1816,7 @@ export function createFollowupRunner(params: {
           originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
           originatingChannel: queued.originatingChannel,
           originatingChatType: queued.originatingChatType,
+          currentMessageId: resolveFollowupCurrentMessageId(),
           originatingReplyToMode: queued.originatingReplyToMode,
           originatingTo: queued.originatingTo,
           originatingThreadId: queued.originatingThreadId,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -346,6 +346,22 @@ describe("runPreparedReply media-only handling", () => {
     expect(storeRuntimeLoads).not.toHaveBeenCalled();
   });
 
+  it("keeps queued event identity separate from the native current message target", async () => {
+    await runPreparedReply(
+      baseParams({
+        sessionCtx: {
+          ...baseParams().sessionCtx,
+          MessageSid: "action-ts",
+          CurrentMessageId: "control-message-ts",
+        },
+      }),
+    );
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call.followupRun.messageId).toBe("action-ts");
+    expect(call.followupRun.currentMessageId).toBe("control-message-ts");
+  });
+
   it("passes approved elevated defaults to the runner", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1473,6 +1473,8 @@ export async function runPreparedReply(
     queuedLifecycle: opts?.queuedFollowupLifecycle,
     onFollowupAdmissionWaitChange: opts?.onFollowupAdmissionWaitChange,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
+    currentMessageId:
+      sessionCtx.CurrentMessageId ?? sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
     images: currentTurnImages.images,

--- a/src/auto-reply/reply/queue/drain.client-caps.test.ts
+++ b/src/auto-reply/reply/queue/drain.client-caps.test.ts
@@ -34,4 +34,35 @@ describe("followup delivery context", () => {
       resolveFollowupDeliveryContextKey(second),
     );
   });
+
+  it("groups distinct interaction events by their shared native reply anchor", () => {
+    const first = createQueueTestRun({ prompt: "first click" });
+    Object.assign(first, {
+      messageId: "action-1",
+      currentMessageId: "control-1",
+      originatingChannel: "slack",
+      originatingReplyToMode: "first",
+    });
+    const second = createQueueTestRun({ prompt: "second click" });
+    Object.assign(second, {
+      messageId: "action-2",
+      currentMessageId: "control-1",
+      originatingChannel: "slack",
+      originatingReplyToMode: "first",
+    });
+    const otherControl = createQueueTestRun({ prompt: "other control" });
+    Object.assign(otherControl, {
+      messageId: "action-3",
+      currentMessageId: "control-2",
+      originatingChannel: "slack",
+      originatingReplyToMode: "first",
+    });
+
+    expect(resolveFollowupDeliveryContextKey(first)).toBe(
+      resolveFollowupDeliveryContextKey(second),
+    );
+    expect(resolveFollowupDeliveryContextKey(first)).not.toBe(
+      resolveFollowupDeliveryContextKey(otherControl),
+    );
+  });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -227,7 +227,9 @@ export function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined
   // Slack standalone turns have no parent reply id, but enabled reply policies
   // still need the message id so collect groups cannot cross independent roots.
   // A routed thread already owns that boundary and remains collectable across turns.
-  return hasRoutedThread ? undefined : normalizeOptionalString(run.messageId);
+  return hasRoutedThread
+    ? undefined
+    : normalizeOptionalString(run.currentMessageId ?? run.messageId);
 }
 
 function splitCollectItemsByDeliveryContext(items: FollowupRun[]): FollowupRun[][] {
@@ -880,6 +882,7 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     queueAbortSignal: source.queueAbortSignal,
     transcriptPrompt: source.transcriptPrompt,
     messageId: source.messageId,
+    currentMessageId: source.currentMessageId,
     summaryLine: source.summaryLine,
     enqueuedAt: source.enqueuedAt,
     originatingChannel: source.originatingChannel,
@@ -948,6 +951,7 @@ async function runSyntheticOverflowSummary(params: {
     queueAbortSignal: params.source.queueAbortSignal,
     transcriptPrompt: params.prompt,
     messageId: params.source.messageId,
+    currentMessageId: params.source.currentMessageId,
     userTurnTranscriptRecorder,
     run: params.source.run,
     enqueuedAt: Date.now(),
@@ -1266,6 +1270,9 @@ export function scheduleFollowupDrain(
                 run,
                 messageId:
                   groupSource?.messageId ??
+                  (groupSource ? resolveFollowupReplyAnchor(groupSource) : undefined),
+                currentMessageId:
+                  groupSource?.currentMessageId ??
                   (groupSource ? resolveFollowupReplyAnchor(groupSource) : undefined),
                 enqueuedAt: Date.now(),
                 ...routing,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -77,6 +77,8 @@ export type FollowupRun = {
   onFollowupAdmissionWaitChange?: (waiting: boolean) => void;
   /** Provider message ID, when available (for deduplication). */
   messageId?: string;
+  /** Native provider message targeted by reply threading and current-message tools. */
+  currentMessageId?: string;
   summaryLine?: string;
   /** Force individual drain; never merge this run into a collect batch. */
   disableCollectBatching?: boolean;

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -133,6 +133,8 @@ export type MsgContext = {
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */
   MessageSidFull?: string;
+  /** Native provider message targeted by current-message actions when it differs from this turn's id. */
+  CurrentMessageId?: string;
   MessageSids?: string[];
   MessageSidFirst?: string;
   MessageSidLast?: string;

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -65,6 +65,7 @@ export type BuildChannelInboundEventContextParams = {
   surface?: string;
   messageId?: string;
   messageIdFull?: string;
+  currentMessageId?: string;
   timestamp?: number;
   from: string;
   sender: SenderFacts;
@@ -492,6 +493,7 @@ export function buildChannelInboundEventContext(
     ModelParentSessionKey: params.route.modelParentSessionKey,
     MessageSid: params.messageId,
     MessageSidFull: params.messageIdFull,
+    CurrentMessageId: params.currentMessageId,
     ReplyToId: params.reply.replyToId,
     ReplyToIdFull: params.reply.replyToIdFull,
     ChatType: params.conversation.kind,


### PR DESCRIPTION
Closes #102380

## What Problem This Solves

Slack reply buttons and selects currently enqueue a system event and request a heartbeat wake. On an idle session, that can hide the selection from the model, fail to deliver a visible reply, or lose the interaction during session initialization.

## Why This Change Was Made

Authorized controls in persisted Slack messages now enter the normal inbound reply pipeline. Slack's per-action `action_ts` remains the unique event and deduplication identity, while the source message timestamp is carried separately for native tools, thread delivery, queues, compaction notices, and retries.

Approvals, plugin callbacks, links, and non-reply actions retain their existing behavior. Ephemeral reply controls are rejected in place through their `response_url`: dispatching them through the ordinary inbound pipeline could turn a private slash-command interaction into a public channel reply.

## User Impact

Persisted Slack reply controls now behave like user replies, including authorization checks, queueing, retries, thread targeting, and visible delivery. Unpaired DM users remain blocked. Unsupported ephemeral controls remain private and show guidance to send the choice as a message.

## Evidence

- Focused Crabbox run `run_c1eca846adb7`: 746 tests passed across queue, auto-reply, and Slack interaction paths; the stable patch is unchanged after the latest main refresh.
- Exact-head hosted CI on `7d5a3c2b8b5a8335746e514077f4b9ef5fe1d32d`: 68 passed, 33 skipped, 0 failed.
- A fresh Crabbox changed-gate retry verified the exact base and 28-file diff, but its hydrated workspace pruned tracked dependency links and could not start the gate (`yaml` missing); no code failure occurred.
- Fresh autoreview: no accepted or actionable findings after fixing an authorization-gate finding.
- Rebased from `9b1c36d23c3` to `d92d5774f5c`; stable patch ID remained `9392c30ffb6284df215c01f1d3723e4bd6d6c766`.
- Slack contracts: [`block_actions` payload](https://docs.slack.dev/reference/interaction-payloads/block_actions-payload/), [interaction acknowledgements and `response_url`](https://docs.slack.dev/interactivity/handling-user-interaction/), and [`chat.update` ephemeral restriction](https://docs.slack.dev/reference/methods/chat.update/).
- Live `steipeteclaw` DM proof: pending exact-head canary.

AI-assisted: yes. The implementation and tests were reviewed and understood by the maintainer.
