### PR TITLE
fix(agents): collect unreachable transcript branches during compaction rotation

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -11,6 +11,7 @@ import {
   shouldRotateCompactionTranscript,
 } from "./compaction-successor-transcript.js";
 import { hardenManualCompactionBoundary } from "./manual-compaction-boundary.js";
+import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
 let tmpDir: string | undefined;
 
@@ -446,28 +447,29 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(successorCompaction.firstKeptEntryId).toBe(compactionId);
   });
 
-  it("preserves unsummarized sibling branches and branch summaries", async () => {
+  it("collects abandoned sibling branches while keeping the active-chain branch summary", async () => {
     const dir = await createTmpDir();
     const manager = SessionManager.create(dir, dir);
 
     manager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
     const branchFromId = manager.appendMessage(makeAssistant("hi there", 2));
 
-    const branchSummaryId = manager.branchWithSummary(
-      branchFromId,
-      "Summary of the abandoned branch.",
-    );
     const siblingMsgId = manager.appendMessage({
       role: "user",
       content: "do task B instead",
       timestamp: 3,
     });
-    manager.appendMessage(makeAssistant("done B", 4));
+    const siblingReplyId = manager.appendMessage(makeAssistant("done B", 4));
 
-    manager.branch(branchFromId);
+    const branchSummaryId = manager.branchWithSummary(
+      branchFromId,
+      "Summary of the abandoned branch.",
+    );
     manager.appendMessage({ role: "user", content: "do task A", timestamp: 5 });
-    const firstKeptId = manager.appendMessage(makeAssistant("done A", 6));
-    manager.appendCompaction("Summary of main branch.", firstKeptId, 5000);
+    manager.appendMessage(makeAssistant("done A", 6));
+    // Keep the branch summary in the kept pre-compaction span so the test can
+    // separate "on the active chain" from "summarized away".
+    manager.appendCompaction("Summary of main branch.", branchSummaryId, 5000);
     manager.appendMessage({ role: "user", content: "next", timestamp: 7 });
 
     const sessionFile = requireString(manager.getSessionFile(), "source session file");
@@ -486,19 +488,13 @@ describe("rotateTranscriptAfterCompaction", () => {
       allEntries,
       branchSummaryId,
       "branch_summary",
-      "preserved branch summary",
+      "preserved active-chain branch summary",
     );
     expect(branchSummary.summary).toBe("Summary of the abandoned branch.");
-    const siblingMessage = requireEntryByIdAndType(
-      allEntries,
-      siblingMsgId,
-      "message",
-      "preserved sibling message",
-    );
-    if (!("content" in siblingMessage.message)) {
-      throw new Error("expected sibling message content");
-    }
-    expect(siblingMessage.message.content).toBe("do task B instead");
+    // The abandoned task-B branch is unreachable from the active leaf; rotation
+    // collects it instead of copying it into every successor file (#103934).
+    expect(allEntries.some((entry) => entry.id === siblingMsgId)).toBe(false);
+    expect(allEntries.some((entry) => entry.id === siblingReplyId)).toBe(false);
 
     const activeContextText = JSON.stringify(successor.buildSessionContext().messages);
     expect(activeContextText).toContain("Summary of main branch.");
@@ -506,28 +502,30 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(activeContextText).not.toContain("do task B instead");
   });
 
-  it("orders preserved sibling branches after their surviving parents", async () => {
+  it("keeps scanned custom entries and kept-target labels while collecting dead branches", async () => {
     const dir = await createTmpDir();
     const manager = SessionManager.create(dir, dir);
 
     manager.appendMessage({ role: "user", content: "hello", timestamp: 1 });
     const branchFromId = manager.appendMessage(makeAssistant("hi there", 2));
 
-    const branchSummaryId = manager.branchWithSummary(
-      branchFromId,
-      "Summary of the inactive branch.",
-    );
-    const inactiveMsgId = manager.appendMessage({
+    // Custom entries are consumed via whole-file scans (provider replay
+    // markers, bootstrap completion), so they survive rotation even when a
+    // rewind left them off the active chain.
+    const customEntryId = manager.appendCustomEntry("test-replay-marker", { flag: true });
+    const deadMsgId = manager.appendMessage({
       role: "user",
-      content: "inactive branch",
+      content: "abandoned path",
       timestamp: 3,
     });
-    manager.appendMessage(makeAssistant("inactive done", 4));
+    const deadLabelTargetId = manager.appendMessage(makeAssistant("abandoned reply", 4));
+    manager.appendLabelChange(deadLabelTargetId, "dead-branch-label");
 
     manager.branch(branchFromId);
     manager.appendMessage({ role: "user", content: "active branch", timestamp: 5 });
-    manager.appendMessage(makeAssistant("active done", 6));
-    manager.appendCompaction("Summary of active work.", branchFromId, 5000);
+    const keptAssistantId = manager.appendMessage(makeAssistant("active done", 6));
+    const keptLabelId = manager.appendLabelChange(keptAssistantId, "kept-label");
+    manager.appendCompaction("Summary of active work.", keptAssistantId, 5000);
     const activeLeafId = manager.appendMessage({
       role: "user",
       content: "next active",
@@ -545,16 +543,82 @@ describe("rotateTranscriptAfterCompaction", () => {
       requireString(result.sessionFile, "successor session file"),
     );
     const entries = successor.getEntries();
-    const indexById = new Map(entries.map((entry, index) => [entry.id, index]));
-    expect(indexById.get(branchFromId)).toBeLessThan(indexById.get(branchSummaryId)!);
-    expect(indexById.get(branchSummaryId)).toBeLessThan(indexById.get(inactiveMsgId)!);
+    const entryIds = new Set(entries.map((entry) => entry.id));
+    expect(entryIds.has(customEntryId)).toBe(true);
+    expect(entryIds.has(keptLabelId)).toBe(true);
+    expect(entryIds.has(deadMsgId)).toBe(false);
+    expect(entryIds.has(deadLabelTargetId)).toBe(false);
+    expect(
+      entries.some((entry) => entry.type === "label" && entry.label === "dead-branch-label"),
+    ).toBe(false);
     expect(entries.at(-1)?.id).toBe(activeLeafId);
     expect(successor.getLeafId()).toBe(activeLeafId);
 
     const activeContextText = JSON.stringify(successor.buildSessionContext().messages);
     expect(activeContextText).toContain("Summary of active work.");
     expect(activeContextText).toContain("next active");
-    expect(activeContextText).not.toContain("inactive branch");
+    expect(activeContextText).not.toContain("abandoned path");
+  });
+
+  it("collects overflow-rewrite orphan suffixes at the next rotation (#103934)", async () => {
+    const dir = await createTmpDir();
+    const manager = SessionManager.create(dir, dir);
+
+    manager.appendMessage({ role: "user", content: "start", timestamp: 1 });
+    const oversizedAssistantId = manager.appendMessage(
+      makeAssistant(`huge tool output ${"x".repeat(2000)}`, 2),
+    );
+    manager.appendMessage({ role: "user", content: "follow-up", timestamp: 3 });
+    const tailAssistantId = manager.appendMessage(makeAssistant("tail answer", 4));
+
+    // Overflow recovery rewrites by forking from the rewritten entry's parent
+    // and re-appending the suffix; the original suffix entries stay behind as
+    // an unreachable branch.
+    const rewrite = rewriteTranscriptEntriesInSessionManager({
+      sessionManager: manager,
+      replacements: [
+        {
+          entryId: oversizedAssistantId,
+          message: makeAssistant("huge tool output [truncated]", 2),
+        },
+      ],
+    });
+    expect(rewrite.changed).toBe(true);
+    const entriesBeforeRotation = manager.getEntries();
+    // The dead originals are still physically present before rotation.
+    expect(entriesBeforeRotation.some((entry) => entry.id === oversizedAssistantId)).toBe(true);
+    expect(entriesBeforeRotation.some((entry) => entry.id === tailAssistantId)).toBe(true);
+
+    const branch = manager.getBranch();
+    // Keep the whole rewritten suffix: firstKept = the first re-appended copy.
+    const firstKeptId = requireString(branch.at(1)?.id, "first rewritten suffix id");
+    manager.appendCompaction("Summary of truncated work.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: "after compaction", timestamp: 5 });
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: requireString(manager.getSessionFile(), "source session file"),
+      now: () => new Date("2026-04-27T13:15:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    const successor = SessionManager.open(
+      requireString(result.sessionFile, "successor session file"),
+    );
+    const entries = successor.getEntries();
+    const entryIds = new Set(entries.map((entry) => entry.id));
+    // The abandoned pre-rewrite originals disappear from the successor.
+    expect(entryIds.has(oversizedAssistantId)).toBe(false);
+    expect(entryIds.has(tailAssistantId)).toBe(false);
+    const serialized = JSON.stringify(entries);
+    expect(serialized).not.toContain(`huge tool output ${"x".repeat(20)}`);
+
+    const activeContextText = JSON.stringify(successor.buildSessionContext().messages);
+    expect(activeContextText).toContain("Summary of truncated work.");
+    expect(activeContextText).toContain("after compaction");
+    // Exactly one copy of the rewritten suffix survives.
+    const followUpMatches = serialized.match(/follow-up/g) ?? [];
+    expect(followUpMatches).toHaveLength(1);
   });
 });
 

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -227,6 +227,24 @@ function buildSuccessorEntries(params: {
   for (const entryId of preservedPreCompactionIds) {
     preCompactionKeptBranchIds.add(entryId);
   }
+  const activeBranchIds = new Set<string>();
+  for (const entry of branch) {
+    activeBranchIds.add(entry.id);
+  }
+  // Rotation is the transcript's single full-rewrite point, so unreachable
+  // branches are collected here (#103934): overflow-recovery rewrites fork and
+  // re-append the active suffix, and the abandoned originals would otherwise be
+  // copied whole into every successor file forever. Keep the active-leaf
+  // ancestry plus entry types with whole-file consumers: `custom` entries are
+  // read via full scans (provider replay markers, bootstrap completion) and
+  // labels follow their targets below. Full history stays in the predecessor
+  // file, which the successor header links via parentSession.
+  for (const entry of allEntries) {
+    if (activeBranchIds.has(entry.id) || entry.type === "custom" || entry.type === "label") {
+      continue;
+    }
+    removedIds.add(entry.id);
+  }
   for (const entry of allEntries) {
     if (entry.type === "label" && removedIds.has(entry.targetId)) {
       removedIds.add(entry.id);
@@ -239,10 +257,6 @@ function buildSuccessorEntries(params: {
     const entry = allEntries[index];
     entryById.set(entry.id, entry);
     originalIndexById.set(entry.id, index);
-  }
-  const activeBranchIds = new Set<string>();
-  for (const entry of branch) {
-    activeBranchIds.add(entry.id);
   }
   const keptEntries: SessionEntry[] = [];
   for (const entry of allEntries) {


### PR DESCRIPTION
## What Problem This Solves

#103934: overflow-recovery rewrites (`transcript-rewrite.ts`) fork from the rewritten entry's parent and re-append the active suffix, leaving the abandoned originals as an unreachable branch in the JSONL. `buildSuccessorEntries` then computed `removedIds` only from the *active branch* (summarized span, stale state entries, duplicate prompts) and copied everything else in `allEntries` into the successor file. Dead branches can never enter `removedIds`, so **every rotation re-persisted every accumulated dead branch into the brand-new successor** — dead bytes grow monotonically, and the byte-based `maxActiveTranscriptBytes` rotation trigger fires ever sooner while carrying 100% of the dead weight forward.

## Why This Change Was Made

Rotation is the transcript's single full-rewrite choke point (the shape clawsweeper's triage named as the best solution: "retain the active leaf ancestry after existing compaction pruning plus only metadata explicitly referenced by retained entries"). The fix collects unreachable entries exactly there:

- Keep the active-leaf ancestry; all existing compaction pruning (summarized span, preserved assistant/tool-result turns, stale state entries, duplicate prompts, hardened boundaries) is unchanged.
- Keep `custom` entries unconditionally — they have whole-file scan consumers (`getCustomEntries()` in `replay-history.ts:551` for provider replay markers, the bootstrap-completion scan in `bootstrap-files.ts:134`), so equating "off-branch" with "garbage" would break them. This is the reference-closure caveat the triage warned about.
- Keep labels whose target survives (existing label-follows-target rule now also drops labels of dead targets).
- Everything else off the active chain is collected. Full history is not lost: the predecessor file keeps every byte, and the successor header links it via `parentSession`.

**Changed tested behavior, named per policy:** two tests asserted that abandoned sibling branches are preserved through rotation. That retention has no runtime consumer (no `buildSessionTree` callers outside `SessionManager`, no branch-switch RPC in the gateway), contradicts rotation's original design (#41021: "keep only session header + latest compaction entry + post-compaction messages"), and is precisely the mechanism that makes #103934 unbounded. The tests were retargeted: active-chain branch summaries still survive; unreachable siblings are collected.

## User Impact

Long-lived sessions with `truncateAfterCompaction: true` stop inheriting dead weight at every rotation. In the measured 3-rewrite scenario below the successor shrinks from ~155 KB to ~2 KB with an identical active context; real deployments reported 67–73% dead bytes in >5 MB transcripts.

## Evidence

**Executed before/after measurement** (same probe: 3 overflow-rewrite cycles with 50 KB tool outputs, then compaction + rotation; run once on current `main`, once on this branch):

| | source file | successor (main) | successor (this PR) |
|---|---|---|---|
| bytes | 156,678 | **155,079** (98.9% carried) | **2,115** |
| JSONL lines | 22 | 16 | 7 |
| dead 50 KB blobs present | 3 | **yes** | **no** |
| active context intact | — | yes | yes (identical) |

**Regression tests** (`compaction-successor-transcript.test.ts`, 13/13):
- New: "collects overflow-rewrite orphan suffixes at the next rotation (#103934)" — drives the real `rewriteTranscriptEntriesInSessionManager` (the actual Part-1 producer), rotates, asserts the abandoned originals disappear and exactly one copy of the rewritten suffix survives.
- New: "keeps scanned custom entries and kept-target labels while collecting dead branches" — off-chain `custom` entry survives, kept-target label survives, dead-target label and dead messages are collected, leaf/ordering intact.
- Retargeted: "collects abandoned sibling branches while keeping the active-chain branch summary".

**Validation:** rotation suites 13/13 + duplicate-prompt suites 8/8 + compact hooks/manual-boundary/duplicate-user-messages 104/104; `pnpm tsgo:core` clean; oxlint/oxfmt clean. Prod diff +18/−4 (mostly the ownership comment).

**Scope:** Part 1 (the rewrite fork+re-append litter creation) stays owned by #66443/#89387 — untouched here. This PR makes rotation stop perpetuating the litter and retroactively cleans existing dead branches at each rotation, which #89387 alone would not (bot triage: "partial_overlap … does not change successor transcript retention").

Fixes #103934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJogTw4aGDiacwqju1uod6
