### PR TITLE
fix(ui): resize dividers paint a fat multi-line bar when hovered or dragged

### DIFF
--- a/ui/src/components/resizable-divider.ts
+++ b/ui/src/components/resizable-divider.ts
@@ -23,8 +23,6 @@ export class ResizableDivider extends OpenClawLitElement {
     :host {
       width: 4px;
       cursor: col-resize;
-      background: var(--border, #333);
-      transition: background 150ms ease-out;
       flex-shrink: 0;
       position: relative;
       touch-action: none;
@@ -38,16 +36,31 @@ export class ResizableDivider extends OpenClawLitElement {
       right: -4px;
       bottom: 0;
     }
-    :host(:hover) {
-      background: var(--accent, #007bff);
+    /* The visible divider is a centered hairline, not the whole gutter:
+       filling the host paints a fat bar that stacks with neighboring pane
+       borders into a multi-line smear while dragging. */
+    :host::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 50%;
+      width: 1px;
+      transform: translateX(-50%);
+      background: var(--border, #333);
+      transition:
+        background 150ms ease-out,
+        width 150ms ease-out;
     }
-    :host(.dragging) {
+    :host(:hover)::after,
+    :host(.dragging)::after,
+    :host(:focus-visible)::after {
+      width: 2px;
       background: var(--accent, #007bff);
     }
     :host(:focus-visible) {
       outline: 2px solid var(--accent, #007bff);
       outline-offset: 2px;
-      background: var(--accent, #007bff);
     }
     :host([orientation="horizontal"]) {
       width: auto;
@@ -59,6 +72,24 @@ export class ResizableDivider extends OpenClawLitElement {
       left: 0;
       right: 0;
       bottom: -4px;
+    }
+    :host([orientation="horizontal"])::after {
+      top: 50%;
+      bottom: auto;
+      left: 0;
+      right: 0;
+      width: auto;
+      height: 1px;
+      transform: translateY(-50%);
+      transition:
+        background 150ms ease-out,
+        height 150ms ease-out;
+    }
+    :host([orientation="horizontal"]:hover)::after,
+    :host([orientation="horizontal"].dragging)::after,
+    :host([orientation="horizontal"]:focus-visible)::after {
+      width: auto;
+      height: 2px;
     }
   `;
 

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -161,10 +161,11 @@
   transition: flex 250ms ease-out;
 }
 
+/* No border-left: the resizable divider rendered next to this panel draws
+   the separator line; a border here doubles it. */
 .chat-sidebar {
   flex: 1;
   min-width: 300px;
-  border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -1370,6 +1371,5 @@
   .chat-split-container--open .chat-sidebar {
     width: 100%;
     min-width: 0;
-    border-left: none;
   }
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -664,13 +664,14 @@ html.openclaw-native-macos .shell-nav-expand {
   display: none;
 }
 
+/* 1px overlay on the nav border edge; the divider paints its own centered
+   line, so the host needs no background here. */
 .sidebar-resizer {
   grid-area: nav;
   align-self: stretch;
   justify-self: end;
   z-index: 20;
   width: 1px;
-  background: transparent;
 }
 
 .shell:has(.sidebar-resizer.dragging) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where hovering or dragging any resizable divider (chat split view, chat detail sidebar, navigation sidebar) painted the entire 4px gutter as a solid accent bar. Stacked against the active-pane ring and the detail panel's own `border-left`, the drag affordance read as an ugly multi-line smear instead of a single divider line.

The navigation sidebar resizer had the opposite bug: the document-level `.sidebar-resizer { background: transparent }` override defeats the component's shadow `:host(:hover)`/`:host(.dragging)` accent styles (document rules win over `:host` rules), so dragging the nav sidebar gave no visual feedback at all.

## Why This Change Was Made

Resize dividers should look like the hairline separators used everywhere else in the Control UI, with a thin accent highlight while interacting — not a filled gutter bar.

- `resizable-divider` host is now transparent; the visible line is a centered `::after` — 1px `var(--border)` hairline at rest, 2px `var(--accent)` on hover/drag/keyboard focus. The extended `::before` hit area and all pointer/keyboard behavior are unchanged.
- `.chat-sidebar` loses its `border-left`: the divider rendered next to it already draws that separator, so the border doubled the line (mobile already suppressed it).
- `.sidebar-resizer` drops the now-dead `background: transparent`; since the divider paints its own line, the nav resizer also gains the intended thin accent hover/drag feedback.

## User Impact

Dragging or hovering pane/sidebar dividers shows one thin accent line (color feedback preserved), instead of a fat bar flanked by extra border lines. The navigation sidebar resizer now gives hover/drag feedback at all.

| Surface | Before | After |
| --- | --- | --- |
| Split view, dragging | ![before drag](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/before-split-drag-wide.png) | ![after drag](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/after-split-drag-wide.png) |
| Divider close-up, hover (4x zoom) | ![before hover zoom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/before-zoom-hover.png) | ![after hover zoom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/after-zoom-hover.png) |
| Divider close-up, idle (4x zoom) | ![before idle zoom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/before-zoom-idle.png) | ![after idle zoom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/after-zoom-idle.png) |
| Nav sidebar, dragging | ![before nav drag](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/before-nav-drag.png) | ![after nav drag](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/after-nav-drag.png) |

Full-window drag state: [before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/before-full-split.png) / [after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/resizable-divider-thin-line/after-full-split.png)

## Evidence

- Screenshots above captured with the repo's mock-gateway Playwright harness (`ui/src/test-helpers/control-ui-e2e.ts`), light theme, split view open, mid-drag / hover / idle.
- `pnpm test ui/src/components/resizable-divider.test.ts ui/src/pages/chat/chat-page.test.ts` — 18/18 passed. These cover separator semantics, keyboard resize, and pointer drag, all untouched by this change.
- `ui/src/e2e/sidebar-customization.e2e.test.ts` asserts `elementFromPoint` hits the divider and drag-resizes the nav to an exact width; the host box and `::before` hit area are unchanged, so those contracts hold.
- `pnpm check:changed` (lint/format/typecheck lanes) green.
- Structured autoreview (Codex, gpt-5.5): clean.
