### PR TITLE
fix: surface stalled-session interruptions

### DIFF
--- a/src/agents/agent-tools.abort.test.ts
+++ b/src/agents/agent-tools.abort.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+
+describe("wrapToolWithAbortSignal", () => {
+  it("returns promptly on run abort while a non-cooperative tool settles later", async () => {
+    const abort = new AbortController();
+    let resolveTool: (() => void) | undefined;
+    let receivedSignal: AbortSignal | undefined;
+    const tool = {
+      name: "slow-tool",
+      description: "waits until released",
+      parameters: {},
+      execute: async (_toolCallId: string, _params: unknown, signal?: AbortSignal) => {
+        receivedSignal = signal;
+        await new Promise<void>((resolve) => {
+          resolveTool = resolve;
+        });
+        return { content: [] };
+      },
+    } as unknown as AnyAgentTool;
+    const execute = wrapToolWithAbortSignal(tool, abort.signal).execute;
+    if (!execute) {
+      throw new Error("Expected wrapped tool execute function");
+    }
+
+    const result = execute("tool-call", {}, undefined, undefined);
+    abort.abort();
+
+    await expect(result).rejects.toMatchObject({ name: "AbortError", message: "Aborted" });
+    expect(receivedSignal?.aborted).toBe(true);
+
+    resolveTool?.();
+  });
+});

--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -13,6 +13,25 @@ function throwAbortError(): never {
   throw createAbortError("Aborted");
 }
 
+function rejectOnAbort(signal: AbortSignal): { promise: Promise<never>; dispose: () => void } {
+  let onAbort: (() => void) | undefined;
+  const promise = new Promise<never>((_, reject) => {
+    onAbort = () => reject(createAbortError("Aborted"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+  return {
+    promise,
+    dispose: () => {
+      if (onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    },
+  };
+}
+
 /** Wrap a tool so every execute call observes the supplied run abort signal. */
 export function wrapToolWithAbortSignal(
   tool: AnyAgentTool,
@@ -32,7 +51,17 @@ export function wrapToolWithAbortSignal(
       if (combinedSignal.aborted) {
         throwAbortError();
       }
-      return await execute(toolCallId, params, combinedSignal, onUpdate);
+      const aborted = rejectOnAbort(combinedSignal);
+      try {
+        // Tool cancellation is cooperative, so the handler may settle after
+        // the caller exits. The race keeps the run responsive and observes late rejection.
+        return await Promise.race([
+          execute(toolCallId, params, combinedSignal, onUpdate),
+          aborted.promise,
+        ]);
+      } finally {
+        aborted.dispose();
+      }
     },
   };
   copyPluginToolMeta(tool, wrappedTool);

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -38,6 +38,7 @@ import {
   buildAuthProfileFailoverFailureText,
   buildExternalRunFailureReply,
   buildRateLimitCooldownMessage,
+  buildStalledRunReplyPayload,
   hasBillingAttemptSummary,
   isNonDirectConversationContext,
   isPureTransientRateLimitSummary,
@@ -48,10 +49,12 @@ import {
 } from "./agent-runner-failure-reply.js";
 import type { AgentFallbackCycleState } from "./agent-runner-fallback-cycle.js";
 import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
+import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { classifyProviderRequestError } from "./provider-request-error-classifier.js";
 import {
   buildRestartLifecycleReplyText,
   isReplyOperationRestartAbort,
+  isReplyOperationStalled,
   isReplyOperationUserAbort,
   resolveRestartLifecycleError,
 } from "./reply-operation-abort.js";
@@ -229,6 +232,13 @@ export async function handleAgentExecutionError(params: {
     isTransientHttpError(message) ||
     (isFailoverError(err) && (err.reason === "timeout" || err.reason === "server_error"));
 
+  // Stale recovery records run_stalled before aborting this operation.
+  // Handle it before the broad user-abort predicate so the interruption remains visible.
+  if (isReplyOperationStalled(turn.replyOperation)) {
+    takePendingLifecycleTerminal()?.emit("error", err);
+    await drainPendingToolTasks({ tasks: turn.pendingToolTasks, onTimeout: logVerbose });
+    return { kind: "final", payload: buildStalledRunReplyPayload(turn.isHeartbeat) };
+  }
   const replyOperationAbortAction = resolveReplyOperationAbortAction(err);
   if (replyOperationAbortAction) {
     return replyOperationAbortAction;

--- a/src/auto-reply/reply/agent-runner-execution-stalled-recovery.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-stalled-recovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMinimalRunAgentTurnParams,
+  getRunAgentTurnWithFallback,
+  setupAgentRunnerExecutionTestState,
+} from "./agent-runner-execution.test-support.js";
+import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
+import { createReplyOperation, expireStaleReplyOperation } from "./reply-run-registry.js";
+
+const state = setupAgentRunnerExecutionTestState();
+
+function createStalledReplyOperation(sessionId: string) {
+  const replyOperation = createReplyOperation({
+    sessionKey: `agent:main:${sessionId}`,
+    sessionId,
+    resetTriggered: false,
+  });
+  replyOperation.setPhase("running");
+  return replyOperation;
+}
+
+describe("runAgentTurnWithFallback: stalled recovery", () => {
+  it("surfaces a stalled reply operation after the embedded run returns no payload", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-empty-reply");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      expect(replyOperation.abortSignal.aborted).toBe(true);
+      return { payloads: [], meta: {} };
+    });
+    let releaseToolTask: () => void = () => undefined;
+    const pendingToolTask = new Promise<void>((resolve) => {
+      releaseToolTask = resolve;
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pending = runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      pendingToolTasks: new Set([pendingToolTask]),
+    });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(settled).toBe(false);
+    releaseToolTask();
+
+    await expect(pending).resolves.toEqual({
+      kind: "final",
+      payload: {
+        text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+        isError: true,
+      },
+    });
+  });
+
+  it("surfaces a stalled reply operation after its aborted embedded run rejects", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-rejected-reply");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      expect(replyOperation.abortSignal.aborted).toBe(true);
+      throw new Error("embedded run aborted after stale recovery");
+    });
+    let releaseToolTask: () => void = () => undefined;
+    const pendingToolTask = new Promise<void>((resolve) => {
+      releaseToolTask = resolve;
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pending = runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      pendingToolTasks: new Set([pendingToolTask]),
+    });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(settled).toBe(false);
+    releaseToolTask();
+
+    await expect(pending).resolves.toEqual({
+      kind: "final",
+      payload: {
+        text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+        isError: true,
+      },
+    });
+  });
+
+  it("uses heartbeat failure copy for a stalled heartbeat operation", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-heartbeat");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      return { payloads: [], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      isHeartbeat: true,
+    });
+
+    expect(result).toEqual({
+      kind: "final",
+      payload: {
+        text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+        isError: true,
+      },
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -5,6 +5,9 @@ export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
 export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT =
   "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.";
 
+export const STALLED_RUN_FAILURE_TEXT =
+  "⚠️ This turn was interrupted because it stopped making progress. Please try again.";
+
 /** True when text is exactly the generic external run failure copy. */
 function isGenericExternalRunFailureText(text: string | undefined): boolean {
   return text?.trim() === GENERIC_EXTERNAL_RUN_FAILURE_TEXT;

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -36,6 +36,7 @@ import type { ReplyPayload } from "../types.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  STALLED_RUN_FAILURE_TEXT,
 } from "./agent-runner-failure-copy.js";
 import { classifyProviderRequestError } from "./provider-request-error-classifier.js";
 
@@ -457,6 +458,12 @@ export function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload:
     marked.isError = true;
   }
   return marked;
+}
+
+export function buildStalledRunReplyPayload(isHeartbeat: boolean): ReplyPayload {
+  return markAgentRunFailureReplyPayload({
+    text: isHeartbeat ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT : STALLED_RUN_FAILURE_TEXT,
+  });
 }
 
 export function buildTerminalAgentRunFailureReplyPayload(params: {

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -10,7 +10,10 @@ import { defaultRuntime } from "../../runtime.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
-import { markAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
+import {
+  buildStalledRunReplyPayload,
+  markAgentRunFailureReplyPayload,
+} from "./agent-runner-failure-reply.js";
 import type { AgentFallbackCandidatesResult } from "./agent-runner-fallback-candidate.js";
 import type {
   AgentFallbackCycleParams,
@@ -23,6 +26,7 @@ import {
 } from "./provider-request-error-classifier.js";
 import {
   isReplyOperationRestartAbort,
+  isReplyOperationStalled,
   isReplyOperationUserAbort,
 } from "./reply-operation-abort.js";
 
@@ -48,6 +52,16 @@ export async function settleAgentFallbackCycle(params: {
     throw isAgentRunRestartAbortReason(cycle.runAbortSignal?.reason)
       ? cycle.runAbortSignal?.reason
       : createAgentRunRestartAbortError();
+  }
+  // Stale recovery records run_stalled before aborting this operation.
+  // Prefer that terminal cause so the broader abort-signal fallback does not hide its reply.
+  if (isReplyOperationStalled(turn.replyOperation)) {
+    settledLifecycleTerminal?.emit(
+      "error",
+      new Error("Reply operation expired after making no progress"),
+    );
+    await drainPendingToolTasks({ tasks: turn.pendingToolTasks, onTimeout: logVerbose });
+    return { kind: "final", payload: buildStalledRunReplyPayload(turn.isHeartbeat) };
   }
   if (isReplyOperationUserAbort(turn.replyOperation)) {
     settledLifecycleTerminal?.emit("end", runResult);

--- a/src/auto-reply/reply/reply-operation-abort.ts
+++ b/src/auto-reply/reply/reply-operation-abort.ts
@@ -29,6 +29,10 @@ export function isReplyOperationRestartAbort(replyOperation?: ReplyOperation): b
   return abortSignal?.aborted === true && isAgentRunRestartAbortReason(abortSignal.reason);
 }
 
+export function isReplyOperationStalled(replyOperation?: ReplyOperation): boolean {
+  return replyOperation?.result?.kind === "failed" && replyOperation.result.code === "run_stalled";
+}
+
 export function resolveRestartLifecycleError(
   error: unknown,
 ): GatewayDrainingError | CommandLaneClearedError | undefined {


### PR DESCRIPTION
Closes #103905

## What Problem This Solves

Fixes an issue where a stuck-session recovery could remove a channel's streamed draft without sending a terminal notice. A non-cooperative tool could also keep running after the owning turn was aborted, leaving the caller blocked until it eventually settled.

## Why This Change Was Made

The reply-operation terminal state now preserves `run_stalled` as a user-visible interruption while explicit user and restart cancellations keep their existing behavior. Tool execution races the existing cooperative `AbortSignal`, so an aborted run stops waiting while late tool settlement remains observed. Risk note: external side effects cannot be undone; the tool still receives the abort signal and its late promise is deliberately drained rather than delivered into the terminated run.

## User Impact

Users whose stalled turn is recovered now receive a clear interruption message instead of losing all visible trace of the turn. Plugin tools that honor cancellation can stop promptly, and tools that do not no longer hold the aborted turn open.

## Evidence

Focused regression proof drives the real reply-run registry expiry path into the production runner: `expireStaleReplyOperation()` records `run_stalled` and aborts the same operation before both terminal projections run. The tool abort proof exercises `wrapToolWithAbortSignal` with a non-cooperative handler. Negative control used the real pre-fix sources via `git show HEAD^ -- <files>`. 

Before (pre-fix abort wrapper): caller stays blocked after run abort while the non-cooperative tool keeps running.

```text
=== abort promptness ===
{
  "result": { "kind": "timeout", "ms": 523.063467 },
  "toolSettled": true,
  "signalAborted": true
}
Error: abort promptness FAIL: {"kind":"timeout","ms":523.063467}
```

Before (pre-fix reply runner): stalled recovery leaves an empty success outcome, so the channel-facing draft can disappear with no interruption notice.

```text
{
  "result": { "kind": "failed", "code": "run_stalled" },
  "outcome": {
    "kind": "success",
    "runResult": { "payloads": [], "meta": {} }
  }
}
pre-fix stalled path: no interruption notice (bug reproduced)
```

After (fixed branch): abort returns in ~21ms, and stalled recovery surfaces the interruption payload.

```text
=== abort promptness ===
{
  "result": {
    "kind": "rejected",
    "err": { "name": "AbortError" },
    "ms": 21.162068000000545
  },
  "toolSettled": true,
  "signalAborted": true
}
abort_promptness: PASS

=== stalled interruption ===
{
  "result": { "kind": "failed", "code": "run_stalled" },
  "outcome": {
    "kind": "final",
    "payload": {
      "text": "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
      "isError": true
    }
  }
}
stalled_interruption: PASS
ALL PASS
```

Focused local verification:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts -t "stalled reply operation|stalled heartbeat operation"
3 passed | 254 skipped

node scripts/run-vitest.mjs src/agents/agent-tools.abort.test.ts
1 passed

pnpm tsgo:core:test
passed
```

What was not tested: no live Slack Socket Mode round-trip of a 15-minute blocked tool. The proven boundary is the channel-facing reply projection and tool-wrapper abort race before outbound send, which is where the silent draft deletion and blocked caller originate.

AI-assisted: Codex/Cursor; focused proof run manually.


