### PR TITLE
fix(anthropic): interrupted thinking no longer bricks replay

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -25,11 +25,53 @@ type AnthropicStreamOptions = Parameters<AnthropicStreamFn>[2];
 type RequestTransportConfig = Parameters<typeof attachModelProviderRequestTransport>[1];
 
 function createSseResponse(events: Record<string, unknown>[] = []): Response {
-  const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  const body = serializeSseEvents(events);
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
   });
+}
+
+function serializeSseEvents(events: Record<string, unknown>[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+function createFailingSseResponse(events: Record<string, unknown>[], error: Error): Response {
+  const encoder = new TextEncoder();
+  let sentEvents = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!sentEvents) {
+        sentEvents = true;
+        controller.enqueue(encoder.encode(serializeSseEvents(events)));
+        return;
+      }
+      controller.error(error);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function createInterruptedThinkingEvents(): Record<string, unknown>[] {
+  return [
+    {
+      type: "message_start",
+      message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "thinking", thinking: "step by step", signature: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "signature_delta", signature: "partial-signature" },
+    },
+  ];
 }
 
 function createStalledSseResponse(params: { onCancel: (reason: unknown) => void }): Response {
@@ -1939,6 +1981,124 @@ describe("anthropic transport stream", () => {
       thinking: "step by step",
       thinkingSignature: "chunk1chunk2chunk3",
     });
+  });
+
+  it.each([
+    {
+      label: "the stream ends before content_block_stop",
+      response: () => createSseResponse(createInterruptedThinkingEvents()),
+      stopReason: "stop",
+    },
+    {
+      label: "the provider errors before content_block_stop",
+      response: () =>
+        createSseResponse([
+          ...createInterruptedThinkingEvents(),
+          { type: "error", error: { message: "provider failed" } },
+        ]),
+      stopReason: "error",
+    },
+    {
+      label: "the response body fails",
+      response: () =>
+        createFailingSseResponse(
+          createInterruptedThinkingEvents(),
+          new Error("response body failed"),
+        ),
+      stopReason: "error",
+    },
+  ])("does not persist signature deltas when $label", async ({ response, stopReason }) => {
+    guardedFetchMock.mockResolvedValueOnce(response());
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "think" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe(stopReason);
+    expect(result.content[0]).toMatchObject({
+      type: "thinking",
+      thinking: "step by step",
+      thinkingSignature: "",
+    });
+  });
+
+  it("does not persist signature deltas when the request aborts", async () => {
+    const controller = new AbortController();
+    guardedFetchMock.mockResolvedValueOnce(
+      createOpenRawSseResponse({
+        body: serializeSseEvents(createInterruptedThinkingEvents()),
+        onCancel: () => undefined,
+      }),
+    );
+    setTimeout(() => controller.abort(new Error("request aborted")), 20);
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "think" }] } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        signal: controller.signal,
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("aborted");
+    expect(result.content[0]).toMatchObject({
+      type: "thinking",
+      thinkingSignature: "",
+    });
+  });
+
+  it("commits only stopped signatures across interleaved thinking blocks", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "first", signature: "" },
+        },
+        {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "thinking", thinking: "second", signature: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 1,
+          delta: { type: "signature_delta", signature: "complete-second" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "partial-first" },
+        },
+        { type: "content_block_stop", index: 1 },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "think" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: "thinking",
+        thinking: "first",
+        thinkingSignature: "",
+      }),
+      expect.objectContaining({
+        type: "thinking",
+        thinking: "second",
+        thinkingSignature: "complete-second",
+      }),
+    ]);
   });
 
   it("captures OpenAI-style reasoning_content deltas from Anthropic-compatible streams", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -1256,7 +1256,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         );
         const blocks = output.content;
         const blockIndexes = new Map<number, number>();
-        const signatureDeltaIndexes = new Set<number>();
+        // Signature deltas are opaque and only complete at content_block_stop.
+        // Keep partial bytes out of output so interrupted streams cannot poison replay.
+        const pendingThinkingSignatures = new Map<number, string>();
         const allowReasoningContentReplay = supportsReasoningContentReplay(model);
         const reasoningContentThinkingBlocks = new Map<number, number>();
         const reasoningContentTextBlocks = new Map<number, number>();
@@ -1453,6 +1455,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               refusalBuffer?.discard();
               pendingTextEnds.length = 0;
               blockIndexes.clear();
+              pendingThinkingSignatures.clear();
               applyAnthropicFallbackBoundary({
                 output,
                 boundary: fallbackBoundary,
@@ -1492,6 +1495,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               }
               continue;
             }
+            pendingThinkingSignatures.delete(index);
             if (contentBlock?.type === "text") {
               const text =
                 typeof contentBlock.text === "string"
@@ -1695,16 +1699,23 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               typeof delta.signature === "string"
             ) {
               const signatureIndex = eventIndexKey(event.index);
-              if (!signatureDeltaIndexes.has(signatureIndex)) {
-                signatureDeltaIndexes.add(signatureIndex);
+              const pendingSignature = pendingThinkingSignatures.get(signatureIndex);
+              if (pendingSignature === undefined) {
                 block.thinkingSignature = "";
+                pendingThinkingSignatures.set(signatureIndex, delta.signature);
+              } else {
+                pendingThinkingSignatures.set(signatureIndex, pendingSignature + delta.signature);
               }
-              block.thinkingSignature = (block.thinkingSignature || "") + delta.signature;
             }
             continue;
           }
           if (event.type === "content_block_stop") {
             const eventIndex = typeof event.index === "number" ? event.index : undefined;
+            const pendingSignature =
+              eventIndex === undefined ? undefined : pendingThinkingSignatures.get(eventIndex);
+            if (eventIndex !== undefined) {
+              pendingThinkingSignatures.delete(eventIndex);
+            }
             const index = eventIndex === undefined ? undefined : blockIndexes.get(eventIndex);
             const block = index === undefined ? undefined : blocks[index];
             if (eventIndex === undefined || index === undefined || !block) {
@@ -1724,6 +1735,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               continue;
             }
             if (block.type === "thinking") {
+              if (pendingSignature !== undefined) {
+                block.thinkingSignature = pendingSignature;
+              }
               eventSink.push({
                 type: "thinking_end",
                 contentIndex: index,


### PR DESCRIPTION
Closes #103830
Supersedes the administratively closed #103938.

## What Problem This Solves

Fixes an issue where an interrupted Anthropic extended-thinking stream could persist an incomplete cryptographic signature. Every later turn in that session replayed the truncated signature, causing Anthropic to reject the request and effectively making the session unusable.

## Why This Change Was Made

Signature deltas are opaque and only known to be complete when the matching `content_block_stop` arrives. The transport now stages delta bytes privately by content-block index, clears the replay-visible signature when delta streaming begins, and commits the exact staged bytes only at that lifecycle boundary.

This preserves completed signatures byte-for-byte, preserves provider-seeded signatures when no delta follows, clears pending state across fallback boundaries, and avoids format, length, or cryptographic guesses about provider-owned data. Existing rejection-time repair remains available for sessions poisoned by older versions.

This change was developed with Codex assistance. I reviewed the implementation and understand the affected transport and replay behavior.

## User Impact

An interrupted Anthropic thinking response no longer poisons the session's future conversation history. Users can continue the same session after a network interruption or incomplete provider stream instead of resetting it and losing conversational context.

## Evidence

- `pnpm test src/agents/anthropic-transport-stream.test.ts`
  - 107 tests passed.
- `pnpm test src/agents/embedded-agent-runner/replay-history.test.ts src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner/thinking-replay-repair.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`
  - 199 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed`
  - Passed core type checks, test type checks, changed lint, import-cycle checks, and repository guards.
- `$autoreview`
  - Clean, with no accepted or actionable findings.
- Rebased onto current `origin/main`; `git range-diff` confirmed the patch remained content-identical.

All tests and live proof ran through Crabbox on Blacksmith Testbox `tbx_01kx7c9m7z63hk8kcyn3vb4466`.

### Live behavior proof

A loopback fault proxy forwarded real Anthropic Claude Sonnet 4.6 traffic, intercepted the provider's 432-byte `signature_delta`, forwarded only the first 216 bytes, and terminated the stream before `content_block_stop`.

Before the fix:

- The interrupted output persisted the 216-byte partial signature.
- The next request replayed that signature.
- Anthropic returned HTTP 400 with an invalid-signature response.

After the fix:

- The interrupted output persisted no signature delta bytes.
- The replay request and another same-session continuation contained no incomplete thinking signature.
- All three Anthropic requests returned HTTP 200 and both subsequent turns completed normally.

The live proof was executed against the committed patch before a content-preserving rebase; `git range-diff` maps that commit directly to the current PR head.
