### PR TITLE
fix(tui): preserve UTF-16 pairs in long tokens

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -382,6 +382,12 @@ describe("sanitizeRenderableText", () => {
     expectTokenWidthUnderLimit(input);
   });
 
+  it("keeps surrogate pairs intact when breaking long prose tokens", () => {
+    const input = `${"a".repeat(31)}😀b`;
+
+    expect(sanitizeRenderableText(input)).toBe(`${"a".repeat(31)} 😀b`);
+  });
+
   it("preserves long CJK prose without inserting display spaces", () => {
     const input =
       "特蕾莎修女是一个极端投入极有宗教信念愿意亲身服务底层苦难者的人但她不是现代公共卫生意义上的慈善改革者";

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -5,6 +5,7 @@ import type { SessionGoal } from "../config/sessions/types.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
+import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
@@ -55,17 +56,6 @@ function stripControlChars(text: string): string {
     }
   }
   return sanitized;
-}
-
-function chunkToken(token: string, maxChars: number): string[] {
-  if (token.length <= maxChars) {
-    return [token];
-  }
-  const chunks: string[] = [];
-  for (let i = 0; i < token.length; i += maxChars) {
-    chunks.push(token.slice(i, i + maxChars));
-  }
-  return chunks;
 }
 
 function isCopySensitiveToken(token: string): boolean {
@@ -122,7 +112,7 @@ function normalizeLongTokenForDisplay(token: string): string {
   if (!ALPHANUMERIC_RE.test(token)) {
     return token;
   }
-  return chunkToken(token, MAX_TOKEN_CHARS).join(" ");
+  return chunkTextByBreakResolver(token, MAX_TOKEN_CHARS, () => MAX_TOKEN_CHARS).join(" ");
 }
 
 type Segment = { kind: "prose" | "code"; text: string };


### PR DESCRIPTION
## What Problem This Solves

The TUI's long-prose-token display wrapping used raw UTF-16 slicing. When the 32-unit boundary landed between an emoji's surrogate halves, the rendered text contained two replacement characters separated by the inserted display space.

## Why This Change Was Made

Delete the TUI-local slicer and reuse the shared surrogate-safe chunking primitive. The matched input is a single non-whitespace token, so the shared helper preserves the existing display behavior while moving only unsafe UTF-16 boundaries.

## User Impact

Long unbroken prose still wraps for narrow terminals, but emoji and other supplementary-plane characters remain intact at wrap boundaries.

## Evidence

- Blacksmith Testbox `tbx_01kx7a49qv2xqp9yt3dbrt1mmh`: `pnpm test src/tui/tui-formatters.test.ts` — 55 passed.
- Same Testbox: `pnpm check:changed -- src/tui/tui-formatters.ts src/tui/tui-formatters.test.ts` — passed core/type/lint and repository guards.
- Fresh autoreview — clean, correctness 0.98.
- Regression verifies the exact 31 ASCII units + emoji boundary.
- Production code shrinks by 10 lines; `git diff --check` passed.
