### PR TITLE
fix(macos): let onboarding use taller windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS onboarding layout:** make the setup dialog vertically resizable, give taller windows' extra space to the active page, and center short pages instead of crowding their controls against the top.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS onboarding layout:** make the setup dialog vertically resizable, give taller windows' extra space to the active page, and center short pages instead of crowding their controls against the top.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18763,7 +18763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 225,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -18771,7 +18771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 225,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
@@ -19091,7 +19091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 156,
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -19,6 +19,7 @@ enum RemoteOnboardingProbeState: Equatable {
 @MainActor
 final class OnboardingController: NSObject, NSWindowDelegate {
     static let shared = OnboardingController()
+    static let windowStyleMask: NSWindow.StyleMask = [.titled, .closable, .resizable, .fullSizeContentView]
     private var window: NSWindow?
     /// Human description of work in flight ("Installing the Gateway…").
     /// While set, closing the window asks for confirmation instead of quitting
@@ -47,7 +48,10 @@ final class OnboardingController: NSObject, NSWindowDelegate {
         let window = NSWindow(contentViewController: hosting)
         window.title = UIStrings.welcomeTitle
         window.setContentSize(NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight))
-        window.styleMask = [.titled, .closable, .fullSizeContentView]
+        window.styleMask = Self.windowStyleMask
+        // Keep the focused dialog width while letting taller displays give setup more breathing room.
+        window.contentMinSize = NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight)
+        window.contentMaxSize = NSSize(width: OnboardingView.windowWidth, height: .greatestFiniteMagnitude)
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
@@ -166,10 +170,16 @@ struct OnboardingView: View {
         self.usesCompactHero ? 64 : 130
     }
 
-    /// Sized so the permissions page fits all capabilities without scrolling:
-    /// heroFrameHeight + contentHeight + ~72 (nav bar) fills windowHeight 752.
-    var contentHeight: CGFloat {
-        Self.windowHeight - self.heroFrameHeight - 72
+    /// The baseline fits every setup control. Taller windows donate all extra room
+    /// to the active page instead of leaving the content pinned to a fixed canvas.
+    func contentHeight(for windowHeight: CGFloat) -> CGFloat {
+        Self.contentHeight(for: windowHeight, usesCompactHero: self.usesCompactHero)
+    }
+
+    static func contentHeight(for windowHeight: CGFloat, usesCompactHero: Bool) -> CGFloat {
+        let availableHeight = max(Self.windowHeight, windowHeight)
+        let heroHeight: CGFloat = usesCompactHero ? 78 : 145
+        return availableHeight - heroHeight - 72
     }
 
     static func pageOrder(

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -5,7 +5,7 @@ extension OnboardingView {
     /// best option live, fall through automatically, offer an API-key form
     /// when nothing works. Crestodian becomes available only after inference
     /// has completed a live round-trip.
-    func aiSetupPage() -> some View {
+    func aiSetupPage(contentHeight: CGFloat) -> some View {
         VStack(spacing: 12) {
             Text("Connect your AI")
                 .font(.largeTitle.weight(.semibold))
@@ -28,7 +28,7 @@ extension OnboardingView {
         }
         .padding(.horizontal, 28)
         .padding(.top, 48)
-        .frame(width: self.pageWidth, height: self.contentHeight, alignment: .top)
+        .frame(width: self.pageWidth, height: contentHeight, alignment: .top)
     }
 
     private var aiSetupSubtitle: String {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -3,34 +3,42 @@ import SwiftUI
 
 extension OnboardingView {
     var body: some View {
-        VStack(spacing: 0) {
-            // Chat-heavy pages shrink the mascot so the content gets the room.
-            GlowingOpenClawIcon(size: self.heroSize)
-                .offset(y: self.usesCompactHero ? 4 : 10)
-                .frame(height: self.heroFrameHeight)
+        GeometryReader { windowGeometry in
+            let contentHeight = self.contentHeight(for: windowGeometry.size.height)
+            VStack(spacing: 0) {
+                // Chat-heavy pages shrink the mascot so the content gets the room.
+                GlowingOpenClawIcon(size: self.heroSize)
+                    .offset(y: self.usesCompactHero ? 4 : 10)
+                    .frame(height: self.heroFrameHeight)
+                    .animation(.spring(response: 0.45, dampingFraction: 0.85), value: self.usesCompactHero)
+
+                GeometryReader { _ in
+                    HStack(spacing: 0) {
+                        ForEach(self.pageOrder, id: \.self) { pageIndex in
+                            self.pageView(for: pageIndex, contentHeight: contentHeight)
+                                .frame(width: self.pageWidth)
+                        }
+                    }
+                    .offset(x: CGFloat(-self.currentPage) * self.pageWidth)
+                    .animation(
+                        .interactiveSpring(response: 0.5, dampingFraction: 0.86, blendDuration: 0.25),
+                        value: self.currentPage)
+                    .frame(height: contentHeight, alignment: .top)
+                    .clipped()
+                }
+                .frame(height: contentHeight)
                 .animation(.spring(response: 0.45, dampingFraction: 0.85), value: self.usesCompactHero)
 
-            GeometryReader { _ in
-                HStack(spacing: 0) {
-                    ForEach(self.pageOrder, id: \.self) { pageIndex in
-                        self.pageView(for: pageIndex)
-                            .frame(width: self.pageWidth)
-                    }
-                }
-                .offset(x: CGFloat(-self.currentPage) * self.pageWidth)
-                .animation(
-                    .interactiveSpring(response: 0.5, dampingFraction: 0.86, blendDuration: 0.25),
-                    value: self.currentPage)
-                .frame(height: self.contentHeight, alignment: .top)
-                .clipped()
+                Spacer(minLength: 0)
+                self.navigationBar
             }
-            .frame(height: self.contentHeight)
-            .animation(.spring(response: 0.45, dampingFraction: 0.85), value: self.usesCompactHero)
-
-            Spacer(minLength: 0)
-            self.navigationBar
+            .frame(maxHeight: .infinity)
         }
-        .frame(width: pageWidth, height: Self.windowHeight)
+        .frame(
+            minWidth: pageWidth,
+            maxWidth: pageWidth,
+            minHeight: Self.windowHeight,
+            maxHeight: .infinity)
         .background(Color(NSColor.windowBackgroundColor))
         .onAppear {
             self.onboardingVisible = true
@@ -210,19 +218,21 @@ extension OnboardingView {
         .frame(minHeight: 60, alignment: .bottom)
     }
 
-    func onboardingPage(@ViewBuilder _ content: () -> some View) -> some View {
+    func onboardingPage(@ViewBuilder _ content: @escaping () -> some View) -> some View {
         let scrollIndicatorGutter: CGFloat = 18
-        return ScrollView {
-            VStack(spacing: 16) {
-                content()
-                Spacer(minLength: 0)
+        return GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 16) {
+                    content()
+                }
+                .frame(maxWidth: .infinity)
+                .frame(minHeight: geometry.size.height, alignment: .center)
+                .padding(.trailing, scrollIndicatorGutter)
             }
-            .frame(maxWidth: .infinity, alignment: .top)
-            .padding(.trailing, scrollIndicatorGutter)
+            .scrollIndicators(.automatic)
+            .padding(.horizontal, 28)
+            .frame(width: pageWidth, alignment: .top)
         }
-        .scrollIndicators(.automatic)
-        .padding(.horizontal, 28)
-        .frame(width: pageWidth, alignment: .top)
     }
 
     func onboardingCard(

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 extension OnboardingView {
     @ViewBuilder
-    func pageView(for pageIndex: Int) -> some View {
+    func pageView(for pageIndex: Int, contentHeight: CGFloat) -> some View {
         switch pageIndex {
         case 0:
             self.welcomePage()
@@ -16,11 +16,11 @@ extension OnboardingView {
         case 2:
             self.cliPage()
         case 3:
-            self.aiSetupPage()
+            self.aiSetupPage(contentHeight: contentHeight)
         case 5:
-            self.permissionsPage()
+            self.permissionsPage(contentHeight: contentHeight)
         case 8:
-            self.onboardingChatPage()
+            self.onboardingChatPage(contentHeight: contentHeight)
         case 9:
             self.readyPage()
         default:
@@ -655,7 +655,7 @@ extension OnboardingView {
         .buttonStyle(.plain)
     }
 
-    func permissionsPage() -> some View {
+    func permissionsPage(contentHeight: CGFloat) -> some View {
         // Fixed layout (no ScrollView): sorted by importance and sized so all
         // permissions stay visible at once — no scrollbars during onboarding.
         VStack(spacing: 12) {
@@ -689,7 +689,7 @@ extension OnboardingView {
             }
         }
         .padding(.horizontal, 28)
-        .frame(width: self.pageWidth, height: self.contentHeight, alignment: .top)
+        .frame(width: self.pageWidth, height: contentHeight, alignment: .top)
     }
 
     func cliPage() -> some View {
@@ -902,7 +902,7 @@ extension OnboardingView {
         }
     }
 
-    func onboardingChatPage() -> some View {
+    func onboardingChatPage(contentHeight: CGFloat) -> some View {
         VStack(spacing: 12) {
             Text("Meet your agent")
                 .font(.largeTitle.weight(.semibold))
@@ -922,7 +922,7 @@ extension OnboardingView {
             .frame(maxHeight: .infinity)
         }
         .padding(.horizontal, 28)
-        .frame(width: self.pageWidth, height: self.contentHeight, alignment: .top)
+        .frame(width: self.pageWidth, height: contentHeight, alignment: .top)
     }
 
     func readyPage() -> some View {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
@@ -38,13 +38,14 @@ extension OnboardingView {
         view.workspacePath = "/tmp/openclaw"
         view.workspaceStatus = "Saved workspace"
         view.state.connectionMode = .local
+        let contentHeight = view.contentHeight(for: OnboardingView.windowHeight)
         _ = view.welcomePage()
         _ = view.connectionPage()
-        _ = view.aiSetupPage()
-        _ = view.permissionsPage()
+        _ = view.aiSetupPage(contentHeight: contentHeight)
+        _ = view.permissionsPage(contentHeight: contentHeight)
         _ = view.cliPage()
         _ = view.workspacePage()
-        _ = view.onboardingChatPage()
+        _ = view.onboardingChatPage(contentHeight: contentHeight)
         _ = view.readyPage()
 
         view.selectLocalGateway()

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import OpenClawDiscovery
 import OpenClawIPC
@@ -15,6 +16,19 @@ struct OnboardingViewSmokeTests {
             permissionMonitor: PermissionMonitor.shared,
             discoveryModel: GatewayDiscoveryModel(localDisplayName: InstanceIdentity.displayName))
         _ = view.body
+    }
+
+    @Test func `onboarding window resizes vertically and gives the page the extra height`() {
+        #expect(OnboardingController.windowStyleMask.contains(.resizable))
+
+        let baseline = OnboardingView.contentHeight(
+            for: OnboardingView.windowHeight,
+            usesCompactHero: false)
+        let taller = OnboardingView.contentHeight(
+            for: OnboardingView.windowHeight + 200,
+            usesCompactHero: false)
+
+        #expect(taller - baseline == 200)
     }
 
     @Test func `page order omits workspace and identity steps`() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users opening onboarding on a taller display were limited to a fixed-height dialog, leaving setup content crowded toward the top and preventing the window from using available vertical space.

## Why This Change Was Made

The onboarding window now supports vertical-only resizing while preserving its focused 630-point width and existing minimum height. Page layout derives its content height from the live window size; short scrollable pages center their content, while longer and chat-heavy pages receive the extra viewport space.

AI-assisted: implemented and reviewed with Codex; no agent transcript attached because the session includes private local VM and credential coordination.

## User Impact

Users can drag or zoom the onboarding dialog taller. Welcome and connection pages breathe naturally in the larger viewport, and content-heavy setup pages gain usable room without widening the dialog or regressing the current minimum-size layout.

## Evidence

- Reproduced on exact landed main `a0354e5243cd1eca0968fe57347aa62fd9a24340`: edge drag and title-bar zoom left the 630×752 onboarding canvas unchanged.
- Signed arm64 provisional app at `a9ccc4e57736c0d5caf97af640b7a11bdcc4d278`: the green resize control expanded the dialog to the full available height; Welcome and “Where should your assistant live?” redistributed and centered their content. Independently captured through Parallels after Computer Use interaction.
- `swift test --package-path apps/macos --filter OnboardingViewSmokeTests` — 15 tests passed.
- SwiftFormat 0.62.1 and SwiftLint 0.65.0 on all touched Swift files — clean.
- Testbox-through-Crabbox `tbx_01kx76v79avebvhp2ybettk83e`: `check:changed` passed, including 180 macOS packaging/daemon tests.
- Structured Codex autoreview — no accepted/actionable findings.

The full fresh-system CLI/Mac provider matrix remains intentionally post-land: it will be rerun from this PR's exact landed `main` artifacts on the pristine `macOS latest` snapshot.
