### PR TITLE
fix(telegram): preserve UTF-16 model labels

### DIFF
--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -397,6 +397,33 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("does not split surrogate pairs when truncating model labels", () => {
+    const longLabel = `a😀${"b".repeat(36)}`;
+    const cases = [
+      {
+        name: "model ID fallback",
+        model: longLabel,
+      },
+      {
+        name: "configured display name",
+        model: "short-model-id",
+        modelNames: new Map([["test/short-model-id", longLabel]]),
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const result = buildModelsKeyboard({
+        provider: "test",
+        models: [testCase.model],
+        currentPage: 1,
+        totalPages: 1,
+        modelNames: "modelNames" in testCase ? testCase.modelNames : undefined,
+      });
+
+      expect(result[0]?.[0]?.text, testCase.name).toBe(`…${"b".repeat(36)}`);
+    }
+  });
+
   it("uses compact selection callback when provider/model callback exceeds 64 bytes", () => {
     const model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
     const result = buildModelsKeyboard({

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -9,6 +9,7 @@
  * - mdl_back              - back to providers list
  */
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { fitsTelegramCallbackData } from "./approval-callback-data.js";
 
 export type ButtonRow = Array<{ text: string; callback_data: string }>;
@@ -41,6 +42,7 @@ export type ModelsKeyboardParams = {
 };
 
 const MODELS_PAGE_SIZE = 8;
+const MODEL_BUTTON_LABEL_MAX_LENGTH = 38;
 const CALLBACK_PREFIX = {
   providers: "mdl_prov",
   back: "mdl_back",
@@ -220,7 +222,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     const isCurrentModel = isCurrentModelSelection({ currentModel, provider, model });
     const fallbackLabel = model.includes("/") ? `${provider}/${model}` : model;
     const displayLabel = modelNames?.get(`${provider}/${model}`) ?? fallbackLabel;
-    const displayText = truncateModelId(displayLabel, 38);
+    const displayText = truncateModelLabel(displayLabel, MODEL_BUTTON_LABEL_MAX_LENGTH);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 
     rows.push([
@@ -271,14 +273,13 @@ export function buildBrowseProvidersButton(): ButtonRow[] {
 }
 
 /**
- * Truncate model ID for display, preserving end if too long.
+ * Truncate a model label for display, preserving its end if too long.
  */
-function truncateModelId(modelId: string, maxLen: number): string {
-  if (modelId.length <= maxLen) {
-    return modelId;
+function truncateModelLabel(modelLabel: string, maxLen: number): string {
+  if (modelLabel.length <= maxLen) {
+    return modelLabel;
   }
-  // Show last part with ellipsis prefix
-  return `…${modelId.slice(-(maxLen - 1))}`;
+  return `…${sliceUtf16Safe(modelLabel, -(maxLen - 1))}`;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Telegram's model picker preserves the tail of model button labels by slicing at 38 UTF-16 code units. When that suffix boundary falls between an emoji's surrogate halves, the button text contains an unpaired surrogate and renders as a replacement character.

This affects both fallback model IDs and configured model display names. The open callback-data PRs #98230 and #98694 change model selection encoding, but do not repair this independent label-rendering boundary.

## Why This Change Was Made

Use the existing public `sliceUtf16Safe` plugin SDK helper for the suffix operation, while retaining the existing 38-code-unit display budget and tail-preserving behavior. Rename the local helper around its actual input, centralize the label limit, and cover both label sources.

## User Impact

Long Telegram model labels no longer contain a broken replacement character when truncation lands inside an emoji. Short labels and the existing ellipsis-plus-suffix presentation remain unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kx7a49qv2xqp9yt3dbrt1mmh`: `pnpm test extensions/telegram/src/model-buttons.test.ts` — 27/27 tests passed.
- Same Testbox: path-scoped `check:changed` for both touched files — extension production/test type checks, lint, import-cycle checks, and repository guards passed.
- `git diff --check` passed.
- Fresh autoreview: no actionable findings; correctness confidence 0.98.
- Regression coverage verifies both a raw model ID and a configured display name whose old suffix started on a low surrogate.

The path-scoped check emitted only the unrelated warning-only temporary-directory migration report already present on current `main`.
