### PR TITLE
fix(clickclack): add timeouts to REST client requests

### DIFF
--- a/extensions/clickclack/src/http-client-response-timeout.test.ts
+++ b/extensions/clickclack/src/http-client-response-timeout.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClickClackClient } from "./http-client.js";
+
+function createSignalAbortedJsonResponse(signal: AbortSignal): {
+  response: Response;
+  wasAborted: () => boolean;
+} {
+  let aborted = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const abortBody = () => {
+        aborted = true;
+        controller.error(signal.reason ?? new Error("body aborted"));
+      };
+      if (signal.aborted) {
+        abortBody();
+        return;
+      }
+      signal.addEventListener("abort", abortBody, { once: true });
+    },
+    async pull() {
+      await new Promise<void>(() => {});
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    wasAborted: () => aborted,
+  };
+}
+
+describe("ClickClack HTTP response timeout", () => {
+  it("keeps the REST deadline active while reading a hanging response body", async () => {
+    vi.useFakeTimers();
+    let body: ReturnType<typeof createSignalAbortedJsonResponse> | undefined;
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("expected ClickClack client to pass an AbortSignal");
+      }
+      const responseBody = createSignalAbortedJsonResponse(signal);
+      body = responseBody;
+      return responseBody.response;
+    });
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "placeholder",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    try {
+      const pending = client.me().catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const error = await pending;
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("request timed out");
+      expect(body?.wasAborted()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not add implicit deadlines to message creates", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ message: { id: "msg_1" } }, { status: 201 }),
+    );
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "placeholder",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.createChannelMessage("chn_1", "channel");
+    await client.createThreadReply("msg_root", "thread");
+    await client.createDirectMessage("dm_1", "direct");
+
+    expect(fetchMock.mock.calls.map((call) => call[1]?.signal)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("does not add an implicit deadline to multipart uploads", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({
+        upload: {
+          id: "upl_1",
+          workspace_id: "wsp_1",
+          owner_id: "usr_1",
+          filename: "proof.txt",
+          content_type: "text/plain",
+          byte_size: 5,
+          width: 0,
+          height: 0,
+          duration_ms: 0,
+          created_at: "2026-08-16T00:00:00Z",
+        },
+      }),
+    );
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "placeholder",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.createUpload({
+      workspaceId: "wsp_1",
+      buffer: Buffer.from("proof"),
+      filename: "proof.txt",
+      contentType: "text/plain",
+    });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeUndefined();
+  });
+});

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -2,6 +2,7 @@
  * Thin ClickClack REST/websocket client used by gateway, resolver, and outbound
  * delivery code.
  */
+import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderJsonResponse,
@@ -58,6 +59,7 @@ type ClientOptions = {
   fetch?: typeof fetch;
 };
 
+const CLICKCLACK_REST_REQUEST_TIMEOUT_MS = 30_000;
 const CLICKCLACK_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const CLICKCLACK_CORRELATION_ID_MAX_LENGTH = 128;
 const CLICKCLACK_CORRELATION_ID_PATTERN = /^[A-Za-z0-9._:-]+$/u;
@@ -97,6 +99,17 @@ export class ClickClackHttpError extends Error {
   ) {
     super(`ClickClack ${status}: ${detail}`);
   }
+}
+
+function isMessageCreateRequest(method: string, path: string): boolean {
+  if (method !== "POST") {
+    return false;
+  }
+  return (
+    /^\/api\/channels\/[^/]+\/messages$/u.test(path) ||
+    /^\/api\/messages\/[^/]+\/thread\/replies$/u.test(path) ||
+    /^\/api\/dms\/[^/]+\/messages$/u.test(path)
+  );
 }
 
 /** Matches the workspace/name uniqueness error returned by current ClickClack servers. */
@@ -145,27 +158,33 @@ export function createClickClackClient(options: ClientOptions) {
     init: RequestInit = {},
     requestOptions: { timeoutMs?: number; responseMode?: "json" | "none" } = {},
   ): Promise<T> {
+    const url = `${baseUrl}${path}`;
+    const method = (init.method ?? "GET").toUpperCase();
     const requestHeaders = new Headers(init.headers);
+    const isMultipartUpload = init.body instanceof FormData;
     for (const [key, value] of Object.entries(headers)) {
       requestHeaders.set(key, value);
     }
     if (correlationId) {
       requestHeaders.set(CLICKCLACK_CORRELATION_ID_HEADER, correlationId);
     }
-    if (init.body && !(init.body instanceof FormData)) {
+    if (init.body && !isMultipartUpload) {
       requestHeaders.set("Content-Type", "application/json");
     }
-    const controller =
-      requestOptions.timeoutMs !== undefined && !init.signal ? new AbortController() : undefined;
-    const timeout = controller
-      ? setTimeout(() => controller.abort(), requestOptions.timeoutMs)
-      : undefined;
+    // Message creation can commit before its response completes. Until every
+    // caller has durable nonce reconciliation, only explicit signals may abort it.
+    const defaultTimeoutMs =
+      isMultipartUpload || isMessageCreateRequest(method, path)
+        ? undefined
+        : CLICKCLACK_REST_REQUEST_TIMEOUT_MS;
+    const { signal, cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: requestOptions.timeoutMs ?? defaultTimeoutMs,
+      signal: init.signal ?? undefined,
+      operation: "clickclack-rest",
+      url,
+    });
     try {
-      const response = await fetcher(`${baseUrl}${path}`, {
-        ...init,
-        ...(controller ? { signal: controller.signal } : {}),
-        headers: requestHeaders,
-      });
+      const response = await fetcher(url, { ...init, headers: requestHeaders, signal });
       if (!response.ok) {
         const detail = await readResponseTextLimited(response, CLICKCLACK_ERROR_BODY_LIMIT_BYTES);
         // Remote error bodies are untrusted output; redact them even when the
@@ -188,9 +207,7 @@ export function createClickClackClient(options: ClientOptions) {
         maxBytes: CLICKCLACK_INBOUND_JSON_LIMIT_BYTES,
       });
     } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
+      cleanup();
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

ClickClack REST reads could wait indefinitely after the service returned headers but stalled the JSON response body. A blanket deadline on message creation is unsafe, however: the message can commit before its response completes, while direct streamed replies do not yet have durable nonce identity across regenerated callback boundaries.

## Why This Change Was Made

- Keep a 30-second owner-local deadline active through ordinary JSON response reads, not only until response headers arrive.
- Preserve explicit caller abort signals and explicit per-request deadlines.
- Exempt multipart uploads from the implicit deadline so slow healthy media transfers are not cut off.
- Exempt the three ClickClack message-create routes from the implicit deadline until every direct caller has durable nonce reconciliation.
- Leave the existing `blockStreaming: true` inbound delivery path unchanged.

This replaces the earlier 11-file atomic-reply redesign. That approach made replayed final replies easier to reconcile but silently deferred all default streamed text until the turn ended. The narrower HTTP-owner fix removes that compatibility regression instead of changing the channel contract.

## User Impact

Ordinary ClickClack JSON reads and control requests now fail in bounded time when a response body stalls. Existing streamed replies remain visible block by block. Message creation and multipart uploads retain their existing no-implicit-deadline behavior, avoiding ambiguous committed writes and truncated healthy uploads; explicit caller cancellation still applies.

## Safety Boundary

Direct inspection of `openclaw/clickclack@1b46da07a6cccbe45e35e6d0bdad17efb3a2776f` confirms that message creation can be keyed by nonce and queried by nonce. OpenClaw's durable outbound path uses that contract, but direct inbound block callbacks do not have a persisted cross-replay part identity. The safe current boundary is therefore to avoid injecting a timeout into message creation rather than buffer all blocks into one final message.

## Evidence

Exact head: `29cfef1bdce932d34052c377c490cbb5afb4968c`  
Rebased base: `1113d1d2458`

- Node v24.15.0: `node scripts/run-vitest.mjs extensions/clickclack/src/http-client.test.ts extensions/clickclack/src/http-client-response-timeout.test.ts` passed 2 files / 33 tests after the final rebase.
- The focused timeout proof keeps the deadline active through a hanging successful response body and observes the abort at 30 seconds.
- The focused safety proof covers channel, thread, and DM message-create routes plus multipart upload, confirming that none receives an implicit signal.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` passed with no diagnostics on the final patch before the conflict-free squash/rebase.
- `node_modules/.bin/oxfmt --check` and `node_modules/.bin/oxlint` passed for both changed files after the final rebase.
- `git diff --check upstream/main...HEAD` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` completed clean with `patch is correct (0.99)` and no accepted/actionable findings. It specifically confirmed the narrow multipart/message-create exemptions and preservation of explicit timeouts/signals.
- Surface: 2 files, +150/-14, reduced from the previous 11 files, +718/-49.
- Exact-head CI is refreshing.

Original timeout patch by @Alix-007; final scope and validation by @Leon-SK668.

AI-assisted: developed with Codex; the author reviewed the complete owner boundary, current callers, tests, and validation results.
