### PR TITLE
fix(maint): refuse unsafe PR ancestry rewrites

### DIFF
--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -336,8 +336,7 @@ EOF_PREP
       ); then
       echo "Pre-sync local and hosted trees differ; fresh exact-head evidence is required."
     fi
-    # Preserve local lineage separately from the hosted SHA: GraphQL creates
-    # a remote commit with the same tree but the old branch parent.
+    # Preserve the prepared tree and mainline base for post-push evidence.
     printf '%s=%q\n' \
       PREP_SYNC_MAINLINE_BASE_SHA "$mainline_base_sha" \
       PREP_SYNC_TREE "$prep_sync_tree" \

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -18,6 +18,21 @@ resolve_head_push_url() {
   return 1
 }
 
+# A prior GraphQL push records distinct hosted/local OIDs with identical trees.
+resolve_graphql_local_base() (
+  local hosted_oid="$1"
+  if [ -s .local/prep.env ]; then
+    unset PREP_HEAD_SHA LOCAL_PREP_HEAD_SHA
+    # shellcheck disable=SC1091
+    source .local/prep.env
+    if [ "${PREP_HEAD_SHA:-}" = "$hosted_oid" ] && [ -n "${LOCAL_PREP_HEAD_SHA:-}" ]; then
+      printf '%s\n' "$LOCAL_PREP_HEAD_SHA"
+      return 0
+    fi
+  fi
+  printf '%s\n' "$hosted_oid"
+)
+
 # Push to a fork PR branch via GitHub GraphQL createCommitOnBranch.
 # This uses the same permission model as the GitHub web editor, bypassing
 # the git-protocol 403 that occurs even when maintainer_can_modify is true.
@@ -30,6 +45,40 @@ graphql_push_to_fork() {
   local branch="$2"
   local expected_oid="$3"
   local max_blob_bytes=$((5 * 1024 * 1024))
+
+  # createCommitOnBranch always parents the new commit to expected_oid. Refuse
+  # rewritten history, while accepting a recorded same-tree local twin from a
+  # prior verified GraphQL push.
+  local local_base_oid
+  local_base_oid=$(resolve_graphql_local_base "$expected_oid")
+  local diff_base_oid=""
+  if git merge-base --is-ancestor "$expected_oid" HEAD 2>/dev/null; then
+    diff_base_oid="$expected_oid"
+  elif [ "$local_base_oid" != "$expected_oid" ] &&
+    git merge-base --is-ancestor "$local_base_oid" HEAD 2>/dev/null &&
+    [ "$(git rev-parse "${local_base_oid}^{tree}" 2>/dev/null)" = "$(git rev-parse "${expected_oid}^{tree}" 2>/dev/null)" ]; then
+    diff_base_oid="$local_base_oid"
+  fi
+  if [ -z "$diff_base_oid" ]; then
+    echo "GitHub createCommitOnBranch cannot rewrite branch ancestry: remote PR head $expected_oid is not an ancestor of local HEAD." >&2
+    echo "Refusing to materialize mainline changes as a PR commit. Use an ancestry-preserving git push for rewritten history." >&2
+    return 3
+  fi
+
+  # A merge can keep the old PR head as an ancestor while incorporating newer
+  # mainline commits. GraphQL would flatten those commits into the PR as files.
+  if git rev-parse --verify 'origin/main^{commit}' >/dev/null 2>&1; then
+    local head_mainline_base
+    head_mainline_base=$(git merge-base HEAD origin/main) || {
+      echo "Unable to verify the prepared head against origin/main ancestry." >&2
+      return 3
+    }
+    if ! git merge-base --is-ancestor "$head_mainline_base" "$expected_oid"; then
+      echo "GitHub createCommitOnBranch cannot preserve newly incorporated mainline ancestry." >&2
+      echo "Refusing to materialize mainline changes as a PR commit. Use an ancestry-preserving git push for rewritten history." >&2
+      return 3
+    fi
+  fi
 
   local additions="[]"
   local deletions="[]"
@@ -258,14 +307,27 @@ push_prep_head_to_pr_branch() {
   if [ "$remote_sha" = "$prep_head_sha" ]; then
     echo "Remote branch already at local prep HEAD; skipping push."
   else
+    local remote_sha_changed=false
     if [ "$remote_sha" != "$lease_sha" ]; then
       echo "Remote SHA $remote_sha differs from PR head SHA $lease_sha. Refreshing lease SHA from remote."
       lease_sha="$remote_sha"
+      remote_sha_changed=true
     fi
     pushed_from_sha="$lease_sha"
-    local push_output
-    if ! push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
+    local push_output push_status
+    if push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
+      push_status=0
+    else
+      push_status=$?
+    fi
+    if [ "$push_status" -ne 0 ]; then
       echo "Push failed: $push_output"
+
+      if [ "$push_status" -eq 3 ] && [ "$remote_sha_changed" != "true" ]; then
+        echo "The prepared history requires an ancestry-preserving push; rerunning the GraphQL sync cannot fix it."
+        echo "After reviewing the rewritten commits, rerun with OPENCLAW_PR_PUSH_MODE=git OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1."
+        exit 1
+      fi
 
       if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
         echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
@@ -336,8 +398,7 @@ push_prep_head_to_pr_branch() {
   fi
 
   # merge-verify owns relevance-aware mainline drift checks. Requiring every
-  # prepared head to contain main here forces needless rebases, while GraphQL
-  # createCommitOnBranch cannot move a rebased branch's commit ancestry.
+  # prepared head to contain main here forces needless rebases.
   # Security: shell-escape values to prevent command injection when sourced.
   printf '%s=%q\n' \
     PUSH_PREP_HEAD_SHA "$prep_head_sha" \

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -47,7 +47,12 @@ function sanitizedEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 
 function runGatesBash(
   script: string,
-  options: { cwd?: string; env?: NodeJS.ProcessEnv; sourcePrepareCore?: boolean } = {},
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    sourcePrepareCore?: boolean;
+    sourcePush?: boolean;
+  } = {},
 ) {
   return spawnSync(
     "bash",
@@ -58,6 +63,7 @@ function runGatesBash(
         `script_parent_dir='${repoRoot}/scripts'`,
         `source '${repoRoot}/scripts/pr-lib/common.sh'`,
         `source '${repoRoot}/scripts/pr-lib/gates.sh'`,
+        ...(options.sourcePush ? [`source '${repoRoot}/scripts/pr-lib/push.sh'`] : []),
         ...(options.sourcePrepareCore
           ? [`source '${repoRoot}/scripts/pr-lib/prepare-core.sh'`]
           : []),
@@ -171,6 +177,49 @@ function makeSyncRepo(options: { needsRebase: boolean }): string {
   writeFileSync(join(repoDir, ".local", "prep-context.env"), "PR_HEAD=topic\nPREP_BRANCH=prep\n");
   writeFileSync(join(repoDir, ".local", "prep.md"), "# Prepare\n");
   return repoDir;
+}
+
+function makeGraphqlMainRefreshRepo(
+  strategy: "merge" | "rebase" = "rebase",
+): { repoDir: string; staleHead: string } {
+  const repoDir = join(makeTempDir("openclaw-pr-graphql-rewrite-"), "repo");
+  mkdirSync(repoDir);
+
+  const git = (...args: string[]) => {
+    const result = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    return result.stdout.trim();
+  };
+  git("init", "-q", "-b", "main");
+  git("config", "user.name", "t");
+  git("config", "user.email", "t@example.com");
+
+  writeFileSync(join(repoDir, "feature.txt"), "old\n");
+  writeFileSync(join(repoDir, "main-only.txt"), "old\n");
+  git("add", ".");
+  git("commit", "-qm", "base");
+
+  git("checkout", "-qb", "prep");
+  writeFileSync(join(repoDir, "feature.txt"), "from pr\n");
+  git("add", "feature.txt");
+  git("commit", "-qm", "pr change");
+  const staleHead = git("rev-parse", "HEAD");
+
+  git("checkout", "-q", "main");
+  writeFileSync(join(repoDir, "main-only.txt"), "from main\n");
+  git("add", "main-only.txt");
+  git("commit", "-qm", "main refresh");
+  git("remote", "add", "origin", ".");
+  git("fetch", "-q", "origin", "main");
+
+  git("checkout", "-q", "prep");
+  if (strategy === "rebase") {
+    git("rebase", "origin/main");
+  } else {
+    git("merge", "-qm", "merge main refresh", "origin/main");
+  }
+  mkdirSync(join(repoDir, ".local"));
+  return { repoDir, staleHead };
 }
 
 function prepareSyncHeadStubs(): string[] {
@@ -392,6 +441,138 @@ describe("lease-retry gate stamp refresh", () => {
 });
 
 describe("prepare sync-head transitions", () => {
+  it("keeps GraphQL follow-up pushes for a recorded hosted/local twin", () => {
+    const { repoDir } = makeGraphqlMainRefreshRepo();
+
+    const result = runGatesBash(
+      [
+        "local_head=$(git rev-parse HEAD)",
+        "local_tree=$(git rev-parse 'HEAD^{tree}')",
+        "local_parent=$(git rev-parse 'HEAD^')",
+        "hosted_head=$(printf 'hosted twin\\n' | git commit-tree \"$local_tree\" -p \"$local_parent\")",
+        "printf 'PREP_HEAD_SHA=%q\\nLOCAL_PREP_HEAD_SHA=%q\\n' \"$hosted_head\" \"$local_head\" > .local/prep.env",
+        "printf 'prepared follow-up\\n' > feature.txt",
+        "git add feature.txt",
+        "git commit -qm 'prepared follow-up'",
+        "gh() { cat > .local/graphql-payload.json; printf '%s\\n' '{\"data\":{\"createCommitOnBranch\":{\"commit\":{\"oid\":\"deadbeef\"}}}}'; }",
+        'test "$(graphql_push_to_fork openclaw/openclaw topic "$hosted_head")" = deadbeef',
+        'test "$(jq -r \'.variables.input.fileChanges.additions[].path\' .local/graphql-payload.json)" = feature.txt',
+      ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("GraphQL push succeeded: deadbeef");
+  });
+
+  it("refuses a GraphQL tree push after main refresh rewrites the PR ancestry", () => {
+    const { repoDir, staleHead } = makeGraphqlMainRefreshRepo();
+
+    const result = runGatesBash(
+      [
+        'test "$(git diff --name-only "$stale_head" HEAD)" = "main-only.txt"',
+        "gh() { cat > .local/graphql-payload.json; printf '%s\\n' '{\"data\":{\"createCommitOnBranch\":{\"commit\":{\"oid\":\"deadbeef\"}}}}'; }",
+        'if graphql_push_to_fork openclaw/openclaw topic "$stale_head"; then',
+        '  echo "unsafe GraphQL ancestry rewrite succeeded" >&2',
+        "  exit 97",
+        "else",
+        '  test "$?" -eq 3',
+        "fi",
+        "test ! -e .local/graphql-payload.json",
+      ].join("\n"),
+      {
+        cwd: repoDir,
+        env: { stale_head: staleHead },
+        sourcePush: true,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("cannot rewrite branch ancestry");
+    expect(result.stderr).toContain("materialize mainline changes");
+  });
+
+  it("refuses follow-ups from a legacy hosted commit with flattened mainline ancestry", () => {
+    const { repoDir, staleHead } = makeGraphqlMainRefreshRepo();
+
+    const result = runGatesBash(
+      [
+        "local_head=$(git rev-parse HEAD)",
+        "local_tree=$(git rev-parse 'HEAD^{tree}')",
+        'hosted_head=$(printf \'legacy flattened host\\n\' | git commit-tree "$local_tree" -p "$stale_head")',
+        "printf 'PREP_HEAD_SHA=%q\\nLOCAL_PREP_HEAD_SHA=%q\\n' \"$hosted_head\" \"$local_head\" > .local/prep.env",
+        "printf 'prepared follow-up\\n' > feature.txt",
+        "git add feature.txt",
+        "git commit -qm 'prepared follow-up'",
+        "gh() { cat > .local/graphql-payload.json; exit 97; }",
+        'if graphql_push_to_fork openclaw/openclaw topic "$hosted_head"; then exit 98; else test "$?" -eq 3; fi',
+        "test ! -e .local/graphql-payload.json",
+      ].join("\n"),
+      {
+        cwd: repoDir,
+        env: { stale_head: staleHead },
+        sourcePush: true,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("cannot preserve newly incorporated mainline ancestry");
+  });
+
+  it("refuses to flatten a merged main refresh even when the PR head remains an ancestor", () => {
+    const { repoDir, staleHead } = makeGraphqlMainRefreshRepo("merge");
+
+    const result = runGatesBash(
+      [
+        'git merge-base --is-ancestor "$stale_head" HEAD',
+        "gh() { cat > .local/graphql-payload.json; exit 97; }",
+        'if graphql_push_to_fork openclaw/openclaw topic "$stale_head"; then exit 98; else test "$?" -eq 3; fi',
+        "test ! -e .local/graphql-payload.json",
+      ].join("\n"),
+      {
+        cwd: repoDir,
+        env: { stale_head: staleHead },
+        sourcePush: true,
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("cannot preserve newly incorporated mainline ancestry");
+  });
+
+  it("keeps the lease retry when the remote PR head advanced concurrently", () => {
+    const repoDir = makeSyncRepo({ needsRebase: false });
+
+    const result = runGatesBash(
+      [
+        "prep_head=$(git rev-parse HEAD)",
+        "lease_sha=$(git rev-parse HEAD^)",
+        'git checkout -qb contributor "$lease_sha"',
+        "printf 'contributor update\\n' > contributor.txt",
+        "git add contributor.txt",
+        "git commit -qm 'contributor update'",
+        "concurrent_head=$(git rev-parse HEAD)",
+        'git update-ref refs/pull/4242/head "$concurrent_head"',
+        "git checkout -q prep",
+        "setup_prhead_remote() { :; }",
+        'resolve_prhead_remote_sha() { printf \'%s\\n\' "$concurrent_head"; }',
+        "gh() { git rev-parse refs/pull/4242/head; }",
+        "run_prepare_push_retry_gates() { touch .local/retry-gates; }",
+        'push_prep_head_once() { if [ ! -e .local/retry-gates ]; then return 3; fi; git update-ref refs/pull/4242/head "$3"; printf \'%s\\n\' "$3"; }',
+        'wait_for_pr_head_sha() { test "$(git rev-parse refs/pull/4242/head)" = "$2"; }',
+        'push_prep_head_to_pr_branch 4242 topic "$prep_head" "$lease_sha" true false .local/push-result.env',
+        "test -e .local/retry-gates",
+        "source .local/push-result.env",
+        'test "$PUSHED_FROM_SHA" = "$concurrent_head"',
+        'test "$PUSH_PREP_HEAD_SHA" = "$(git rev-parse HEAD)"',
+      ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Lease push failed, retrying once with fresh PR head");
+  });
+
   it("publishes a changed-patch Testbox rebase with fresh sync evidence", () => {
     const repoDir = makeSyncRepo({ needsRebase: true });
     writeFileSync(join(repoDir, ".local", "prep-sync.env"), "PREP_SYNC_TREE=stale\n");


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr prepare-sync-head` could send a locally rebased tree through GitHub's `createCommitOnBranch` mutation. That mutation always parents its commit to the current hosted PR head, so it cannot represent rewritten ancestry; changes brought in from `main` were instead materialized as ordinary files in a new PR commit.

## Why This Change Was Made

- Reject GraphQL pushes when the hosted PR head cannot safely anchor the prepared local history.
- Preserve legitimate follow-up pushes when the prior verified GraphQL commit and recorded local prep commit have identical trees and compatible mainline ancestry.
- Reject rebases, merged-in main refreshes, and legacy already-flattened hosted commits with guidance to use the explicit ancestry-preserving git push path.
- Preserve the existing fetch/rebase/gate retry when a contributor advances the PR head concurrently.

## User Impact

Maintainer preparation now fails closed instead of turning unrelated `main` changes into a PR commit. Ordinary verified GraphQL preparation and concurrent-head recovery continue to work.

## Evidence

- Pre-fix regression: the stale-head rebase fixture reached the GraphQL mutation and reported `unsafe GraphQL ancestry rewrite succeeded`.
- `pnpm test test/scripts/pr-prepare-gates.test.ts` on Blacksmith Testbox: 30/30 passed (`tbx_01kx735xtyg2t4q7akq5jx2782`).
- `pnpm check:changed` on the same Testbox lease: passed with 0 warnings and 0 errors.
- Fresh autoreview: no accepted/actionable findings after follow-up coverage for hosted/local twin commits, legacy flattened state, merged mainline ancestry, and concurrent lease retry.
