### PR TITLE
fix(signal): drain accepted messages during shutdown

### DIFF
--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -169,6 +169,75 @@ describe("monitorSignalProvider tool results", () => {
     }
   });
 
+  it("drains an inline inbound message accepted before the monitor stops", async () => {
+    const abortController = new AbortController();
+    setSignalToolResultTestConfig({
+      channels: { signal: { autoStart: false, dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    replyMock.mockResolvedValue({ text: "accepted reply" });
+    streamMock.mockImplementation(async ({ onEvent }) => {
+      onEvent({
+        event: "receive",
+        data: JSON.stringify({
+          envelope: {
+            sourceNumber: "+15550001111",
+            sourceName: "Ada",
+            timestamp: 1,
+            dataMessage: { message: "accepted message" },
+          },
+        }),
+      });
+      abortController.abort(new Error("monitor stopped"));
+    });
+
+    await monitorSignalProvider({
+      autoStart: false,
+      baseUrl: "http://127.0.0.1:8080",
+      abortSignal: abortController.signal,
+    });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith("+15550001111", "accepted reply", expect.anything());
+  });
+
+  it("does not dispatch a buffered inbound message after the monitor stops", async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    setSignalToolResultTestConfig({
+      messages: { inbound: { debounceMs: 10 } },
+      channels: { signal: { autoStart: false, dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    replyMock.mockResolvedValue({ text: "late reply" });
+    streamMock.mockImplementation(async ({ onEvent }) => {
+      onEvent({
+        event: "receive",
+        data: JSON.stringify({
+          envelope: {
+            sourceNumber: "+15550001111",
+            sourceName: "Ada",
+            timestamp: 1,
+            dataMessage: { message: "wait for more" },
+          },
+        }),
+      });
+      abortController.abort(new Error("monitor stopped"));
+    });
+
+    try {
+      await monitorSignalProvider({
+        autoStart: false,
+        baseUrl: "http://127.0.0.1:8080",
+        abortSignal: abortController.signal,
+      });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(replyMock).not.toHaveBeenCalled();
+      expect(sendMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("sizes attachment RPC response caps from mediaMaxMb", async () => {
     const abortController = new AbortController();
     const maxBytes = 2 * 1024 * 1024;

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -236,6 +236,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     replyToSender?: string;
     replyToIsQuote?: boolean;
   };
+  const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
     const fromLabel = formatInboundFromLabel({
@@ -756,17 +757,20 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
-      if (deps.abortSignal?.aborted) {
+      // enqueue() awaits inline and overflow flushes, but not timer-backed work.
+      // Drain tracked inline work on shutdown; stop delayed work with no owner.
+      const hasActiveEnqueue = entries.some((entry) => activeEnqueueEntries.has(entry));
+      if (!hasActiveEnqueue && deps.abortSignal?.aborted) {
         return;
       }
       try {
         await flushSignalInboundEntries(entries);
       } catch (err) {
-        if (deps.abortSignal?.aborted) {
-          return;
-        }
         if (!isSignalReplySessionInitConflictError(err)) {
           throw err;
+        }
+        if (deps.abortSignal?.aborted) {
+          return;
         }
         // Keep the current keyed debounce task reserved through backoff so a
         // newer same-conversation flush cannot overtake this failed batch.
@@ -1259,7 +1263,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       typeof nativeReplyTargetTimestamp === "number"
         ? String(nativeReplyTargetTimestamp)
         : undefined;
-    await debouncer.enqueue({
+    const entry: SignalInboundEntry = {
       senderName,
       senderDisplay,
       senderRecipient,
@@ -1283,6 +1287,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
-    });
+    };
+    activeEnqueueEntries.add(entry);
+    try {
+      await debouncer.enqueue(entry);
+    } finally {
+      activeEnqueueEntries.delete(entry);
+    }
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The Signal retry-lifecycle change in #103218 made the inbound debounce abort guard apply to every flush. If shutdown raced with an already accepted, non-debounced event before its tracked handler reached the flush boundary, the event was silently dropped instead of draining through the monitor task runner. The same guard is still needed for timer-backed buffered work, which is not owned by the tracked enqueue after `enqueue()` returns.

## Why This Change Was Made

Signal now records an inbound entry only while its `debouncer.enqueue()` call remains active. Inline and tracked-key-overflow flushes run before that enqueue settles, so they retain an active owner and drain during shutdown. Timer-backed flushes run after their enqueue owner has settled, so they remain suppressed after abort. Conflict retry backoff keeps its existing abort behavior.

This stays inside the Signal owner boundary and avoids adding an internal lifecycle distinction to the public plugin SDK debounce contract.

## User Impact

Signal messages already accepted for immediate processing are no longer lost when monitor shutdown races with access checks or dispatch setup. Delayed buffered messages and pending conflict retries still do not dispatch after shutdown. No configuration or migration is required.

## Evidence

- Reproduced on current `main`: the full Signal shard failed 25 reply-path tests because accepted inline events were dropped after same-tick abort; 468 tests passed.
- Focused Blacksmith Testbox proof: 41/41 passed across the immediate-drain, buffered-cancel, reply-prefix, quote, and conflict-cancellation paths.
- Full Signal shard on the same Testbox: 495/495 passed across 32 files.
- New lifecycle regressions prove both sides explicitly: accepted inline work drains; configured timer-buffered work does not dispatch after stop.
- Targeted `oxfmt`, `git diff --check`, and fresh structured Codex autoreview are clean; autoreview reported no actionable findings (0.91 confidence).
- No live Signal account was available; this is deterministic monitor/debouncer lifecycle behavior exercised through the production monitor boundary.
