### PR TITLE
fix(release): accept Kova collector-only phases

### DIFF
--- a/scripts/lib/kova-report-gate.mjs
+++ b/scripts/lib/kova-report-gate.mjs
@@ -96,6 +96,23 @@ function validateCommandResult(value, label) {
   check(result.status === 0 && result.timedOut === false, `${label} failed`);
 }
 
+function validateCollectorOnlyPhase(phase) {
+  check(
+    phase.driverKind === "none" && phase.collectionIntent === "post-ready-health",
+    "commandless phase was not a collector-only phase",
+  );
+  const evidence = array(phase.evidence, "collector-only phase evidence");
+  check(
+    evidence.length > 0 &&
+      evidence.every((entry) => typeof entry === "string" && entry.trim().length > 0),
+    "collector-only phase evidence was invalid",
+  );
+  check(
+    object(phase.metrics, "collector-only phase metrics").schemaVersion === "kova.envMetrics.v1",
+    "collector-only phase metrics schema was invalid",
+  );
+}
+
 function alreadyAbsent(result, noun) {
   check(
     Number.isSafeInteger(result.status) && result.status !== 0,
@@ -128,9 +145,23 @@ function validateRecord(recordValue) {
   const phases = array(record.phases, "record phases");
   check(phases.length > 0, "record had no phases");
   for (const phaseValue of phases) {
-    const results = array(object(phaseValue, "phase").results, "phase results");
-    check(results.length > 0, "phase had no command results");
-    results.forEach((result, index) => validateCommandResult(result, `phase result ${index}`));
+    const phase = object(phaseValue, "phase");
+    const commands = array(phase.commands, "phase commands");
+    const results = array(phase.results, "phase results");
+    check(commands.length === results.length, "phase command/result counts did not match");
+    if (commands.length === 0) {
+      validateCollectorOnlyPhase(phase);
+      continue;
+    }
+    results.forEach((resultValue, index) => {
+      const result = object(resultValue, `phase result ${index}`);
+      check(
+        text(result.command, `phase result ${index} command`) ===
+          text(commands[index], `phase command ${index}`),
+        `phase command ${index} did not match its result`,
+      );
+      validateCommandResult(result, `phase result ${index}`);
+    });
   }
   validateCleanup(
     record.cleanup,

--- a/test/scripts/kova-report-gate.test.ts
+++ b/test/scripts/kova-report-gate.test.ts
@@ -206,7 +206,13 @@ function partialReport(): JsonObject {
           cpuPercentMax: 80,
           peakRssMb: 650,
         },
-        phases: [{ id: "agent-turn", results: [commandResult()] }],
+        phases: [
+          {
+            commands: [commandResult().command],
+            id: "agent-turn",
+            results: [commandResult()],
+          },
+        ],
         profiling: normalProfiling(),
         scenario: SCENARIO,
         state: { id: STATE },
@@ -300,7 +306,13 @@ function profiledResourceReport(): JsonObject {
             "agent-process": { maxCpuPercent: 156.2, peakRssMb: 923.7 },
           },
         },
-        phases: [{ id: "agent-turn", results: [commandResult()] }],
+        phases: [
+          {
+            commands: [commandResult().command],
+            id: "agent-turn",
+            results: [commandResult()],
+          },
+        ],
         profiling: deepProfiling(),
         scenario: SCENARIO,
         state: { id: STATE },
@@ -415,6 +427,21 @@ describe("scripts/lib/kova-report-gate.mjs", () => {
       classification: "filtered-partial",
       ok: true,
     });
+  });
+
+  it("accepts a declared collector-only phase without commands", () => {
+    const report = partialReport();
+    setAt(report, ["records", 0, "phases", 0], {
+      collectionIntent: "post-ready-health",
+      commands: [],
+      driverKind: "none",
+      evidence: ["startup logs"],
+      id: "logs",
+      metrics: { schemaVersion: "kova.envMetrics.v1" },
+      results: [],
+    });
+
+    expect(evaluateToleratedPartialKovaReport(report)).toEqual({ ok: true });
   });
 
   it("accepts an exact deep-profile resource-only rejection", () => {
@@ -548,6 +575,15 @@ describe("scripts/lib/kova-report-gate.mjs", () => {
     [
       "rejects timed-out phase commands",
       (report) => setAt(report, ["records", 0, "phases", 0, "results", 0, "timedOut"], true),
+    ],
+    [
+      "rejects phase command/result count drift",
+      (report) => setAt(report, ["records", 0, "phases", 0, "results"], []),
+    ],
+    [
+      "rejects phase command/result identity drift",
+      (report) =>
+        setAt(report, ["records", 0, "phases", 0, "results", 0, "command"], "different command"),
     ],
     [
       "rejects retained record cleanup",
@@ -831,6 +867,13 @@ describe("scripts/lib/kova-report-gate.mjs", () => {
     [
       "rejects PARTIAL phase failures",
       (report) => setAt(report, ["records", 0, "phases", 0, "results", 0, "status"], 1),
+    ],
+    [
+      "rejects unmarked commandless PARTIAL phases",
+      (report) => {
+        setAt(report, ["records", 0, "phases", 0, "commands"], []);
+        setAt(report, ["records", 0, "phases", 0, "results"], []);
+      },
     ],
     [
       "rejects PARTIAL cleanup failures",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the OpenClaw Performance release gate rejected successful filtered Kova runs when a scenario included a collector-only phase with no shell commands.

The exact beta candidate run completed all 18 selected scenario records successfully, but the trusted report adapter rejected Kova's intentional `commands: []` / `results: []` startup-log phase.

## Why This Change Was Made

The report adapter now validates exact planned-command/result cardinality and command identity. A commandless phase is accepted only when it carries Kova's explicit collector contract: no driver, post-ready health collection intent, non-empty evidence labels, and `kova.envMetrics.v1` metrics.

This preserves fail-closed command receipt validation without treating collector-only evidence phases as missing execution proof.

## User Impact

Release operators can rely on successful filtered Kova performance evidence without false failures from collector-only phases. Product runtime behavior is unchanged.

## Evidence

- Exact failed workflow artifact from https://github.com/openclaw/openclaw/actions/runs/29131861954: 18/18 selected records passed; the patched adapter classifies the report as `filtered-partial`.
- Blacksmith Testbox `tbx_01kx77afzrrtmvjmt4f93rq9jm`: `pnpm test:serial test/scripts/kova-report-gate.test.ts`, 96/96 passed.
- `oxfmt --check` on both changed files.
- `git diff --check`.
- Autoreview: accepted collector-boundary finding fixed; remaining finding rejected after direct source inspection proved both current pinned Kova `2ef781190516c09df9891317654a0484bf4f0d46` and pending Kova `99b4b5c70fac2b13c48550c1d9bed09b795f0186` emit planned `commands` in `kova.report.v1` phases.
