### PR TITLE
fix(doctor): migrate MCP flags in included config

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -283,6 +283,7 @@ That stages grounded durable candidates into the short-term dreaming store while
     | `browser.profiles.*.driver: "extension"`                                                         | `"existing-session"`                                                          |
     | `browser.relayBindHost`                                                                          | removed (legacy Chrome extension relay setting)                             |
     | `mcp.servers.*.type` (CLI-native aliases)                                                        | `mcp.servers.*.transport`                                                    |
+    | `mcp.servers.*.disabled`                                                                         | inverse `mcp.servers.*.enabled`                                              |
     | MCP timeout aliases `connectTimeout`/`connect_timeout`/`timeout`                                 | `connectionTimeoutMs`/`requestTimeoutMs`                                    |
     | top-level `defaultModel`                                                                         | `agents.defaults.model`                                                      |
     | `messages.messagePrefix`                                                                         | `channels.whatsapp.messagePrefix`                                            |

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -21,6 +21,7 @@ import {
   applyUnknownConfigKeyStep,
 } from "./doctor/shared/config-flow-steps.js";
 import { applyDoctorConfigMutation } from "./doctor/shared/config-mutation-state.js";
+import { isSingleTopLevelIncludeMigration } from "./doctor/shared/include-migration-ownership.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 
 function hasLegacyInternalHookHandlers(raw: unknown): boolean {
@@ -416,6 +417,13 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note,
   });
   cfg = finalized.cfg;
+  const singleTopLevelIncludeWrite =
+    finalized.shouldWriteConfig &&
+    isSingleTopLevelIncludeMigration({
+      parsed: snapshot.parsed,
+      sourceConfig: snapshot.sourceConfig,
+      candidate: cfg,
+    });
 
   noteOpencodeProviderOverrides(cfg);
   noteImplicitFallbackClobberWarnings(cfg);
@@ -428,6 +436,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     sourceConfigValid: snapshot.valid,
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),
+    ...(singleTopLevelIncludeWrite ? { skipWizardMetadataForIncludeWrite: true } : {}),
     ...(shouldRepairCronCodexModelRefsAfterConfigWrite
       ? { shouldRepairCronCodexModelRefsAfterConfigWrite: true }
       : {}),

--- a/src/commands/doctor/legacy-config-repair.ts
+++ b/src/commands/doctor/legacy-config-repair.ts
@@ -1,33 +1,21 @@
 // Update-channel config repair for legacy config files before normal command startup.
 import { readConfigFileSnapshot, replaceConfigFile } from "../../config/config.js";
-import { INCLUDE_KEY } from "../../config/includes.js";
 import { validateConfigObjectWithPlugins } from "../../config/validation.js";
-import { isRecord } from "../../utils.js";
+import {
+  containsAuthoredInclude,
+  isSingleTopLevelIncludeMigration,
+} from "./shared/include-migration-ownership.js";
 import { migrateLegacyConfig } from "./shared/legacy-config-migrate.js";
 
 type ConfigSnapshot = Awaited<ReturnType<typeof readConfigFileSnapshot>>;
 
-/** Return true when a config tree uses authored includes that doctor must not flatten. */
-function containsAuthoredInclude(value: unknown): boolean {
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (Object.hasOwn(value, INCLUDE_KEY)) {
-    return true;
-  }
-  return Object.values(value).some((entry) => containsAuthoredInclude(entry));
-}
-
-/** Migrate a legacy config snapshot during update, unless includes or validation block it. */
+/** Migrate a legacy config snapshot during update, unless validation blocks it. */
 export async function repairLegacyConfigForUpdateChannel(params: {
   configSnapshot: ConfigSnapshot;
   jsonMode: boolean;
 }): Promise<{ snapshot: ConfigSnapshot; repaired: boolean }> {
-  if (containsAuthoredInclude(params.configSnapshot.parsed)) {
-    return { snapshot: params.configSnapshot, repaired: false };
-  }
-
-  const migrated = migrateLegacyConfig(params.configSnapshot.parsed);
+  const hasAuthoredIncludes = containsAuthoredInclude(params.configSnapshot.parsed);
+  const migrated = migrateLegacyConfig(params.configSnapshot.sourceConfig);
   if (!migrated.config) {
     return { snapshot: params.configSnapshot, repaired: false };
   }
@@ -37,8 +25,21 @@ export async function repairLegacyConfigForUpdateChannel(params: {
     return { snapshot: params.configSnapshot, repaired: false };
   }
 
+  const nextConfig =
+    hasAuthoredIncludes && migrated.sourceConfig ? migrated.sourceConfig : validated.config;
+  if (
+    hasAuthoredIncludes &&
+    !isSingleTopLevelIncludeMigration({
+      parsed: params.configSnapshot.parsed,
+      sourceConfig: params.configSnapshot.sourceConfig,
+      candidate: nextConfig,
+    })
+  ) {
+    return { snapshot: params.configSnapshot, repaired: false };
+  }
+
   await replaceConfigFile({
-    nextConfig: validated.config,
+    nextConfig,
     baseHash: params.configSnapshot.hash,
     writeOptions: {
       auditOrigin: "doctor",

--- a/src/commands/doctor/shared/config-flow-steps.test.ts
+++ b/src/commands/doctor/shared/config-flow-steps.test.ts
@@ -74,6 +74,40 @@ describe("doctor config flow steps", () => {
     expect(result.state.pendingChanges).toBe(true);
   });
 
+  it("migrates the resolved config so single-file include values are repairable", () => {
+    const sourceConfig = {
+      mcp: { servers: { local: { command: "node", disabled: true } } },
+    } as unknown as OpenClawConfig;
+    migrateLegacyConfigMock.mockReturnValueOnce({
+      config: {
+        commands: { native: "auto" },
+        mcp: { servers: { local: { command: "node", enabled: false } } },
+      },
+      sourceConfig: { mcp: { servers: { local: { command: "node", enabled: false } } } },
+      changes: ["Moved mcp.servers.local.disabled true → enabled false."],
+    });
+
+    const result = createLegacyStepResult({
+      exists: true,
+      parsed: { mcp: { $include: "./mcp.json5" } },
+      legacyIssues: [{ path: "mcp.servers", message: "disabled is legacy" }],
+      path: "/tmp/config.json",
+      valid: false,
+      issues: [],
+      raw: "{}",
+      resolved: sourceConfig,
+      sourceConfig,
+      config: sourceConfig,
+      runtimeConfig: sourceConfig,
+      warnings: [],
+    } satisfies DoctorConfigPreflightResult["snapshot"]);
+
+    expect(migrateLegacyConfigMock).toHaveBeenCalledWith(sourceConfig);
+    expect(result.state.pendingChanges).toBe(true);
+    expect(result.state.candidate.mcp?.servers?.local?.enabled).toBe(false);
+    expect(result.state.candidate.commands).toBeUndefined();
+  });
+
   it("keeps pending repair state for legacy issues even when the snapshot is already normalized", () => {
     const result = createLegacyStepResult({
       exists: true,

--- a/src/commands/doctor/shared/config-flow-steps.ts
+++ b/src/commands/doctor/shared/config-flow-steps.ts
@@ -4,6 +4,7 @@ import { protectActiveAuthProfileConfig } from "../../doctor-auth-profile-config
 import { stripUnknownConfigKeys } from "../../doctor-config-analysis.js";
 import type { DoctorConfigPreflightResult } from "../../doctor-config-preflight.js";
 import type { DoctorConfigMutationState } from "./config-mutation-state.js";
+import { containsAuthoredInclude } from "./include-migration-ownership.js";
 import { migrateLegacyConfig } from "./legacy-config-migrate.js";
 
 /** Apply legacy config migrations and update preview/fix state for doctor config flow. */
@@ -27,7 +28,16 @@ export function applyLegacyCompatibilityStep(params: {
   }
 
   const issueLines = formatConfigIssueLines(params.snapshot.legacyIssues, "-");
-  const { config: migrated, changes, partiallyValid } = migrateLegacyConfig(params.snapshot.parsed);
+  const hasAuthoredIncludes = containsAuthoredInclude(params.snapshot.parsed);
+  const migrationInput = hasAuthoredIncludes
+    ? params.snapshot.sourceConfig
+    : params.snapshot.parsed;
+  const {
+    config: migrated,
+    sourceConfig: migratedSource,
+    changes,
+    partiallyValid,
+  } = migrateLegacyConfig(migrationInput);
   if (!migrated) {
     return {
       state: {
@@ -45,6 +55,8 @@ export function applyLegacyCompatibilityStep(params: {
     };
   }
 
+  const migrationCandidate = hasAuthoredIncludes && migratedSource ? migratedSource : migrated;
+
   return {
     state: {
       // Doctor should keep using the best-effort migrated shape in memory even
@@ -52,8 +64,8 @@ export function applyLegacyCompatibilityStep(params: {
       // When partiallyValid, the migration succeeded but unrelated validation issues
       // remain — still commit the migration so doctor --fix always applies safe migrations
       // even when other problems prevent full validation from passing.
-      cfg: migrated,
-      candidate: migrated,
+      cfg: migrationCandidate,
+      candidate: migrationCandidate,
       // The read path can normalize legacy config into the snapshot before
       // migrateLegacyConfig emits concrete mutations. Legacy issues still mean
       // the on-disk config needs a doctor --fix path.

--- a/src/commands/doctor/shared/include-migration-ownership.test.ts
+++ b/src/commands/doctor/shared/include-migration-ownership.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { isSingleTopLevelIncludeMigration } from "./include-migration-ownership.js";
+
+const sourceConfig = {
+  mcp: { servers: { local: { command: "node", disabled: true } } },
+} as unknown as OpenClawConfig;
+const candidate = {
+  mcp: { servers: { local: { command: "node", enabled: false } } },
+} as OpenClawConfig;
+
+describe("include migration ownership", () => {
+  it("allows one isolated direct top-level string include", () => {
+    expect(
+      isSingleTopLevelIncludeMigration({
+        parsed: { mcp: { $include: "./mcp.json5" } },
+        sourceConfig,
+        candidate,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["root include", { $include: "./openclaw.json5" }],
+    ["include array", { mcp: { $include: ["./a.json5", "./b.json5"] } }],
+    ["nested include", { mcp: { servers: { $include: "./servers.json5" } } }],
+    ["sibling override", { mcp: { $include: "./mcp.json5", sessionIdleTtlMs: 1000 } }],
+  ])("rejects %s ownership", (_label, parsed) => {
+    expect(isSingleTopLevelIncludeMigration({ parsed, sourceConfig, candidate })).toBe(false);
+  });
+
+  it("rejects migrations that change more than one top-level section", () => {
+    expect(
+      isSingleTopLevelIncludeMigration({
+        parsed: { mcp: { $include: "./mcp.json5" }, gateway: { mode: "local" } },
+        sourceConfig: { ...sourceConfig, gateway: { mode: "local" } },
+        candidate: { ...candidate, gateway: { mode: "remote" } },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/commands/doctor/shared/include-migration-ownership.ts
+++ b/src/commands/doctor/shared/include-migration-ownership.ts
@@ -1,0 +1,39 @@
+import { isDeepStrictEqual } from "node:util";
+import { INCLUDE_KEY } from "../../../config/includes.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { isRecord } from "../../../utils.js";
+
+export function containsAuthoredInclude(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsAuthoredInclude);
+  }
+  const record = value as Record<string, unknown>;
+  return Object.hasOwn(record, INCLUDE_KEY) || Object.values(record).some(containsAuthoredInclude);
+}
+
+export function isSingleTopLevelIncludeMigration(params: {
+  parsed: unknown;
+  sourceConfig: OpenClawConfig;
+  candidate: OpenClawConfig;
+}): boolean {
+  if (!isRecord(params.parsed)) {
+    return false;
+  }
+  const keys = new Set([...Object.keys(params.sourceConfig), ...Object.keys(params.candidate)]);
+  const sourceConfig = params.sourceConfig as Record<string, unknown>;
+  const candidate = params.candidate as Record<string, unknown>;
+  const changed = [...keys].filter((key) => !isDeepStrictEqual(sourceConfig[key], candidate[key]));
+  const changedKey = changed.length === 1 ? changed[0] : undefined;
+  if (changedKey === undefined) {
+    return false;
+  }
+  const authoredSection = params.parsed[changedKey];
+  return (
+    isRecord(authoredSection) &&
+    Object.keys(authoredSection).length === 1 &&
+    typeof authoredSection[INCLUDE_KEY] === "string"
+  );
+}

--- a/src/commands/doctor/shared/legacy-config-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.ts
@@ -6,6 +6,7 @@ import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 /** Apply legacy migrations and validate the resulting OpenClaw config shape when possible. */
 export function migrateLegacyConfig(raw: unknown): {
   config: OpenClawConfig | null;
+  sourceConfig?: OpenClawConfig;
   changes: string[];
   partiallyValid?: boolean;
 } {
@@ -18,5 +19,5 @@ export function migrateLegacyConfig(raw: unknown): {
     changes.push("Migration applied; other validation issues remain — run doctor to review.");
     return { config: next as OpenClawConfig, changes, partiallyValid: true };
   }
-  return { config: validated.config, changes };
+  return { config: validated.config, sourceConfig: next as OpenClawConfig, changes };
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3367,6 +3367,32 @@ describe("doctor health contributions", () => {
     );
   });
 
+  it("preserves a single-file include write by omitting wizard metadata", async () => {
+    const cfg = { mcp: { servers: { local: { command: "node", enabled: false } } } };
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await requireDoctorContribution("doctor:write-config").run({
+      cfg,
+      cfgForPersistence: cfg,
+      configResult: {
+        cfg,
+        shouldWriteConfig: true,
+        skipWizardMetadataForIncludeWrite: true,
+      },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime,
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext);
+
+    expect(mocks.applyWizardMetadata).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({ nextConfig: cfg }),
+    );
+  });
+
   describe("config size drops during update", () => {
     beforeEach(() => {
       mocks.replaceConfigFile.mockReset();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -28,6 +28,7 @@ type DoctorConfigResult = {
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
+  skipWizardMetadataForIncludeWrite?: boolean;
   preservedLegacyRootKeys?: readonly string[];
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;
   blockedCodexModelIdentities?: readonly string[];
@@ -1316,10 +1317,12 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
   if (shouldWriteConfig) {
     const updateDoctorRun = isUpdateDoctorRun(ctx.env ?? process.env);
-    ctx.cfg = applyWizardMetadata(ctx.cfg, {
-      command: "doctor",
-      mode: resolveDoctorMode(ctx.cfg),
-    });
+    if (ctx.configResult.skipWizardMetadataForIncludeWrite !== true) {
+      ctx.cfg = applyWizardMetadata(ctx.cfg, {
+        command: "doctor",
+        mode: resolveDoctorMode(ctx.cfg),
+      });
+    }
     if (shouldSkipLegacyUpdateDoctorConfigWrite({ env: ctx.env ?? process.env })) {
       ctx.runtime.log("Skipping doctor config write during legacy update handoff.");
       return;


### PR DESCRIPTION
## What Problem This Solves

Merged #104495 already rejects unsupported MCP `disabled` keys and migrates root/node-host config through `openclaw doctor --fix`. For a supported direct top-level `$include`, however, the same repair guidance could not update the owning include file; update repair skipped all includes and interactive doctor could not preserve include ownership.

## Why This Change Was Made

- Run legacy migration against the resolved source shape when authored includes are present, while persisting the pre-default authored migration result.
- Permit automatic write-through only when exactly one changed top-level section is wholly owned by one direct string include.
- Skip doctor wizard metadata for that isolated write so the canonical include-aware writer sees a one-section mutation and updates the include file.
- Keep root, array, nested, sibling-override, multi-section, external-target, concurrent-change, and other ambiguous include layouts fail-closed through the existing writer guards.
- Preserve the previous validated-shape behavior for non-include update repairs.

Runtime consumers remain on the single canonical `enabled` field; this adds no runtime alias or new config surface.

## User Impact

Operators whose MCP section is stored in one direct include can run `openclaw doctor --fix` and retain the authored root include. Complex ownership still requires editing the owning file directly rather than risking flattened or overwritten config.

## Evidence

- Current main baseline: merged #104495 solves the reported startup bug and issue #103954 is closed; this PR contains only the remaining include-aware repair.
- `node scripts/run-vitest.mjs <config mutate, doctor flow, include ownership, migration, health, update CLI>` — 547 tests passed across five shards before rebase.
- Exact rebased head `c19e81e6757`: 266 focused doctor/migration tests passed across three shards.
- `node scripts/check-changed.mjs -- <ten touched files>` — core/core-test typecheck, full core lint, format, import cycles, dependency/API/database guards passed on Node 24.18. Blacksmith status timed out before repository proof, so the documented trusted-source local fallback ran the same plan with a worktree-scoped lock.
- AutoReview: clean, no accepted/actionable findings.
- `node scripts/check-docs-mdx.mjs docs/gateway/doctor.md` and `git diff --check` passed.

Follow-up to #104495. Original include-repair work by @harjothkhara; replacement commit preserves `Co-authored-by: Harjoth Khara <harjoth.khara@gmail.com>`.
