### PR TITLE
improve(ui): drag sidebar group headers to reorder custom groups

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -2,7 +2,7 @@
 
 import { ContextProvider } from "@lit/context";
 import { LitElement } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { SessionsListResult } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
@@ -107,6 +107,7 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   let state = createSessionState(agentId, keys);
   let canonicalListRevision = 1;
   const listeners = new Set<(next: SessionState) => void>();
+  const groupsPut = vi.fn(() => Promise.resolve());
   const sessions = {
     get state() {
       return state;
@@ -120,6 +121,7 @@ function createSessionsHarness(agentId: string, keys: string[]) {
     },
     subscribeCreated: () => () => undefined,
     groupsLoad: () => Promise.resolve(),
+    groupsPut,
   } as unknown as SessionCapability;
   const publish = (patch: Partial<SessionState>) => {
     state = { ...state, ...patch };
@@ -129,6 +131,7 @@ function createSessionsHarness(agentId: string, keys: string[]) {
   };
   return {
     sessions,
+    groupsPut,
     publish,
     publishList(patch: Partial<SessionState>) {
       canonicalListRevision += 1;
@@ -326,5 +329,71 @@ describe("AppSidebar session source lifecycle", () => {
     expect(sidebar.sessionsAgentId).toBeNull();
     expect(sidebar.sessionRowsByAgent).toEqual({});
     expect(sidebar.sessionCreatedOrder.size).toBe(0);
+  });
+});
+
+function createDataTransferStub() {
+  const data = new Map<string, string>();
+  return {
+    get types() {
+      return [...data.keys()];
+    },
+    setData: (type: string, value: string) => void data.set(type, value),
+    getData: (type: string) => data.get(type) ?? "",
+    effectAllowed: "none",
+    dropEffect: "none",
+  };
+}
+
+function dispatchDragEvent(
+  target: Element,
+  type: "dragstart" | "dragover" | "drop",
+  dataTransfer: ReturnType<typeof createDataTransferStub>,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  target.dispatchEvent(event);
+}
+
+describe("AppSidebar custom group reordering", () => {
+  async function mountWithGroups(groups: string[]) {
+    const client = {} as GatewayBrowserClient;
+    const gateway = createGateway(client);
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    harness.publish({ groups });
+    await sidebar.updateComplete;
+    return { sidebar, harness };
+  }
+
+  function groupHeader(sidebar: SidebarLifecycleState, sectionId: string) {
+    const header = sidebar.querySelector(
+      `[data-session-section="${sectionId}"] .sidebar-recent-sessions__head`,
+    );
+    if (!header) {
+      throw new Error(`expected header for section ${sectionId}`);
+    }
+    return header;
+  }
+
+  it("marks custom group headers draggable but keeps smart sections static", async () => {
+    const { sidebar } = await mountWithGroups(["Alpha", "Beta"]);
+
+    expect(groupHeader(sidebar, "category:Alpha").getAttribute("draggable")).toBe("true");
+    expect(groupHeader(sidebar, "ungrouped").getAttribute("draggable")).toBe("false");
+  });
+
+  it("persists the new catalog order when a group header drops onto another group", async () => {
+    const { sidebar, harness } = await mountWithGroups(["Alpha", "Beta", "Gamma"]);
+    const dataTransfer = createDataTransferStub();
+
+    dispatchDragEvent(groupHeader(sidebar, "category:Gamma"), "dragstart", dataTransfer);
+    const alphaSection = sidebar.querySelector('[data-session-section="category:Alpha"]');
+    if (!alphaSection) {
+      throw new Error("expected Alpha section");
+    }
+    dispatchDragEvent(alphaSection, "drop", dataTransfer);
+
+    expect(harness.groupsPut).toHaveBeenCalledWith(["Gamma", "Alpha", "Beta"]);
   });
 });

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1511,6 +1511,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
             : t("chat.sidebar.chats");
     // Smart channel/work sections classify rows automatically; only custom
     // groups and Chats accept manual drops (a drop means category assignment).
+    // Custom group headers drag as a whole (mirroring whole-row session drags);
+    // the dot handle inside is a pure visual affordance.
     const acceptsSessions =
       !isPinned &&
       this.sessionsGrouping === "category" &&
@@ -1518,6 +1520,9 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     const sectionClass = [
       "sidebar-recent-sessions__group",
       collapsed ? "sidebar-recent-sessions__group--collapsed" : "",
+      group && this.draggingSessionGroup === group
+        ? "sidebar-recent-sessions__group--dragging"
+        : "",
       this.sessionDropTarget === section.id ? "sidebar-recent-sessions__group--session-drop" : "",
       group && this.sessionGroupDropTarget?.group === group
         ? `sidebar-recent-sessions__group--group-drop-${this.sessionGroupDropTarget.position}`
@@ -1542,7 +1547,24 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         ${showHeader
           ? html`
               <div
-                class="sidebar-recent-sessions__head"
+                class="sidebar-recent-sessions__head ${group
+                  ? "sidebar-recent-sessions__head--draggable"
+                  : ""}"
+                draggable=${group ? "true" : "false"}
+                @dragstart=${group
+                  ? (event: DragEvent) => {
+                      if (event.dataTransfer) {
+                        writeSessionGroupDragData(event.dataTransfer, group);
+                        this.draggingSessionGroup = group;
+                      }
+                    }
+                  : nothing}
+                @dragend=${group
+                  ? () => {
+                      this.draggingSessionGroup = null;
+                      this.sessionGroupDropTarget = null;
+                    }
+                  : nothing}
                 @contextmenu=${group
                   ? (event: MouseEvent) => {
                       event.preventDefault();
@@ -1552,21 +1574,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               >
                 ${group
                   ? html`
-                      <span
-                        class="sidebar-session-group-drag-handle"
-                        draggable="true"
-                        aria-hidden="true"
-                        @dragstart=${(event: DragEvent) => {
-                          if (event.dataTransfer) {
-                            writeSessionGroupDragData(event.dataTransfer, group);
-                            this.draggingSessionGroup = group;
-                          }
-                        }}
-                        @dragend=${() => {
-                          this.draggingSessionGroup = null;
-                          this.sessionGroupDropTarget = null;
-                        }}
-                      ></span>
+                      <span class="sidebar-session-group-drag-handle" aria-hidden="true"></span>
                     `
                   : nothing}
                 <button

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -810,7 +810,8 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await alphaToggle.click();
       await expect.poll(() => alpha.locator(".sidebar-recent-session").count()).toBe(0);
 
-      await gamma.locator(".sidebar-session-group-drag-handle").dragTo(alpha, {
+      // Reorder by dragging the whole group header (not just the dot handle).
+      await gamma.locator(".sidebar-recent-sessions__head").dragTo(alpha, {
         targetPosition: { x: 4, y: 2 },
       });
       const customGroupOrder = () =>

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -657,6 +657,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
         "sessions.patch": {},
       },
       sessionKey: "agent:main:main",
+      sessionGroups: ["Apps", "Research"],
     });
 
     try {
@@ -669,8 +670,8 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await expect.poll(() => researchGroup.locator(".sidebar-recent-session").count()).toBe(2);
       await captureUiProof(page, "sidebar-session-groups.png");
 
-      // Rename group: every member session is patched, including the archived
-      // row that only the unbounded archived list window can see.
+      // Rename group: the gateway renames the catalog entry and repoints every
+      // member session server-side (sessions.groups.rename), no per-member patches.
       const groupMenuButton = researchGroup.getByRole("button", {
         name: "Group options for Research",
       });
@@ -680,13 +681,11 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await captureUiProof(page, "sidebar-group-menu.png");
       page.once("dialog", (dialog) => void dialog.accept("Projects"));
       await page.getByRole("menuitem", { name: "Rename group…" }).click();
-      for (const key of ["agent:main:paper-a", "agent:main:paper-b", "agent:main:old-notes"]) {
-        const patch = await waitForPatch(
-          gateway,
-          (params) => params.key === key && params.category === "Projects",
-        );
-        expect(requireRecord(patch.params)).toMatchObject({ category: "Projects", key });
-      }
+      const renameRequest = await gateway.waitForRequest("sessions.groups.rename");
+      expect(requireRecord(renameRequest.params)).toMatchObject({
+        name: "Research",
+        to: "Projects",
+      });
       await expect
         .poll(() =>
           page
@@ -696,10 +695,11 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
             ),
         )
         .toEqual(["category:Apps", "category:Projects"]);
-
-      // Delete group: sessions survive and move back to Ungrouped.
       const projectsGroup = groups.filter({ hasText: "Projects" });
-      await projectsGroup.waitFor({ state: "visible" });
+      await expect.poll(() => projectsGroup.locator(".sidebar-recent-session").count()).toBe(2);
+
+      // Delete group: the gateway drops the catalog entry and moves member
+      // sessions back to Chats server-side (sessions.groups.delete).
       const projectsMenuButton = projectsGroup.getByRole("button", {
         name: "Group options for Projects",
       });
@@ -707,14 +707,22 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       page.once("dialog", (dialog) => void dialog.accept());
       await projectsMenuButton.click();
       await page.getByRole("menuitem", { name: "Delete group…" }).click();
-      const dissolvePatch = await waitForPatch(
-        gateway,
-        (params) => params.key === "agent:main:paper-a" && params.category === null,
-      );
-      expect(requireRecord(dissolvePatch.params)).toMatchObject({
-        category: null,
-        key: "agent:main:paper-a",
-      });
+      const deleteRequest = await gateway.waitForRequest("sessions.groups.delete");
+      expect(requireRecord(deleteRequest.params)).toMatchObject({ name: "Projects" });
+      await expect
+        .poll(() =>
+          page
+            .locator('[data-session-section^="category:"]')
+            .evaluateAll((elements) =>
+              elements.map((element) => element.getAttribute("data-session-section")),
+            ),
+        )
+        .toEqual(["category:Apps"]);
+      await expect
+        .poll(() =>
+          page.locator('[data-session-section="ungrouped"] .sidebar-recent-session').count(),
+        )
+        .toBe(3);
 
       // Group by "None" flattens the category sections into the plain list.
       const sortSessionsButton = page.getByRole("button", { name: "Sort sessions" });
@@ -755,6 +763,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
         "sessions.patch": {},
       },
       sessionKey: "agent:main:session-0",
+      sessionGroups: ["Alpha", "Beta"],
     });
 
     try {
@@ -764,10 +773,28 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await expect.poll(() => page.getByText("All sessions", { exact: true }).count()).toBe(0);
       await captureUiProof(page, "sidebar-all-sessions.png");
 
+      // New groups are created from a session's menu (Move to group → New group…),
+      // which files that session into the new group.
+      const sessionTen = page.locator(
+        '.sidebar-recent-session[data-session-key="agent:main:session-10"]',
+      );
+      await sessionTen.hover();
+      await sessionTen.getByRole("button", { name: "Open session menu" }).click();
+      // The submenu opens on pointerenter; clicking the host item would toggle
+      // the hover-opened submenu straight back closed.
+      await page.getByRole("menuitem", { name: "Move to group" }).hover();
       page.once("dialog", (dialog) => void dialog.accept("Gamma"));
-      await page.getByRole("button", { name: "New group…" }).click();
+      await page.getByRole("menuitem", { name: "New group…" }).click();
       const gamma = page.locator('[data-session-section="category:Gamma"]');
       await gamma.waitFor({ state: "visible" });
+      const createdPatch = await waitForPatch(
+        gateway,
+        (params) => params.key === "agent:main:session-10" && params.category === "Gamma",
+      );
+      expect(requireRecord(createdPatch.params)).toMatchObject({
+        category: "Gamma",
+        key: "agent:main:session-10",
+      });
 
       const sessionEleven = page.locator(
         '.sidebar-recent-session[data-session-key="agent:main:session-11"]',
@@ -783,11 +810,13 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       });
       await expect
         .poll(() => gamma.locator(".sidebar-recent-session").count(), { timeout: 10_000 })
-        .toBe(1);
+        .toBe(2);
       await captureUiProof(page, "sidebar-session-dropped-into-group.png");
 
       const ungrouped = page.locator('[data-session-section="ungrouped"]');
-      await gamma.locator(".sidebar-recent-session").dragTo(ungrouped);
+      await gamma
+        .locator('.sidebar-recent-session[data-session-key="agent:main:session-11"]')
+        .dragTo(ungrouped);
       const ungroupedPatch = await waitForPatch(
         gateway,
         (params) => params.key === "agent:main:session-11" && params.category === null,
@@ -798,7 +827,7 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       });
       await expect
         .poll(() => ungrouped.locator(".sidebar-recent-session").count(), { timeout: 10_000 })
-        .toBe(10);
+        .toBe(9);
 
       const alpha = page.locator('[data-session-section="category:Alpha"]');
       const alphaToggle = alpha.getByRole("button", { name: "Alpha", exact: true });
@@ -859,22 +888,34 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    await installMockGateway(page, {
+    const gateway = await installMockGateway(page, {
       methodResponses: {
         "sessions.list": sessionsListResponse([]),
       },
       sessionKey: "agent:main:main",
+      // Stored-but-empty catalog groups stay visible as sections/move targets.
+      sessionGroups: ["First group"],
     });
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      page.once("dialog", (dialog) => void dialog.accept("First group"));
-      await page.getByRole("button", { name: "New group…" }).click();
-      await page.locator('[data-session-section="category:First group"]').waitFor({
-        state: "visible",
-      });
+      const firstGroup = page.locator('[data-session-section="category:First group"]');
+      await firstGroup.waitFor({ state: "visible" });
       await page.locator('[data-session-section="ungrouped"] .sidebar-recent-session').waitFor({
         state: "visible",
+      });
+
+      // A header-menu-created group starts empty and still gets a section.
+      await firstGroup.locator(".sidebar-recent-sessions__head").hover();
+      await firstGroup.getByRole("button", { name: "Group options for First group" }).click();
+      page.once("dialog", (dialog) => void dialog.accept("Second group"));
+      await page.getByRole("menuitem", { name: "New group…" }).click();
+      await page.locator('[data-session-section="category:Second group"]').waitFor({
+        state: "visible",
+      });
+      const putRequest = await gateway.waitForRequest("sessions.groups.put");
+      expect(requireRecord(putRequest.params)).toMatchObject({
+        names: ["First group", "Second group"],
       });
     } finally {
       await context.close();

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -910,6 +910,10 @@ html.openclaw-native-macos .shell-nav-expand {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
+.sidebar-recent-sessions__group--dragging {
+  opacity: 0.45;
+}
+
 .sidebar-recent-sessions__group--group-drop-before {
   box-shadow: inset 0 2px 0 color-mix(in srgb, var(--accent) 75%, transparent);
 }
@@ -925,6 +929,14 @@ html.openclaw-native-macos .shell-nav-expand {
   min-height: 24px;
   padding: 0 10px;
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
+}
+
+.sidebar-recent-sessions__head--draggable {
+  cursor: grab;
+}
+
+.sidebar-recent-sessions__head--draggable:active {
+  cursor: grabbing;
 }
 
 .sidebar-recent-sessions__head--root {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -65,6 +65,8 @@ export type ControlUiMockGatewayScenario = {
     available?: boolean;
   }>;
   sessionKey?: string;
+  /** Initial gateway-owned custom group catalog (sessions.groups.*), in order. */
+  sessionGroups?: string[];
   terminalEnabled?: boolean;
   workspaceGit?: boolean;
 };
@@ -231,6 +233,7 @@ function normalizeScenario(
     methodResponses: scenario.methodResponses ?? {},
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
     sessionKey,
+    sessionGroups: scenario.sessionGroups ?? [],
     terminalEnabled: scenario.terminalEnabled ?? false,
     workspaceGit: scenario.workspaceGit ?? false,
   };
@@ -315,13 +318,58 @@ function installControlUiMockGateway(input: {
   const sessionPatches = new Map<string, Record<string, unknown>>();
   const sockets: Array<{ readonly url: string }> = [];
   const offlineStateKey = "openclaw.control-ui-e2e.gatewayOffline";
+  // Gateway-owned custom group catalog (sessions.groups.*). Persisted in
+  // sessionStorage so a page reload keeps the catalog the way the real
+  // gateway's SQLite store does; renames replay onto static sessions.list
+  // fixtures because the real gateway rewrites member categories server-side.
+  const groupsStateKey = "openclaw.control-ui-e2e.sessionGroups";
+  let groupsState: { names: string[]; renames: Array<{ from: string; to: string | null }> } = {
+    names: [...input.scenario.sessionGroups],
+    renames: [],
+  };
   let online = true;
   try {
     online = window.sessionStorage.getItem(offlineStateKey) !== "1";
   } catch {
     // Storage-disabled browser contexts still get the in-memory mock default.
   }
+  try {
+    const rawGroups = window.sessionStorage.getItem(groupsStateKey);
+    if (rawGroups) {
+      groupsState = JSON.parse(rawGroups) as typeof groupsState;
+    }
+  } catch {
+    // Storage-disabled browser contexts still get the scenario catalog.
+  }
   let seq = 0;
+
+  function persistGroupsState(): void {
+    try {
+      window.sessionStorage.setItem(groupsStateKey, JSON.stringify(groupsState));
+    } catch {
+      // In-memory catalog still serves the current page.
+    }
+  }
+
+  function groupsPayload(): { groups: Array<{ name: string; position: number }> } {
+    return { groups: groupsState.names.map((name, position) => ({ name, position })) };
+  }
+
+  function normalizedGroupNames(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    const seen = new Set<string>();
+    const names: string[] = [];
+    for (const raw of value) {
+      const name = typeof raw === "string" ? raw.trim() : "";
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        names.push(name);
+      }
+    }
+    return names;
+  }
 
   function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -412,7 +460,21 @@ function installControlUiMockGateway(input: {
           return row;
         }
         const patch = sessionPatches.get(row.key);
-        return patch ? { ...row, ...patch } : row;
+        const next = patch ? { ...row, ...patch } : { ...row };
+        // Replay group renames/deletes over static fixtures: the real gateway
+        // rewrites member categories server-side before the next sessions.list.
+        let category = typeof next.category === "string" ? next.category : undefined;
+        for (const rename of groupsState.renames) {
+          if (category === rename.from) {
+            category = rename.to ?? undefined;
+          }
+        }
+        if (category === undefined) {
+          delete next.category;
+        } else {
+          next.category = category;
+        }
+        return next;
       }),
     };
   }
@@ -587,6 +649,38 @@ function installControlUiMockGateway(input: {
           sessions: [sessionRow()],
           ts: Date.now(),
         });
+      case "sessions.groups.list":
+        return groupsPayload();
+      case "sessions.groups.put": {
+        groupsState.names = normalizedGroupNames(isRecord(params) ? params.names : undefined);
+        persistGroupsState();
+        return { ok: true, ...groupsPayload() };
+      }
+      case "sessions.groups.rename": {
+        const from = isRecord(params) && typeof params.name === "string" ? params.name.trim() : "";
+        const to = isRecord(params) && typeof params.to === "string" ? params.to.trim() : "";
+        if (from && to && from !== to) {
+          const sourceIndex = groupsState.names.indexOf(from);
+          const names = groupsState.names.filter((name) => name !== from);
+          if (!names.includes(to)) {
+            // Renames keep the source position, like the real catalog.
+            names.splice(sourceIndex < 0 ? names.length : sourceIndex, 0, to);
+          }
+          groupsState.names = names;
+          groupsState.renames.push({ from, to });
+          persistGroupsState();
+        }
+        return { ok: true, updatedSessions: 0, ...groupsPayload() };
+      }
+      case "sessions.groups.delete": {
+        const name = isRecord(params) && typeof params.name === "string" ? params.name.trim() : "";
+        if (name) {
+          groupsState.names = groupsState.names.filter((existing) => existing !== name);
+          groupsState.renames.push({ from: name, to: null });
+          persistGroupsState();
+        }
+        return { ok: true, updatedSessions: 0, ...groupsPayload() };
+      }
       case "sessions.subscribe":
         return { ok: true };
       default:


### PR DESCRIPTION
## What Problem This Solves

The sessions sidebar redesign (#103498, part of #103431) moved the custom group catalog and its order to the gateway (`sessions.groups.*`) and documented that "custom group headers can be … dragged to reorder them". In practice only the 8px dot handle at the left edge of a group header initiated the drag — grabbing the group name (the natural drag target, and how session rows behave) did nothing, so reordering groups felt broken.

The redesign also left the sidebar-group e2e coverage stale: three tests in `ui/src/e2e/session-management.e2e.test.ts` still exercised the pre-redesign UX (a visible "New group…" button, client-side per-member rename patches, localStorage catalog), so they fail on current `main`, and the mock gateway had no `sessions.groups.*` support at all.

## Why This Change Was Made

Group headers should drag the way session rows do: the whole row is the drag surface.

- `ui/src/components/app-sidebar.ts`: the group header div is `draggable` when it renders a custom group; the dot handle stays as a visual affordance. Dragged groups dim like dragged session rows. Smart sections (channels, Work, Chats, Pinned) stay non-draggable; their order is fixed by design.
- `ui/src/styles/layout.css`: grab/grabbing cursor on draggable headers, `--dragging` opacity state.
- `ui/src/test-helpers/control-ui-e2e.ts`: the mock gateway now implements `sessions.groups.list/put/rename/delete` with an ordered catalog that survives reloads (sessionStorage, mirroring the gateway's SQLite store) and replays renames/deletes onto static `sessions.list` fixtures the way the real gateway rewrites member categories server-side.
- `ui/src/e2e/session-management.e2e.test.ts`: the three stale tests now follow the redesigned UX — groups are created from a session's menu (Move to group → New group…) or a group header menu, rename/delete assert `sessions.groups.rename/delete` RPCs instead of per-member patches, and the reorder step drags the whole group header (not the dot handle).

## User Impact

Dragging a custom group header anywhere (name, count, whitespace) reorders groups; the order persists in the gateway catalog and syncs across browsers. No API, config, or i18n changes. The sidebar-group e2e lane matches shipped behavior again.

## Evidence

- Live-verified against a scratch gateway (isolated `OPENCLAW_STATE_DIR`, seeded groups Alpha/Beta/Gamma): header shows `draggable="true"`, dragging Gamma onto Alpha reordered the sidebar to Gamma/Alpha/Beta, `sessions.groups.list` returned `Gamma(0), Alpha(1), Beta(2)`, and the order survived a full page reload. Chats/channel headers report `draggable="false"`.
- `node scripts/run-vitest.mjs ui/src/e2e/session-management.e2e.test.ts` → 9/9 pass (was 6/9 on clean `main`; the drag-managed-groups test now performs a real Playwright drag from the header, over the collapse toggle, and verifies reorder plus reload persistence).
- New jsdom tests: custom group headers are draggable while smart sections are not; dropping one group header on another calls `sessions.groupsPut` with the reordered catalog. `app-sidebar.test.ts` + `custom-groups.test.ts` + `grouping.test.ts` → 30/30 pass.
- `check:changed` lanes green locally (Testbox leases were dying mid-hydration, so gates ran with `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1`); `oxfmt --check` and oxlint clean on touched files.
- Codex autoreview (gpt-5.5, xhigh) on the full branch diff: clean, no actionable findings.
- PR CI: green on the first head after one rerun of `checks-node-compact-large-whole-1` (shard-composition mock-leakage flake, reproduced on `main`'s own CI run at the same merge-base; the named tests pass in isolation locally).
