### PR TITLE
fix(macos): reject revoked forwarded exec approvals

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18747,6 +18747,22 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 934,
+      "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
+      "source": "approvalSource requires matching systemRunPlan",
+      "surface": "apple",
+      "id": "native.apple.386595fa18585dbb"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 934,
+      "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
+      "source": "explicit approval requires matching systemRunPlan",
+      "surface": "apple",
+      "id": "native.apple.014ff905cecd753b"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 426,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18747,7 +18747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 934,
+      "line": 936,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "approvalSource requires matching systemRunPlan",
       "surface": "apple",
@@ -18755,7 +18755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 934,
+      "line": 936,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "explicit approval requires matching systemRunPlan",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalEvaluation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 
 struct ExecApprovalEvaluation {
     let displayCommand: String
@@ -71,7 +72,7 @@ struct ExecApprovalPolicySnapshot: Sendable, Equatable {
         self.allowlistRules = Set(allowlist.map { entry in
             AllowlistRule(
                 match: ExecApprovalsStore.allowlistEntryMatchKey(entry),
-                source: entry.source)
+                source: entry.source == "allow-always" ? "allow-always" : nil)
         })
     }
 
@@ -82,6 +83,43 @@ struct ExecApprovalPolicySnapshot: Sendable, Equatable {
             askFallback: approvals.agent.askFallback,
             autoAllowSkills: approvals.agent.autoAllowSkills,
             allowlist: approvals.allowlist)
+    }
+
+    init(portable: OpenClawSystemRunApprovalPolicySnapshot) {
+        self.init(
+            security: ExecSecurity(rawValue: portable.security.rawValue)!,
+            ask: ExecAsk(rawValue: portable.ask.rawValue)!,
+            askFallback: ExecSecurity(rawValue: portable.askFallback.rawValue)!,
+            autoAllowSkills: portable.autoAllowSkills,
+            allowlist: portable.allowlistRules.map { rule in
+                ExecAllowlistEntry(
+                    pattern: rule.pattern,
+                    source: rule.source?.rawValue,
+                    argPattern: rule.argPattern)
+            })
+    }
+
+    var portable: OpenClawSystemRunApprovalPolicySnapshot {
+        OpenClawSystemRunApprovalPolicySnapshot(
+            security: .init(rawValue: self.security.rawValue)!,
+            ask: .init(rawValue: self.ask.rawValue)!,
+            askFallback: .init(rawValue: self.askFallback.rawValue)!,
+            autoAllowSkills: self.autoAllowSkills,
+            allowlistRules: self.allowlistRules.map { rule in
+                OpenClawSystemRunApprovalPolicySnapshot.Rule(
+                    pattern: Self.portableString(rule.match.pattern),
+                    argPattern: rule.match.argPattern.isEmpty
+                        ? nil
+                        : Self.portableString(rule.match.argPattern),
+                    source: rule.source == "allow-always" ? .allowAlways : nil)
+            })
+    }
+
+    private static func portableString(_ data: Data) -> String {
+        guard let value = String(data: data, encoding: .utf8) else {
+            preconditionFailure("exec approval match keys must contain UTF-8 strings")
+        }
+        return value
     }
 
     func isCurrent(_ current: Self) -> Bool {
@@ -126,7 +164,8 @@ struct ExecApprovalExecutionCommit: Sendable {
         effectiveSecurity: ExecSecurity,
         approvalSource: ExecApprovalRequestSource?,
         explicitlyApproved: Bool,
-        persistAllowlist: Bool) -> ExecApprovalExecutionCommit
+        persistAllowlist: Bool,
+        delayedPolicySnapshot: ExecApprovalPolicySnapshot? = nil) -> ExecApprovalExecutionCommit
     {
         let uses = effectiveSecurity == .allowlist &&
             context.authorizationBasis == .allowlistEntries
@@ -134,23 +173,24 @@ struct ExecApprovalExecutionCommit: Sendable {
             : []
         let grants = persistAllowlist ? self.allowAlwaysGrants(context: context) : []
         let basis = effectiveSecurity == .allowlist ? context.authorizationBasis : nil
-        // The socket and native runtime both cross an asynchronous approval
-        // boundary. Carry the evaluated policy into their shared commit path.
+        // Forwarded decisions were evaluated before the Mac rebuilt its context.
+        // Local prompt decisions have no override and bind to this evaluation.
+        let policySnapshot = delayedPolicySnapshot ?? context.policySnapshot
         let authorization: ExecApprovalAuthorization = if approvalSource == .askFallback {
             .askFallback(evaluatedSecurity: effectiveSecurity, basis: basis)
         } else if approvalSource == .autoReview {
             .autoReview(
                 evaluatedSecurity: effectiveSecurity,
-                policySnapshot: context.policySnapshot)
+                policySnapshot: policySnapshot)
         } else if explicitlyApproved {
             if grants.isEmpty {
                 .explicitOnce(
                     evaluatedSecurity: effectiveSecurity,
-                    policySnapshot: context.policySnapshot)
+                    policySnapshot: policySnapshot)
             } else {
                 .explicitAlways(
                     evaluatedSecurity: effectiveSecurity,
-                    policySnapshot: context.policySnapshot,
+                    policySnapshot: policySnapshot,
                     grants: grants)
             }
         } else {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -126,6 +126,7 @@ struct ExecHostRequest: Codable {
     var sessionKey: String?
     var approvalDecision: ExecApprovalDecision?
     var approvalSource: String?
+    var policySnapshot: OpenClawSystemRunApprovalPolicySnapshot?
 }
 
 private struct ExecHostRunResult: Codable {
@@ -862,7 +863,8 @@ private enum ExecHostExecutor {
             effectiveSecurity: security,
             approvalSource: approvalSource,
             explicitlyApproved: explicitlyApproved,
-            persistAllowlist: persistAllowlist)
+            persistAllowlist: persistAllowlist,
+            delayedPolicySnapshot: validatedRequest.delayedPolicySnapshot)
         let timeoutSec = request.timeoutMs.flatMap { Double($0) / 1000.0 }
         let cwd = request.cwd
         let env = context.env

--- a/apps/macos/Sources/OpenClaw/ExecHostRequestEvaluator.swift
+++ b/apps/macos/Sources/OpenClaw/ExecHostRequestEvaluator.swift
@@ -5,6 +5,7 @@ struct ExecHostValidatedRequest {
     let displayCommand: String
     let evaluationRawCommand: String?
     let approvalSource: ExecApprovalRequestSource?
+    let delayedPolicySnapshot: ExecApprovalPolicySnapshot?
 }
 
 enum ExecHostPolicyDecision {
@@ -35,13 +36,29 @@ enum ExecHostRequestEvaluator {
                 message: "approvalSource cannot be combined with explicit approval",
                 reason: "invalid"))
         }
+        let carriesDelayedAuthority = approvalSource == .autoReview ||
+            request.approvalDecision == .allowOnce ||
+            request.approvalDecision == .allowAlways
+        let delayedPolicySnapshot: ExecApprovalPolicySnapshot?
+        if carriesDelayedAuthority {
+            guard let policySnapshot = request.policySnapshot else {
+                return .failure(ExecHostError(
+                    code: "INVALID_REQUEST",
+                    message: "delayed approval requires a prepared policy snapshot",
+                    reason: "invalid"))
+            }
+            delayedPolicySnapshot = ExecApprovalPolicySnapshot(portable: policySnapshot)
+        } else {
+            delayedPolicySnapshot = nil
+        }
         switch self.validateCommand(command: request.command, rawCommand: request.rawCommand) {
         case let .success(validated):
             return .success(ExecHostValidatedRequest(
                 command: validated.command,
                 displayCommand: validated.displayCommand,
                 evaluationRawCommand: validated.evaluationRawCommand,
-                approvalSource: approvalSource))
+                approvalSource: approvalSource,
+                delayedPolicySnapshot: delayedPolicySnapshot))
         case let .failure(error):
             return .failure(error)
         }
@@ -77,7 +94,8 @@ enum ExecHostRequestEvaluator {
                 command: command,
                 displayCommand: resolved.displayCommand,
                 evaluationRawCommand: resolved.evaluationRawCommand,
-                approvalSource: nil))
+                approvalSource: nil,
+                delayedPolicySnapshot: nil))
         case let .invalid(message):
             return .failure(
                 ExecHostError(

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CryptoKit
 import Foundation
 import OpenClawIPC
 import OpenClawKit
@@ -748,6 +749,7 @@ extension MacNodeRuntime {
         let validatedCommand: ExecHostValidatedRequest
         let evaluation: ExecApprovalEvaluation
         let security: ExecSecurity
+        let delayedPolicySnapshot: ExecApprovalPolicySnapshot?
         let sessionKey: String
         let runId: String
     }
@@ -859,7 +861,8 @@ extension MacNodeRuntime {
             effectiveSecurity: security,
             approvalSource: approvalSource,
             explicitlyApproved: approvedByAsk,
-            persistAllowlist: persistAllowlist)
+            persistAllowlist: persistAllowlist,
+            delayedPolicySnapshot: prepared.delayedPolicySnapshot)
         let timeoutSec = params.timeoutMs.flatMap { Double($0) / 1000.0 }
         let cwd = params.cwd
         let executionEnv = evaluation.env
@@ -906,6 +909,10 @@ extension MacNodeRuntime {
                     code: .invalidRequest,
                     message: "INVALID_REQUEST: approvalSource cannot be combined with explicit approval"))
         }
+        let explicitDecision = ExecApprovalHelpers.parseDecision(params.approvalDecision)
+        let explicitApproval = params.approved == true ||
+            explicitDecision == .allowOnce ||
+            explicitDecision == .allowAlways
         let validatedCommand: ExecHostValidatedRequest
         switch ExecHostRequestEvaluator.validateCommand(
             command: params.command,
@@ -918,6 +925,42 @@ extension MacNodeRuntime {
                 ? error.message
                 : "INVALID_REQUEST: \(error.message)"
             return .response(Self.errorResponse(req, code: .invalidRequest, message: message))
+        }
+        if approvalSource != nil || explicitApproval {
+            guard let plan = params.systemRunPlan,
+                  Self.systemRunPlan(plan, matches: params, validatedCommand: validatedCommand)
+            else {
+                let message = approvalSource != nil
+                    ? "approvalSource requires matching systemRunPlan"
+                    : "explicit approval requires matching systemRunPlan"
+                return .response(Self.errorResponse(req, code: .invalidRequest, message: message))
+            }
+        }
+        let carriesDelayedAuthority = approvalSource == .autoReview || explicitApproval
+        let delayedPolicySnapshot: ExecApprovalPolicySnapshot?
+        if carriesDelayedAuthority {
+            if let operand = params.systemRunPlan?.mutableFileOperand,
+               !Self.revalidateMutableFileOperand(
+                   operand,
+                   command: validatedCommand.command,
+                   cwd: params.cwd)
+            {
+                return .response(
+                    Self.errorResponse(
+                        req,
+                        code: .unavailable,
+                        message: "SYSTEM_RUN_DENIED: approval script operand changed before execution"))
+            }
+            guard let policySnapshot = params.systemRunPlan?.policySnapshot else {
+                return .response(
+                    Self.errorResponse(
+                        req,
+                        code: .invalidRequest,
+                        message: "INVALID_REQUEST: delayed approval requires a prepared policy snapshot"))
+            }
+            delayedPolicySnapshot = ExecApprovalPolicySnapshot(portable: policySnapshot)
+        } else {
+            delayedPolicySnapshot = nil
         }
         let sessionKey = (params.sessionKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
             ? params.sessionKey!.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -991,8 +1034,81 @@ extension MacNodeRuntime {
             validatedCommand: validatedCommand,
             evaluation: evaluation,
             security: security,
+            delayedPolicySnapshot: delayedPolicySnapshot,
             sessionKey: sessionKey,
             runId: runId))
+    }
+
+    private static func systemRunPlan(
+        _ plan: OpenClawSystemRunApprovalPlan,
+        matches params: OpenClawSystemRunParams,
+        validatedCommand: ExecHostValidatedRequest) -> Bool
+    {
+        // Delayed authority is signed for one normalized request. Match the
+        // same fields as the Node host before trusting its policy snapshot.
+        plan.argv == validatedCommand.command &&
+            plan.commandText == validatedCommand.displayCommand &&
+            self.normalizedSystemRunPlanString(plan.cwd) == self.normalizedSystemRunPlanString(params.cwd) &&
+            self.normalizedSystemRunPlanString(plan.agentId) == self.normalizedSystemRunPlanString(params.agentId) &&
+            self.normalizedSystemRunPlanString(plan.sessionKey) ==
+            self.normalizedSystemRunPlanString(params.sessionKey)
+    }
+
+    private static func normalizedSystemRunPlanString(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let scalars = value.unicodeScalars
+        var start = scalars.startIndex
+        while start != scalars.endIndex, self.isECMAScriptTrimScalar(scalars[start]) {
+            start = scalars.index(after: start)
+        }
+        var end = scalars.endIndex
+        while end != start {
+            let previous = scalars.index(before: end)
+            guard self.isECMAScriptTrimScalar(scalars[previous]) else { break }
+            end = previous
+        }
+        let trimmed = String(scalars[start..<end])
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func revalidateMutableFileOperand(
+        _ operand: OpenClawSystemRunApprovalFileOperand,
+        command: [String],
+        cwd: String?) -> Bool
+    {
+        guard operand.argvIndex >= 0,
+              operand.argvIndex < command.count,
+              let rawPath = self.normalizedSystemRunPlanString(command[operand.argvIndex])
+        else { return false }
+
+        let basePath = self.normalizedSystemRunPlanString(cwd) ?? FileManager.default.currentDirectoryPath
+        let resolvedURL = URL(fileURLWithPath: rawPath, relativeTo: URL(fileURLWithPath: basePath, isDirectory: true))
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard resolvedURL.path == operand.path,
+              let data = try? Data(contentsOf: resolvedURL, options: .mappedIfSafe)
+        else { return false }
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        return digest == operand.sha256
+    }
+
+    private static func isECMAScriptTrimScalar(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x0009...0x000D,
+             0x0020,
+             0x00A0,
+             0x1680,
+             0x2000...0x200A,
+             0x2028,
+             0x2029,
+             0x202F,
+             0x205F,
+             0x3000,
+             0xFEFF:
+            true
+        default:
+            false
+        }
     }
 
     private func handleSystemWhich(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1,5 +1,4 @@
 import AppKit
-import CryptoKit
 import Foundation
 import OpenClawIPC
 import OpenClawKit
@@ -928,7 +927,10 @@ extension MacNodeRuntime {
         }
         if approvalSource != nil || explicitApproval {
             guard let plan = params.systemRunPlan,
-                  Self.systemRunPlan(plan, matches: params, validatedCommand: validatedCommand)
+                  MacSystemRunApprovalPlanValidator.matches(
+                      plan,
+                      params: params,
+                      validatedCommand: validatedCommand)
             else {
                 let message = approvalSource != nil
                     ? "approvalSource requires matching systemRunPlan"
@@ -940,7 +942,7 @@ extension MacNodeRuntime {
         let delayedPolicySnapshot: ExecApprovalPolicySnapshot?
         if carriesDelayedAuthority {
             if let operand = params.systemRunPlan?.mutableFileOperand,
-               !Self.revalidateMutableFileOperand(
+               !MacSystemRunApprovalPlanValidator.revalidateMutableFileOperand(
                    operand,
                    command: validatedCommand.command,
                    cwd: params.cwd)
@@ -1037,78 +1039,6 @@ extension MacNodeRuntime {
             delayedPolicySnapshot: delayedPolicySnapshot,
             sessionKey: sessionKey,
             runId: runId))
-    }
-
-    private static func systemRunPlan(
-        _ plan: OpenClawSystemRunApprovalPlan,
-        matches params: OpenClawSystemRunParams,
-        validatedCommand: ExecHostValidatedRequest) -> Bool
-    {
-        // Delayed authority is signed for one normalized request. Match the
-        // same fields as the Node host before trusting its policy snapshot.
-        plan.argv == validatedCommand.command &&
-            plan.commandText == validatedCommand.displayCommand &&
-            self.normalizedSystemRunPlanString(plan.cwd) == self.normalizedSystemRunPlanString(params.cwd) &&
-            self.normalizedSystemRunPlanString(plan.agentId) == self.normalizedSystemRunPlanString(params.agentId) &&
-            self.normalizedSystemRunPlanString(plan.sessionKey) ==
-            self.normalizedSystemRunPlanString(params.sessionKey)
-    }
-
-    private static func normalizedSystemRunPlanString(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let scalars = value.unicodeScalars
-        var start = scalars.startIndex
-        while start != scalars.endIndex, self.isECMAScriptTrimScalar(scalars[start]) {
-            start = scalars.index(after: start)
-        }
-        var end = scalars.endIndex
-        while end != start {
-            let previous = scalars.index(before: end)
-            guard self.isECMAScriptTrimScalar(scalars[previous]) else { break }
-            end = previous
-        }
-        let trimmed = String(scalars[start..<end])
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private static func revalidateMutableFileOperand(
-        _ operand: OpenClawSystemRunApprovalFileOperand,
-        command: [String],
-        cwd: String?) -> Bool
-    {
-        guard operand.argvIndex >= 0,
-              operand.argvIndex < command.count,
-              let rawPath = self.normalizedSystemRunPlanString(command[operand.argvIndex])
-        else { return false }
-
-        let basePath = self.normalizedSystemRunPlanString(cwd) ?? FileManager.default.currentDirectoryPath
-        let resolvedURL = URL(fileURLWithPath: rawPath, relativeTo: URL(fileURLWithPath: basePath, isDirectory: true))
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-        guard resolvedURL.path == operand.path,
-              let data = try? Data(contentsOf: resolvedURL, options: .mappedIfSafe)
-        else { return false }
-        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-        return digest == operand.sha256
-    }
-
-    private static func isECMAScriptTrimScalar(_ scalar: Unicode.Scalar) -> Bool {
-        switch scalar.value {
-        case 0x0009...0x000D,
-             0x0020,
-             0x00A0,
-             0x1680,
-             0x2000...0x200A,
-             0x2028,
-             0x2029,
-             0x202F,
-             0x205F,
-             0x3000,
-             0xFEFF:
-            true
-        default:
-            false
-        }
     }
 
     private func handleSystemWhich(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacSystemRunApprovalPlanValidator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacSystemRunApprovalPlanValidator.swift
@@ -1,0 +1,77 @@
+import CryptoKit
+import Foundation
+import OpenClawIPC
+import OpenClawKit
+
+enum MacSystemRunApprovalPlanValidator {
+    static func matches(
+        _ plan: OpenClawSystemRunApprovalPlan,
+        params: OpenClawSystemRunParams,
+        validatedCommand: ExecHostValidatedRequest) -> Bool
+    {
+        // Delayed authority is signed for one normalized request. Match the
+        // same fields as the Node host before trusting its policy snapshot.
+        plan.argv == validatedCommand.command &&
+            plan.commandText == validatedCommand.displayCommand &&
+            self.normalized(plan.cwd) == self.normalized(params.cwd) &&
+            self.normalized(plan.agentId) == self.normalized(params.agentId) &&
+            self.normalized(plan.sessionKey) == self.normalized(params.sessionKey)
+    }
+
+    static func revalidateMutableFileOperand(
+        _ operand: OpenClawSystemRunApprovalFileOperand,
+        command: [String],
+        cwd: String?) -> Bool
+    {
+        guard operand.argvIndex >= 0,
+              operand.argvIndex < command.count,
+              let rawPath = self.normalized(command[operand.argvIndex])
+        else { return false }
+
+        let basePath = self.normalized(cwd) ?? FileManager.default.currentDirectoryPath
+        let resolvedURL = URL(fileURLWithPath: rawPath, relativeTo: URL(fileURLWithPath: basePath, isDirectory: true))
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard resolvedURL.path == operand.path,
+              let data = try? Data(contentsOf: resolvedURL, options: .mappedIfSafe)
+        else { return false }
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        return digest == operand.sha256
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let scalars = value.unicodeScalars
+        var start = scalars.startIndex
+        while start != scalars.endIndex, self.isECMAScriptTrimScalar(scalars[start]) {
+            start = scalars.index(after: start)
+        }
+        var end = scalars.endIndex
+        while end != start {
+            let previous = scalars.index(before: end)
+            guard self.isECMAScriptTrimScalar(scalars[previous]) else { break }
+            end = previous
+        }
+        let trimmed = String(scalars[start..<end])
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isECMAScriptTrimScalar(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x0009...0x000D,
+             0x0020,
+             0x00A0,
+             0x1680,
+             0x2000...0x200A,
+             0x2028,
+             0x2029,
+             0x202F,
+             0x205F,
+             0x3000,
+             0xFEFF:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPolicySnapshotTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPolicySnapshotTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -16,6 +18,76 @@ struct ExecApprovalPolicySnapshotTests {
         let current = Self.snapshot(source: nil)
 
         #expect(!expected.isCurrent(current))
+    }
+
+    @Test
+    func `portable snapshot round trips canonical policy semantics`() {
+        let snapshot = ExecApprovalPolicySnapshot(
+            security: .allowlist,
+            ask: .onMiss,
+            askFallback: .deny,
+            autoAllowSkills: true,
+            allowlist: [
+                ExecAllowlistEntry(pattern: "/usr/bin/tool", source: "legacy"),
+                ExecAllowlistEntry(
+                    pattern: "/usr/bin/tool",
+                    source: "allow-always",
+                    argPattern: "^ok$"),
+            ])
+
+        let portable = snapshot.portable
+
+        #expect(portable.security == .allowlist)
+        #expect(portable.ask == .onMiss)
+        #expect(portable.askFallback == .deny)
+        #expect(portable.autoAllowSkills)
+        #expect(portable.allowlistRules == [
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/usr/bin/tool"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(
+                pattern: "/usr/bin/tool",
+                argPattern: "^ok$",
+                source: .allowAlways),
+        ])
+        #expect(snapshot == ExecApprovalPolicySnapshot(portable: portable))
+    }
+
+    @Test
+    func `portable snapshot decode deduplicates and sorts rules by utf8 bytes`() throws {
+        let data = Data(#"""
+        {
+          "security": "allowlist",
+          "ask": "on-miss",
+          "askFallback": "deny",
+          "autoAllowSkills": false,
+          "allowlistRules": [
+            {"pattern": "/ä"},
+            {"pattern": "/A", "source": "allow-always"},
+            {"pattern": "/", "argPattern": "é"},
+            {"pattern": "/"},
+            {"pattern": "/", "argPattern": "A"},
+            {"pattern": "/"},
+            {"pattern": "/A"},
+            {"pattern": "/é"},
+            {"pattern": "/e\u0301"}
+          ]
+        }
+        """#.utf8)
+
+        let portable = try JSONDecoder().decode(
+            OpenClawSystemRunApprovalPolicySnapshot.self,
+            from: data)
+
+        #expect(portable.allowlistRules == [
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/", argPattern: "A"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/", argPattern: "é"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/A"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/A", source: .allowAlways),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/e\u{0301}"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/ä"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/é"),
+        ])
+        #expect(ExecApprovalPolicySnapshot(portable: portable).portable == portable)
     }
 
     private static func snapshot(source: String?) -> ExecApprovalPolicySnapshot {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketAuthTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -90,7 +91,8 @@ struct ExecApprovalsSocketAuthTests {
             needsScreenRecording: nil,
             agentId: nil,
             sessionKey: nil,
-            approvalDecision: .allowOnce)
+            approvalDecision: .allowOnce,
+            policySnapshot: Self.policySnapshot)
         let requestJSON = try JSONEncoder().encode(request)
         let socketDecodedRequest = try JSONDecoder().decode(ExecHostRequest.self, from: requestJSON)
 
@@ -136,25 +138,52 @@ struct ExecApprovalsSocketAuthTests {
     }
 
     @Test
-    func `socket serialization preserves marker only auto review provenance`() throws {
-        let request = ExecHostRequest(
-            command: ["/usr/bin/printf", "ok"],
-            rawCommand: nil,
-            cwd: nil,
-            env: nil,
-            timeoutMs: nil,
-            needsScreenRecording: nil,
-            agentId: "main",
-            sessionKey: "agent:main:main",
-            approvalDecision: nil,
-            approvalSource: "auto-review")
+    func `socket decodes TypeScript auto review policy snapshot`() throws {
+        let requestJSON = Data(#"""
+        {
+          "command": ["/usr/bin/printf", "ok"],
+          "agentId": "main",
+          "sessionKey": "agent:main:main",
+          "approvalSource": "auto-review",
+          "policySnapshot": {
+            "security": "allowlist",
+            "ask": "on-miss",
+            "askFallback": "deny",
+            "autoAllowSkills": true,
+            "allowlistRules": [
+              {"pattern": "/ä"},
+              {"pattern": "/A", "source": "allow-always"},
+              {"pattern": "/"},
+              {"pattern": "/"},
+              {"pattern": "/A"}
+            ]
+          }
+        }
+        """#.utf8)
 
-        let decoded = try JSONDecoder().decode(
-            ExecHostRequest.self,
-            from: JSONEncoder().encode(request))
+        let decoded = try JSONDecoder().decode(ExecHostRequest.self, from: requestJSON)
         #expect(decoded.approvalSource == "auto-review")
         #expect(decoded.approvalDecision == nil)
+        #expect(decoded.policySnapshot?.allowlistRules == [
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/A"),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/A", source: .allowAlways),
+            OpenClawSystemRunApprovalPolicySnapshot.Rule(pattern: "/ä"),
+        ])
+        switch ExecHostRequestEvaluator.validateRequest(decoded) {
+        case let .success(validated):
+            #expect(validated.delayedPolicySnapshot?.portable == decoded.policySnapshot)
+        case let .failure(error):
+            Issue.record("unexpected invalid request: \(error.message)")
+        }
     }
+
+    private static let policySnapshot = OpenClawSystemRunApprovalPolicySnapshot(
+        security: .full,
+        ask: .off,
+        askFallback: .deny,
+        autoAllowSkills: false,
+        allowlistRules: [])
 
     private struct EncodedExecHostResponse: Codable {
         var type: String

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import OpenClawKit
 import Testing
@@ -22,6 +23,26 @@ struct ExecApprovalsStoreRefactorTests {
         func capturedCommands() -> [[String]] {
             self.commands
         }
+    }
+
+    private static func forwardedApprovalPlan(
+        command: [String],
+        rawCommand: String? = nil,
+        agentId: String? = "main",
+        policySnapshot: ExecApprovalPolicySnapshot? = nil,
+        mutableFileOperand: OpenClawSystemRunApprovalFileOperand? = nil) -> OpenClawSystemRunApprovalPlan
+    {
+        let snapshot = policySnapshot ?? ExecApprovalPolicySnapshot(
+            resolved: ExecApprovalsStore.resolve(agentId: agentId))
+        return OpenClawSystemRunApprovalPlan(
+            argv: command,
+            cwd: nil,
+            commandText: ExecCommandFormatter.displayString(for: command),
+            commandPreview: rawCommand,
+            agentId: agentId,
+            sessionKey: nil,
+            policySnapshot: snapshot.portable,
+            mutableFileOperand: mutableFileOperand)
     }
 
     private var realTemporaryDirectory: URL {
@@ -579,6 +600,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalDecision: "allow-always")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -708,6 +730,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalDecision: "allow-once")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -743,6 +766,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalDecision: "allow-once")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -777,6 +801,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -811,6 +836,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -859,6 +885,171 @@ struct ExecApprovalsStoreRefactorTests {
     }
 
     @Test
+    func `native runtime requires the prepared snapshot for forwarded delayed authority`() async throws {
+        try await self.withTempStateDir { _ in
+            let probe = ShellRunProbe()
+            let runtime = MacNodeRuntime(
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let command = ["/usr/bin/printf", "ok"]
+            let planWithoutSnapshot = OpenClawSystemRunApprovalPlan(
+                argv: command,
+                cwd: nil,
+                commandText: ExecCommandFormatter.displayString(for: command),
+                agentId: "main",
+                sessionKey: nil)
+            let cases = [
+                OpenClawSystemRunParams(
+                    command: command,
+                    agentId: "main",
+                    systemRunPlan: planWithoutSnapshot,
+                    approvalDecision: "allow-once"),
+                OpenClawSystemRunParams(
+                    command: command,
+                    agentId: "main",
+                    systemRunPlan: planWithoutSnapshot,
+                    approvalSource: "auto-review"),
+                OpenClawSystemRunParams(
+                    command: command,
+                    agentId: "main",
+                    systemRunPlan: planWithoutSnapshot,
+                    approved: true),
+            ]
+
+            for (index, params) in cases.enumerated() {
+                let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+                let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                    id: "missing-delayed-snapshot-\(index)",
+                    command: OpenClawSystemCommand.run.rawValue,
+                    paramsJSON: json))
+
+                #expect(!response.ok)
+                #expect(response.error?.code == .invalidRequest)
+                #expect(response.error?.message.contains("prepared policy snapshot") == true)
+            }
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
+    func `native runtime rejects forwarded delayed authority for a mismatched plan`() async throws {
+        try await self.withTempStateDir { _ in
+            let probe = ShellRunProbe()
+            let runtime = MacNodeRuntime(
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let command = ["/usr/bin/printf", "ok"]
+            let params = OpenClawSystemRunParams(
+                command: command,
+                agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "different"]),
+                approvalDecision: "allow-once")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "mismatched-forwarded-plan",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.code == .invalidRequest)
+            #expect(response.error?.message.contains("matching systemRunPlan") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+        }
+    }
+
+    @Test
+    func `forwarded node session approval cannot restore a rule revoked before Mac evaluation`() async throws {
+        try await self.withTempStateDir { _ in
+            let stale = ExecAllowlistEntry(
+                pattern: "/usr/bin/echo",
+                source: "allow-always")
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .allowlist
+                entry.ask = .onMiss
+                entry.allowlist = [stale]
+            }.get()
+            let forwardedSnapshot = ExecApprovalPolicySnapshot(
+                resolved: ExecApprovalsStore.resolve(agentId: "main"))
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.allowlist = []
+            }.get()
+
+            let probe = ShellRunProbe()
+            let runtime = MacNodeRuntime(
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let command = ["/usr/bin/printf", "ok"]
+            let params = OpenClawSystemRunParams(
+                command: command,
+                agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(
+                    command: command,
+                    policySnapshot: forwardedSnapshot),
+                approvalDecision: "allow-always")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "revoked-node-session-approval",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("exec approvals update unavailable") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+            #expect(ExecApprovalsStore.resolve(agentId: "main").allowlist.isEmpty)
+        }
+    }
+
+    @Test
+    func `forwarded node session approval rejects a changed mutable script operand`() async throws {
+        try await self.withTempStateDir { stateDir in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .off
+            }.get()
+            let scriptURL = stateDir.appendingPathComponent("script.py")
+            let approvedData = Data("print('approved')\n".utf8)
+            try approvedData.write(to: scriptURL)
+            let approvedHash = SHA256.hash(data: approvedData)
+                .map { String(format: "%02x", $0) }
+                .joined()
+            let command = ["/usr/bin/python3", scriptURL.path]
+            let operand = OpenClawSystemRunApprovalFileOperand(
+                argvIndex: 1,
+                path: scriptURL.resolvingSymlinksInPath().path,
+                sha256: approvedHash)
+            try Data("print('changed')\n".utf8).write(to: scriptURL)
+
+            let probe = ShellRunProbe()
+            let runtime = MacNodeRuntime(
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunParams(
+                command: command,
+                agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(
+                    command: command,
+                    mutableFileOperand: operand),
+                approvalDecision: "allow-once")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "changed-script-operand",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+
+            #expect(!response.ok)
+            #expect(response.error?.message.contains("script operand changed") == true)
+            #expect(await probe.capturedCommands().isEmpty)
+
+            try approvedData.write(to: scriptURL)
+            let restoredResponse = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "restored-script-operand",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: json))
+            #expect(restoredResponse.ok)
+            #expect(await probe.capturedCommands() == [command])
+        }
+    }
+
+    @Test
     func `native runtime cannot persist allow always after concurrent policy revocation`() async throws {
         try await self.withTempStateDir { _ in
             _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
@@ -878,6 +1069,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalDecision: "allow-always")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -906,6 +1098,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalSource: "ask-fallback")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -935,6 +1128,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: command,
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: command),
                 approvalSource: "ask-fallback")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -986,6 +1180,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: command,
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: command),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1013,6 +1208,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1047,6 +1243,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/usr/bin/printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/usr/bin/printf", "ok"]),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1077,6 +1274,7 @@ struct ExecApprovalsStoreRefactorTests {
                 command: command,
                 rawCommand: payload,
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: command, rawCommand: payload),
                 approvalSource: "auto-review")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1129,6 +1327,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["printf", "ok"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["printf", "ok"]),
                 approvalSource: "ask-fallback")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1157,6 +1356,7 @@ struct ExecApprovalsStoreRefactorTests {
             let params = OpenClawSystemRunParams(
                 command: ["/bin/echo", "miss"],
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: ["/bin/echo", "miss"]),
                 approvalSource: "ask-fallback")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1188,6 +1388,7 @@ struct ExecApprovalsStoreRefactorTests {
                 command: original,
                 rawCommand: payload,
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: original, rawCommand: payload),
                 approvalDecision: "allow-once")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1217,6 +1418,7 @@ struct ExecApprovalsStoreRefactorTests {
                 command: original,
                 rawCommand: payload,
                 agentId: "main",
+                systemRunPlan: Self.forwardedApprovalPlan(command: original, rawCommand: payload),
                 approvalDecision: "allow-always")
             let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
 
@@ -1551,6 +1753,55 @@ struct ExecApprovalsStoreRefactorTests {
                 Issue.record("expected deny policy to override auto review")
                 return
             }
+        }
+    }
+
+    @Test
+    func `forwarded explicit approval cannot restore a rule revoked before Mac evaluation`() async throws {
+        try await self.withTempStateDir { _ in
+            let stale = ExecAllowlistEntry(
+                pattern: "/usr/bin/printf",
+                source: "allow-always")
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .allowlist
+                entry.ask = .always
+                entry.allowlist = [stale]
+            }.get()
+            let forwardedSnapshot = ExecApprovalPolicySnapshot(
+                resolved: ExecApprovalsStore.resolve(agentId: "main"))
+
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.allowlist = []
+            }.get()
+            let freshContext = await ExecApprovalEvaluator.evaluate(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                envOverrides: nil,
+                agentId: "main")
+            #expect(freshContext.policySnapshot != forwardedSnapshot)
+
+            let commit = ExecApprovalExecutionCommit.build(
+                context: freshContext,
+                effectiveSecurity: .allowlist,
+                approvalSource: nil,
+                explicitlyApproved: true,
+                persistAllowlist: true,
+                delayedPolicySnapshot: forwardedSnapshot)
+            if case let .explicitAlways(_, policySnapshot, grants) = commit.authorization {
+                #expect(policySnapshot == forwardedSnapshot)
+                #expect(grants.map(\.match.pattern) == ["/usr/bin/printf"])
+            } else {
+                Issue.record("expected forwarded durable approval")
+            }
+
+            let result = ExecApprovalsStore.commitExecution(commit)
+
+            guard case .failure(.unavailable) = result else {
+                Issue.record("expected revoked forwarded approval to fail")
+                return
+            }
+            #expect(ExecApprovalsStore.resolve(agentId: "main").allowlist.isEmpty)
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -163,13 +164,105 @@ struct ExecHostRequestEvaluatorTests {
             agentId: nil,
             sessionKey: nil,
             approvalDecision: nil,
-            approvalSource: "auto-review")
+            approvalSource: "auto-review",
+            policySnapshot: Self.portablePolicySnapshot)
 
         switch ExecHostRequestEvaluator.validateRequest(request) {
         case let .success(validated):
             #expect(validated.approvalSource == .autoReview)
+            #expect(validated.delayedPolicySnapshot == ExecApprovalPolicySnapshot(
+                portable: Self.portablePolicySnapshot))
         case let .failure(error):
             Issue.record("unexpected invalid request: \(error.message)")
+        }
+    }
+
+    @Test func `validate request requires snapshots only for forwarded delayed authority`() {
+        let delayedRequests = [
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: .allowOnce),
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: .allowAlways),
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: nil,
+                approvalSource: "auto-review"),
+        ]
+        for request in delayedRequests {
+            switch ExecHostRequestEvaluator.validateRequest(request) {
+            case .success:
+                Issue.record("expected delayed approval without snapshot to fail")
+            case let .failure(error):
+                #expect(error.code == "INVALID_REQUEST")
+                #expect(error.message == "delayed approval requires a prepared policy snapshot")
+                #expect(error.reason == "invalid")
+            }
+        }
+
+        let nonDelayedRequests = [
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: nil,
+                policySnapshot: Self.portablePolicySnapshot),
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: nil,
+                approvalSource: "ask-fallback"),
+            ExecHostRequest(
+                command: ["/usr/bin/printf", "ok"],
+                rawCommand: nil,
+                cwd: nil,
+                env: nil,
+                timeoutMs: nil,
+                needsScreenRecording: nil,
+                agentId: nil,
+                sessionKey: nil,
+                approvalDecision: .deny),
+        ]
+        for request in nonDelayedRequests {
+            switch ExecHostRequestEvaluator.validateRequest(request) {
+            case let .success(validated):
+                #expect(validated.delayedPolicySnapshot == nil)
+            case let .failure(error):
+                Issue.record("unexpected invalid request: \(error.message)")
+            }
         }
     }
 
@@ -300,12 +393,20 @@ struct ExecHostRequestEvaluatorTests {
             ask: .off,
             allowlistSatisfied: false,
             skillAllow: false)
+        let forwardedSnapshot = ExecApprovalPolicySnapshot(
+            security: .allowlist,
+            ask: .always,
+            askFallback: .allowlist,
+            autoAllowSkills: true,
+            allowlist: [ExecAllowlistEntry(pattern: "/usr/bin/printf")])
+        #expect(forwardedSnapshot != currentContext.policySnapshot)
         let current = ExecApprovalExecutionCommit.build(
             context: currentContext,
             effectiveSecurity: .full,
             approvalSource: nil,
             explicitlyApproved: false,
-            persistAllowlist: false)
+            persistAllowlist: false,
+            delayedPolicySnapshot: forwardedSnapshot)
         if case let .currentPolicy(security, ask, basis) = current.authorization {
             #expect(security == .full)
             #expect(ask == .off)
@@ -319,10 +420,11 @@ struct ExecHostRequestEvaluatorTests {
             effectiveSecurity: .full,
             approvalSource: nil,
             explicitlyApproved: true,
-            persistAllowlist: false)
+            persistAllowlist: false,
+            delayedPolicySnapshot: forwardedSnapshot)
         if case let .explicitOnce(security, policySnapshot) = explicit.authorization {
             #expect(security == .full)
-            #expect(policySnapshot == currentContext.policySnapshot)
+            #expect(policySnapshot == forwardedSnapshot)
         } else {
             Issue.record("expected explicit authorization")
         }
@@ -338,7 +440,8 @@ struct ExecHostRequestEvaluatorTests {
             effectiveSecurity: .full,
             approvalSource: .askFallback,
             explicitlyApproved: false,
-            persistAllowlist: false)
+            persistAllowlist: false,
+            delayedPolicySnapshot: forwardedSnapshot)
         if case let .askFallback(security, basis) = fallback.authorization {
             #expect(security == .full)
             #expect(basis == nil)
@@ -356,12 +459,35 @@ struct ExecHostRequestEvaluatorTests {
             effectiveSecurity: .allowlist,
             approvalSource: .autoReview,
             explicitlyApproved: true,
-            persistAllowlist: false)
+            persistAllowlist: false,
+            delayedPolicySnapshot: forwardedSnapshot)
         if case let .autoReview(security, policySnapshot) = autoReview.authorization {
             #expect(security == .allowlist)
-            #expect(policySnapshot == autoReviewContext.policySnapshot)
+            #expect(policySnapshot == forwardedSnapshot)
         } else {
             Issue.record("expected auto-review authorization")
+        }
+
+        let durableContext = Self.makeContext(
+            security: .allowlist,
+            ask: .onMiss,
+            allowlistSatisfied: false,
+            skillAllow: false,
+            boundCommand: ["/usr/bin/printf", "ok"],
+            allowAlwaysPatterns: ["/usr/bin/printf"])
+        let durable = ExecApprovalExecutionCommit.build(
+            context: durableContext,
+            effectiveSecurity: .allowlist,
+            approvalSource: nil,
+            explicitlyApproved: true,
+            persistAllowlist: true,
+            delayedPolicySnapshot: forwardedSnapshot)
+        if case let .explicitAlways(security, policySnapshot, grants) = durable.authorization {
+            #expect(security == .allowlist)
+            #expect(policySnapshot == forwardedSnapshot)
+            #expect(grants.map(\.match.pattern) == ["/usr/bin/printf"])
+        } else {
+            Issue.record("expected durable explicit authorization")
         }
     }
 
@@ -410,7 +536,9 @@ struct ExecHostRequestEvaluatorTests {
         ask: ExecAsk,
         askFallback: ExecSecurity = .deny,
         allowlistSatisfied: Bool,
-        skillAllow: Bool) -> ExecApprovalEvaluation
+        skillAllow: Bool,
+        boundCommand: [String]? = nil,
+        allowAlwaysPatterns: [String] = []) -> ExecApprovalEvaluation
     {
         ExecApprovalEvaluation(
             displayCommand: "/usr/bin/echo hi",
@@ -421,8 +549,8 @@ struct ExecHostRequestEvaluatorTests {
             env: [:],
             resolution: nil,
             allowlistResolutions: [],
-            boundCommand: nil,
-            allowAlwaysPatterns: [],
+            boundCommand: boundCommand,
+            allowAlwaysPatterns: allowAlwaysPatterns,
             allowlistMatches: [],
             allowlistAuthorizationSatisfied: allowlistSatisfied,
             allowlistSatisfied: allowlistSatisfied,
@@ -435,4 +563,11 @@ struct ExecHostRequestEvaluatorTests {
                 autoAllowSkills: false,
                 allowlist: []))
     }
+
+    private static let portablePolicySnapshot = OpenClawSystemRunApprovalPolicySnapshot(
+        security: .full,
+        ask: .off,
+        askFallback: .deny,
+        autoAllowSkills: false,
+        allowlistRules: [])
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalPolicySnapshot.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ExecApprovalPolicySnapshot.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Canonical persisted-policy snapshot carried with delayed exec authority.
+public struct OpenClawSystemRunApprovalPolicySnapshot: Codable, Sendable, Equatable {
+    public enum Security: String, Codable, Sendable, Hashable {
+        case deny
+        case allowlist
+        case full
+    }
+
+    public enum Ask: String, Codable, Sendable, Hashable {
+        case off
+        case onMiss = "on-miss"
+        case always
+    }
+
+    public enum RuleSource: String, Codable, Sendable, Hashable {
+        case allowAlways = "allow-always"
+    }
+
+    public struct Rule: Codable, Sendable, Hashable {
+        public let pattern: String
+        public let argPattern: String?
+        public let source: RuleSource?
+
+        public init(pattern: String, argPattern: String? = nil, source: RuleSource? = nil) {
+            self.pattern = pattern
+            self.argPattern = argPattern
+            self.source = source
+        }
+    }
+
+    public let security: Security
+    public let ask: Ask
+    public let askFallback: Security
+    public let autoAllowSkills: Bool
+    public let allowlistRules: [Rule]
+
+    private struct RuleKey: Hashable {
+        let pattern: Data
+        let argPattern: Data?
+        let source: RuleSource?
+
+        init(_ rule: Rule) {
+            self.pattern = Data(rule.pattern.utf8)
+            self.argPattern = rule.argPattern.map { Data($0.utf8) }
+            self.source = rule.source
+        }
+    }
+
+    public init(
+        security: Security,
+        ask: Ask,
+        askFallback: Security,
+        autoAllowSkills: Bool,
+        allowlistRules: [Rule])
+    {
+        self.security = security
+        self.ask = ask
+        self.askFallback = askFallback
+        self.autoAllowSkills = autoAllowSkills
+        self.allowlistRules = Dictionary(
+            allowlistRules.map { (RuleKey($0), $0) },
+            uniquingKeysWith: { first, _ in first }).values.sorted(by: Self.rulePrecedes)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case security
+        case ask
+        case askFallback
+        case autoAllowSkills
+        case allowlistRules
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            security: container.decode(Security.self, forKey: .security),
+            ask: container.decode(Ask.self, forKey: .ask),
+            askFallback: container.decode(Security.self, forKey: .askFallback),
+            autoAllowSkills: container.decode(Bool.self, forKey: .autoAllowSkills),
+            allowlistRules: container.decode([Rule].self, forKey: .allowlistRules))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.security, forKey: .security)
+        try container.encode(self.ask, forKey: .ask)
+        try container.encode(self.askFallback, forKey: .askFallback)
+        try container.encode(self.autoAllowSkills, forKey: .autoAllowSkills)
+        try container.encode(self.allowlistRules, forKey: .allowlistRules)
+    }
+
+    private static func rulePrecedes(_ lhs: Rule, _ rhs: Rule) -> Bool {
+        let patternOrder = self.compareUTF8(lhs.pattern, rhs.pattern)
+        if patternOrder != 0 {
+            return patternOrder < 0
+        }
+        let argPatternOrder = self.compareOptionalUTF8(lhs.argPattern, rhs.argPattern)
+        if argPatternOrder != 0 {
+            return argPatternOrder < 0
+        }
+        return self.compareOptionalUTF8(lhs.source?.rawValue, rhs.source?.rawValue) < 0
+    }
+
+    private static func compareOptionalUTF8(_ lhs: String?, _ rhs: String?) -> Int {
+        switch (lhs, rhs) {
+        case (nil, nil): 0
+        case (nil, .some): -1
+        case (.some, nil): 1
+        case let (.some(lhs), .some(rhs)):
+            self.compareUTF8(lhs, rhs)
+        }
+    }
+
+    private static func compareUTF8(_ lhs: String, _ rhs: String) -> Int {
+        let lhsBytes = Array(lhs.utf8)
+        let rhsBytes = Array(rhs.utf8)
+        if lhsBytes == rhsBytes {
+            return 0
+        }
+        return lhsBytes.lexicographicallyPrecedes(rhsBytes) ? -1 : 1
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
@@ -20,6 +20,49 @@ public enum OpenClawNotificationDelivery: String, Codable, Sendable {
     case auto
 }
 
+public struct OpenClawSystemRunApprovalFileOperand: Codable, Sendable, Equatable {
+    public var argvIndex: Int
+    public var path: String
+    public var sha256: String
+
+    public init(argvIndex: Int, path: String, sha256: String) {
+        self.argvIndex = argvIndex
+        self.path = path
+        self.sha256 = sha256
+    }
+}
+
+public struct OpenClawSystemRunApprovalPlan: Codable, Sendable, Equatable {
+    public var argv: [String]
+    public var cwd: String?
+    public var commandText: String
+    public var commandPreview: String?
+    public var agentId: String?
+    public var sessionKey: String?
+    public var policySnapshot: OpenClawSystemRunApprovalPolicySnapshot?
+    public var mutableFileOperand: OpenClawSystemRunApprovalFileOperand?
+
+    public init(
+        argv: [String],
+        cwd: String?,
+        commandText: String,
+        commandPreview: String? = nil,
+        agentId: String?,
+        sessionKey: String?,
+        policySnapshot: OpenClawSystemRunApprovalPolicySnapshot? = nil,
+        mutableFileOperand: OpenClawSystemRunApprovalFileOperand? = nil)
+    {
+        self.argv = argv
+        self.cwd = cwd
+        self.commandText = commandText
+        self.commandPreview = commandPreview
+        self.agentId = agentId
+        self.sessionKey = sessionKey
+        self.policySnapshot = policySnapshot
+        self.mutableFileOperand = mutableFileOperand
+    }
+}
+
 public struct OpenClawSystemRunParams: Codable, Sendable, Equatable {
     public var command: [String]
     public var rawCommand: String?
@@ -30,6 +73,7 @@ public struct OpenClawSystemRunParams: Codable, Sendable, Equatable {
     public var agentId: String?
     public var sessionKey: String?
     public var runId: String?
+    public var systemRunPlan: OpenClawSystemRunApprovalPlan?
     public var approved: Bool?
     public var approvalDecision: String?
     public var approvalSource: String?
@@ -44,6 +88,7 @@ public struct OpenClawSystemRunParams: Codable, Sendable, Equatable {
         agentId: String? = nil,
         sessionKey: String? = nil,
         runId: String? = nil,
+        systemRunPlan: OpenClawSystemRunApprovalPlan? = nil,
         approved: Bool? = nil,
         approvalDecision: String? = nil,
         approvalSource: String? = nil)
@@ -57,6 +102,7 @@ public struct OpenClawSystemRunParams: Codable, Sendable, Equatable {
         self.agentId = agentId
         self.sessionKey = sessionKey
         self.runId = runId
+        self.systemRunPlan = systemRunPlan
         self.approved = approved
         self.approvalDecision = approvalDecision
         self.approvalSource = approvalSource

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -4,7 +4,6 @@
  * requirements, and formats node invoke results for the exec tool.
  */
 import crypto from "node:crypto";
-import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import {
   describeInterpreterInlineEval,
   type InterpreterInlineEvalHit,
@@ -34,7 +33,6 @@ import {
 } from "../infra/system-run-approval-context.js";
 import {
   extractShellCommandFromArgv,
-  formatExecCommand,
   resolveSystemRunCommandRequest,
 } from "../infra/system-run-command.js";
 import { addSafeTimeoutDelayGraceMs } from "../utils/timer-delay.js";
@@ -425,7 +423,7 @@ export async function prepareNodeSystemRun(params: {
   target: NodeExecutionTarget;
 }): Promise<PreparedNodeRun> {
   if (!params.target.supportsSystemRunPrepare) {
-    return buildLocalPreparedNodeRun(params);
+    throw new Error("exec denied: node approval requires system.run.prepare support");
   }
 
   const prepareRaw = await callGatewayTool(
@@ -460,45 +458,6 @@ export async function prepareNodeSystemRun(params: {
     sessionKey: prepared.plan.sessionKey ?? params.request.sessionKey,
     ...(prepared.execPolicy ? { execPolicy: prepared.execPolicy } : {}),
     allowAlwaysCoverage: prepared.allowAlwaysCoverage,
-  };
-}
-
-function buildLocalPreparedNodeRun(params: {
-  request: ExecuteNodeHostCommandParams;
-  target: NodeExecutionTarget;
-}): PreparedNodeRun {
-  const rawCommand = formatExecCommand(params.target.argv);
-  const command = resolveSystemRunCommandRequest({
-    command: params.target.argv,
-    rawCommand,
-  });
-  if (!command.ok) {
-    throw new Error(command.message);
-  }
-  if (command.argv.length === 0) {
-    throw new Error("command required");
-  }
-  const commandText = formatExecCommand(command.argv);
-  const previewText = params.request.command.trim() || command.previewText?.trim();
-  const commandPreview = previewText && previewText !== commandText ? previewText : null;
-  const plan = {
-    argv: [...command.argv],
-    cwd: normalizeNullableString(params.request.workdir),
-    commandText,
-    commandPreview,
-    agentId: normalizeNullableString(params.request.agentId),
-    sessionKey: normalizeNullableString(params.request.sessionKey),
-  } satisfies SystemRunApprovalPlan;
-  return {
-    plan,
-    argv: plan.argv,
-    rawCommand: plan.commandText,
-    // Legacy macOS nodes parse the bound shell payload for allowlist matching.
-    // Analysis and approval binding remain anchored to the canonical plan text.
-    transportRawCommand: plan.commandPreview ?? plan.commandText,
-    cwd: plan.cwd ?? params.request.workdir,
-    agentId: plan.agentId ?? params.request.agentId,
-    sessionKey: plan.sessionKey ?? params.request.sessionKey,
   };
 }
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -2639,7 +2639,7 @@ describe("executeNodeHostCommand", () => {
     ).toBe(false);
   });
 
-  it("builds a local systemRunPlan when approval is required and the node omits prepare", async () => {
+  it("rejects approval when the node omits prepare", async () => {
     listNodesMock.mockResolvedValueOnce([
       {
         nodeId: "node-1",
@@ -2654,38 +2654,21 @@ describe("executeNodeHostCommand", () => {
       askFallback: "deny",
     });
 
-    const result = await executeNodeHostCommand({
-      command: "bun ./script.ts",
-      workdir: "/tmp/work",
-      env: {},
-      security: "full",
-      ask: "off",
-      defaultTimeoutSec: 30,
-      approvalRunningNoticeMs: 0,
-      warnings: [],
-      agentId: "requested-agent",
-      sessionKey: "requested-session",
-    });
-
-    expect(result.details?.status).toBe("approval-pending");
-    expect(parsePreparedSystemRunPayloadMock).not.toHaveBeenCalled();
-    const expectedPlan = {
-      argv: ["/bin/sh", "-lc", "bun ./script.ts"],
-      cwd: "/tmp/work",
-      commandText: '/bin/sh -lc "bun ./script.ts"',
-      commandPreview: "bun ./script.ts",
-      agentId: "requested-agent",
-      sessionKey: "requested-session",
-    };
-    expect(requireRegisteredApprovalRequest().systemRunPlan).toEqual(expectedPlan);
-
-    await vi.waitFor(() => {
-      const call = requireGatewayCommand("system.run");
-      expect(call.callOptions).toEqual({ scopes: ["operator.write", "operator.approvals"] });
-      const runParams = requireRunParams(call);
-      expect(runParams.rawCommand).toBe(expectedPlan.commandPreview);
-      expect(runParams.systemRunPlan).toEqual(expectedPlan);
-    });
+    await expect(
+      executeNodeHostCommand({
+        command: "bun ./script.ts",
+        workdir: "/tmp/work",
+        env: {},
+        security: "full",
+        ask: "off",
+        defaultTimeoutSec: 30,
+        approvalRunningNoticeMs: 0,
+        warnings: [],
+        agentId: "requested-agent",
+        sessionKey: "requested-session",
+      }),
+    ).rejects.toThrow("node approval requires system.run.prepare support");
+    expect(registerExecApprovalRequestForHostOrThrowMock).not.toHaveBeenCalled();
   });
 
   it("requires approval when node allowlist matching would depend on gateway PATH", async () => {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -1758,6 +1758,37 @@ describe("exec approvals store helpers", () => {
     ).rejects.toThrow("Exec approval changed before execution");
   });
 
+  it("normalizes legacy allowlist sources in portable policy snapshots", () => {
+    const dir = createHomeDir();
+    const approvalsPath = approvalsFilePath(dir);
+    fs.mkdirSync(path.dirname(approvalsPath), { recursive: true });
+    fs.writeFileSync(
+      approvalsPath,
+      JSON.stringify({
+        version: 1,
+        defaults: { security: "allowlist", ask: "always" },
+        agents: {
+          main: {
+            allowlist: [
+              { pattern: "/usr/bin/jq", source: "legacy" },
+              { pattern: "/usr/bin/rg", source: "allow-always" },
+            ],
+          },
+        },
+      }),
+    );
+
+    const policySnapshot = createExecApprovalPolicySnapshot({
+      file: readExecApprovalsSnapshot().file,
+      agentId: "main",
+    });
+
+    expect(policySnapshot.allowlistRules).toEqual([
+      { pattern: "/usr/bin/jq" },
+      { pattern: "/usr/bin/rg", source: "allow-always" },
+    ]);
+  });
+
   it("rejects an explicit approval after policy changes to deny without persisting its grant", async () => {
     const dir = createHomeDir();
     saveExecApprovals({

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -2050,7 +2050,7 @@ export function createExecApprovalPolicySnapshot(params: {
       const rule = {
         pattern: entry.pattern,
         ...(entry.argPattern !== undefined ? { argPattern: entry.argPattern } : {}),
-        ...(entry.source !== undefined ? { source: entry.source } : {}),
+        ...(entry.source === "allow-always" ? { source: entry.source } : {}),
       };
       return [buildExecApprovalPolicyRuleKey(rule), rule] as const;
     }),

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -946,6 +946,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(macHostCall.request?.command).toEqual(["env", "sh", "-c", "echo SAFE"]);
           expect(macHostCall.request?.rawCommand).toBe('env sh -c "echo SAFE"');
           expect(macHostCall.request?.cwd).toBe(canonicalCwd);
+          expect(macHostCall.request?.approvalDecision).toBe("allow-once");
+          expect(macHostCall.request?.approvalSource).toBeUndefined();
           expect(macHostCall.request?.policySnapshot).toEqual(
             createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
           );

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -954,6 +954,11 @@ async function executeSystemRunPhase(
     const macApprovalSource =
       phase.approvalSource ??
       (phase.approvalGrantSource === "auto-review" ? "auto-review" : undefined);
+    const macApprovalDecision = macApprovalSource
+      ? null
+      : phase.approvalGrantSource === "explicit-approval" && phase.approvalDecision === null
+        ? "allow-once"
+        : phase.approvalDecision;
     const execRequest: ExecHostRequest = {
       command: execArgv,
       // Forward canonical display text so companion approval/prompt surfaces bind to
@@ -965,7 +970,7 @@ async function executeSystemRunPhase(
       needsScreenRecording: phase.needsScreenRecording,
       agentId: phase.agentId ?? null,
       sessionKey: phase.sessionKey ?? null,
-      approvalDecision: macApprovalSource ? null : phase.approvalDecision,
+      approvalDecision: macApprovalDecision,
       approvalSource: macApprovalSource,
       ...(phase.approvalGrantSource ? { policySnapshot: phase.evaluationPolicySnapshot } : {}),
     };


### PR DESCRIPTION
Depends on #103950

## What Problem This Solves

Fixes an issue where delayed Gateway approval for a Mac App node could be rebound to freshly evaluated Mac policy. A rule revoked after upstream approval could therefore be restored by a later allow-always commit.

## Why This Change Was Made

The node host now carries the canonical persisted-policy snapshot through both Mac execution routes: the authenticated exec socket and the native node session. The Mac requires the original snapshot for forwarded explicit and auto-review authority, revalidates it under the approval-store write lock, and rejects changed mutable script operands before execution.

Gateway no longer synthesizes delayed authority for nodes that omit `system.run.prepare`. It cannot prove remote executable or file identity from its own filesystem, so approval-requiring legacy native runs now fail closed before approval registration. Direct full/off execution remains unchanged.

Legacy boolean approvals normalize to one-shot socket decisions, and legacy allowlist source strings normalize to the portable `allow-always` contract before Swift decoding.

## User Impact

Mac App and CLI nodes now reject delayed approvals when policy is revoked while approval is in flight. Native nodes without prepare support receive a clear fail-closed error for approval-requiring runs instead of an unsafe Gateway-local plan. Local prompts, current-policy execution, ask-fallback ownership, and direct full/off execution are unchanged.

## Evidence

- clawmac native macOS run: 147 tests across five approval/runtime suites passed, including policy revocation, changed-script rejection, restored-byte execution, plan identity, and denial behavior.
- Follow-up native clawmac run: 115 tests across `ExecApprovalsStoreRefactorTests` and `MacNodeRuntimeTests` passed.
- Blacksmith Testbox `tbx_01kx79tebvg3g9rgnan3fwffcj`: 220 focused tests passed across agent node routing, node-host invocation, and approval-store suites.
- Same Testbox: `pnpm check:changed` passed in 8m08s, including typechecks, complete core lint shards, macOS packaging tests, import-cycle checks, and repository safety guards.
- Native i18n inventory check passed with 2,931 entries and no drift.
- SwiftFormat lint and targeted oxfmt checks passed.
- Exact-head CI repair at `99b2189300`: extracted the pure native plan/hash validator after SwiftLint caught `MacNodeRuntime.swift` over its 1,500-line limit; full Mac Swift lint, repository formatting, native i18n inventory, native package rebuild, and the 147-test clawmac suite passed.
- Fresh structured autoreview: no accepted/actionable findings; patch judged correct (0.90).
