### PR TITLE
fix(agents): fail closed when compaction qualityGuard rejects the final summary (#103931)

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1625,6 +1625,64 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels compaction when the summary still fails the quality audit after all retries", async () => {
+    // #103931: adopting a summary the guard just proved structurally broken
+    // silently replaced history with known-bad content. Exhausted retries with
+    // a failing audit must fail closed like the exception path.
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages
+      .mockResolvedValueOnce("unstructured fragment one")
+      .mockResolvedValueOnce("unstructured fragment two");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 1,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "older context", timestamp: 1 },
+          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          { role: "user", content: "latest ask status", timestamp: 3 },
+          {
+            role: "assistant",
+            content: "latest assistant reply",
+            timestamp: 4,
+          } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).toBe(true);
+    expect(result.compaction).toBeUndefined();
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+  });
+
   it("retries when generated summary misses headings even if preserved turns contain them", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages
@@ -1632,7 +1690,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       .mockResolvedValueOnce(
         [
           "## Decisions",
-          "Keep current flow.",
+          "Keep current flow for the older context thread.",
           "## Open TODOs",
           "None.",
           "## Constraints/Rules",

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1262,6 +1262,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               `Compaction safeguard: quality retry failed on attempt ${attempt + 1}; ` +
                 `keeping last successful summary: ${formatErrorMessage(attemptError)}`,
             );
+            // Deliberate resilience adoption (already surfaced via the warn):
+            // the fail-closed audit gate below only applies when the final
+            // attempt's audit actually completed and rejected the summary.
+            finalQualityFailureReasons = undefined;
             summary = lastSuccessfulSummary;
             break;
           }
@@ -1275,6 +1279,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           messagesToSummarize.length > 0 ||
           (preparation.isSplitTurn && turnPrefixMessages.length > 0);
         if (!qualityGuardEnabled || !canRegenerate) {
+          // No final audit ran on this attempt: adopting here is the
+          // pre-existing contract, so a stale failure from an earlier
+          // attempt must not cancel the compaction.
+          finalQualityFailureReasons = undefined;
           summary = summaryWithPreservedTurns;
           break;
         }

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1201,6 +1201,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       let lastSplitTurnSection = "";
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
+      // Set on every audited attempt; still defined after the loop means the
+      // guard rejected the final attempt too and compaction must fail closed.
+      let finalQualityFailureReasons: string[] | undefined;
       let lastSuccessfulSummary: string | null = null;
 
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
@@ -1282,6 +1285,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           identifierPolicy,
         });
         summary = summaryWithPreservedTurns;
+        finalQualityFailureReasons = quality.ok ? undefined : quality.reasons;
         if (quality.ok || attempt >= totalAttempts - 1) {
           break;
         }
@@ -1297,6 +1301,21 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         currentInstructions = qualityFeedbackReasons
           ? `${structuredInstructions}\n\n${qualityFeedbackInstruction}\n\n${qualityFeedbackReasons}`
           : `${structuredInstructions}\n\n${qualityFeedbackInstruction}`;
+      }
+
+      if (finalQualityFailureReasons) {
+        // Quality-audit rejection must fail closed like the exception path
+        // below: adopting a summary the guard just proved structurally broken
+        // silently replaces older history with known-bad content (#103931).
+        const reasons = finalQualityFailureReasons.join(", ");
+        log.warn(
+          `Compaction safeguard: summary failed quality audit after ${totalAttempts} attempt(s) (${reasons}); cancelling compaction to preserve history`,
+        );
+        setCompactionSafeguardCancelReason(
+          ctx.sessionManager,
+          `Compaction safeguard rejected the summary after ${totalAttempts} attempt(s): ${reasons}`,
+        );
+        return { cancel: true };
       }
 
       // Cap the main history body first, then append split-turn context, preserved


### PR DESCRIPTION
## Summary

Fixes #103931.

Safeguard-mode compaction's `qualityGuard` runs a structural audit (`auditSummaryQuality`) and retries on failure — but the retry loop's `if (quality.ok || attempt >= totalAttempts - 1) break;` exits identically for "passed" and "retries exhausted", and nothing after the loop re-checks the outcome. A summary the guard had just proven structurally broken (missing required sections, dropped exact identifiers, unreflected latest user ask) was silently adopted as the compaction result: no warning, no `cancel: true`, and the session's older history was permanently replaced by known-bad content. The exception path a few lines below already fails closed; the completed-but-rejected audit did not.

### Change

`src/agents/agent-hooks/compaction-safeguard.ts`:
- Track the final audit outcome per attempt (`finalQualityFailureReasons`). If the last attempt's audit still fails, mirror the exception path: `log.warn` with the audit reasons, `setCompactionSafeguardCancelReason(...)`, and `return { cancel: true }` so history is preserved instead of overwritten (the issue's suggested fix, option 1).
- Deliberate resilience adoptions are explicitly preserved: the no-regenerate break (nothing to retry with — no final audit ran) and the mid-retry-throw keep-last-summary fallback (which already emits its own warn) clear the flag, so those paths behave exactly as before.
- Two existing fixtures that leaned on the silent fail-open adoption were corrected rather than deleted: the retry-success test's second summary now genuinely reflects the summarized window's latest ask (so it exercises pass-after-retry, its stated purpose), and the capped-fallback test stays on the intended keep-last-summary path.

## Verification

- New regression `cancels compaction when the summary still fails the quality audit after all retries` — both mocked attempts fail the audit → `cancel: true`, no `compaction` payload, exactly 2 summarize calls. Confirmed this is the previously-silent path (instrumentation showed `latest_user_ask_not_reflected` adopted with zero logging on main).
- `pnpm test src/agents/agent-hooks/compaction-safeguard.test.ts` — 106/106 pass.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt — clean.

## Real behavior proof

Behavior addressed: qualityGuard-rejected summaries are adopted silently after retries are exhausted, replacing history with content the guard proved malformed.
Real environment tested: the real `session_before_compact` safeguard handler driven end to end through its existing harness (real audit, real retry loop, mocked LLM output only).
Exact steps or command run after this patch: `pnpm test src/agents/agent-hooks/compaction-safeguard.test.ts`
Evidence after fix: two consecutively failing audits now produce `cancel: true` with the reasons recorded via `setCompactionSafeguardCancelReason`; a failing-then-passing retry still adopts the passing summary; the mid-retry-throw fallback still keeps the last successful summary with its warn.
Observed result after fix: compaction fails closed on confirmed-bad summaries, matching the mode's purpose and the existing exception path.
What was not tested: a live model producing structurally broken summaries; the audit and adoption logic is deterministic and fully exercised by the harness.
