### PR TITLE
fix(logging): redact assistant-media capability tickets in URL query logs

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -194,6 +194,15 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("cdp=https://browserless.example.com/?token=***");
   });
 
+  it("masks assistant-media capability tickets in URL query strings", () => {
+    const input =
+      "serve https://gateway.example/media/asset?mediaTicket=v1.eyJzIjoiYSJ9.abcdef1234567890sig&safe=value";
+    const output = redactSensitiveText(input, { mode: "tools" });
+    expect(output).not.toContain("v1.eyJzIjoiYSJ9.abcdef1234567890sig");
+    expect(output).toContain("mediaTicket=");
+    expect(output).toContain("safe=value");
+  });
+
   it("masks standalone lowercase token assignments in diagnostic output", () => {
     const input = "matrix access_token=abcdef1234567890ghij next";
     const output = redactSensitiveText(input, { mode: "tools" });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -18,7 +18,7 @@ const DEFAULT_REDACT_KEEP_END = 4;
 
 const PAYMENT_CREDENTIAL_ENV_KEYS = String.raw`CARD[_-]?NUMBER|CARD[_-]?CVC|CARD[_-]?CVV|CVC|CVV|SECURITY[_-]?CODE|PAYMENT[_-]?CREDENTIAL|SHARED[_-]?PAYMENT[_-]?TOKEN`;
 const PAYMENT_CREDENTIAL_QUERY_KEYS = String.raw`card[-_]?number|card[-_]?cvc|card[-_]?cvv|cvc|cvv|security[-_]?code|payment[-_]?credential|shared[-_]?payment[-_]?token`;
-const AUTH_QUERY_KEYS = String.raw`access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|id[-_]?token|api[-_]?key|apikey|client[-_]?secret|app[-_]?secret|private[-_]?key|credential|authorization|token|key|secret|password|pass|passwd|auth|jwt|session|code|signature|x[-_]?amz[-_]?(?:signature|security[-_]?token)`;
+const AUTH_QUERY_KEYS = String.raw`access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|id[-_]?token|api[-_]?key|apikey|client[-_]?secret|app[-_]?secret|private[-_]?key|credential|authorization|token|key|secret|password|pass|passwd|auth|jwt|session|code|signature|media[-_]?ticket|x[-_]?amz[-_]?(?:signature|security[-_]?token)`;
 const FORM_BODY_FIRST_PAIR_KEYS = String.raw`${AUTH_QUERY_KEYS}|app[-_]?secret|credential|${PAYMENT_CREDENTIAL_QUERY_KEYS}`;
 const STANDALONE_ASSIGNMENT_SECRET_KEYS = String.raw`access_token|refresh_token|id_token|auth[-_]?token|hook[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|private[-_]?key|authorization|jwt|token|secret|password|pass|passwd|credential|${PAYMENT_CREDENTIAL_QUERY_KEYS}`;
 const BODY_SECRET_KEYS = new Set([


### PR DESCRIPTION
## What Problem This Solves

Assistant-media capability tickets are passed as `?mediaTicket=v1.<b64>.<sig>` query parameters (`src/gateway/control-ui.ts`). The log redactor's `AUTH_QUERY_KEYS` alternation (`src/logging/redact.ts`) did not include `mediaTicket`, so if a request URL carrying one were ever written to a log it would appear in clear. The other query-borne credentials (`token`, `signature`, `access_token`, …) are already redacted; this key was simply missing from the list.

## Why This Change Was Made

Defense-in-depth / consistency. Capability tickets are short-lived, HMAC-signed, source-scoped bearer values. I did not find a current code path that logs one of these URLs, so this is not a demonstrated leak — but the redaction set should cover this credential the same way it covers the others, so a future logging site can't quietly expose it.

## User Impact

No functional change. Any log line that happens to contain a `mediaTicket` query value now masks it (e.g. `v1.xxx…yyy`) instead of printing it in clear.

## Evidence

- Added `media[-_]?ticket` to `AUTH_QUERY_KEYS` in `src/logging/redact.ts`.
- Added a regression test asserting a `?mediaTicket=…` value is masked in a logged URL while a benign param (`safe=value`) is preserved.
- `pnpm test src/logging/redact.test.ts` → **119 passed**.
