### PR TITLE
fix(ui): suppress login gate flash on refresh with stored token

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -14,6 +14,7 @@ type AppLifecycleState = {
   loginPassword: string;
   loginShowGatewayToken: boolean;
   loginShowGatewayPassword: boolean;
+  initialConnectSplashGuard: boolean;
   disconnectedCallback: () => void;
   synchronizeGateway: (gateway: ApplicationGateway) => void;
 };
@@ -95,6 +96,64 @@ describe("OpenClaw app lifecycle", () => {
     expect(app.loginShowGatewayPassword).toBe(false);
     expect(app.loginToken).toBe("second");
     expect(app.loginPassword).toBe("second-password");
+  });
+
+  it("keeps the initial connect splash guard until a connect attempt is observable", () => {
+    const app = document.createElement("openclaw-app") as unknown as AppLifecycleState;
+    app.initialConnectSplashGuard = true;
+    const gateway = {
+      snapshot: {
+        client: null,
+        connected: false,
+        reconnecting: false,
+        lastError: null,
+        lastErrorCode: null,
+      } as ApplicationGatewaySnapshot,
+      connection: { gatewayUrl: "ws://first.test", token: "first", password: "" },
+    } as ApplicationGateway;
+
+    app.synchronizeGateway(gateway);
+
+    expect(app.initialConnectSplashGuard).toBe(true);
+  });
+
+  it("clears the initial connect splash guard when the gateway creates a client", () => {
+    const app = document.createElement("openclaw-app") as unknown as AppLifecycleState;
+    app.initialConnectSplashGuard = true;
+    const client = {} as GatewayBrowserClient;
+    const gateway = {
+      snapshot: {
+        client,
+        connected: false,
+        reconnecting: false,
+        lastError: null,
+        lastErrorCode: null,
+      } as ApplicationGatewaySnapshot,
+      connection: { gatewayUrl: "ws://first.test", token: "first", password: "" },
+    } as ApplicationGateway;
+
+    app.synchronizeGateway(gateway);
+
+    expect(app.initialConnectSplashGuard).toBe(false);
+  });
+
+  it("clears the initial connect splash guard when the first connect attempt fails", () => {
+    const app = document.createElement("openclaw-app") as unknown as AppLifecycleState;
+    app.initialConnectSplashGuard = true;
+    const gateway = {
+      snapshot: {
+        client: null,
+        connected: false,
+        reconnecting: false,
+        lastError: "gateway closed (1006): no reason",
+        lastErrorCode: null,
+      } as ApplicationGatewaySnapshot,
+      connection: { gatewayUrl: "ws://first.test", token: "first", password: "" },
+    } as ApplicationGateway;
+
+    app.synchronizeGateway(gateway);
+
+    expect(app.initialConnectSplashGuard).toBe(false);
   });
 });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -143,6 +143,10 @@ class OpenClawApp extends OpenClawLightDomElement {
   // password, or stored device token) before the first connect attempt.
   // Later manual gate submissions are covered by loginGatePinned instead.
   private initialAuthPresent = false;
+  // True while the first paint after mount should suppress the login gate
+  // because stored credentials exist but the gateway has not yet started its
+  // first connect attempt. Cleared once a connect attempt is observable.
+  private initialConnectSplashGuard = false;
   private runtime: ApplicationRuntime | undefined;
   private readonly contextProvider = new ContextProvider(this, {
     context: applicationContext,
@@ -175,6 +179,7 @@ class OpenClawApp extends OpenClawLightDomElement {
     this.runtime = bootstrapApplication();
     const context = this.runtime.context;
     this.initialAuthPresent = hasStoredGatewayAuth(context.gateway.connection);
+    this.initialConnectSplashGuard = this.initialAuthPresent;
     this.pendingGatewayUrl = this.runtime.pendingGatewayConnection?.gatewayUrl ?? null;
     // Context identity changes only across a full app-tree connection epoch;
     // descendants reconnect and rebuild their controller-owned state afterward.
@@ -196,6 +201,7 @@ class OpenClawApp extends OpenClawLightDomElement {
     this.loginGatewaySource = null;
     this.loginConnectionClient = null;
     this.pendingGatewayUrl = null;
+    this.initialConnectSplashGuard = false;
     this.resetLoginSensitivePresentation();
     super.disconnectedCallback();
   }
@@ -218,6 +224,14 @@ class OpenClawApp extends OpenClawLightDomElement {
     }
     if (snapshot.connected) {
       this.loginGatePinned = false;
+    }
+    // Once the gateway has created a client, connected, or produced an error,
+    // the first connect attempt is observable and the splash guard is done.
+    if (
+      this.initialConnectSplashGuard &&
+      (snapshot.client !== null || snapshot.connected || snapshot.lastError !== null)
+    ) {
+      this.initialConnectSplashGuard = false;
     }
   }
 
@@ -291,7 +305,7 @@ class OpenClawApp extends OpenClawLightDomElement {
       !gatewaySnapshot.reconnecting &&
       !this.loginGatePinned &&
       gatewaySnapshot.lastError === null &&
-      gatewaySnapshot.client !== null;
+      (gatewaySnapshot.client !== null || this.initialConnectSplashGuard);
     if (initialConnectPending) {
       return html`
         <openclaw-tooltip-provider>

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -110,4 +110,21 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await gateway.resolveDeferred("connect");
     await page.locator("openclaw-app-shell").waitFor();
   });
+
+  it("paints the splash on first paint before the connect request starts", async () => {
+    const page = await createPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    await page.goto(`${server.baseUrl}#token=e2e-shared-token`);
+    // The splash must be present immediately on first paint, before the gateway
+    // mock has even observed the connect request. This regresses a flash of the
+    // login gate that could occur while stored credentials were waiting for the
+    // first WebSocket connect to be created (#103342).
+    await page.locator(".connect-splash").waitFor({ timeout: 1_000 });
+    expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+
+    await gateway.waitForRequest("connect");
+    await gateway.resolveDeferred("connect");
+    await page.locator("openclaw-app-shell").waitFor();
+  });
 });


### PR DESCRIPTION
Closes #103342

## What Problem This Solves

Fixes an issue where refreshing the Control UI while authenticated with token auth (or any stored credentials) briefly flashed the login gate before the gateway connection finished. The flash was most noticeable behind an Nginx HTTPS reverse proxy, where the WebSocket handshake introduced a small delay, but the root cause was a race in the initial paint: the splash that should cover the first connect was only shown after the gateway client had been created, leaving a window where the login gate rendered even though credentials were present.

## Why This Change Was Made

The Control UI's `initialConnectPending` condition required `gatewaySnapshot.client !== null` to show the connecting splash. The client is created asynchronously when `runtime.start()` calls `gateway.start()` → `connect()`, so the first paint after `connectedCallback` could render the login gate while stored credentials were already loaded.

This change introduces an `initialConnectSplashGuard` that is set when stored credentials are detected at mount and is cleared once the first connect attempt becomes observable (client created, connection opened, or an error emitted). The splash now covers the first paint through the end of the first connect attempt, eliminating the transient unauthenticated state.

## User Impact

Control UI users with stored tokens, passwords, or device tokens no longer see a forced-logout flash when refreshing the page. The experience is a smooth loading splash that transitions directly to the app shell on success or to the login gate on a real auth failure.

## Evidence

- Added unit tests in `ui/src/app/app-host.test.ts` verifying the splash guard stays active before a connect attempt is observable and is cleared when the gateway creates a client or emits an error.
- Added an E2E regression in `ui/src/e2e/initial-connect-splash.e2e.test.ts` that navigates with a stored token and asserts the splash is present on first paint before the mock gateway observes the connect request, with no `openclaw-login-gate` in the DOM.
- Ran focused tests locally:
  - `cd ui && npx vitest run app-host.test.ts --config vitest.config.ts` — 9 tests passed.
  - `npx vitest run ui/src/e2e/initial-connect-splash.e2e.test.ts --config test/vitest/vitest.ui-e2e.config.ts` — 5 tests passed.
