### PR TITLE
fix(export): prevent broken emoji in HTML tool call previews

### DIFF
--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -640,6 +640,25 @@
     return p;
   }
 
+  function truncateUtf16Safe(s, maxLen) {
+    const limit = Math.max(0, Math.floor(maxLen));
+    if (s.length <= limit) {
+      return s;
+    }
+
+    let end = limit;
+    if (end > 0) {
+      const lastCodeUnit = s.charCodeAt(end - 1);
+      const nextCodeUnit = s.charCodeAt(end);
+      const endsWithHighSurrogate = lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff;
+      const continuesWithLowSurrogate = nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff;
+      if (endsWithHighSurrogate && continuesWithLowSurrogate) {
+        end -= 1;
+      }
+    }
+    return s.slice(0, end);
+  }
+
   function formatToolCall(name, args) {
     switch (name) {
       case "read": {
@@ -660,11 +679,8 @@
         return `[edit: ${shortenPath(String(args.path || args.file_path || ""))}]`;
       case "bash": {
         const rawCmd = String(args.command || "");
-        const cmd = rawCmd
-          .replace(/[\n\t]/g, " ")
-          .trim()
-          .slice(0, 50);
-        return `[bash: ${cmd}${rawCmd.length > 50 ? "..." : ""}]`;
+        const cmd = rawCmd.replace(/[\n\t]/g, " ").trim();
+        return `[bash: ${truncateUtf16Safe(cmd, 50)}${rawCmd.length > 50 ? "..." : ""}]`;
       }
       case "grep":
         return `[grep: /${args.pattern || ""}/ in ${shortenPath(String(args.path || "."))}]`;
@@ -673,8 +689,9 @@
       case "ls":
         return `[ls: ${shortenPath(String(args.path || "."))}]`;
       default: {
-        const argsStr = JSON.stringify(args).slice(0, 40);
-        return `[${name}: ${argsStr}${JSON.stringify(args).length > 40 ? "..." : ""}]`;
+        const argsJson = JSON.stringify(args);
+        const argsStr = truncateUtf16Safe(argsJson, 40);
+        return `[${name}: ${argsStr}${argsJson.length > 40 ? "..." : ""}]`;
       }
     }
   }
@@ -726,19 +743,7 @@
     if (s.length <= maxLen) {
       return s;
     }
-    let endOffset = maxLen;
-    const beforeBoundary = s.charCodeAt(endOffset - 1);
-    const afterBoundary = s.charCodeAt(endOffset);
-    // Keep the existing UTF-16 unit ceiling, but retreat if it splits a surrogate pair.
-    if (
-      beforeBoundary >= 0xd800 &&
-      beforeBoundary <= 0xdbff &&
-      afterBoundary >= 0xdc00 &&
-      afterBoundary <= 0xdfff
-    ) {
-      endOffset -= 1;
-    }
-    return s.slice(0, endOffset) + "...";
+    return truncateUtf16Safe(s, maxLen) + "...";
   }
 
   /**

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -792,3 +792,95 @@ describe("export html security hardening", () => {
     }
   });
 });
+
+describe("export html tool call previews", () => {
+  it("truncates tool previews without splitting emoji", async () => {
+    const bashPrefix = "a".repeat(49);
+    const genericPrefix = "b".repeat(29);
+    const bashExecutionPrefix = "c".repeat(99);
+    const session: SessionData = {
+      header: { id: "session-tool-preview-emoji", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: { role: "user", content: "run tools" },
+        },
+        {
+          id: "2",
+          parentId: "1",
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-bash",
+                name: "bash",
+                arguments: { command: `${bashPrefix}😀tail` },
+              },
+              {
+                type: "toolCall",
+                id: "call-custom",
+                name: "custom",
+                arguments: { value: `${genericPrefix}😀tail` },
+              },
+            ],
+          },
+        },
+        {
+          id: "3",
+          parentId: "2",
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-bash",
+            content: "bash output",
+          },
+        },
+        {
+          id: "4",
+          parentId: "3",
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-custom",
+            content: "custom output",
+          },
+        },
+        {
+          id: "5",
+          parentId: "4",
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "bashExecution",
+            command: `${bashExecutionPrefix}😀tail`,
+          },
+        },
+      ],
+      leafId: "5",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = await renderTemplate(session);
+    const previews = ["3", "4", "5"].map((id) =>
+      requireElement(
+        document.querySelector(`.tree-node[data-id="${id}"] .tree-content`),
+        `tool preview ${id} missing`,
+      ).textContent,
+    );
+
+    expect(previews).toEqual([
+      `[bash: ${bashPrefix}...]`,
+      `[custom: {"value":"${genericPrefix}...]`,
+      `[bash]: ${bashExecutionPrefix}...`,
+    ]);
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users exporting a session to HTML could see a broken replacement glyph in compact tool-call previews when a bash command or serialized tool argument was truncated through an emoji.

The corrupted preview was written into the standalone HTML artifact, so it remained visible when the export was saved or shared.

## Why This Change Was Made

The standalone viewer truncated compact sidebar strings at raw UTF-16 code-unit boundaries. The change uses one surrogate-safe helper for the 50-code-unit assistant bash preview, the 40-code-unit generic argument preview, and the shared sidebar truncation path used by persisted `bashExecution` records. It preserves the existing limits and ellipsis behavior while dropping a boundary surrogate half instead of emitting invalid text.

This is a root-cause, display-layer fix. It does not alter the stored transcript, embedded session data, full tool-call rendering, model input, schema, configuration, or wire format.

## User Impact

Exported HTML transcripts now show stable compact tool labels when long commands or arguments contain emoji at a truncation boundary. Existing ASCII previews and their length limits remain unchanged.

## Evidence

After resolving the current-main conflict, the complete export template test file passes:

```text
Test Files  1 passed (1)
Tests       17 passed (17)
[test] passed 1 Vitest shard
```

Fresh end-to-end proof used the built production `/export-session` command handler with an isolated canonical SQLite session store and five transcript entries. It wrote a 362,241-byte standalone HTML file inside the agent workspace, opened it in Chromium, and asserted the rendered sidebar labels:

```text
seeded_transcript_entries=5
✅ Session exported!
📊 Entries: 5
result: {
  'actual': [
    '[bash: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...]',
    '[custom: {"value":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbb...]',
    '[bash]: ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc...'
  ],
  'replacementCharacterPresent': False
}
Browser closed
```

A 764,811-byte full-page screenshot was captured during the same browser run. Additional fresh checks passed:

- `node scripts/run-oxlint.mjs` on the two changed files
- `git diff --check` on the two changed files
- `pnpm build`, including the export HTML asset copy step
