### PR TITLE
fix(release): restore Telegram QA environment secrets

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -15,6 +15,13 @@ on:
         description: Exact full candidate commit SHA
         required: true
         type: string
+    secrets:
+      OPENCLAW_QA_CONVEX_SECRET_CI:
+        description: Credential-lease coordinator secret supplied by qa-live-shared
+        required: false
+      OPENCLAW_QA_CONVEX_SITE_URL:
+        description: Credential-lease coordinator URL supplied by qa-live-shared
+        required: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -255,6 +255,7 @@ describe("release Telegram QA workflow", () => {
       on?: {
         workflow_call?: {
           inputs?: Record<string, { required?: boolean; type?: string }>;
+          secrets?: Record<string, { description?: string; required?: boolean }>;
         };
       };
     };
@@ -262,6 +263,16 @@ describe("release Telegram QA workflow", () => {
       description: "Resolved main SHA authorized for this trusted reusable workflow",
       required: true,
       type: "string",
+    });
+    expect(reusableWorkflow.on?.workflow_call?.secrets).toEqual({
+      OPENCLAW_QA_CONVEX_SECRET_CI: {
+        description: "Credential-lease coordinator secret supplied by qa-live-shared",
+        required: false,
+      },
+      OPENCLAW_QA_CONVEX_SITE_URL: {
+        description: "Credential-lease coordinator URL supplied by qa-live-shared",
+        required: false,
+      },
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the newly blocking Telegram release QA lane stopped before execution because its reusable workflow resolved both credential-lease environment secrets as empty.

## Why This Change Was Made

The reusable workflow now declares the two optional secrets it references under `on.workflow_call.secrets`. The isolated runner remains attached to `qa-live-shared`, so GitHub uses the environment-owned values and the caller still does not pass or inherit credentials.

## User Impact

Release maintainers can run the isolated Telegram candidate lane using the existing protected credential-lease environment. Product runtime behavior is unchanged.

## Evidence

- Failure: [focused Telegram validation 29133998728](https://github.com/openclaw/openclaw/actions/runs/29133998728), isolated runner job `86495379175`; both declared environment secret names resolved empty.
- Environment metadata confirms `qa-live-shared` owns both required secret names and has no branch protection rule.
- [GitHub reusable-workflow documentation](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) requires reusable-workflow secrets to be declared and specifies that job-level environment secrets take precedence.
- Added workflow contract coverage for the optional declarations.
- Targeted `oxfmt --check`, workflow YAML parse, and `git diff --check` passed.
- Fresh Codex autoreview clean, confidence 0.98.
- Hosted PR CI and exact Telegram QA rerun will be linked before merge/closeout.
