### PR TITLE
fix(llm): share one rate-limit window policy across session and failover retries (alt to #103200)

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -43,6 +43,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../process/command-queue.types.js";
+import { isShortWindowRateLimitMessage } from "../../shared/rate-limit-window.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../tasks/agent-harness-task-runtime-scope.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -175,10 +176,7 @@ import {
   PostCompactionLoopPersistedError,
 } from "./post-compaction-loop-guard.js";
 import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-state.js";
-import {
-  handleAssistantFailover,
-  isShortWindowRateLimitMessage,
-} from "./run/assistant-failover.js";
+import { handleAssistantFailover } from "./run/assistant-failover.js";
 import {
   createEmbeddedRunStageTracker,
   EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { formatBillingErrorMessage } from "../../embedded-agent-helpers.js";
 import { FailoverError } from "../../failover-error.js";
-import { handleAssistantFailover, isShortWindowRateLimitMessage } from "./assistant-failover.js";
+import { handleAssistantFailover } from "./assistant-failover.js";
 
 type Params = Parameters<typeof handleAssistantFailover>[0];
 type Outcome = Awaited<ReturnType<typeof handleAssistantFailover>>;
@@ -757,17 +757,5 @@ describe("handleAssistantFailover", () => {
       expect(err.message).toBe(formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"));
       expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 402 });
     });
-  });
-});
-
-describe("isShortWindowRateLimitMessage", () => {
-  it.each([
-    ["429 Provider returned error", true],
-    ["429 insufficient_quota: You exceeded your current quota", false],
-    ["429 usage limit reached for this billing period", false],
-    ["Provider API error (429): Provider returned error", false],
-    ["rate limit exceeded", false],
-  ])("classifies %s", (message, expected) => {
-    expect(isShortWindowRateLimitMessage(message)).toBe(expected);
   });
 });

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -4,7 +4,10 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
-import { extractLeadingHttpStatus } from "../../../shared/assistant-error-format.js";
+import {
+  resolveShortWindowRateLimitRetry,
+  type ShortWindowRateLimitRetry,
+} from "../../../shared/rate-limit-window.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
   formatAssistantErrorText,
@@ -35,88 +38,6 @@ type AssistantFailoverOutcome =
       overloadProfileRotations: number;
       error: FailoverError;
     };
-type ShortWindowRateLimitRetry = {
-  retryAfterSeconds?: number;
-};
-
-const LONG_WINDOW_RATE_LIMIT_RE =
-  /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
-const SHORT_RATE_LIMIT_WINDOW_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
-const SHORT_WINDOW_RATE_LIMIT_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
-const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
-const RETRY_AFTER_SECONDS_RE =
-  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m))?\b/i;
-const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
-
-function parseRetryAfterSeconds(message: string): number | null {
-  const valueText = RETRY_AFTER_VALUE_RE.exec(message)?.[1]?.trim();
-  if (!valueText) {
-    return null;
-  }
-  const secondsMatch = RETRY_AFTER_SECONDS_RE.exec(valueText);
-  if (secondsMatch?.[1]) {
-    const value = Number(secondsMatch[1]);
-    if (!Number.isFinite(value) || value < 0) {
-      return null;
-    }
-    const unit = secondsMatch[2]?.toLowerCase();
-    if (
-      unit?.startsWith("m") &&
-      unit !== "ms" &&
-      !unit.startsWith("msec") &&
-      !unit.startsWith("millisecond")
-    ) {
-      return value * 60;
-    }
-    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
-      return value / 1000;
-    }
-    return value;
-  }
-  const retryAtMs = Date.parse(valueText);
-  if (!Number.isFinite(retryAtMs)) {
-    return null;
-  }
-  return Math.max(0, (retryAtMs - Date.now()) / 1000);
-}
-
-function resolveShortWindowRateLimitRetry(
-  message: string | undefined,
-): ShortWindowRateLimitRetry | null {
-  const raw = message?.trim();
-  if (!raw) {
-    return null;
-  }
-  const retryAfterSeconds = parseRetryAfterSeconds(raw);
-  if (retryAfterSeconds !== null && retryAfterSeconds > MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS) {
-    return null;
-  }
-  const shortRetryAfter =
-    retryAfterSeconds !== null && retryAfterSeconds <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS;
-  const hasShortWindowSignal = SHORT_RATE_LIMIT_WINDOW_RE.test(raw);
-  if (RETRY_AFTER_VALUE_RE.test(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
-    return null;
-  }
-  if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !hasShortWindowSignal && !shortRetryAfter) {
-    return null;
-  }
-  // Providers such as Gemini use quota wording for per-minute RPM/TPM
-  // throttles. Treat quota as long-window only when no short-window hint is
-  // present; hard daily/usage/subscription limits are filtered above.
-  // Some gateways strip throttle details and Retry-After. Preserve the
-  // long-window exclusions above before treating a bare 429 as transient.
-  const statusPrefixed429 = extractLeadingHttpStatus(raw)?.code === 429;
-  if (!SHORT_WINDOW_RATE_LIMIT_RE.test(raw) && !shortRetryAfter && !statusPrefixed429) {
-    return null;
-  }
-  return retryAfterSeconds !== null ? { retryAfterSeconds } : {};
-}
-
-export function isShortWindowRateLimitMessage(message: string | undefined): boolean {
-  return resolveShortWindowRateLimitRetry(message) !== null;
-}
 
 /**
  * Applies an assistant-stage failover decision and returns the next run action.

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -54,4 +54,44 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it.each([
+    "model gpt-5.5-preview-0429 not found",
+    "Image dimensions 1504x1504 exceed the maximum allowed size",
+    "invalid api key sk-proj-abc502xyz",
+    // A standalone number that is not a leading HTTP status must not look like a
+    // 5xx; word boundaries alone did not catch this. (issue #102250)
+    "maximum width is 500 pixels",
+  ])(
+    "does not retry permanent errors whose text merely embeds a status-code-like number: %s",
+    (text) => {
+      expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+    },
+  );
+
+  it.each([
+    "404 model not found",
+    "400 Bad Request: unsupported image dimensions",
+    "401 invalid api key",
+  ])("does not retry permanent errors carrying a leading 4xx status: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
+    "429 You exceeded your daily request limit. Please try again in 24 hours.",
+    "rate limit reached for requests. Retry after 6h.",
+    "You have hit your allotted requests per day.",
+  ])("does not retry long-window rate limits the shared window policy rejects: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
+    "429 Too Many Requests",
+    "HTTP 503 Service Unavailable",
+    "500 Internal Server Error",
+    "Error 502 Bad Gateway",
+    "504 Gateway Timeout",
+  ])("still retries genuine transient HTTP status errors: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,3 +1,5 @@
+import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
+import { isLongWindowRateLimitMessage } from "../../shared/rate-limit-window.js";
 import type { AssistantMessage } from "../types.js";
 
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
@@ -17,12 +19,8 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
   "service.?unavailable",
+  "bad gateway",
   "server.?error",
   "internal.?error",
   "provider.?returned.?error",
@@ -49,13 +47,41 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+// A leading HTTP status is retryable only for transient server/throttle codes:
+// request-timeout (408), too-early (425), too-many-requests (429), and any 5xx
+// (server/gateway/overloaded/Cloudflare). Every other status — the permanent
+// 4xx family (400/401/403/404/422 …) — fails fast.
+function isRetryableHttpStatus(code: number): boolean {
+  if (code === 408 || code === 425 || code === 429) {
+    return true;
+  }
+  return code >= 500 && code <= 599;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
     return false;
   }
-  if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message.errorMessage)) {
+  const errorText = message.errorMessage;
+  if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorText)) {
     return false;
   }
-  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);
+  // Long-window rate limits (daily/weekly/monthly/quota or a multi-hour
+  // Retry-After) cannot clear within the session's short exponential backoff, so
+  // retrying only re-sends context and re-bills. Defer to the shared window
+  // policy the embedded-agent failover path also uses, so both classify the same
+  // message identically. (issue #102250)
+  if (isLongWindowRateLimitMessage(errorText)) {
+    return false;
+  }
+  // Prefer structured status classification over substring matching: a leading
+  // status code is authoritative, so permanent 4xx errors fail fast and a bare
+  // number embedded in prose (e.g. "maximum width is 500 pixels", a model id, or
+  // an API key) is never mistaken for a 5xx and retried. (issue #102250)
+  const status = extractLeadingHttpStatus(errorText);
+  if (status) {
+    return isRetryableHttpStatus(status.code);
+  }
+  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorText);
 }

--- a/src/shared/rate-limit-window.test.ts
+++ b/src/shared/rate-limit-window.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLongWindowRateLimitMessage,
+  isShortWindowRateLimitMessage,
+} from "./rate-limit-window.js";
+
+describe("isShortWindowRateLimitMessage", () => {
+  it.each([
+    ["429 Provider returned error", true],
+    ["429 insufficient_quota: You exceeded your current quota", false],
+    ["429 usage limit reached for this billing period", false],
+    ["Provider API error (429): Provider returned error", false],
+    ["rate limit exceeded", false],
+  ])("classifies %s", (message, expected) => {
+    expect(isShortWindowRateLimitMessage(message)).toBe(expected);
+  });
+});
+
+describe("isLongWindowRateLimitMessage", () => {
+  it.each([
+    "429 You exceeded your daily request limit. Please try again in 24 hours.",
+    "rate limit reached for requests. Retry after 6h.",
+    "You have hit your allotted requests per day.",
+    "429 insufficient_quota: You exceeded your current quota",
+    "429 usage limit reached for this billing period",
+  ])("treats long-reset rate limits as long-window: %s", (message) => {
+    expect(isLongWindowRateLimitMessage(message)).toBe(true);
+  });
+
+  it.each([
+    "429 Provider returned error",
+    "429 Too Many Requests",
+    "429 RESOURCE_EXHAUSTED: Quota exceeded for quota metric requests per minute",
+  ])("treats short-window rate limits as not long-window: %s", (message) => {
+    expect(isLongWindowRateLimitMessage(message)).toBe(false);
+  });
+
+  it.each([
+    "socket hang up",
+    "500 Internal Server Error",
+    "overloaded_error: the model is overloaded",
+    "",
+  ])("returns false for non-rate-limit errors: %s", (message) => {
+    expect(isLongWindowRateLimitMessage(message)).toBe(false);
+  });
+});

--- a/src/shared/rate-limit-window.ts
+++ b/src/shared/rate-limit-window.ts
@@ -1,0 +1,113 @@
+// Shared provider rate-limit window classification: the single source of truth
+// for separating short-window (minute-scale, retryable) rate limits from
+// long-window (daily/weekly/monthly/quota or multi-hour Retry-After) limits that
+// a short exponential backoff cannot clear. Consumed by the embedded-agent
+// failover path (same-model rate-limit retry) and the session-level auto-retry
+// classifier so both paths agree on window semantics. (issue #102250)
+import { extractLeadingHttpStatus } from "./assistant-error-format.js";
+
+export type ShortWindowRateLimitRetry = {
+  retryAfterSeconds?: number;
+};
+
+const LONG_WINDOW_RATE_LIMIT_RE =
+  /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
+const SHORT_RATE_LIMIT_WINDOW_RE =
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
+const SHORT_WINDOW_RATE_LIMIT_RE =
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
+const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
+const RETRY_AFTER_SECONDS_RE =
+  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m))?\b/i;
+const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
+const RATE_LIMIT_HINT_RE = /\brate.?limit\b|\btoo many requests\b/i;
+
+function parseRetryAfterSeconds(message: string): number | null {
+  const valueText = RETRY_AFTER_VALUE_RE.exec(message)?.[1]?.trim();
+  if (!valueText) {
+    return null;
+  }
+  const secondsMatch = RETRY_AFTER_SECONDS_RE.exec(valueText);
+  if (secondsMatch?.[1]) {
+    const value = Number(secondsMatch[1]);
+    if (!Number.isFinite(value) || value < 0) {
+      return null;
+    }
+    const unit = secondsMatch[2]?.toLowerCase();
+    if (
+      unit?.startsWith("m") &&
+      unit !== "ms" &&
+      !unit.startsWith("msec") &&
+      !unit.startsWith("millisecond")
+    ) {
+      return value * 60;
+    }
+    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
+      return value / 1000;
+    }
+    return value;
+  }
+  const retryAtMs = Date.parse(valueText);
+  if (!Number.isFinite(retryAtMs)) {
+    return null;
+  }
+  return Math.max(0, (retryAtMs - Date.now()) / 1000);
+}
+
+export function resolveShortWindowRateLimitRetry(
+  message: string | undefined,
+): ShortWindowRateLimitRetry | null {
+  const raw = message?.trim();
+  if (!raw) {
+    return null;
+  }
+  const retryAfterSeconds = parseRetryAfterSeconds(raw);
+  if (retryAfterSeconds !== null && retryAfterSeconds > MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS) {
+    return null;
+  }
+  const shortRetryAfter =
+    retryAfterSeconds !== null && retryAfterSeconds <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS;
+  const hasShortWindowSignal = SHORT_RATE_LIMIT_WINDOW_RE.test(raw);
+  if (RETRY_AFTER_VALUE_RE.test(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
+    return null;
+  }
+  if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !hasShortWindowSignal && !shortRetryAfter) {
+    return null;
+  }
+  // Providers such as Gemini use quota wording for per-minute RPM/TPM
+  // throttles. Treat quota as long-window only when no short-window hint is
+  // present; hard daily/usage/subscription limits are filtered above.
+  // Some gateways strip throttle details and Retry-After. Preserve the
+  // long-window exclusions above before treating a bare 429 as transient.
+  const statusPrefixed429 = extractLeadingHttpStatus(raw)?.code === 429;
+  if (!SHORT_WINDOW_RATE_LIMIT_RE.test(raw) && !shortRetryAfter && !statusPrefixed429) {
+    return null;
+  }
+  return retryAfterSeconds !== null ? { retryAfterSeconds } : {};
+}
+
+export function isShortWindowRateLimitMessage(message: string | undefined): boolean {
+  return resolveShortWindowRateLimitRetry(message) !== null;
+}
+
+/**
+ * True when a rate-limit error's reset horizon (daily/weekly/monthly/quota, or
+ * an unparseable / multi-hour Retry-After) exceeds what a short exponential
+ * backoff can clear. Returns false for non-rate-limit errors so callers only
+ * suppress retries on genuine rate limits, and defers to the short-window policy
+ * above so session and embedded paths classify the same message identically.
+ */
+export function isLongWindowRateLimitMessage(message: string | undefined): boolean {
+  const raw = message?.trim();
+  if (!raw) {
+    return false;
+  }
+  const isRateLimit =
+    LONG_WINDOW_RATE_LIMIT_RE.test(raw) ||
+    RATE_LIMIT_HINT_RE.test(raw) ||
+    extractLeadingHttpStatus(raw)?.code === 429;
+  if (!isRateLimit) {
+    return false;
+  }
+  return !isShortWindowRateLimitMessage(raw);
+}


### PR DESCRIPTION
Closes #102250

> **Alternative to #103200 — same issue, two designs.** This PR implements the ClawSweeper-preferred "best solution" for #102250: consolidate the rate-limit window policy into one shared source of truth. **#103200** is the smaller, in-layer variant (structured status detection only; long-window handling deferred to its owner, no changes to the failover module). Maintainers can pick whichever shape they prefer — I'll close the other. See **Difference vs #103200** below.

## What Problem This Solves

The session auto-retry classifier (`isRetryableAssistantError`) treated **permanent** provider errors as transient and retried them up to `maxRetries` (default 3), re-sending the entire conversation each time and re-billing tokens on requests that can never succeed. The trigger was substring matching of bare HTTP status tokens (`429`/`500`/`502`/`503`/`504`) anywhere in the error text:

- `model gpt-5.5-preview-0429 not found` → matched `429` → permanent **404** retried
- `Image dimensions 1504x1504 exceed the maximum allowed size` → matched `504` → permanent **400** retried
- `invalid api key sk-proj-abc502xyz` → matched `502` → permanent **401** retried
- `maximum width is 500 pixels` → matched `500` → retried

Separately, long-window rate limits (daily/quota, multi-hour `Retry-After`) were retried inside the sub-15s backoff that can never clear them — while the embedded-agent failover path **already** had a correct window policy for exactly this. The two paths had no shared source of truth.

## Why This Change Was Made

Consolidate the window policy so the session classifier and the embedded-agent failover path classify the same error identically:

- **New leaf module `src/shared/rate-limit-window.ts`** owns the rate-limit window policy — long/short-window detection, `Retry-After` parsing, and the per-minute-quota exception. The policy is **moved byte-for-byte** out of `src/agents/embedded-agent-runner/run/assistant-failover.ts`; that file and `run.ts` now import it, and its behavior is unchanged (its 27 tests pass untouched).
- **`isLongWindowRateLimitMessage`** (new, in the shared module) defers to the same short-window policy, so daily/weekly/monthly/quota and multi-hour `Retry-After` limits are long-window for *both* paths, while per-minute (RPM/TPM) throttles stay retryable for both.
- **The session classifier** (`src/llm/utils/retry.ts`) now classifies by **structured leading HTTP status** (`extractLeadingHttpStatus`) instead of bare-number substrings — a leading code is authoritative, so permanent `4xx` fail fast and a standalone number in prose is never mistaken for a `5xx` — and defers long-window rate limits to the shared policy.

`src/shared/` imports nothing from `agents`/`llm`, so there is no new module cycle (`pnpm check:import-cycles`: 0).

## Difference vs #103200

| | **#103200** (focused) | **This PR** (shared policy) |
|---|---|---|
| Status classification | structured leading-status detection | same |
| Long-window rate limits | deferred to owner (not handled in the session path) | handled via the **shared** policy — one source of truth |
| Per-minute quota subtlety | n/a | preserved (stays retryable) via shared policy |
| Touches `assistant-failover.ts` | no | yes — pure extraction, behavior unchanged |
| Blast radius | 2 files (`llm` only) | 7 files (new shared module + failover/run rewiring) |
| Trade-off | smallest, lowest-risk; long-window unhandled | reviewer's "best solution"; larger, crosses into the failover owner's module |

## User Impact

Permanent errors fail fast on the first response instead of being retried up to 3× with full context re-sent — cutting token spend and surfacing the real error sooner. Long-window rate limits stop being retried uselessly. Genuine transient failures (real 429/5xx, overload, timeouts, connection resets, per-minute throttles, explicit retry guidance) retry exactly as before, on both the session and embedded paths.

## Evidence

**Session-boundary proof.** Replays the exact `AgentSession` retry budget (`prepareRetry`: `retryCount++`, stop when `> maxRetries`, `delayMs = baseDelayMs * 2 ** (retryCount - 1)`; defaults `maxRetries=3`, `baseDelayMs=2000`) driving the **real** post-fix classifier vs. current `main`. Each `auto_retry_start` is one extra full-context provider call. Messages are synthetic; the API key is fake.

```
Retry budget: maxRetries=3, baseDelayMs=2000 (2s/4s/8s)

[FIX ] permanent 404 (embeds 0429)        "model gpt-5.5-preview-0429 not found"          BEFORE 3 -> AFTER 0
[FIX ] permanent 400 (embeds 1504)        "Image dimensions 1504x1504 exceed ..."         BEFORE 3 -> AFTER 0
[FIX ] permanent 401 (embeds 502)         "invalid api key sk-proj-abc502xyz"             BEFORE 3 -> AFTER 0
[FIX ] permanent (prose '500 pixels')     "maximum width is 500 pixels"                   BEFORE 3 -> AFTER 0
[FIX ] long-window daily limit            "429 ... daily request limit ... 24 hours."     BEFORE 3 -> AFTER 0
[FIX ] long-window Retry-After 6h         "rate limit reached ... Retry after 6h."        BEFORE 3 -> AFTER 0
[KEEP] short-window per-minute quota      "429 ... requests per minute; please retry"     BEFORE 3 -> AFTER 3
[KEEP] transient 503 / 429 / overload     ...                                             BEFORE 3 -> AFTER 3

Permanent + long-window: 18 wasted full-context provider calls -> 0
Transient + short-window: 12 -> 12 (unchanged; per-minute quota stays retryable)
```

**Tests** —
- `src/llm/utils/retry.test.ts` (21 passed): permanent errors that embed a status-code-like number (incl. the `maximum width is 500 pixels` regression), leading-`4xx` permanent errors, and long-window rate limits → non-retryable; genuine transient HTTP status errors and short-window quota → retryable.
- `src/shared/rate-limit-window.test.ts` (new, 17 passed): the migrated `isShortWindowRateLimitMessage` cases plus `isLongWindowRateLimitMessage` coverage (long vs. short vs. non-rate-limit).
- `src/agents/embedded-agent-runner/run/assistant-failover.test.ts` (27 passed): unchanged — proves the policy extraction did not alter the embedded failover path.

**Static checks** — `oxfmt`, `oxlint`, and `pnpm check:import-cycles` (0 cycles) pass on the changed files; `tsgo` reports no errors in the changed files.
