### PR TITLE
fix(macos): start existing CLI gateway during onboarding

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18771,7 +18771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 236,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -18779,7 +18779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 235,
+      "line": 236,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
@@ -19099,7 +19099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 164,
+      "line": 165,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",
@@ -19243,7 +19243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 179,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Existing gateway detected",
       "surface": "apple",
@@ -19251,7 +19251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 179,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
@@ -19259,7 +19259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 181,
+      "line": 182,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " (\\(probe.command) pid \\(probe.pid))",
       "surface": "apple",
@@ -19267,7 +19267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
@@ -19275,7 +19275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
@@ -19283,7 +19283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 204,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
@@ -19291,7 +19291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
@@ -19299,7 +19299,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 212,
+      "line": 213,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
@@ -19307,7 +19307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 240,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
@@ -19315,7 +19315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 240,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide Advanced",
       "surface": "apple",
@@ -19323,7 +19323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 260,
+      "line": 261,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
@@ -19331,7 +19331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 261,
+      "line": 262,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -19339,7 +19339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 263,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -19347,7 +19347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 269,
+      "line": 270,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -19355,7 +19355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 273,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -19363,7 +19363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 280,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -19371,7 +19371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 299,
+      "line": 300,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -19379,7 +19379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 303,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -19387,7 +19387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 307,
+      "line": 308,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
@@ -19395,7 +19395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 310,
+      "line": 311,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -19403,7 +19403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 315,
+      "line": 316,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -19411,7 +19411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 319,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -19419,7 +19419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 328,
+      "line": 329,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
@@ -19427,7 +19427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 328,
+      "line": 329,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
@@ -19435,7 +19435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 390,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
@@ -19443,7 +19443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 391,
+      "line": 392,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checks the real remote websocket and auth handshake.",
       "surface": "apple",
@@ -19451,7 +19451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 405,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
@@ -19459,7 +19459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 434,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -19467,7 +19467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 437,
+      "line": 438,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
@@ -19475,7 +19475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 441,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
@@ -19483,7 +19483,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 445,
+      "line": 446,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -19491,7 +19491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 462,
+      "line": 463,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
@@ -19499,7 +19499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 593,
+      "line": 594,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
@@ -19507,7 +19507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 663,
+      "line": 664,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
@@ -19515,7 +19515,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 670,
+      "line": 671,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
@@ -19523,7 +19523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 697,
+      "line": 698,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
@@ -19531,7 +19531,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 699,
+      "line": 700,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw is setting up its background service on this Mac. This usually takes under a minute — no Terminal, no administrator password.",
       "surface": "apple",
@@ -19539,7 +19539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 710,
+      "line": 711,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -19547,7 +19547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 717,
+      "line": 718,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -19555,7 +19555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 718,
+      "line": 719,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -19563,7 +19563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 721,
+      "line": 722,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -19571,7 +19571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 722,
+      "line": 723,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -19579,7 +19579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 727,
+      "line": 728,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -19587,7 +19587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 730,
+      "line": 731,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -19595,7 +19595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 817,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Agent workspace",
       "surface": "apple",
@@ -19603,7 +19603,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 819,
+      "line": 824,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
       "surface": "apple",
@@ -19611,7 +19611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 835,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway detected",
       "surface": "apple",
@@ -19619,7 +19619,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 832,
+      "line": 837,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
       "surface": "apple",
@@ -19627,7 +19627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 838,
+      "line": 843,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copied",
       "surface": "apple",
@@ -19635,7 +19635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 838,
+      "line": 843,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copy setup command",
       "surface": "apple",
@@ -19643,7 +19643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 844,
+      "line": 849,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Workspace folder",
       "surface": "apple",
@@ -19651,7 +19651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 863,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create workspace",
       "surface": "apple",
@@ -19659,7 +19659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 864,
+      "line": 869,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open folder",
       "surface": "apple",
@@ -19667,7 +19667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 871,
+      "line": 876,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Save in config",
       "surface": "apple",
@@ -19675,7 +19675,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 892,
+      "line": 897,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
       "surface": "apple",
@@ -19683,7 +19683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 907,
+      "line": 912,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Meet your agent",
       "surface": "apple",
@@ -19691,7 +19691,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 909,
+      "line": 914,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
       "surface": "apple",
@@ -19699,7 +19699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 930,
+      "line": 935,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -19707,7 +19707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 933,
+      "line": 938,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -19715,7 +19715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 941,
+      "line": 946,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -19723,7 +19723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 942,
+      "line": 947,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -19731,7 +19731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 949,
+      "line": 954,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -19739,7 +19739,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 950,
+      "line": 955,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -19747,7 +19747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 959,
+      "line": 964,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -19755,7 +19755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 960,
+      "line": 965,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for quick chat and status.",
       "surface": "apple",
@@ -19763,7 +19763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 963,
+      "line": 968,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -19771,7 +19771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 964,
+      "line": 969,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -19779,7 +19779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 966,
+      "line": 971,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -19787,7 +19787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 976,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -19795,7 +19795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 972,
+      "line": 977,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -19803,7 +19803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 975,
+      "line": 980,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -19811,7 +19811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 976,
+      "line": 981,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel for quick chat; the agent can show previews ",
       "surface": "apple",
@@ -19819,7 +19819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 985,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -19827,7 +19827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 981,
+      "line": 986,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -19835,7 +19835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 983,
+      "line": 988,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -19843,7 +19843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 988,
+      "line": 993,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -19851,7 +19851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1017,
+      "line": 1022,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -19859,7 +19859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1024,
+      "line": 1029,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19867,7 +19867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1033,
+      "line": 1038,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -19875,7 +19875,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1036,
+      "line": 1041,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -19883,7 +19883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1042,
+      "line": 1047,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -19891,7 +19891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1048,
+      "line": 1053,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -114,6 +114,7 @@ struct OnboardingView: View {
     @State var copied = false
     @State var monitoringPermissions = false
     @State var monitoringDiscovery = false
+    @State var cliExecutableReady = false
     @State var cliInstalled = false
     @State var cliStatusKnown = false
     @State var onboardingVisible = false

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -97,6 +97,7 @@ extension OnboardingView {
         self.resetGatewayBoundAIState()
         let oldActive = self.activePageIndex
         self.reconcilePageForModeChange(previousActivePageIndex: oldActive)
+        self.startExistingCLIActivationIfNeeded()
         self.returnToInferenceSetupIfNeeded()
         if let updatePageMonitoring {
             updatePageMonitoring(self.activePageIndex)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -51,11 +51,16 @@ extension OnboardingView {
     }
 
     func maybeInstallCLI(for pageIndex: Int) {
+        if pageIndex == cliPageIndex, cliExecutableReady {
+            self.startExistingCLIActivationIfNeeded()
+            return
+        }
         guard Self.shouldAutoInstallCLI(
             onCLIPage: pageIndex == cliPageIndex,
             isLocal: state.connectionMode == .local,
             visible: onboardingVisible,
             statusKnown: cliStatusKnown,
+            executableReady: cliExecutableReady,
             installed: cliInstalled,
             installing: installingCLI)
         else { return }
@@ -67,10 +72,62 @@ extension OnboardingView {
         isLocal: Bool,
         visible: Bool,
         statusKnown: Bool,
+        executableReady: Bool,
         installed: Bool,
         installing: Bool) -> Bool
     {
-        onCLIPage && isLocal && visible && statusKnown && !installed && !installing
+        onCLIPage && isLocal && visible && statusKnown && !executableReady && !installed && !installing
+    }
+
+    func startExistingCLIActivationIfNeeded() {
+        guard Self.shouldStartExistingCLIActivation(
+            isLocal: state.connectionMode == .local,
+            executableReady: cliExecutableReady,
+            installing: installingCLI)
+        else { return }
+        // Keep the CLI setup gate in the page order until its Gateway is reachable.
+        cliInstalled = false
+        installingCLI = true
+        cliInstallPhase = .startingService
+        OnboardingController.shared.setWindowCloseEnabled(false)
+        OnboardingController.shared.busyReason = "OpenClaw is starting the Gateway service."
+        cliStatus = "Starting OpenClaw Gateway…"
+        Task { @MainActor in await self.finishExistingCLIActivation() }
+    }
+
+    static func shouldStartExistingCLIActivation(
+        isLocal: Bool,
+        executableReady: Bool,
+        installing: Bool) -> Bool
+    {
+        isLocal && executableReady && !installing
+    }
+
+    func finishExistingCLIActivation() async {
+        defer {
+            installingCLI = false
+            cliInstallPhase = .idle
+            OnboardingController.shared.setWindowCloseEnabled(true)
+            OnboardingController.shared.busyReason = nil
+        }
+
+        let result = await CLIInstaller.activateLocalGateway()
+        guard state.connectionMode == .local else {
+            cliInstalled = true
+            return
+        }
+
+        switch result {
+        case .ready:
+            cliInstalled = true
+            cliStatus = "OpenClaw Gateway is ready."
+        case .deferred:
+            cliInstalled = false
+            cliStatus = "OpenClaw is paused. Resume it, then retry setup to start the Gateway."
+        case .failed:
+            cliInstalled = false
+            cliStatus = "OpenClaw is installed, but the Gateway did not start. Retry setup."
+        }
     }
 
     func startCLIInstall() {
@@ -104,6 +161,7 @@ extension OnboardingView {
             self.cliStatus = message
         }
         guard installed else { return }
+        cliExecutableReady = true
         cliInstallLocation = CLIInstaller.managedExecutableLocation()
         cliStatus = "Starting OpenClaw Gateway…"
         // The step checklist shows one spinner at a time: install first,
@@ -127,9 +185,11 @@ extension OnboardingView {
         // Never let that stale result replace live installation progress.
         guard self.onboardingVisible, !Task.isCancelled, !installingCLI else { return }
         cliInstallLocation = status.location
+        cliExecutableReady = status.isReady
         cliInstalled = status.isReady
         cliStatusKnown = true
         cliStatus = status.message
+        self.startExistingCLIActivationIfNeeded()
         self.maybeInstallCLI(for: self.activePageIndex)
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -147,6 +147,7 @@ extension OnboardingView {
                     .multilineTextAlignment(.center)
             }
         }
+        .disabled(self.installingCLI)
         .onChange(of: self.state.connectionMode) { _, newValue in
             guard Self.shouldResetRemoteProbeFeedback(
                 for: newValue,
@@ -729,7 +730,11 @@ extension OnboardingView {
                         docsSlug: "platforms/mac/bundled-gateway",
                         retryTitle: "Try again")
                     {
-                        self.startCLIInstall()
+                        if self.cliExecutableReady {
+                            self.startExistingCLIActivationIfNeeded()
+                        } else {
+                            self.startCLIInstall()
+                        }
                     }
                 } else if let cliStatus, !self.cliInstalled {
                     Text(cliStatus)

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -115,6 +115,7 @@ struct OnboardingViewSmokeTests {
             isLocal: true,
             visible: true,
             statusKnown: false,
+            executableReady: false,
             installed: false,
             installing: false))
         #expect(OnboardingView.shouldAutoInstallCLI(
@@ -122,6 +123,7 @@ struct OnboardingViewSmokeTests {
             isLocal: true,
             visible: true,
             statusKnown: true,
+            executableReady: false,
             installed: false,
             installing: false))
         #expect(!OnboardingView.shouldAutoInstallCLI(
@@ -129,8 +131,32 @@ struct OnboardingViewSmokeTests {
             isLocal: true,
             visible: false,
             statusKnown: true,
+            executableReady: false,
             installed: false,
             installing: false))
+        #expect(!OnboardingView.shouldAutoInstallCLI(
+            onCLIPage: true,
+            isLocal: true,
+            visible: true,
+            statusKnown: true,
+            executableReady: true,
+            installed: false,
+            installing: false))
+    }
+
+    @Test func `detected CLI starts its gateway after this Mac is selected`() {
+        #expect(!OnboardingView.shouldStartExistingCLIActivation(
+            isLocal: false,
+            executableReady: true,
+            installing: false))
+        #expect(OnboardingView.shouldStartExistingCLIActivation(
+            isLocal: true,
+            executableReady: true,
+            installing: false))
+        #expect(!OnboardingView.shouldStartExistingCLIActivation(
+            isLocal: true,
+            executableReady: true,
+            installing: true))
     }
 
     @Test func `connection mode change restarts full page monitoring`() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fresh macOS onboarding with an already-compatible OpenClaw CLI would skip installation but never start the local Gateway, causing the AI setup step to fail with a loopback connection error.

## Why This Change Was Made

Executable readiness and Gateway readiness are tracked separately. When This Mac is selected, onboarding starts and verifies the detected CLI's Gateway before removing the setup gate; retries restart the service instead of reinstalling a valid CLI, and connection choices stay fixed during the short activation probe.

## User Impact

Users who already have the CLI— including Claude Code or Codex CLI onboarding variants—can continue directly into AI setup without a spurious Gateway connection failure or redundant CLI download.

## Evidence

- Reproduced in a pristine Parallels macOS snapshot with the exact signed app and matching exact-head CLI: AI setup failed with `Could not connect to ws://127.0.0.1:18789` before this fix.
- `swift test --package-path apps/macos --filter OnboardingViewSmokeTests` (16 tests passed)
- `swift test --package-path apps/macos --filter CLIInstallerTests` (9 tests passed)
- `scripts/format-swift.sh macos`
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- No changelog file change; release-note context is retained here for release generation.
