### PR TITLE
fix(auth): refresh OAuth tokens inside pre-expiry margin

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-margin.manager-path.proof.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-margin.manager-path.proof.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Real behavior proof for #103846 / PR #103988.
+ *
+ * Exercises the production manager → lock → refreshCredential → getOAuthApiKey
+ * → provider.refreshToken → persist path with a credential inside the shared
+ * 5-minute pre-expiry margin. Only the provider network refresh is stubbed.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+// Import the real oauth helper module path so shared Vitest mocks of
+// `src/llm/oauth.js` do not replace register/refresh behavior for this proof.
+import {
+  getOAuthApiKey,
+  registerOAuthProvider,
+  resetOAuthProviders,
+  type OAuthCredentials,
+  type OAuthProviderInterface,
+} from "../../llm/utils/oauth/index.js";
+import { captureEnv } from "../../test-utils/env.js";
+import { DEFAULT_OAUTH_REFRESH_MARGIN_MS, hasUsableOAuthCredential } from "./credential-state.js";
+import { testing as externalAuthTesting } from "./external-auth.js";
+import { createOAuthManager } from "./oauth-manager.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  loadAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { OAuthCredential } from "./types.js";
+
+const PROFILE_ID = "anthropic:default";
+const PROVIDER = "anthropic";
+
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_AGENT_DIR"]);
+const tempDirs: string[] = [];
+
+function logProof(label: string, payload: unknown): void {
+  // eslint-disable-next-line no-console -- proof transcript for PR body / CI logs
+  console.log(`[oauth-margin-proof] ${label}: ${JSON.stringify(payload)}`);
+}
+
+async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-margin-proof-"));
+  tempDirs.push(root);
+  const agentDir = path.join(root, "agents", "main", "agent");
+  await fs.mkdir(agentDir, { recursive: true });
+  process.env.OPENCLAW_STATE_DIR = root;
+  process.env.OPENCLAW_AGENT_DIR = agentDir;
+  await run(agentDir);
+}
+
+function seedCredential(expires: number): OAuthCredential {
+  return {
+    type: "oauth",
+    provider: PROVIDER,
+    access: "stale-access-margin",
+    refresh: "stale-refresh-margin",
+    expires,
+  };
+}
+
+function registerSpyProvider(refreshToken: OAuthProviderInterface["refreshToken"]): void {
+  registerOAuthProvider({
+    id: PROVIDER,
+    name: "Anthropic (Claude Pro/Max)",
+    async login() {
+      throw new Error("login unused in margin proof");
+    },
+    refreshToken,
+    getApiKey(creds: OAuthCredentials) {
+      return creds.access;
+    },
+  } satisfies OAuthProviderInterface);
+}
+
+beforeEach(() => {
+  resetFileLockStateForTest();
+  clearRuntimeAuthProfileStoreSnapshots();
+  externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+  resetOAuthProviders();
+});
+
+afterEach(async () => {
+  envSnapshot.restore();
+  resetFileLockStateForTest();
+  clearRuntimeAuthProfileStoreSnapshots();
+  externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+  resetOAuthProviders();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("oauth refresh margin manager-path real behavior proof (#103846)", () => {
+  it("refreshes and persists when manager needs refresh inside the pre-expiry margin", async () => {
+    await withAgentDir(async (agentDir) => {
+      const now = Date.now();
+      const expires = now + 4 * 60 * 1000; // inside 5m margin, not raw-expired
+      const stale = seedCredential(expires);
+      const freshExpires = now + 3_600_000;
+      const refreshToken = vi.fn(async (_creds: OAuthCredentials) => ({
+        access: "fresh-access-margin",
+        refresh: "fresh-refresh-margin",
+        expires: freshExpires,
+      }));
+      registerSpyProvider(refreshToken);
+
+      const managerNeedsRefresh = !hasUsableOAuthCredential(stale, {
+        now,
+        refreshMarginMs: DEFAULT_OAUTH_REFRESH_MARGIN_MS,
+      });
+      expect(managerNeedsRefresh).toBe(true);
+
+      // Control: unmargined helper (main-era contract) is a silent no-op.
+      const mainEra = await getOAuthApiKey(
+        PROVIDER,
+        { [PROVIDER]: { access: stale.access, refresh: stale.refresh, expires: stale.expires } },
+        { now, refreshMarginMs: 0 },
+      );
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(mainEra?.newCredentials.access).toBe(stale.access);
+
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [PROFILE_ID]: stale,
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false },
+      );
+
+      // Production-shaped refresh: manager → refreshCredential → real getOAuthApiKey.
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, credential) => credential.access,
+        refreshCredential: async (credential) => {
+          const result = await getOAuthApiKey(PROVIDER, {
+            [PROVIDER]: {
+              access: credential.access,
+              refresh: credential.refresh,
+              expires: credential.expires,
+            },
+          });
+          return result?.newCredentials ?? null;
+        },
+        readBootstrapCredential: () => null,
+        isRefreshTokenReusedError: () => false,
+      });
+
+      const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
+      const result = await manager.resolveOAuthAccess({
+        store,
+        profileId: PROFILE_ID,
+        credential: stale,
+        agentDir,
+      });
+
+      expect(result?.apiKey).toBe("fresh-access-margin");
+      expect(result?.credential.access).toBe("fresh-access-margin");
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+
+      const reloaded = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+      const persisted = reloaded.profiles[PROFILE_ID];
+      expect(persisted?.type).toBe("oauth");
+      if (persisted?.type !== "oauth") {
+        throw new Error("expected persisted oauth credential");
+      }
+      expect(persisted.access).toBe("fresh-access-margin");
+      expect(persisted.refresh).toBe("fresh-refresh-margin");
+      expect(persisted.expires).toBe(freshExpires);
+
+      logProof("result", {
+        managerNeedsRefresh,
+        networkRefreshCallWasMade: refreshToken.mock.calls.length === 1,
+        returnedApiKey: result?.apiKey,
+        mainEraNoOpAccess: mainEra?.newCredentials.access,
+        persistedAccess: persisted.access,
+        persistedExpires: persisted.expires,
+        staleExpires: expires,
+        marginMs: DEFAULT_OAUTH_REFRESH_MARGIN_MS,
+        agentDirBasename: path.basename(path.dirname(path.dirname(agentDir))),
+      });
+    });
+  });
+});

--- a/src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
+++ b/src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 function registerAnthropicProvider(refreshToken: OAuthProviderInterface["refreshToken"]) {
   registerOAuthProvider({
     id: "anthropic",
+    name: "Anthropic (Claude Pro/Max)",
     async login() {
       throw new Error("unused");
     },
@@ -26,7 +27,7 @@ function registerAnthropicProvider(refreshToken: OAuthProviderInterface["refresh
     getApiKey(creds: OAuthCredentials) {
       return creds.access;
     },
-  } as OAuthProviderInterface);
+  } satisfies OAuthProviderInterface);
 }
 
 describe("getOAuthApiKey refresh margin", () => {

--- a/src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
+++ b/src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_OAUTH_REFRESH_MARGIN_MS,
+  hasUsableOAuthCredential,
+} from "../../../agents/auth-profiles/credential-state.js";
+import {
+  getOAuthApiKey,
+  OAUTH_API_KEY_REFRESH_MARGIN_MS,
+  registerOAuthProvider,
+  resetOAuthProviders,
+} from "./index.js";
+import type { OAuthCredentials, OAuthProviderInterface } from "./types.js";
+
+afterEach(() => {
+  resetOAuthProviders();
+  vi.restoreAllMocks();
+});
+
+function registerAnthropicProvider(refreshToken: OAuthProviderInterface["refreshToken"]) {
+  registerOAuthProvider({
+    id: "anthropic",
+    async login() {
+      throw new Error("unused");
+    },
+    refreshToken,
+    getApiKey(creds: OAuthCredentials) {
+      return creds.access;
+    },
+  } as OAuthProviderInterface);
+}
+
+describe("getOAuthApiKey refresh margin", () => {
+  it("keeps the oauth api-key margin aligned with auth-profiles default", () => {
+    expect(OAUTH_API_KEY_REFRESH_MARGIN_MS).toBe(DEFAULT_OAUTH_REFRESH_MARGIN_MS);
+  });
+
+  it("refreshes when the credential is inside the shared pre-expiry margin", async () => {
+    const now = 1_700_000_000_000;
+    const expires = now + 4 * 60 * 1000;
+    const stale: OAuthCredentials = {
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires,
+    };
+    const refreshToken = vi.fn(async (_creds: OAuthCredentials) => ({
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      expires: now + 3_600_000,
+    }));
+    registerAnthropicProvider(refreshToken);
+
+    const managerSaysUsable = hasUsableOAuthCredential(
+      {
+        type: "oauth",
+        provider: "anthropic",
+        access: stale.access,
+        refresh: stale.refresh,
+        expires,
+      },
+      { now, refreshMarginMs: DEFAULT_OAUTH_REFRESH_MARGIN_MS },
+    );
+    expect(managerSaysUsable).toBe(false);
+
+    const result = await getOAuthApiKey("anthropic", { anthropic: stale }, { now });
+    expect(refreshToken).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      apiKey: "fresh-access",
+      newCredentials: {
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: now + 3_600_000,
+      },
+    });
+  });
+
+  it("does not refresh when the credential is still outside the margin", async () => {
+    const now = 1_700_000_000_000;
+    const expires = now + DEFAULT_OAUTH_REFRESH_MARGIN_MS + 60_000;
+    const fresh: OAuthCredentials = {
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      expires,
+    };
+    const refreshToken = vi.fn(async (creds: OAuthCredentials) => creds);
+    registerAnthropicProvider(refreshToken);
+
+    expect(
+      hasUsableOAuthCredential(
+        {
+          type: "oauth",
+          provider: "anthropic",
+          access: fresh.access,
+          refresh: fresh.refresh,
+          expires,
+        },
+        { now, refreshMarginMs: DEFAULT_OAUTH_REFRESH_MARGIN_MS },
+      ),
+    ).toBe(true);
+
+    const result = await getOAuthApiKey("anthropic", { anthropic: fresh }, { now });
+    expect(refreshToken).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      apiKey: "fresh-access",
+      newCredentials: fresh,
+    });
+  });
+
+  it("still refreshes when the raw expires timestamp has already elapsed", async () => {
+    const now = 1_700_000_000_000;
+    const expires = now - 1;
+    const stale: OAuthCredentials = {
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires,
+    };
+    const refreshToken = vi.fn(async (_creds: OAuthCredentials) => ({
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      expires: now + 3_600_000,
+    }));
+    registerAnthropicProvider(refreshToken);
+
+    const result = await getOAuthApiKey("anthropic", { anthropic: stale }, { now });
+    expect(refreshToken).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("fresh-access");
+  });
+
+  it("allows callers to disable the pre-expiry margin", async () => {
+    const now = 1_700_000_000_000;
+    const expires = now + 4 * 60 * 1000;
+    const stale: OAuthCredentials = {
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires,
+    };
+    const refreshToken = vi.fn(async (creds: OAuthCredentials) => creds);
+    registerAnthropicProvider(refreshToken);
+
+    const result = await getOAuthApiKey(
+      "anthropic",
+      { anthropic: stale },
+      { now, refreshMarginMs: 0 },
+    );
+    expect(refreshToken).not.toHaveBeenCalled();
+    expect(result?.newCredentials).toEqual(stale);
+  });
+});

--- a/src/llm/utils/oauth/index.ts
+++ b/src/llm/utils/oauth/index.ts
@@ -33,11 +33,7 @@ export * from "./types.js";
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-chatgpt.js";
-import type {
-  OAuthCredentials,
-  OAuthProviderId,
-  OAuthProviderInterface,
-} from "./types.js";
+import type { OAuthCredentials, OAuthProviderId, OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
   anthropicOAuthProvider,
@@ -85,8 +81,19 @@ export function getOAuthProviders(): OAuthProviderInterface[] {
 // ============================================================================
 
 /**
+ * Pre-expiry refresh window for {@link getOAuthApiKey}.
+ *
+ * Must match auth-profiles `DEFAULT_OAUTH_REFRESH_MARGIN_MS` so manager-driven
+ * refresh (hasUsableOAuthCredential → getOAuthApiKey) is not a silent no-op
+ * when the access token is still within the raw `expires` timestamp but inside
+ * the shared margin. See issue #103846.
+ */
+export const OAUTH_API_KEY_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+/**
  * Get API key for a provider from OAuth credentials.
- * Automatically refreshes expired tokens.
+ * Automatically refreshes tokens that are expired or inside the shared
+ * pre-expiry refresh margin.
  *
  * @returns API key string and updated credentials, or null if no credentials
  * @throws Error if refresh fails
@@ -94,6 +101,10 @@ export function getOAuthProviders(): OAuthProviderInterface[] {
 export async function getOAuthApiKey(
   providerId: OAuthProviderId,
   credentials: Record<string, OAuthCredentials>,
+  opts?: {
+    now?: number;
+    refreshMarginMs?: number;
+  },
 ): Promise<{ newCredentials: OAuthCredentials; apiKey: string } | null> {
   const provider = getOAuthProvider(providerId);
   if (!provider) {
@@ -105,8 +116,11 @@ export async function getOAuthApiKey(
     return null;
   }
 
-  // Refresh if expired
-  if (Date.now() >= creds.expires) {
+  const now = opts?.now ?? Date.now();
+  const refreshMarginMs = Math.max(0, opts?.refreshMarginMs ?? OAUTH_API_KEY_REFRESH_MARGIN_MS);
+  // Align with hasUsableOAuthCredential: refresh once remaining life is within
+  // the margin, not only after the stored expires timestamp has fully elapsed.
+  if (now + refreshMarginMs >= creds.expires) {
     try {
       creds = await provider.refreshToken(creds);
     } catch (error) {


### PR DESCRIPTION
Fixes #103846

## What Problem This Solves

Fixes an issue where operators with Anthropic OAuth credentials would silently skip token refresh while still inside the intended pre-expiry refresh window: the auth manager decided a refresh was required, took the refresh lock, then the shared OAuth helper returned the unchanged credential without calling the provider token endpoint.

## Why This Change Was Made

`getOAuthApiKey` only refreshed after the stored `expires` timestamp had fully elapsed, while `hasUsableOAuthCredential` treats credentials as unusable once they are within the shared 5-minute margin. This change makes `getOAuthApiKey` use the same pre-expiry margin by default (with optional override/disable) so manager-driven refresh actually attempts a provider refresh instead of no-opping.

## User Impact

Anthropic (and other built-in OAuth providers routed through `getOAuthApiKey`) refresh earlier and more reliably near expiry, reducing silent keep-using-stale-token windows that the auth manager already intended to close.

## Evidence

Verification host: local macOS (Crabbox bypass)

Commands:
```text
# Before fix (repro on origin/main): manager needs refresh, but getOAuthApiKey no-ops
node scripts/run-vitest.mjs src/llm/utils/oauth/get-oauth-api-key.margin.repro.test.ts
# OBSERVED
# {"managerSaysNeedsRefresh":true,"networkRefreshCallWasMade":false,"returnedAccessSameAsStale":true,"returnedExpiresSameAsStale":true}

# After fix
node scripts/run-vitest.mjs src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
# 5 tests passed
node scripts/run-vitest.mjs src/llm/utils/oauth/anthropic.test.ts
# 12 tests passed
./node_modules/.bin/oxfmt --check src/llm/utils/oauth/index.ts src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
./node_modules/.bin/oxlint src/llm/utils/oauth/index.ts src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
```

Focused margin suite result after patch:
```text
 ✓ |unit| src/llm/utils/oauth/get-oauth-api-key.margin.test.ts (5 tests)
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Real behavior proof

- Behavior addressed: When an Anthropic OAuth credential is inside the 5-minute pre-expiry margin, manager-driven refresh must call the provider refresh path and persist updated credentials (not silently return the stale credential).
- Environment: local macOS openclaw checkout on `fix/103846-oauth-refresh-margin`, Node via `node scripts/run-vitest.mjs` (provider token endpoint stubbed; manager/lock/store paths real).
- Current-main contrast: With `refreshMarginMs: 0` (main-era helper contract), the same inside-margin credential returns unchanged access and never calls `refreshToken` (`mainEraNoOpAccess: "stale-access-margin"`). After this patch, the default-margin helper + manager path refreshes and persists.
- Exact steps after patch:
  1. Seed auth profile store with Anthropic OAuth `expires = now + 4m` (inside `DEFAULT_OAUTH_REFRESH_MARGIN_MS`).
  2. Assert `hasUsableOAuthCredential` → false (manager needs refresh).
  3. Control: `getOAuthApiKey(..., { refreshMarginMs: 0 })` → no network refresh, stale access returned.
  4. Run `createOAuthManager.resolveOAuthAccess` with production-shaped `refreshCredential` that calls real `getOAuthApiKey`.
  5. Assert provider `refreshToken` called once, API key is fresh, and reloaded store has new access/refresh/expires.
- Command:
```text
node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-margin.manager-path.proof.test.ts
# ✓ 1 passed
# [oauth-margin-proof] result: {
#   "managerNeedsRefresh": true,
#   "networkRefreshCallWasMade": true,
#   "returnedApiKey": "fresh-access-margin",
#   "mainEraNoOpAccess": "stale-access-margin",
#   "persistedAccess": "fresh-access-margin",
#   "marginMs": 300000
# }
```
- Focused helper suite (still green):
```text
node scripts/run-vitest.mjs src/llm/utils/oauth/get-oauth-api-key.margin.test.ts
# 5 tests passed
node scripts/run-vitest.mjs src/llm/utils/oauth/anthropic.test.ts
# 12 tests passed
```
- Evidence after fix: manager-path proof logs `networkRefreshCallWasMade: true` and `persistedAccess: "fresh-access-margin"`; main-era control remains a no-op.
- Control check: `refreshMarginMs: 0` / outside-margin cases still skip refresh; fully elapsed expiry still refreshes; constant alignment test keeps helper margin == auth-profiles default.
- Observed result after fix: inside-margin manager refresh is no longer a silent no-op; credentials are refreshed and persisted under the real lock/store path.
- What was not tested: Live Anthropic token endpoint exchange over the public network; multi-agent cross-store mirror races (covered by sibling oauth.mirror-refresh tests).


## AI disclosure

This fix was authored with AI assistance (Grok). Human operator reviewed selection and submission under the auto contributor pipeline. Proof commands and observed outputs above are from real local runs on this host.

