### PR TITLE
fix(ui): preserve UTF-16 workshop previews

### DIFF
--- a/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
@@ -75,6 +75,43 @@ afterEach(() => {
 });
 
 describe("SkillWorkshopPage lifecycle", () => {
+  it("renders truncated Today previews without dangling surrogates", async () => {
+    const previewText = `${"a".repeat(118)}😀trailing`;
+    const proposal = {
+      key: "proposal-utf16-preview",
+      slug: "proposal-utf16-preview",
+      name: "UTF-16 preview",
+      oneLine: "Preview boundary coverage",
+      body: `## Workflow\n- ${previewText}`,
+      status: "pending",
+      version: 1,
+      createdAt: 0,
+      updatedAt: 0,
+      recencyGroup: "today",
+      ageLabel: "now",
+      supportFiles: [],
+      isNew: false,
+      origin: {
+        agentId: "research",
+        sessionKey: "agent:research:proposal-utf16-preview",
+      },
+    } satisfies SkillWorkshopProposal;
+    const loadedState = createSkillWorkshopState();
+    loadedState.skillWorkshopAgentId = "research";
+    loadedState.skillWorkshopLoaded = true;
+    loadedState.skillWorkshopProposals = [proposal];
+    loadedState.skillWorkshopSelectedKey = proposal.key;
+    const page = document.createElement(
+      "openclaw-skill-workshop-page",
+    ) as SkillWorkshopPageTestElement;
+    page.data = skillWorkshopRouteData(loadedState);
+    page.context = createContext(vi.fn(async () => ({})));
+    document.body.append(page);
+    await page.updateComplete;
+
+    expect(page.querySelector(".sw-today__does li")?.textContent).toBe(`${"a".repeat(118)}…`);
+  });
+
   it("forces a fresh proposal load when the gateway source changes", async () => {
     const firstRequest = vi.fn(async () => ({}));
     const secondRequest = vi.fn(async () => ({

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -1,4 +1,5 @@
 // Control UI view renders skill workshop screen content.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -916,7 +917,7 @@ function truncateAtWord(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
-  const clipped = value.slice(0, maxChars - 1);
+  const clipped = truncateUtf16Safe(value, maxChars - 1);
   const boundary = clipped.lastIndexOf(" ");
   const base = boundary > 48 ? clipped.slice(0, boundary) : clipped;
   return `${base.trimEnd()}…`;


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop's Today preview truncates proposal list items at 120 UTF-16 code units. A raw `String.slice` can stop after an emoji's high surrogate, leaving malformed text in the rendered preview.

## Why This Change Was Made

Use the browser-compatible `truncateUtf16Safe` primitive already used across Control UI. Preserve the existing 120-unit budget, word-boundary behavior, and ellipsis presentation; only the unsafe cutoff changes.

## User Impact

Long Skill Workshop proposal previews no longer render a replacement character when their truncation boundary falls inside an emoji.

## Evidence

- Blacksmith Testbox `tbx_01kx7a49qv2xqp9yt3dbrt1mmh`: focused Skill Workshop UI tests passed 4/4.
- The regression renders a real Today preview in the DOM with an emoji spanning the old cutoff and verifies the clean ellipsis result.
- Same Testbox: path-scoped core production/test type checks, lint, import-cycle checks, and repository guards passed.
- `git diff --check` passed.
- Fresh autoreview: no actionable findings; correctness confidence 0.99.

The path-scoped lane emitted only the unrelated warning-only temporary-directory migration report already present on current `main`.
