### PR TITLE
fix: installer removes temporary files after failed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 - **Canvas A2UI validation:** reject malformed or unsupported JSONL at CLI, agent-tool, and final node-invoke boundaries while preserving native v0.8 dispatch. (#103713) Thanks @qingminglong.
 - **Twilio RCS inbound routing:** normalize RCS consumer addresses only after signed webhook validation so sender matching and sessions work without changing outbound RCS semantics. (#102373) Thanks @clawSean.
 - **ClickClack output sanitization:** strip internal tool and XML scaffolding at the sender boundary, suppress scaffold-only sends, and preserve optional modern delivery IDs. (#103142) Thanks @masatohoshino.
-- **CLI installer cleanup:** remove Node staging directories and pnpm workspace-rewrite temporary files on failure. (#103725) Thanks @SebTardif.
+- **Installer cleanup:** remove installer-owned temporary paths after failed CLI and primary installer operations by keeping cleanup registration in the parent shell. (#103725) Thanks @SebTardif.
 - **Agent-core truncation:** avoid empty-output crashes when head truncation receives negative line or byte ceilings. (#103425) Thanks @qingminglong.
 - **Windows Node resolution:** preserve the current executable when resolving bare case-insensitive `node.exe` entries under hostile `PATH` values. (#103907) Thanks @soldforaloss.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 - **Canvas A2UI validation:** reject malformed or unsupported JSONL at CLI, agent-tool, and final node-invoke boundaries while preserving native v0.8 dispatch. (#103713) Thanks @qingminglong.
 - **Twilio RCS inbound routing:** normalize RCS consumer addresses only after signed webhook validation so sender matching and sessions work without changing outbound RCS semantics. (#102373) Thanks @clawSean.
 - **ClickClack output sanitization:** strip internal tool and XML scaffolding at the sender boundary, suppress scaffold-only sends, and preserve optional modern delivery IDs. (#103142) Thanks @masatohoshino.
-- **Installer cleanup:** remove installer-owned temporary paths after failed CLI and primary installer operations by keeping cleanup registration in the parent shell. (#103725) Thanks @SebTardif.
+- **CLI installer cleanup:** remove Node staging directories and pnpm workspace-rewrite temporary files on failure. (#103725) Thanks @SebTardif.
 - **Agent-core truncation:** avoid empty-output crashes when head truncation receives negative line or byte ceilings. (#103425) Thanks @qingminglong.
 - **Windows Node resolution:** preserve the current executable when resolving bare case-insensitive `node.exe` entries under hostile `PATH` values. (#103907) Thanks @soldforaloss.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,10 +49,12 @@ trap abort_install_int INT
 trap abort_install_term TERM
 
 mktempfile() {
-    local f
+    local output_var="${1:?output variable required}" f
     f="$(mktemp)"
+    # Assign into caller scope; command substitution would lose this cleanup
+    # registration in its subshell.
     TMPFILES+=("$f")
-    echo "$f"
+    printf -v "$output_var" '%s' "$f"
 }
 
 resolve_openclaw_effective_home() {
@@ -117,7 +119,7 @@ download_file() {
 run_remote_bash() {
     local url="$1"
     local tmp
-    tmp="$(mktempfile)"
+    mktempfile tmp
     download_file "$url" "$tmp"
     /bin/bash "$tmp"
 }
@@ -479,8 +481,8 @@ run_with_spinner() {
 
     if [[ -n "$GUM" ]] && gum_is_tty && ! is_shell_function "${1:-}"; then
         local gum_err gum_out
-        gum_err="$(mktempfile)"
-        gum_out="$(mktempfile)"
+        mktempfile gum_err
+        mktempfile gum_out
         if "$GUM" spin --spinner dot --title "$title" -- "$@" >"$gum_out" 2>"$gum_err"; then
             if is_gum_raw_mode_failure "$gum_out" || is_gum_raw_mode_failure "$gum_err"; then
                 GUM=""
@@ -523,7 +525,7 @@ run_quiet_step() {
     fi
 
     local log
-    log="$(mktempfile)"
+    mktempfile log
     local showed_progress=false
 
     local cmd_exit=0
@@ -1012,7 +1014,7 @@ print_npm_failure_diagnostics() {
 install_openclaw_npm() {
     local spec="$1"
     local log
-    log="$(mktempfile)"
+    mktempfile log
     if ! run_npm_global_install "$spec" "$log"; then
         local attempted_build_tool_fix=false
         if auto_install_build_tools_for_npm_failure "$log"; then
@@ -1860,7 +1862,7 @@ install_node() {
         ui_info "Installing Node.js via NodeSource"
         if command -v apt-get &> /dev/null; then
             local tmp
-            tmp="$(mktempfile)"
+            mktempfile tmp
             run_required_step "Downloading NodeSource setup script" download_file "https://deb.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_required_step "Configuring NodeSource repository" bash "$tmp"
@@ -1871,7 +1873,7 @@ install_node() {
             fi
         elif command -v dnf &> /dev/null; then
             local tmp
-            tmp="$(mktempfile)"
+            mktempfile tmp
             run_required_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_required_step "Configuring NodeSource repository" bash "$tmp"
@@ -1882,7 +1884,7 @@ install_node() {
             fi
         elif command -v yum &> /dev/null; then
             local tmp
-            tmp="$(mktempfile)"
+            mktempfile tmp
             run_required_step "Downloading NodeSource setup script" download_file "https://rpm.nodesource.com/setup_${NODE_DEFAULT_MAJOR}.x" "$tmp"
             if is_root; then
                 run_required_step "Configuring NodeSource repository" bash "$tmp"

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1,6 +1,14 @@
 // Install Sh tests cover install sh script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -45,6 +53,30 @@ describe("install.sh", () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout).toBe("leaked=0\n");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+  });
+
+  it("removes a downloaded script temp file when remote execution fails", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-remote-cleanup-"));
+    const tempFile = join(tmp, "remote-script.sh");
+
+    try {
+      const result = runInstallShell(
+        [
+          "set -euo pipefail",
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          'mktemp() { : > "$PROBE_PATH"; printf \'%s\\n\' "$PROBE_PATH"; }',
+          "download_file() { printf '#!/bin/bash\\nexit 42\\n' > \"$2\"; }",
+          'run_remote_bash "https://example.invalid/setup.sh"',
+        ].join("\n"),
+        { PROBE_PATH: tempFile },
+      );
+
+      expect(result.status).toBe(42);
+      expect(existsSync(tempFile)).toBe(false);
+      expect(script).not.toMatch(/\$\(\s*mktempfile\s*\)/);
     } finally {
       rmSync(tmp, { force: true, recursive: true });
     }


### PR DESCRIPTION
Related: #103725

## What Problem This Solves

Fixes an issue where failed primary installer operations could leave downloaded scripts and diagnostic logs in `/tmp` because their cleanup registrations were lost before the installer exited.

## Why This Change Was Made

`mktempfile` now assigns its result into a caller variable, so the parent shell retains every path in its cleanup list. All seven callers use that interface; the existing Bash 3.2-safe cleanup loop remains unchanged.

This is an AI-assisted maintainer follow-up to the CLI installer cleanup in #103725.

## User Impact

Failed and successful `install.sh` operations now remove installer-owned temporary files while preserving the wrapped command's exit status.

## Evidence

- Blacksmith Testbox `tbx_01kx7czzpbmz1019khv7ss8tza` (Linux): `corepack pnpm test test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts` — 91 tests passed.
- Source-blind behavior validation: failure exits 42 and 43 preserved; randomized temp paths removed; success exit 0 also cleaned up.
- `/bin/bash -n scripts/install.sh`
- `pnpm exec oxfmt --check test/scripts/install-sh.test.ts`
- `git diff --check`
- Fresh Codex autoreview: clean, no accepted/actionable findings.
