### PR TITLE
fix(release): consume Kova model contract

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 24c26969e57d4d49f9d1a5071af85dd3d79daa2d
+        default: 2ef781190516c09df9891317654a0484bf4f0d46
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '24c26969e57d4d49f9d1a5071af85dd3d79daa2d' }}
+      KOVA_REF: ${{ inputs.kova_ref || '2ef781190516c09df9891317654a0484bf4f0d46' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}
@@ -369,42 +369,6 @@ jobs:
             echo "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS=$workspace_dependency_dirs"
           } >> "$GITHUB_ENV"
 
-      - name: Pin Kova OpenAI model to GPT 5.6
-        if: steps.lane.outputs.run == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          node - <<'NODE'
-          const fs = require("node:fs");
-          const path = require("node:path");
-          const root = process.env.KOVA_SRC;
-          const sourceModel = "gpt-5.5";
-          const targetModel = process.env.PERFORMANCE_MODEL_ID;
-          if (!targetModel || targetModel === sourceModel) {
-            throw new Error("Kova performance model pin must replace the source model");
-          }
-          const files = [
-            "support/configure-openclaw-mock-auth.mjs",
-            "support/configure-openclaw-live-auth.mjs",
-            "states/mock-openai-provider.json"
-          ];
-          const rewrites = files.map((rel) => {
-            const file = path.join(root, rel);
-            const before = fs.readFileSync(file, "utf8");
-            if (!before.includes(sourceModel)) {
-              throw new Error(`${rel} did not contain the Kova source model`);
-            }
-            const after = before.replaceAll(sourceModel, targetModel);
-            if (after.includes(sourceModel) || !after.includes(targetModel)) {
-              throw new Error(`${rel} did not pin the Kova performance model`);
-            }
-            return { file, after };
-          });
-          for (const { file, after } of rewrites) {
-            fs.writeFileSync(file, after, "utf8");
-          }
-          NODE
-
       - name: Kova version and plan sanity
         if: steps.lane.outputs.run == 'true'
         shell: bash
@@ -506,6 +470,9 @@ jobs:
             --json
           )
 
+          if [[ "$AUTH_MODE" == "live" ]]; then
+            args+=(--model "$PERFORMANCE_MODEL_ID")
+          fi
           if [[ "$MATRIX_DEEP_PROFILE" == "true" ]]; then
             args+=(--deep-profile)
           fi

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "24c26969e57d4d49f9d1a5071af85dd3d79daa2d";
+    const kovaRef = "2ef781190516c09df9891317654a0484bf4f0d46";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 
@@ -129,23 +129,15 @@ describe("OpenClaw performance workflow", () => {
     ).toHaveLength(1);
   });
 
-  it("pins the Kova model through exact current source owners and fails closed on drift", () => {
-    const pinModel = findStep("Pin Kova OpenAI model to GPT 5.6");
-    const run = pinModel.run ?? "";
-    const configuredFiles = [...run.matchAll(/^\s*"((?:support|states)\/[^"]+)",?$/gm)].map(
-      (match) => match[1],
-    );
+  it("passes the requested model through Kova live auth without rewriting Kova source", () => {
+    const workflow = readFileSync(WORKFLOW, "utf8");
+    const run = findStep("Run Kova").run ?? "";
 
-    expect(configuredFiles).toEqual([
-      "support/configure-openclaw-mock-auth.mjs",
-      "support/configure-openclaw-live-auth.mjs",
-      "states/mock-openai-provider.json",
-    ]);
-    expect(run).not.toContain("support/mock-openai-server.mjs");
-    expect(run).toContain("if (!before.includes(sourceModel))");
-    expect(run).toContain("after.includes(sourceModel) || !after.includes(targetModel)");
-    expect(run.indexOf("const rewrites = files.map")).toBeLessThan(
-      run.indexOf("fs.writeFileSync(file, after"),
+    expect(workflow).not.toContain("Pin Kova OpenAI model to GPT 5.6");
+    expect(run).toContain('if [[ "$AUTH_MODE" == "live" ]]; then');
+    expect(run).toContain('args+=(--model "$PERFORMANCE_MODEL_ID")');
+    expect(run.indexOf('if [[ "$AUTH_MODE" == "live" ]]; then')).toBeLessThan(
+      run.indexOf('args+=(--model "$PERFORMANCE_MODEL_ID")'),
     );
   });
 


### PR DESCRIPTION
Related: https://github.com/openclaw/Kova/issues/22
Related: https://github.com/openclaw/Kova/pull/23

## What Problem This Solves

Fixes an issue where OpenClaw release performance runs rewrote immutable Kova source files to select GPT 5.6, leaving the workflow coupled to Kova internal file contents and blocking the beta release when those contents changed.

## Why This Change Was Made

Pins the landed Kova release-contract commit and passes GPT 5.6 through Kova public `--model` option only for the live-auth lane. Mock lanes keep their scenario-owned model configuration, and the source-rewrite step is deleted.

## User Impact

Release operators can run the beta performance matrix against an immutable Kova revision without patching third-party source during CI. The live OpenAI lane still selects GPT 5.6 before the first service start.

## Evidence

- Kova fix: https://github.com/openclaw/Kova/pull/23
- Testbox-through-Crabbox `tbx_01kx70f501vcfrk5nwwkswtwkr`: 26/26 focused workflow tests
- same Testbox: `pnpm check:changed` passed
- `actionlint .github/workflows/openclaw-performance.yml`
- `git diff --check`
- fresh Codex autoreview: no accepted/actionable findings