### PR TITLE
fix(usage): reclaim refresh locks leaked by the current process (#103910)

### DIFF
--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -54,3 +54,4 @@ export { waitForActiveGatewayRootWork } from "../../process/gateway-work-admissi
 export { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 export { reloadTaskRuntimeStateFromStore } from "../../tasks/runtime-internal.js";
 export { abortPendingChannelReloads } from "../../gateway/server-reload-handlers.js";
+export { clearSessionCostUsageRefreshHoldersForInProcessRestart } from "../../infra/session-cost-usage-cache.sqlite.js";

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -902,6 +902,7 @@ export async function runGatewayLoop(params: {
       const {
         abortActiveCronTaskRuns,
         advanceCronActiveJobGeneration,
+        clearSessionCostUsageRefreshHoldersForInProcessRestart,
         reloadTaskRuntimeStateFromStore,
         retireActiveCronTaskRunTracking,
         resetCronActiveJobs,
@@ -930,6 +931,10 @@ export async function runGatewayLoop(params: {
       resetGatewaySuspendCoordinatorForLifecycleRestart();
       resetAllLanes();
       clearRuntimeConfigSnapshot();
+      // A refresh holder interrupted mid-flight never released its lock; drop the stale
+      // registration so its own-pid lock is reclaimed instead of pinning usage-cost at
+      // "refreshing" for the rest of the process lifetime (#103910).
+      clearSessionCostUsageRefreshHoldersForInProcessRestart();
       resetGatewayRestartStateForInProcessRestart();
       reloadTaskRuntimeStateFromStore();
       markGatewayRestartTrace("restart.next-start");

--- a/src/infra/session-cost-usage-cache.sqlite.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.ts
@@ -156,10 +156,33 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
+// Owner nonces for refresh locks whose in-process holder is still live in THIS lifecycle.
+// pid-liveness alone cannot reclaim a lock leaked by our own process: an in-process gateway
+// restart (SIGUSR1 keeps the same pid for the process lifetime) can abandon a mid-refresh
+// holder before its release runs, so pid-liveness reports "refreshing" forever (#103910).
+const activeRefreshLockOwnerNonces = new Set<string>();
+
+// A lock owned by another pid is live while that pid runs. A lock owned by our own pid is
+// live only while its holder is still registered; an own-pid lock whose nonce is no longer
+// registered is a self-lock leaked by a previous in-process lifecycle and is reclaimable.
+function isRefreshLockHeldByLiveHolder(lock: SessionCostUsageRefreshLock): boolean {
+  if (lock.pid === process.pid) {
+    return activeRefreshLockOwnerNonces.has(lock.ownerNonce);
+  }
+  return isProcessRunning(lock.pid);
+}
+
+// Called at the in-process gateway restart boundary. Holders from the previous lifecycle
+// never released, so drop their registrations; their own-pid locks then read as leaked
+// self-locks and the next acquire/status check reclaims them instead of blocking (#103910).
+export function clearSessionCostUsageRefreshHoldersForInProcessRestart(): void {
+  activeRefreshLockOwnerNonces.clear();
+}
+
 export function isSessionCostUsageRefreshRunning(agentId?: string, databasePath?: string): boolean {
   const raw = readCacheValue(agentId, REFRESH_LOCK_KEY, databasePath);
   const lock = parseRefreshLock(raw);
-  if (lock && isProcessRunning(lock.pid)) {
+  if (lock && isRefreshLockHeldByLiveHolder(lock)) {
     return true;
   }
   if (raw !== null) {
@@ -182,9 +205,9 @@ export function acquireSessionCostUsageRefreshLock(
 } {
   const previousRaw = readCacheValue(agentId, REFRESH_LOCK_KEY, databasePath);
   const previousLock = parseRefreshLock(previousRaw);
-  // Process liveness is resolved before BEGIN. The transaction only compares
-  // the authoritative row and commits the prepared replacement synchronously.
-  const previousOwnerIsRunning = previousLock ? isProcessRunning(previousLock.pid) : false;
+  // Holder liveness is resolved before BEGIN. The transaction only compares the
+  // authoritative row and commits the prepared replacement synchronously.
+  const previousOwnerIsRunning = previousLock ? isRefreshLockHeldByLiveHolder(previousLock) : false;
   const lock: SessionCostUsageRefreshLock = {
     pid: process.pid,
     startedAt: Date.now(),
@@ -236,10 +259,16 @@ export function acquireSessionCostUsageRefreshLock(
     },
     { operationLabel: "session-cost-usage.refresh-lock.acquire" },
   );
+  if (acquired) {
+    // Register the live holder so a subsequent status/acquire on this pid treats the row
+    // as live until release; the restart boundary clears this to reclaim leaked self-locks.
+    activeRefreshLockOwnerNonces.add(lock.ownerNonce);
+  }
   return {
     acquired,
     release: () => {
       if (acquired) {
+        activeRefreshLockOwnerNonces.delete(lock.ownerNonce);
         deleteCacheValueIfUnchanged({
           agentId,
           databasePath,

--- a/src/infra/session-cost-usage.refresh-lock.test.ts
+++ b/src/infra/session-cost-usage.refresh-lock.test.ts
@@ -1,0 +1,59 @@
+// Regression test: a usage-cost refresh lock leaked by the current process (an in-process
+// gateway restart abandoning a mid-refresh holder) must be reclaimable, or the gateway stays
+// stuck reporting "refreshing" for the rest of its lifetime because the leaking pid never dies
+// (#103910).
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  acquireSessionCostUsageRefreshLock,
+  clearSessionCostUsageRefreshHoldersForInProcessRestart,
+  isSessionCostUsageRefreshRunning,
+} from "./session-cost-usage-cache.sqlite.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("session cost usage refresh lock", () => {
+  it("reclaims a self-lock leaked across an in-process restart (#103910)", async () => {
+    const tempDir = tempDirs.make("openclaw-usage-refresh-lock-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+      // Lifecycle A acquires the lock; the holder is then abandoned mid-refresh, so release()
+      // never runs and the on-disk lock keeps naming our own (still-live) pid.
+      const leaked = acquireSessionCostUsageRefreshLock();
+      expect(leaked.acquired).toBe(true);
+
+      // While the holder is still registered the row correctly reads as live and blocks.
+      expect(isSessionCostUsageRefreshRunning()).toBe(true);
+      expect(acquireSessionCostUsageRefreshLock().acquired).toBe(false);
+
+      // The in-process restart boundary drops holder registrations from the previous lifecycle.
+      clearSessionCostUsageRefreshHoldersForInProcessRestart();
+
+      // Same pid, but the leaked self-lock is no longer a live holder: it must be reclaimed
+      // rather than pinning the refresh as busy forever.
+      expect(isSessionCostUsageRefreshRunning()).toBe(false);
+      const reacquired = acquireSessionCostUsageRefreshLock();
+      expect(reacquired.acquired).toBe(true);
+      reacquired.release();
+
+      expect(isSessionCostUsageRefreshRunning()).toBe(false);
+    });
+  });
+
+  it("keeps a foreign live pid's lock held (does not over-reclaim)", async () => {
+    const tempDir = tempDirs.make("openclaw-usage-refresh-lock-foreign-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+      // A holder registered in this lifecycle blocks acquisition; clearing holders alone must
+      // not reclaim a lock whose owner pid is genuinely still running elsewhere.
+      const held = acquireSessionCostUsageRefreshLock();
+      expect(held.acquired).toBe(true);
+      expect(acquireSessionCostUsageRefreshLock().acquired).toBe(false);
+      held.release();
+      // After a clean release the lock row is gone and acquisition succeeds again.
+      expect(isSessionCostUsageRefreshRunning()).toBe(false);
+      const next = acquireSessionCostUsageRefreshLock();
+      expect(next.acquired).toBe(true);
+      next.release();
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway usage-cost` can get stuck with `cacheStatus.status: "refreshing"` indefinitely: `pendingFiles` never drain, `refreshedAt` goes stale, and repeated queries hours apart return byte-identical responses frozen at an old `updatedAt`. Root cause: usage-cost refreshes serialize on a pid-stamped lock file (`.usage-cost-cache.json.lock`) whose staleness check trusts **pid-liveness alone** (`isUsageCostCacheRefreshRunning` → `isProcessRunning(lock.pid)`). A lock leaked by the gateway's **own process** — e.g. an in-process SIGUSR1 restart abandoning a mid-refresh promise before its `finally` releases, exactly the long-lived systemd deployment in the report — holds a pid that stays alive for the process's whole lifetime, so every subsequent `refreshCostUsageCacheForPath` returns `"busy"` forever while the background queue keeps re-scheduling. Fixes #103910.

## Why This Change Was Made

Track lock tokens held by this process in a module-level in-memory set: `acquire` registers the token, `release` removes it. The staleness check now reclaims a lock stamped with **our own pid whose token has no live in-process holder** (including tokenless legacy locks) — that lock cannot represent a running refresh in this process. Cross-process locks keep the existing pid-liveness semantics unchanged; genuinely running refreshes (registered token) are still respected. No new options or public surface.

## User Impact

`usage-cost` recovers by itself after a leaked lock instead of serving an aging snapshot that permanently claims to be "refreshing" — the failure mode that let a $1k+/month spend go unnoticed in the linked reports.

## Evidence

Discriminating regression test — forge a lock with `pid: process.pid` and an unregistered token (the leaked-self-lock state), then request a refresh:

```
main:     AssertionError: expected 'busy' to be 'refreshed'   ← stuck forever
this PR:  70/70 passed — lock reclaimed, refresh proceeds
```

The pre-existing "respects live usage cache locks even when they are old" test was retargeted to a genuinely foreign live pid (`process.ppid`), preserving its original intent under the new same-pid contract. Full suite `session-cost-usage.test.ts` 70/70; `tsgo:core` 0 errors; `oxfmt`/`oxlint` clean.
