### PR TITLE
feat(ui): render assistant replies as a flat text stream in web chat

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -752,13 +752,15 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           };
         };
         return {
-          bubble: styleFor(".chat-group.assistant .chat-bubble:first-child"),
+          assistantBubble: styleFor(".chat-group.assistant .chat-bubble:first-child"),
+          bubble: styleFor(".chat-group.user .chat-bubble:first-child"),
           composer: styleFor(".agent-chat__input"),
           footer: styleFor(".agent-chat__composer-footer"),
           textarea: styleFor(".agent-chat__composer-combobox > textarea"),
         };
       });
 
+      expect(geometry.assistantBubble).not.toBeNull();
       expect(geometry.bubble).not.toBeNull();
       expect(geometry.composer).not.toBeNull();
       expect(geometry.footer).not.toBeNull();
@@ -773,6 +775,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           geometry.bubble?.paddingLeft,
         ]),
       ).toEqual(new Set([16]));
+      // Assistant replies render flat (no bubble card): zero horizontal inset
+      // keeps the text on the tool-row left edge.
+      expect(geometry.assistantBubble?.paddingLeft).toBe(0);
+      expect(geometry.assistantBubble?.paddingRight).toBe(0);
       expect(geometry.composer?.borderRadius).toBe(10);
 
       const composerInset = width <= 768 ? 4 : 8;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -266,6 +266,25 @@ img.chat-avatar {
   box-shadow: none;
 }
 
+/* Assistant replies render as a flat text stream: only user messages keep the
+   bubble card. Border collapses to 0 so the streaming border pulse and hover
+   outline become no-ops without extra rules. */
+.chat-group.assistant .chat-group-messages {
+  max-width: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
+}
+
+.chat-group.assistant .chat-bubble {
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+/* Keep the typing dots on the same left edge as the flat text column. */
+.chat-group.assistant .chat-bubble.chat-reading-indicator {
+  padding: 10px 0;
+}
+
 .chat-duplicate-count {
   display: inline-flex;
   align-items: center;
@@ -397,7 +416,8 @@ img.chat-avatar {
   box-shadow: inset 0 1px 0 var(--card-highlight);
 }
 
-:root[data-theme-mode="light"] .chat-bubble--tool-shell {
+:root[data-theme-mode="light"] .chat-bubble--tool-shell,
+:root[data-theme-mode="light"] .chat-group.assistant .chat-bubble {
   border-color: transparent;
   background: transparent;
   box-shadow: none;
@@ -622,7 +642,8 @@ details.msg-meta:not([open]) .msg-meta__details {
     max-width: 82%;
   }
 
-  .chat-group.tool .chat-group-messages {
+  .chat-group.tool .chat-group-messages,
+  .chat-group.assistant .chat-group-messages {
     max-width: calc(100% - 46px);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The Control UI chat renders both sides of a conversation as card bubbles. Long assistant replies read as heavy floating boxes, and the double-bubble layout wastes horizontal space and falls apart in narrow windows (see the sidebar-overlap complaints in narrow layouts). Assistant output is a stream of prose, code, and tool activity — a card border and background add chrome without meaning.

## Why This Change Was Made

Assistant replies now render as a flat text stream: no card background, border, hover outline, or inner padding, with the reply column widened to the same measure as tool activity rows so agent text, tool rows, and code blocks share one left edge. User messages keep the accent bubble on the right, so turns stay easy to scan. This is CSS-only (`ui/src/styles/chat/grouped.css`) using the same reset pattern as the existing flat tool-row shell; DOM structure, hover actions, right-click reply, and delete affordances are unchanged. This also aligns the Control UI with the documented Mac WebChat presentation ("assistant messages render as plain text with an avatar, user messages as accent bubbles", `docs/platforms/mac/webchat.md`). Web (Control UI) only; channel transports are untouched.

## User Impact

Agent replies in the web UI (and the Mac app's embedded web view) read as a continuous document instead of stacked cards: wider readable measure, aligned code blocks and tool rows, and less visual noise in narrow windows. User messages look the same as before.

## Evidence

Deterministic mock-gateway screenshots (Playwright, seeded history with user/assistant/tool turns):

| Desktop dark | Desktop light |
|---|---|
| ![desktop dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream/desktop-dark.png) | ![desktop light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream/desktop-light.png) |

| Narrow (620px) dark | Mobile (390px) light |
|---|---|
| ![narrow dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream/narrow-dark.png) | ![mobile light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream/mobile-light.png) |

- `ui/src/pages/chat/chat-responsive.browser.test.ts` updated: card-inset assertions now target the user bubble (which keeps the card), plus a new flat-contract assertion that assistant bubbles have zero horizontal inset. 56/56 tests pass on Blacksmith Testbox.
- `pnpm check:changed` green (delegated).
- Streaming border pulse and hover outline collapse to no-ops via `border: 0` — no JS churn; the `.chat-bubble` class stays in the DOM so reply/copy/expand handlers are untouched.
