### PR TITLE
fix(ci): keep hydrate-github pnpm shims writable

### DIFF
--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -70,7 +70,14 @@ runs:
             exit 1
             ;;
         esac
-        corepack enable
+        if [ -n "${PNPM_HOME:-}" ]; then
+          mkdir -p "$PNPM_HOME"
+          corepack enable --install-directory "$PNPM_HOME"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+        else
+          corepack enable
+        fi
         for attempt in 1 2 3; do
           if corepack prepare "$package_manager" --activate; then
             exit 0

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -577,6 +577,8 @@ jobs:
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
+        env:
+          PNPM_HOME: ${{ runner.temp }}/pnpm-home
         with:
           install-bun: "false"
           use-actions-cache: "false"

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -437,6 +437,8 @@ describe("package acceptance workflow", () => {
     expect(setupPnpmAction).not.toContain("shasum");
     expect(setupPnpmAction).not.toContain("PNPM_VERSION_INPUT");
     expect(setupPnpmAction).not.toContain("version: ${{ inputs.pnpm-version }}");
+    expect(setupPnpmAction).toContain('corepack enable --install-directory "$PNPM_HOME"');
+    expect(setupPnpmAction).toContain('echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"');
 
     const setupNodeAction = readFileSync(".github/actions/setup-node-env/action.yml", "utf8");
     expect(setupNodeAction).toContain("Normalize container toolcache");
@@ -575,6 +577,9 @@ describe("package acceptance workflow", () => {
     expect(hydrateGithub.if).toBe("${{ inputs.crabbox_job == 'hydrate-github' }}");
     expect(workflowStep(hydrateGithub, "Setup Node environment").uses).toBe(
       "./.github/actions/setup-node-env",
+    );
+    expect(workflowStep(hydrateGithub, "Setup Node environment").env?.PNPM_HOME).toBe(
+      "${{ runner.temp }}/pnpm-home",
     );
     const hydrateGithubCrabboxShell = workflowStep(hydrateGithub, "Prepare Crabbox shell").run;
     expect(hydrateGithubCrabboxShell).toContain("link_node_tool()");


### PR DESCRIPTION
## What Problem This Solves

`hydrate-github` cannot prepare its repository because the unprivileged Crabbox runner invokes bare `corepack enable`, which tries to replace `/usr/local/bin/pnpm`. Runs 29123891578 and 29124361134 both fail in setup with `EACCES` before dependency hydration starts.

## Why This Change Was Made

The shared pnpm setup action now honors an explicit `PNPM_HOME` as its Corepack shim directory while preserving the existing default when that variable is unset. Only the `hydrate-github` job opts into a runner-temporary `PNPM_HOME`, keeping the fix scoped to the failing replay path and carrying the writable shim path into the hydrated shell.

## User Impact

No product behavior changes. Maintainer Crabbox GitHub hydration can install the pinned pnpm toolchain without requiring write access to `/usr/local/bin`.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/29123891578 and https://github.com/openclaw/openclaw/actions/runs/29124361134 fail at `corepack enable` with `/usr/local/bin/pnpm` permission errors.
- Blacksmith Testbox `tbx_01kx71m8h632d7ayyxntm26dfx`: `corepack pnpm test test/scripts/package-acceptance-workflow.test.ts test/scripts/ci-workflow-guards.test.ts` passed 2 files / 116 tests.
- Same Testbox: `corepack pnpm check:changed` passed the tooling lane, lint, and guards.
- Exact-head behavior proof: AWS Crabbox `cbx_94e77e56b975` reached the `hydrate-github` ready marker in https://github.com/openclaw/openclaw/actions/runs/29127805730; the pinned dependencies and provider environment hydrated successfully.
- `git diff --check` passed.
- Fresh Codex autoreview reported no accepted or actionable findings.
- Scope: one composite action, one workflow job, and focused workflow assertions; no changelog or runtime changes.
