### PR TITLE
fix(config): register zod locale explicitly so packaged builds keep real validation messages

### DIFF
--- a/src/config/zod-schema.locale.test.ts
+++ b/src/config/zod-schema.locale.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { installZodDefaultLocale, OpenClawSchema } from "./zod-schema.js";
+
+function firstIssueMessage(result: z.ZodSafeParseResult<unknown>): string {
+  if (result.success) {
+    throw new Error("expected parse failure");
+  }
+  return result.error.issues[0]?.message ?? "";
+}
+
+describe("installZodDefaultLocale", () => {
+  const previousLocaleError = z.config().localeError;
+
+  afterEach(() => {
+    z.config({ localeError: previousLocaleError });
+  });
+
+  it("restores real issue messages when the bundled locale registration was tree-shaken", () => {
+    // Simulate a built dist: zod@4 is sideEffects:false, so the classic
+    // entry's implicit config(en()) call is dropped and no locale is set.
+    z.config({ localeError: undefined });
+    const degraded = OpenClawSchema.safeParse({
+      agents: { defaults: { session: { pruneAfter: "1d" } } },
+    });
+    expect(firstIssueMessage(degraded)).toBe("Invalid input");
+
+    installZodDefaultLocale();
+
+    const restored = OpenClawSchema.safeParse({
+      agents: { defaults: { session: { pruneAfter: "1d" } } },
+    });
+    expect(firstIssueMessage(restored)).toBe('Unrecognized key: "session"');
+    const typeError = OpenClawSchema.safeParse({ gateway: { port: "not-a-number" } });
+    expect(firstIssueMessage(typeError)).toBe("Invalid input: expected number, received string");
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -35,6 +35,16 @@ import {
   SessionSendPolicySchema,
 } from "./zod-schema.session.js";
 
+// zod@4 ships "sideEffects": false, so bundlers tree-shake the classic entry's
+// implicit config(en()) locale registration (zod/v4/classic/external.js) and a
+// built dist renders every issue as the bare "Invalid input" fallback. Register
+// the locale explicitly where the config schemas live; zod stores it on
+// globalThis, so one call covers every zod parse in the process.
+export function installZodDefaultLocale(): void {
+  z.config(z.locales.en());
+}
+installZodDefaultLocale();
+
 const BrowserSnapshotDefaultsSchema = z
   .object({
     mode: z.literal("efficient").optional(),


### PR DESCRIPTION
## What Problem This Solves

Every config validation error in a **packaged/built** OpenClaw collapses to the bare fallback `Invalid input`, while a source checkout prints the real zod message. Users hit unactionable startup errors like `agents.list.*: Invalid input` (#89445) or `agents.defaults: Invalid input` (#103956's misnested `session.pruneAfter`), with no hint which key is wrong or what type was expected.

Root cause (#104014): `zod@4.4.3` declares `"sideEffects": false`, and zod v4 registers its English locale as a module side effect — `config(en())` in `zod/v4/classic/external.js:10`. tsdown/rolldown honors `sideEffects: false` and tree-shakes that call: the built `dist/schemas-*.js` chunk contains zod core and even the en-locale data, but zero locale-registration calls survive. With no locale configured, zod renders every issue with the generic `"Invalid input"` fallback.

## Why This Change Was Made

- Restores actionable config errors for all packaged installs (`Unrecognized key: "session"`, `Invalid input: expected number, received string`) on every zod-backed surface in the process.
- Removes a silent source-vs-shipped behavior divergence: `src/config/validation.ts:776-779` filters/merges SecretRef schema issues by regex-matching message text (`/Unrecognized key|must not have additional properties/i`) and extracts key names from the message. In a built dist those messages are `Invalid input`, so this logic silently stops matching in production while unit tests (which run unbundled and get the locale side effect) keep passing.
- Fix shape: one explicit first-party registration co-located with the config schemas (`src/config/zod-schema.ts`), where zod is already imported — no new startup import cost, no bundler-config coupling. `node_modules/zod/v4/core/core.js:72-73` stores the config on `globalThis.__zod_globalConfig`, so a single call covers every zod parse in the process. Idempotent in source runs.

## User Impact

Anyone on a packaged install (npm/managed) who makes any config mistake gets a real diagnostic instead of `Invalid input`. Directly improves the failure mode behind #89445 (user downgraded a release to recover) and the diagnostic gap in #103956.

## Evidence

**Live before (freshly rebuilt current main dist, `node openclaw.mjs config get agents`):**
```
Problem:
  - agents.defaults: Invalid input
```
and with `gateway.port: "not-a-number"`:
```
  - gateway.port: Invalid input
```

**Live after (same commands, dist rebuilt on this branch):**
```
  - agents.defaults: Unrecognized key: "session"
  - gateway.port: Invalid input: expected number, received string
```

**Mechanism proof:** before — `grep -c "config(en" dist/schemas-*.js` → 0 (locale data present, registration call tree-shaken); after — registration retained in `dist/zod-schema-*.js` (`installZodDefaultLocale`).

**Regression test** (`src/config/zod-schema.locale.test.ts`): simulates the stripped-bundle state via public API (`z.config({ localeError: undefined })`), asserts the degraded `Invalid input` message, then asserts `installZodDefaultLocale()` restores `Unrecognized key: "session"` and `Invalid input: expected number, received string` through `OpenClawSchema`; restores prior global locale in cleanup.

**Validation:** locale + agent-defaults + session-maintenance + models schema tests 60/60; `validation.test.ts` + `config-misc.test.ts` 131/131; `pnpm tsgo:core` clean; oxlint/oxfmt clean; `pnpm build` green.

Fixes #104014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJogTw4aGDiacwqju1uod6
