### PR TITLE
fix(release): avoid token-shaped Claude live probe

### DIFF
--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -374,11 +374,10 @@ WRAP
   fi
   if [ "$auth_mode" = "subscription" ]; then
     claude --version
-    direct_token="violet-lantern-42"
     direct_probe_log="$(mktemp)"
     set +e
     claude \
-      -p "This is a local CLI smoke test. Reply with only this harmless phrase: $direct_token" \
+      -p "This is a local CLI smoke test. What is two plus two? Reply with only the result." \
       --output-format text \
       --model sonnet \
       --permission-mode bypassPermissions \
@@ -388,22 +387,25 @@ WRAP
       --no-session-persistence >"$direct_probe_log" 2>&1
     direct_probe_status=$?
     set -e
-    direct_output="$(<"$direct_probe_log")"
-    if [ "$direct_probe_status" -ne 0 ]; then
-      echo "ERROR: direct Claude subscription probe exited with status $direct_probe_status." >&2
+    print_redacted_direct_probe_log() {
       sed -E \
         -e 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/<redacted-email>/g' \
         -e 's/(sk-ant-|sk-)[A-Za-z0-9_-]+/<redacted-secret>/g' \
         "$direct_probe_log" >&2
+    }
+    if [ "$direct_probe_status" -ne 0 ]; then
+      echo "ERROR: direct Claude subscription probe exited with status $direct_probe_status." >&2
+      print_redacted_direct_probe_log
       rm -f "$direct_probe_log"
       exit "$direct_probe_status"
     fi
-    rm -f "$direct_probe_log"
-    if [[ "$direct_output" != *"$direct_token"* ]]; then
-      echo "ERROR: direct Claude subscription probe did not return expected token." >&2
-      echo "$direct_output" >&2
+    if ! grep -Eiq '(^|[^[:alnum:]])(4|four)([^[:alnum:]]|$)' "$direct_probe_log"; then
+      echo "ERROR: direct Claude subscription probe did not return the expected arithmetic result." >&2
+      print_redacted_direct_probe_log
+      rm -f "$direct_probe_log"
       exit 1
     fi
+    rm -f "$direct_probe_log"
     echo "[claude-subscription] direct claude -p probe ok"
   else
     claude auth status || true

--- a/test/scripts/test-live-cli-backend-docker.test.ts
+++ b/test/scripts/test-live-cli-backend-docker.test.ts
@@ -61,6 +61,10 @@ describe("scripts/test-live-cli-backend-docker.sh", () => {
 
     expect(script).toContain('direct_probe_log="$(mktemp)"');
     expect(script).toContain("This is a local CLI smoke test.");
+    expect(script).toContain("What is two plus two?");
+    expect(script).toContain("(4|four)");
+    expect(script).not.toContain("direct_token=");
+    expect(script).not.toContain("expected token");
     expect(script).not.toContain("OPENCLAW-CLAUDE-SUBSCRIPTION-DIRECT");
     expect(script).toContain("direct Claude subscription probe exited with status");
     expect(script).toContain("<redacted-email>");


### PR DESCRIPTION
## What Problem This Solves

Full release validation could fail even with a healthy Claude subscription because the direct CLI preflight asked the model to echo a token-shaped phrase. Claude treated that phrase as an authentication challenge and refused it, so the harness reported a false credential failure before running the real Gateway CLI-backend scenario.

## Why This Change Was Made

The preflight now asks a harmless arithmetic question and accepts either the numeric or word-form answer. It still requires a real `claude -p` completion, preserves nonzero CLI failures, keeps failure output redacted, and leaves the full Gateway CLI-backend live test unchanged.

## User Impact

No product runtime behavior changes. Release validation no longer depends on a token-like echo prompt that current Claude safety behavior may reject.

## Evidence

- Deterministic failure: [Full Release Validation child](https://github.com/openclaw/openclaw/actions/runs/29123887696/job/86468364634) returned a successful Claude completion that explicitly refused the token-shaped echo request.
- Blacksmith Testbox run [29127193481](https://github.com/openclaw/openclaw/actions/runs/29127193481): `docker-build-helper` 164/164 and `test-live-cli-backend-docker` 6/6, 170/170 total.
- `bash -n scripts/test-live-cli-backend-docker.sh`
- targeted `oxfmt --check`
- `git diff --check`
- Fresh Codex autoreview: no accepted/actionable findings; patch correct, confidence 0.93.

