### PR TITLE
fix: gateway watch stays detached in limited terminals

### DIFF
--- a/scripts/gateway-watch-tmux.mjs
+++ b/scripts/gateway-watch-tmux.mjs
@@ -26,6 +26,7 @@ const TMUX_CHILD_ENV_KEYS = [
   "OPENCLAW_GATEWAY_PORT",
   "OPENCLAW_GATEWAY_RESTART_TRACE",
   "OPENCLAW_GATEWAY_STARTUP_TRACE",
+  "OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR",
   "OPENCLAW_HOME",
   "OPENCLAW_PROFILE",
   RUN_NODE_CPU_PROF_DIR_ENV,
@@ -185,9 +186,12 @@ export const buildGatewayWatchTmuxCommand = ({
 } = {}) => {
   const shell = resolveShell(env);
   const colorEnv = resolveColorEnv(env);
+  // tmux sessions retain their own environment across respawns. Clear supported
+  // selectors before applying the invoking process's current values.
   const childEnv = [
     "env",
     ...colorEnv.options,
+    ...TMUX_CHILD_ENV_KEYS.flatMap((key) => ["-u", key]),
     `OPENCLAW_GATEWAY_WATCH_TMUX_CHILD=1`,
     `OPENCLAW_GATEWAY_WATCH_SESSION=${sessionName}`,
     ...colorEnv.assignments,
@@ -242,7 +246,16 @@ const shouldAttachTmux = ({ env, stdinIsTTY, stdoutIsTTY }) => {
   if (TMUX_ATTACH_DISABLE_VALUES.has(raw)) {
     return false;
   }
-  return !env.CI && stdinIsTTY === true && stdoutIsTTY === true;
+  // TERM=dumb pseudo-TTYs cannot satisfy tmux's clear/cursor requirements.
+  const term = String(env.TERM ?? "")
+    .trim()
+    .toLowerCase();
+  return (
+    !env.CI &&
+    stdinIsTTY === true &&
+    stdoutIsTTY === true &&
+    (Boolean(env.TMUX) || (term !== "" && term !== "dumb"))
+  );
 };
 
 const attachTmux = ({ env, sessionName, spawnSyncImpl }) => {

--- a/src/infra/gateway-watch-tmux.test.ts
+++ b/src/infra/gateway-watch-tmux.test.ts
@@ -77,6 +77,7 @@ describe("gateway-watch tmux wrapper", () => {
         OPENCLAW_GATEWAY_PORT: "19001",
         OPENCLAW_GATEWAY_RESTART_TRACE: "1",
         OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR: "0",
         OPENCLAW_PROFILE: "Dev Profile",
         OPENCLAW_TRACE_SYNC_IO: "0",
         SHELL: "/bin/zsh",
@@ -94,8 +95,10 @@ describe("gateway-watch tmux wrapper", () => {
     expect(command).toContain("'OPENCLAW_GATEWAY_PORT=19001'");
     expect(command).toContain("'OPENCLAW_GATEWAY_RESTART_TRACE=1'");
     expect(command).toContain("'OPENCLAW_GATEWAY_STARTUP_TRACE=1'");
+    expect(command).toContain("'OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0'");
     expect(command).toContain("'OPENCLAW_PROFILE=Dev Profile'");
     expect(command).toContain("'OPENCLAW_TRACE_SYNC_IO=0'");
+    expect(command).toContain("'\\''-u'\\'' '\\''OPENCLAW_SKIP_CHANNELS'\\''");
     expect(command).toContain("/opt/node");
     expect(command).toContain("scripts/watch-node.mjs");
     expect(command).toContain("gateway");
@@ -320,7 +323,7 @@ describe("gateway-watch tmux wrapper", () => {
     const code = runGatewayWatchTmuxMain({
       args: ["gateway", "--force"],
       cwd: "/repo",
-      env: { SHELL: "/bin/zsh" },
+      env: { SHELL: "/bin/zsh", TERM: "xterm-256color" },
       nodePath: "/node",
       spawnSync,
       stderr: stderr.stream,
@@ -337,6 +340,36 @@ describe("gateway-watch tmux wrapper", () => {
     expect(stdout.chunks.join("")).not.toContain("tmux attach -t");
   });
 
+  it.each([undefined, "", "dumb", "DUMB"])(
+    "keeps a capability-limited TERM=%s pseudo-terminal detached",
+    (term) => {
+      const stdout = createOutput();
+      const stderr = createOutput();
+      const spawnSync = vi
+        .fn()
+        .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+        .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+
+      const code = runGatewayWatchTmuxMain({
+        args: ["gateway", "--force"],
+        cwd: "/repo",
+        env: { SHELL: "/bin/zsh", TERM: term },
+        nodePath: "/node",
+        spawnSync,
+        stderr: stderr.stream,
+        stdinIsTTY: true,
+        stdout: stdout.stream,
+        stdoutIsTTY: true,
+      });
+
+      expect(code).toBe(0);
+      expect(spawnSync).toHaveBeenCalledTimes(4);
+      expect(stdout.chunks.join("")).toContain("tmux attach -t openclaw-gateway-watch-main");
+    },
+  );
+
   it("switches tmux clients instead of nesting attach when already inside tmux", () => {
     const stdout = createOutput();
     const stderr = createOutput();
@@ -351,7 +384,7 @@ describe("gateway-watch tmux wrapper", () => {
     const code = runGatewayWatchTmuxMain({
       args: ["gateway", "--force"],
       cwd: "/repo",
-      env: { SHELL: "/bin/zsh", TMUX: "/tmp/tmux-501/default,1,0" },
+      env: { SHELL: "/bin/zsh", TERM: "dumb", TMUX: "/tmp/tmux-501/default,1,0" },
       nodePath: "/node",
       spawnSync,
       stderr: stderr.stream,
@@ -407,7 +440,11 @@ describe("gateway-watch tmux wrapper", () => {
     const code = runGatewayWatchTmuxMain({
       args: ["gateway", "--force", "--port=19001"],
       cwd: "/repo",
-      env: { OPENCLAW_PROFILE: "dev", SHELL: "/bin/zsh" },
+      env: {
+        OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR: "0",
+        OPENCLAW_PROFILE: "dev",
+        SHELL: "/bin/zsh",
+      },
       nodePath: "/node",
       spawnSync,
       stderr: stderr.stream,
@@ -427,6 +464,8 @@ describe("gateway-watch tmux wrapper", () => {
       "/repo",
     ]);
     expect(String(respawnArgs[6])).toContain("scripts/watch-node.mjs");
+    expect(String(respawnArgs[6])).toContain("OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0");
+    expect(String(respawnArgs[6])).toContain("OPENCLAW_SKIP_CHANNELS");
     expect(requireRecord(respawnCall[2], "spawn options").encoding).toBe("utf8");
     expect(stderr.chunks.join("")).toContain(
       "gateway:watch restarted in tmux session openclaw-gateway-watch-dev-19001",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running `pnpm gateway:watch` from an agent or pseudo-terminal would see tmux start the watch session successfully, then fail the command with `terminal does not support clear` when `TERM` was missing or set to `dumb`.

Repeated watch runs could also retain stale supported OpenClaw selectors in the long-lived tmux environment, and the documented `OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR` selector was not forwarded to the watched child.

## Why This Change Was Made

Default auto-attach now requires a usable terminal capability declaration, while explicit attach choices and in-tmux client switching remain authoritative. The tmux child command clears every supported selector before applying the invoking process's current values, including the auto-doctor override, so pane respawns cannot reuse stale settings.

This is AI-assisted. I reviewed the implementation and understand the tmux attach and environment-lifecycle changes.

## User Impact

Agent execs and capability-limited pseudo-terminals can start or restart `gateway:watch` without a false command failure. Operators still receive attach, restart, and stop instructions, and repeated runs use the current supported watch environment rather than values retained by tmux.

## Evidence

- Before: `TERM=dumb pnpm gateway:watch` started `openclaw-gateway-watch-main`, attempted `tmux attach-session`, reported `terminal does not support clear`, and exited 1.
- After: the same command restarted the detached session, printed attach/restart/stop instructions, and exited 0; the watched Gateway then reached `[gateway] ready`.
- Blacksmith Testbox `tbx_01kx77z0frwb5swvn3hh1kzz7k`: `pnpm test src/infra/gateway-watch-tmux.test.ts` — 19 tests passed.
- Same Testbox: `pnpm check:changed -- scripts/gateway-watch-tmux.mjs src/infra/gateway-watch-tmux.test.ts` — passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Source-blind behavior probe: `TERM=dumb` exited 0, remained detached, and printed usable lifecycle instructions.
