### PR TITLE
fix(release): prevent Telegram attestor buffer overflow

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -645,7 +645,13 @@ jobs:
 
           const sourceRoot = process.env.SOURCE_ROOT;
           const candidateRoot = process.env.CANDIDATE_ROOT;
-          const records = execFileSync("git", ["-C", sourceRoot, "ls-files", "-s", "-z"])
+          // Node defaults to 1 MiB, smaller than this repo's tracked-file index output.
+          const trackedFileOutput = execFileSync(
+            "git",
+            ["-C", sourceRoot, "ls-files", "-s", "-z"],
+            { maxBuffer: 16 * 1024 * 1024 },
+          );
+          const records = trackedFileOutput
             .toString("utf8")
             .split("\0")
             .filter(Boolean);

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -328,6 +328,15 @@ describe("release Telegram QA workflow", () => {
     }
   });
 
+  it("allows the tracked-file index to exceed Node's default child-process buffer", () => {
+    const compareStep = workflowStep(
+      workflowJob("attest_candidate"),
+      "Compare candidate tracked source and tree",
+    );
+
+    expect(compareStep.run).toContain("maxBuffer: 16 * 1024 * 1024");
+  });
+
   it("emits the release-check terminal status contract and fails closed", () => {
     const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8")) as {
       jobs?: Record<string, WorkflowJob>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stable release validation could fail before Telegram live QA when the tracked-file index exceeded Node's default synchronous child-process output buffer.

## Why This Change Was Made

The candidate attestor still compares every tracked file, symlink, executable bit, and byte against the independently checked-out source. It now gives the bounded `git ls-files -s -z` call a 16 MiB buffer instead of relying on Node's 1 MiB default.

## User Impact

Release maintainers can complete Telegram candidate attestation as the repository grows. Product runtime behavior is unchanged.

## Evidence

- Failure: [Full Release Validation 29133134040](https://github.com/openclaw/openclaw/actions/runs/29133134040), Telegram attestor job `86492953024`, `spawnSync git ENOBUFS` at 1,060,864 bytes.
- Added workflow contract coverage for the explicit buffer cap.
- Targeted `oxfmt --check` passed.
- Workflow YAML parse passed.
- `git diff --check` passed.
- Fresh Codex autoreview clean, confidence 0.98.
- Hosted focused test and exact Telegram QA rerun will be linked before merge.
