### PR TITLE
fix(exec): prevent revoked policy from authorizing delayed node runs

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -17115,7 +17115,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 282,
+      "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "surface": "apple",
+      "id": "native.apple.5b9878c76d9a0995"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
@@ -75,6 +75,15 @@ struct ExecApprovalPolicySnapshot: Sendable, Equatable {
         })
     }
 
+    init(resolved approvals: ExecApprovalsResolved) {
+        self.init(
+            security: approvals.agent.security,
+            ask: approvals.agent.ask,
+            askFallback: approvals.agent.askFallback,
+            autoAllowSkills: approvals.agent.autoAllowSkills,
+            allowlist: approvals.allowlist)
+    }
+
     func isCurrent(_ current: Self) -> Bool {
         self.security == current.security &&
             self.ask == current.ask &&
@@ -94,8 +103,12 @@ enum ExecApprovalAuthorization: Sendable {
 
     case currentPolicy(evaluatedSecurity: ExecSecurity, evaluatedAsk: ExecAsk, basis: Basis?)
     case askFallback(evaluatedSecurity: ExecSecurity, basis: Basis?)
-    case autoReview(evaluatedSecurity: ExecSecurity)
-    case explicitOnce(evaluatedSecurity: ExecSecurity)
+    case autoReview(
+        evaluatedSecurity: ExecSecurity,
+        policySnapshot: ExecApprovalPolicySnapshot)
+    case explicitOnce(
+        evaluatedSecurity: ExecSecurity,
+        policySnapshot: ExecApprovalPolicySnapshot)
     case explicitAlways(
         evaluatedSecurity: ExecSecurity,
         policySnapshot: ExecApprovalPolicySnapshot,
@@ -121,13 +134,19 @@ struct ExecApprovalExecutionCommit: Sendable {
             : []
         let grants = persistAllowlist ? self.allowAlwaysGrants(context: context) : []
         let basis = effectiveSecurity == .allowlist ? context.authorizationBasis : nil
+        // The socket and native runtime both cross an asynchronous approval
+        // boundary. Carry the evaluated policy into their shared commit path.
         let authorization: ExecApprovalAuthorization = if approvalSource == .askFallback {
             .askFallback(evaluatedSecurity: effectiveSecurity, basis: basis)
         } else if approvalSource == .autoReview {
-            .autoReview(evaluatedSecurity: effectiveSecurity)
+            .autoReview(
+                evaluatedSecurity: effectiveSecurity,
+                policySnapshot: context.policySnapshot)
         } else if explicitlyApproved {
             if grants.isEmpty {
-                .explicitOnce(evaluatedSecurity: effectiveSecurity)
+                .explicitOnce(
+                    evaluatedSecurity: effectiveSecurity,
+                    policySnapshot: context.policySnapshot)
             } else {
                 .explicitAlways(
                     evaluatedSecurity: effectiveSecurity,
@@ -258,12 +277,7 @@ enum ExecApprovalEvaluator {
             allowlistSatisfied: allowlistSatisfied,
             allowlistMatch: allowlistSatisfied ? allowlistMatches.first : nil,
             skillAllow: skillAllow,
-            policySnapshot: ExecApprovalPolicySnapshot(
-                security: approvals.agent.security,
-                ask: approvals.agent.ask,
-                askFallback: approvals.agent.askFallback,
-                autoAllowSkills: approvals.agent.autoAllowSkills,
-                allowlist: approvals.allowlist))
+            policySnapshot: ExecApprovalPolicySnapshot(resolved: approvals))
     }
 
     static func isSkillAutoAllowed(

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -272,12 +272,15 @@ enum ExecApprovalsConditionalSaveResult {
 
 enum ExecApprovalsMutationError: Error, Equatable, Sendable {
     case invalidPattern(ExecAllowlistPatternValidationReason)
+    case entryNotOwned
     case unavailable
 
     var message: String {
         switch self {
         case let .invalidPattern(reason):
             reason.message
+        case .entryNotOwned:
+            "This allowlist entry is inherited. Edit its owning scope and retry."
         case .unavailable:
             "Could not save exec approvals. Last known settings are shown; retry the change."
         }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -614,21 +614,28 @@ enum ExecApprovalsStore {
     {
         do {
             return try self.withWriteLock {
-                let current = try self.ensureFileUnlocked()
+                // A conditional write must not create or normalize policy state
+                // before it proves the caller still owns the observed snapshot.
+                guard self.legacyFileURLIfPending() == nil else {
+                    return .baseHashUnavailable
+                }
                 let snapshot = try self.readSnapshotUnlocked()
+                let expected = baseHash?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 if snapshot.exists {
                     if snapshot.hash.isEmpty {
                         return .baseHashUnavailable
                     }
-                    let expected = baseHash?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                     if expected.isEmpty {
                         return .baseHashRequired
                     }
                     if expected != snapshot.hash {
                         return .conflict
                     }
+                } else if !expected.isEmpty, expected != snapshot.hash {
+                    return .conflict
                 }
 
+                let current = try self.ensureFileUnlocked()
                 var normalized = self.normalizeIncoming(incoming)
                 let socketPath = normalized.socket?.path?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let token = normalized.socket?.token?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -940,33 +947,29 @@ extension ExecApprovalsStore {
         authorization: ExecApprovalAuthorization) throws
     {
         let current = self.resolveFromFile(file, agentId: agentId)
-        let currentKeys = Set(current.allowlist.map(self.allowlistEntryMatchKey))
         let evaluatedSecurity: ExecSecurity
         let evaluatedAsk: ExecAsk?
         let basis: ExecApprovalAuthorization.Basis?
         let appliesFallback: Bool
         switch authorization {
-        case let .autoReview(security):
+        case let .autoReview(security, policySnapshot):
             guard ExecSecurity.narrower(security, current.agent.security) != .deny,
-                  current.agent.ask != .always
+                  current.agent.ask != .always,
+                  policySnapshot.isCurrent(ExecApprovalPolicySnapshot(resolved: current))
             else {
                 throw self.executionAuthorizationChangedError()
             }
             return
-        case let .explicitOnce(security):
-            guard ExecSecurity.narrower(security, current.agent.security) != .deny else {
+        case let .explicitOnce(security, policySnapshot):
+            guard ExecSecurity.narrower(security, current.agent.security) != .deny,
+                  policySnapshot.isCurrent(ExecApprovalPolicySnapshot(resolved: current))
+            else {
                 throw self.executionAuthorizationChangedError()
             }
             return
         case let .explicitAlways(security, policySnapshot, _):
-            let currentSnapshot = ExecApprovalPolicySnapshot(
-                security: current.agent.security,
-                ask: current.agent.ask,
-                askFallback: current.agent.askFallback,
-                autoAllowSkills: current.agent.autoAllowSkills,
-                allowlist: current.allowlist)
             guard ExecSecurity.narrower(security, current.agent.security) != .deny,
-                  policySnapshot.isCurrent(currentSnapshot)
+                  policySnapshot.isCurrent(ExecApprovalPolicySnapshot(resolved: current))
             else {
                 throw self.executionAuthorizationChangedError()
             }
@@ -983,6 +986,7 @@ extension ExecApprovalsStore {
             appliesFallback = true
         }
 
+        let currentKeys = Set(current.allowlist.map(self.allowlistEntryMatchKey))
         let currentSecurity = ExecSecurity.narrower(evaluatedSecurity, current.agent.security)
         let authorizationSecurity = appliesFallback
             ? ExecSecurity.narrower(currentSecurity, current.agent.askFallback)
@@ -1109,7 +1113,12 @@ extension ExecApprovalsStore {
             var agents = file.agents ?? [:]
             var agent = agents[key] ?? ExecApprovalsAgent()
             var allowlist = agent.allowlist ?? []
-            guard let index = allowlist.firstIndex(where: { $0.id == id }) else { return }
+            guard let index = allowlist.firstIndex(where: { $0.id == id }) else {
+                if key != "*", agents["*"]?.allowlist?.contains(where: { $0.id == id }) == true {
+                    throw ExecApprovalsMutationError.entryNotOwned
+                }
+                return
+            }
             allowlist[index].pattern = normalizedPattern
             agent.allowlist = allowlist
             agents[key] = agent
@@ -1126,7 +1135,14 @@ extension ExecApprovalsStore {
             let key = self.agentKey(agentId)
             var agents = file.agents ?? [:]
             var agent = agents[key] ?? ExecApprovalsAgent()
-            let allowlist = (agent.allowlist ?? []).filter { $0.id != id }
+            var allowlist = agent.allowlist ?? []
+            guard let index = allowlist.firstIndex(where: { $0.id == id }) else {
+                if key != "*", agents["*"]?.allowlist?.contains(where: { $0.id == id }) == true {
+                    throw ExecApprovalsMutationError.entryNotOwned
+                }
+                return
+            }
+            allowlist.remove(at: index)
             agent.allowlist = allowlist
             agents[key] = agent
             file.agents = agents
@@ -1153,15 +1169,17 @@ extension ExecApprovalsStore {
     }
 
     private static func updateFile(
-        _ mutate: (inout ExecApprovalsFile) -> Void) -> Result<Void, ExecApprovalsMutationError>
+        _ mutate: (inout ExecApprovalsFile) throws -> Void) -> Result<Void, ExecApprovalsMutationError>
     {
         do {
             try self.withWriteLock {
                 var file = try self.ensureFileUnlocked()
-                mutate(&file)
+                try mutate(&file)
                 try self.saveFileUnlocked(file)
             }
             return .success(())
+        } catch let error as ExecApprovalsMutationError {
+            return .failure(error)
         } catch {
             self.logger.error("exec approvals update failed: \(error.localizedDescription, privacy: .public)")
             return .failure(.unavailable)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -2146,8 +2146,11 @@ extension ExecApprovalsStoreRefactorTests {
 
             let result = ExecApprovalsStore.saveFile(stale.file, ifBaseHash: stale.hash)
 
-            if case .conflict = result {} else {
-                Issue.record("expected deleted approval state to conflict")
+            switch result {
+            case .conflict, .baseHashUnavailable:
+                break
+            default:
+                Issue.record("expected deleted approval state to remain absent")
             }
             #expect(!FileManager().fileExists(atPath: ExecApprovalsStore.fileURL().path))
         }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -689,6 +689,143 @@ struct ExecApprovalsStoreRefactorTests {
     }
 
     @Test
+    func `native runtime rejects explicit once when security tightens to allowlist`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .always
+            }.get()
+            let probe = ShellRunProbe()
+            let mutations = ExecApprovalStoreMutations(commitExecution: { commit in
+                _ = ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                    entry.security = .allowlist
+                }
+                return ExecApprovalsStore.commitExecution(commit)
+            })
+            let runtime = MacNodeRuntime(
+                execApprovalStoreMutations: mutations,
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunParams(
+                command: ["/usr/bin/printf", "ok"],
+                agentId: "main",
+                approvalDecision: "allow-once")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "explicit-once-security-race",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("exec approvals update unavailable") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
+    func `native runtime rejects explicit once after allowlist revocation`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .allowlist
+                entry.ask = .onMiss
+                entry.allowlist = [ExecAllowlistEntry(pattern: "/usr/bin/echo")]
+            }.get()
+            let probe = ShellRunProbe()
+            let mutations = ExecApprovalStoreMutations(commitExecution: { commit in
+                _ = ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                    entry.allowlist = []
+                }
+                return ExecApprovalsStore.commitExecution(commit)
+            })
+            let runtime = MacNodeRuntime(
+                execApprovalStoreMutations: mutations,
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunParams(
+                command: ["/usr/bin/printf", "ok"],
+                agentId: "main",
+                approvalDecision: "allow-once")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "explicit-once-allowlist-race",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("exec approvals update unavailable") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
+    func `native runtime rejects auto review when security tightens to allowlist`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .onMiss
+            }.get()
+            let probe = ShellRunProbe()
+            let mutations = ExecApprovalStoreMutations(commitExecution: { commit in
+                _ = ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                    entry.security = .allowlist
+                }
+                return ExecApprovalsStore.commitExecution(commit)
+            })
+            let runtime = MacNodeRuntime(
+                execApprovalStoreMutations: mutations,
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunParams(
+                command: ["/usr/bin/printf", "ok"],
+                agentId: "main",
+                approvalSource: "auto-review")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "auto-review-security-race",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("exec approvals update unavailable") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
+    func `native runtime rejects auto review when ask tightens from off to on miss`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .off
+            }.get()
+            let probe = ShellRunProbe()
+            let mutations = ExecApprovalStoreMutations(commitExecution: { commit in
+                _ = ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                    entry.ask = .onMiss
+                }
+                return ExecApprovalsStore.commitExecution(commit)
+            })
+            let runtime = MacNodeRuntime(
+                execApprovalStoreMutations: mutations,
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunParams(
+                command: ["/usr/bin/printf", "ok"],
+                agentId: "main",
+                approvalSource: "auto-review")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "auto-review-ask-tightening",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("exec approvals update unavailable") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
     func `native runtime treats a successful commit as the authorization linearization point`() async throws {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
@@ -1348,6 +1485,12 @@ struct ExecApprovalsStoreRefactorTests {
     func `execution commit rejects explicit approval after concurrent deny`() async throws {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .off
+            }.get()
+            let policySnapshot = ExecApprovalPolicySnapshot(
+                resolved: ExecApprovalsStore.resolve(agentId: "main"))
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
                 entry.security = .deny
                 entry.ask = .off
             }.get()
@@ -1355,7 +1498,9 @@ struct ExecApprovalsStoreRefactorTests {
             let result = ExecApprovalsStore.commitExecution(ExecApprovalExecutionCommit(
                 agentId: "main",
                 command: "printf ok",
-                authorization: .explicitOnce(evaluatedSecurity: .full),
+                authorization: .explicitOnce(
+                    evaluatedSecurity: .full,
+                    policySnapshot: policySnapshot),
                 uses: []))
 
             guard case .failure(.unavailable) = result else {
@@ -1370,13 +1515,20 @@ struct ExecApprovalsStoreRefactorTests {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
                 entry.security = .full
+                entry.ask = .onMiss
+            }.get()
+            let policySnapshot = ExecApprovalPolicySnapshot(
+                resolved: ExecApprovalsStore.resolve(agentId: "main"))
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
                 entry.ask = .always
             }.get()
 
             let result = ExecApprovalsStore.commitExecution(ExecApprovalExecutionCommit(
                 agentId: "main",
                 command: "printf ok",
-                authorization: .autoReview(evaluatedSecurity: .full),
+                authorization: .autoReview(
+                    evaluatedSecurity: .full,
+                    policySnapshot: policySnapshot),
                 uses: []))
 
             guard case .failure(.unavailable) = result else {
@@ -1391,7 +1543,9 @@ struct ExecApprovalsStoreRefactorTests {
             let denied = ExecApprovalsStore.commitExecution(ExecApprovalExecutionCommit(
                 agentId: "main",
                 command: "printf ok",
-                authorization: .autoReview(evaluatedSecurity: .full),
+                authorization: .autoReview(
+                    evaluatedSecurity: .full,
+                    policySnapshot: policySnapshot),
                 uses: []))
             guard case .failure(.unavailable) = denied else {
                 Issue.record("expected deny policy to override auto review")
@@ -1926,6 +2080,35 @@ extension ExecApprovalsStoreRefactorTests {
     }
 
     @Test
+    func `entry scoped mutations reject inherited wildcard entries`() async throws {
+        try await self.withTempStateDir { _ in
+            let inherited = ExecAllowlistEntry(id: "wildcard-entry", pattern: "/bin/echo")
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "*") { entry in
+                entry.allowlist = [inherited]
+            }.get()
+            #expect(ExecApprovalsStore.resolve(agentId: "main").allowlist.map(\.id) == [inherited.id])
+
+            let update = ExecApprovalsStore.updateAllowlistEntry(
+                agentId: "main",
+                id: inherited.id,
+                pattern: "/bin/cat")
+            let removal = ExecApprovalsStore.removeAllowlistEntry(
+                agentId: "main",
+                id: inherited.id)
+
+            if case .failure(.entryNotOwned) = update {} else {
+                Issue.record("expected inherited update to report entryNotOwned")
+            }
+            if case .failure(.entryNotOwned) = removal {} else {
+                Issue.record("expected inherited removal to report entryNotOwned")
+            }
+            let persisted = ExecApprovalsStore.loadFile().agents?["*"]?.allowlist
+            #expect(persisted?.map(\.id) == [inherited.id])
+            #expect(persisted?.map(\.pattern) == [inherited.pattern])
+        }
+    }
+
+    @Test
     func `conditional save cannot restore revoked approvals`() async throws {
         try await self.withTempStateDir { _ in
             ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
@@ -1948,6 +2131,25 @@ extension ExecApprovalsStoreRefactorTests {
             let current = ExecApprovalsStore.resolve(agentId: "main")
             #expect(current.agent.security == .deny)
             #expect(current.allowlist.isEmpty)
+        }
+    }
+
+    @Test
+    func `conditional save does not recreate deleted approval state`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .allowlist
+                entry.allowlist = [ExecAllowlistEntry(pattern: "/bin/echo")]
+            }.get()
+            let stale = ExecApprovalsStore.readSnapshot()
+            try FileManager().removeItem(at: ExecApprovalsStore.fileURL())
+
+            let result = ExecApprovalsStore.saveFile(stale.file, ifBaseHash: stale.hash)
+
+            if case .conflict = result {} else {
+                Issue.record("expected deleted approval state to conflict")
+            }
+            #expect(!FileManager().fileExists(atPath: ExecApprovalsStore.fileURL().path))
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsUIRollbackTests.swift
@@ -222,6 +222,25 @@ struct ExecApprovalsUIRollbackTests {
         }
     }
 
+    @Test
+    func `inherited allowlist removal remains visible and reports its owning scope`() async throws {
+        try await self.withTempStateDir { _ in
+            let inherited = ExecAllowlistEntry(id: "wildcard-entry", pattern: "/usr/bin/printf")
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "*") { entry in
+                entry.allowlist = [inherited]
+            }.get()
+            let model = ExecApprovalsSettingsModel()
+            await model.loadSettings(for: "main")
+            #expect(model.entries.map(\.id) == [inherited.id])
+
+            model.removeEntry(id: inherited.id)
+
+            #expect(model.entries.map(\.id) == [inherited.id])
+            #expect(model.mutationErrorMessage == ExecApprovalsMutationError.entryNotOwned.message)
+            #expect(ExecApprovalsStore.loadFile().agents?["*"]?.allowlist?.map(\.id) == [inherited.id])
+        }
+    }
+
     private func withTempStateDir<T>(
         _ body: (URL) async throws -> T) async throws -> T
     {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
@@ -320,8 +320,9 @@ struct ExecHostRequestEvaluatorTests {
             approvalSource: nil,
             explicitlyApproved: true,
             persistAllowlist: false)
-        if case let .explicitOnce(security) = explicit.authorization {
+        if case let .explicitOnce(security, policySnapshot) = explicit.authorization {
             #expect(security == .full)
+            #expect(policySnapshot == currentContext.policySnapshot)
         } else {
             Issue.record("expected explicit authorization")
         }
@@ -356,8 +357,9 @@ struct ExecHostRequestEvaluatorTests {
             approvalSource: .autoReview,
             explicitlyApproved: true,
             persistAllowlist: false)
-        if case let .autoReview(security) = autoReview.authorization {
+        if case let .autoReview(security, policySnapshot) = autoReview.authorization {
             #expect(security == .allowlist)
+            #expect(policySnapshot == autoReviewContext.policySnapshot)
         } else {
             Issue.record("expected auto-review authorization")
         }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -305,6 +305,10 @@ struct MacNodeRuntimeTests {
         let home = root.appendingPathComponent("home", isDirectory: true)
         let stateDir = root.appendingPathComponent("state", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
+        try FileManager().createDirectory(at: stateDir, withIntermediateDirectories: true)
+        let initial = ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+        try JSONEncoder().encode(initial)
+            .write(to: stateDir.appendingPathComponent("exec-approvals.json"))
 
         try await TestIsolation.withEnvValues([
             "OPENCLAW_HOME": home.path,

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -247,6 +247,32 @@ export const ExecApprovalGetParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const ExecApprovalPolicySecuritySchema = Type.Union([
+  Type.Literal("deny"),
+  Type.Literal("allowlist"),
+  Type.Literal("full"),
+]);
+
+const ExecApprovalPolicySnapshotSchema = Type.Object(
+  {
+    security: ExecApprovalPolicySecuritySchema,
+    ask: Type.Union([Type.Literal("off"), Type.Literal("on-miss"), Type.Literal("always")]),
+    askFallback: ExecApprovalPolicySecuritySchema,
+    autoAllowSkills: Type.Boolean(),
+    allowlistRules: Type.Array(
+      Type.Object(
+        {
+          pattern: Type.String(),
+          argPattern: Type.Optional(Type.String()),
+          source: Type.Optional(Type.Literal("allow-always")),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
 /** Pending command execution approval request shown to reviewers. */
 export const ExecApprovalRequestParamsSchema = Type.Object(
   {
@@ -262,6 +288,7 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
           commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
           agentId: Type.Union([Type.String(), Type.Null()]),
           sessionKey: Type.Union([Type.String(), Type.Null()]),
+          policySnapshot: Type.Optional(ExecApprovalPolicySnapshotSchema),
           mutableFileOperand: Type.Optional(
             Type.Union([
               Type.Object(

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -996,7 +996,7 @@ describe("processGatewayAllowlist", () => {
     expect(runExecProcessMock).not.toHaveBeenCalled();
   });
 
-  it("rejects auto-review when the locked policy commit sees always-ask tightening", async () => {
+  it("binds auto-review to the evaluated snapshot before the locked policy commit", async () => {
     const command = "echo reviewed";
     await configurePlanBackedCommand({ command });
     commitExecAuthorizationMock.mockRejectedValueOnce(new Error("approval changed"));
@@ -1010,7 +1010,17 @@ describe("processGatewayAllowlist", () => {
     ).rejects.toThrow("approval changed");
     expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        authorization: expect.objectContaining({ source: "auto-review", ask: "on-miss" }),
+        authorization: expect.objectContaining({
+          source: "auto-review",
+          ask: "on-miss",
+          policySnapshot: {
+            security: "full",
+            ask: "off",
+            askFallback: "deny",
+            autoAllowSkills: false,
+            allowlistRules: [],
+          },
+        }),
       }),
     );
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
@@ -2100,9 +2110,39 @@ EOF`,
 
     expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        authorization: expect.objectContaining({ source: "explicit-approval" }),
+        authorization: expect.objectContaining({
+          source: "explicit-approval",
+          policySnapshot: expect.any(Object),
+        }),
       }),
     );
+  });
+
+  it("rejects explicit foreground allow-once when the locked policy snapshot changed", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    commitExecAuthorizationMock.mockRejectedValueOnce(new Error("approval changed"));
+
+    await expect(
+      runGatewayAllowlist({
+        command: "pwd",
+        turnSourceChannel: "webchat",
+      }),
+    ).rejects.toThrow("approval changed");
+
+    expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: expect.objectContaining({
+          source: "explicit-approval",
+          policySnapshot: expect.any(Object),
+        }),
+      }),
+    );
+    expect(runExecProcessMock).not.toHaveBeenCalled();
   });
 
   it("binds explicit allow-always persistence to its evaluated policy snapshot", async () => {
@@ -2162,7 +2202,7 @@ EOF`,
             ask: "off",
             askFallback: "deny",
             autoAllowSkills: false,
-            allowlistRuleKeys: [],
+            allowlistRules: [],
           },
           requireAutoAllowSkills: false,
           requireExactCommandApproval: false,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -468,7 +468,7 @@ export async function processGatewayAllowlist(
     ask: params.ask,
     host: "gateway",
   });
-  const allowAlwaysPolicySnapshot = createExecApprovalPolicySnapshot({
+  const evaluationPolicySnapshot = createExecApprovalPolicySnapshot({
     file: approvals.file,
     agentId: params.agentId,
   });
@@ -605,8 +605,8 @@ export async function processGatewayAllowlist(
       allowlist: approvals.allowlist,
       commandText: params.command,
     });
-    const persistsAllowAlways =
-      options.allowAlwaysDecision !== undefined && options.allowAlwaysDecision.kind !== "one-shot";
+    const delayedAuthorization =
+      options.source === "explicit-approval" || options.source === "auto-review";
     return commitExecAuthorizationLocked({
       agentId: params.agentId,
       matches: allowlistMatches,
@@ -617,7 +617,7 @@ export async function processGatewayAllowlist(
         security: options.source === "ask-fallback" ? fallbackSecurity : hostSecurity,
         ask: hostAsk,
         allowlistSatisfied: allowlistAuthorizationSatisfied || durableApprovalSatisfied,
-        ...(persistsAllowAlways ? { policySnapshot: allowAlwaysPolicySnapshot } : {}),
+        ...(delayedAuthorization ? { policySnapshot: evaluationPolicySnapshot } : {}),
         requireAutoAllowSkills:
           policyAuthorization && allowlistEval.segmentSatisfiedBy.includes("skills"),
         requireExactCommandApproval:

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -78,6 +78,13 @@ const preparedPlan = vi.hoisted(() => ({
   commandPreview: "bun ./script.ts",
   agentId: "prepared-agent",
   sessionKey: "prepared-session",
+  policySnapshot: {
+    security: "full" as const,
+    ask: "off" as const,
+    askFallback: "deny" as const,
+    autoAllowSkills: false,
+    allowlistRules: [{ pattern: "/usr/local/bin/bun" }],
+  },
   mutableFileOperand: {
     argvIndex: 1,
     path: "/tmp/work/script.ts",

--- a/src/cli/exec-policy-cli.test.ts
+++ b/src/cli/exec-policy-cli.test.ts
@@ -289,7 +289,16 @@ describe("exec-policy CLI", () => {
       file: mocks.getApprovals(),
     }));
     mocks.restoreExecApprovalsSnapshot.mockReset();
-    mocks.restoreExecApprovalsSnapshot.mockImplementation(async () => true);
+    mocks.restoreExecApprovalsSnapshot.mockImplementation(
+      async (snapshot: ExecApprovalsSnapshot, baseHash: string) => {
+        if (baseHash !== "written-approvals-hash") {
+          return false;
+        }
+        mocks.setApprovals(structuredClone(snapshot.file));
+        mocks.setApprovalsHash(snapshot.hash);
+        return true;
+      },
+    );
     mocks.updateExecApprovals.mockClear();
   });
 
@@ -525,6 +534,7 @@ describe("exec-policy CLI", () => {
       originalSnapshot,
       "written-approvals-hash",
     );
+    expect(mocks.getApprovals()).toEqual(originalApprovals);
     expect(mocks.runtimeErrors).toEqual(["config write failed"]);
   });
 
@@ -551,7 +561,7 @@ describe("exec-policy CLI", () => {
     );
   });
 
-  it("does not clobber a newer approvals write during rollback", async () => {
+  it("rebases rollback over a newer approvals write", async () => {
     const originalApprovals = structuredClone(mocks.getApprovals());
     const originalRaw = JSON.stringify(originalApprovals, null, 2);
     const originalSnapshot = {
@@ -562,7 +572,151 @@ describe("exec-policy CLI", () => {
       file: originalApprovals,
     };
     mockRollbackApprovalSnapshots(originalSnapshot);
-    mocks.restoreExecApprovalsSnapshot.mockResolvedValueOnce(false);
+    mocks.restoreExecApprovalsSnapshot.mockImplementationOnce(async () => {
+      const concurrentFile = structuredClone(mocks.getApprovals());
+      concurrentFile.defaults = {
+        ...concurrentFile.defaults,
+        security: "deny",
+      };
+      concurrentFile.agents = {
+        ...concurrentFile.agents,
+        worker: { security: "deny" },
+      };
+      mocks.setApprovals(concurrentFile);
+      mocks.setApprovalsHash("concurrent-write-hash");
+      return false;
+    });
+    mocks.replaceConfigFile.mockImplementationOnce(async () => {
+      throw new Error("config write failed");
+    });
+
+    await expect(runExecPolicyCommand(["exec-policy", "preset", "yolo"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(mocks.restoreExecApprovalsSnapshot).toHaveBeenCalledWith(
+      originalSnapshot,
+      "written-approvals-hash",
+    );
+    expect(mocks.updateExecApprovals).toHaveBeenCalledTimes(2);
+    expect(mocks.getApprovals()).toEqual({
+      ...originalApprovals,
+      defaults: {
+        ...originalApprovals.defaults,
+        security: "deny",
+      },
+      agents: {
+        ...originalApprovals.agents,
+        worker: { security: "deny" },
+      },
+    });
+    expect(mocks.runtimeErrors).toEqual(["config write failed"]);
+  });
+
+  it("does not loosen a same-valued concurrent policy after rollback loses provenance", async () => {
+    const originalApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+      },
+      agents: {},
+    };
+    mocks.setApprovals(originalApprovals);
+    const originalSnapshot = {
+      path: "/tmp/exec-approvals.json",
+      exists: true,
+      raw: JSON.stringify(originalApprovals, null, 2),
+      hash: "original-hash",
+      file: originalApprovals,
+    };
+    mockRollbackApprovalSnapshots(originalSnapshot);
+    mocks.restoreExecApprovalsSnapshot.mockImplementationOnce(async () => {
+      const concurrentFile = structuredClone(mocks.getApprovals());
+      concurrentFile.agents = { worker: { security: "deny" } };
+      mocks.setApprovals(concurrentFile);
+      mocks.setApprovalsHash("concurrent-write-hash");
+      return false;
+    });
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("config write failed"));
+
+    await expect(runExecPolicyCommand(["exec-policy", "preset", "cautious"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(mocks.updateExecApprovals).toHaveBeenCalledTimes(2);
+    expect(mocks.getApprovals()).toEqual({
+      version: 1,
+      defaults: {
+        security: "allowlist",
+        ask: "on-miss",
+        askFallback: "deny",
+      },
+      agents: { worker: { security: "deny" } },
+    });
+    expect(mocks.runtimeErrors).toEqual(["config write failed"]);
+  });
+
+  it("clears an applied default that was originally unset during rebased rollback", async () => {
+    const originalApprovals: ExecApprovalsFile = {
+      version: 1,
+      defaults: {
+        ask: "on-miss",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      agents: {},
+    };
+    mocks.setApprovals(originalApprovals);
+    const originalSnapshot = {
+      path: "/tmp/exec-approvals.json",
+      exists: true,
+      raw: JSON.stringify(originalApprovals, null, 2),
+      hash: "original-hash",
+      file: originalApprovals,
+    };
+    mockRollbackApprovalSnapshots(originalSnapshot);
+    mocks.restoreExecApprovalsSnapshot.mockImplementationOnce(async () => {
+      const concurrentFile = structuredClone(mocks.getApprovals());
+      concurrentFile.defaults = {
+        ...concurrentFile.defaults,
+        autoAllowSkills: true,
+      };
+      mocks.setApprovals(concurrentFile);
+      mocks.setApprovalsHash("concurrent-write-hash");
+      return false;
+    });
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("config write failed"));
+
+    await expect(
+      runExecPolicyCommand(["exec-policy", "set", "--security", "full"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(mocks.getApprovals().defaults).toEqual({
+      ask: "on-miss",
+      askFallback: "deny",
+      autoAllowSkills: true,
+      security: undefined,
+    });
+    expect(mocks.runtimeErrors).toEqual(["config write failed"]);
+  });
+
+  it("reports when field-level rollback cannot be persisted", async () => {
+    const originalApprovals = structuredClone(mocks.getApprovals());
+    const originalSnapshot = {
+      path: "/tmp/exec-approvals.json",
+      exists: true,
+      raw: JSON.stringify(originalApprovals, null, 2),
+      hash: "original-hash",
+      file: originalApprovals,
+    };
+    mockRollbackApprovalSnapshots(originalSnapshot);
+    mocks.restoreExecApprovalsSnapshot.mockImplementationOnce(async () => {
+      mocks.setApprovalsHash("concurrent-write-hash");
+      mocks.updateExecApprovals.mockRejectedValueOnce(new Error("approval rollback failed"));
+      return false;
+    });
     mocks.replaceConfigFile.mockImplementationOnce(async () => {
       throw new Error("config write failed");
     });
@@ -571,11 +725,8 @@ describe("exec-policy CLI", () => {
       runExecPolicyCommand(["exec-policy", "set", "--security", "full"]),
     ).rejects.toThrow("__exit__:1");
 
-    expect(mocks.restoreExecApprovalsSnapshot).toHaveBeenCalledWith(
-      originalSnapshot,
-      "written-approvals-hash",
-    );
-    expect(mocks.updateExecApprovals).toHaveBeenCalledTimes(1);
-    expect(mocks.runtimeErrors).toEqual(["config write failed"]);
+    expect(mocks.runtimeErrors).toEqual([
+      "Config update failed: config write failed; exec approvals rollback failed: approval rollback failed",
+    ]);
   });
 });

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -16,6 +16,7 @@ import {
   normalizeExecSecurity,
   normalizeExecTarget,
   readExecApprovalsSnapshot,
+  resolveExecApprovalsFromFile,
   restoreExecApprovalsSnapshotLocked,
   updateExecApprovals,
   type ExecApprovalsFile,
@@ -26,6 +27,9 @@ import {
 import { defaultRuntime } from "../runtime.js";
 
 type ExecPolicyPresetName = "yolo" | "cautious" | "deny-all";
+
+const EXEC_SECURITY_PERMISSIVENESS = { deny: 0, allowlist: 1, full: 2 } as const;
+const EXEC_ASK_PERMISSIVENESS = { always: 0, "on-miss": 1, off: 2 } as const;
 
 type ExecPolicyResolved = {
   host?: ExecTarget;
@@ -207,6 +211,45 @@ function applyApprovalsDefaults(
   return next;
 }
 
+function buildExecPolicyApprovalsRollback(params: {
+  current: ExecApprovalsFile;
+  original: ExecApprovalsFile;
+  written: ExecApprovalsFile;
+  policy: ExecPolicyResolved;
+}): ExecApprovalsFile | null {
+  // Whole-file restore can lose to an unrelated concurrent edit. Revert only
+  // matching fields, and never loosen ambiguous same-value concurrent writes.
+  const fields = [
+    ["security", params.policy.security],
+    ["ask", params.policy.ask],
+    ["askFallback", params.policy.askFallback],
+  ] as const;
+  const originalDefaults = resolveExecApprovalsFromFile({ file: params.original }).defaults;
+  const currentDefaults = resolveExecApprovalsFromFile({ file: params.current }).defaults;
+  const next = structuredClone(params.current);
+  let changed = false;
+  for (const [field, appliedValue] of fields) {
+    const currentValue = params.current.defaults?.[field];
+    const originalValue = params.original.defaults?.[field];
+    const rollbackDoesNotLoosen =
+      field === "ask"
+        ? EXEC_ASK_PERMISSIVENESS[originalDefaults.ask] <=
+          EXEC_ASK_PERMISSIVENESS[currentDefaults.ask]
+        : EXEC_SECURITY_PERMISSIVENESS[originalDefaults[field]] <=
+          EXEC_SECURITY_PERMISSIVENESS[currentDefaults[field]];
+    if (
+      appliedValue !== undefined &&
+      currentValue === params.written.defaults?.[field] &&
+      currentValue !== originalValue &&
+      rollbackDoesNotLoosen
+    ) {
+      next.defaults = { ...next.defaults, [field]: originalValue };
+      changed = true;
+    }
+  }
+  return changed ? next : null;
+}
+
 function buildNextExecPolicyConfig(
   config: OpenClawConfig,
   policy: ExecPolicyResolved,
@@ -352,7 +395,24 @@ async function applyLocalExecPolicy(policy: ExecPolicyResolved): Promise<ExecPol
       nextConfig,
     });
   } catch (err) {
-    await restoreExecApprovalsSnapshotLocked(approvalsSnapshot, writtenApprovals.hash);
+    try {
+      if (!(await restoreExecApprovalsSnapshotLocked(approvalsSnapshot, writtenApprovals.hash))) {
+        await updateExecApprovals({
+          update: (current) =>
+            buildExecPolicyApprovalsRollback({
+              current,
+              original: approvalsSnapshot.file,
+              written: writtenApprovals.file,
+              policy,
+            }),
+        });
+      }
+    } catch (rollbackError) {
+      throw new Error(
+        `Config update failed: ${formatExecPolicyError(err)}; exec approvals rollback failed: ${formatExecPolicyError(rollbackError)}`,
+        { cause: rollbackError },
+      );
+    }
     throw err;
   }
   return await buildLocalExecPolicyShowPayload();

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -12,6 +12,8 @@ import {
   type ExecPolicyScopeSnapshot,
 } from "../infra/exec-approvals-effective.js";
 import {
+  maxAsk,
+  minSecurity,
   normalizeExecAsk,
   normalizeExecSecurity,
   normalizeExecTarget,
@@ -27,9 +29,6 @@ import {
 import { defaultRuntime } from "../runtime.js";
 
 type ExecPolicyPresetName = "yolo" | "cautious" | "deny-all";
-
-const EXEC_SECURITY_PERMISSIVENESS = { deny: 0, allowlist: 1, full: 2 } as const;
-const EXEC_ASK_PERMISSIVENESS = { always: 0, "on-miss": 1, off: 2 } as const;
 
 type ExecPolicyResolved = {
   host?: ExecTarget;
@@ -233,10 +232,8 @@ function buildExecPolicyApprovalsRollback(params: {
     const originalValue = params.original.defaults?.[field];
     const rollbackDoesNotLoosen =
       field === "ask"
-        ? EXEC_ASK_PERMISSIVENESS[originalDefaults.ask] <=
-          EXEC_ASK_PERMISSIVENESS[currentDefaults.ask]
-        : EXEC_SECURITY_PERMISSIVENESS[originalDefaults[field]] <=
-          EXEC_SECURITY_PERMISSIVENESS[currentDefaults[field]];
+        ? maxAsk(originalDefaults.ask, currentDefaults.ask) === originalDefaults.ask
+        : minSecurity(originalDefaults[field], currentDefaults[field]) === originalDefaults[field];
     if (
       appliedValue !== undefined &&
       currentValue === params.written.defaults?.[field] &&

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -51,6 +51,7 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     turnSourceThreadId?: string | null;
     approvalSource?: string;
     runId?: string;
+    systemRunPlan?: Record<string, unknown>;
   };
 
   function approvedRunParams(overrides: ApprovedRunParamOverrides): Record<string, unknown> {

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -650,6 +650,13 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
       commandText: "/usr/bin/echo SAFE",
       agentId: "main",
       sessionKey: "agent:main:main",
+      policySnapshot: {
+        security: "allowlist",
+        ask: "on-miss",
+        askFallback: "deny",
+        autoAllowSkills: false,
+        allowlistRules: [{ pattern: "/usr/bin/echo" }],
+      },
     };
     record.request.systemRunBinding = buildSystemRunApprovalBinding({
       argv: ["/usr/bin/echo", "SAFE"],
@@ -664,6 +671,20 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
         cwd: "/tmp/attacker-link/sub",
         agentId: "attacker",
         sessionKey: "agent:attacker:main",
+        systemRunPlan: {
+          argv: ["echo", "PWNED"],
+          cwd: "/tmp/attacker-link/sub",
+          commandText: "echo PWNED",
+          agentId: "attacker",
+          sessionKey: "agent:attacker:main",
+          policySnapshot: {
+            security: "full",
+            ask: "off",
+            askFallback: "full",
+            autoAllowSkills: true,
+            allowlistRules: [],
+          },
+        },
       },
       record,
     });
@@ -677,6 +698,7 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
           commandText?: string;
           agentId?: string;
           sessionKey?: string;
+          policySnapshot?: unknown;
         }
       | undefined;
     expect(systemRunPlan?.argv).toEqual(["/usr/bin/echo", "SAFE"]);
@@ -684,6 +706,13 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expect(systemRunPlan?.commandText).toBe("/usr/bin/echo SAFE");
     expect(systemRunPlan?.agentId).toBe("main");
     expect(systemRunPlan?.sessionKey).toBe("agent:main:main");
+    expect(systemRunPlan?.policySnapshot).toEqual({
+      security: "allowlist",
+      ask: "on-miss",
+      askFallback: "deny",
+      autoAllowSkills: false,
+      allowlistRules: [{ pattern: "/usr/bin/echo" }],
+    });
     expect(forwarded.cwd).toBe("/real/cwd");
     expect(forwarded.agentId).toBe("main");
     expect(forwarded.sessionKey).toBe("agent:main:main");

--- a/src/gateway/server-methods/exec-approvals.test.ts
+++ b/src/gateway/server-methods/exec-approvals.test.ts
@@ -105,6 +105,93 @@ describe("exec approvals gateway methods", () => {
     );
   });
 
+  it("rejects a stale local save without recreating a deleted approvals file", async () => {
+    ensureExecApprovalsSnapshotMock.mockClear();
+    readExecApprovalsSnapshotMock.mockClear();
+    updateExecApprovalsMock.mockClear();
+    const missingSnapshot = {
+      ...makeSnapshot(),
+      exists: false,
+      raw: null,
+      hash: "sha256:missing",
+    };
+    readExecApprovalsSnapshotMock.mockReturnValueOnce(missingSnapshot);
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.set"]({
+      req: { type: "req", id: "req-deleted", method: "exec.approvals.set", params: {} },
+      params: { baseHash: "base-hash", file: { version: 1, agents: {} } },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(readExecApprovalsSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(ensureExecApprovalsSnapshotMock).not.toHaveBeenCalled();
+    expect(updateExecApprovalsMock).not.toHaveBeenCalled();
+    expect(missingSnapshot.file.socket).toBeUndefined();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("exec approvals changed since last load"),
+      }),
+    );
+  });
+
+  it("lets the locked update perform the first write for a missing approvals file", async () => {
+    ensureExecApprovalsSnapshotMock.mockClear();
+    readExecApprovalsSnapshotMock.mockClear();
+    updateExecApprovalsMock.mockReset();
+    const missingSnapshot = {
+      ...makeSnapshot(),
+      exists: false,
+      raw: null,
+      hash: "sha256:missing",
+    };
+    readExecApprovalsSnapshotMock.mockReturnValueOnce(missingSnapshot);
+    let createdFile: ExecApprovalsFile | undefined;
+    updateExecApprovalsMock.mockImplementationOnce(
+      async (params: {
+        baseHash?: string;
+        update: (file: ExecApprovalsFile) => ExecApprovalsFile | null;
+      }) => {
+        createdFile = params.update(missingSnapshot.file) ?? undefined;
+        if (!createdFile) {
+          throw new Error("expected first write");
+        }
+        return { ...makeSnapshot(createdFile), hash: "sha256:created" };
+      },
+    );
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.set"]({
+      req: { type: "req", id: "req-bootstrap", method: "exec.approvals.set", params: {} },
+      params: { file: { version: 1, agents: { main: {} } } },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+
+    expect(ensureExecApprovalsSnapshotMock).not.toHaveBeenCalled();
+    expect(updateExecApprovalsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseHash: missingSnapshot.hash }),
+    );
+    expect(createdFile?.socket?.path).toBeTruthy();
+    expect(createdFile?.socket?.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        hash: "sha256:created",
+        file: expect.objectContaining({ socket: { path: createdFile?.socket?.path } }),
+      }),
+      undefined,
+    );
+  });
+
   it.each([
     {
       method: "exec.approvals.node.get" as const,

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -17,6 +17,7 @@ import {
   ensureExecApprovalsSnapshot,
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
+  readExecApprovalsSnapshot,
   updateExecApprovals,
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
@@ -39,7 +40,12 @@ function requireApprovalsBaseHash(
 ): boolean {
   // Approval allowlists are admin-editable state. Require the caller's last
   // observed hash before writing so stale UI tabs cannot overwrite changes.
+  const baseHash = resolveBaseHashParam(params);
   if (!snapshot.exists) {
+    if (baseHash && baseHash !== snapshot.hash) {
+      respondApprovalsChanged(respond);
+      return false;
+    }
     return true;
   }
   if (!snapshot.hash) {
@@ -53,7 +59,6 @@ function requireApprovalsBaseHash(
     );
     return false;
   }
-  const baseHash = resolveBaseHashParam(params);
   if (!baseHash) {
     respond(
       false,
@@ -195,7 +200,9 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
       return;
     }
     await respondUnavailableOnThrow(respond, async () => {
-      const snapshot = await ensureExecApprovalsSnapshot();
+      // Do not ensure/create state before checking freshness: a rejected stale
+      // save must not recreate a file that an operator deleted.
+      const snapshot = readExecApprovalsSnapshot();
       if (!requireApprovalsBaseHash(params, snapshot, respond)) {
         return;
       }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3915,6 +3915,13 @@ describe("exec approval handlers", () => {
           commandPreview: "echo ok",
           agentId: "main",
           sessionKey: "agent:main:main",
+          policySnapshot: {
+            security: "allowlist",
+            ask: "on-miss",
+            askFallback: "deny",
+            autoAllowSkills: false,
+            allowlistRules: [{ pattern: "/usr/bin/echo" }],
+          },
         },
       },
     });
@@ -3932,6 +3939,13 @@ describe("exec approval handlers", () => {
       commandPreview: "echo ok",
       agentId: "main",
       sessionKey: "agent:main:main",
+      policySnapshot: {
+        security: "allowlist",
+        ask: "on-miss",
+        askFallback: "deny",
+        autoAllowSkills: false,
+        allowlistRules: [{ pattern: "/usr/bin/echo" }],
+      },
     });
   });
 

--- a/src/infra/exec-approval-policy-snapshot.ts
+++ b/src/infra/exec-approval-policy-snapshot.ts
@@ -1,0 +1,104 @@
+// Canonicalizes the portable policy snapshot carried with delayed exec approvals.
+import type { ExecApprovalPolicySnapshot } from "./exec-approvals.js";
+
+type ExecApprovalPolicyRule = ExecApprovalPolicySnapshot["allowlistRules"][number];
+
+const utf8Encoder = new TextEncoder();
+
+function compareUtf8(left: string, right: string): number {
+  const leftBytes = utf8Encoder.encode(left);
+  const rightBytes = utf8Encoder.encode(right);
+  const sharedLength = Math.min(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < sharedLength; index += 1) {
+    const difference = (leftBytes[index] ?? 0) - (rightBytes[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return leftBytes.length - rightBytes.length;
+}
+
+function compareOptionalUtf8(left: string | undefined, right: string | undefined): number {
+  if (left === undefined) {
+    return right === undefined ? 0 : -1;
+  }
+  if (right === undefined) {
+    return 1;
+  }
+  return compareUtf8(left, right);
+}
+
+/** Cross-runtime order: tuple fields, absent before present, UTF-8 byte lexicographic. */
+export function compareExecApprovalPolicyRules(
+  left: ExecApprovalPolicyRule,
+  right: ExecApprovalPolicyRule,
+): number {
+  return (
+    compareUtf8(left.pattern, right.pattern) ||
+    compareOptionalUtf8(left.argPattern, right.argPattern) ||
+    compareOptionalUtf8(left.source, right.source)
+  );
+}
+
+function buildExecApprovalPolicyRuleKey(rule: ExecApprovalPolicyRule): string {
+  return JSON.stringify([rule.pattern, rule.argPattern ?? null, rule.source ?? null]);
+}
+
+export function canonicalizeExecApprovalPolicyRules(
+  rules: readonly ExecApprovalPolicyRule[],
+): ExecApprovalPolicyRule[] {
+  const rulesByKey = new Map(rules.map((rule) => [buildExecApprovalPolicyRuleKey(rule), rule]));
+  return [...rulesByKey.values()].toSorted(compareExecApprovalPolicyRules);
+}
+
+export function normalizeExecApprovalPolicySnapshot(
+  value: unknown,
+): ExecApprovalPolicySnapshot | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const security = candidate.security;
+  const ask = candidate.ask;
+  const askFallback = candidate.askFallback;
+  const autoAllowSkills = candidate.autoAllowSkills;
+  const allowlistRules = candidate.allowlistRules;
+  if (
+    (security !== "deny" && security !== "allowlist" && security !== "full") ||
+    (ask !== "off" && ask !== "on-miss" && ask !== "always") ||
+    (askFallback !== "deny" && askFallback !== "allowlist" && askFallback !== "full") ||
+    typeof autoAllowSkills !== "boolean" ||
+    !Array.isArray(allowlistRules)
+  ) {
+    return null;
+  }
+  const normalizedRules: ExecApprovalPolicyRule[] = [];
+  for (const value of allowlistRules) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return null;
+    }
+    const rule = value as Record<string, unknown>;
+    if (
+      typeof rule.pattern !== "string" ||
+      (rule.argPattern !== undefined && typeof rule.argPattern !== "string") ||
+      (rule.source !== undefined && rule.source !== "allow-always")
+    ) {
+      return null;
+    }
+    normalizedRules.push({
+      pattern: rule.pattern,
+      ...(typeof rule.argPattern === "string" ? { argPattern: rule.argPattern } : {}),
+      ...(rule.source === "allow-always" ? { source: rule.source } : {}),
+    });
+  }
+  return {
+    security,
+    ask,
+    askFallback,
+    autoAllowSkills,
+    allowlistRules: canonicalizeExecApprovalPolicyRules(normalizedRules),
+  };
+}

--- a/src/infra/exec-approval-policy-snapshot.ts
+++ b/src/infra/exec-approval-policy-snapshot.ts
@@ -1,7 +1,17 @@
 // Canonicalizes the portable policy snapshot carried with delayed exec approvals.
-import type { ExecApprovalPolicySnapshot } from "./exec-approvals.js";
+export type ExecApprovalPolicyRule = {
+  pattern: string;
+  argPattern?: string;
+  source?: "allow-always";
+};
 
-type ExecApprovalPolicyRule = ExecApprovalPolicySnapshot["allowlistRules"][number];
+export type ExecApprovalPolicySnapshot = {
+  security: "deny" | "allowlist" | "full";
+  ask: "off" | "on-miss" | "always";
+  askFallback: "deny" | "allowlist" | "full";
+  autoAllowSkills: boolean;
+  allowlistRules: readonly ExecApprovalPolicyRule[];
+};
 
 const utf8Encoder = new TextEncoder();
 
@@ -76,11 +86,11 @@ export function normalizeExecApprovalPolicySnapshot(
     return null;
   }
   const normalizedRules: ExecApprovalPolicyRule[] = [];
-  for (const value of allowlistRules) {
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
+  for (const rawRule of allowlistRules) {
+    if (!rawRule || typeof rawRule !== "object" || Array.isArray(rawRule)) {
       return null;
     }
-    const rule = value as Record<string, unknown>;
+    const rule = rawRule as Record<string, unknown>;
     if (
       typeof rule.pattern !== "string" ||
       (rule.argPattern !== undefined && typeof rule.argPattern !== "string") ||

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -385,14 +385,11 @@ describe("exec approvals store helpers", () => {
     });
 
     createHomeDir();
-    expect(
-      mergeExecApprovalsSocketDefaults({
-        normalized: normalizeExecApprovals({ version: 1, agents: {} }),
-      }).socket,
-    ).toEqual({
-      path: resolveExecApprovalsSocketPath(),
-      token: "",
+    const initialized = mergeExecApprovalsSocketDefaults({
+      normalized: normalizeExecApprovals({ version: 1, agents: {} }),
     });
+    expect(initialized.socket?.path).toBe(resolveExecApprovalsSocketPath());
+    expect(initialized.socket?.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
   });
 
   it("distinguishes a missing approvals file from malformed persisted policy", () => {
@@ -1967,7 +1964,7 @@ describe("exec approvals store helpers", () => {
     expect(allowlist.every((entry) => entry.source === "allow-always")).toBe(true);
   });
 
-  it("rejects a persistent explicit allow-always grant without a policy snapshot", async () => {
+  it("rejects explicit allow-once without a policy snapshot", async () => {
     const dir = createHomeDir();
     saveExecApprovals({
       version: 1,
@@ -1986,13 +1983,32 @@ describe("exec approvals store helpers", () => {
           ask: "always",
           allowlistSatisfied: false,
         },
-        allowAlwaysDecision: {
-          kind: "exact-command",
-          commandText: "printf approved",
+      }),
+    ).rejects.toThrow("Delayed exec authorization requires a policy snapshot");
+    expect(allowlistEntries(dir, "main")).toEqual([]);
+  });
+
+  it("rejects auto-review without a policy snapshot", async () => {
+    createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "full", ask: "on-miss" },
+      agents: { main: {} },
+    });
+
+    await expect(
+      commitExecAuthorization({
+        agentId: "main",
+        matches: [],
+        command: "printf reviewed",
+        authorization: {
+          source: "auto-review",
+          security: "full",
+          ask: "on-miss",
+          allowlistSatisfied: false,
         },
       }),
-    ).rejects.toThrow("Allow-always persistence requires a policy snapshot");
-    expect(allowlistEntries(dir, "main")).toEqual([]);
+    ).rejects.toThrow("Delayed exec authorization requires a policy snapshot");
   });
 
   it("does not let current policy create an allow-always grant", async () => {
@@ -2074,8 +2090,18 @@ describe("exec approvals store helpers", () => {
     createHomeDir();
     saveExecApprovals({
       version: 1,
-      defaults: { security: "full", ask: "always" },
+      defaults: { security: "full", ask: "on-miss" },
       agents: { main: {} },
+    });
+    const policySnapshot = createExecApprovalPolicySnapshot({
+      file: readExecApprovalsSnapshot().file,
+      agentId: "main",
+    });
+    await updateExecApprovals({
+      update: (current) => ({
+        ...current,
+        defaults: { ...current.defaults, ask: "always" },
+      }),
     });
 
     await expect(
@@ -2088,6 +2114,75 @@ describe("exec approvals store helpers", () => {
           security: "full",
           ask: "on-miss",
           allowlistSatisfied: false,
+          policySnapshot,
+        },
+      }),
+    ).rejects.toThrow("Exec approval changed before execution");
+  });
+
+  it("rejects auto-review when current ask tightens from off to on-miss", async () => {
+    createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "full", ask: "off" },
+      agents: { main: {} },
+    });
+    const policySnapshot = createExecApprovalPolicySnapshot({
+      file: readExecApprovalsSnapshot().file,
+      agentId: "main",
+    });
+    await updateExecApprovals({
+      update: (current) => ({
+        ...current,
+        defaults: { ...current.defaults, ask: "on-miss" },
+      }),
+    });
+
+    await expect(
+      commitExecAuthorization({
+        agentId: "main",
+        matches: [],
+        command: "printf reviewed",
+        authorization: {
+          source: "auto-review",
+          security: "full",
+          ask: "off",
+          allowlistSatisfied: false,
+          policySnapshot,
+        },
+      }),
+    ).rejects.toThrow("Exec approval changed before execution");
+  });
+
+  it("rejects auto-review when current security tightens from full to allowlist", async () => {
+    createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "full", ask: "off" },
+      agents: { main: {} },
+    });
+    const policySnapshot = createExecApprovalPolicySnapshot({
+      file: readExecApprovalsSnapshot().file,
+      agentId: "main",
+    });
+    await updateExecApprovals({
+      update: (current) => ({
+        ...current,
+        defaults: { ...current.defaults, security: "allowlist" },
+      }),
+    });
+
+    await expect(
+      commitExecAuthorization({
+        agentId: "main",
+        matches: [],
+        command: "printf reviewed",
+        authorization: {
+          source: "auto-review",
+          security: "full",
+          ask: "off",
+          allowlistSatisfied: false,
+          policySnapshot,
         },
       }),
     ).rejects.toThrow("Exec approval changed before execution");

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -13,7 +13,10 @@ import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import { sha256Hex, sha256HexPrefix } from "./crypto-digest.js";
-import { canonicalizeExecApprovalPolicyRules } from "./exec-approval-policy-snapshot.js";
+import {
+  canonicalizeExecApprovalPolicyRules,
+  type ExecApprovalPolicySnapshot,
+} from "./exec-approval-policy-snapshot.js";
 import {
   type AllowAlwaysPattern,
   resolveAllowAlwaysPatternEntries,
@@ -38,6 +41,7 @@ import {
 import { isLockOwnerDefinitelyStale } from "./stale-lock-file.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
+export type { ExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
 export type { ExecAllowlistEntry } from "./exec-approvals.types.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
@@ -2013,14 +2017,6 @@ function buildAllowlistEntryMatchKey(
 ): string {
   return JSON.stringify([entry.pattern, entry.argPattern ?? null]);
 }
-
-export type ExecApprovalPolicySnapshot = {
-  security: ExecSecurity;
-  ask: ExecAsk;
-  askFallback: ExecSecurity;
-  autoAllowSkills: boolean;
-  allowlistRules: readonly Pick<ExecAllowlistEntry, "pattern" | "argPattern" | "source">[];
-};
 
 function buildExecApprovalPolicyRuleKey(
   entry: Pick<ExecAllowlistEntry, "pattern" | "argPattern" | "source">,

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -13,6 +13,7 @@ import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import { sha256Hex, sha256HexPrefix } from "./crypto-digest.js";
+import { canonicalizeExecApprovalPolicyRules } from "./exec-approval-policy-snapshot.js";
 import {
   type AllowAlwaysPattern,
   resolveAllowAlwaysPatternEntries,
@@ -202,6 +203,7 @@ export type SystemRunApprovalPlan = {
   commandPreview?: string | null;
   agentId: string | null;
   sessionKey: string | null;
+  policySnapshot?: ExecApprovalPolicySnapshot;
   mutableFileOperand?: SystemRunApprovalFileOperand | null;
 };
 
@@ -1043,7 +1045,7 @@ export function mergeExecApprovalsSocketDefaults(params: {
   const currentToken = params.current?.socket?.token?.trim();
   const socketPath =
     params.normalized.socket?.path?.trim() ?? currentSocketPath ?? resolveExecApprovalsSocketPath();
-  const token = params.normalized.socket?.token?.trim() ?? currentToken ?? "";
+  const token = params.normalized.socket?.token?.trim() ?? currentToken ?? generateToken();
   return {
     ...params.normalized,
     socket: {
@@ -2017,31 +2019,23 @@ export type ExecApprovalPolicySnapshot = {
   ask: ExecAsk;
   askFallback: ExecSecurity;
   autoAllowSkills: boolean;
-  allowlistRuleKeys: readonly string[];
+  allowlistRules: readonly Pick<ExecAllowlistEntry, "pattern" | "argPattern" | "source">[];
 };
 
-function buildExecApprovalPolicyRuleKey(entry: ExecAllowlistEntry): string {
+function buildExecApprovalPolicyRuleKey(
+  entry: Pick<ExecAllowlistEntry, "pattern" | "argPattern" | "source">,
+): string {
   // A JSON tuple preserves exact regex bytes without delimiter collisions.
   return JSON.stringify([entry.pattern, entry.argPattern ?? null, entry.source ?? null]);
 }
 
-function buildAllowAlwaysUpgradeRuleKey(key: string): string | null {
-  let rule: unknown;
-  try {
-    rule = JSON.parse(key) as unknown;
-  } catch {
+function buildAllowAlwaysUpgradeRuleKey(
+  rule: Pick<ExecAllowlistEntry, "pattern" | "argPattern" | "source">,
+): string | null {
+  if (rule.source !== undefined) {
     return null;
   }
-  if (
-    !Array.isArray(rule) ||
-    rule.length !== 3 ||
-    typeof rule[0] !== "string" ||
-    (rule[1] !== null && typeof rule[1] !== "string") ||
-    rule[2] !== null
-  ) {
-    return null;
-  }
-  return JSON.stringify([rule[0], rule[1], "allow-always"]);
+  return buildExecApprovalPolicyRuleKey({ ...rule, source: "allow-always" });
 }
 
 /** Captures effective file policy while excluding ids and mutable usage metadata. */
@@ -2055,22 +2049,30 @@ export function createExecApprovalPolicySnapshot(params: {
     file: params.file,
     agentId: params.agentId,
   });
+  const allowlistRulesByKey = new Map(
+    resolved.allowlist.map((entry) => {
+      const rule = {
+        pattern: entry.pattern,
+        ...(entry.argPattern !== undefined ? { argPattern: entry.argPattern } : {}),
+        ...(entry.source !== undefined ? { source: entry.source } : {}),
+      };
+      return [buildExecApprovalPolicyRuleKey(rule), rule] as const;
+    }),
+  );
   return {
     security: resolved.agent.security,
     ask: resolved.agent.ask,
     askFallback: resolved.agent.askFallback,
     autoAllowSkills: resolved.agent.autoAllowSkills,
-    allowlistRuleKeys: [
-      ...new Set(resolved.allowlist.map(buildExecApprovalPolicyRuleKey)),
-    ].toSorted(),
+    allowlistRules: canonicalizeExecApprovalPolicyRules([...allowlistRulesByKey.values()]),
   };
 }
 
-function execApprovalPolicySnapshotIsCurrent(
+export function isExecApprovalPolicySnapshotCurrent(
   expected: ExecApprovalPolicySnapshot,
   current: ExecApprovalPolicySnapshot,
 ): boolean {
-  const currentRuleKeys = new Set(current.allowlistRuleKeys);
+  const currentRuleKeys = new Set(current.allowlistRules.map(buildExecApprovalPolicyRuleKey));
   return (
     expected.security === current.security &&
     expected.ask === current.ask &&
@@ -2079,11 +2081,12 @@ function execApprovalPolicySnapshotIsCurrent(
     // Concurrent operator-approved grants are additive. Preserve them while
     // accepting an in-place allow-always upgrade of the same rule. Revocations
     // and reverse source downgrades still remove an expected authority.
-    expected.allowlistRuleKeys.every((key) => {
+    expected.allowlistRules.every((rule) => {
+      const key = buildExecApprovalPolicyRuleKey(rule);
       if (currentRuleKeys.has(key)) {
         return true;
       }
-      const upgradedKey = buildAllowAlwaysUpgradeRuleKey(key);
+      const upgradedKey = buildAllowAlwaysUpgradeRuleKey(rule);
       return upgradedKey !== null && currentRuleKeys.has(upgradedKey);
     })
   );
@@ -2120,17 +2123,24 @@ function assertCurrentUsageAuthorization(params: {
   if (security === "deny") {
     throw new Error("Exec approval changed before execution");
   }
-  if (params.authorization.source === "explicit-approval") {
+  // Human and model decisions are delayed authority. Bind both one-shot and
+  // persistent decisions to the persisted policy they were evaluated against.
+  const delayedAuthorization =
+    params.authorization.source === "explicit-approval" ||
+    params.authorization.source === "auto-review";
+  if (delayedAuthorization) {
     const expectedPolicy = params.authorization.policySnapshot;
     if (
-      expectedPolicy &&
-      !execApprovalPolicySnapshotIsCurrent(
+      !expectedPolicy ||
+      !isExecApprovalPolicySnapshotCurrent(
         expectedPolicy,
         createExecApprovalPolicySnapshot({ file: params.file, agentId: params.agentId }),
       )
     ) {
       throw new Error("Exec approval changed before execution");
     }
+  }
+  if (params.authorization.source === "explicit-approval") {
     return;
   }
   if (params.authorization.source === "auto-review") {
@@ -2343,12 +2353,16 @@ export async function commitExecAuthorizationLocked(params: {
   authorization: ExecApprovalUsageAuthorization;
   allowAlwaysDecision?: AllowAlwaysPersistenceDecision;
 }): Promise<void> {
+  if (
+    (params.authorization.source === "explicit-approval" ||
+      params.authorization.source === "auto-review") &&
+    !params.authorization.policySnapshot
+  ) {
+    throw new Error("Delayed exec authorization requires a policy snapshot");
+  }
   if (params.allowAlwaysDecision && params.allowAlwaysDecision.kind !== "one-shot") {
     if (params.authorization.source !== "explicit-approval") {
       throw new Error("Allow-always persistence requires explicit approval");
-    }
-    if (!params.authorization.policySnapshot) {
-      throw new Error("Allow-always persistence requires a policy snapshot");
     }
   }
   await updateExecApprovals({

--- a/src/infra/exec-host.ts
+++ b/src/infra/exec-host.ts
@@ -1,5 +1,6 @@
 // Sends HMAC-protected exec host requests over the local socket.
 import crypto from "node:crypto";
+import type { ExecApprovalPolicySnapshot } from "./exec-approvals.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 
 // Exec host requests cross the local JSONL socket boundary into a privileged
@@ -15,6 +16,7 @@ export type ExecHostRequest = {
   sessionKey?: string | null;
   approvalDecision?: "allow-once" | "allow-always" | null;
   approvalSource?: "ask-fallback" | "auto-review" | null;
+  policySnapshot?: ExecApprovalPolicySnapshot | null;
 };
 
 export type ExecHostRunResult = {

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -49,6 +49,89 @@ describe("normalizeSystemRunApprovalPlan", () => {
       },
     },
     {
+      name: "accepts and canonicalizes a prepared policy snapshot",
+      input: {
+        argv: ["echo", "hi"],
+        commandText: "echo hi",
+        policySnapshot: {
+          security: "allowlist",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [
+            { pattern: "/usr/bin/zsh", source: "allow-always" },
+            { pattern: "/usr/bin/echo" },
+            { pattern: "/usr/bin/echo" },
+          ],
+        },
+      },
+      expected: {
+        argv: ["echo", "hi"],
+        commandText: "echo hi",
+        commandPreview: null,
+        cwd: null,
+        agentId: null,
+        sessionKey: null,
+        policySnapshot: {
+          security: "allowlist",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [
+            { pattern: "/usr/bin/echo" },
+            { pattern: "/usr/bin/zsh", source: "allow-always" },
+          ],
+        },
+        mutableFileOperand: undefined,
+      },
+    },
+    {
+      name: "uses locale-independent UTF-8 ordering for portable policy rules",
+      input: {
+        argv: ["echo", "hi"],
+        commandText: "echo hi",
+        policySnapshot: {
+          security: "allowlist",
+          ask: "always",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [
+            { pattern: "/😀" },
+            { pattern: "/A", argPattern: "z" },
+            { pattern: "/é" },
+            { pattern: "/A", source: "allow-always" },
+            { pattern: "/a" },
+            { pattern: "/A" },
+            { pattern: "/A", argPattern: "A" },
+          ],
+        },
+      },
+      expected: {
+        argv: ["echo", "hi"],
+        commandText: "echo hi",
+        commandPreview: null,
+        cwd: null,
+        agentId: null,
+        sessionKey: null,
+        policySnapshot: {
+          security: "allowlist",
+          ask: "always",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [
+            { pattern: "/A" },
+            { pattern: "/A", source: "allow-always" },
+            { pattern: "/A", argPattern: "A" },
+            { pattern: "/A", argPattern: "z" },
+            { pattern: "/a" },
+            { pattern: "/é" },
+            { pattern: "/😀" },
+          ],
+        },
+        mutableFileOperand: undefined,
+      },
+    },
+    {
       name: "falls back to rawCommand",
       input: {
         argv: ["bash", "-lc", "echo hi"],
@@ -77,6 +160,22 @@ describe("normalizeSystemRunApprovalPlan", () => {
           argvIndex: -1,
           path: "/tmp/payload.txt",
           sha256: "abc123",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects malformed prepared policy snapshots", () => {
+    expect(
+      normalizeSystemRunApprovalPlan({
+        argv: ["echo", "hi"],
+        commandText: "echo hi",
+        policySnapshot: {
+          security: "full",
+          ask: "off",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [{ pattern: "valid" }, { pattern: 42 }],
         },
       }),
     ).toBeNull();

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -1,4 +1,5 @@
 import { sha256Hex } from "./crypto-digest.js";
+import { normalizeExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
 // Binds system-run approval requests to stable command identities.
 import type {
   SystemRunApprovalBinding,
@@ -51,6 +52,10 @@ export function normalizeSystemRunApprovalPlan(value: unknown): SystemRunApprova
   if (candidate.mutableFileOperand !== undefined && mutableFileOperand === null) {
     return null;
   }
+  const policySnapshot = normalizeExecApprovalPolicySnapshot(candidate.policySnapshot);
+  if (candidate.policySnapshot !== undefined && policySnapshot === null) {
+    return null;
+  }
   const commandText =
     normalizeNonEmptyString(candidate.commandText) ?? normalizeNonEmptyString(candidate.rawCommand);
   if (!commandText) {
@@ -63,6 +68,7 @@ export function normalizeSystemRunApprovalPlan(value: unknown): SystemRunApprova
     commandPreview: normalizeNonEmptyString(candidate.commandPreview),
     agentId: normalizeNonEmptyString(candidate.agentId),
     sessionKey: normalizeNonEmptyString(candidate.sessionKey),
+    ...(policySnapshot ? { policySnapshot } : {}),
     mutableFileOperand: mutableFileOperand ?? undefined,
   };
 }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -187,6 +187,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       cwd?: string;
       approvalDecision?: string | null;
       approvalSource?: string | null;
+      policySnapshot?: unknown;
     };
   } {
     const call = firstMockCallArg(runViaMacAppExecHost, "runViaMacAppExecHost", 0);
@@ -198,6 +199,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         cwd?: string;
         approvalDecision?: string | null;
         approvalSource?: string | null;
+        policySnapshot?: unknown;
       };
     };
   }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -22,6 +22,7 @@ import {
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import {
   commitExecAuthorizationLocked,
+  createExecApprovalPolicySnapshot,
   loadExecApprovals,
   resolveExecApprovalsPath,
   saveExecApprovals,
@@ -123,6 +124,17 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       throw new Error(prepared.message);
     }
     return prepared.plan;
+  }
+
+  function bindCurrentPolicyToPlan(plan: SystemRunApprovalPlan): SystemRunApprovalPlan {
+    return {
+      ...plan,
+      sessionKey: plan.sessionKey ?? "agent:main:main",
+      policySnapshot: createExecApprovalPolicySnapshot({
+        file: loadExecApprovals(),
+        agentId: plan.agentId ?? undefined,
+      }),
+    };
   }
 
   function expectInvokeOk(
@@ -476,6 +488,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     rawCommand?: string | null;
     systemRunPlan?: SystemRunApprovalPlan | null;
     cwd?: string;
+    agentId?: string;
     security?: "full" | "allowlist";
     ask?: "off" | "on-miss" | "always";
     approvalDecision?: "allow" | "allow-once" | "allow-always" | "deny" | null;
@@ -495,6 +508,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     resolveExecAsk?: HandleSystemRunInvokeOptions["resolveExecAsk"];
     autoReviewer?: ExecAutoReviewer;
     commitExecAuthorization?: HandleSystemRunInvokeOptions["commitExecAuthorization"];
+    prepareDelayedApprovalPlan?: boolean;
   }): Promise<{
     runCommand: MockedRunCommand;
     runViaMacAppExecHost: MockedRunViaMacAppExecHost;
@@ -534,14 +548,48 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       sendExecFinishedEvent.mockImplementation(params.sendExecFinishedEvent);
     }
 
+    const command = params.command ?? ["echo", "ok"];
+    let dispatchCommand = command;
+    let dispatchRawCommand = params.rawCommand;
+    let dispatchCwd = params.cwd;
+    let dispatchAgentId = params.agentId;
+    const forwardsDelayedApproval =
+      params.approvalSource === "auto-review" ||
+      params.approved === true ||
+      params.approvalDecision === "allow" ||
+      params.approvalDecision === "allow-once" ||
+      params.approvalDecision === "allow-always";
+    let systemRunPlan = params.systemRunPlan;
+    if (forwardsDelayedApproval && params.prepareDelayedApprovalPlan !== false) {
+      if (!systemRunPlan) {
+        const prepared = buildSystemRunApprovalPlan({
+          command,
+          rawCommand: params.rawCommand,
+          cwd: params.cwd,
+          agentId: params.agentId,
+          sessionKey: "agent:main:main",
+        });
+        if (!prepared.ok) {
+          throw new Error(prepared.message);
+        }
+        systemRunPlan = prepared.plan;
+        dispatchCommand = prepared.plan.argv;
+        dispatchRawCommand = prepared.plan.commandText;
+        dispatchCwd = prepared.plan.cwd ?? undefined;
+        dispatchAgentId = prepared.plan.agentId ?? undefined;
+      }
+      systemRunPlan = bindCurrentPolicyToPlan(systemRunPlan);
+    }
+
     await handleSystemRunInvoke({
       client: {} as never,
       params: {
-        command: params.command ?? ["echo", "ok"],
+        command: dispatchCommand,
         env: params.env,
-        rawCommand: params.rawCommand,
-        systemRunPlan: params.systemRunPlan,
-        cwd: params.cwd,
+        rawCommand: dispatchRawCommand,
+        systemRunPlan,
+        cwd: dispatchCwd,
+        agentId: dispatchAgentId,
         approvalDecision: params.approvalDecision,
         approvalSource: params.approvalSource,
         approved: params.approved,
@@ -696,6 +744,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       const macCall = requireMacExecHostCall(macInvoke.runViaMacAppExecHost);
       expect(macCall.request?.approvalSource).toBe("auto-review");
       expect(macCall.request?.approvalDecision).toBeNull();
+      expect(macCall.request?.policySnapshot).toEqual(
+        createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
+      );
       expect(macInvoke.runCommand).not.toHaveBeenCalled();
       expectInvokeOk(macInvoke.sendInvokeResult, { payloadContains: "app-ok" });
     } finally {
@@ -893,6 +944,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(macHostCall.request?.command).toEqual(["env", "sh", "-c", "echo SAFE"]);
           expect(macHostCall.request?.rawCommand).toBe('env sh -c "echo SAFE"');
           expect(macHostCall.request?.cwd).toBe(canonicalCwd);
+          expect(macHostCall.request?.policySnapshot).toEqual(
+            createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
+          );
           expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
           continue;
         }
@@ -1241,7 +1295,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "denies approval-based execution for symlinked cwd paths",
+    "rejects symlinked cwd paths during approval preparation",
     async () => {
       for (const testCase of [
         {
@@ -1278,16 +1332,14 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         },
       ]) {
         const { cwd, message } = testCase.setup();
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
+        const prepared = buildSystemRunApprovalPlan({
           command: ["./run.sh"],
           cwd,
-          approved: true,
-          security: "full",
-          ask: "off",
         });
-        expect(runCommand, testCase.label).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(sendInvokeResult, { message });
+        expect(prepared.ok, testCase.label).toBe(false);
+        if (!prepared.ok) {
+          expect(prepared.message, testCase.label).toContain(message);
+        }
       }
     },
   );
@@ -1329,14 +1381,25 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
     fs.chmodSync(script, 0o755);
     const canonicalCwd = fs.realpathSync(tmp);
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["./run.sh"],
+      cwd: tmp,
+      sessionKey: "agent:main:main",
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("unreachable");
+    }
     await withMockedCwdIdentityDrift({
       canonicalCwd,
       driftDir: fallback,
       run: async () => {
         const { runCommand, sendInvokeResult } = await runSystemInvoke({
           preferMacAppExecHost: false,
-          command: ["./run.sh"],
-          cwd: tmp,
+          command: prepared.plan.argv,
+          rawCommand: prepared.plan.commandText,
+          systemRunPlan: prepared.plan,
+          cwd: prepared.plan.cwd ?? tmp,
           approved: true,
           security: "full",
           ask: "off",
@@ -1851,7 +1914,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       ask: "always" as const,
       askFallback: "deny" as const,
       autoAllowSkills: false,
-      allowlistRuleKeys: [JSON.stringify([matchedEntry.pattern, null, null])],
+      allowlistRules: [matchedEntry],
     };
 
     await withTempApprovalsHome({
@@ -2048,6 +2111,44 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
   });
 
+  it("rejects explicit allow-once when persisted security tightens to allowlist", async () => {
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "full", ask: "always", askFallback: "deny" },
+      },
+      run: async () => {
+        const commitAuthorization = vi.fn(
+          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
+            const current = loadExecApprovals();
+            current.defaults = { ...current.defaults, security: "allowlist" };
+            saveExecApprovals(current);
+            await commitExecAuthorizationLocked(params);
+          },
+        );
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          security: "full",
+          ask: "always",
+          approvalDecision: "allow-once",
+          approved: true,
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authorization: expect.objectContaining({
+              source: "explicit-approval",
+              policySnapshot: expect.any(Object),
+            }),
+          }),
+        );
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectApprovalStateWriteDenied(invoke);
+      },
+    });
+  });
+
   it("treats authenticated auto-review provenance as marker-only one-shot authority", async () => {
     const prepared = buildSystemRunApprovalPlan({
       command: ["echo", "ok"],
@@ -2130,6 +2231,102 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         expect(commitAuthorization).toHaveBeenCalledWith(
           expect.objectContaining({
             authorization: expect.objectContaining({ source: "auto-review" }),
+          }),
+        );
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectApprovalStateWriteDenied(invoke);
+      },
+    });
+  });
+
+  it("rejects forwarded auto-review when persisted security tightens to allowlist", async () => {
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["echo", "ok"],
+      sessionKey: "agent:main:main",
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("unreachable");
+    }
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
+      },
+      run: async () => {
+        const commitAuthorization = vi.fn(
+          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
+            const current = loadExecApprovals();
+            current.defaults = { ...current.defaults, security: "allowlist" };
+            saveExecApprovals(current);
+            await commitExecAuthorizationLocked(params);
+          },
+        );
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: prepared.plan.argv,
+          rawCommand: prepared.plan.commandText,
+          systemRunPlan: prepared.plan,
+          security: "full",
+          ask: "on-miss",
+          approvalSource: "auto-review",
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authorization: expect.objectContaining({
+              source: "auto-review",
+              policySnapshot: expect.any(Object),
+            }),
+          }),
+        );
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectApprovalStateWriteDenied(invoke);
+      },
+    });
+  });
+
+  it("rejects forwarded auto-review when persisted ask tightens from off to on-miss", async () => {
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["echo", "ok"],
+      sessionKey: "agent:main:main",
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("unreachable");
+    }
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "full", ask: "off", askFallback: "deny" },
+      },
+      run: async () => {
+        const commitAuthorization = vi.fn(
+          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
+            const current = loadExecApprovals();
+            current.defaults = { ...current.defaults, ask: "on-miss" };
+            saveExecApprovals(current);
+            await commitExecAuthorizationLocked(params);
+          },
+        );
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: prepared.plan.argv,
+          rawCommand: prepared.plan.commandText,
+          systemRunPlan: prepared.plan,
+          security: "full",
+          ask: "off",
+          approvalSource: "auto-review",
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authorization: expect.objectContaining({
+              source: "auto-review",
+              policySnapshot: expect.any(Object),
+            }),
           }),
         );
         expect(invoke.runCommand).not.toHaveBeenCalled();
@@ -2347,12 +2544,192 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       security: "full",
       ask: "on-miss",
       approvalSource: "auto-review",
+      prepareDelayedApprovalPlan: false,
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
     expectInvokeErrorMessage(invoke.sendInvokeResult, {
       message: "approvalSource requires matching systemRunPlan",
       exact: true,
+    });
+  });
+
+  it("requires a canonical plan for explicit approval provenance", async () => {
+    const invoke = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      security: "full",
+      ask: "always",
+      approvalDecision: "allow-once",
+      approved: true,
+      prepareDelayedApprovalPlan: false,
+    });
+
+    expect(invoke.runCommand).not.toHaveBeenCalled();
+    expectInvokeErrorMessage(invoke.sendInvokeResult, {
+      message: "explicit approval requires matching systemRunPlan",
+      exact: true,
+    });
+  });
+
+  it("requires a prepared policy snapshot for forwarded delayed approval", async () => {
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["echo", "ok"],
+      sessionKey: "agent:main:main",
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("unreachable");
+    }
+    const invoke = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      command: prepared.plan.argv,
+      rawCommand: prepared.plan.commandText,
+      systemRunPlan: prepared.plan,
+      security: "full",
+      ask: "on-miss",
+      approvalSource: "auto-review",
+      prepareDelayedApprovalPlan: false,
+    });
+
+    expect(invoke.runCommand).not.toHaveBeenCalled();
+    expectInvokeErrorMessage(invoke.sendInvokeResult, {
+      message: "delayed approval requires a prepared policy snapshot",
+      exact: true,
+    });
+  });
+
+  it("rejects explicit approval when policy tightens after prepare", async () => {
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "full", ask: "always", askFallback: "deny" },
+      },
+      run: async () => {
+        const prepared = buildSystemRunApprovalPlan({
+          command: ["echo", "ok"],
+          sessionKey: "agent:main:main",
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+        const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
+        const current = loadExecApprovals();
+        current.defaults = { ...current.defaults, security: "allowlist" };
+        saveExecApprovals(current);
+        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: policyBoundPlan.argv,
+          rawCommand: policyBoundPlan.commandText,
+          systemRunPlan: policyBoundPlan,
+          security: "full",
+          ask: "always",
+          approvalDecision: "allow-once",
+          approved: true,
+          prepareDelayedApprovalPlan: false,
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).not.toHaveBeenCalled();
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(invoke.sendInvokeResult, {
+          message: "exec approval policy changed; request approval again",
+        });
+      },
+    });
+  });
+
+  it("rejects forwarded auto-review when ask tightens after prepare", async () => {
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "full", ask: "off", askFallback: "deny" },
+      },
+      run: async () => {
+        const prepared = buildSystemRunApprovalPlan({
+          command: ["echo", "ok"],
+          sessionKey: "agent:main:main",
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+        const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
+        const current = loadExecApprovals();
+        current.defaults = { ...current.defaults, ask: "on-miss" };
+        saveExecApprovals(current);
+        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: policyBoundPlan.argv,
+          rawCommand: policyBoundPlan.commandText,
+          systemRunPlan: policyBoundPlan,
+          security: "full",
+          ask: "off",
+          approvalSource: "auto-review",
+          prepareDelayedApprovalPlan: false,
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).not.toHaveBeenCalled();
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(invoke.sendInvokeResult, {
+          message: "exec approval policy changed; request approval again",
+        });
+      },
+    });
+  });
+
+  it("rejects explicit approval when an allowlist rule is revoked after prepare", async () => {
+    await withTempApprovalsHome({
+      approvals: {
+        version: 1,
+        defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
+        agents: {
+          main: {
+            allowlist: [{ id: "rule-1", pattern: "/usr/bin/echo" }],
+          },
+        },
+      },
+      run: async () => {
+        const prepared = buildSystemRunApprovalPlan({
+          command: ["echo", "ok"],
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+        const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
+        const current = loadExecApprovals();
+        current.agents = { ...current.agents, main: { allowlist: [] } };
+        saveExecApprovals(current);
+        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+
+        const invoke = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: policyBoundPlan.argv,
+          rawCommand: policyBoundPlan.commandText,
+          systemRunPlan: policyBoundPlan,
+          security: "allowlist",
+          ask: "always",
+          agentId: "main",
+          approvalDecision: "allow-once",
+          approved: true,
+          prepareDelayedApprovalPlan: false,
+          commitExecAuthorization: commitAuthorization,
+        });
+
+        expect(commitAuthorization).not.toHaveBeenCalled();
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(invoke.sendInvokeResult, {
+          message: "exec approval policy changed; request approval again",
+        });
+      },
     });
   });
 
@@ -2611,6 +2988,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         const call = requireMacExecHostCall(invoke.runViaMacAppExecHost);
         expect(call.request?.approvalSource).toBe("auto-review");
         expect(call.request?.approvalDecision).toBeNull();
+        expect(call.request?.policySnapshot).toEqual(
+          createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
+        );
         expect(invoke.runCommand).not.toHaveBeenCalled();
         expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
       },
@@ -2742,9 +3122,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
   });
 
-  it("does not persist allow-always approvals for strict inline-eval carriers", async () => {
-    // Persistence behavior is covered generically in exec-approvals tests; keep
-    // one handler-level smoke for strictInlineEval allow-always suppression.
+  it("rejects unbindable strict inline-eval carriers before delayed approval", async () => {
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -2761,18 +3139,15 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             dir: tempDir,
             name: "python3.13",
           });
-          const { runCommand, sendInvokeResult } = await runSystemInvoke({
-            preferMacAppExecHost: false,
+          const prepared = buildSystemRunApprovalPlan({
             command: [executablePath, "-c", "print('hi')"],
-            security: "allowlist",
-            ask: "on-miss",
-            approvalDecision: "allow-always",
-            approved: true,
-            runCommand: vi.fn(async () => createLocalRunResult("inline-eval-ok")),
           });
 
-          expect(runCommand).toHaveBeenCalledTimes(1);
-          expectInvokeOk(sendInvokeResult, { payloadContains: "inline-eval-ok" });
+          expect(prepared).toEqual({
+            ok: false,
+            message:
+              "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+          });
           expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
         },
       });
@@ -2796,11 +3171,12 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           const tempDir = createFixtureDir("openclaw-inline-eval-awk-");
           const executablePath = createTempExecutable({
             dir: tempDir,
-            name: "awk",
+            name: "gawk",
           });
+          fs.writeFileSync(path.join(tempDir, "script.awk"), "{ print }\n");
           const benign = await runSystemInvoke({
             preferMacAppExecHost: false,
-            command: [executablePath, "-F", ",", "-f", "script.awk", "data.csv"],
+            command: [executablePath, "-F", ",", "-f", "script.awk"],
             cwd: tempDir,
             security: "allowlist",
             ask: "on-miss",

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -13,6 +13,7 @@ import {
   commandRequiresSecurityAuditSuppressionApproval,
   createExecApprovalPolicySnapshot,
   hasDurableExecApproval,
+  isExecApprovalPolicySnapshotCurrent,
   maxAsk,
   minSecurity,
   resolveApprovalAuditTrustPath,
@@ -106,6 +107,7 @@ type SystemRunParsePhase = {
   execution: SystemRunExecutionContext;
   approvalDecision: ReturnType<typeof resolveExecApprovalDecision>;
   approvalSource: "ask-fallback" | "auto-review" | undefined;
+  delayedApprovalPolicySnapshot: ExecApprovalPolicySnapshot | null;
   envOverrides: Record<string, string> | undefined;
   env: Record<string, string> | undefined;
   cwd: string | undefined;
@@ -117,7 +119,7 @@ type SystemRunParsePhase = {
 
 type SystemRunPolicyPhase = SystemRunParsePhase & {
   approvals: ExecApprovalsResolved;
-  allowAlwaysPolicySnapshot: ExecApprovalPolicySnapshot;
+  evaluationPolicySnapshot: ExecApprovalPolicySnapshot;
   security: ExecSecurity;
   ask: ExecAsk;
   policy: ReturnType<typeof evaluateSystemRunPolicy>;
@@ -425,7 +427,9 @@ async function parseSystemRunPhase(
     });
     return null;
   }
-  if (approvalSource != null) {
+  const explicitApproval = approved || approvalDecision !== null;
+  const forwardedDelayedApproval = approvalSource === "auto-review" || explicitApproval;
+  if (approvalSource != null || explicitApproval) {
     const planMatchesRequest =
       approvalPlan !== null &&
       argvArraysMatch(approvalPlan.argv, command.argv) &&
@@ -438,11 +442,27 @@ async function parseSystemRunPhase(
         ok: false,
         error: {
           code: "INVALID_REQUEST",
-          message: "approvalSource requires matching systemRunPlan",
+          message:
+            approvalSource != null
+              ? "approvalSource requires matching systemRunPlan"
+              : "explicit approval requires matching systemRunPlan",
         },
       });
       return null;
     }
+  }
+  const delayedApprovalPolicySnapshot = forwardedDelayedApproval
+    ? (approvalPlan?.policySnapshot ?? null)
+    : null;
+  if (forwardedDelayedApproval && !delayedApprovalPolicySnapshot) {
+    await opts.sendInvokeResult({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "delayed approval requires a prepared policy snapshot",
+      },
+    });
+    return null;
   }
   const envAssignmentKeys = extractEnvAssignmentKeysFromDispatchWrappers(command.argv);
   const envAssignmentOverrides =
@@ -510,6 +530,7 @@ async function parseSystemRunPhase(
     execution: { sessionKey, runId, commandText, suppressNotifyOnExit },
     approvalDecision,
     approvalSource: approvalSource ?? undefined,
+    delayedApprovalPolicySnapshot,
     envOverrides,
     env: opts.sanitizeEnv(envOverrides),
     cwd,
@@ -533,10 +554,24 @@ async function evaluateSystemRunPolicyPhase(
     requireSocket: opts.preferMacAppExecHost,
   });
   const { agentExec, globalExec, approvals } = effectivePolicy;
-  const allowAlwaysPolicySnapshot = createExecApprovalPolicySnapshot({
+  const currentPolicySnapshot = createExecApprovalPolicySnapshot({
     file: approvals.file,
     agentId: parsed.agentId,
   });
+  if (
+    parsed.delayedApprovalPolicySnapshot &&
+    !isExecApprovalPolicySnapshotCurrent(
+      parsed.delayedApprovalPolicySnapshot,
+      currentPolicySnapshot,
+    )
+  ) {
+    await sendSystemRunDenied(opts, parsed.execution, {
+      reason: "approval-required",
+      message: "SYSTEM_RUN_DENIED: exec approval policy changed; request approval again",
+    });
+    return null;
+  }
+  const evaluationPolicySnapshot = parsed.delayedApprovalPolicySnapshot ?? currentPolicySnapshot;
   const baseSecurity = effectivePolicy.security;
   const baseAsk = effectivePolicy.ask;
   const fallbackRequest = parsed.approvalSource === "ask-fallback";
@@ -797,7 +832,7 @@ async function evaluateSystemRunPolicyPhase(
     argv: hardenedPaths.argv,
     cwd: hardenedPaths.cwd,
     approvals,
-    allowAlwaysPolicySnapshot,
+    evaluationPolicySnapshot,
     security,
     ask,
     policy,
@@ -932,6 +967,7 @@ async function executeSystemRunPhase(
       sessionKey: phase.sessionKey ?? null,
       approvalDecision: macApprovalSource ? null : phase.approvalDecision,
       approvalSource: macApprovalSource,
+      ...(phase.approvalGrantSource ? { policySnapshot: phase.evaluationPolicySnapshot } : {}),
     };
     const response = await opts.runViaMacAppExecHost({
       approvals: phase.approvals,
@@ -985,14 +1021,14 @@ async function executeSystemRunPhase(
       : phase.approvalSource === "auto-review"
         ? "auto-review"
         : (phase.approvalGrantSource ?? "current-policy");
-  const persistsAllowAlways =
-    allowAlwaysDecision !== undefined && allowAlwaysDecision.kind !== "one-shot";
+  const delayedAuthorization =
+    authorizationSource === "explicit-approval" || authorizationSource === "auto-review";
   const authorization: ExecApprovalUsageAuthorization = {
     source: authorizationSource,
     security: phase.security,
     ask: phase.ask,
     allowlistSatisfied: phase.allowlistAuthorizationSatisfied || phase.durableApprovalSatisfied,
-    ...(persistsAllowAlways ? { policySnapshot: phase.allowAlwaysPolicySnapshot } : {}),
+    ...(delayedAuthorization ? { policySnapshot: phase.evaluationPolicySnapshot } : {}),
     requireAutoAllowSkills: phase.segmentSatisfiedBy.includes("skills"),
     requireExactCommandApproval: phase.durableApprovalRequirement === "exact-command",
     requireDurableAllowlistApproval: phase.durableApprovalRequirement === "segment-allowlist",

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -10,14 +10,23 @@ import type { SkillBinsProvider } from "./invoke-types.js";
 import { handleInvoke } from "./invoke.js";
 
 const approvalResolutionFailure = vi.hoisted(() => ({ error: null as Error | null }));
+type ExecApprovalsUpdate = Parameters<
+  typeof import("../infra/exec-approvals.js").updateExecApprovals
+>[0];
 const execApprovalsStoreMock = vi.hoisted(() => ({
   ensureError: undefined as Error | undefined,
   ensureResult: undefined as unknown,
   hasEnsureResult: false,
+  ensureCalls: 0,
+  readError: undefined as Error | undefined,
+  readResult: undefined as unknown,
+  hasReadResult: false,
+  readCalls: 0,
   updateError: undefined as Error | undefined,
   updateResult: undefined as unknown,
   hasUpdateResult: false,
   updateCalls: 0,
+  updateParams: undefined as ExecApprovalsUpdate | undefined,
 }));
 
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
@@ -25,6 +34,7 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   return {
     ...original,
     ensureExecApprovalsSnapshot: async () => {
+      execApprovalsStoreMock.ensureCalls += 1;
       if (execApprovalsStoreMock.ensureError !== undefined) {
         throw execApprovalsStoreMock.ensureError;
       }
@@ -35,8 +45,21 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
       }
       return await original.ensureExecApprovalsSnapshot();
     },
+    readExecApprovalsSnapshot: () => {
+      execApprovalsStoreMock.readCalls += 1;
+      if (execApprovalsStoreMock.readError !== undefined) {
+        throw execApprovalsStoreMock.readError;
+      }
+      if (execApprovalsStoreMock.hasReadResult) {
+        return execApprovalsStoreMock.readResult as ReturnType<
+          typeof original.readExecApprovalsSnapshot
+        >;
+      }
+      return original.readExecApprovalsSnapshot();
+    },
     updateExecApprovals: async (...args: Parameters<typeof original.updateExecApprovals>) => {
       execApprovalsStoreMock.updateCalls += 1;
+      execApprovalsStoreMock.updateParams = args[0];
       if (execApprovalsStoreMock.updateError !== undefined) {
         throw execApprovalsStoreMock.updateError;
       }
@@ -114,10 +137,16 @@ describe("node host invoke", () => {
     execApprovalsStoreMock.ensureError = undefined;
     execApprovalsStoreMock.ensureResult = undefined;
     execApprovalsStoreMock.hasEnsureResult = false;
+    execApprovalsStoreMock.ensureCalls = 0;
+    execApprovalsStoreMock.readError = undefined;
+    execApprovalsStoreMock.readResult = undefined;
+    execApprovalsStoreMock.hasReadResult = false;
+    execApprovalsStoreMock.readCalls = 0;
     execApprovalsStoreMock.updateError = undefined;
     execApprovalsStoreMock.updateResult = undefined;
     execApprovalsStoreMock.hasUpdateResult = false;
     execApprovalsStoreMock.updateCalls = 0;
+    execApprovalsStoreMock.updateParams = undefined;
   });
 
   it("returns a redacted exec approvals snapshot", async () => {
@@ -137,8 +166,8 @@ describe("node host invoke", () => {
   });
 
   it("updates exec approvals and redacts the resulting snapshot", async () => {
-    execApprovalsStoreMock.hasEnsureResult = true;
-    execApprovalsStoreMock.ensureResult = createExecApprovalsSnapshot();
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = createExecApprovalsSnapshot();
     execApprovalsStoreMock.hasUpdateResult = true;
     execApprovalsStoreMock.updateResult = createExecApprovalsSnapshot({
       hash: "hash-after",
@@ -154,6 +183,8 @@ describe("node host invoke", () => {
     });
 
     expect(execApprovalsStoreMock.updateCalls).toBe(1);
+    expect(execApprovalsStoreMock.ensureCalls).toBe(0);
+    expect(execApprovalsStoreMock.readCalls).toBe(1);
     expect(JSON.parse(result.payloadJSON ?? "{}")).toEqual({
       path: "/tmp/exec-approvals.json",
       exists: true,
@@ -167,8 +198,8 @@ describe("node host invoke", () => {
   });
 
   it("rejects an exec approvals update with a stale base hash", async () => {
-    execApprovalsStoreMock.hasEnsureResult = true;
-    execApprovalsStoreMock.ensureResult = createExecApprovalsSnapshot();
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = createExecApprovalsSnapshot();
     const result = await invokeExecApprovals("system.execApprovals.set", {
       baseHash: "stale-hash",
       file: { version: 1 },
@@ -184,9 +215,66 @@ describe("node host invoke", () => {
     });
   });
 
+  it("rejects a stale save without recreating deleted node approval state", async () => {
+    const missingSnapshot = createExecApprovalsSnapshot({
+      exists: false,
+      raw: null,
+      hash: "sha256:missing",
+      file: { version: 1, agents: {} },
+    });
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = missingSnapshot;
+
+    const result = await invokeExecApprovals("system.execApprovals.set", {
+      baseHash: "hash-before",
+      file: { version: 1, agents: {} },
+    });
+
+    expect(execApprovalsStoreMock.ensureCalls).toBe(0);
+    expect(execApprovalsStoreMock.readCalls).toBe(1);
+    expect(execApprovalsStoreMock.updateCalls).toBe(0);
+    expect(missingSnapshot.file.socket).toBeUndefined();
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("exec approvals changed"),
+      },
+    });
+  });
+
+  it("initializes socket credentials in the first accepted node approval write", async () => {
+    const missingSnapshot = createExecApprovalsSnapshot({
+      exists: false,
+      raw: null,
+      hash: "sha256:missing",
+      file: { version: 1, agents: {} },
+    });
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = missingSnapshot;
+    execApprovalsStoreMock.hasUpdateResult = true;
+    execApprovalsStoreMock.updateResult = createExecApprovalsSnapshot({ hash: "sha256:created" });
+
+    const result = await invokeExecApprovals("system.execApprovals.set", {
+      file: { version: 1, agents: { main: {} } },
+    });
+    const prepared = execApprovalsStoreMock.updateParams?.update(missingSnapshot.file);
+
+    expect(execApprovalsStoreMock.ensureCalls).toBe(0);
+    expect(execApprovalsStoreMock.readCalls).toBe(1);
+    expect(execApprovalsStoreMock.updateCalls).toBe(1);
+    expect(execApprovalsStoreMock.updateParams?.baseHash).toBe(missingSnapshot.hash);
+    expect(prepared?.socket?.path).toBeTruthy();
+    expect(prepared?.socket?.token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(JSON.parse(result.payloadJSON ?? "{}")).toMatchObject({
+      hash: "sha256:created",
+      file: { socket: { path: "/tmp/exec-approvals.sock" } },
+    });
+  });
+
   it("rejects an exec approvals update when the locked CAS loses its race", async () => {
-    execApprovalsStoreMock.hasEnsureResult = true;
-    execApprovalsStoreMock.ensureResult = createExecApprovalsSnapshot();
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = createExecApprovalsSnapshot();
     execApprovalsStoreMock.hasUpdateResult = true;
     execApprovalsStoreMock.updateResult = null;
     const result = await invokeExecApprovals("system.execApprovals.set", {
@@ -235,7 +323,7 @@ describe("node host invoke", () => {
   });
 
   it("classifies exec approvals filesystem failures as UNAVAILABLE", async () => {
-    execApprovalsStoreMock.ensureError = Object.assign(new Error("permission denied"), {
+    execApprovalsStoreMock.readError = Object.assign(new Error("permission denied"), {
       code: "EACCES",
     });
     const result = await invokeExecApprovals("system.execApprovals.set", {
@@ -252,8 +340,8 @@ describe("node host invoke", () => {
   });
 
   it("classifies exec approvals update failures as UNAVAILABLE", async () => {
-    execApprovalsStoreMock.hasEnsureResult = true;
-    execApprovalsStoreMock.ensureResult = createExecApprovalsSnapshot();
+    execApprovalsStoreMock.hasReadResult = true;
+    execApprovalsStoreMock.readResult = createExecApprovalsSnapshot();
     execApprovalsStoreMock.updateError = new Error("approval store write failed");
     const result = await invokeExecApprovals("system.execApprovals.set", {
       baseHash: "hash-before",
@@ -464,14 +552,43 @@ describe("node host invoke", () => {
           version: 1,
           defaults: { security: "allowlist", ask: "on-miss", askFallback: "deny" },
         });
+        const scriptPath = path.join(tempHome, "noop.cjs");
+        fs.writeFileSync(scriptPath, "");
         const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
+        await handleInvoke(
+          {
+            id: "invoke-suppress-notify-prepare",
+            nodeId: "node-1",
+            command: "system.run.prepare",
+            paramsJSON: JSON.stringify({
+              command: [process.execPath, scriptPath],
+              cwd: tempHome,
+              sessionKey: "agent:main:main",
+            }),
+          },
+          { request } as unknown as GatewayClient,
+          { current: async () => [] },
+        );
+        const prepareResult = request.mock.calls.find(
+          ([method, params]) =>
+            method === "node.invoke.result" &&
+            (params as { id?: string } | undefined)?.id === "invoke-suppress-notify-prepare",
+        )?.[1] as { payloadJSON?: string | null } | undefined;
+        const prepared = JSON.parse(prepareResult?.payloadJSON ?? "{}") as {
+          plan?: Record<string, unknown>;
+        };
+        expect(prepared.plan).toBeDefined();
         await handleInvoke(
           {
             id: "invoke-suppress-notify",
             nodeId: "node-1",
             command: "system.run",
             paramsJSON: JSON.stringify({
-              command: [process.execPath, "-e", ""],
+              command: prepared.plan?.argv,
+              rawCommand: prepared.plan?.commandText,
+              cwd: prepared.plan?.cwd,
+              sessionKey: "agent:main:main",
+              systemRunPlan: prepared.plan,
               approved: true,
               approvalDecision: "allow-once",
               suppressNotifyOnExit: true,
@@ -548,7 +665,17 @@ describe("node host invoke", () => {
     };
     const payload = JSON.parse(result.payloadJSON ?? "{}") as {
       execPolicy?: { security?: string; ask?: string };
+      plan?: { policySnapshot?: unknown };
     };
     expect(payload.execPolicy).toEqual({ security: "allowlist", ask: "on-miss" });
+    // The plan snapshot binds persisted approval state. Effective config-layer
+    // policy is returned separately above and re-evaluated at execution.
+    expect(payload.plan?.policySnapshot).toEqual({
+      security: "full",
+      ask: "off",
+      askFallback: "deny",
+      autoAllowSkills: false,
+      allowlistRules: [],
+    });
   });
 });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -8,9 +8,11 @@ import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { GatewayClient } from "../gateway/client.js";
 import {
   analyzeArgvCommand,
+  createExecApprovalPolicySnapshot,
   ensureExecApprovalsSnapshot,
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
+  readExecApprovalsSnapshot,
   resolveAllowAlwaysPatternCoverage,
   updateExecApprovals,
   type ExecAsk,
@@ -255,13 +257,16 @@ function requireExecApprovalsBaseHash(
   params: SystemExecApprovalsSetParams,
   snapshot: ExecApprovalsSnapshot,
 ) {
+  const baseHash = typeof params.baseHash === "string" ? params.baseHash.trim() : "";
   if (!snapshot.exists) {
+    if (baseHash && baseHash !== snapshot.hash) {
+      throw new Error("INVALID_REQUEST: exec approvals changed; reload and retry");
+    }
     return;
   }
   if (!snapshot.hash) {
     throw new Error("INVALID_REQUEST: exec approvals base hash unavailable; reload and retry");
   }
-  const baseHash = typeof params.baseHash === "string" ? params.baseHash.trim() : "";
   if (!baseHash) {
     throw new Error("INVALID_REQUEST: exec approvals base hash required; reload and retry");
   }
@@ -661,7 +666,8 @@ async function dispatchInvoke(
 
     let snapshot: ExecApprovalsSnapshot;
     try {
-      snapshot = await ensureExecApprovalsSnapshot();
+      // A stale save must not initialize state before its base hash is checked.
+      snapshot = readExecApprovalsSnapshot();
     } catch (err) {
       await sendExecApprovalsStorageErrorResult(client, frame, err);
       return;
@@ -755,8 +761,15 @@ async function dispatchInvoke(
         defaultAsk: resolveExecAsk(undefined),
         requireSocket: preferMacAppExecHost,
       });
+      const plan = {
+        ...prepared.plan,
+        policySnapshot: createExecApprovalPolicySnapshot({
+          file: execPolicy.approvals.file,
+          agentId: prepared.plan.agentId ?? undefined,
+        }),
+      };
       await sendJsonPayloadResult(client, frame, {
-        plan: prepared.plan,
+        plan,
         execPolicy: {
           security: execPolicy.security,
           ask: execPolicy.ask,


### PR DESCRIPTION
Related: #103877

Dependency: a focused macOS HMAC socket-owner follow-up must land immediately after this PR before #103877 is closed. This PR adds the portable snapshot contract and fixes the CLI, Gateway, node host, and direct macOS approval paths, but the current socket owner does not yet decode the forwarded snapshot. #103873 remains open for the broader Mac App `system.run.prepare` capability-parity work.

Adjacent: #103900 remains open for a focused dependent fix. This PR binds delayed authority to the persisted `exec-approvals.json` projection; it deliberately does not bind hot `tools.exec` runtime inputs such as model auto-review eligibility, safe bins, safe-bin profiles, or trusted directories.

## What Problem This Solves

Fixes issues where revoked or tightened exec policy could be restored by a failed CLI rollback, overwritten by a stale Gateway/node save, or bypassed by a delayed explicit or auto-reviewed node approval. The races occur when another policy writer changes the approvals store between prepare, approval, persistence, and execution.

## Why This Change Was Made

Rollback and approval-store writes now use locked compare-and-swap updates without mutating rejected state, including safe first-write socket credential initialization. Prepared node runs carry a canonical snapshot of persisted approval policy, and delayed explicit/model authority is rejected when that snapshot no longer matches at the final local commit. Snapshot rule ordering is defined cross-runtime as UTF-8 byte lexicographic tuple order so TypeScript and Swift preserve the same wire value.

The macOS store also keeps stale/revoked row mutations as no-ops, rejects edits to inherited wildcard rows, and revalidates direct delayed approvals. A focused dependent PR owns the remaining HMAC decode/final-owner use of this new protocol field and is intentionally stacked on this exact head; #103873 continues separately as the broader native prepare/capability repair.

## User Impact

Failed policy synchronization can no longer silently leave permissive defaults or restore revoked access. Stale approval-editor saves fail without recreating deleted state, and delayed node approvals require a fresh review after policy tightening. Operators retain concurrent socket, agent, and allowlist changes.

## Evidence

- Blacksmith Testbox focused proof: 195 tests passed across CLI/node/policy/store paths; core tsgo passed. Workflow: https://github.com/openclaw/openclaw/actions/runs/29124249127
- Exact follow-up proof on Testbox-through-Crabbox `tbx_01kx6z34b7xazac3tcbacfpqpq`: architecture guards and import cycles passed, native i18n reported `entries=2924 changed=false`, core and extension test types reported zero errors, path oxlint reported zero findings, and 272 focused TS assertions passed. Workflow: https://github.com/openclaw/openclaw/actions/runs/29124975164
- Earlier full focused TS batch: 91/91 passed across system-run binding and invocation paths.
- macOS focused proof: 100/100 tests passed across `ExecApprovalsStoreRefactorTests`, `ExecHostRequestEvaluatorTests`, and `ExecApprovalsUIRollbackTests`.
- The focused macOS HMAC owner follow-up will publish its own exact-head Swift proof before this PR merges.
- `git diff --check` passed on exact head `d5b4fe6f288f4aadc1edd17995e9bed8b7f08da7`.
- Fresh exact-diff autoreview reported no accepted/actionable findings (0.97 correctness). Integrated security review found no other P0-P2 issue beyond the explicitly declared focused Mac socket-owner dependency, the broader #103873 parity work, and distinct #103900 runtime-config follow-up.

AI-assisted implementation; the author reviewed the owner boundaries, rollback/CAS invariants, policy snapshot contract, cross-runtime canonicalization, and focused proof.
