### PR TITLE
fix(tasks): show registry restore errors in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
 - **Discord thread-title prompts:** truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007.
-- **Task state migration:** canonicalize legacy `not-requested` delivery statuses during sidecar import and existing shared-database open so upgraded task registries and linked TaskFlows recover without manual SQL. (#103946) Thanks @bek91.
+- **Task state migration:** canonicalize legacy `not-requested` delivery statuses during sidecar import and existing shared-database open so upgraded task registries and linked TaskFlows recover without manual SQL, and surface rejected persisted values in compact console diagnostics. (#103946) Thanks @bek91.
 
 ## 2026.7.1
 

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -7,6 +7,8 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -113,6 +115,9 @@ describe("task-registry store runtime", () => {
     ORIGINAL_ENV.restore();
     resetTaskRegistryForTests();
     resetTaskFlowRegistryForTests({ persist: false });
+    loggingState.rawConsole = null;
+    setLoggerOverride(null);
+    resetLogger();
   });
 
   it("uses the configured task store for restore and save", () => {
@@ -175,6 +180,34 @@ describe("task-registry store runtime", () => {
     } finally {
       warnLogs.cleanup();
     }
+  });
+
+  it("includes restore parser failures in compact console warnings", () => {
+    const warn = vi.fn();
+    const invalidValue = "future-invalid-status";
+    setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "compact" });
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => {
+          throw new Error(
+            `Invalid persisted task delivery status: ${JSON.stringify(invalidValue)}`,
+          );
+        },
+        saveSnapshot: () => {},
+      },
+    });
+
+    expect(findTaskByRunId("run-restored")).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      `Failed to restore task registry: Invalid persisted task delivery status: "${invalidValue}"`,
+    );
   });
 
   it("uses scoped owner lookups for fresh owner task reads", () => {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1232,7 +1232,12 @@ function restoreTaskRegistryOnce() {
       tasks: snapshotTaskRecords(tasks),
     }));
   } catch (error) {
-    log.warn("Failed to restore task registry", { error: formatErrorMessage(error) });
+    const message = formatErrorMessage(error);
+    // Compact console logs omit structured metadata, so keep the rejected value visible there too.
+    log.warn("Failed to restore task registry", {
+      error: message,
+      consoleMessage: `Failed to restore task registry: ${message}`,
+    });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

#103946 repairs the released legacy task-status migration, but its restore warning puts the formatted parser error only in structured log metadata. Compact and pretty console output intentionally omit metadata, so `openclaw tasks list --json` still prints only `Failed to restore task registry` when an unrelated persisted value is invalid.

That leaves operators unable to identify the rejected value even though the registry correctly stays fail-closed.

## Why This Change Was Made

Use the subsystem logger's existing `consoleMessage` override for the formatted restore error while retaining the structured `error` field for file and JSON logs. This fixes the owning call site without changing global logger behavior or relaxing persisted-state parsing.

The regression test exercises compact console output directly, alongside the existing structured-log test.

## User Impact

When task-registry restore rejects persisted state, console diagnostics now name the actual parser error and rejected value. Valid migrations continue to self-heal through #103946, and unrelated invalid values remain rejected rather than silently accepted or skipped.

## Evidence

- Source-blind pre-fix public-CLI validation reproduced the gap at #103946's exact head: repair and TaskFlow audit behavior passed, while compact stderr omitted the rejected value.
- Source-blind post-fix public-CLI validation passed at exact head `3d36ce0a27502f33843fe936900a181276cfeba6` (tree `032f429f1569d961aaa1b70458c7d9decda59e34`): randomized invalid values appeared verbatim in compact list/audit stderr, JSON stdout stayed clean, invalid tasks remained absent/fail-closed, and raw SQLite stayed unchanged. Blacksmith Testbox `tbx_01kx742kv3g44w1x3gk1yqkkvp`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29129181569).
- Blacksmith Testbox `tbx_01kx73r7sh0nbxk3zp3qfkzj88`: `pnpm test src/tasks/task-registry.store.test.ts` passed all 29 tests.
- Fresh final branch autoreview: no accepted or actionable findings (0.98).
- `git diff --check` passed.

Follow-up to #103946.
Closes #103168.
