### PR TITLE
fix(telegram): suppress replies superseded during adoption

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -6392,7 +6392,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
         }
       | undefined;
     let deliverQueuedRoomEvent:
-      | ((payload: { text: string }, info: { kind: "final" }) => Promise<void> | void)
+      | DispatchReplyWithBufferedBlockDispatcherArgs["dispatcherOptions"]["deliver"]
       | undefined;
     let adoptionStarted: (() => void) | undefined;
     const adoptionStartGate = new Promise<void>((resolve) => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -6011,6 +6011,61 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await firstPromise;
   });
 
+  it("keeps supersession latched when it arrives during adoption", async () => {
+    const sessionKey = "agent:main:telegram:direct:adoption-race";
+    let adoptionStarted: (() => void) | undefined;
+    const adoptionStartGate = new Promise<void>((resolve) => {
+      adoptionStarted = resolve;
+    });
+    let releaseAdoption: (() => void) | undefined;
+    const adoptionGate = new Promise<void>((resolve) => {
+      releaseAdoption = resolve;
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onTurnAdopted?.();
+        await dispatcherOptions.deliver({ text: "stale final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const dispatchPromise = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: sessionKey,
+          ChatType: "direct",
+          MessageSid: "101",
+          RawBody: "long turn",
+          BodyForAgent: "long turn",
+          CommandBody: "long turn",
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: 123, type: "private" },
+          message_id: 101,
+          text: "long turn",
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: 123,
+        isGroup: false,
+        threadSpec: { id: undefined, scope: "none" },
+      }),
+      streamMode: "off",
+      onTurnAdopted: async () => {
+        adoptionStarted?.();
+        await adoptionGate;
+      },
+    });
+    await adoptionStartGate;
+
+    const { supersedeTelegramReplyFence } = await import("./telegram-reply-fence.js");
+    expect(supersedeTelegramReplyFence(sessionKey)).toBe(true);
+    releaseAdoption?.();
+    await dispatchPromise;
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("lets authorized /stop kill an adopted run without the released fence controller", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);
@@ -6329,11 +6384,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);
     let roomEventAbortSignal: AbortSignal | undefined;
-    let queuedLifecycle: { onEnqueued?: () => void; onComplete?: () => void } | undefined;
+    let queuedLifecycle:
+      | {
+          onEnqueued?: () => void;
+          onAdmitted?: () => Promise<void> | void;
+          onComplete?: () => void;
+        }
+      | undefined;
+    let deliverQueuedRoomEvent:
+      | ((payload: { text: string }, info: { kind: "final" }) => Promise<void> | void)
+      | undefined;
+    let adoptionStarted: (() => void) | undefined;
+    const adoptionStartGate = new Promise<void>((resolve) => {
+      adoptionStarted = resolve;
+    });
+    let releaseAdoption: (() => void) | undefined;
+    const adoptionGate = new Promise<void>((resolve) => {
+      releaseAdoption = resolve;
+    });
     dispatchReplyWithBufferedBlockDispatcher
-      .mockImplementationOnce(async ({ replyOptions }) => {
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
         roomEventAbortSignal = replyOptions?.abortSignal;
         queuedLifecycle = replyOptions?.queuedFollowupLifecycle;
+        deliverQueuedRoomEvent = dispatcherOptions.deliver;
         queuedLifecycle?.onEnqueued?.();
         return {
           queuedFinal: false,
@@ -6380,8 +6453,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({
       context: createGroupContext("room_event", 99, "ambient chatter"),
       streamMode: "off",
+      onTurnAdopted: async () => {
+        adoptionStarted?.();
+        await adoptionGate;
+      },
     });
     expect(roomEventAbortSignal?.aborted).toBe(false);
+
+    const admissionPromise = queuedLifecycle?.onAdmitted?.();
+    await adoptionStartGate;
 
     await dispatchWithContext({
       context: createGroupContext("user_request", 100, "@bot answer now"),
@@ -6389,6 +6469,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(roomEventAbortSignal?.aborted).toBe(true);
+    releaseAdoption?.();
+    await admissionPromise;
+    await deliverQueuedRoomEvent?.({ text: "stale ambient answer" }, { kind: "final" });
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
     queuedLifecycle?.onComplete?.();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -889,12 +889,15 @@ export const dispatchTelegramMessage = async ({
   let replyAbortControllerQueued = false;
   let queuedTurnAdmitted = false;
   let dispatchWasSuperseded;
+  // Queued source dispatches release their generation before admission but retain this controller.
+  // Its aborted bit preserves supersession across the later async adoption handoff.
   const isDispatchSuperseded = () =>
-    replyFenceGeneration !== undefined &&
-    isTelegramReplyFenceSuperseded({
-      key: activeReplyFenceKey,
-      generation: replyFenceGeneration,
-    });
+    replyAbortController.signal.aborted ||
+    (replyFenceGeneration !== undefined &&
+      isTelegramReplyFenceSuperseded({
+        key: activeReplyFenceKey,
+        generation: replyFenceGeneration,
+      }));
   const releaseReplyFence = () => {
     if (replyFenceGeneration === undefined) {
       return;

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -781,6 +781,49 @@ describe("createFollowupRunner reply-lane admission", () => {
     expect(events).toEqual(["admission-started", "admitted", "run", "complete"]);
   });
 
+  it("stops an aborted queued followup after asynchronous owner admission", async () => {
+    const events: string[] = [];
+    const abortController = new AbortController();
+    let releaseAdmission!: () => void;
+    const admissionBarrier = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
+    });
+    const onBlockReply = vi.fn(async () => {});
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude",
+      opts: { onBlockReply },
+    });
+
+    const pending = runner(
+      createQueuedRun({
+        abortSignal: abortController.signal,
+        queuedLifecycle: {
+          onAdmitted: async () => {
+            events.push("admission-started");
+            await admissionBarrier;
+            events.push("admitted");
+          },
+          onComplete: () => events.push("complete"),
+        },
+        run: { provider: "anthropic", model: "claude" },
+      }),
+    );
+
+    await vi.waitFor(() => expect(events).toEqual(["admission-started"]));
+    abortController.abort();
+    releaseAdmission();
+    await pending;
+
+    expect(events).toEqual(["admission-started", "admitted", "complete"]);
+    expect(runPreflightCompactionIfNeededMock).not.toHaveBeenCalled();
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("passes prepared media user turns to embedded runtime dispatch", async () => {
     const preparedUserTurnMessage = {
       role: "user",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -718,6 +718,11 @@ export function createFollowupRunner(params: {
       // Multi-source collected turns become atomic at reply-lane admission.
       // Their queue owner uses this boundary to retire source cancellation ids.
       await admitFollowupRunLifecycle(effectiveQueued);
+      // Admission can await transport-owned durability. Supersession during that handoff is
+      // sticky; stop before preflight can emit notices or start provider work for the stale turn.
+      if (isFollowupRunAborted(effectiveQueued)) {
+        return;
+      }
       if (replyOperation.sessionId !== run.sessionId) {
         run = { ...run, sessionId: replyOperation.sessionId };
         effectiveQueued = { ...effectiveQueued, run };


### PR DESCRIPTION
Related: #102468
Follow-up to #103952

## What Problem This Solves

Fixes an issue where Telegram users could receive a stale final or fallback reply when a newer authorized request superseded the old turn while its asynchronous adoption handoff was still completing. Queued turns could also continue into preflight work after being superseded during that same handoff.

## Why This Change Was Made

The Telegram dispatch now treats its local fence controller's irreversible abort state as the durable supersession latch, including queued dispatches whose generation was already released. The shared queued runner also rechecks cancellation immediately after asynchronous owner admission, before session reload, preflight notices, or provider work.

## User Impact

Newer Telegram requests consistently win during adoption races: stale direct and ambient replies stay suppressed, and superseded queued turns do not start preflight or model execution.

## Evidence

- AWS Crabbox run `run_9522a059016c`: https://crabbox.openclaw.ai/portal/runs/run_9522a059016c
- `pnpm test src/auto-reply/reply/followup-runner.test.ts`: 144 passed.
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/telegram-reply-fence.test.ts`: 185 passed.
- Deterministic regressions cover direct supersession during adoption, queued room-event supersession after generation release, and abort during queued owner admission before preflight/runtime work.
- Fresh mandatory autoreview: no accepted or actionable findings for either commit.
- `git diff --check`: clean.

The user-facing changelog entry is intentionally owned by the active `2026.7.1-beta.3` release task so the complete Telegram adoption stack is documented once with all landed PR references.
