### PR TITLE
feat(auto-reply): add "commentary" verbose level for narration-only progress

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ModelControls.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ModelControls.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension OpenClawChatViewModel {
-    public static let verboseLevelOptions = ["off", "on", "full"]
+    public static let verboseLevelOptions = ["off", "on", "full", "commentary"]
 
     public var thinkingSelectionID: String {
         self.thinkingOverrideIsInherited ? Self.inheritedThinkingSelectionID : self.thinkingLevel

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1023,7 +1023,7 @@ Existing apps that already use `features.assistant_view` can keep their current 
     {
       "command": "/verbose",
       "description": "Toggle verbose output",
-      "usage_hint": "on|off|full"
+      "usage_hint": "on|off|full|commentary"
     },
     {
       "command": "/fast",

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -135,7 +135,7 @@ This is evaluation-only evidence, not a CI or release gate. Results do not chang
 - `--agent <id>`: agent id; overrides routing bindings
 - `--model <id>`: model override for this run (`provider/model` or model id)
 - `--thinking <level>`: agent thinking level (`off`, `minimal`, `low`, `medium`, `high`, plus provider-supported custom levels such as `xhigh`, `adaptive`, or `max`)
-- `--verbose <on|off>`: persist verbose level for the session
+- `--verbose <off|on|full|commentary>`: persist verbose level for the session
 - `--channel <channel>`: delivery channel; omit to use the main session channel
 - `--reply-to <target>`: delivery target override
 - `--reply-channel <channel>`: delivery channel override

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -422,7 +422,7 @@ Time format in system prompt. Default: `auto` (OS preference).
   - If omitted, the PDF tool falls back to `imageModel`, then to the resolved session/default model.
 - `pdfMaxMb`: default PDF size limit for the `pdf` tool when `maxBytesMb` is not passed at call time.
 - `pdfMaxPages`: default maximum pages considered by extraction fallback mode in the `pdf` tool.
-- `verboseDefault`: default verbose level for agents. Values: `"off"`, `"on"`, `"full"`. Default: `"off"`.
+- `verboseDefault`: default verbose level for agents. Values: `"off"`, `"on"`, `"full"`. Default: `"off"`. Per-agent `agents.entries.*.verboseDefault` overrides this default. (The `commentary` level is available per-session via `/verbose commentary` but is intentionally not a persisted default, to keep configs forward/backward compatible across runtime versions.)
 - `toolProgressDetail`: detail mode for `/verbose` tool summaries and progress-draft tool lines. Values: `"explain"` (default, compact human labels) or `"raw"` (append raw command/detail when available). Per-agent `agents.entries.*.toolProgressDetail` overrides this default.
 - `reasoningDefault`: default reasoning visibility for agents. Values: `"off"`, `"on"`, `"stream"`. Per-agent `agents.entries.*.reasoningDefault` overrides this default. Configured reasoning defaults are only applied for owners, authorized senders, or operator-admin gateway contexts when no per-message or session reasoning override is set.
 - `elevatedDefault`: default elevated-output level for agents. Values: `"off"`, `"on"`, `"ask"`, `"full"`. Default: `"on"`.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -195,7 +195,7 @@ plugins.
     | Command | Description |
     | --- | --- |
     | `/think <level\|default>` | Set the thinking level or clear the session override. Aliases: `/thinking`, `/t` |
-    | `/verbose on\|off\|full` | Toggle verbose output. Alias: `/v` |
+    | `/verbose on\|off\|full\|commentary` | Toggle verbose output. Alias: `/v` |
     | `/trace on\|off` | Toggle plugin trace output for the current session |
     | `/fast [status\|auto\|on\|off\|default]` | Show, set, or clear fast mode |
     | `/reasoning [on\|off\|stream]` | Toggle reasoning visibility. Alias: `/reason` |
@@ -210,6 +210,7 @@ plugins.
     <AccordionGroup>
       <Accordion title="verbose / trace / fast / reasoning safety">
         - `/verbose` is for debugging — keep it **off** in normal use.
+        - `/verbose commentary` shows only the agent's inter-tool commentary; tool summaries and tool output stay off.
         - `/trace` reveals only plugin-owned trace/debug lines; normal verbose chatter stays off.
         - `/fast auto|on|off` persists a session override; use the Sessions UI `inherit` option to clear it.
         - `/fast` is provider-specific: OpenAI/Codex map it to `service_tier=priority`; direct Anthropic requests map it to `service_tier=auto` or `standard_only`.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -82,7 +82,7 @@ title: "Thinking levels"
 
 ## Verbose directives (/verbose or /v)
 
-- Levels: `on` (minimal) | `full` | `off` (default).
+- Levels: `on` (minimal) | `full` | `commentary` | `off` (default).
 - Directive-only message toggles session verbose and replies `Verbose logging enabled.` / `Verbose logging disabled.`; invalid levels return a hint without changing state.
 - `/verbose off` stores an explicit session override; clear it via the Sessions UI by choosing `inherit`.
 - Authorized external channel senders may persist the session verbose override. Internal gateway/webchat clients need `operator.admin` to persist it.
@@ -91,6 +91,7 @@ title: "Thinking levels"
 - When verbose is on, agents that emit structured tool results send each tool call back as its own metadata-only message, prefixed with `<emoji> <tool-name>: <arg>` when available. These tool summaries are sent as soon as each tool starts (separate bubbles), not as streaming deltas.
 - Tool failure summaries remain visible in normal mode, but raw error detail suffixes are hidden unless verbose is `full`.
 - When verbose is `full`, tool outputs are also forwarded after completion (separate bubble, truncated to a safe length). If you toggle `/verbose on|full|off` while a run is in-flight, subsequent tool bubbles honor the new setting.
+- `commentary` keeps only the inter-tool commentary lane (the `💬` progress messages an agent narrates between tool calls); tool summaries and tool outputs stay off.
 - `agents.defaults.toolProgressDetail` controls the shape of `/verbose` tool summaries and progress-draft tool lines. Use `"explain"` (default) for compact human labels such as `🛠️ Exec: checking JS syntax`; use `"raw"` when you also want the raw command/detail appended for debugging. Per-agent `agents.entries.*.toolProgressDetail` overrides the default.
   - `explain`: `🛠️ Exec: check JS syntax for /tmp/app.js`
   - `raw`: `🛠️ Exec: check JS syntax for /tmp/app.js, node --check /tmp/app.js`

--- a/src/acp/commands.ts
+++ b/src/acp/commands.ts
@@ -32,7 +32,7 @@ const BASE_AVAILABLE_COMMANDS: AvailableCommand[] = [
     name: "think",
     description: `Set thinking level (${THINKING_LEVELS_HELP}).`,
   },
-  { name: "verbose", description: "Set verbose mode (on|full|off)." },
+  { name: "verbose", description: "Set verbose mode (off|on|full|commentary)." },
   { name: "trace", description: "Set plugin trace mode (on|off)." },
   { name: "reasoning", description: "Toggle reasoning output (on|off|stream)." },
   { name: "elevated", description: "Toggle elevated mode (on|off)." },

--- a/src/acp/translator.presentation.ts
+++ b/src/acp/translator.presentation.ts
@@ -179,7 +179,7 @@ export function buildSessionPresentation(params: {
       description:
         "Controls how much tool progress and output detail OpenClaw keeps enabled for the session.",
       currentValue: normalizeOptionalString(row.verboseLevel) || "off",
-      values: ["off", "on", "full"],
+      values: ["off", "on", "full", "commentary"],
     }),
     buildSelectConfigOption({
       id: ACP_TRACE_LEVEL_CONFIG_ID,

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -195,7 +195,7 @@ export async function prepareAgentCommandExecution(opts: AgentCommandOpts, runti
 
   const verboseOverride = normalizeVerboseLevel(opts.verbose);
   if (opts.verbose && !verboseOverride) {
-    throw new Error('Invalid verbose level. Use "on", "full", or "off".');
+    throw new Error('Invalid verbose level. Use "on", "full", "commentary", or "off".');
   }
 
   const laneRaw = normalizeOptionalString(opts.lane) ?? "";

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -18,6 +18,7 @@ import {
   type ReplyPayloadMetadata,
 } from "../../../auto-reply/reply-payload.js";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
+import { resolveVerboseKinds } from "../../../auto-reply/thinking.shared.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import {
   HEARTBEAT_TOKEN,
@@ -85,7 +86,7 @@ function isRecoverableToolError(error: string | undefined): boolean {
 }
 
 function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
-  return level === "full";
+  return resolveVerboseKinds(level)?.toolOutput === true;
 }
 
 function isAssistantTextContentBlockType(value: unknown): boolean {
@@ -623,7 +624,10 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: errorText, isError: true });
   }
   const inlineToolResults =
-    params.inlineToolResultsAllowed && params.verboseLevel !== "off" && params.toolMetas.length > 0;
+    params.inlineToolResultsAllowed &&
+    (params.verboseLevel === undefined ||
+      resolveVerboseKinds(params.verboseLevel)?.toolSummaries === true) &&
+    params.toolMetas.length > 0;
   if (inlineToolResults) {
     for (const { toolName, meta } of params.toolMetas) {
       const agg = formatToolAggregate(toolName, meta ? [meta] : [], {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -11,6 +11,7 @@ import {
 import type { FenceScanState } from "../../packages/markdown-core/src/fences.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
+import { resolveVerboseKinds } from "../auto-reply/thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent, emitAgentEventIfCurrent } from "../infra/agent-events.js";
@@ -760,11 +761,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const shouldEmitToolResult = () =>
     typeof params.shouldEmitToolResult === "function"
       ? params.shouldEmitToolResult()
-      : params.verboseLevel === "on" || params.verboseLevel === "full";
+      : resolveVerboseKinds(params.verboseLevel)?.toolSummaries === true;
   const shouldEmitToolOutput = () =>
     typeof params.shouldEmitToolOutput === "function"
       ? params.shouldEmitToolOutput()
-      : params.verboseLevel === "full";
+      : resolveVerboseKinds(params.verboseLevel)?.toolOutput === true;
   const formatToolOutputBlock = (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) {

--- a/src/auto-reply/command-status-builders.ts
+++ b/src/auto-reply/command-status-builders.ts
@@ -64,7 +64,7 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
     "/think <level|default>",
     "/model <id>",
     "/fast status|auto|on|off|default",
-    "/verbose on|off|full",
+    "/verbose on|off|full|commentary",
     "/trace on|off|raw",
   ];
   if (isCommandFlagEnabled(cfg, "config")) {

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -870,9 +870,9 @@ export function buildBuiltinChatCommands(
       args: [
         {
           name: "mode",
-          description: "on, off, or full",
+          description: "on, off, full, or commentary",
           type: "string",
-          choices: ["on", "off", "full"],
+          choices: ["on", "off", "full", "commentary"],
         },
       ],
     }),

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -753,7 +753,7 @@ describe("commands registry args", () => {
     const verbose = requireChatCommand("verbose");
 
     const modeArg = requireCommandArgAt(verbose, 0);
-    expect(modeArg.choices).toEqual(["on", "off", "full"]);
+    expect(modeArg.choices).toEqual(["on", "off", "full", "commentary"]);
     expect(
       resolveCommandArgMenu({ command: verbose, args: undefined, cfg: {} as never }),
     ).toBeNull();

--- a/src/auto-reply/reply.directive.directive-behavior.shows-current-verbose-level-verbose-has-no.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.shows-current-verbose-level-verbose-has-no.test.ts
@@ -97,7 +97,7 @@ describe("directive behavior", () => {
       currentVerboseLevel: "on",
     });
     expect(verboseText).toContain("Current verbose level: on");
-    expect(verboseText).toContain("Options: on, full, off.");
+    expect(verboseText).toContain("Options: on, full, commentary, off.");
 
     const { text: reasoningText } = await runDirectiveStatus("/reasoning");
     expect(reasoningText).toContain("Current reasoning level: off");

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -40,6 +40,19 @@ describe("directive parsing", () => {
     expect(res.verboseLevel).toBe("on");
   });
 
+  it("matches the commentary verbose level", () => {
+    const res = extractVerboseDirective("/verbose commentary");
+    expect(res.hasDirective).toBe(true);
+    expect(res.verboseLevel).toBe("commentary");
+    expect(res.cleaned).toBe("");
+  });
+
+  it("parses inline commentary verbose directives", () => {
+    const res = parseInlineDirectives("/verbose commentary");
+    expect(res.hasVerboseDirective).toBe(true);
+    expect(res.verboseLevel).toBe("commentary");
+  });
+
   it("matches trace with leading space", () => {
     const res = extractTraceDirective(" please /trace on now");
     expect(res.hasDirective).toBe(true);

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -27,7 +27,7 @@ import {
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
+import { resolveVerboseKinds, type VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
@@ -237,7 +237,7 @@ export function buildInlinePluginStatusPayload(params: {
   includeTraceLines: boolean;
 }): ReplyPayload | undefined {
   const statusLines =
-    params.entry?.verboseLevel && params.entry.verboseLevel !== "off"
+    resolveVerboseKinds(params.entry?.verboseLevel)?.toolSummaries === true
       ? resolveSessionPluginStatusLines(params.entry)
       : [];
   const traceLines =

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -30,7 +30,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
+import { resolveVerboseKinds, type VerboseLevel } from "../thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -197,7 +197,7 @@ export function isNonDirectConversationContext(ctx: ExternalFailureConversationC
 }
 
 export function isVerboseFailureDetailEnabled(level: VerboseLevel | undefined): boolean {
-  return level === "on" || level === "full";
+  return resolveVerboseKinds(level)?.toolSummaries === true;
 }
 
 export function resolveExternalRunFailureTextForConversation(params: {

--- a/src/auto-reply/reply/agent-runner-helpers.test.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.test.ts
@@ -45,6 +45,21 @@ describe("agent runner helpers", () => {
     expect(createShouldEmitToolOutput({ resolvedVerboseLevel: "full" })()).toBe(true);
   });
 
+  it("keeps tool summaries and outputs hidden for commentary-only verbose", () => {
+    expect(createShouldEmitToolResult({ resolvedVerboseLevel: "commentary" })()).toBe(false);
+    expect(createShouldEmitToolOutput({ resolvedVerboseLevel: "commentary" })()).toBe(false);
+  });
+
+  it("uses a session commentary override to hide tool summaries mid-run", () => {
+    hoisted.loadSessionEntryMock.mockReturnValue({ verboseLevel: "commentary" });
+    const shouldEmitResult = createShouldEmitToolResult({
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/store.json",
+      resolvedVerboseLevel: "full",
+    });
+    expect(shouldEmitResult()).toBe(false);
+  });
+
   it("uses session verbose level when present", () => {
     hoisted.loadSessionEntryMock.mockReturnValue({ verboseLevel: "full" });
     const shouldEmitResult = createShouldEmitToolResult({

--- a/src/auto-reply/reply/agent-runner-helpers.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.ts
@@ -5,7 +5,7 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
-import { normalizeVerboseLevel, type VerboseLevel } from "../thinking.js";
+import { resolveVerboseKinds, type VerboseKinds, type VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
@@ -24,7 +24,7 @@ type VerboseGateParams = {
 
 const VERBOSE_GATE_SESSION_REFRESH_MS = 250;
 
-function readCurrentVerboseLevel(params: VerboseGateParams): VerboseLevel | undefined {
+function readCurrentVerboseKinds(params: VerboseGateParams): VerboseKinds | undefined {
   if (!params.sessionKey || !params.storePath) {
     return undefined;
   }
@@ -35,7 +35,7 @@ function readCurrentVerboseLevel(params: VerboseGateParams): VerboseLevel | unde
       clone: false,
     });
     return typeof entry?.verboseLevel === "string"
-      ? normalizeVerboseLevel(entry.verboseLevel)
+      ? resolveVerboseKinds(entry.verboseLevel)
       : undefined;
   } catch {
     // ignore store read failures
@@ -43,10 +43,10 @@ function readCurrentVerboseLevel(params: VerboseGateParams): VerboseLevel | unde
   }
 }
 
-function createCurrentVerboseLevelResolver(
+function createCurrentVerboseKindsResolver(
   params: VerboseGateParams,
-): () => VerboseLevel | undefined {
-  let cachedLevel: VerboseLevel | undefined;
+): () => VerboseKinds | undefined {
+  let cachedKinds: VerboseKinds | undefined;
   let cachedAtMs = Number.NEGATIVE_INFINITY;
   return () => {
     if (!params.sessionKey || !params.storePath) {
@@ -54,34 +54,35 @@ function createCurrentVerboseLevelResolver(
     }
     const now = Date.now();
     if (now - cachedAtMs < VERBOSE_GATE_SESSION_REFRESH_MS) {
-      return cachedLevel;
+      return cachedKinds;
     }
-    cachedLevel = readCurrentVerboseLevel(params);
+    cachedKinds = readCurrentVerboseKinds(params);
     cachedAtMs = now;
-    return cachedLevel;
+    return cachedKinds;
   };
 }
 
 function createVerboseGate(
   params: VerboseGateParams,
-  shouldEmit: (level: VerboseLevel) => boolean,
+  shouldEmit: (kinds: VerboseKinds) => boolean,
 ): () => boolean {
   // Normalize verbose values from session store/config so false/"false" still means off.
-  const fallbackVerbose = params.resolvedVerboseLevel;
-  const resolveCurrentVerboseLevel = createCurrentVerboseLevelResolver(params);
+  const fallbackKinds = resolveVerboseKinds(params.resolvedVerboseLevel);
+  const resolveCurrentVerboseKinds = createCurrentVerboseKindsResolver(params);
   return () => {
-    return shouldEmit(resolveCurrentVerboseLevel() ?? fallbackVerbose);
+    const kinds = resolveCurrentVerboseKinds() ?? fallbackKinds;
+    return kinds ? shouldEmit(kinds) : false;
   };
 }
 
 /** Creates the visibility gate for tool result summaries. */
 export const createShouldEmitToolResult = (params: VerboseGateParams): (() => boolean) => {
-  return createVerboseGate(params, (level) => level !== "off");
+  return createVerboseGate(params, (kinds) => kinds.toolSummaries);
 };
 
 /** Creates the visibility gate for command/tool output streams. */
 export const createShouldEmitToolOutput = (params: VerboseGateParams): (() => boolean) => {
-  return createVerboseGate(params, (level) => level === "full");
+  return createVerboseGate(params, (kinds) => kinds.toolOutput);
 };
 
 /** Sends typing signals for visible text payloads when typing is enabled. */

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -8,7 +8,7 @@ import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveFallbackTransition } from "../fallback-state.js";
-import { normalizeVerboseLevel } from "../thinking.js";
+import { normalizeVerboseLevel, resolveVerboseKinds } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveConfiguredFallbackModel } from "./agent-runner-core.js";
 import type { FinalizeReplyAgentRunInput } from "./agent-runner-result.types.js";
@@ -169,7 +169,9 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
     lastCallUsage,
   });
   recordReplyUsageState(runId, replyUsageState);
-  const verboseEnabled = resolvedVerboseLevel !== "off";
+  // Operational notices (new-session, auto-compaction, plugin status) ride
+  // the toolSummaries lane: "commentary" delivers narration only.
+  const verboseEnabled = resolveVerboseKinds(resolvedVerboseLevel)?.toolSummaries === true;
   const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
     followupRun.run.inputProvenance,
   );

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -234,11 +234,11 @@ export async function handleDirectiveOnly(
     if (!directives.rawVerboseLevel) {
       const level = currentVerboseLevel ?? "off";
       return {
-        text: withOptions(`Current verbose level: ${level}.`, "on, full, off"),
+        text: withOptions(`Current verbose level: ${level}.`, "on, full, commentary, off"),
       };
     }
     return {
-      text: `Unrecognized verbose level "${directives.rawVerboseLevel}". Valid levels: off, on, full.`,
+      text: `Unrecognized verbose level "${directives.rawVerboseLevel}". Valid levels: off, on, full, commentary.`,
     };
   }
   if (directives.hasTraceDirective && !directives.traceLevel) {
@@ -709,7 +709,9 @@ export async function handleDirectiveOnly(
           ? formatDirectiveAck("Verbose logging disabled.")
           : directives.verboseLevel === "full"
             ? formatDirectiveAck("Verbose logging set to full.")
-            : formatDirectiveAck("Verbose logging enabled."),
+            : directives.verboseLevel === "commentary"
+              ? formatDirectiveAck("Verbose logging set to commentary.")
+              : formatDirectiveAck("Verbose logging enabled."),
     );
   }
   if (directives.hasTraceDirective && directives.traceLevel) {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -2813,6 +2813,24 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(sessionEntry.verboseLevel).toBe("full");
   });
 
+  it("acks the commentary verbose level in directive-only handling", async () => {
+    const directives = parseInlineDirectives("/verbose commentary");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives,
+        sessionEntry,
+        sessionStore,
+        surface: "webchat",
+        gatewayClientScopes: ["operator.admin"],
+      }),
+    );
+
+    expect(result?.text).toContain("Verbose logging set to commentary.");
+    expect(sessionEntry.verboseLevel).toBe("commentary");
+  });
+
   it("allows internal operator.admin exec persistence in directive-only handling", async () => {
     const directives = parseInlineDirectives(
       "/exec host=node security=allowlist ask=always node=worker-1",

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -71,8 +71,9 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     sessionKey,
     sessionStoreEntry,
     sessionTtsAuto,
-    shouldEmitFullVerboseProgress,
-    shouldEmitVerboseProgress,
+    shouldEmitCommentaryProgress,
+    shouldEmitToolOutputProgress,
+    shouldEmitToolSummaryProgress,
     shouldRouteToOriginating,
     sourceReplyDeliveryMode,
     suppressAutomaticSourceDelivery,
@@ -86,7 +87,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   const shouldSuppressProgressDelivery = () =>
     sendPolicyDenied ||
     (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
-  const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitVerboseProgress();
+  const shouldSuppressDefaultToolProgressMessages = () => !shouldEmitToolSummaryProgress();
   const shouldSendVerboseProgressMessages = () => !shouldSuppressDefaultToolProgressMessages();
   const shouldSendToolSummaries = () => shouldSendVerboseProgressMessages();
   const shouldSendToolStartStatuses = false;
@@ -118,8 +119,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     sourceReplyDeliveryMode === "message_tool_only" &&
     ctx.InboundEventKind !== "room_event" &&
     !sendPolicyDenied &&
-    shouldEmitVerboseProgress() &&
-    shouldSendVerboseProgressMessages();
+    (shouldEmitCommentaryProgress() || shouldSendVerboseProgressMessages());
   const shouldDeliverForcedToolProgressDespiteSourceSuppression = () =>
     suppressAutomaticSourceDelivery &&
     sourceReplyDeliveryMode === "message_tool_only" &&
@@ -166,7 +166,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   // and flushed when the producer moves on, always before the final reply.
   let pendingCommentaryProgress: { itemId?: string; text: string } | null = null;
   const deliverCommentaryProgressMessage = async (text: string) => {
-    if (!shouldSendToolSummaries() || shouldSuppressProgressDelivery()) {
+    if (!shouldEmitCommentaryProgress() || shouldSuppressProgressDelivery()) {
       return;
     }
     const payload: ReplyPayload = { text: `💬 ${text}` };
@@ -215,7 +215,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   const shouldSuppressMessageToolOnlyTextErrorProgress = (payload: ReplyPayload) => {
     if (
       sourceReplyDeliveryMode !== "message_tool_only" ||
-      shouldEmitFullVerboseProgress() ||
+      shouldEmitToolOutputProgress() ||
       payload.isError !== true
     ) {
       return false;

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -154,8 +154,10 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   forwardWhenSourceDeliverySuppressed: true,
                   requiresToolSummaryVisibility: true,
                   waitForDirectBlockReplyDelivery: true,
-                  onForward: async () => {
-                    // Commentary precedes the tool that follows it.
+                  // Commentary precedes the tool that follows it — flush even
+                  // when the tool line itself is hidden (narration-only
+                  // /verbose commentary keeps tool summaries off).
+                  onBeforeGate: async () => {
                     await flushPendingCommentaryProgress();
                   },
                 }),

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -24,7 +24,6 @@ import { stripLegacyMediaContextFields } from "../../media/media-facts.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeTtsAutoMode } from "../../tts/tts-config.js";
 import type { FinalizedRuntimeMsgContext as FinalizedMsgContext } from "../templating.js";
-import { normalizeVerboseLevel } from "../thinking.js";
 import type {
   DispatchProcessedOptions,
   DispatchProcessedOutcome,
@@ -295,15 +294,13 @@ export async function gatherDispatchRequest(
     storePath: sessionStoreEntry.storePath,
     initialExplicitLevel: sessionStoreEntry.entry?.verboseLevel,
     fallbackLevel:
-      normalizeVerboseLevel(
-        sessionStoreEntry.entry?.verboseLevel ??
-          sessionAgentCfg?.verboseDefault ??
-          cfg.agents?.defaults?.verboseDefault ??
-          "",
-      ) ?? "off",
+      sessionStoreEntry.entry?.verboseLevel ??
+      sessionAgentCfg?.verboseDefault ??
+      cfg.agents?.defaults?.verboseDefault,
   });
-  const shouldEmitVerboseProgress = verboseProgress.shouldEmit;
-  const shouldEmitFullVerboseProgress = verboseProgress.shouldEmitFull;
+  const shouldEmitCommentaryProgress = verboseProgress.shouldEmitCommentary;
+  const shouldEmitToolSummaryProgress = verboseProgress.shouldEmitToolSummaries;
+  const shouldEmitToolOutputProgress = verboseProgress.shouldEmitToolOutput;
   const replyRoute = resolveEffectiveReplyRoute({ ctx, entry: sessionStoreEntry.entry });
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
@@ -453,8 +450,9 @@ export async function gatherDispatchRequest(
       notePreparedSession,
       resolvePreparedTranscriptBinding,
       sessionAgentId,
-      shouldEmitVerboseProgress,
-      shouldEmitFullVerboseProgress,
+      shouldEmitCommentaryProgress,
+      shouldEmitToolSummaryProgress,
+      shouldEmitToolOutputProgress,
       replyRoute,
       routeReplyThreadId,
       inboundAudio,

--- a/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
+++ b/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
@@ -19,7 +19,7 @@ import {
 } from "../../utils/delivery-context.shared.js";
 import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import type { FinalizedMsgContext } from "../templating.js";
-import { normalizeVerboseLevel } from "../thinking.js";
+import { resolveVerboseKinds } from "../thinking.js";
 import { loadSessionStoreEntry, resolveStorePath } from "./dispatch-from-config.runtime.js";
 import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
@@ -36,9 +36,14 @@ export function createShouldEmitVerboseProgress(params: {
   sessionKey?: string;
   storePath?: string;
   initialExplicitLevel?: string;
-  fallbackLevel: string;
+  fallbackLevel: string | undefined;
 }) {
-  const resolveCurrentExplicitLevel = () => {
+  const fallbackKinds = resolveVerboseKinds(params.fallbackLevel ?? "") ?? {
+    commentary: false,
+    toolSummaries: false,
+    toolOutput: false,
+  };
+  const resolveCurrentExplicitKinds = () => {
     if (params.sessionKey && params.storePath) {
       try {
         const entry = loadSessionStoreEntry({
@@ -48,23 +53,18 @@ export function createShouldEmitVerboseProgress(params: {
           readConsistency: "latest",
           clone: false,
         });
-        return normalizeVerboseLevel(entry?.verboseLevel ?? "");
+        return resolveVerboseKinds(entry?.verboseLevel ?? "");
       } catch {
         // Ignore transient store read failures and fall back to the current dispatch snapshot.
       }
     }
-    return normalizeVerboseLevel(params.initialExplicitLevel ?? "");
+    return resolveVerboseKinds(params.initialExplicitLevel ?? "");
   };
-  const resolveLevel = () => {
-    const explicitLevel = resolveCurrentExplicitLevel();
-    if (explicitLevel) {
-      return explicitLevel;
-    }
-    return normalizeVerboseLevel(params.fallbackLevel) ?? "off";
-  };
+  const resolveKinds = () => resolveCurrentExplicitKinds() ?? fallbackKinds;
   return {
-    shouldEmit: () => resolveLevel() !== "off",
-    shouldEmitFull: () => resolveLevel() === "full",
+    shouldEmitCommentary: () => resolveKinds().commentary,
+    shouldEmitToolSummaries: () => resolveKinds().toolSummaries,
+    shouldEmitToolOutput: () => resolveKinds().toolOutput,
   };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-execution.ts
@@ -50,8 +50,9 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     sessionStoreEntry,
     sessionTtsAuto,
     shouldDeliverVerboseProgressDespiteSourceSuppression,
-    shouldEmitFullVerboseProgress,
-    shouldEmitVerboseProgress,
+    shouldEmitCommentaryProgress,
+    shouldEmitToolOutputProgress,
+    shouldEmitToolSummaryProgress,
     shouldRouteToOriginating,
     shouldSendToolStartStatuses,
     shouldSendToolSummaries,
@@ -100,7 +101,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     }
     const normalizedLabel = normalizeWorkingLabel(label);
     if (
-      !shouldEmitVerboseProgress() ||
+      !shouldEmitToolSummaryProgress() ||
       !shouldSendToolStartStatuses ||
       !normalizedLabel ||
       toolStartStatusCount >= 2 ||
@@ -238,8 +239,8 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     sendPolicyDenied ||
     (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
   const hasVisibleRegularVerboseToolProgress = () =>
-    shouldEmitVerboseProgress() &&
-    !shouldEmitFullVerboseProgress() &&
+    shouldEmitToolSummaryProgress() &&
+    !shouldEmitToolOutputProgress() &&
     shouldSendVerboseProgressMessages() &&
     ctx.InboundEventKind !== "room_event" &&
     !shouldSuppressProgressDelivery();
@@ -262,7 +263,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
     if (params.replyOptions?.suppressToolErrorWarnings !== undefined) {
       return params.replyOptions.suppressToolErrorWarnings;
     }
-    if (!shouldEmitVerboseProgress()) {
+    if (!shouldEmitToolSummaryProgress()) {
       return false;
     }
     return observedVisibleToolErrorProgress ? true : undefined;
@@ -352,6 +353,8 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
       allowWhenToolSummariesHidden?: boolean;
       forwardWhenSourceDeliverySuppressed?: boolean;
       requiresToolSummaryVisibility?: boolean;
+      /** Runs in source order even when the callback itself is not forwarded. */
+      onBeforeGate?: (...args: Args) => Promise<void> | void;
       onForward?: (...args: Args) => Promise<void> | void;
       onVisible?: (...args: Args) => Promise<void> | void;
       waitForDirectBlockReplyDelivery?: boolean;
@@ -376,6 +379,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
             return undefined;
           }
         }
+        await options?.onBeforeGate?.(...args);
         if (shouldForwardProgressCallback(options)) {
           if (preserveProgressCallbackStartOrder && options?.onForward) {
             await options.onForward(...args);
@@ -413,7 +417,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   // Snapshot verbose progress visibility for this run: commentary
   // classification in the CLI runners is wired once at run start, so a
   // mid-run verbose toggle cannot move inter-tool commentary between lanes.
-  const deliverStandaloneCommentaryProgress = shouldEmitVerboseProgress();
+  const deliverStandaloneCommentaryProgress = shouldEmitCommentaryProgress();
   const itemEventForwardingOptions = {
     forwardWhenSourceDeliverySuppressed: true,
     requiresToolSummaryVisibility: true,
@@ -472,7 +476,7 @@ export async function prepareDispatchExecution(state: ChooseDispatchRouteReadySt
   params.replyOptions?.onVerboseProgressVisibility?.(
     () =>
       deliverStandaloneCommentaryProgress &&
-      shouldSendVerboseProgressMessages() &&
+      shouldEmitCommentaryProgress() &&
       !shouldSuppressProgressDelivery(),
   );
 

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -1042,6 +1042,100 @@ describe("dispatchReplyFromConfig", () => {
     expect(callbackOrder).toEqual(["item", "partial"]);
   });
 
+  it("delivers commentary without tool summaries for the commentary verbose level", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "commentary",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    let commentaryEnabled: boolean | undefined;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      commentaryEnabled = opts?.commentaryProgressEnabled;
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "checking the config first",
+      });
+      const onToolResult = requireToolResultHandler(opts?.onToolResult);
+      await onToolResult({ text: "🔧 exec: ls" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(commentaryEnabled).toBe(true);
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(1);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 checking the config first",
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes buffered commentary at a hidden tool start under the commentary level", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "commentary",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "group",
+      From: "whatsapp:group:123@g.us",
+      SessionKey: "agent:main:whatsapp:group:123@g.us",
+    });
+
+    const onToolStart = vi.fn();
+    let commentaryDeliveredAtToolStart = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({
+        itemId: "c1",
+        kind: "preamble",
+        progressText: "checking the config first",
+      });
+      await opts?.onToolStart?.({ name: "exec", phase: "start" });
+      commentaryDeliveredAtToolStart =
+        (dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls.length === 1;
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: automaticGroupReplyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onToolStart },
+    });
+
+    // The buffered 💬 landed when the (hidden) tool started, not at finalize.
+    expect(commentaryDeliveredAtToolStart).toBe(true);
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(1);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 checking the config first",
+    );
+    // The tool line itself stays hidden in narration-only mode.
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
+
   it("flushes trailing verbose commentary before the final reply", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -10,6 +10,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import { resolveVerboseKinds } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveRunAfterAutoFallbackPrimaryProbeRecheck } from "./agent-runner-auto-fallback.js";
 import { resolveAdmittedRunSessionFile } from "./agent-runner-core.js";
@@ -638,7 +639,7 @@ export async function admitFollowupTurn(params: {
       operation.fail("run_failed", error);
       const admittedVerboseLevel = session.current()?.verboseLevel ?? turn.queued.run.verboseLevel;
       const text = buildPreflightCompactionFailureText(formatErrorMessage(error), {
-        includeDetails: admittedVerboseLevel === "on" || admittedVerboseLevel === "full",
+        includeDetails: resolveVerboseKinds(admittedVerboseLevel)?.toolSummaries === true,
       });
       if (!text) {
         turn.preflightError = error;

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -672,3 +672,116 @@ describe("executeFollowupTurn", () => {
     expect(order).toEqual(["slow-finished"]);
   });
 });
+
+describe("executeFollowupTurn commentary lanes", () => {
+  it("forwards preamble items and the commentary bridge flag under the commentary verbose level", async () => {
+    const onItemEvent = vi.fn(async () => {});
+    const onToolStart = vi.fn(async () => {});
+    const turn = createTurn({
+      session: {
+        kind: "session",
+        key: "main",
+        current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "commentary" }),
+        publish: () => undefined,
+        adopt: () => undefined,
+      },
+    });
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      await params.opts?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "embedded-commentary-1",
+        progressText: "Checking the workspace.",
+      });
+      await params.opts?.onItemEvent?.({ kind: "tool", name: "exec", phase: "start" });
+      await params.opts?.onToolStart?.({ name: "exec", itemId: "tool-1" });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "instant",
+        defaultModel: "claude",
+        opts: { onItemEvent, onToolStart },
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+
+    const call = state.execute.mock.calls[0]?.[0] as AgentTurnParams;
+    // The CLI preamble bridge is enabled from the live session level…
+    expect(call.opts?.commentaryProgressEnabled).toBe(true);
+    // …while isCommentary FINAL payloads stay behind the explicit opt-in.
+    expect(call.opts?.commentaryPayloadsEnabled).toBeUndefined();
+    expect(call.resolvedVerboseLevel).toBe("commentary");
+    expect(onItemEvent).toHaveBeenCalledTimes(1);
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "preamble",
+        itemId: "embedded-commentary-1",
+        progressText: "Checking the workspace.",
+      }),
+    );
+    // Commentary must not leak the tool lanes on the queued path.
+    expect(onToolStart).not.toHaveBeenCalled();
+  });
+
+  it("bridges queued commentary when the session switched to commentary after admission", async () => {
+    const onItemEvent = vi.fn(async () => {});
+    const currentEntry = {
+      sessionId: "session",
+      lifecycleRevision: "owned",
+      updatedAt: 1,
+      verboseLevel: "off" as const,
+    };
+    const turn = createTurn({
+      session: {
+        kind: "session",
+        key: "main",
+        storePath: "/tmp/sessions.json",
+        current: () => currentEntry,
+        publish: () => undefined,
+        adopt: () => undefined,
+      },
+    });
+    // No commentary flag at admission: enablement must come from the live
+    // session verbose level ("commentary") re-read at run start.
+    state.loadEntryReadOnly.mockReturnValue({
+      ...currentEntry,
+      updatedAt: 2,
+      verboseLevel: "commentary",
+    });
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      await params.opts?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "commentary-live-1",
+        progressText: "Reading the queue state.",
+      });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "instant",
+        defaultModel: "claude",
+        opts: { onItemEvent },
+      },
+      onToolResult: vi.fn(async () => {}),
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+
+    const call = state.execute.mock.calls[0]?.[0] as AgentTurnParams;
+    expect(call.opts?.commentaryProgressEnabled).toBe(true);
+    expect(call.resolvedVerboseLevel).toBe("commentary");
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "preamble",
+        itemId: "commentary-live-1",
+        progressText: "Reading the queue state.",
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -1,7 +1,7 @@
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TemplateContext } from "../templating.js";
-import type { VerboseLevel } from "../thinking.js";
+import { resolveVerboseKinds, type VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import { executeAgentTurn } from "./agent-runner-execution.js";
 import type { AgentTurnExecutionResult } from "./agent-runner-execution.types.js";
@@ -85,7 +85,7 @@ export async function executeFollowupTurn(params: {
           loadedEntry.updatedAt >= ownedEntry.updatedAt;
         if (loadedGenerationMatches) {
           const level = loadedEntry.verboseLevel;
-          if (level === "off" || level === "on" || level === "full") {
+          if (level === "off" || level === "on" || level === "full" || level === "commentary") {
             return level;
           }
         }
@@ -94,14 +94,22 @@ export async function executeFollowupTurn(params: {
       }
     }
     const level = session.current()?.verboseLevel ?? turn.queued.run.verboseLevel;
-    return level === "on" || level === "full" ? level : "off";
+    return level === "on" || level === "full" || level === "commentary" ? level : "off";
   };
+  const currentVerboseKinds = () => resolveVerboseKinds(currentVerboseLevel());
   const shouldEmitToolResult = () =>
     progressAllowed() &&
     (defaults.opts?.forceToolResultProgress === true ||
-      currentVerboseLevel() === "on" ||
-      currentVerboseLevel() === "full");
-  const shouldEmitToolOutput = () => progressAllowed() && currentVerboseLevel() === "full";
+      currentVerboseKinds()?.toolSummaries === true);
+  const shouldEmitToolOutput = () =>
+    progressAllowed() && currentVerboseKinds()?.toolOutput === true;
+  // Commentary PROGRESS is re-read live like the tool lanes: a session
+  // switched to "commentary" after this run was queued still gets its
+  // narration. Scope: the progress bridge only — isCommentary FINAL payloads
+  // stay behind the explicit commentaryPayloadsEnabled opt-in, matching
+  // direct dispatch.
+  const shouldEmitCommentary = () =>
+    progressAllowed() && currentVerboseKinds()?.commentary === true;
   const shouldEmitToolLifecycle = () =>
     progressAllowed() &&
     (shouldEmitToolResult() || defaults.opts?.allowToolLifecycleWhenProgressHidden === true);
@@ -150,6 +158,11 @@ export async function executeFollowupTurn(params: {
   const sourceOpts = defaults.opts;
   const progressOpts: InternalGetReplyOptions = {
     ...sourceOpts,
+    // Commentary classification in the CLI runners is wired once at run
+    // start: snapshot the live commentary lane here so a queued run admitted
+    // under /verbose commentary bridges preamble events.
+    commentaryProgressEnabled:
+      sourceOpts?.commentaryProgressEnabled === true || shouldEmitCommentary(),
     runId: turn.runId,
     onAgentRunStart: (runId) => {
       params.onExecutionStarted?.();
@@ -179,11 +192,16 @@ export async function executeFollowupTurn(params: {
     onItemEvent: sourceOpts?.onItemEvent
       ? (item) =>
           enqueueProgress(async () => {
-            if (!shouldEmitToolResult()) {
+            // Commentary narration (preamble items) rides its own lane so
+            // queued runs emit it under /verbose commentary, matching the
+            // direct dispatch path.
+            const toolResultVisible = shouldEmitToolResult();
+            if (!toolResultVisible && !(item.kind === "preamble" && shouldEmitCommentary())) {
               return;
             }
             const visible = (await sourceOpts.onItemEvent?.(item)) !== false;
             if (
+              toolResultVisible &&
               visible &&
               (item.phase === "error" || item.status === "failed" || item.status === "error")
             ) {

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -20,7 +20,13 @@ export type ThinkLevel =
   | "adaptive"
   | "max"
   | "ultra";
-export type VerboseLevel = "off" | "on" | "full";
+export type VerboseLevel = "off" | "on" | "full" | "commentary";
+/** Per-kind verbose output toggles resolved from a level preset. */
+export type VerboseKinds = {
+  commentary: boolean;
+  toolSummaries: boolean;
+  toolOutput: boolean;
+};
 export type TraceLevel = "off" | "on" | "raw";
 export type ElevatedLevel = "off" | "on" | "ask" | "full";
 export type ReasoningLevel = "off" | "on" | "stream";
@@ -152,7 +158,26 @@ function normalizeOnOffFullLevel(raw?: string | null): OnOffFullLevel | undefine
 
 /** Normalizes /verbose values. */
 export function normalizeVerboseLevel(raw?: string | null): VerboseLevel | undefined {
+  if (normalizeOptionalLowercaseString(raw) === "commentary") {
+    return "commentary";
+  }
   return normalizeOnOffFullLevel(raw);
+}
+
+const VERBOSE_LEVEL_KINDS: Record<VerboseLevel, VerboseKinds> = {
+  off: { commentary: false, toolSummaries: false, toolOutput: false },
+  commentary: { commentary: true, toolSummaries: false, toolOutput: false },
+  on: { commentary: true, toolSummaries: true, toolOutput: false },
+  full: { commentary: true, toolSummaries: true, toolOutput: true },
+};
+
+/** Resolves a verbose level preset to per-kind booleans. */
+export function resolveVerboseKinds(raw?: string | null): VerboseKinds | undefined {
+  const level = normalizeVerboseLevel(raw);
+  if (!level) {
+    return undefined;
+  }
+  return { ...VERBOSE_LEVEL_KINDS[level] };
 }
 
 /** Normalizes /trace values. */

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -15,11 +15,13 @@ const {
   listThinkingLevels,
   normalizeReasoningLevel,
   normalizeThinkLevel,
+  normalizeVerboseLevel,
   isThinkingLevelSupported,
   formatThinkingLevels,
   resolveSupportedThinkingLevel,
   resolveThinkingDefaultForModel,
   resolveEffectiveResponseUsage,
+  resolveVerboseKinds,
 } = await import("./thinking.js");
 
 beforeEach(() => {
@@ -899,6 +901,72 @@ describe("resolveThinkingDefaultForModel", () => {
         catalog: [{ provider: "ollama", id: "gemma4", reasoning: true }],
       }),
     ).toBe("off");
+  });
+});
+
+describe("normalizeVerboseLevel", () => {
+  it("accepts levels and aliases", () => {
+    expect(normalizeVerboseLevel("on")).toBe("on");
+    expect(normalizeVerboseLevel("OFF")).toBe("off");
+    expect(normalizeVerboseLevel("false")).toBe("off");
+    expect(normalizeVerboseLevel("full")).toBe("full");
+    expect(normalizeVerboseLevel("all")).toBe("full");
+    expect(normalizeVerboseLevel("everything")).toBe("full");
+    expect(normalizeVerboseLevel("true")).toBe("on");
+    expect(normalizeVerboseLevel("commentary")).toBe("commentary");
+    expect(normalizeVerboseLevel("Commentary")).toBe("commentary");
+  });
+
+  it("rejects unknown levels", () => {
+    expect(normalizeVerboseLevel("loud")).toBeUndefined();
+    expect(normalizeVerboseLevel("")).toBeUndefined();
+    expect(normalizeVerboseLevel(undefined)).toBeUndefined();
+    expect(normalizeVerboseLevel(null)).toBeUndefined();
+  });
+});
+
+describe("resolveVerboseKinds", () => {
+  it("maps level presets to per-kind toggles", () => {
+    expect(resolveVerboseKinds("off")).toEqual({
+      commentary: false,
+      toolSummaries: false,
+      toolOutput: false,
+    });
+    expect(resolveVerboseKinds("on")).toEqual({
+      commentary: true,
+      toolSummaries: true,
+      toolOutput: false,
+    });
+    expect(resolveVerboseKinds("full")).toEqual({
+      commentary: true,
+      toolSummaries: true,
+      toolOutput: true,
+    });
+    expect(resolveVerboseKinds("commentary")).toEqual({
+      commentary: true,
+      toolSummaries: false,
+      toolOutput: false,
+    });
+  });
+
+  it("maps level aliases through the level normalizer", () => {
+    expect(resolveVerboseKinds("everything")).toEqual({
+      commentary: true,
+      toolSummaries: true,
+      toolOutput: true,
+    });
+    expect(resolveVerboseKinds("false")).toEqual({
+      commentary: false,
+      toolSummaries: false,
+      toolOutput: false,
+    });
+  });
+
+  it("returns undefined for garbage input", () => {
+    expect(resolveVerboseKinds("loud")).toBeUndefined();
+    expect(resolveVerboseKinds("")).toBeUndefined();
+    expect(resolveVerboseKinds(undefined)).toBeUndefined();
+    expect(resolveVerboseKinds(null)).toBeUndefined();
   });
 });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -19,6 +19,7 @@ export {
   normalizeVerboseLevel,
   resolveEffectiveResponseUsage,
   resolveResponseUsageMode,
+  resolveVerboseKinds,
 } from "./thinking.shared.js";
 export type {
   ElevatedLevel,
@@ -27,6 +28,7 @@ export type {
   TraceLevel,
   ThinkLevel,
   ThinkingCatalogEntry,
+  VerboseKinds,
   VerboseLevel,
 } from "./thinking.shared.js";
 import {

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -55,7 +55,7 @@ export function registerAgentTurnCommand(
       "--thinking <level>",
       `Thinking level: ${THINKING_LEVELS_HELP.replaceAll("|", " | ")} where supported`,
     )
-    .option("--verbose <on|off>", "Persist agent verbose level for the session")
+    .option("--verbose <off|on|full|commentary>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",
       `Delivery channel: ${args.agentChannelOptions} (omit to use the main session channel)`,

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -139,6 +139,22 @@ describe("config schema regressions", () => {
     ).toBe(true);
   });
 
+  it("rejects commentary as a persisted verboseDefault (session-level only)", () => {
+    // `commentary` is a `/verbose` session level, deliberately NOT a persisted
+    // config default — persisting it would break strict config validation on
+    // downgrade to an older runtime.
+    expect(
+      validateConfigObject({
+        agents: { defaults: { verboseDefault: "commentary" } },
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateConfigObject({
+        agents: { defaults: { verboseDefault: "loud" } },
+      }).ok,
+    ).toBe(false);
+  });
+
   it("rejects local memorySearch GPU policy", () => {
     const res = validateConfigObject({
       memory: {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -239,7 +239,11 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: AgentThinkingLevel;
   /** Default fast-mode policy inherited by agent entries that omit it. */
   fastModeDefault?: FastMode;
-  /** Default verbose level when no /verbose directive is present. */
+  /**
+   * Default verbose level when no /verbose directive is present.
+   * Note: `commentary` is a session-level `/verbose` level only, not a
+   * persisted default (keeps the config forward/backward compatible).
+   */
   verboseDefault?: "off" | "on" | "full";
   /**
    * Detail mode for user-visible tool progress in /verbose and editable progress drafts.

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -118,6 +118,23 @@ describe("agent defaults schema", () => {
     }
   });
 
+  it("rejects commentary as a persisted verbose default (session-level only)", () => {
+    // `commentary` is a `/verbose` session level, not a persisted config
+    // default — keeping it out of the strict schema preserves downgrade safety.
+    expectSchemaFailurePath(
+      AgentDefaultsSchema.safeParse({ verboseDefault: "commentary" }),
+      "verboseDefault",
+    );
+    expectSchemaFailurePath(
+      AgentEntrySchema.safeParse({ id: "ops", verboseDefault: "commentary" }),
+      "verboseDefault",
+    );
+    expectSchemaFailurePath(
+      AgentDefaultsSchema.safeParse({ verboseDefault: "loud" }),
+      "verboseDefault",
+    );
+  });
+
   it("accepts subagent archiveAfterMinutes=0 to disable archiving", () => {
     expectSchemaSuccess(
       AgentDefaultsSchema.safeParse({

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -12,7 +12,7 @@ import { isTimeoutError, resolveFailoverReasonFromError } from "../agents/failov
 import { resolveToolSearchCodeDisplayTarget } from "../agents/tool-display-common.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
-import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
+import { resolveVerboseKinds } from "../auto-reply/thinking.js";
 import { normalizeAgentPlanSteps } from "../channels/streaming.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
@@ -1267,15 +1267,15 @@ export function createAgentEventHandler({
     state.lastSentAt = now;
   };
 
-  const resolveToolVerboseLevel = (runId: string, sessionKey?: string) => {
+  const resolveToolVerboseKinds = (runId: string, sessionKey?: string) => {
     const runContext = getAgentRunContext(runId);
-    const runVerbose = normalizeVerboseLevel(runContext?.verboseLevel);
+    const runVerbose = resolveVerboseKinds(runContext?.verboseLevel);
     if (!sessionKey) {
-      return runVerbose ?? "off";
+      return runVerbose;
     }
     try {
       const { cfg, entry } = loadSessionEntryReadOnly(sessionKey);
-      const sessionVerbose = normalizeVerboseLevel(entry?.verboseLevel);
+      const sessionVerbose = resolveVerboseKinds(entry?.verboseLevel);
       const sessionUpdatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : undefined;
       const sessionChangedAfterRunStarted =
         sessionUpdatedAt !== undefined &&
@@ -1287,10 +1287,9 @@ export function createAgentEventHandler({
       if (runVerbose) {
         return runVerbose;
       }
-      const defaultVerbose = normalizeVerboseLevel(cfg.agents?.defaults?.verboseDefault);
-      return defaultVerbose ?? "off";
+      return resolveVerboseKinds(cfg.agents?.defaults?.verboseDefault);
     } catch {
-      return runVerbose ?? "off";
+      return runVerbose;
     }
   };
 
@@ -1368,14 +1367,14 @@ export function createAgentEventHandler({
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
     const isItemEvent = evt.stream === "item";
-    const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
+    const toolVerbose = isToolEvent ? resolveToolVerboseKinds(evt.runId, sessionKey) : undefined;
     const suppressHeartbeatToolEvents =
       isToolEvent && shouldSuppressHeartbeatToolEvents(clientRunId, evt.runId);
     const shouldCoalesceAgentEvent = shouldCoalesceAgentTextEvent(evt);
     // Channel/node subscribers respect verbose; authenticated Control UI
     // recipients need tool result payloads to render live tool cards.
     const channelToolPayload =
-      isToolEvent && toolVerbose !== "full"
+      isToolEvent && toolVerbose?.toolOutput !== true
         ? (() => {
             const data = evt.data ? { ...evt.data } : {};
             delete data.result;
@@ -1594,7 +1593,7 @@ export function createAgentEventHandler({
         isControlUiVisible &&
         isToolEvent &&
         !suppressHeartbeatToolEvents &&
-        toolVerbose !== "off"
+        toolVerbose?.toolSummaries === true
       ) {
         sendNodeAgentPayload(
           sessionKey,

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -719,11 +719,20 @@ describe("gateway sessions patch", () => {
     expect(entry.verboseLevel).toBe("full");
   });
 
+  test("persists verboseLevel=commentary", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        patch: { key: MAIN_SESSION_KEY, verboseLevel: "commentary" },
+      }),
+    );
+    expect(entry.verboseLevel).toBe("commentary");
+  });
+
   test("rejects invalid verboseLevel values with all valid choices in the error", async () => {
     const result = await runPatch({
       patch: { key: MAIN_SESSION_KEY, verboseLevel: "maybe" },
     });
-    expectPatchError(result, 'invalid verboseLevel (use "on"|"off"|"full")');
+    expectPatchError(result, 'invalid verboseLevel (use "on"|"off"|"full"|"commentary")');
   });
 
   test("persists elevatedLevel=off (does not clear)", async () => {

--- a/src/sessions/level-overrides.ts
+++ b/src/sessions/level-overrides.ts
@@ -7,7 +7,7 @@ import {
 } from "../auto-reply/thinking.js";
 import type { SessionEntry } from "../config/sessions.js";
 
-const INVALID_VERBOSE_LEVEL_ERROR = 'invalid verboseLevel (use "on"|"off"|"full")';
+const INVALID_VERBOSE_LEVEL_ERROR = 'invalid verboseLevel (use "on"|"off"|"full"|"commentary")';
 
 // Session-level override parsers use tri-state results: undefined means no
 // change, null clears the saved override, and a level writes the override.

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -40,6 +40,60 @@ describe("buildStatusMessage current time", () => {
   });
 });
 
+describe("buildStatusMessage verbose label", () => {
+  it("renders verbose:commentary for the commentary verbose level", () => {
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "anthropic/claude-haiku-4-5" },
+      resolvedVerbose: "commentary",
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("verbose:commentary");
+  });
+});
+
+describe("buildStatusMessage plugin status lane", () => {
+  const pluginStatusEntry = {
+    sessionId: "plugin-status-lane",
+    updatedAt: 0,
+    pluginDebugEntries: [{ pluginId: "weather", lines: ["weather-plugin: cache warm"] }],
+  } as const;
+
+  it("suppresses plugin status lines at the commentary verbose level (narration-only lane)", () => {
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "anthropic/claude-haiku-4-5" },
+      resolvedVerbose: "commentary",
+      sessionEntry: { ...pluginStatusEntry },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).not.toContain("weather-plugin: cache warm");
+  });
+
+  it("renders plugin status lines at the on verbose level (toolSummaries lane)", () => {
+    const text = buildStatusMessage({
+      config: {},
+      agent: { model: "anthropic/claude-haiku-4-5" },
+      resolvedVerbose: "on",
+      sessionEntry: { ...pluginStatusEntry },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("weather-plugin: cache warm");
+  });
+});
+
 describe("buildStatusMessage context window", () => {
   it("ignores stale runtime context after a manual session model switch", () => {
     const text = buildStatusMessage({

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -26,6 +26,7 @@ import {
   formatProviderModelRef,
   resolveSelectedAndActiveModel,
 } from "../auto-reply/model-runtime.js";
+import { resolveVerboseKinds } from "../auto-reply/thinking.js";
 import type {
   ElevatedLevel,
   ReasoningLevel,
@@ -965,11 +966,14 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueMode = args.queue?.mode ?? "unknown";
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
-    verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
+    verboseLevel === "off" ? null : verboseLevel === "on" ? "verbose" : `verbose:${verboseLevel}`;
   const traceLevel =
     entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
   const traceLabel = traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
-  const pluginStatusLines = verboseLevel !== "off" ? resolveSessionPluginStatusLines(entry) : [];
+  const pluginStatusLines =
+    resolveVerboseKinds(verboseLevel)?.toolSummaries === true
+      ? resolveSessionPluginStatusLines(entry)
+      : [];
   const pluginTraceLines =
     traceLevel === "on" || traceLevel === "raw" ? resolveSessionPluginTraceLines(entry) : [];
   const pluginStatusLine =

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -1,8 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "../agents/subagent-registry.test-helpers.js";
+import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import { appendSessionCostLine } from "./status-runtime-lines.js";
 import { buildStatusText } from "./status-text.js";
+import type { BuildStatusTextParams } from "./status-text.types.js";
 
 const mocks = vi.hoisted(() => ({
   loadSessionCostSummariesFromCache: vi.fn(),
@@ -351,5 +358,82 @@ describe("buildStatusText thinking facts", () => {
 
     expect(text).toContain("Think: high");
     expect(text).not.toMatch(/Think:\s*off\b/);
+  });
+});
+
+describe("buildStatusText subagent done-only summary verbose gate", () => {
+  // Drives the real verbose→subagent-line mapping in buildStatusText. The
+  // completed-count ("0 active · N done") line is tool-summary-class status:
+  // "commentary" is narration-only and must suppress it, while off/on/full stay
+  // unchanged. This mirrors the sibling /status plugin-status gate test.
+  beforeEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  afterEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  // Seed a DONE-ONLY run (endedAt set, outcome ok, no descendants) owned by the
+  // orchestrator session key so listControlledSubagentRuns("agent:main:main")
+  // surfaces exactly one completed run and zero active.
+  function seedDoneOnlyRun(): void {
+    addSubagentRunForTests({
+      runId: "run-status-text-done-only",
+      childSessionKey: "agent:main:subagent:status-text-done-only",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "finished status-text task",
+      cleanup: "keep",
+      createdAt: 1000,
+      startedAt: 1000,
+      endedAt: 2000,
+      outcome: { status: "ok" },
+    });
+  }
+
+  function buildParams(resolvedVerboseLevel: VerboseLevel): BuildStatusTextParams {
+    return {
+      cfg: {
+        commands: { text: true },
+        session: { mainKey: "main", scope: "per-sender" },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:main",
+      statusChannel: "whatsapp",
+      workspaceDir: "/tmp",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 0,
+      resolvedFastMode: false,
+      resolvedVerboseLevel,
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      // Overrides keep the render side-effect-free: skip harness selection, auth
+      // label lookups, plugin-health collection, and task-registry probes so the
+      // test exercises only the verbose→subagent-line gate.
+      resolvedHarness: "openclaw",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+      pluginHealthLineOverride: "🔌 Plugins: test",
+      skipDefaultTaskLookup: true,
+    };
+  }
+
+  it("suppresses the completed-count line under commentary and renders it under on/full", async () => {
+    seedDoneOnlyRun();
+
+    const commentary = await buildStatusText(buildParams("commentary"));
+    // commentary = narration-only: the done-only summary is a tool-summary lane
+    // line and must not appear.
+    expect(commentary).not.toContain("🤖 Subagents:");
+    expect(commentary).not.toContain("0 active");
+
+    const on = await buildStatusText(buildParams("on"));
+    expect(on).toContain("🤖 Subagents: 0 active · 1 done");
+
+    const full = await buildStatusText(buildParams("full"));
+    expect(full).toContain("🤖 Subagents: 0 active · 1 done");
   });
 });

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -28,7 +28,7 @@ import {
 } from "../agents/tools/sessions-helpers.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
-import type { ThinkLevel } from "../auto-reply/thinking.js";
+import { resolveVerboseKinds, type ThinkLevel } from "../auto-reply/thinking.js";
 import { toAgentModelListLike } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
@@ -544,7 +544,10 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     const { buildSubagentsStatusLine, countPendingDescendantRuns, listControlledSubagentRuns } =
       await loadStatusSubagentsRuntime();
     const runs = listControlledSubagentRuns(requesterKey);
-    const verboseEnabled = resolvedVerboseLevel && resolvedVerboseLevel !== "off";
+    // Subagent completed-count lines are tool-summary-class status: "commentary"
+    // is narration-only and suppresses them, matching the /status plugin-status
+    // gate (agent-runner.ts buildInlinePluginStatusPayload). off/on/full unchanged.
+    const verboseEnabled = resolveVerboseKinds(resolvedVerboseLevel)?.toolSummaries === true;
     subagentsLine = buildSubagentsStatusLine({
       runs,
       verboseEnabled,

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -48,8 +48,8 @@ describe("getSlashCommands", () => {
     const verbose = commands.find((command) => command.name === "verbose");
     const activation = commands.find((command) => command.name === "activation");
     expect(verbose?.getArgumentCompletions?.("o")).toEqual([
-      { value: "on", label: "on" },
       { value: "off", label: "off" },
+      { value: "on", label: "on" },
     ]);
     expect(activation?.getArgumentCompletions?.("a")).toEqual([
       { value: "always", label: "always" },
@@ -57,7 +57,7 @@ describe("getSlashCommands", () => {
   });
 
   it.each([
-    { commandName: "verbose", level: "full", description: "Set verbose on/off/full" },
+    { commandName: "verbose", level: "full", description: "Set verbose off/on/full/commentary" },
     { commandName: "reasoning", level: "stream", description: "Set reasoning on/off/stream" },
   ])(
     "exposes and submits the canonical /$commandName $level completion",
@@ -70,6 +70,17 @@ describe("getSlashCommands", () => {
       expect(shouldSubmitExactArgumentCompletion(`/${commandName} ${level}`, commands)).toBe(true);
     },
   );
+
+  it("exposes commentary and full as discoverable /verbose levels", () => {
+    const commands = getSlashCommands();
+    const verbose = commands.find((command) => command.name === "verbose");
+    expect(verbose?.getArgumentCompletions?.("")).toEqual([
+      { value: "off", label: "off" },
+      { value: "on", label: "on" },
+      { value: "full", label: "full" },
+      { value: "commentary", label: "commentary" },
+    ]);
+  });
 
   it("keeps session status on the shared command path and exposes gateway status separately", () => {
     const commands = getSlashCommands();
@@ -185,7 +196,7 @@ describe("helpText", () => {
     expect(output).toContain("Shift+Enter or Ctrl+J: insert a newline");
   });
 
-  it.each(["/verbose <on|off|full>", "/reasoning <on|off|stream>"])(
+  it.each(["/verbose <off|on|full|commentary>", "/reasoning <on|off|stream>"])(
     "includes the full canonical directive levels for %s",
     (usage) => {
       expect(helpText()).toContain(usage);

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -15,7 +15,7 @@ import {
 } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.js";
 
-const VERBOSE_LEVELS = ["on", "off", "full"] satisfies VerboseLevel[];
+const VERBOSE_LEVELS = ["off", "on", "full", "commentary"] satisfies VerboseLevel[];
 const TRACE_LEVELS = ["on", "off"];
 const FAST_LEVELS = ["status", "auto", "on", "off"];
 const REASONING_LEVELS = ["on", "off", "stream"] satisfies ReasoningLevel[];

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1641,7 +1641,7 @@ describe("tui command handlers", () => {
   });
 
   it.each([
-    { command: "verbose", usage: "usage: /verbose <on|off|full>" },
+    { command: "verbose", usage: "usage: /verbose <off|on|full|commentary>" },
     { command: "reasoning", usage: "usage: /reasoning <on|off|stream>" },
   ])("shows the complete canonical no-argument /$command usage", async ({ command, usage }) => {
     const { handleCommand, addSystem, patchSession } = createHarness();
@@ -1715,6 +1715,16 @@ describe("tui command handlers", () => {
     expect(loadHistory).toHaveBeenCalledTimes(1);
     expect(refreshSessionInfo).not.toHaveBeenCalled();
     expect(clearTools).not.toHaveBeenCalled();
+  });
+
+  it("lists every verbose level in the /verbose usage hint when args are omitted", async () => {
+    const patchSession = vi.fn();
+    const { handleCommand, addSystem } = createHarness({ patchSession });
+
+    await handleCommand("/verbose");
+
+    expect(addSystem).toHaveBeenCalledWith("usage: /verbose <off|on|full|commentary>");
+    expect(patchSession).not.toHaveBeenCalled();
   });
 
   it("refreshes session info for /trace without reloading history", async () => {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -253,6 +253,146 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("buffers preamble commentary and flushes it before lifecycle end under /verbose commentary", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "commentary" } },
+    });
+
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "Checking the" },
+    });
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "Checking the workspace." },
+    });
+    // Snapshots for one item collapse; nothing renders until the flush point.
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
+
+    handleAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenCalledWith("💬 Checking the workspace.");
+    // Tool summaries stay hidden in commentary mode.
+    expect(chatLog.startTool).not.toHaveBeenCalled();
+  });
+
+  it("flushes the previous commentary item when a new preamble starts", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "commentary" } },
+    });
+
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "First thought." },
+    });
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c2", progressText: "Second thought." },
+    });
+
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenCalledWith("💬 First thought.");
+  });
+
+  it("drops retracted commentary that has not been rendered", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "commentary" } },
+    });
+
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "Never mind." },
+    });
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "" },
+    });
+    handleAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
+  });
+
+  it("keeps preamble items hidden while verbose is off", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "off" } },
+    });
+
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "Hidden narration." },
+    });
+    handleAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
+  });
+
+  it("flushes buffered commentary when a hidden tool starts", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "commentary" } },
+    });
+
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "c1", progressText: "About to run a tool." },
+    });
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "tool",
+      data: { phase: "start", toolCallId: "tc1", name: "exec" },
+    });
+
+    // Commentary precedes the tool even though the tool line stays hidden.
+    expect(chatLog.addSystem).toHaveBeenCalledWith("💬 About to run a tool.");
+    expect(chatLog.startTool).not.toHaveBeenCalled();
+  });
+
+  it("keeps concurrent runs' buffered commentary isolated", () => {
+    const { chatLog, handleAgentEvent } = createHandlersHarness({
+      state: { sessionInfo: { verboseLevel: "commentary" } },
+    });
+
+    // Register a concurrent side run for the same session; run-1 stays active.
+    handleAgentEvent({
+      runId: "run-2",
+      sessionKey: "agent:main:main",
+      stream: "lifecycle",
+      data: { phase: "start" },
+    });
+    handleAgentEvent({
+      runId: "run-1",
+      stream: "item",
+      data: { kind: "preamble", itemId: "m1", progressText: "Main narration." },
+    });
+    handleAgentEvent({
+      runId: "run-2",
+      stream: "item",
+      data: { kind: "preamble", itemId: "s1", progressText: "Side narration." },
+    });
+
+    handleAgentEvent({
+      runId: "run-2",
+      sessionKey: "agent:main:main",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    // The side run's terminal flushes only its own narration.
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenCalledWith("💬 Side narration.");
+
+    handleAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "end" } });
+    expect(chatLog.addSystem).toHaveBeenCalledTimes(2);
+    expect(chatLog.addSystem).toHaveBeenLastCalledWith("💬 Main narration.");
+  });
+
   it("ignores tool events when runId does not match activeChatRunId", () => {
     const { chatLog, tui, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: "run-1" },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -4,6 +4,7 @@ import {
   hasSessionProjectionAcceptedFinal,
   reduceSessionProjectionRunEvent,
 } from "../../packages/gateway-client/src/session-projection.js";
+import { resolveVerboseKinds } from "../auto-reply/thinking.js";
 import {
   asString,
   extractTextFromMessage,
@@ -139,6 +140,23 @@ export function createEventHandlers(context: EventHandlerContext) {
     postFinalizingRuns,
     streamAssembler,
   } = runCoordinator;
+  // Inter-tool commentary (item/preamble events) buffered per run and item
+  // id, like the dispatch progress path: snapshots for one item collapse into
+  // the latest text, flushed when the producer moves on and always before the
+  // run's final reply. Keyed by run id so concurrent runs (e.g. btw side
+  // questions) never overwrite or misorder each other's narration.
+  const pendingCommentaryByRun = new Map<string, { itemId: string; text: string }>();
+  const flushPendingCommentary = (runId: string) => {
+    const pending = pendingCommentaryByRun.get(runId);
+    if (!pending) {
+      return;
+    }
+    pendingCommentaryByRun.delete(runId);
+    const text = pending.text.trim();
+    if (text && resolveVerboseKinds(state.sessionInfo.verboseLevel)?.commentary === true) {
+      chatLog.addSystem(`💬 ${text}`);
+    }
+  };
   const {
     acknowledgeChatRun,
     applyFallbackStepModelUpdate,
@@ -292,6 +310,7 @@ export function createEventHandlers(context: EventHandlerContext) {
           allowLocalWithoutDisplayableFinal: true,
           wasPendingChatRun: isPendingChatRun,
         });
+        flushPendingCommentary(evt.runId);
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender(true);
@@ -329,6 +348,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         hasDisplayableFinal: !suppressEmptyExternalPlaceholder,
         wasPendingChatRun: isPendingChatRun,
       });
+      flushPendingCommentary(evt.runId);
       if (suppressEmptyExternalPlaceholder) {
         chatLog.dropAssistant(evt.runId);
       } else {
@@ -353,6 +373,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       // Abort envelopes carry the complete buffered reply, including text
       // suppressed by Gateway delta throttling; finalize it before run cleanup.
       const abortedText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
+      flushPendingCommentary(evt.runId);
       if (hasDisplayableAbortedText) {
         chatLog.finalizeAssistant(abortedText, evt.runId);
       }
@@ -596,18 +617,53 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (!isKnownRun) {
       return;
     }
+    if (evt.stream === "item") {
+      const data = evt.data ?? {};
+      if (
+        asString(data.kind, "") !== "preamble" ||
+        resolveVerboseKinds(state.sessionInfo.verboseLevel)?.commentary !== true
+      ) {
+        return;
+      }
+      if (isActiveRun) {
+        armStreamingWatchdog(evt.runId);
+      }
+      const itemId = asString(data.itemId, "");
+      const text = asString(data.progressText, "").trim();
+      const pending = pendingCommentaryByRun.get(evt.runId);
+      if (!text) {
+        // Empty commentary with a buffered item id means the producer
+        // retracted that item; drop it if it has not been rendered yet.
+        if (pending && pending.itemId === itemId) {
+          pendingCommentaryByRun.delete(evt.runId);
+        }
+        return;
+      }
+      if (pending && pending.itemId !== itemId) {
+        flushPendingCommentary(evt.runId);
+        tui.requestRender();
+      }
+      pendingCommentaryByRun.set(evt.runId, { itemId, text });
+      return;
+    }
     if (evt.stream === "tool") {
       if (isActiveRun) {
         armStreamingWatchdog(evt.runId);
       }
-      const verbose = state.sessionInfo.verboseLevel ?? "off";
-      const allowToolEvents = verbose !== "off";
-      const allowToolOutput = verbose === "full";
+      const data = evt.data ?? {};
+      const phase = asString(data.phase, "");
+      if (phase === "start" && pendingCommentaryByRun.has(evt.runId)) {
+        // Commentary precedes the tool that follows it — flush even when the
+        // tool line itself is hidden (narration-only /verbose commentary).
+        flushPendingCommentary(evt.runId);
+        tui.requestRender();
+      }
+      const verboseKinds = resolveVerboseKinds(state.sessionInfo.verboseLevel);
+      const allowToolEvents = verboseKinds?.toolSummaries === true;
+      const allowToolOutput = verboseKinds?.toolOutput === true;
       if (!allowToolEvents) {
         return;
       }
-      const data = evt.data ?? {};
-      const phase = asString(data.phase, "");
       const toolCallId = asString(data.toolCallId, "");
       const toolName = asString(data.name, "tool");
       if (!toolCallId) {
@@ -644,6 +700,11 @@ export function createEventHandlers(context: EventHandlerContext) {
         clearPendingSubmit(state, evt.runId);
       }
       const phase = typeof evt.data?.phase === "string" ? evt.data.phase : "";
+      if (phase === "end" || phase === "error") {
+        // Terminal backstop for any known run (including side runs that never
+        // own the active slot): buffered narration must not outlive its run.
+        flushPendingCommentary(evt.runId);
+      }
       if (phase && phase !== "error") {
         clearPendingTerminalLifecycleError(evt.runId);
       }

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1054,6 +1054,104 @@ describe("tui session actions", () => {
     expect(listSessions).not.toHaveBeenCalled();
   });
 
+  it("skips persisted toolResult replay under commentary verbose level", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-2",
+      sessionInfo: {
+        key: "agent:main:other",
+        sessionId: "session-2",
+        verboseLevel: "commentary",
+        updatedAt: 50,
+      },
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "exec",
+          content: [{ type: "text", text: "tool output" }],
+        },
+        { role: "assistant", content: [{ type: "text", text: "all done" }] },
+      ],
+    });
+    const startTool = vi.fn().mockReturnValue({ setResult: vi.fn() });
+    const finalizeAssistant = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant,
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      startTool,
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ historyLoaded: true });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+    });
+
+    await setSession("agent:main:other");
+
+    // Live rendering hides tool events under "commentary", so history replay
+    // must too: the toolResult entry is skipped while normal messages render.
+    expect(state.sessionInfo.verboseLevel).toBe("commentary");
+    expect(startTool).not.toHaveBeenCalled();
+    expect(finalizeAssistant).toHaveBeenCalledWith("all done");
+  });
+
+  it("replays persisted toolResults when the verbose level shows tool summaries", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-2",
+      sessionInfo: {
+        key: "agent:main:other",
+        sessionId: "session-2",
+        verboseLevel: "on",
+        updatedAt: 50,
+      },
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "exec",
+          content: [{ type: "text", text: "tool output" }],
+        },
+        { role: "assistant", content: [{ type: "text", text: "all done" }] },
+      ],
+    });
+    const setResult = vi.fn();
+    const startTool = vi.fn().mockReturnValue({ setResult });
+    const finalizeAssistant = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant,
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      startTool,
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ historyLoaded: true });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+    });
+
+    await setSession("agent:main:other");
+
+    expect(startTool).toHaveBeenCalledWith("call-1", "exec", {});
+    expect(setResult).toHaveBeenCalledWith(
+      { content: [{ type: "text", text: "tool output" }], details: undefined },
+      { isError: false },
+    );
+    expect(finalizeAssistant).toHaveBeenCalledWith("all done");
+  });
+
   it("renders a fresh session total as 0 (not '?') when totalTokensFresh is set", async () => {
     const listSessions = vi.fn().mockResolvedValue({ sessions: [] });
     const loadHistory = vi.fn().mockResolvedValue({

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,8 +1,9 @@
-// Implements TUI session actions such as switching, forking, and resuming.
 import type { TUI } from "@earendil-works/pi-tui";
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
 import { resolveSessionInfoModelSelection } from "../agents/model-selection-display.js";
+// Implements TUI session actions such as switching, forking, and resuming.
+import { resolveVerboseKinds } from "../auto-reply/thinking.js";
 import {
   agentSessionKeysMatchByRequestKey,
   normalizeAgentId,
@@ -526,11 +527,13 @@ export function createSessionActions(context: SessionActionContext) {
         messages: record.messages ?? [],
         scope: readTuiSessionProjectionScope(state),
         options: {
+          // History replay must match live rendering: only the toolSummaries
+          // lane shows tool results ("commentary" hides them in both places).
           shouldIncludeMessage: (message) =>
             Boolean(message) &&
             typeof message === "object" &&
             ((message as { role?: unknown }).role !== "toolResult" ||
-              (state.sessionInfo.verboseLevel ?? "off") !== "off"),
+              resolveVerboseKinds(state.sessionInfo.verboseLevel)?.toolSummaries === true),
         },
       });
       chatLog.clearAll();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -748,6 +748,7 @@ export const en: TranslationMap = {
     on: "on",
     off: "off",
     full: "full",
+    commentary: "commentary",
     stream: "stream",
     customOption: "{value} (custom)",
     manual: "manual",
@@ -4396,7 +4397,7 @@ export const en: TranslationMap = {
       verbose: {
         current: "Current verbose level: {level}.",
         getFailed: "Failed to get verbose level: {error}",
-        unrecognized: 'Unrecognized verbose level "{level}". Valid levels: off, on, full.',
+        unrecognized: 'Unrecognized verbose level "{level}". Valid levels: off, on, full, commentary.',
         set: "Verbose mode set to {level}.",
         setFailed: "Failed to set verbose mode: {error}",
       },

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -1204,10 +1204,55 @@ describe("executeSlashCommand directives", () => {
     expect(result.content).toBe(
       [
         t("chat.commandResults.verbose.current", { level: "full" }),
-        t("chat.commandResults.options", { options: "on, full, off" }),
+        t("chat.commandResults.options", { options: "on, full, commentary, off" }),
       ].join("\n"),
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", { agentId: "main" });
+  });
+
+  it("reports the current verbose level for a commentary session", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [row("agent:main:main", { verboseLevel: "commentary" })],
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "verbose",
+      "",
+    );
+
+    expect(result.content).toBe(
+      "Current verbose level: commentary.\nOptions: on, full, commentary, off.",
+    );
+  });
+
+  it("sets the verbose level to commentary", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return { ok: true };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "verbose",
+      "commentary",
+    );
+
+    expect(result.content).toBe("Verbose mode set to **commentary**.");
+    expect(result.action).toBe("refresh");
+    expect(requireRequestCall(request, "sessions.patch").payload).toMatchObject({
+      key: "agent:main:main",
+      verboseLevel: "commentary",
+    });
   });
 
   it("reports the current fast mode for bare /fast", async () => {

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -76,11 +76,16 @@ type SlashCommandContext = {
   agentId?: string;
 };
 
-function normalizeVerboseLevel(raw?: string | null): "off" | "on" | "full" | undefined {
+function normalizeVerboseLevel(
+  raw?: string | null,
+): "off" | "on" | "full" | "commentary" | undefined {
   if (!raw) {
     return undefined;
   }
   const key = normalizeLowercaseStringOrEmpty(raw);
+  if (key === "commentary") {
+    return "commentary";
+  }
   if (["off", "false", "no", "0"].includes(key)) {
     return "off";
   }
@@ -397,7 +402,7 @@ async function executeVerbose(
           t("chat.commandResults.verbose.current", {
             level: normalizeVerboseLevel(session?.verboseLevel) ?? "off",
           }),
-          "on, full, off",
+          "on, full, commentary, off",
         ),
       };
     } catch (err) {

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -1267,6 +1267,7 @@ describe("sessions view", () => {
     expect(Array.from(verbose?.options ?? []).map((option) => option.value)).toEqual([
       "",
       "off",
+      "commentary",
       "on",
       "full",
     ]);

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -150,7 +150,7 @@ export type SessionsProps = {
 };
 
 const DEFAULT_THINK_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
-const VERBOSE_LEVEL_VALUES = ["", "off", "on", "full"] as const;
+const VERBOSE_LEVEL_VALUES = ["", "off", "commentary", "on", "full"] as const;
 const FAST_LEVEL_VALUES = ["", "auto", "on", "off"] as const;
 const REASONING_LEVELS = ["", "off", "on", "stream"] as const;
 const PAGE_SIZES = [10, 25, 50, 100] as const;


### PR DESCRIPTION
Closes #103170

## What Problem This Solves

`/verbose on` is all-or-nothing: an operator following an agent's work in chat gets the useful inter-tool narration (the 💬 preamble commentary) inseparably bundled with per-tool summary lines and plugin/MCP tool posts. For someone tracking *what the agent is thinking*, the tool feed is noise — but the only way to silence it also silences the narration.

## Why This Change Was Made

The narration and tool posts are already independent delivery paths in the dispatch layer; they were wired to a single boolean. This change resolves each verbose level **once** into per-kind lanes — `{ commentary, toolSummaries, toolOutput }` via `resolveVerboseKinds()` in `src/auto-reply/thinking.shared.ts` — and points each existing consumer (dispatch, the followup/embedded runners, gateway chat events, TUI rendering, the `/status` card, the Control UI) at its specific lane instead of scattered `level === "on" || level === "full"` comparisons.

A fourth preset, **`commentary`**, enables only the narration lane.

**Scope decision (adopting the review's recommended option): `commentary` is a session-level control only.** It is deliberately **not** added to the persisted `verboseDefault` config enum (global or per-agent) — the strict config schema is unchanged, which resolves the review's P1: a config written by this version validates unchanged on older runtimes, so there is no downgrade boundary. The persisted-default surface can be a separate follow-up if maintainers want it; this PR keeps the config contract untouched.

**Relation to #103995 (merged):** that fix decouples commentary from tool progress in Slack's channel-specific transient rendering. This PR is the complementary cross-channel layer: a session-level preset feeding the shared lanes that channel renderers consume. This branch is rebased on top of #103995 and validated against it (contract suites included) — the two compose; neither replaces the other.

## User Impact

- **`/verbose commentary`** (directive or standalone, any channel; also TUI, web chat, and the Control UI sessions view): inter-tool narration is delivered as progress messages while tool summaries, tool outputs, and tool-class operational notices (new-session, auto-compaction, plugin-status, `/status` tool-detail lines) stay suppressed. Sticky for the session until changed or the session rotates.
- `off | on | full` are byte-identical to before at every gate — verified site-by-site; every non-lane verbose boolean across `src/`, `extensions/`, and `ui/` was audited, and remaining legacy comparisons are labels/persistence or provably equivalent.
- Every user-visible enumeration of levels includes the new preset: command registry choices, directive acks, `/help` and CLI usage strings, session-patch errors, the ACP dropdown, TUI autocomplete, the Control UI verbose selector + web-chat `/verbose`, and docs (all 21 Control UI locales).
- Two intentional edges: `commentary` omits run-failure detail that `on` shows (that detail rides the `toolSummaries` lane); and the runner's fallback gate now normalizes its level input, so a garbage fallback value no longer counts as verbose-enabled (latent bug fixed in passing).
- The `isCommentary` **final-payload** opt-in (`commentaryPayloadsEnabled`) stays distinct from the commentary **progress** lane — verbose level never enables final commentary payloads, on the queued path exactly as in direct dispatch.

## Compatibility

- **Config: no schema change.** `verboseDefault` still accepts exactly `off | on | full`; regression tests now assert `commentary` is rejected as a persisted default, guarding the session-only scope.
- **Session state:** a session entry may persist `verboseLevel: "commentary"`. The gateway protocol transports `verboseLevel` as an open string, and an older runtime reading it treats it as unrecognized — `normalizeVerboseLevel()` returns `undefined`, resolving to the default (no error, value round-trips). Older runtimes reject *setting* the level (`/verbose commentary` → "unrecognized level"), a bounded mixed-version UX limit with no persistence hazard.
- No migration required in either direction.

## Evidence

- **Live behavior proof** (PR comment below): redacted terminal capture of a real `claude-cli` tool-using turn — the `🛠️` tool-summary line present under `/verbose on` and absent under `/verbose commentary`, plus transcript and Control-UI evidence that the narration lane carries real content; the surfaces are disclosed explicitly. Mantis's native Telegram before/after stills additionally show the command rejected on `main` and accepted + persisted on this branch.
- **Validation on the current head** (rebased onto latest `main`): typecheck (core/ui/extensions) 0 errors; oxlint + oxfmt clean; `pnpm build` exit 0; config + verbose + dispatch + followup + status + sessions suites (~2,950 tests) and `pnpm test:contracts` (987) all green. `docs/.generated/config-baseline.sha256` regenerated after the schema narrowing; `CHANGELOG.md` untouched.
- Tests added across the surface: lane-resolver presets, directive parse/ack, dispatch gating, queued CLI + embedded followup commentary (incl. mid-queue level switch and queued/direct payload parity, mutation-checked), TUI history replay, `/status` plugin-status + subagent-count lanes, Control UI command executor + sessions view, and config-schema tests guarding the session-only scope.
- Note: a couple of hunks in `thinking.test.ts` are `oxfmt`-driven (the file on `main` fails `oxfmt --check`); reverting them fails the formatter.

## AI-Assisted Disclosure

This PR was authored with AI assistance (Claude, via Claude Code) — reflected in the commit's `Co-Authored-By` trailer.

- [x] Marked as AI-assisted
- [x] Author has reviewed the full diff and understands what the code does
- [x] `codex review --base origin/main` was run locally before opening and re-run after every substantive update (including the session-only scope narrowing and each rebase); findings were addressed across multiple rounds: the per-kind lane split, queued-followup commentary (CLI + embedded), TUI history replay, operational-notice gating, `/status` plugin-status and subagent-count leaks, and the persisted-default downgrade concern (resolved by scope narrowing)
- [x] Will resolve or reply to bot review conversations after addressing them

Session logs available on request.
