### PR TITLE
fix(macos): drag the window from split-view pane headers

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardFailurePage.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardFailurePage.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Renders the static error page the dashboard window shows when the Control
+/// UI cannot load. Presentation-only; kept out of `DashboardWindowController`
+/// so the controller stays focused on window/navigation behavior.
+enum DashboardFailurePage {
+    static func html(title: String, message: String, detail: String?, url: URL?) -> String {
+        let detailHTML = detail.map { "<p class=\"detail\">\(self.htmlEscape($0))</p>" } ?? ""
+        let urlHTML = url.map { "<code>\(self.htmlEscape($0.absoluteString))</code>" } ?? ""
+        return """
+        <!doctype html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <style>
+            :root { color-scheme: light dark; }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              min-height: 100vh;
+              display: grid;
+              place-items: center;
+              background: #101114;
+              color: rgba(255,255,255,.92);
+              font: 15px -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+            }
+            main {
+              width: min(540px, calc(100vw - 72px));
+              padding: 34px;
+              border: 1px solid rgba(255,255,255,.12);
+              border-radius: 22px;
+              background: rgba(255,255,255,.035);
+              box-shadow: 0 28px 90px rgba(0,0,0,.36);
+              line-height: 1.45;
+            }
+            .badge {
+              width: 44px;
+              height: 44px;
+              display: grid;
+              place-items: center;
+              margin-bottom: 20px;
+              border-radius: 14px;
+              background: rgba(255,255,255,.07);
+              color: #ff746b;
+              font-size: 24px;
+            }
+            h1 {
+              margin: 0 0 12px;
+              font-size: 24px;
+              line-height: 1.16;
+              font-weight: 700;
+              letter-spacing: 0;
+            }
+            p {
+              margin: 0;
+              color: rgba(255,255,255,.76);
+              font-size: 16px;
+            }
+            .detail {
+              margin-top: 14px;
+              color: rgba(255,255,255,.56);
+              font-size: 13px;
+            }
+            code {
+              display: block;
+              margin-top: 18px;
+              padding: 12px;
+              border: 1px solid rgba(255,255,255,.08);
+              border-radius: 10px;
+              background: rgba(0,0,0,.26);
+              color: rgba(255,255,255,.76);
+              overflow-wrap: anywhere;
+              font: 12px ui-monospace, SFMono-Regular, Menlo, monospace;
+            }
+            @media (prefers-color-scheme: light) {
+              body { background: #f5f6f8; color: rgba(0,0,0,.86); }
+              main {
+                background: rgba(255,255,255,.84);
+                border-color: rgba(0,0,0,.1);
+                box-shadow: 0 28px 90px rgba(0,0,0,.12);
+              }
+              .badge { background: rgba(0,0,0,.06); }
+              p { color: rgba(0,0,0,.68); }
+              .detail { color: rgba(0,0,0,.54); }
+              code {
+                background: rgba(0,0,0,.05);
+                border-color: rgba(0,0,0,.08);
+                color: rgba(0,0,0,.68);
+              }
+            }
+          </style>
+        </head>
+        <body>
+          <main>
+            <div class="badge">!</div>
+            <h1>\(self.htmlEscape(title))</h1>
+            <p>\(self.htmlEscape(message))</p>
+            \(detailHTML)
+            \(urlHTML)
+          </main>
+        </body>
+        </html>
+        """
+    }
+
+    private static func htmlEscape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -242,7 +242,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.refreshNativeAuthScript(url: self.currentURL, auth: self.auth)
         self.webView.stopLoading()
         self.webView.loadHTMLString(
-            Self.failureHTML(title: title, message: message, detail: detail, url: nil),
+            DashboardFailurePage.html(title: title, message: message, detail: detail, url: nil),
             baseURL: nil)
         self.show()
     }
@@ -846,120 +846,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) \
             error=\(error.localizedDescription, privacy: .public)
             """)
-        let html = Self.failureHTML(
+        let html = DashboardFailurePage.html(
             title: "Dashboard unavailable",
             message: error.localizedDescription,
             detail: "The dashboard window is open, but the web UI could not load from this endpoint.",
             url: self.currentURL)
         self.webView.loadHTMLString(html, baseURL: nil)
-    }
-
-    private static func failureHTML(title: String, message: String, detail: String?, url: URL?) -> String {
-        let detailHTML = detail.map { "<p class=\"detail\">\(self.htmlEscape($0))</p>" } ?? ""
-        let urlHTML = url.map { "<code>\(self.htmlEscape($0.absoluteString))</code>" } ?? ""
-        return """
-        <!doctype html>
-        <html>
-        <head>
-          <meta charset="utf-8">
-          <style>
-            :root { color-scheme: light dark; }
-            * { box-sizing: border-box; }
-            body {
-              margin: 0;
-              min-height: 100vh;
-              display: grid;
-              place-items: center;
-              background: #101114;
-              color: rgba(255,255,255,.92);
-              font: 15px -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
-            }
-            main {
-              width: min(540px, calc(100vw - 72px));
-              padding: 34px;
-              border: 1px solid rgba(255,255,255,.12);
-              border-radius: 22px;
-              background: rgba(255,255,255,.035);
-              box-shadow: 0 28px 90px rgba(0,0,0,.36);
-              line-height: 1.45;
-            }
-            .badge {
-              width: 44px;
-              height: 44px;
-              display: grid;
-              place-items: center;
-              margin-bottom: 20px;
-              border-radius: 14px;
-              background: rgba(255,255,255,.07);
-              color: #ff746b;
-              font-size: 24px;
-            }
-            h1 {
-              margin: 0 0 12px;
-              font-size: 24px;
-              line-height: 1.16;
-              font-weight: 700;
-              letter-spacing: 0;
-            }
-            p {
-              margin: 0;
-              color: rgba(255,255,255,.76);
-              font-size: 16px;
-            }
-            .detail {
-              margin-top: 14px;
-              color: rgba(255,255,255,.56);
-              font-size: 13px;
-            }
-            code {
-              display: block;
-              margin-top: 18px;
-              padding: 12px;
-              border: 1px solid rgba(255,255,255,.08);
-              border-radius: 10px;
-              background: rgba(0,0,0,.26);
-              color: rgba(255,255,255,.76);
-              overflow-wrap: anywhere;
-              font: 12px ui-monospace, SFMono-Regular, Menlo, monospace;
-            }
-            @media (prefers-color-scheme: light) {
-              body { background: #f5f6f8; color: rgba(0,0,0,.86); }
-              main {
-                background: rgba(255,255,255,.84);
-                border-color: rgba(0,0,0,.1);
-                box-shadow: 0 28px 90px rgba(0,0,0,.12);
-              }
-              .badge { background: rgba(0,0,0,.06); }
-              p { color: rgba(0,0,0,.68); }
-              .detail { color: rgba(0,0,0,.54); }
-              code {
-                background: rgba(0,0,0,.05);
-                border-color: rgba(0,0,0,.08);
-                color: rgba(0,0,0,.68);
-              }
-            }
-          </style>
-        </head>
-        <body>
-          <main>
-            <div class="badge">!</div>
-            <h1>\(self.htmlEscape(title))</h1>
-            <p>\(self.htmlEscape(message))</p>
-            \(detailHTML)
-            \(urlHTML)
-          </main>
-        </body>
-        </html>
-        """
-    }
-
-    private static func htmlEscape(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
-            .replacingOccurrences(of: "'", with: "&#39;")
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -28,8 +28,18 @@ private final class DashboardLinkMessageHandler: NSObject, WKScriptMessageHandle
 }
 
 @MainActor
+private final class DashboardWindowDragMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var owner: DashboardWindowController?
+
+    func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+        self.owner?.receiveWindowDragMessage(message)
+    }
+}
+
+@MainActor
 final class DashboardWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     private static let linkMessageHandlerName = "openclawLink"
+    private static let windowDragMessageHandlerName = "openclawWindowDrag"
 
     private let webView: WKWebView
     private let linkBrowser: DashboardLinkBrowserView
@@ -55,6 +65,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         config.userContentController = WKUserContentController()
         let linkMessageHandler = DashboardLinkMessageHandler()
         config.userContentController.add(linkMessageHandler, name: Self.linkMessageHandlerName)
+        let windowDragMessageHandler = DashboardWindowDragMessageHandler()
+        config.userContentController.add(windowDragMessageHandler, name: Self.windowDragMessageHandlerName)
         Self.installNativeChromeScript(into: config.userContentController)
         Self.installNativeAuthScript(into: config.userContentController, url: url, auth: auth)
 
@@ -104,6 +116,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         // optional browser collapsed until a link explicitly opens it.
         self.linkBrowserItem.isCollapsed = true
         linkMessageHandler.owner = self
+        windowDragMessageHandler.owner = self
         self.webView.navigationDelegate = self
         self.webView.uiDelegate = self
         self.linkBrowser.webViewNavigationDelegate = self
@@ -276,6 +289,36 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         case .external:
             self.openExternal(request.url)
         }
+    }
+
+    /// The Control UI posts this from mousedown on passive pane-header chrome
+    /// (split-view session titles). WKWebView swallows titlebar-style drags, so
+    /// the web side asks the window to take over the in-flight mouse gesture.
+    fileprivate func receiveWindowDragMessage(_ message: WKScriptMessage) {
+        guard message.name == Self.windowDragMessageHandlerName,
+              message.webView === self.webView,
+              message.frameInfo.isMainFrame,
+              Self.isTrustedLinkSource(message.frameInfo.request.url, dashboardURL: self.currentURL),
+              Self.isWindowDragRequest(message.body),
+              let window
+        else {
+            return
+        }
+        // The script message arrives async; during a press the app's current
+        // event is still the initiating left-mouse-down (or a later drag). A
+        // finished click leaves left-mouse-up here and starts no drag.
+        guard let event = NSApp.currentEvent,
+              event.type == .leftMouseDown || event.type == .leftMouseDragged,
+              event.window === window
+        else {
+            return
+        }
+        window.performDrag(with: event)
+    }
+
+    static func isWindowDragRequest(_ body: Any) -> Bool {
+        guard let payload = body as? [String: Any] else { return false }
+        return payload["type"] as? String == "window-drag"
     }
 
     static func linkRequest(from body: Any) -> DashboardLinkRequest? {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -86,6 +86,13 @@ struct DashboardWindowSmokeTests {
         ]) == nil)
     }
 
+    @Test func `dashboard accepts only typed window drag requests`() {
+        #expect(DashboardWindowController.isWindowDragRequest(["type": "window-drag"]))
+        #expect(!DashboardWindowController.isWindowDragRequest(["type": "open-link"]))
+        #expect(!DashboardWindowController.isWindowDragRequest(["type": 1]))
+        #expect(!DashboardWindowController.isWindowDragRequest("window-drag"))
+    }
+
     @Test func `dashboard trusts only its main control path for link messages`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let trusted = try #require(URL(string: "http://127.0.0.1:18789/control/chat"))

--- a/ui/src/app/native-window-drag.test.ts
+++ b/ui/src/app/native-window-drag.test.ts
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { beginNativeWindowDrag } from "./native-window-drag.ts";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+function installBridge() {
+  const postMessage = vi.fn();
+  vi.stubGlobal("webkit", { messageHandlers: { openclawWindowDrag: { postMessage } } });
+  return postMessage;
+}
+
+function buildHeader() {
+  const header = document.createElement("div");
+  header.className = "chat-pane__header";
+  const title = document.createElement("span");
+  title.textContent = "iPhone";
+  const button = document.createElement("button");
+  button.type = "button";
+  header.append(title, button);
+  header.addEventListener("mousedown", beginNativeWindowDrag);
+  document.body.append(header);
+  return { header, title, button };
+}
+
+function mouseDown(target: Element, init: MouseEventInit = {}) {
+  const event = new MouseEvent("mousedown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    button: 0,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("native window drag", () => {
+  it("posts a window-drag message for presses on passive header chrome", () => {
+    const postMessage = installBridge();
+    const { header } = buildHeader();
+
+    const event = mouseDown(header);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: "window-drag" });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("treats the static title text as draggable chrome", () => {
+    const postMessage = installBridge();
+    const { title } = buildHeader();
+
+    const event = mouseDown(title);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: "window-drag" });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("leaves presses on interactive children alone", () => {
+    const postMessage = installBridge();
+    const { button } = buildHeader();
+
+    const event = mouseDown(button);
+
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores secondary buttons and already-handled presses", () => {
+    const postMessage = installBridge();
+    const { header } = buildHeader();
+
+    mouseDown(header, { button: 2 });
+    const handled = new MouseEvent("mousedown", { cancelable: true, button: 0 });
+    handled.preventDefault();
+    beginNativeWindowDrag(handled);
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps default behavior without the WebKit bridge", () => {
+    const { header } = buildHeader();
+
+    const event = mouseDown(header);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/ui/src/app/native-window-drag.ts
+++ b/ui/src/app/native-window-drag.ts
@@ -1,0 +1,49 @@
+type NativeWindowDragMessage = { type: "window-drag" };
+
+type WebKitMessageHandler = {
+  postMessage(message: NativeWindowDragMessage): void;
+};
+
+function getNativeWindowDragPoster(): WebKitMessageHandler["postMessage"] | undefined {
+  // Native macOS hosts install this handler before navigation; its absence
+  // (plain browsers, other hosts) keeps default mouse behavior.
+  const handler = (
+    window as unknown as {
+      webkit?: { messageHandlers?: { openclawWindowDrag?: WebKitMessageHandler } };
+    }
+  ).webkit?.messageHandlers?.openclawWindowDrag;
+  return handler?.postMessage.bind(handler);
+}
+
+const INTERACTIVE_TARGET_SELECTOR =
+  "a, button, input, select, textarea, [role='button'], [contenteditable]";
+
+/**
+ * mousedown handler for chrome-like rows (split pane headers): asks the native
+ * macOS host to move the window, matching titlebar drag behavior. Presses on
+ * interactive children keep their normal click handling.
+ */
+export function beginNativeWindowDrag(event: MouseEvent): void {
+  // Synthetic events cannot force a drag: the native handler only acts while
+  // an actual left-mouse press is the app's current event.
+  if (event.button !== 0 || event.defaultPrevented) {
+    return;
+  }
+  for (const target of event.composedPath()) {
+    if (target instanceof Element && target.matches(INTERACTIVE_TARGET_SELECTOR)) {
+      return;
+    }
+  }
+  const post = getNativeWindowDragPoster();
+  if (!post) {
+    return;
+  }
+  try {
+    post({ type: "window-drag" });
+  } catch {
+    return;
+  }
+  // The native drag session owns the rest of the gesture; without this the
+  // page still starts a text selection underneath the moving window.
+  event.preventDefault();
+}

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -18,6 +18,7 @@ import {
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
+import { beginNativeWindowDrag } from "../../app/native-window-drag.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import {
   COMMAND_PALETTE_TARGET_EVENT,
@@ -1124,7 +1125,10 @@ class ChatPane extends OpenClawLightDomElement {
     backgroundTasks: BackgroundTasksProps,
   ) {
     return html`
-      <div class="chat-pane__header ${this.active ? "chat-pane__header--active" : ""}">
+      <div
+        class="chat-pane__header ${this.active ? "chat-pane__header--active" : ""}"
+        @mousedown=${beginNativeWindowDrag}
+      >
         <!-- Static text on purpose: an interactive session picker here would
              fight pane focus. Panes change sessions via the sidebar or
              drag-and-drop. -->

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -136,6 +136,10 @@ openclaw-chat-pane {
   padding: 0 6px 0 12px;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   background: color-mix(in srgb, var(--panel) 62%, transparent);
+  /* Chrome row, not content: a selectable title would fight the native
+     window drag the macOS app starts from this row. */
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .chat-pane__header--active {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users of the macOS app in split-screen chat would try to drag the window by a pane's top header row (the strip showing the session title) and instead start a text selection of the title. The pane header sits at the very top of the window where a titlebar is expected, but WKWebView swallows the mouse gesture: the window never moves and a meaningless title selection appears instead.

## Why This Change Was Made

WKWebView honors neither `isMovableByWindowBackground` nor Electron-style `app-region: drag`, and the existing native drag-region strips in the dashboard window are fixed-geometry overlays that cannot follow per-pane split layout or avoid each pane's header buttons. The fix mirrors the existing `openclawLink` bridge: the Control UI posts an `openclawWindowDrag` script message on mousedown over passive pane-header chrome, and the dashboard window validates the source (main frame, trusted control path, typed body) plus the in-flight gesture (`NSApp.currentEvent` must be a left-mouse press in this window) before handing the event to `NSWindow.performDrag(with:)`. The header row is also marked `user-select: none` since it is chrome, not content. Browsers and other hosts see no behavior change: without the native handler, the mousedown keeps its default behavior.

## User Impact

In the macOS app, split-screen pane headers now behave like a titlebar: press-and-drag on the title or any empty header area moves the window, and the header no longer starts a pointless text selection. Header buttons (workspace toggle, split down/right, close) keep working as before. Browser users only lose the accidental selectability of the pane title.

## Evidence

- Live mechanism proof on macOS (standalone WKWebView harness using the exact bridge and guards): synthetic press on the header followed by a +300/+100 drag invoked `performDrag` from the left-mouse-down current event and moved the window frame exactly from (200,300) to (500,400).
- `swift build --package-path apps/macos`: Build complete.
- `swift test --filter DashboardWindowSmokeTests` (local macOS): 24 tests passed, including the new `dashboard accepts only typed window drag requests`.
- `pnpm test ui/src/app/native-window-drag.test.ts ui/src/pages/chat/chat-pane.test.ts ui/src/pages/chat/chat-page.test.ts` (Testbox): 27 passed.
- `pnpm check:changed -- <touched files>` (Testbox): exit 0 (format, lint, typecheck core/test lanes, guards).
- Autoreview (Codex gpt-5.5, xhigh): clean, no actionable findings.
