### PR TITLE
fix(agent-core): weight CJK characters in compaction token estimates (#103930)

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-cjk-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-cjk-tokens.test.ts
@@ -1,0 +1,32 @@
+// CJK text is ~1 token per character in real tokenizers; the raw chars/4
+// heuristic under-counted CJK sessions ~3-4x so keepRecentTokens kept far
+// more than budgeted (#103930).
+import { describe, expect, it } from "vitest";
+import { estimateTokens } from "./compaction.js";
+
+type EstimateInput = Parameters<typeof estimateTokens>[0];
+
+describe("estimateTokens CJK weighting", () => {
+  it("weights CJK characters as ~1 token each", () => {
+    const cjk = "深度学习模型的上下文窗口管理策略".repeat(10); // 160 CJK chars
+    const tokens = estimateTokens({ role: "user", content: cjk } as EstimateInput);
+    // 160 chars weighted at 4 chars each -> ~160 tokens (raw chars/4 gave 40).
+    expect(tokens).toBe(160);
+  });
+
+  it("keeps pure Latin estimates unchanged", () => {
+    const latin = "a".repeat(160);
+    const tokens = estimateTokens({ role: "user", content: latin } as EstimateInput);
+    expect(tokens).toBe(40);
+  });
+
+  it("weights assistant text blocks the same way", () => {
+    const tokens = estimateTokens({
+      role: "assistant",
+      content: [{ type: "text", text: "요약을 계속 진행하겠습니다".repeat(10) }],
+    } as EstimateInput);
+    const cjkChars = "요약을 계속 진행하겠습니다".repeat(10);
+    const hangul = (cjkChars.match(/[가-힯]/g) ?? []).length;
+    expect(tokens).toBe(Math.ceil((cjkChars.length + hangul * 3) / 4));
+  });
+});

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -258,10 +258,31 @@ function countContentBlockChars(
     if (block.type === "image") {
       chars += IMAGE_BLOCK_CHARS;
     } else {
-      chars += getCompactionContentBlockText(block).length;
+      chars += weightedChars(getCompactionContentBlockText(block));
     }
   }
   return chars;
+}
+
+/**
+ * Matches CJK Unified Ideographs, CJK Extension A/B, CJK Compatibility
+ * Ideographs, Hangul Syllables, Hiragana, Katakana, and East Asian fullwidth
+ * forms that typically use ~1 token per character. Mirrors the canonical
+ * estimator in src/utils/cjk-chars.ts.
+ */
+const NON_LATIN_RE =
+  /[\u2E80-\u9FFF\uA000-\uA4FF\uAC00-\uD7AF\uF900-\uFAFF\uFF01-\uFF60\uFFE0-\uFFE6\u{20000}-\u{2FA1F}]/gu;
+
+// Most tokenizers encode a CJK character as ~1 token, not 1/4. Weight each
+// non-Latin char as 4 chars so the shared chars/4 heuristic stays accurate:
+// raw .length under-counted CJK sessions ~3-4x and blew keepRecentTokens
+// far past the configured budget (#103930).
+function weightedChars(text: string): number {
+  if (text.length === 0) {
+    return 0;
+  }
+  const nonLatinCount = (text.match(NON_LATIN_RE) ?? []).length;
+  return text.length + nonLatinCount * 3;
 }
 
 /** Estimate token count for one message using a conservative character heuristic. */
@@ -275,7 +296,7 @@ export function estimateTokens(message: AgentMessage): number {
         harnessMessage as { content: string | Array<{ type: string; text?: string }> }
       ).content;
       if (typeof content === "string") {
-        chars = content.length;
+        chars = weightedChars(content);
       } else if (Array.isArray(content)) {
         chars = countContentBlockChars(content);
       }
@@ -285,11 +306,11 @@ export function estimateTokens(message: AgentMessage): number {
       const assistant = harnessMessage;
       for (const block of assistant.content) {
         if (block.type === "text") {
-          chars += block.text.length;
+          chars += weightedChars(block.text);
         } else if (block.type === "thinking") {
-          chars += block.thinking.length;
+          chars += weightedChars(block.thinking);
         } else if (block.type === "toolCall") {
-          chars += block.name.length + safeJsonStringify(block.arguments).length;
+          chars += block.name.length + weightedChars(safeJsonStringify(block.arguments));
         }
       }
       return Math.ceil(chars / 4);
@@ -297,19 +318,19 @@ export function estimateTokens(message: AgentMessage): number {
     case "custom":
     case "toolResult": {
       if (typeof harnessMessage.content === "string") {
-        chars = harnessMessage.content.length;
+        chars = weightedChars(harnessMessage.content);
       } else {
         chars = countContentBlockChars(harnessMessage.content);
       }
       return Math.ceil(chars / 4);
     }
     case "bashExecution": {
-      chars = harnessMessage.command.length + harnessMessage.output.length;
+      chars = weightedChars(harnessMessage.command) + weightedChars(harnessMessage.output);
       return Math.ceil(chars / 4);
     }
     case "branchSummary":
     case "compactionSummary": {
-      chars = harnessMessage.summary.length;
+      chars = weightedChars(harnessMessage.summary);
       return Math.ceil(chars / 4);
     }
   }


### PR DESCRIPTION
## Summary

Fixes #103930.

Compaction's `estimateTokens` (feeding `findCutPoint`/`keepRecentTokens`) used raw `chars / 4` for every script. Most tokenizers encode a CJK character as ~1 token, not 1/4 — a contract the codebase already encodes in its canonical CJK-aware estimator (`src/utils/cjk-chars.ts`, `NON_LATIN_RE` + weight-4 adjustment). Compaction therefore under-counted CJK sessions ~3–4x: `keepRecentTokens` retained several times its configured budget and CJK-heavy sessions blew out the context window.

### Change

`packages/agent-core/src/harness/compaction/compaction.ts`: a local `weightedChars` helper (agent-core is a standalone package and cannot import `src/utils`) mirrors the canonical `NON_LATIN_RE` ranges — CJK Unified Ideographs, Extensions A/B, Compatibility Ideographs, Hangul, Kana, fullwidth forms — weighting each non-Latin char as 4 chars so the shared `chars/4` heuristic stays accurate. Applied across every message shape `estimateTokens` handles (user string/blocks, assistant text/thinking/toolCall args, toolResult/custom, bashExecution, branch/compaction summaries). Pure Latin estimates are byte-identical.

## Verification

- New `compaction-cjk-tokens.test.ts` (confirmed failing without the fix): 160 CJK chars estimate ~160 tokens (was 40); pure-Latin estimates unchanged; assistant text blocks weighted identically.
- Full `pnpm test compaction` sweep across agent-core and all core compaction consumers — passed.
- `pnpm tsgo:all`, oxfmt — clean.

## Real behavior proof

Behavior addressed: `keepRecentTokens` retains ~3–4x its budget on CJK sessions because compaction token estimates ignore CJK token density.
Real environment tested: the real `estimateTokens` production function with representative Chinese/Korean text through the package's test harness; the full compaction suite proves cut-point/rotation behavior is unchanged for Latin content.
Exact steps or command run after this patch: `pnpm test compaction` and `pnpm test packages/agent-core/src/harness/compaction/compaction-cjk-tokens.test.ts`
Evidence after fix: 160 CJK chars → 160 estimated tokens (raw chars/4 previously gave 40, a 4x under-count matching the issue's report).
Observed result after fix: CJK and Latin sessions are budgeted consistently; no change for ASCII content.
What was not tested: a live multi-hour CJK chat session end to end; the estimator is deterministic and the weighting mirrors the repo's own canonical CJK contract.
