### PR TITLE
fix(mac): deflake exec-approvals socket guard test and create state dir with 0700 directly

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift
@@ -1199,7 +1199,14 @@ extension ExecApprovalsStore {
 
     private static func ensureSecureStateDirectory() throws {
         let url = self.stateDirURL()
-        try FileManager().createDirectory(at: url, withIntermediateDirectories: true)
+        // Create with the final 0700 mode directly: a default-mode (0755)
+        // create followed by the chmod below leaves a transient window where
+        // the directory is world-listable and concurrent observers see the
+        // wrong permissions.
+        try FileManager().createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: self.secureStateDirPermissions])
         try ExecApprovalsFileIO.assertSafeDirectory(at: url)
         try FileManager().setAttributes(
             [.posixPermissions: self.secureStateDirPermissions],

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -159,20 +159,36 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
-    func `harden canonical parent directory creates it with0700 permissions`() async throws {
+    func `socket path resolves under the configured state directory`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: stateDir) }
 
+        // String-level assertion only. The isolation lock serializes env
+        // mutation but not env consumption: concurrent suites that resolve
+        // OPENCLAW_STATE_DIR mid-window would create this directory and the
+        // old filesystem assertions here flaked on their 0755 default
+        // (#104019). Creation-with-0700 is covered by the explicit-path
+        // tests in this suite.
         try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": stateDir.path]) {
             let socketPath = ExecApprovalsStore.socketPath()
-            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
-
-            #expect(FileManager().fileExists(atPath: stateDir.path))
-            let attrs = try FileManager().attributesOfItem(atPath: stateDir.path)
-            let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
-            #expect(permissions & 0o777 == 0o700)
+            #expect(socketPath == stateDir.appendingPathComponent("exec-approvals.sock").path)
         }
+    }
+
+    @Test
+    func `harden canonical parent directory creates it with 0700 permissions`() throws {
+        let root = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        let stateDir = root.appendingPathComponent("state", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(
+            for: stateDir.appendingPathComponent("exec-approvals.sock").path)
+
+        let attrs = try FileManager().attributesOfItem(atPath: stateDir.path)
+        let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+        #expect(permissions & 0o777 == 0o700)
     }
 
     @Test


### PR DESCRIPTION
## What Problem This Solves

`ExecApprovalsSocketPathGuardTests` / `harden canonical parent directory creates it with0700 permissions` flakes under `swift test --package-path apps/macos --parallel` — the exact invocation the mac CI lane uses — failing with the state dir at 0755 instead of 0700 (reproduced 3 failures across 8 parallel runs; always passes in isolation). Fixes #104019.

## Why This Change Was Made

Root cause has two halves:

1. **The isolation lock serializes env mutation, not env consumption.** The flaky test advertised its unique temp state dir through process-global `OPENCLAW_STATE_DIR` (via `TestIsolation.withEnvValues`). Concurrent suites that drive `ExecApprovalsStore` paths without holding the lock (e.g. `MacNodeRuntimeTests` exercising `ensureSnapshotResult()`/`saveFile`) resolve whatever env is globally visible at that instant — the flaky test's temp dir — and create it first. `hardenParentDirectory` deliberately does not tighten pre-existing safe directories (0755 has no group/other write, so it validates), so the 0700 assertion failed.
2. **`ensureSecureStateDirectory` had a create-0755-then-chmod-0700 window**: `createDirectory` with default attributes followed by `setAttributes`, so even the "creator chmods to 0700" path exposes a transient 0755 directory to concurrent observers.

The fix addresses both boundaries:

- **Prod**: `ensureSecureStateDirectory` now creates the state directory with `posixPermissions: 0o700` attributes directly — the directory is never world-listable, even transiently. The follow-up `setAttributes` stays, since the ensure contract also tightens pre-existing directories.
- **Test**: the flaky test is split into its two orthogonal concerns. Env resolution (`socketPath()` resolves under `OPENCLAW_STATE_DIR`) is now a pure string assertion inside the env window — no filesystem, so concurrent creators cannot perturb it. Creation-with-0700 is asserted against an explicit hermetic temp path (like the suite's existing nested-directories test), which never appears in process-global env, closing the interference channel entirely. The test-name typo ("with0700") is fixed in passing.

Follow-up (out of scope here): lock-free env consumption by concurrently running suites is a broader test-architecture class; this PR removes the only known flaking instance without refactoring `ExecApprovalsStore` to injected paths.

## User Impact

CI/test determinism for everyone running the mac lane. Minor prod hardening: the exec-approvals state directory is created atomically with 0700 instead of briefly existing as 0755.

## Evidence

- Before (main): 3 failures across 8 `swift test --parallel` runs, always `Expectation failed: (permissions & 0o777 -> 493) == (0o700 -> 448)` at ExecApprovalsSocketPathGuardTests.swift:174; 6/6 isolated runs pass.
- After (this branch): 10/10 consecutive full `swift test --package-path apps/macos --parallel` runs pass (955 tests / 127 suites each).
- `swift test --filter ExecApprovals`: 117 tests / 6 suites pass.
- `swiftformat --lint` clean on both changed files.
