### PR TITLE
fix(macos): keep launchd Gateway running from renamed checkouts

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -63,6 +63,11 @@ enum GatewayLaunchAgentManager {
         return loaded
     }
 
+    static func runningGatewayPID() async -> Int32? {
+        guard let service = await self.readDaemonService() else { return nil }
+        return self.runningGatewayPID(from: service)
+    }
+
     static func set(enabled: Bool, bundlePath: String, port: Int) async -> String? {
         _ = bundlePath
         guard !CommandResolver.connectionModeIsRemote() else {
@@ -121,6 +126,10 @@ enum GatewayLaunchAgentManager {
 
 extension GatewayLaunchAgentManager {
     private static func readDaemonLoaded() async -> Bool? {
+        await self.readDaemonService()?["loaded"] as? Bool
+    }
+
+    private static func readDaemonService() async -> [String: Any]? {
         let result = await self.runDaemonCommandResult(
             ["status", "--json", "--no-probe"],
             timeout: 15,
@@ -128,12 +137,24 @@ extension GatewayLaunchAgentManager {
         guard result.success, let payload = result.payload else { return nil }
         guard
             let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
-            let service = json["service"] as? [String: Any],
-            let loaded = service["loaded"] as? Bool
+            let service = json["service"] as? [String: Any]
         else {
             return nil
         }
-        return loaded
+        return service
+    }
+
+    private static func runningGatewayPID(from service: [String: Any]) -> Int32? {
+        guard service["loaded"] as? Bool == true,
+              let runtime = service["runtime"] as? [String: Any],
+              runtime["status"] as? String == "running",
+              let pid = runtime["pid"] as? Int,
+              pid > 0,
+              pid <= Int(Int32.max)
+        else {
+            return nil
+        }
+        return Int32(pid)
     }
 
     private struct CommandResult {
@@ -234,6 +255,16 @@ extension GatewayLaunchAgentManager {
 
     static func testingDaemonCommandCallsSnapshot() -> [[String]] {
         self.testingDaemonCommandCalls
+    }
+
+    static func _testRunningGatewayPID(from json: String) -> Int32? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let service = object["service"] as? [String: Any]
+        else {
+            return nil
+        }
+        return self.runningGatewayPID(from: service)
     }
     #endif
 }

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -52,8 +52,19 @@ actor PortGuardian {
             return
         }
         let port = GatewayEnvironment.gatewayPort()
-        for listener in await self.listeners(on: port) {
-            if Self.isExpected(listener, port: port, mode: mode) {
+        // Capture the listener before launchd status. If its process exits and the
+        // PID is reused, the newer status snapshot cannot bless the replacement.
+        let listeners = await self.listeners(on: port)
+        let managedGatewayPID = mode == .local
+            ? await GatewayLaunchAgentManager.runningGatewayPID()
+            : nil
+        for listener in listeners {
+            if Self.isExpected(
+                listener,
+                port: port,
+                mode: mode,
+                managedGatewayPID: managedGatewayPID)
+            {
                 let message = """
                 port \(port) already served by expected \(listener.command)
                 (pid \(listener.pid)) — keeping
@@ -520,7 +531,12 @@ actor PortGuardian {
         #endif
     }
 
-    private static func isExpected(_ listener: Listener, port: Int, mode: AppState.ConnectionMode) -> Bool {
+    private static func isExpected(
+        _ listener: Listener,
+        port: Int,
+        mode: AppState.ConnectionMode,
+        managedGatewayPID: Int32? = nil) -> Bool
+    {
         let cmd = listener.command.lowercased()
         let full = listener.fullCommand.lowercased()
         switch mode {
@@ -528,6 +544,9 @@ actor PortGuardian {
             if port == GatewayEnvironment.gatewayPort() { return true }
             return false
         case .local:
+            // Daemon status owns this process identity; the listener snapshot proves
+            // that the same launchd PID currently holds the configured Gateway port.
+            if let managedGatewayPID, listener.pid == managedGatewayPID { return true }
             // Preserve both the legacy hidden alias and the current service process title.
             if full.contains("gateway-daemon") || full.contains("openclaw-gateway")
                 || cmd.contains("openclaw-gateway")
@@ -650,10 +669,16 @@ extension PortGuardian {
         command: String,
         fullCommand: String,
         port: Int,
-        mode: AppState.ConnectionMode) -> Bool
+        mode: AppState.ConnectionMode,
+        pid: Int32 = 0,
+        managedGatewayPID: Int32? = nil) -> Bool
     {
-        let listener = Listener(pid: 0, command: command, fullCommand: fullCommand, user: nil)
-        return Self.isExpected(listener, port: port, mode: mode)
+        let listener = Listener(pid: pid, command: command, fullCommand: fullCommand, user: nil)
+        return Self.isExpected(
+            listener,
+            port: port,
+            mode: mode,
+            managedGatewayPID: managedGatewayPID)
     }
 
     static func _testBuildReport(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -3,6 +3,31 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayLaunchAgentManagerTests {
+    @Test func `daemon status exposes only a loaded running gateway pid`() {
+        #expect(GatewayLaunchAgentManager._testRunningGatewayPID(from: """
+        {
+          "service": {
+            "loaded": true,
+            "runtime": { "status": "running", "pid": 4242 }
+          }
+        }
+        """) == 4242)
+
+        let rejected = [
+            #"{"service":{"loaded":false,"runtime":{"status":"running","pid":4242}}}"#,
+            #"{"service":{"loaded":true,"runtime":{"status":"stopped","pid":4242}}}"#,
+            #"{"service":{"loaded":true,"runtime":{"status":"running","pid":0}}}"#,
+            #"{"service":{"loaded":true,"runtime":{"status":"running","pid":2147483648}}}"#,
+            #"{"service":{"loaded":true,"runtime":{"status":"running","pid":"4242"}}}"#,
+            #"{"service":{"loaded":true,"runtime":{"status":"running"}}}"#,
+            #"{"service":null}"#,
+            "not-json",
+        ]
+        for json in rejected {
+            #expect(GatewayLaunchAgentManager._testRunningGatewayPID(from: json) == nil)
+        }
+    }
+
     @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
         let dir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
@@ -35,6 +35,46 @@ struct PortGuardianIsExpectedTests {
             mode: .local))
     }
 
+    @Test func `local mode preserves exact launchd pid from renamed checkout`() {
+        let fullCommand = """
+        /usr/local/bin/node /Users/dev/Projects/openclaw-codex-coexistence-live/dist/index.js gateway --port 18789
+        """
+
+        #expect(PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: fullCommand,
+            port: 18789,
+            mode: .local,
+            pid: 4242,
+            managedGatewayPID: 4242))
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: fullCommand,
+            port: 18789,
+            mode: .local,
+            pid: 4242))
+    }
+
+    @Test func `local mode rejects stale launchd pid after listener replacement`() {
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/tmp/openclaw-tools/dist/index.js gateway --port 18789",
+            port: 18789,
+            mode: .local,
+            pid: 5252,
+            managedGatewayPID: 4242))
+    }
+
+    @Test func `local mode rejects unmanaged listener when launchd pid is absent`() {
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/tmp/service/dist/index.js gateway --port 18789",
+            port: 18789,
+            mode: .local,
+            pid: 5252,
+            managedGatewayPID: nil))
+    }
+
     @Test func `local mode rejects gateway appearing after another node argument`() {
         #expect(!PortGuardian._testIsExpected(
             command: "node",


### PR DESCRIPTION
Closes #103969

AI-assisted: yes. The maintainer inspected the full ownership path, verified the live daemon-status contract, and ran a fresh structured autoreview before commit.

## What Problem This Solves

Fixes an issue where macOS local-mode users running a launchd-managed Gateway from a renamed source checkout would have that valid Gateway terminated and restarted whenever the Mac App launched.

## Why This Change Was Made

PortGuardian now preserves a local listener only when its PID exactly matches the loaded, running Gateway PID reported by `gateway status --json --no-probe`. Missing, malformed, stopped, stale, or non-listening daemon status continues through the existing conservative command matcher; the `openclaw-*` path allowlist is not widened.

The listener is captured before the newer launchd status snapshot so a dead managed process cannot bless a replacement that reused its PID.

## User Impact

Launching the Mac App no longer interrupts a valid launchd Gateway solely because its source checkout has a non-canonical directory name. Unmanaged or ambiguously identified listeners remain fail-closed.

## Evidence

- Before: a signed Mac App launch against a Gateway installed from `openclaw-codex-coexistence-live` produced two PortGuardian termination attempts and two launchd restarts.
- After, exact head `1714fe2633616c535fdaadb4e6b0cdf1640d57ed`: two independent Developer ID-signed Mac App launches produced four PortGuardian sweeps that all kept Gateway PID/listener `17055`; the launchd run count stayed `12`, proving no restart.
- Live contract check on macOS: `gateway status --json --no-probe` reported the loaded/running launchd PID, and the configured Gateway port reported that exact listener PID.
- Apple Silicon macOS: `swift test --package-path apps/macos --filter "PortGuardianIsExpectedTests|GatewayLaunchAgentManagerTests"` passed 14/14 tests.
- Apple Silicon macOS: `swiftformat --lint ... --config config/swiftformat` reported 0/4 files requiring formatting.
- Blacksmith Testbox `tbx_01kx71r93aj66tkh1nck0j14qd`: `pnpm check:changed` passed, including 171 tests with 37 expected skips plus repository guards.
- Exact-head GitHub CI run `29127866397`: all selected macOS, security, workflow, dependency, and changed-path checks passed or skipped as expected; no failures or pending checks.
- Fresh local autoreview: no accepted/actionable findings; patch judged correct (0.93).
