### PR TITLE
fix(memory): preserve Unicode in QMD search snippets

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4395,6 +4395,75 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("keeps per-result and aggregate QMD snippet limits UTF-16 safe", async () => {
+    const expectedDocId = "unicode-boundary";
+    const snippet = "@@ -1,1\nabc😀tail";
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify({
+            results: [
+              {
+                docid: expectedDocId,
+                score: 0.91,
+                collection: "workspace-main",
+                snippet,
+              },
+            ],
+          }),
+        );
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const searchWithLimits = async (limits: {
+      maxSnippetChars: number;
+      maxInjectedChars: number;
+    }) => {
+      const testConfig = {
+        ...cfg,
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            searchMode: "query",
+            update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+            paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+            limits,
+            mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+          },
+        },
+      } as OpenClawConfig;
+      const { manager } = await createManager({ cfg: testConfig });
+      const inner = manager as unknown as {
+        db: { prepare: () => { all: () => unknown }; close: () => void };
+      };
+      inner.db = {
+        prepare: () => ({
+          all: () => [{ collection: "workspace-main", path: "notes/unicode.md" }],
+        }),
+        close: () => {},
+      };
+      const results = await manager.search("unicode", {
+        sessionKey: "agent:main:slack:dm:u123",
+      });
+      await manager.close();
+      return results;
+    };
+
+    await expect(searchWithLimits({ maxSnippetChars: 12, maxInjectedChars: 100 })).resolves.toEqual(
+      [expect.objectContaining({ snippet: "@@ -1,1\nabc" })],
+    );
+    await expect(searchWithLimits({ maxSnippetChars: 100, maxInjectedChars: 12 })).resolves.toEqual(
+      [expect.objectContaining({ snippet: "@@ -1,1\nabc" })],
+    );
+  });
+
   it("uses snippet header width when mcporter only returns a start line", async () => {
     const expectedDocId = "line-456";
     cfg = {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -17,6 +17,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveGlobalSingleton,
   resolveStateDir,
+  truncateUtf16Safe,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
@@ -1719,7 +1720,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (!doc) {
         continue;
       }
-      const snippet = entry.snippet?.slice(0, this.qmd.limits.maxSnippetChars) ?? "";
+      const snippet = truncateUtf16Safe(entry.snippet ?? "", this.qmd.limits.maxSnippetChars);
       const lines = this.resolveSnippetLines(entry, snippet);
       const score = typeof entry.score === "number" ? entry.score : 0;
       const minScore = opts?.minScore ?? 0;
@@ -3526,7 +3527,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         clamped.push(entry);
         remaining -= snippet.length;
       } else {
-        const trimmed = snippet.slice(0, Math.max(0, remaining));
+        const trimmed = truncateUtf16Safe(snippet, remaining);
         clamped.push(copyQmdSessionArtifactHit(entry, { ...entry, snippet: trimmed }));
         break;
       }

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -121,15 +121,25 @@ describe("memory search citations", () => {
 
   it("clamps decorated snippets to qmd injected budget", async () => {
     setMemoryBackend("qmd");
+    setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 5,
+        endLine: 7,
+        score: 0.9,
+        snippet: "abc😀tail",
+        source: "memory" as const,
+      },
+    ]);
     const cfg = asOpenClawConfig({
-      memory: { citations: "on", backend: "qmd", qmd: { limits: { maxInjectedChars: 20 } } },
+      memory: { citations: "on", backend: "qmd", qmd: { limits: { maxInjectedChars: 4 } } },
       agents: { list: [{ id: "main", default: true }] },
     });
     const tool = createMemorySearchToolOrThrow({ config: cfg });
     const result = await tool.execute("call_citations_qmd", { query: "notes" });
     const details = result.details as { results: Array<{ snippet: string; citation?: string }> };
     const firstResult = expectFirstMemoryResult(details);
-    expect(firstResult.snippet.length).toBeLessThanOrEqual(20);
+    expect(firstResult.snippet).toBe("abc");
   });
 
   it("honors auto mode for direct chats", async () => {

--- a/extensions/memory-core/src/tools.citations.ts
+++ b/extensions/memory-core/src/tools.citations.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export function resolveMemoryCitationsMode(cfg: OpenClawConfig): MemoryCitationsMode {
   const mode = cfg.memory?.citations;
@@ -55,7 +56,7 @@ export function clampResultsByInjectedChars(
       clamped.push(entry);
       remaining -= snippet.length;
     } else {
-      const trimmed = snippet.slice(0, Math.max(0, remaining));
+      const trimmed = truncateUtf16Safe(snippet, remaining);
       clamped.push({ ...entry, snippet: trimmed });
       break;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QMD memory results could contain malformed Unicode when an emoji crossed a configured snippet or prompt-injection budget. The corruption could surface in `memory_search`, prompts, and CLI output, including after source citations were appended.

## Why This Change Was Made

All three QMD-owned prefix limits now use the existing surrogate-safe text helper: the per-result snippet limit, the manager's aggregate injected-character budget, and the post-citation aggregate budget. Both aggregate clamps remain because the CLI consumes manager results directly while the memory tool appends citations afterward.

## User Impact

QMD memory snippets remain valid Unicode at configured size boundaries. Existing result sizes, ordering, source metadata, citations, and ASCII behavior are unchanged.

## Evidence

- Regression input `@@ -1,1\nabc😀tail` at a 12-unit boundary now yields exactly `@@ -1,1\nabc` for both the per-result and aggregate manager paths instead of ending in a lone high surrogate.
- Post-citation input `abc😀tail` at a 4-unit budget now yields exactly `abc` through the public memory-search tool path.
- Blacksmith Testbox-through-Crabbox `tbx_01kx76v3wggn4091s5shmsdan3`: 176 focused tests passed across `qmd-manager.test.ts` and `tools.citations.test.ts`.
- The same Testbox passed path-scoped `check:changed`, including extension production/test typechecks, lint, dependency/package guards, database-first guard, and runtime import-cycle checks.
- Targeted `oxfmt`, `git diff --check`, and fresh Codex autoreview passed; autoreview reported no actionable findings with 0.98 correctness confidence.
