### PR TITLE
[AI-assisted] Simplify Android Canvas standby surface

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -475,7 +475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 45,
+      "line": 44,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Home canvas",
       "surface": "android",
@@ -483,7 +483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 45,
+      "line": 44,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Live page",
       "surface": "android",
@@ -491,7 +491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 56,
+      "line": 55,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -499,7 +499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 57,
+      "line": 56,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Current screen output and interactive app surface.",
       "surface": "android",
@@ -507,7 +507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 64,
+      "line": 63,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -515,7 +515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 64,
+      "line": 63,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -523,7 +523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 66,
+      "line": 65,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 66,
+      "line": 65,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Standby",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 71,
+      "line": 70,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refresh Screen",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 71,
+      "line": 70,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 77,
+      "line": 76,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open Screen",
       "surface": "android",
@@ -563,7 +563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 77,
+      "line": 76,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -571,7 +571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 122,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Connect the gateway",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 122,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Screen surface ready",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 128,
+      "line": 120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas output needs an active gateway connection.",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 128,
+      "line": 120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open the current Canvas surface to inspect or interact with it.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -84,17 +83,10 @@ internal fun CanvasSettingsScreen(
         Text(text = it, style = ClawTheme.type.body, color = ClawTheme.colors.warning)
       }
     }
-    ClawPanel(contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp)) {
-      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    ClawPanel(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 14.dp)) {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(text = canvasLabel, style = ClawTheme.type.section, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        Surface(
-          modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(ClawTheme.radii.panel)),
-          shape = RoundedCornerShape(ClawTheme.radii.panel),
-          color = ClawTheme.colors.canvas,
-          border = BorderStroke(1.dp, ClawTheme.colors.border),
-        ) {
-          CanvasStandbyPanel(isConnected = isConnected)
-        }
+        CanvasStandbyPanel(isConnected = isConnected)
       }
     }
   }
@@ -103,7 +95,7 @@ internal fun CanvasSettingsScreen(
 @Composable
 private fun CanvasStandbyPanel(isConnected: Boolean) {
   Column(
-    modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 48.dp),
+    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 28.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
   ) {


### PR DESCRIPTION
## What Problem This Solves

The Android Canvas settings screen wrapped its standby content in a second framed surface inside the existing panel. The nested border and generous padding made the screen feel visually heavy and weakened the hierarchy between connection details, actions, and the standby state.

## Why This Change Was Made

The existing panel now acts as the single visual container for the standby content. The standby panel is rendered directly inside it with tighter outer padding and slightly clearer element spacing. Text, actions, connection handling, and Canvas behavior remain unchanged.

The native app i18n source inventory is also synchronized with the updated Kotlin source locations so the repository's generated inventory check remains current.

## User Impact

Canvas settings are easier to scan and use less vertical space. The connection summary, Refresh Screen and Open Screen actions, and standby messaging keep the same behavior.

## Evidence

Validated with the patched Android debug APK on an Android 16 emulator connected to a paired test Gateway. The Canvas screen reported Connection Online and retained the existing Home canvas standby behavior.

| Before | After |
| --- | --- |
| <img width="360" src="https://github.com/user-attachments/assets/07c88551-d15e-47a1-a889-9737b8e31c98" alt="Canvas standby surface before" /> | <img width="360" src="https://github.com/user-attachments/assets/44c72f42-315a-4dd7-80d2-b20b48d93d2d" alt="Canvas standby surface after" /> |

Checks completed:

- `pnpm android:assemble`
- `./gradlew --no-daemon :app:ktlintCheck --console=plain`
- `pnpm native:i18n:check`
- `git diff --check`

The static before/after screenshots cover this visual-only spacing and hierarchy change; no video evidence is included.