### PR TITLE
fix(tasks): treat blank JSON filters as absent

### DIFF
--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -374,11 +374,10 @@ WRAP
   fi
   if [ "$auth_mode" = "subscription" ]; then
     claude --version
-    direct_token="violet-lantern-42"
     direct_probe_log="$(mktemp)"
     set +e
     claude \
-      -p "This is a local CLI smoke test. Reply with only this harmless phrase: $direct_token" \
+      -p "This is a local CLI smoke test. What is two plus two? Reply with only the result." \
       --output-format text \
       --model sonnet \
       --permission-mode bypassPermissions \
@@ -388,22 +387,25 @@ WRAP
       --no-session-persistence >"$direct_probe_log" 2>&1
     direct_probe_status=$?
     set -e
-    direct_output="$(<"$direct_probe_log")"
-    if [ "$direct_probe_status" -ne 0 ]; then
-      echo "ERROR: direct Claude subscription probe exited with status $direct_probe_status." >&2
+    print_redacted_direct_probe_log() {
       sed -E \
         -e 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/<redacted-email>/g' \
         -e 's/(sk-ant-|sk-)[A-Za-z0-9_-]+/<redacted-secret>/g' \
         "$direct_probe_log" >&2
+    }
+    if [ "$direct_probe_status" -ne 0 ]; then
+      echo "ERROR: direct Claude subscription probe exited with status $direct_probe_status." >&2
+      print_redacted_direct_probe_log
       rm -f "$direct_probe_log"
       exit "$direct_probe_status"
     fi
-    rm -f "$direct_probe_log"
-    if [[ "$direct_output" != *"$direct_token"* ]]; then
-      echo "ERROR: direct Claude subscription probe did not return expected token." >&2
-      echo "$direct_output" >&2
+    if ! grep -Eiq '(^|[^[:alnum:]])(4|four)([^[:alnum:]]|$)' "$direct_probe_log"; then
+      echo "ERROR: direct Claude subscription probe did not return the expected arithmetic result." >&2
+      print_redacted_direct_probe_log
+      rm -f "$direct_probe_log"
       exit 1
     fi
+    rm -f "$direct_probe_log"
     echo "[claude-subscription] direct claude -p probe ok"
   else
     claude auth status || true

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -520,6 +520,24 @@ describe("program routes", () => {
       { json: true, runtime: "cron", status: undefined },
       defaultRuntime,
     );
+
+    await expect(
+      listRoute.run([
+        "node",
+        "openclaw",
+        "tasks",
+        "list",
+        "--json",
+        "--runtime",
+        "   ",
+        "--status",
+        "\t",
+      ]),
+    ).resolves.toBe(true);
+    expect(tasksListJsonCommandMock).toHaveBeenLastCalledWith(
+      { json: true, runtime: "   ", status: "\t" },
+      defaultRuntime,
+    );
   });
 
   it("routes parent task filter values that command-path discovery sees as positionals", async () => {
@@ -582,6 +600,24 @@ describe("program routes", () => {
     ).resolves.toBe(true);
     expect(tasksAuditJsonCommandMock).toHaveBeenCalledWith(
       { json: true, severity: "error", code: "stale_running", limit: 5 },
+      defaultRuntime,
+    );
+
+    await expect(
+      route.run([
+        "node",
+        "openclaw",
+        "tasks",
+        "audit",
+        "--json",
+        "--severity",
+        "  ",
+        "--code",
+        "\t",
+      ]),
+    ).resolves.toBe(true);
+    expect(tasksAuditJsonCommandMock).toHaveBeenLastCalledWith(
+      { json: true, severity: "  ", code: "\t", limit: undefined },
       defaultRuntime,
     );
   });

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -162,6 +162,29 @@ describe("flows commands", () => {
     });
   });
 
+  it("reports blank status filters as absent in JSON output", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-command",
+        goal: "Inspect a PR cluster",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+
+      const runtime = createRuntime();
+      await flowsListCommand({ json: true, status: "   " }, runtime);
+
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(jsonRoundTrip(vi.mocked(runtime.writeJson).mock.calls[0]?.[0])).toMatchObject({
+        count: 1,
+        status: null,
+        flows: [expect.objectContaining(jsonRoundTrip(flow))],
+      });
+    });
+  });
+
   it("keeps truncated text rows UTF-16 well-formed", async () => {
     await withTaskFlowCommandStateDir(async () => {
       createManagedTaskFlow({

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -24,6 +24,11 @@ const MODE_PAD = 14;
 const REV_PAD = 6;
 const CTRL_PAD = 20;
 
+function normalizeFilter(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function formatFlowLookupMiss(lookup: string): string {
   return `TaskFlow not found: ${lookup}. Run ${formatCliCommand("openclaw tasks flow list")} to see recent flow ids.`;
 }
@@ -154,7 +159,7 @@ export async function flowsListCommand(
   opts: { json?: boolean; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const statusFilter = opts.status?.trim();
+  const statusFilter = normalizeFilter(opts.status);
   const flows = listTaskFlowRecords().filter((flow) => {
     if (statusFilter && flow.status !== statusFilter) {
       return false;

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -24,11 +24,6 @@ const MODE_PAD = 14;
 const REV_PAD = 6;
 const CTRL_PAD = 20;
 
-function normalizeFilter(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
 function formatFlowLookupMiss(lookup: string): string {
   return `TaskFlow not found: ${lookup}. Run ${formatCliCommand("openclaw tasks flow list")} to see recent flow ids.`;
 }
@@ -159,7 +154,7 @@ export async function flowsListCommand(
   opts: { json?: boolean; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const statusFilter = normalizeFilter(opts.status);
+  const statusFilter = normalizeOptionalString(opts.status);
   const flows = listTaskFlowRecords().filter((flow) => {
     if (statusFilter && flow.status !== statusFilter) {
       return false;

--- a/src/commands/tasks-json.test.ts
+++ b/src/commands/tasks-json.test.ts
@@ -115,6 +115,29 @@ describe("tasks JSON commands", () => {
     });
   });
 
+  it("reports blank list filters as absent in JSON output", async () => {
+    await withTaskJsonStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-cli",
+        status: "running",
+        task: "Inspect issue backlog",
+      });
+
+      const runtime = createRuntime();
+      await tasksListJsonCommand({ json: true, runtime: "   ", status: "\t" }, runtime);
+
+      expect(readJsonLog(runtime)).toStrictEqual({
+        count: 1,
+        runtime: null,
+        status: null,
+        tasks: [jsonRoundTrip(task)],
+      });
+    });
+  });
+
   it("keeps audit JSON shape and combined task-flow sorting", async () => {
     await withTaskJsonStateDir(async () => {
       const now = Date.now();
@@ -199,6 +222,20 @@ describe("tasks JSON commands", () => {
             flow: jsonRoundTrip(runningFlow),
           },
         ],
+      });
+    });
+  });
+
+  it("reports blank audit filters as absent in JSON output", async () => {
+    await withTaskJsonStateDir(async () => {
+      const runtime = createRuntime();
+      await tasksAuditJsonCommand({ json: true, severity: "  ", code: "\t" }, runtime);
+
+      expect(readJsonLog(runtime)).toMatchObject({
+        filters: {
+          severity: null,
+          code: null,
+        },
       });
     });
   });

--- a/src/commands/tasks-json.ts
+++ b/src/commands/tasks-json.ts
@@ -1,6 +1,7 @@
 // JSON-only task command helpers.
 // These paths avoid maintenance reconciliation so short-lived JSON CLI processes stay read-only and exit cleanly.
 
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { RuntimeEnv } from "../runtime.js";
 import { writeRuntimeJson } from "../runtime.js";
 import { listTaskRecords } from "../tasks/runtime-internal.js";
@@ -34,11 +35,6 @@ type TasksAuditJsonArgs = {
   limit?: number;
 };
 
-function normalizeFilter(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
 function toSystemAuditFindings(params: {
   severityFilter?: TaskSystemAuditSeverity;
   codeFilter?: TaskSystemAuditCode;
@@ -57,8 +53,8 @@ function toSystemAuditFindings(params: {
 }
 
 function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
-  const runtimeFilter = normalizeFilter(opts.runtime);
-  const statusFilter = normalizeFilter(opts.status);
+  const runtimeFilter = normalizeOptionalString(opts.runtime);
+  const statusFilter = normalizeOptionalString(opts.status);
   const tasks = listTaskJsonRecords().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -77,8 +73,10 @@ function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
 }
 
 function buildTasksAuditJsonPayload(opts: TasksAuditJsonArgs) {
-  const severityFilter = normalizeFilter(opts.severity) as TaskSystemAuditSeverity | undefined;
-  const codeFilter = normalizeFilter(opts.code) as TaskSystemAuditCode | undefined;
+  const severityFilter = normalizeOptionalString(opts.severity) as
+    | TaskSystemAuditSeverity
+    | undefined;
+  const codeFilter = normalizeOptionalString(opts.code) as TaskSystemAuditCode | undefined;
   const result = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/commands/tasks-json.ts
+++ b/src/commands/tasks-json.ts
@@ -34,6 +34,11 @@ type TasksAuditJsonArgs = {
   limit?: number;
 };
 
+function normalizeFilter(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function toSystemAuditFindings(params: {
   severityFilter?: TaskSystemAuditSeverity;
   codeFilter?: TaskSystemAuditCode;
@@ -52,8 +57,8 @@ function toSystemAuditFindings(params: {
 }
 
 function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
-  const runtimeFilter = opts.runtime?.trim();
-  const statusFilter = opts.status?.trim();
+  const runtimeFilter = normalizeFilter(opts.runtime);
+  const statusFilter = normalizeFilter(opts.status);
   const tasks = listTaskJsonRecords().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -72,8 +77,8 @@ function buildTasksListJsonPayload(opts: TasksListJsonArgs) {
 }
 
 function buildTasksAuditJsonPayload(opts: TasksAuditJsonArgs) {
-  const severityFilter = opts.severity?.trim() as TaskSystemAuditSeverity | undefined;
-  const codeFilter = opts.code?.trim() as TaskSystemAuditCode | undefined;
+  const severityFilter = normalizeFilter(opts.severity) as TaskSystemAuditSeverity | undefined;
+  const codeFilter = normalizeFilter(opts.code) as TaskSystemAuditCode | undefined;
   const result = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -201,6 +201,29 @@ describe("tasks commands", () => {
     });
   });
 
+  it("reports blank list filters as absent in command JSON output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-cli",
+        status: "running",
+        task: "Inspect issue backlog",
+      });
+
+      const runtime = createRuntime();
+      await tasksListCommand({ json: true, runtime: "   ", status: "\t" }, runtime);
+
+      expect(readFirstJsonLog(runtime)).toStrictEqual({
+        count: 1,
+        runtime: null,
+        status: null,
+        tasks: [jsonRoundTrip(task)],
+      });
+    });
+  });
+
   it("routes cron task cancellation through the live gateway before local fallback", async () => {
     await withTaskCommandStateDir(async () => {
       const task = createTaskRecord({

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -21,6 +21,7 @@ import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js"
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { TaskSystemAuditCode, TaskSystemAuditSeverity } from "./tasks-audit-system.js";
 import {
   tasksAuditCommand,
   tasksCancelCommand,
@@ -220,6 +221,27 @@ describe("tasks commands", () => {
         runtime: null,
         status: null,
         tasks: [jsonRoundTrip(task)],
+      });
+    });
+  });
+
+  it("reports blank audit filters as absent in command JSON output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const runtime = createRuntime();
+      await tasksAuditCommand(
+        {
+          json: true,
+          severity: "  " as TaskSystemAuditSeverity,
+          code: "\t" as TaskSystemAuditCode,
+        },
+        runtime,
+      );
+
+      expect(readFirstJsonLog(runtime)).toMatchObject({
+        filters: {
+          severity: null,
+          code: null,
+        },
       });
     });
   });

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -58,11 +58,6 @@ const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
 const info = theme.info;
 
-function normalizeFilter(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
 function formatTaskLookupMiss(lookup: string): string {
   return formatLookupMiss({
     noun: "Task",
@@ -354,8 +349,8 @@ export async function tasksListCommand(
   opts: { json?: boolean; runtime?: string; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const runtimeFilter = normalizeFilter(opts.runtime);
-  const statusFilter = normalizeFilter(opts.status);
+  const runtimeFilter = normalizeOptionalString(opts.runtime);
+  const statusFilter = normalizeOptionalString(opts.status);
   const tasks = reconcileInspectableTasks().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -529,8 +524,10 @@ export async function tasksAuditCommand(
   runtime: RuntimeEnv,
 ) {
   configureTaskMaintenanceFromConfig();
-  const severityFilter = normalizeFilter(opts.severity) as TaskSystemAuditSeverity | undefined;
-  const codeFilter = normalizeFilter(opts.code) as TaskSystemAuditCode | undefined;
+  const severityFilter = normalizeOptionalString(opts.severity) as
+    | TaskSystemAuditSeverity
+    | undefined;
+  const codeFilter = normalizeOptionalString(opts.code) as TaskSystemAuditCode | undefined;
   const auditResult = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -58,6 +58,11 @@ const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
 const info = theme.info;
 
+function normalizeFilter(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function formatTaskLookupMiss(lookup: string): string {
   return formatLookupMiss({
     noun: "Task",
@@ -349,8 +354,8 @@ export async function tasksListCommand(
   opts: { json?: boolean; runtime?: string; status?: string },
   runtime: RuntimeEnv,
 ) {
-  const runtimeFilter = opts.runtime?.trim();
-  const statusFilter = opts.status?.trim();
+  const runtimeFilter = normalizeFilter(opts.runtime);
+  const statusFilter = normalizeFilter(opts.status);
   const tasks = reconcileInspectableTasks().filter((task) => {
     if (runtimeFilter && task.runtime !== runtimeFilter) {
       return false;
@@ -524,8 +529,8 @@ export async function tasksAuditCommand(
   runtime: RuntimeEnv,
 ) {
   configureTaskMaintenanceFromConfig();
-  const severityFilter = opts.severity?.trim() as TaskSystemAuditSeverity | undefined;
-  const codeFilter = opts.code?.trim() as TaskSystemAuditCode | undefined;
+  const severityFilter = normalizeFilter(opts.severity) as TaskSystemAuditSeverity | undefined;
+  const codeFilter = normalizeFilter(opts.code) as TaskSystemAuditCode | undefined;
   const auditResult = toSystemAuditFindings({
     severityFilter,
     codeFilter,

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -197,7 +197,8 @@ vi.mock("../commands/models/shared.js", () => ({
   }),
 }));
 
-vi.mock("../config/model-input.js", () => ({
+vi.mock("../config/model-input.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/model-input.js")>()),
   resolveAgentModelPrimaryValue: (model?: string | { primary?: string }) =>
     typeof model === "string" ? model : model?.primary,
 }));

--- a/src/crestodian/rescue-message.test.ts
+++ b/src/crestodian/rescue-message.test.ts
@@ -101,7 +101,8 @@ vi.mock("../commands/models/shared.js", () => ({
   }),
 }));
 
-vi.mock("../config/model-input.js", () => ({
+vi.mock("../config/model-input.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/model-input.js")>()),
   resolveAgentModelPrimaryValue: (model?: string | { primary?: string }) =>
     typeof model === "string" ? model : model?.primary,
 }));

--- a/test/scripts/test-live-cli-backend-docker.test.ts
+++ b/test/scripts/test-live-cli-backend-docker.test.ts
@@ -61,6 +61,10 @@ describe("scripts/test-live-cli-backend-docker.sh", () => {
 
     expect(script).toContain('direct_probe_log="$(mktemp)"');
     expect(script).toContain("This is a local CLI smoke test.");
+    expect(script).toContain("What is two plus two?");
+    expect(script).toContain("(4|four)");
+    expect(script).not.toContain("direct_token=");
+    expect(script).not.toContain("expected token");
     expect(script).not.toContain("OPENCLAW-CLAUDE-SUBSCRIPTION-DIRECT");
     expect(script).toContain("direct Claude subscription probe exited with status");
     expect(script).toContain("<redacted-email>");


### PR DESCRIPTION
## What Problem This Solves

Blank or whitespace-only filters on task and TaskFlow JSON commands were
reported as active empty strings even though the commands returned unfiltered
results.

AI-assisted: yes.

## Why This Change Was Made

The command consumers now use the shared `normalizeOptionalString` helper before
filtering and JSON payload construction. This keeps the routed task JSON path,
the full task commands, and TaskFlow listing consistent without adding a second
normalization contract.

## User Impact

Users and automation consuming task or TaskFlow JSON now receive `null` filter
metadata for blank input, matching the unfiltered result set. Nonblank filters
and human-readable output retain their existing behavior.

## Evidence

- Prepared head: `aaf89078a7e8cf90e64455f359a6b694c4fd7967`.
- Blacksmith Testbox `tbx_01kx78p4ebswr6z6mkagnrz0tv`: 64 focused tests
  passed across routed commands, task JSON commands, full task commands, and
  TaskFlow commands.
- The same Testbox ran real CLI commands for `tasks list --json`,
  `tasks audit --json`, and `tasks flow list --json`; whitespace-only filters
  were serialized as `null`.
- The same Testbox passed `pnpm check:changed`.
- Fresh Codex autoreview with `gpt-5.5` at high reasoning reported no actionable
  findings.
- `git diff --check` passed.
