### PR TITLE
fix(slack): apply sender policy to group DMs

### DIFF
--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -31,6 +31,7 @@ function makeSlackCtx(allowFrom: string[]): SlackMonitorContext {
 function makeAuthorizeCtx(params?: {
   allowFrom?: string[];
   channelsConfig?: Record<string, { users?: string[] }>;
+  dmPolicy?: SlackMonitorContext["dmPolicy"];
   resolveUserName?: (userId: string) => Promise<{ name?: string }>;
   resolveChannelName?: (
     channelId: string,
@@ -39,7 +40,7 @@ function makeAuthorizeCtx(params?: {
   return {
     allowFrom: params?.allowFrom ?? [],
     accountId: "main",
-    dmPolicy: "open",
+    dmPolicy: params?.dmPolicy ?? "open",
     dmEnabled: true,
     allowNameMatching: false,
     channelsConfig: params?.channelsConfig ?? {},
@@ -119,6 +120,7 @@ describe("authorizeSlackSystemEventSender", () => {
   });
 
   beforeEach(() => {
+    readChannelIngressStoreAllowFromForDmPolicyMock.mockReset();
     clearSlackAllowFromCacheForTest();
     delete process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS;
   });
@@ -283,6 +285,44 @@ describe("authorizeSlackSystemEventSender", () => {
       allowed: true,
       channelType: "channel",
       channelName: "general",
+    });
+  });
+
+  it("does not use pairing-store allowFrom for MPIM system events", async () => {
+    readChannelIngressStoreAllowFromForDmPolicyMock.mockResolvedValue(["U_ATTACKER"]);
+    const result = await authorizeSlackSystemEventSender({
+      ctx: makeAuthorizeCtx({
+        allowFrom: [],
+        dmPolicy: "pairing",
+        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+      }),
+      senderId: "U_ATTACKER",
+      channelId: "G_MPIM",
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "sender-not-allowlisted",
+      channelType: "mpim",
+      channelName: "group-dm",
+    });
+    expect(readChannelIngressStoreAllowFromForDmPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it("allows MPIM system-event senders in the configured allowFrom", async () => {
+    const result = await authorizeSlackSystemEventSender({
+      ctx: makeAuthorizeCtx({
+        allowFrom: ["U_OWNER"],
+        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+      }),
+      senderId: "U_OWNER",
+      channelId: "G_MPIM",
+    });
+
+    expect(result).toEqual({
+      allowed: true,
+      channelType: "mpim",
+      channelName: "group-dm",
     });
   });
 
@@ -478,6 +518,36 @@ describe("resolveSlackCommandIngress", () => {
     expect(result.ingress.decision).toBe("block");
     expect(result.commandAccess.authorized).toBe(false);
     expect(result.commandAccess.shouldBlockControlCommand).toBe(false);
+  });
+
+  it("blocks MPIM senders outside the configured allowFrom", async () => {
+    const result = await resolveSlackCommandIngress({
+      ctx: makeAuthorizeCtx(),
+      senderId: "U_ATTACKER",
+      channelType: "mpim",
+      channelId: "G_MPIM",
+      ownerAllowFromLower: ["u_owner"],
+      allowTextCommands: false,
+      hasControlCommand: false,
+    });
+
+    expect(result.senderAccess.decision).toBe("block");
+    expect(result.senderAccess.gate?.allowed).toBe(false);
+  });
+
+  it("allows MPIM senders in the configured allowFrom", async () => {
+    const result = await resolveSlackCommandIngress({
+      ctx: makeAuthorizeCtx(),
+      senderId: "U_OWNER",
+      channelType: "mpim",
+      channelId: "G_MPIM",
+      ownerAllowFromLower: ["u_owner"],
+      allowTextCommands: false,
+      hasControlCommand: false,
+    });
+
+    expect(result.senderAccess.decision).toBe("allow");
+    expect(result.senderAccess.gate?.allowed).toBe(true);
   });
 });
 

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -377,8 +377,16 @@ export async function resolveSlackCommandIngress(params: {
   >["modeWhenAccessGroupsOff"];
 }) {
   const isDirectMessage = params.channelType === "im";
+  const isGroupDm = params.channelType === "mpim";
   const channelUsers = normalizeAllowListLower(params.channelUsers);
-  const channelUsersConfigured = !isDirectMessage && channelUsers.length > 0;
+  const channelUsersConfigured = !isDirectMessage && !isGroupDm && channelUsers.length > 0;
+  // MPIM ingress is group-shaped, but its sender policy is DM-owned. Callers
+  // pass configured allowFrom without pairing-store approvals for this path.
+  const groupAllowFrom = isGroupDm
+    ? params.ownerAllowFromLower
+    : channelUsersConfigured
+      ? channelUsers
+      : [];
   const result = await createSlackIngressResolver(params.ctx).message({
     subject: createSlackIngressSubject({
       senderId: params.senderId,
@@ -394,7 +402,7 @@ export async function resolveSlackCommandIngress(params: {
       mayPair: false,
     },
     dmPolicy: isDirectMessage ? "open" : "disabled",
-    groupPolicy: channelUsersConfigured ? "allowlist" : "open",
+    groupPolicy: isGroupDm || channelUsersConfigured ? "allowlist" : "open",
     policy: {
       groupAllowFromFallbackToAllowFrom: false,
       mutableIdentifierMatching: params.ctx.allowNameMatching ? "enabled" : "disabled",
@@ -402,7 +410,7 @@ export async function resolveSlackCommandIngress(params: {
     },
     mentionFacts: params.mentionFacts,
     allowFrom: isDirectMessage ? ["*"] : params.ownerAllowFromLower,
-    groupAllowFrom: channelUsersConfigured ? channelUsers : [],
+    groupAllowFrom,
     command: {
       allowTextCommands: params.allowTextCommands,
       hasControlCommand: params.hasControlCommand,
@@ -424,8 +432,9 @@ async function decideSlackSystemIngress(params: {
   interactiveEvent: boolean;
 }): Promise<ChannelIngressDecision> {
   const isDirectMessage = params.channelType === "im";
+  const isGroupDm = params.channelType === "mpim";
   const channelUsers = normalizeAllowListLower(params.channelUsers);
-  const channelUsersConfigured = !isDirectMessage && channelUsers.length > 0;
+  const channelUsersConfigured = !isDirectMessage && !isGroupDm && channelUsers.length > 0;
   const ownerAllowFrom =
     params.interactiveEvent && channelUsersConfigured
       ? params.ownerAllowFromLower.filter((entry) => entry !== "*")
@@ -434,6 +443,9 @@ async function decideSlackSystemIngress(params: {
   const groupAllowFrom = (() => {
     if (isDirectMessage) {
       return [];
+    }
+    if (isGroupDm) {
+      return ownerAllowFrom;
     }
     if (params.interactiveEvent && hasAnyCommandAllowlist) {
       return channelUsersConfigured ? channelUsers : [];
@@ -458,8 +470,9 @@ async function decideSlackSystemIngress(params: {
       mayPair: false,
     },
     dmPolicy: isDirectMessage ? "open" : "disabled",
-    groupPolicy:
-      params.interactiveEvent && hasAnyCommandAllowlist
+    groupPolicy: isGroupDm
+      ? "allowlist"
+      : params.interactiveEvent && hasAnyCommandAllowlist
         ? "open"
         : channelUsersConfigured || (!params.channelId && params.ownerAllowFromLower.length > 0)
           ? "allowlist"

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1922,6 +1922,79 @@ describe("registerSlackInteractionEvents", () => {
     });
   });
 
+  it("blocks MPIM block actions when sender is outside configured allowFrom", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, app, getHandler } = createContext({
+      allowFrom: ["U_OWNER"],
+      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler({
+      ack,
+      respond,
+      body: {
+        user: { id: "U_ATTACKER" },
+        channel: { id: "G_MPIM" },
+        message: {
+          ts: "311.312",
+          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:verify",
+        block_id: "verify_block",
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to use this control.",
+      response_type: "ephemeral",
+    });
+  });
+
+  it("allows MPIM block actions when sender is in configured allowFrom", async () => {
+    enqueueSystemEventMock.mockClear();
+    const { ctx, app, getHandler } = createContext({
+      allowFrom: ["U_OWNER"],
+      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await handler({
+      ack,
+      respond,
+      body: {
+        user: { id: "U_OWNER" },
+        channel: { id: "G_MPIM" },
+        message: {
+          ts: "313.314",
+          blocks: [{ type: "actions", block_id: "verify_block", elements: [] }],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:verify",
+        block_id: "verify_block",
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+    expect(respond).not.toHaveBeenCalled();
+  });
+
   it("ignores malformed action payloads after ack and logs warning", async () => {
     enqueueSystemEventMock.mockClear();
     const { ctx, app, getHandler, runtimeLog } = createContext();

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -677,6 +677,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     channel: string;
     channelType: SlackMessageEvent["channel_type"];
     user: string;
+    historyUser?: string;
     userName: string;
     starterText: string;
     followUpText: string;
@@ -696,16 +697,17 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
   async function prepareThreadContextAllowlistCase(params: ThreadContextAllowlistCaseParams) {
     const { storePath } = storeFixture.makeTmpStorePath();
+    const historyUser = params.historyUser ?? params.user;
     const replies = vi
       .fn()
       .mockResolvedValueOnce({
-        messages: [{ text: params.starterText, user: params.user, ts: params.startTs }],
+        messages: [{ text: params.starterText, user: historyUser, ts: params.startTs }],
       })
       .mockResolvedValueOnce({
         messages: [
-          { text: params.starterText, user: params.user, ts: params.startTs },
+          { text: params.starterText, user: historyUser, ts: params.startTs },
           { text: "assistant reply", bot_id: "B1", ts: params.replyTs },
-          { text: params.followUpText, user: params.user, ts: params.followUpTs },
+          { text: params.followUpText, user: historyUser, ts: params.followUpTs },
           { text: "current message", user: params.user, ts: params.currentTs },
         ],
         response_metadata: { next_cursor: "" },
@@ -1912,6 +1914,39 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
+  it("blocks MPIM messages from senders outside the configured allowFrom", async () => {
+    const ctx = createReplyToAllSlackCtx();
+    ctx.allowFrom = ["U_OWNER"];
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        channel: "G123",
+        channel_type: "mpim",
+        user: "U_ATTACKER",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+  });
+
+  it("allows MPIM messages from senders in the configured allowFrom", async () => {
+    const ctx = createReplyToAllSlackCtx();
+    ctx.allowFrom = ["U_OWNER"];
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        channel: "G123",
+        channel_type: "mpim",
+        user: "U_OWNER",
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.ChatType).toBe("group");
+  });
+
   it("keeps one mpDM classification when a later event omits channel_type (#102676)", async () => {
     const { account, conversationsInfo, ctx } = createMissingChannelInfoBotCtx();
     // The real message ingress boundary records this before preparation starts.
@@ -2370,6 +2405,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       channel: "G400",
       channelType: "mpim",
       user: "U4",
+      historyUser: "U5",
       userName: "Evan",
       starterText: "starter from mpim",
       followUpText: "mpim follow-up",
@@ -2377,6 +2413,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       replyTs: "400.500",
       followUpTs: "400.800",
       currentTs: "401.000",
+      allowFrom: ["U4"],
     });
 
     expectThreadContextAllowsHumanHistory(prepared, replies, "starter from mpim", "mpim follow-up");

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1041,8 +1041,8 @@ export async function prepareSlackMessage(params: {
     },
   });
   const senderGate = messageIngress.senderAccess.gate;
-  if (isRoom && senderGate?.allowed === false) {
-    logVerbose(`Blocked unauthorized slack sender ${senderId} (not in channel users)`);
+  if (isRoomish && senderGate?.allowed === false) {
+    logVerbose(`Blocked unauthorized slack sender ${senderId} (not in sender allowlist)`);
     return null;
   }
   if (

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1357,6 +1357,44 @@ describe("slack slash commands access groups", () => {
     expect(dispatchArg?.ctx?.From).toBe("slack:group:G_MPIM");
   });
 
+  it("blocks MPIM slash commands from senders outside the configured allowFrom", async () => {
+    const harness = createPolicyHarness({
+      allowFrom: ["U_OWNER"],
+      channelId: "G_MPIM",
+      channelName: "group-dm",
+      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+      useAccessGroups: false,
+    });
+    const { respond } = await registerAndRunPolicySlash({
+      harness,
+      command: { user_id: "U_ATTACKER" },
+    });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to use this command here.",
+      response_type: "ephemeral",
+    });
+  });
+
+  it("allows MPIM slash commands from senders in the configured allowFrom", async () => {
+    const harness = createPolicyHarness({
+      allowFrom: ["U_OWNER"],
+      channelId: "G_MPIM",
+      channelName: "group-dm",
+      resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
+    });
+    const { respond } = await registerAndRunPolicySlash({
+      harness,
+      command: { user_id: "U_OWNER" },
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(responseTexts(respond)).not.toContain(
+      "You are not authorized to use this command here.",
+    );
+  });
+
   it("enforces access-group gating when lookup fails for private channels", async () => {
     const harness = createPolicyHarness({
       allowFrom: [],

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -536,7 +536,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         modeWhenAccessGroupsOff: "configured",
       });
       const senderGate = slashIngress.senderAccess.gate;
-      if (isRoom && senderGate?.allowed === false) {
+      if (isRoomish && senderGate?.allowed === false) {
         await respond({
           text: "You are not authorized to use this command here.",
           response_type: "ephemeral",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack group DMs did not consistently follow the account's configured sender policy across messages, slash commands, block actions, and system events.

## Why This Change Was Made

Group DMs remain group-shaped conversations, but sender authorization now comes from the account-level Slack allowlist. Pairing approvals remain scoped to one-to-one DMs, and channel-level access-group behavior is unchanged.

## User Impact

Slack group DMs now apply the configured sender policy consistently across supported ingress paths. Explicitly allowed users continue to use messages, commands, and interactive controls normally.

## Evidence

- Focused Slack monitor suite: 257 tests passed on Blacksmith Testbox (`tbx_01kx773axj8d11kasga2dpkr43`).
- Added deny-path and allowed-path coverage for messages, slash commands, block actions, and system events, including pairing-policy and disabled-access-group cases.
- Changed-file checks passed on Blacksmith Testbox.
- Build passed on AWS Crabbox (`run_330e030e7e91`).
- Live Slack workspace proof passed on AWS Crabbox (`run_3ae19a93b55c`): the group DM followed the configured sender policy in both denied and explicitly allowed cases.
- Fresh automated code review completed with no actionable findings.

AI-assisted implementation; the author reviewed the code and validation results.
