### PR TITLE
fix(nodes): correct system.which examples

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -50,7 +50,7 @@ These commands drive the gateway-owned `node.pair.*` store, separate from device
 ## Invoke
 
 ```bash
-openclaw nodes invoke --node <id> --command system.which --params '{"name":"uname"}'
+openclaw nodes invoke --node <id> --command system.which --params '{"bins":["uname"]}'
 ```
 
 Flags:

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -444,7 +444,7 @@ Examples:
 
 ```bash
 openclaw nodes notify --node <idOrNameOrIp> --title "Ping" --body "Gateway ready"
-openclaw nodes invoke --node <idOrNameOrIp> --command system.which --params '{"name":"git"}'
+openclaw nodes invoke --node <idOrNameOrIp> --command system.which --params '{"bins":["git"]}'
 ```
 
 Notes:

--- a/src/cli/nodes-cli.plugin-registration.test.ts
+++ b/src/cli/nodes-cli.plugin-registration.test.ts
@@ -79,6 +79,22 @@ describe("registerNodesCli plugin registration", () => {
     );
   });
 
+  it("documents the supported system.which parameter shape", async () => {
+    const program = await registerWithArgv(["node", "openclaw", "nodes", "--help"]);
+    const nodesCommand = program.commands.find((command) => command.name() === "nodes");
+    const output: string[] = [];
+
+    nodesCommand?.configureOutput({
+      writeOut: (value) => output.push(value),
+      writeErr: (value) => output.push(value),
+    });
+    nodesCommand?.outputHelp();
+    const help = output.join("");
+
+    expect(help).toContain(`--params '{"bins":["uname"]}'`);
+    expect(help).not.toContain(`--params '{"name":"uname"}'`);
+  });
+
   it("does not route pass-through --json after the terminator", async () => {
     let forceStderrDuringRegistration = true;
     registerPluginCliCommandsFromValidatedConfig.mockImplementationOnce(async () => {

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -27,7 +27,7 @@ export async function registerNodesCli(program: Command, argv: readonly string[]
           ["openclaw nodes pairing pending", "Show pending node pairing requests."],
           ["openclaw nodes remove --node <id|name|ip>", "Remove a stale paired node entry."],
           [
-            'openclaw nodes invoke --node <id> --command system.which --params \'{"name":"uname"}\'',
+            'openclaw nodes invoke --node <id> --command system.which --params \'{"bins":["uname"]}\'',
             "Invoke a node command directly.",
           ],
           ["openclaw nodes camera snap --node <id>", "Capture a photo from a node camera."],


### PR DESCRIPTION
Closes #103888

## What Problem This Solves

Fixes an issue where operators copying the `system.which` example from `openclaw nodes --help` or either node guide would get `INVALID_REQUEST: bins required` because all three examples sent the unsupported singular `name` field.

## Why This Change Was Made

All shipped examples now use the canonical `bins` array accepted by both the headless node host and macOS node. A focused CLI-help regression test keeps the displayed example aligned with that contract; the runtime does not retain an alias for the erroneous documentation shape.

## User Impact

Operators can copy the documented `system.which` invocation to verify node connectivity and binary availability without first correcting its JSON parameters.

## Evidence

- Before: real `openclaw nodes --help` output showed `--params '{"name":"uname"}'`.
- After: real rebuilt CLI help shows `--params '{"bins":["uname"]}'`.
- Live node proof: from the clawmac Gateway, `nodes invoke --node megaclaw --command system.which --params '{"bins":["uname"]}' --json` returned `{"ok":true,"command":"system.which","payload":{"paths":{"uname":"/usr/bin/uname"},"bins":["uname"]}}` against connected macOS node `megaclaw`.
- Blacksmith Testbox `tbx_01kx6yygvd6zjh16w1bkyptsae`: `pnpm test src/cli/nodes-cli.plugin-registration.test.ts` — 5 tests passed.
- Same Testbox lease: `pnpm check:changed` — core/core-tests/docs lanes passed, including typecheck, lint, guards, and zero runtime import cycles.
- `pnpm docs:list` completed successfully.
- `pnpm exec oxfmt --check src/cli/nodes-cli/register.ts src/cli/nodes-cli.plugin-registration.test.ts docs/cli/nodes.md docs/nodes/index.md` passed.
- `git diff --check` passed.
- Fresh autoreview: clean, 0.99 confidence, no accepted or actionable findings.

AI-assisted: Codex implemented and validated this fix; the maintainer requested no transcript attachment.
