### PR TITLE
fix: sanitize oversized plugin command arguments

### DIFF
--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -739,6 +739,29 @@ describe("registerPluginCommand", () => {
     expect(observedOwnerStatus).toBeUndefined();
   });
 
+  it("sanitizes oversized arguments before passing them to plugin handlers", async () => {
+    let observedArgs: string | undefined;
+    registerVoiceCommandForTest({
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        observedArgs = ctx.args;
+        return { text: "ok" };
+      },
+    });
+    const match = requirePluginCommandMatch(`/voice \0${"a".repeat(4094)}😀tail`);
+
+    await executePluginCommand({
+      command: match.command,
+      args: match.args,
+      channel: "telegram",
+      isAuthorizedSender: true,
+      commandBody: "/voice",
+      config: {},
+    });
+
+    expect(observedArgs).toBe("a".repeat(4094));
+  });
+
   it("ignores owner status opt-in from direct plugin command registration", async () => {
     let observedOwnerStatus: boolean | undefined;
     registerPluginCommand("demo-plugin", {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -6,6 +6,7 @@
  */
 
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBoundAgentIdForSession } from "../agents/session-agent-binding.js";
 import { resolveConversationBindingContext } from "../channels/conversation-binding-context.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -122,14 +123,9 @@ function sanitizeArgs(args: string | undefined): string | undefined {
     return undefined;
   }
 
-  // Enforce length limit
-  if (args.length > MAX_ARGS_LENGTH) {
-    return args.slice(0, MAX_ARGS_LENGTH);
-  }
-
   // Remove control characters (except newlines and tabs which may be intentional)
   let sanitized = "";
-  for (const char of args) {
+  for (const char of truncateUtf16Safe(args, MAX_ARGS_LENGTH)) {
     const code = char.charCodeAt(0);
     const isControl = (code <= 0x1f && code !== 0x09 && code !== 0x0a) || code === 0x7f;
     if (!isControl) {


### PR DESCRIPTION
## What Problem This Solves

Plugin command arguments longer than 4,096 UTF-16 units bypassed control-character filtering entirely. The raw cutoff could also split a surrogate pair and pass a lone surrogate to plugin handlers.

## Why This Change Was Made

Bound the input with the shared UTF-16-safe truncation helper before the existing control-character scan. Truncating first preserves the existing defense-in-depth input budget while ensuring every retained character is sanitized.

## User Impact

Oversized plugin command arguments now receive the same control-character filtering as shorter inputs, without malformed Unicode at the length boundary.

## Evidence

- Blacksmith Testbox `tbx_01kx79828z08151qpy9sxa6ad4`: `pnpm test src/plugins/commands.test.ts` — 53 passed.
- Same Testbox: `pnpm check:changed -- src/plugins/commands.ts src/plugins/commands.test.ts` — passed core/type/lint and repository guards.
- Fresh autoreview — clean, correctness 0.99.
- `git diff --check` — passed.
