### PR TITLE
fix(shell): use PowerShell CLI args for custom pwsh/powershell shell paths on Windows

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -144,6 +144,36 @@ describe("getShellConfig", () => {
     expect(getShellConfig(shellPath)).toEqual({ shell: shellPath, args: ["-f", "-c"] });
   });
 
+  it("uses PowerShell CLI args for a custom pwsh.exe shell path", () => {
+    const binDir = createTempCommandDir(tempDirs, [{ name: "pwsh.exe" }]);
+    const shellPath = path.join(binDir, "pwsh.exe");
+
+    expect(getShellConfig(shellPath)).toEqual({
+      shell: shellPath,
+      args: ["-NoProfile", "-NonInteractive", "-Command"],
+    });
+  });
+
+  it("uses PowerShell CLI args for a custom powershell.exe shell path", () => {
+    const binDir = createTempCommandDir(tempDirs, [{ name: "powershell.exe" }]);
+    const shellPath = path.join(binDir, "powershell.exe");
+
+    expect(getShellConfig(shellPath)).toEqual({
+      shell: shellPath,
+      args: ["-NoProfile", "-NonInteractive", "-Command"],
+    });
+  });
+
+  it("uses PowerShell CLI args for a custom pwsh (no extension) shell path", () => {
+    const binDir = createTempCommandDir(tempDirs, [{ name: "pwsh" }]);
+    const shellPath = path.join(binDir, "pwsh");
+
+    expect(getShellConfig(shellPath)).toEqual({
+      shell: shellPath,
+      args: ["-NoProfile", "-NonInteractive", "-Command"],
+    });
+  });
+
   it("rejects a missing explicit custom shell path", () => {
     expect(() => getShellConfig(path.join(os.tmpdir(), "missing-openclaw-shell"))).toThrow(
       "Custom shell path not found",

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -81,6 +81,17 @@ export function getPosixShellArgs(shellPath: string): string[] {
   }
 }
 
+// Windows PowerShell (powershell.exe / pwsh.exe) does not accept POSIX-style
+// invocation flags. When a custom shell path points at a PowerShell binary we
+// must use the PowerShell CLI flags (-NoProfile -NonInteractive -Command)
+// instead of the POSIX default (-c), which PowerShell would reject.
+function isPowerShellShell(shellPath: string): boolean {
+  const base = path.basename(shellPath).toLowerCase();
+  return base === "pwsh.exe" || base === "powershell.exe" || base === "pwsh" || base === "powershell";
+}
+
+const WINDOWS_POWERSHELL_ARGS = ["-NoProfile", "-NonInteractive", "-Command"];
+
 export function resolveWindowsBashPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const candidates = [env.ProgramFiles, env["ProgramFiles(x86)"]]
     .filter((dir): dir is string => Boolean(dir?.trim()))
@@ -98,7 +109,9 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
     if (!fs.existsSync(customShellPath)) {
       throw new Error(`Custom shell path not found: ${customShellPath}`);
     }
-    return { shell: customShellPath, args: getPosixShellArgs(customShellPath) };
+    // A custom PowerShell path must use PowerShell CLI args, not POSIX args.
+    const args = isPowerShellShell(customShellPath) ? WINDOWS_POWERSHELL_ARGS : getPosixShellArgs(customShellPath);
+    return { shell: customShellPath, args };
   }
 
   if (process.platform === "win32") {
@@ -141,7 +154,9 @@ export function getBashShellConfig(customShellPath?: string): ShellConfig {
     if (!fs.existsSync(customShellPath)) {
       throw new Error(`Custom shell path not found: ${customShellPath}`);
     }
-    return { shell: customShellPath, args: getPosixShellArgs(customShellPath) };
+    // A custom PowerShell path must use PowerShell CLI args, not POSIX args.
+    const args = isPowerShellShell(customShellPath) ? WINDOWS_POWERSHELL_ARGS : getPosixShellArgs(customShellPath);
+    return { shell: customShellPath, args };
   }
 
   if (process.platform === "win32") {


### PR DESCRIPTION
## Summary

On Windows, when a user sets a custom shell path (`shellPath` / `settings.shellPath`) that points to a PowerShell binary (e.g. `pwsh.exe` from the Microsoft Store App Execution Alias, or a custom `pwsh` install), OpenClaw invoked it with POSIX-style arguments (`-c`) instead of PowerShell CLI arguments.

PowerShell does not accept `-c` (it uses `-Command`), so the exec command was either rejected or silently ignored — making the `shellPath` setting effectively broken for PowerShell on Windows.

## Root cause

In `src/agents/shell-utils.ts`, `getShellConfig(customShellPath)` and `getBashShellConfig(customShellPath)` both delegate to `getPosixShellArgs()`, whose `default` branch returns `["-c"]`. A custom `pwsh.exe`/`powershell.exe` path fell into that default, producing `pwsh.exe -c "..."`, which is invalid.

Note that the non-custom Windows path already uses the correct args (`-NoProfile -NonInteractive -Command`) via `resolvePowerShellPath()`. The bug only affected the explicit `customShellPath` case.

## Fix

- Add `isPowerShellShell(shellPath)` helper that detects `pwsh`, `pwsh.exe`, `powershell`, `powershell.exe`.
- When a custom shell path is a PowerShell binary, use `WINDOWS_POWERSHELL_ARGS = ["-NoProfile", "-NonInteractive", "-Command"]` instead of the POSIX `-c` args.
- Applied to both `getShellConfig` and `getBashShellConfig` for consistency.

## Test plan

- Added tests in `shell-utils.test.ts` asserting custom `pwsh.exe`, `powershell.exe`, and `pwsh` (no extension) paths yield `["-NoProfile", "-NonInteractive", "-Command"]`.
- Existing tests unchanged; the existing POSIX custom-shell test (zsh) still passes.
