### PR TITLE
feat(mac): add bulk Approve All / Reject All to the pairing approval panel

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19891,15 +19891,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 52,
+      "line": 59,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Not Now",
       "surface": "apple",
       "id": "native.apple.048e9cc88fb7af55"
     },
     {
+      "kind": "ui-call",
+      "line": 73,
+      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
+      "source": "Reject All",
+      "surface": "apple",
+      "id": "native.apple.4f271aca6df52a32"
+    },
+    {
+      "kind": "ui-call",
+      "line": 80,
+      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
+      "source": "Approve All",
+      "surface": "apple",
+      "id": "native.apple.bef7b0a91ca5c184"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 100,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Request",
       "surface": "apple",
@@ -19907,7 +19923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 100,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Requests",
       "surface": "apple",
@@ -19915,7 +19931,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 176,
+      "line": 209,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Copy full ID",
       "surface": "apple",
@@ -19923,7 +19939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 192,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Device",
       "surface": "apple",
@@ -19931,7 +19947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 192,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Node",
       "surface": "apple",
@@ -19939,7 +19955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 214,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Reject",
       "surface": "apple",
@@ -19947,7 +19963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 258,
+      "line": 292,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A device wants to connect to OpenClaw.",
       "surface": "apple",
@@ -19955,7 +19971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 258,
+      "line": 292,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A node wants to connect to OpenClaw.",
       "surface": "apple",
@@ -19963,7 +19979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 269,
+      "line": 303,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "New device",
       "surface": "apple",
@@ -19971,7 +19987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 269,
+      "line": 303,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "OpenClaw Mac app",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -19899,7 +19899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 73,
+      "line": 76,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Reject All",
       "surface": "apple",
@@ -19907,7 +19907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 80,
+      "line": 83,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve All",
       "surface": "apple",
@@ -19915,7 +19915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 100,
+      "line": 103,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Request",
       "surface": "apple",
@@ -19923,7 +19923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 100,
+      "line": 103,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Requests",
       "surface": "apple",
@@ -19931,7 +19931,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 209,
+      "line": 212,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Copy full ID",
       "surface": "apple",
@@ -19939,7 +19939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 227,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Device",
       "surface": "apple",
@@ -19947,7 +19947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 224,
+      "line": 227,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Node",
       "surface": "apple",
@@ -19955,7 +19955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 238,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Reject",
       "surface": "apple",
@@ -19963,7 +19963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 292,
+      "line": 295,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A device wants to connect to OpenClaw.",
       "surface": "apple",
@@ -19971,7 +19971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 292,
+      "line": 295,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A node wants to connect to OpenClaw.",
       "surface": "apple",
@@ -19979,7 +19979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 303,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "New device",
       "surface": "apple",
@@ -19987,7 +19987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 303,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "OpenClaw Mac app",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
+++ b/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
@@ -107,6 +107,15 @@ final class PairingApprovalCenter {
         }
     }
 
+    /// Resolve every visible card with one decision. Iterates a snapshot so
+    /// handler completions that resync the queue cannot skip neighbors;
+    /// `decide`'s in-flight guard keeps repeated clicks idempotent.
+    func decideAll(_ decision: Decision) {
+        for card in self.cards {
+            self.decide(card, decision)
+        }
+    }
+
     /// "Not Now": hide the panel without resolving anything. Requests stay
     /// pending on the gateway (TTL applies) and in the menu-bar count.
     func snooze() {
@@ -161,6 +170,12 @@ final class PairingApprovalCenter {
     }
 
     #if DEBUG
+    /// Test seam: seed the queue without presenting the panel (tests run
+    /// without an NSApplication, so `updatePanel` must not fire).
+    func _testSetCards(_ cards: [Card]) {
+        self.cards = cards
+    }
+
     /// Demo/screenshot hook: decisions on injected cards resolve locally
     /// instead of routing to a prompter.
     private var demoRequestIds: Set<String> = []

--- a/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
+++ b/apps/macos/Sources/OpenClaw/PairingApprovalCenter.swift
@@ -107,11 +107,12 @@ final class PairingApprovalCenter {
         }
     }
 
-    /// Resolve every visible card with one decision. Iterates a snapshot so
-    /// handler completions that resync the queue cannot skip neighbors;
+    /// Resolve a batch of cards with one decision. Takes the caller's
+    /// rendered snapshot instead of reading the live queue: a request that
+    /// arrives between render and click must never be resolved unseen.
     /// `decide`'s in-flight guard keeps repeated clicks idempotent.
-    func decideAll(_ decision: Decision) {
-        for card in self.cards {
+    func decideAll(_ cards: [Card], _ decision: Decision) {
+        for card in cards {
             self.decide(card, decision)
         }
     }
@@ -170,8 +171,8 @@ final class PairingApprovalCenter {
     }
 
     #if DEBUG
-    /// Test seam: seed the queue without presenting the panel (tests run
-    /// without an NSApplication, so `updatePanel` must not fire).
+    /// Test seam: seed the live queue without presenting the panel (tests
+    /// run without an NSApplication, so `updatePanel` must not fire).
     func _testSetCards(_ cards: [Card]) {
         self.cards = cards
     }

--- a/apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift
+++ b/apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift
@@ -66,16 +66,19 @@ struct PairingApprovalPanelView: View {
                 notNow
                 Spacer()
                 // No keyboard shortcuts here: bulk approval is a security
-                // decision and must never be a stray Return press.
+                // decision and must never be a stray Return press. Both
+                // actions resolve the rendered `cards` snapshot, never the
+                // live queue, so a request that arrives mid-click cannot be
+                // approved before it was ever displayed.
                 Button(role: .destructive) {
-                    self.center.decideAll(.reject)
+                    self.center.decideAll(cards, .reject)
                 } label: {
                     Text("Reject All")
                         .padding(.horizontal, 6)
                 }
                 .pairingActionStyle(prominent: false)
                 Button {
-                    self.center.decideAll(.approve)
+                    self.center.decideAll(cards, .approve)
                 } label: {
                     Text("Approve All")
                         .padding(.horizontal, 6)

--- a/apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift
+++ b/apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift
@@ -47,15 +47,48 @@ struct PairingApprovalPanelView: View {
                 }
             }
             .scrollBounceBehavior(.basedOnSize)
-            HStack {
-                Spacer()
-                Button("Not Now") { self.center.snooze() }
-                    .keyboardShortcut(.cancelAction)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-            }
+            self.footer(cards: cards)
         }
         .padding(18)
+    }
+
+    /// Single request keeps the minimal "Not Now" footer; multiple requests
+    /// add one-click bulk actions so a queue never needs card-by-card clicks.
+    @ViewBuilder
+    private func footer(cards: [PairingApprovalCenter.Card]) -> some View {
+        let notNow = Button("Not Now") { self.center.snooze() }
+            .keyboardShortcut(.cancelAction)
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+        if cards.count > 1 {
+            let allBusy = cards.allSatisfy { self.center.decisionsInFlight.contains($0.id) }
+            HStack(spacing: 8) {
+                notNow
+                Spacer()
+                // No keyboard shortcuts here: bulk approval is a security
+                // decision and must never be a stray Return press.
+                Button(role: .destructive) {
+                    self.center.decideAll(.reject)
+                } label: {
+                    Text("Reject All")
+                        .padding(.horizontal, 6)
+                }
+                .pairingActionStyle(prominent: false)
+                Button {
+                    self.center.decideAll(.approve)
+                } label: {
+                    Text("Approve All")
+                        .padding(.horizontal, 6)
+                }
+                .pairingActionStyle(prominent: true)
+            }
+            .disabled(allBusy)
+        } else {
+            HStack {
+                Spacer()
+                notNow
+            }
+        }
     }
 
     private func header(cards: [PairingApprovalCenter.Card]) -> some View {
@@ -184,44 +217,45 @@ struct PairingRequestCardView: View {
         .onHover { self.isHoveringDetail = $0 }
     }
 
-    @ViewBuilder
     private var approveButton: some View {
-        let button = Button {
+        Button {
             self.onDecision(.approve)
         } label: {
             Text(self.card.kind == .node ? "Approve Node" : "Approve Device")
                 .padding(.horizontal, 6)
         }
-        let shortcut: KeyboardShortcut? = self.isOnlyRequest ? .defaultAction : nil
-        if #available(macOS 26.0, *) {
-            button
-                .buttonStyle(.glassProminent)
-                .buttonBorderShape(.capsule)
-                .keyboardShortcut(shortcut)
-        } else {
-            button
-                .buttonStyle(.borderedProminent)
-                .buttonBorderShape(.capsule)
-                .keyboardShortcut(shortcut)
-        }
+        .pairingActionStyle(prominent: true)
+        .keyboardShortcut(self.isOnlyRequest ? .defaultAction : nil)
     }
 
-    @ViewBuilder
     private var rejectButton: some View {
-        let button = Button(role: .destructive) {
+        Button(role: .destructive) {
             self.onDecision(.reject)
         } label: {
             Text("Reject")
                 .padding(.horizontal, 6)
         }
+        .pairingActionStyle(prominent: false)
+    }
+}
+
+extension View {
+    /// Shared capsule styling for pairing decision buttons: Liquid Glass on
+    /// macOS 26+, bordered fallback on macOS 15.
+    @ViewBuilder
+    func pairingActionStyle(prominent: Bool) -> some View {
         if #available(macOS 26.0, *) {
-            button
-                .buttonStyle(.glass)
-                .buttonBorderShape(.capsule)
+            if prominent {
+                self.buttonStyle(.glassProminent).buttonBorderShape(.capsule)
+            } else {
+                self.buttonStyle(.glass).buttonBorderShape(.capsule)
+            }
         } else {
-            button
-                .buttonStyle(.bordered)
-                .buttonBorderShape(.capsule)
+            if prominent {
+                self.buttonStyle(.borderedProminent).buttonBorderShape(.capsule)
+            } else {
+                self.buttonStyle(.bordered).buttonBorderShape(.capsule)
+            }
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
@@ -279,15 +279,15 @@ struct PairingApprovalCenterBulkDecisionTests {
         let recorder = DecisionRecorder()
         center.register(kind: .node) { recorder.record("node", $0, $1) }
         center.register(kind: .device) { recorder.record("device", $0, $1) }
-        center._testSetCards([
+        let rendered = [
             self.card(kind: .node, requestId: "req-1"),
             self.card(kind: .device, requestId: "req-2"),
-        ])
+        ]
 
-        center.decideAll(.approve)
+        center.decideAll(rendered, .approve)
         #expect(center.decisionsInFlight == ["req-1", "req-2"])
         // A second bulk click while decisions are in flight must not re-fire.
-        center.decideAll(.approve)
+        center.decideAll(rendered, .approve)
 
         var attempts = 0
         while recorder.decided.count < 2 || !center.decisionsInFlight.isEmpty, attempts < 10_000 {
@@ -302,12 +302,12 @@ struct PairingApprovalCenterBulkDecisionTests {
         let center = PairingApprovalCenter()
         let recorder = DecisionRecorder()
         center.register(kind: .device) { recorder.record("device", $0, $1) }
-        center._testSetCards([
+        let rendered = [
             self.card(kind: .device, requestId: "req-1"),
             self.card(kind: .device, requestId: "req-2"),
-        ])
+        ]
 
-        center.decideAll(.reject)
+        center.decideAll(rendered, .reject)
 
         var attempts = 0
         while recorder.decided.count < 2, attempts < 10_000 {
@@ -315,5 +315,28 @@ struct PairingApprovalCenterBulkDecisionTests {
             await Task.yield()
         }
         #expect(recorder.decided.sorted() == ["device:req-1:reject", "device:req-2:reject"])
+    }
+
+    @Test func `bulk decisions resolve only the rendered snapshot`() async {
+        // Security invariant: a request that arrives after the footer was
+        // rendered but before the click lands must never be resolved by the
+        // stale bulk button — only what the user actually saw gets decided.
+        let center = PairingApprovalCenter()
+        let recorder = DecisionRecorder()
+        center.register(kind: .node) { recorder.record("node", $0, $1) }
+        center.register(kind: .device) { recorder.record("device", $0, $1) }
+        let rendered = [self.card(kind: .node, requestId: "req-seen")]
+        // "req-unseen" lands in the live queue after render, before the click.
+        center._testSetCards(rendered + [self.card(kind: .device, requestId: "req-unseen")])
+
+        center.decideAll(rendered, .approve)
+
+        var attempts = 0
+        while recorder.decided.isEmpty, attempts < 10_000 {
+            attempts += 1
+            await Task.yield()
+        }
+        #expect(recorder.decided == ["node:req-seen:approve"])
+        #expect(!center.decisionsInFlight.contains("req-unseen"))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
@@ -238,3 +238,82 @@ struct PairingCardPresentationTests {
         #expect(PairingApprovalCenter.shouldAutoPresent(cardIds: ["a", "b"], snoozedIds: ["a"]))
     }
 }
+
+@MainActor
+struct PairingApprovalCenterBulkDecisionTests {
+    @MainActor
+    private final class DecisionRecorder {
+        var decided: [String] = []
+
+        func record(_ kind: String, _ card: PairingApprovalCenter.Card, _ decision: PairingApprovalCenter.Decision) {
+            self.decided.append("\(kind):\(card.requestId):\(decision == .approve ? "approve" : "reject")")
+        }
+    }
+
+    private func card(
+        kind: PairingApprovalCenter.Kind,
+        requestId: String) -> PairingApprovalCenter.Card
+    {
+        PairingApprovalCenter.Card(
+            kind: kind,
+            requestId: requestId,
+            subjectId: "subject-\(requestId)",
+            displayName: nil,
+            platform: nil,
+            deviceFamily: nil,
+            modelIdentifier: nil,
+            version: nil,
+            coreVersion: nil,
+            remoteIp: nil,
+            role: nil,
+            scopes: [],
+            caps: [],
+            commands: [],
+            isRepair: false,
+            previouslyPaired: false,
+            requestedAt: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test func `decide all routes every card to its kind handler exactly once`() async {
+        let center = PairingApprovalCenter()
+        let recorder = DecisionRecorder()
+        center.register(kind: .node) { recorder.record("node", $0, $1) }
+        center.register(kind: .device) { recorder.record("device", $0, $1) }
+        center._testSetCards([
+            self.card(kind: .node, requestId: "req-1"),
+            self.card(kind: .device, requestId: "req-2"),
+        ])
+
+        center.decideAll(.approve)
+        #expect(center.decisionsInFlight == ["req-1", "req-2"])
+        // A second bulk click while decisions are in flight must not re-fire.
+        center.decideAll(.approve)
+
+        var attempts = 0
+        while recorder.decided.count < 2 || !center.decisionsInFlight.isEmpty, attempts < 10_000 {
+            attempts += 1
+            await Task.yield()
+        }
+        #expect(recorder.decided.sorted() == ["device:req-2:approve", "node:req-1:approve"])
+        #expect(center.decisionsInFlight.isEmpty)
+    }
+
+    @Test func `reject all delivers reject to every handler`() async {
+        let center = PairingApprovalCenter()
+        let recorder = DecisionRecorder()
+        center.register(kind: .device) { recorder.record("device", $0, $1) }
+        center._testSetCards([
+            self.card(kind: .device, requestId: "req-1"),
+            self.card(kind: .device, requestId: "req-2"),
+        ])
+
+        center.decideAll(.reject)
+
+        var attempts = 0
+        while recorder.decided.count < 2, attempts < 10_000 {
+            attempts += 1
+            await Task.yield()
+        }
+        #expect(recorder.decided.sorted() == ["device:req-1:reject", "device:req-2:reject"])
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The Mac app's pairing approval panel (#102535) lists every pending node/device pairing request as a card, but each one must be approved or rejected individually. When several devices reconnect at once (gateway restart, node + operator-device repair together), the operator has to click through the queue card by card. Fixes #104005.

## Why This Change Was Made

Bulk resolution belongs in the panel footer, not per card: with more than one pending request, a "Reject All" and an "Approve All" button appear next to the existing "Not Now" snooze. Both route through a new `PairingApprovalCenter.decideAll(_:_:)`, which takes the footer's rendered card snapshot and reuses the existing per-card `decide(_:_:)` path — so the in-flight guard, prompter ownership, and demo-card handling stay unchanged. A single-request panel keeps the current minimal footer.

Design notes:

- **Bulk decisions resolve only the rendered snapshot, never the live queue.** A request that arrives between render and click must never be approved unseen, so the buttons pass the `cards` array they were rendered from instead of letting the center iterate its current queue (caught by autoreview; covered by a dedicated regression test).
- Bulk approval is a security decision, so the bulk buttons deliberately get no keyboard shortcut — a stray Return cannot approve everything (single-request Return-to-approve is unchanged).
- Bulk buttons disable while every card's decision is in flight.
- The duplicated macOS 26 glass / macOS 15 bordered button-style branches in the card view were extracted into a shared `pairingActionStyle(prominent:)` helper, which the new footer buttons reuse.
- A DEBUG-only `_testSetCards` seam seeds the center's queue without presenting the NSPanel, so the new center-level tests run headless.

## User Impact

Mac app operators with multiple simultaneous pairing requests can resolve the whole queue with one click. Single-request behavior, keyboard shortcuts, and snooze are unchanged.

## Evidence

- `swift test --package-path apps/macos --filter Pairing`: 17 tests in 4 suites pass, including three new `PairingApprovalCenterBulkDecisionTests` (`decide all routes every card to its kind handler exactly once`, `reject all delivers reject to every handler`, `bulk decisions resolve only the rendered snapshot`).
- Full `swift test --package-path apps/macos --parallel`: 945+ tests across 127 suites pass.
- Autoreview (Codex `gpt-5.5`, branch vs `origin/main`): one P1 finding on the first pass (bulk action read the live queue instead of the rendered snapshot) — fixed in `fix(mac): resolve bulk pairing decisions against the rendered snapshot`; re-run clean.
- `swiftformat --lint` clean on both changed source files; `native:i18n:check` clean after inventory sync.
- Panel with two pending requests showing the new footer (window-backed test render; glass button chrome does not rasterize offscreen, so buttons appear as plain labels — layout and copy match the shipped panel):

![Pairing panel with Approve All / Reject All footer](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pairing-bulk-actions/pairing-panel-bulk-footer.png)
