### PR TITLE
test(crestodian): preserve model input exports in mocks

### DIFF
--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -197,7 +197,8 @@ vi.mock("../commands/models/shared.js", () => ({
   }),
 }));
 
-vi.mock("../config/model-input.js", () => ({
+vi.mock("../config/model-input.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/model-input.js")>()),
   resolveAgentModelPrimaryValue: (model?: string | { primary?: string }) =>
     typeof model === "string" ? model : model?.primary,
 }));

--- a/src/crestodian/rescue-message.test.ts
+++ b/src/crestodian/rescue-message.test.ts
@@ -101,7 +101,8 @@ vi.mock("../commands/models/shared.js", () => ({
   }),
 }));
 
-vi.mock("../config/model-input.js", () => ({
+vi.mock("../config/model-input.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/model-input.js")>()),
   resolveAgentModelPrimaryValue: (model?: string | { primary?: string }) =>
     typeof model === "string" ? model : model?.primary,
 }));


### PR DESCRIPTION
Related: #103996

## What Problem This Solves

Resolves a current-`main` CI failure where Crestodian's full mock of `config/model-input` leaked into unrelated suites and hid newly added exports. Whole-suite shards then failed every caller of `toAgentModelListLike`, even though those callers and tests were otherwise correct.

## Why This Change Was Made

Both Crestodian mocks now use Vitest's partial-mock pattern: retain every real module export and override only `resolveAgentModelPrimaryValue`, which is the behavior those tests intentionally isolate. This removes the brittle export allowlist without changing production code.

## User Impact

No product behavior changes. CI once again tests model selection, inference onboarding, and subagent model resolution instead of failing during module mock resolution.

## Evidence

- Current-main CI run `29131114108` and #103996 run `29131384934` both fail with the same missing `toAgentModelListLike` export from these mocks.
- Blacksmith Testbox-through-Crabbox `tbx_01kx76v3wggn4091s5shmsdan3`: the two Crestodian suites and all three previously failing consumer suites pass together, 78/78 tests across two Vitest shards.
- The same Testbox passed path-scoped `check:changed`, including core-test typechecking and lint.
- Targeted `oxfmt`, `git diff --check`, and fresh Codex autoreview passed; autoreview reported no actionable findings with 0.99 correctness confidence.
