### PR TITLE
feat(ui): hover-revealed chat message meta with relative timestamps

### DIFF
--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -2,10 +2,13 @@
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatDurationHuman } from "../../../src/infra/format-time/format-duration.ts";
-import { formatRelativeTimestamp } from "../../../src/infra/format-time/format-relative.ts";
+import {
+  formatRelativeTimestamp,
+  formatTimeAgo,
+} from "../../../src/infra/format-time/format-relative.ts";
 import { t } from "../i18n/index.ts";
 
-export { formatRelativeTimestamp, formatDurationHuman };
+export { formatRelativeTimestamp, formatTimeAgo, formatDurationHuman };
 
 export function formatUnknownText(
   value: unknown,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -992,6 +992,19 @@ describe("grouped chat rendering", () => {
     );
   });
 
+  it("clamps skewed-future footer labels but dates far-future ones", () => {
+    const nowMs = Date.UTC(2026, 3, 24, 18, 30);
+    expect(formatChatRelativeTimestampLabel(nowMs + 30 * 1000, nowMs)).toBe("just now");
+    const nextYear = Date.UTC(2027, 3, 24, 18, 30);
+    expect(formatChatRelativeTimestampLabel(nextYear, nowMs)).toBe(
+      new Date(nextYear).toLocaleDateString([], {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }),
+    );
+  });
+
   it("omits streaming bubble class for completed stream segments", () => {
     const container = document.createElement("div");
 

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -6,6 +6,7 @@ import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import { setUiTimeFormatPreference } from "../../../lib/format.ts";
 import {
+  formatChatRelativeTimestampLabel,
   formatChatTimestampForDisplay,
   renderMessageGroup,
   renderStreamGroup,
@@ -905,7 +906,10 @@ describe("grouped chat rendering", () => {
     const time = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
     expect(time).not.toBeNull();
     expect(time?.closest("details.msg-meta")).toBeNull();
-    expect(time?.title).not.toBe("");
+    // Absolute time lives in the styled tooltip around the relative label.
+    expect(time?.closest("openclaw-tooltip")?.getAttribute("content")).toBe(
+      formatChatTimestampForDisplay(1000).label,
+    );
   });
 
   it("uses the largest single assistant call for grouped context usage", () => {
@@ -934,36 +938,58 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".msg-meta__tokens")?.textContent).toBe("↑214.5k");
   });
 
-  it("renders full dates with message and streaming timestamps", () => {
-    const container = document.createElement("div");
+  it("renders relative labels with absolute datetimes for message and streaming timestamps", () => {
+    vi.useFakeTimers();
+    try {
+      const timestamp = Date.UTC(2026, 3, 24, 18, 30);
+      vi.setSystemTime(timestamp + 5 * 60 * 1000);
+      const container = document.createElement("div");
+
+      renderAssistantMessage(container, {
+        role: "assistant",
+        content: "Done",
+        timestamp,
+      });
+
+      const time = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
+      const display = formatChatTimestampForDisplay(timestamp);
+      expect(time?.dateTime).toBe(display.dateTime);
+      expect(time?.textContent?.trim()).toBe("5m ago");
+
+      render(
+        renderStreamGroup([
+          {
+            kind: "stream",
+            key: `stream:${timestamp}`,
+            text: "Working",
+            startedAt: timestamp,
+            isStreaming: true,
+          },
+        ]),
+        container,
+      );
+
+      const streamingTime = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
+      expect(streamingTime?.textContent?.trim()).toBe("5m ago");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to compact dates for footer labels older than a week", () => {
     const timestamp = Date.UTC(2026, 3, 24, 18, 30);
-
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: "Done",
-      timestamp,
-    });
-
-    const time = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
-    const display = formatChatTimestampForDisplay(timestamp);
-    expect(time?.dateTime).toBe(display.dateTime);
-    expect(time?.textContent?.trim()).toBe(display.label);
-
-    render(
-      renderStreamGroup([
-        {
-          kind: "stream",
-          key: `stream:${timestamp}`,
-          text: "Working",
-          startedAt: timestamp,
-          isStreaming: true,
-        },
-      ]),
-      container,
+    const sameYearNow = Date.UTC(2026, 5, 24, 18, 30);
+    const nextYearNow = Date.UTC(2027, 0, 2, 18, 30);
+    expect(formatChatRelativeTimestampLabel(timestamp, sameYearNow)).toBe(
+      new Date(timestamp).toLocaleDateString([], { month: "short", day: "numeric" }),
     );
-
-    const streamingTime = container.querySelector<HTMLTimeElement>(".chat-group-timestamp");
-    expect(streamingTime?.textContent?.trim()).toBe(display.label);
+    expect(formatChatRelativeTimestampLabel(timestamp, nextYearNow)).toBe(
+      new Date(timestamp).toLocaleDateString([], {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }),
+    );
   });
 
   it("omits streaming bubble class for completed stream segments", () => {
@@ -1039,9 +1065,8 @@ describe("grouped chat rendering", () => {
     // One bubble per segment, all under the single group.
     expect(container.querySelectorAll(".chat-bubble")).toHaveLength(3);
     // Footer time anchors to the earliest segment start, not render order.
-    const display = formatChatTimestampForDisplay(10);
-    expect(container.querySelector(".chat-group-timestamp")?.textContent?.trim()).toBe(
-      display.label,
+    expect(container.querySelector<HTMLTimeElement>(".chat-group-timestamp")?.dateTime).toBe(
+      formatChatTimestampForDisplay(10).dateTime,
     );
   });
 

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -127,6 +127,7 @@ export function formatChatTimestampForDisplay(timestamp: number): ChatTimestampD
 }
 
 const CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const CHAT_RELATIVE_TIMESTAMP_FUTURE_SKEW_MS = 2 * 60 * 1000;
 
 /** Footer label: relative for recent messages, compact date beyond a week. */
 export function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date.now()): string {
@@ -135,9 +136,13 @@ export function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date
     return "Unknown date";
   }
   const ageMs = nowMs - date.getTime();
-  if (ageMs < CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS) {
-    // Derive from ageMs so the injected clock stays the single time source;
-    // clamp keeps slightly future (clock-skewed) messages at "just now".
+  // Derive from ageMs so the injected clock stays the single time source.
+  // Slightly-future (clock-skewed) messages clamp to "just now"; anything
+  // further out falls through to the compact date instead of lying forever.
+  if (
+    ageMs >= -CHAT_RELATIVE_TIMESTAMP_FUTURE_SKEW_MS &&
+    ageMs < CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS
+  ) {
     return formatTimeAgo(Math.max(0, ageMs));
   }
   return date.toLocaleDateString([], {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -39,7 +39,7 @@ import {
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
 import { resolveUiHourCycleOptions } from "../../../lib/format.ts";
-import { formatCompactTokenCount } from "../../../lib/format.ts";
+import { formatCompactTokenCount, formatRelativeTimestamp } from "../../../lib/format.ts";
 import "../../../components/tooltip.ts";
 import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
 import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
@@ -109,6 +109,7 @@ export function formatChatTimestampForDisplay(timestamp: number): ChatTimestampD
       year: "numeric",
       hour: "numeric",
       minute: "2-digit",
+      timeZoneName: "short",
     }),
     title: date.toLocaleString([], {
       ...hourCycle,
@@ -125,17 +126,39 @@ export function formatChatTimestampForDisplay(timestamp: number): ChatTimestampD
   };
 }
 
+const CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Footer label: relative for recent messages, compact date beyond a week. */
+export function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date.now()): string {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(date.getTime())) {
+    return "Unknown date";
+  }
+  const ageMs = nowMs - date.getTime();
+  if (ageMs < CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS) {
+    return formatRelativeTimestamp(timestamp);
+  }
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    ...(date.getFullYear() === new Date(nowMs).getFullYear() ? {} : { year: "numeric" }),
+  });
+}
+
+// Footer times read relative ("5m ago"); the absolute timestamp lives in the
+// tooltip, or in the msg-meta popover when usage metadata makes the
+// timestamp interactive (a nested tooltip would fight the popover).
 function renderChatTimestamp(timestamp: number, interactive = false) {
   const display = formatChatTimestampForDisplay(timestamp);
-  return html`
-    <time
-      class="chat-group-timestamp"
-      datetime=${display.dateTime}
-      title=${interactive ? nothing : display.title}
-    >
-      ${display.label}
+  const timeEl = html`
+    <time class="chat-group-timestamp" datetime=${display.dateTime}>
+      ${formatChatRelativeTimestampLabel(timestamp)}
     </time>
   `;
+  if (interactive) {
+    return timeEl;
+  }
+  return html`<openclaw-tooltip content=${display.label}>${timeEl}</openclaw-tooltip>`;
 }
 
 function resolveMessageMetaDetails(target: EventTarget | null): HTMLDetailsElement | null {
@@ -975,6 +998,8 @@ function renderMessageMeta(timestamp: number, meta: GroupMeta | null) {
   }
 
   const display = formatChatTimestampForDisplay(timestamp);
+  // Absolute time leads the popover; the summary label itself stays relative.
+  parts.unshift(html`<span class="msg-meta__time">${display.label}</span>`);
 
   return html`
     <details

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -158,7 +158,7 @@ export function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date
 function renderChatTimestamp(timestamp: number, interactive = false) {
   const display = formatChatTimestampForDisplay(timestamp);
   const timeEl = html`
-    <time class="chat-group-timestamp" datetime=${display.dateTime}>
+    <time class="chat-group-timestamp" datetime=${display.dateTime} aria-live="off">
       ${formatChatRelativeTimestampLabel(timestamp)}
     </time>
   `;

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -39,7 +39,7 @@ import {
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
 import { resolveUiHourCycleOptions } from "../../../lib/format.ts";
-import { formatCompactTokenCount, formatRelativeTimestamp } from "../../../lib/format.ts";
+import { formatCompactTokenCount, formatTimeAgo } from "../../../lib/format.ts";
 import "../../../components/tooltip.ts";
 import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
 import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
@@ -136,7 +136,9 @@ export function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date
   }
   const ageMs = nowMs - date.getTime();
   if (ageMs < CHAT_RELATIVE_TIMESTAMP_MAX_AGE_MS) {
-    return formatRelativeTimestamp(timestamp);
+    // Derive from ageMs so the injected clock stays the single time source;
+    // clamp keeps slightly future (clock-skewed) messages at "just now".
+    return formatTimeAgo(Math.max(0, ageMs));
   }
   return date.toLocaleDateString([], {
     month: "short",

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -67,6 +67,7 @@ type ChatThreadState = {
   historyRenderAnchorFrame: number | null;
   relativeTimeTimer: ReturnType<typeof setInterval> | null;
   relativeTimeRequestUpdate: (() => void) | null;
+  relativeTimeVersion: number;
 };
 
 type ChatThreadProps = {
@@ -131,6 +132,7 @@ function createChatThreadState(): ChatThreadState {
     historyRenderAnchorFrame: null,
     relativeTimeTimer: null,
     relativeTimeRequestUpdate: null,
+    relativeTimeVersion: 0,
   };
 }
 
@@ -138,9 +140,12 @@ const RELATIVE_TIME_REFRESH_MS = 60_000;
 
 // Footer timestamps render relative labels ("5m ago") that go stale on idle
 // panes; one per-pane minute tick keeps them fresh without per-message timers.
+// The version bump must accompany requestUpdate: the message subtree is
+// memoized by guard(), so a tick only re-renders it via this dependency.
 function ensureRelativeTimeRefresh(state: ChatThreadState, requestUpdate: () => void) {
   state.relativeTimeRequestUpdate = requestUpdate;
   state.relativeTimeTimer ??= setInterval(() => {
+    state.relativeTimeVersion = (state.relativeTimeVersion + 1) % Number.MAX_SAFE_INTEGER;
     state.relativeTimeRequestUpdate?.();
   }, RELATIVE_TIME_REFRESH_MS);
 }
@@ -745,6 +750,7 @@ export function renderChatThread(props: ChatThreadProps) {
             deletedChatItemsSignature(deleted, chatItems),
             stableBooleanMapSignature(expandedToolCards),
             getAssistantAttachmentAvailabilityRenderVersion(),
+            state.relativeTimeVersion,
             props.sessionKey,
             props.fullMessageAgentId,
             showReasoning,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -65,6 +65,8 @@ type ChatThreadState = {
     scrollTop: number;
   } | null;
   historyRenderAnchorFrame: number | null;
+  relativeTimeTimer: ReturnType<typeof setInterval> | null;
+  relativeTimeRequestUpdate: (() => void) | null;
 };
 
 type ChatThreadProps = {
@@ -127,7 +129,20 @@ function createChatThreadState(): ChatThreadState {
     historyRenderExpansionFrame: null,
     historyRenderAnchorAdjustment: null,
     historyRenderAnchorFrame: null,
+    relativeTimeTimer: null,
+    relativeTimeRequestUpdate: null,
   };
+}
+
+const RELATIVE_TIME_REFRESH_MS = 60_000;
+
+// Footer timestamps render relative labels ("5m ago") that go stale on idle
+// panes; one per-pane minute tick keeps them fresh without per-message timers.
+function ensureRelativeTimeRefresh(state: ChatThreadState, requestUpdate: () => void) {
+  state.relativeTimeRequestUpdate = requestUpdate;
+  state.relativeTimeTimer ??= setInterval(() => {
+    state.relativeTimeRequestUpdate?.();
+  }, RELATIVE_TIME_REFRESH_MS);
 }
 
 const threadStates = new Map<string, ChatThreadState>();
@@ -173,6 +188,11 @@ export function resetChatThreadPresentationState(paneId?: string) {
     }
     if (state.historyRenderAnchorFrame != null) {
       cancelAnimationFrame(state.historyRenderAnchorFrame);
+    }
+    if (state.relativeTimeTimer != null) {
+      clearInterval(state.relativeTimeTimer);
+      state.relativeTimeTimer = null;
+      state.relativeTimeRequestUpdate = null;
     }
   }
   if (paneId) {
@@ -649,6 +669,7 @@ function renderLoadingSkeleton() {
 export function renderChatThread(props: ChatThreadProps) {
   const state = getChatThreadState(props.paneId);
   const requestUpdate = props.onRequestUpdate ?? (() => {});
+  ensureRelativeTimeRefresh(state, requestUpdate);
   const displayStream = props.stream ?? null;
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -42,7 +42,9 @@
   justify-content: flex-end;
 }
 
-/* Footer at bottom of message group (role + time) */
+/* Footer at bottom of message group (role + time). Hidden until the group is
+   hovered/focused so the thread reads as a clean stream; opacity (not
+   display) keeps the height reserved and avoids layout shift on reveal. */
 .chat-group-footer {
   display: flex;
   flex-wrap: wrap;
@@ -50,7 +52,15 @@
   align-items: center;
   width: 100%;
   min-width: 0;
-  margin-top: 6px;
+  margin-top: 4px;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+
+.chat-group:hover .chat-group-footer,
+.chat-group:focus-within .chat-group-footer,
+.chat-group-footer:has(details.msg-meta[open]) {
+  opacity: 1;
 }
 
 .chat-group-footer__meta {
@@ -274,7 +284,7 @@ img.chat-avatar {
 }
 
 .chat-group.assistant .chat-bubble {
-  padding: 2px 0;
+  padding: 4px 0;
   border: 0;
   background: transparent;
   box-shadow: none;
@@ -309,6 +319,10 @@ img.chat-avatar {
 @media (hover: none),
   (max-width: 768px),
   (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .chat-group-footer {
+    opacity: 1;
+  }
+
   .chat-group-footer-actions button,
   .chat-message-actions-row button {
     opacity: 1;
@@ -518,6 +532,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   left: auto;
 }
 
+.msg-meta__time,
 .msg-meta__tokens,
 .msg-meta__cache,
 .msg-meta__cost,

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -15,6 +15,16 @@
   margin-top: 0;
 }
 
+/* Flat top-level tool rows align their content with the assistant text edge:
+   the row's 8px inline inset bleeds left into the avatar gutter (never right,
+   which could overflow the thread on narrow panes) so the hover pill keeps
+   its inset without indenting the icon/label. Child combinator keeps shells
+   nested in .chat-activity-group__body on the boxed 12px inset. */
+.chat-group-messages > .chat-bubble--tool-shell .chat-tool-msg-summary {
+  width: calc(100% + 8px);
+  margin-left: -8px;
+}
+
 .chat-tool-msg-summary {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #104016 (flat assistant text stream). The chat thread still shows a permanent metadata row under every message ("OpenClaw · Jul 10, 2026, 5:20 PM"), which reads as noise now that assistant replies render as a clean stream. Absolute timestamps on every message are heavy; the details are only interesting on demand. Flat tool rows also sat slightly indented from the assistant text edge.

## Why This Change Was Made

The sender/time footer is now hidden until the message group is hovered or focused (revealed with an opacity fade, height reserved so nothing shifts; always visible on touch devices where there is no hover). Timestamps show a relative label ("2m ago", falling back to a compact date like "Apr 24" past a week), with the absolute date/time in a styled tooltip — or, for messages with usage metadata, leading the existing token/cost popover so the two hover surfaces don't fight. A single per-pane 60-second tick keeps relative labels fresh on idle panes and is cleared on pane disposal. Flat top-level tool rows bleed their 8px inset into the avatar gutter so their icon/label aligns with the assistant text edge, and assistant stream segments get a touch more vertical breathing room. Web (Control UI) only.

## User Impact

The web chat thread reads as a clean document: no repeated name/timestamp rows until you hover the message you care about, familiar "5m ago" times with exact timestamps one hover away, and agent text/tool rows sharing one left edge. Touch/mobile users keep always-visible footers.

## Evidence

Deterministic mock-gateway screenshots (Playwright, seeded history):

| Clean stream (dark) | Clean stream (light) |
|---|---|
| ![desktop dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream-polish/desktop-dark.png) | ![desktop light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream-polish/desktop-light.png) |

| Hover reveals footer + absolute-time popover | User-message tooltip |
|---|---|
| ![hover tooltip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream-polish/hover-time-tooltip.png) | ![user tooltip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/flat-assistant-stream-polish/hover-user-time.png) |

- Hovering the assistant timestamp shows "Jul 10, 2026, 5:54 PM PDT ↑2.4k ↓180 claude-fable-5" (absolute time now leads the usage popover); user messages get a styled tooltip with the absolute time.
- The minute tick bumps a per-pane version that participates in the thread's `guard()` dependencies, so idle panes actually re-render; the timer is cleared with existing pane presentation state. Timestamps carry `aria-live="off"` so ticks don't spam the `role="log"` polite live region.
- Relative labels derive from one injected clock (`formatTimeAgo` on the computed age — same canonical helper family the sessions sidebar uses); slightly-future (clock-skew) messages clamp to "just now" while far-future ones fall back to the compact date instead of lying forever.
- Tests: `chat-message.test.ts`, `chat-view.test.ts`, `chat-responsive.browser.test.ts` — 286/286 pass on Blacksmith Testbox; timestamp tests pin relative labels with fake timers plus compact-date and future-timestamp fallback contracts (including the cross-year case). `pnpm check:changed` green (delegated, exit 0). Codex autoreview iterated to clean (final round: no findings, "patch is correct 0.91").
