### PR TITLE
fix(agents): CJK-aware tool-result truncation budgets

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -247,6 +247,7 @@ import {
 import { mergeAttemptToolMediaPayloads } from "./run/tool-media-payloads.js";
 import type { EmbeddedRunFastModeParam } from "./run/types.js";
 import {
+  resolveLiveToolResultBudgets,
   resolveLiveToolResultMaxChars,
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInSession,
@@ -2944,7 +2945,7 @@ async function runEmbeddedAgentInternal(
                   const truncResult = await truncateOversizedToolResultsInSession({
                     sessionFile: activeSessionFile,
                     contextWindowTokens: ctxInfo.tokens,
-                    maxCharsOverride: resolveLiveToolResultMaxChars({
+                    maxCharsOverride: resolveLiveToolResultBudgets({
                       contextWindowTokens: ctxInfo.tokens,
                       cfg: params.config,
                       agentId: sessionAgentId,
@@ -2990,16 +2991,20 @@ async function runEmbeddedAgentInternal(
             }
             if (!toolResultTruncationAttempted) {
               const contextWindowTokens = ctxInfo.tokens;
-              const toolResultMaxChars = resolveLiveToolResultMaxChars({
+              const toolResultBudgets = resolveLiveToolResultBudgets({
                 contextWindowTokens,
                 cfg: params.config,
                 agentId: sessionAgentId,
               });
+              const toolResultMaxChars = Math.min(
+                toolResultBudgets.estimatedMaxChars,
+                toolResultBudgets.physicalMaxChars,
+              );
               const hasOversized = attempt.messagesSnapshot
                 ? sessionLikelyHasOversizedToolResults({
                     messages: attempt.messagesSnapshot,
                     contextWindowTokens,
-                    maxCharsOverride: toolResultMaxChars,
+                    maxCharsOverride: toolResultBudgets,
                   })
                 : false;
 
@@ -3012,7 +3017,7 @@ async function runEmbeddedAgentInternal(
                 const truncResult = await truncateOversizedToolResultsInSession({
                   sessionFile: activeSessionFile,
                   contextWindowTokens,
-                  maxCharsOverride: toolResultMaxChars,
+                  maxCharsOverride: toolResultBudgets,
                   sessionId: activeSessionId,
                   sessionKey: params.sessionKey,
                   agentId: sessionAgentId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -355,6 +355,7 @@ import {
   installToolResultContextGuard,
 } from "../tool-result-context-guard.js";
 import {
+  resolveLiveToolResultBudgets,
   resolveLiveToolResultMaxChars,
   resolveLiveToolResultAggregateMaxChars,
   truncateOversizedToolResultsInMessages,
@@ -2732,11 +2733,15 @@ export async function runEmbeddedAttempt(
             DEFAULT_CONTEXT_TOKENS,
         ),
       );
-      const toolResultMaxCharsForGuard = resolveLiveToolResultMaxChars({
+      const toolResultBudgetsForGuard = resolveLiveToolResultBudgets({
         contextWindowTokens: contextTokenBudgetForGuard,
         cfg: params.config,
         agentId: sessionAgentId,
       });
+      const toolResultMaxCharsForGuard = Math.min(
+        toolResultBudgetsForGuard.estimatedMaxChars,
+        toolResultBudgetsForGuard.physicalMaxChars,
+      );
       const midTurnPrecheckEnabled =
         params.config?.agents?.defaults?.compaction?.midTurnPrecheck?.enabled === true;
       let pendingMidTurnPrecheckRequest: MidTurnPrecheckRequest | null = null;
@@ -4058,15 +4063,19 @@ export async function runEmbeddedAttempt(
         };
         if (request.route === "truncate_tool_results_only") {
           const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const toolResultMaxChars = resolveLiveToolResultMaxChars({
+          const toolResultBudgets = resolveLiveToolResultBudgets({
             contextWindowTokens: contextTokenBudget,
             cfg: params.config,
             agentId: sessionAgentId,
           });
+          const toolResultMaxChars = Math.min(
+            toolResultBudgets.estimatedMaxChars,
+            toolResultBudgets.physicalMaxChars,
+          );
           const truncationResult = truncateOversizedToolResultsInSessionManager({
             sessionManager: activeSessionManager,
             contextWindowTokens: contextTokenBudget,
-            maxCharsOverride: toolResultMaxChars,
+            maxCharsOverride: toolResultBudgets,
             sessionFile: params.sessionFile,
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
@@ -4396,20 +4405,24 @@ export async function runEmbeddedAttempt(
           }
           prePromptMessageCount = activeSession.messages.length;
           const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const promptToolResultMaxChars = resolveLiveToolResultMaxChars({
+          const promptToolResultBudgets = resolveLiveToolResultBudgets({
             contextWindowTokens: contextTokenBudget,
             cfg: params.config,
             agentId: sessionAgentId,
           });
+          const promptToolResultMaxChars = Math.min(
+            promptToolResultBudgets.estimatedMaxChars,
+            promptToolResultBudgets.physicalMaxChars,
+          );
           const promptToolResultAggregateMaxChars = resolveLiveToolResultAggregateMaxChars({
             contextWindowTokens: contextTokenBudget,
-            perResultMaxChars: promptToolResultMaxChars,
+            perResultMaxChars: promptToolResultBudgets.estimatedMaxChars,
           });
           let promptHistoryMessages = activeSession.messages;
           const promptToolResultTruncation = truncateOversizedToolResultsInMessages(
             activeSession.messages,
             contextTokenBudget,
-            promptToolResultMaxChars,
+            promptToolResultBudgets,
             promptToolResultAggregateMaxChars,
             cloneToolResultPromptProjectionState(toolResultPromptProjectionState),
           );
@@ -4943,16 +4956,20 @@ export async function runEmbeddedAttempt(
             );
           }
           if (preemptiveCompaction?.route === "truncate_tool_results_only") {
-            const toolResultMaxChars = resolveLiveToolResultMaxChars({
+            const toolResultBudgets = resolveLiveToolResultBudgets({
               contextWindowTokens: contextTokenBudget,
               cfg: params.config,
               agentId: sessionAgentId,
             });
+            const toolResultMaxChars = Math.min(
+              toolResultBudgets.estimatedMaxChars,
+              toolResultBudgets.physicalMaxChars,
+            );
             const truncationResult = await withOwnedSessionWriteLock(() =>
               truncateOversizedToolResultsInSessionManager({
                 sessionManager: activeSessionManager,
                 contextWindowTokens: contextTokenBudget,
-                maxCharsOverride: toolResultMaxChars,
+                maxCharsOverride: toolResultBudgets,
                 sessionFile: params.sessionFile,
                 sessionId: params.sessionId,
                 sessionKey: params.sessionKey,
@@ -5037,7 +5054,7 @@ export async function runEmbeddedAttempt(
                   const providerPromptHistoryTruncation = truncateOversizedToolResultsInMessages(
                     messages,
                     contextTokenBudget,
-                    promptToolResultMaxChars,
+                    promptToolResultBudgets,
                     promptToolResultAggregateMaxChars,
                     toolResultPromptProjectionState,
                   );

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -27,6 +27,7 @@ let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncatio
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
+let resolveLiveToolResultBudgets: typeof import("./tool-result-truncation.js").resolveLiveToolResultBudgets;
 let resolveLiveToolResultAggregateMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultAggregateMaxChars;
 let createToolResultPromptProjectionState: typeof import("./tool-result-truncation.js").createToolResultPromptProjectionState;
 let tmpDir: string | undefined;
@@ -47,6 +48,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
+    resolveLiveToolResultBudgets,
     resolveLiveToolResultAggregateMaxChars,
     createToolResultPromptProjectionState,
   } = await import("./tool-result-truncation.js"));
@@ -434,6 +436,84 @@ describe("truncateToolResultMessage", () => {
     expect(Number.isFinite(blocks[1].text.length)).toBe(true);
     expect(blocks[1].text.length).toBeLessThan(8000);
   });
+
+  it("preserves configured physical ceilings for dense CJK", () => {
+    // 5000 CJK physical chars: estimated = 20000. Token-share budget 16000 would
+    // alone keep ~4000 physical, but physical config ceiling of 8000 must still
+    // allow the full 5000 physical characters (config contract is UTF-16 chars).
+    const cjkText = "你".repeat(5000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: cjkText }],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(
+      msg,
+      { estimatedMaxChars: 16_000, physicalMaxChars: 8_000 },
+      {
+        suffix: "\n\n[persist-truncated]",
+        minKeepChars: 2_000,
+      },
+    );
+    // Estimated budget forces truncation (~4000 physical), physical ceiling 8000 is looser.
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const kept = getFirstToolResultText(result);
+    expect(kept.length).toBeLessThan(cjkText.length);
+    expect(kept.length).toBeLessThanOrEqual(5_000);
+    // Must not collapse to ~config/4 (2000) as if config were estimated chars.
+    expect(kept.length).toBeGreaterThan(2_500);
+  });
+
+  it("keeps full CJK payload under a loose estimated budget within physical config", () => {
+    // 3000 CJK physical: estimated 12000. estimated budget 32000 and physical 8000
+    // both allow the full payload — no truncation.
+    const cjkText = "你".repeat(3000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: cjkText }],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(msg, {
+      estimatedMaxChars: 32_000,
+      physicalMaxChars: 8_000,
+    });
+    expect(result).toBe(msg);
+  });
+
+  it("clamps minKeep to the adjusted CJK physical allocation under small caps", () => {
+    // Small estimated budget: dense CJK physical allocation ≈ 1000/4 = 250.
+    // Without clamping, minKeepChars=2000 would retain far above the budget.
+    const cjkText = "你".repeat(4_000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: cjkText }],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(msg, 1_000, {
+      suffix: "\n\n[t]",
+      minKeepChars: 2_000,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const kept = getFirstToolResultText(result);
+    expect(kept.length).toBeLessThan(cjkText.length);
+    // Physical keep should track ~estimated/4, not the unclamped 2000 floor.
+    expect(kept.length).toBeLessThanOrEqual(1_200);
+  });
 });
 
 describe("calculateMaxToolResultChars", () => {
@@ -483,6 +563,35 @@ describe("calculateMaxToolResultChars", () => {
       agentId: "writer",
     });
     expect(result).toBe(24_000);
+  });
+
+  it("separates estimated token-share budget from physical config ceiling", () => {
+    const budgets = resolveLiveToolResultBudgets({
+      contextWindowTokens: 128_000,
+      cfg: {
+        agents: {
+          defaults: {
+            contextLimits: {
+              toolResultMaxChars: 8_000,
+            },
+          },
+        },
+      },
+    });
+    // 128k * 0.3 * 4 = 153600 estimated share
+    expect(budgets.estimatedMaxChars).toBe(Math.floor(128_000 * 0.3) * 4);
+    expect(budgets.physicalMaxChars).toBe(8_000);
+    // Single-number helper still reports the tighter latin-equivalent effective cap.
+    expect(
+      resolveLiveToolResultMaxChars({
+        contextWindowTokens: 128_000,
+        cfg: {
+          agents: {
+            defaults: { contextLimits: { toolResultMaxChars: 8_000 } },
+          },
+        },
+      }),
+    ).toBe(8_000);
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -514,6 +514,58 @@ describe("truncateToolResultMessage", () => {
     // Physical keep should track ~estimated/4, not the unclamped 2000 floor.
     expect(kept.length).toBeLessThanOrEqual(1_200);
   });
+
+  it("charges intact short ASCII siblings against shared dual budgets with dense CJK", async () => {
+    // Short marker stays intact; dense CJK must absorb only the *remaining*
+    // estimated/physical budgets so the completed message stays under cap.
+    const marker = "Image reading is disabled.";
+    const cjkText = "你".repeat(8_000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [
+        { type: "text", text: marker },
+        { type: "text", text: cjkText },
+      ],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const estimatedBudget = 16_000;
+    const physicalBudget = 64_000;
+    const result = truncateToolResultMessage(
+      msg,
+      { estimatedMaxChars: estimatedBudget, physicalMaxChars: physicalBudget },
+      {
+        suffix: "\n\n[persist-truncated]",
+        minKeepChars: 500,
+      },
+    );
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const blocks = result.content as Array<{ type: string; text: string }>;
+    expect(blocks[0].text).toBe(marker);
+    expect(blocks[1].text.length).toBeLessThan(cjkText.length);
+    expect(blocks[1].text).toContain("[persist-truncated]");
+
+    const { estimateStringChars } = await import("../../utils/cjk-chars.js");
+    const totalEstimated =
+      estimateStringChars(blocks[0].text) + estimateStringChars(blocks[1].text);
+    const totalPhysical = blocks[0].text.length + blocks[1].text.length;
+    // Intact sibling cost is reserved first; completed message must not exceed
+    // the shared estimated token-share budget (allow tiny floor/suffix slack).
+    expect(totalEstimated).toBeLessThanOrEqual(estimatedBudget + 64);
+    expect(totalPhysical).toBeLessThanOrEqual(physicalBudget);
+
+    // Regression vs old allocator: if CJK still received the full budget while
+    // the marker rode free, estimated would overshoot by ~marker size * 1.
+    // Kept CJK estimated share must be strictly below full estimated budget.
+    expect(estimateStringChars(blocks[1].text)).toBeLessThanOrEqual(
+      estimatedBudget - estimateStringChars(marker),
+    );
+  });
 });
 
 describe("calculateMaxToolResultChars", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -240,6 +240,43 @@ describe("getToolResultTextLength", () => {
   it("returns zero for non-toolResult messages", () => {
     expect(getToolResultTextLength(makeAssistantMessage("hello"))).toBe(0);
   });
+
+  it("weights CJK characters higher than ASCII in estimated length", () => {
+    const asciiMsg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "a".repeat(100) }],
+      timestamp: nextTimestamp(),
+    };
+    const cjkMsg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_2",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "你".repeat(100) }],
+      timestamp: nextTimestamp(),
+    };
+    const asciiLen = getToolResultTextLength(asciiMsg);
+    const cjkLen = getToolResultTextLength(cjkMsg);
+    expect(asciiLen).toBe(100);
+    expect(cjkLen).toBe(400);
+    expect(cjkLen).toBeGreaterThan(asciiLen);
+  });
+
+  it("accounts for mixed ASCII and CJK content", () => {
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "hi你好" }],
+      timestamp: nextTimestamp(),
+    };
+    // "hi你好" = 2 ASCII + 2 CJK, estimated = 2 + 2*4 = 10
+    expect(getToolResultTextLength(msg)).toBe(10);
+  });
 });
 
 describe("truncateToolResultMessage", () => {
@@ -295,6 +332,107 @@ describe("truncateToolResultMessage", () => {
     expect(firstBlock.text).toContain("[persist-truncated]");
     expect(String(firstBlock.text).length).toBeLessThan(oversized.length);
     expect(firstBlock.content).toBe(firstBlock.text);
+  });
+
+  it("truncates dense CJK content that exceeds the token-derived budget", () => {
+    // 8000 CJK chars: estimateStringChars = 8000*4 = 32000 > 16000 budget
+    const cjkText = "你".repeat(8000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: cjkText }],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(msg, 16_000, {
+      suffix: "\n\n[persist-truncated]",
+      minKeepChars: 2_000,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const kept = getFirstToolResultText(result);
+    // Must be truncated: physical length < original
+    expect(kept.length).toBeLessThan(cjkText.length);
+    expect(kept).toContain("[persist-truncated]");
+    // Physical budget ≈ estimatedBudget / inflationRatio = 16000/4 = 4000 chars
+    expect(kept.length).toBeLessThanOrEqual(5000);
+  });
+
+  it("does not truncate ASCII text within budget", () => {
+    // 16000 ASCII chars: estimateStringChars = 16000 == 16000 budget
+    const asciiText = "a".repeat(16000);
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: asciiText }],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(msg, 16_000, {
+      suffix: "\n\n[persist-truncated]",
+      minKeepChars: 2_000,
+    });
+    expect(result).toBe(msg);
+  });
+
+  it("allocates proportional physical budget for mixed ASCII and CJK blocks", () => {
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [
+        { type: "text", text: "a".repeat(4000) },
+        { type: "text", text: "你".repeat(4000) },
+      ],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    // ASCII block: 4000 estimated chars. CJK block: 4000*4=16000 estimated chars.
+    // Total estimated: 20000. Budget 8000.
+    const result = truncateToolResultMessage(msg, 8000, {
+      suffix: "\n\n[persist-truncated]",
+      minKeepChars: 500,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const blocks = result.content as Array<{ type: string; text: string }>;
+    const asciiResult = blocks[0];
+    const cjkResult = blocks[1];
+    expect(asciiResult.text.length).toBeLessThan(4000);
+    expect(cjkResult.text.length).toBeLessThan(4000);
+    expect(cjkResult.text.length).toBeLessThanOrEqual(asciiResult.text.length + 1000);
+  });
+
+  it("skips empty text blocks without NaN propagation", () => {
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [
+        { type: "text", text: "" },
+        { type: "text", text: "你".repeat(8000) },
+      ],
+      isError: false,
+      timestamp: nextTimestamp(),
+    };
+    const result = truncateToolResultMessage(msg, 16_000, {
+      suffix: "\n\n[persist-truncated]",
+      minKeepChars: 2_000,
+    });
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const blocks = result.content as Array<{ type: string; text: string }>;
+    expect(blocks[0].text).toBe("");
+    expect(Number.isFinite(blocks[1].text.length)).toBe(true);
+    expect(blocks[1].text.length).toBeLessThan(8000);
   });
 });
 
@@ -564,6 +702,30 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(messages.reduce((sum, message) => sum + getToolResultTextLength(message), 0)).toBe(
       medium.length * 3,
     );
+  });
+
+  it("bounds aggregate CJK tool results within estimated-char budget", () => {
+    const cjkMedium = "你".repeat(3000);
+    const messages: AgentMessage[] = [
+      makeUserMessage("hello"),
+      makeAssistantMessage("calling tools"),
+      makeToolResult(cjkMedium, "call_1"),
+      makeToolResult(cjkMedium, "call_2"),
+      makeToolResult(cjkMedium, "call_3"),
+    ];
+    const { messages: result, truncatedCount } = truncateOversizedToolResultsInMessages(
+      messages,
+      128_000,
+      16_000,
+      16_000,
+    );
+    const totalChars = result.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(truncatedCount).toBeGreaterThan(0);
+    expect(totalChars).toBeLessThanOrEqual(16_000);
   });
 
   it("keeps prompt projections stable while enforcing aggregate recovery as history grows", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -66,6 +66,8 @@ const aggregateToolResultRecoveryWarnings = new Set<string>();
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
+  /** Optional physical UTF-16 ceiling when maxChars is a single estimated budget. */
+  physicalMaxChars?: number;
 };
 
 const DEFAULT_SUFFIX = (truncatedChars: number) =>
@@ -245,14 +247,38 @@ export function truncateToolResultText(
 }
 
 /**
+ * Dual-unit live tool-result budgets.
+ *
+ * - `estimatedMaxChars`: automatic token-share budget (`maxTokens * 4`). Compare
+ *   with `getToolResultTextLength` / `estimateStringChars` so dense CJK is not
+ *   under-counted.
+ * - `physicalMaxChars`: UTF-16 character ceiling from configured
+ *   `toolResultMaxChars` or the auto hard-cap ladder. Compare with physical
+ *   `text.length` so existing config stays a physical-character contract.
+ */
+export type ToolResultCharBudgets = {
+  estimatedMaxChars: number;
+  physicalMaxChars: number;
+};
+
+/**
+ * Token-share budget only (estimated chars). Does not apply the physical hard cap.
+ */
+export function calculateTokenShareEstimatedChars(contextWindowTokens: number): number {
+  if (!Number.isFinite(contextWindowTokens)) {
+    return 1;
+  }
+  const maxTokens = Math.floor(Math.max(0, contextWindowTokens) * MAX_TOOL_RESULT_CONTEXT_SHARE);
+  return Math.max(1, maxTokens * 4);
+}
+
+/**
  * Calculate the maximum allowed characters for a single tool result
  * based on the model's context window tokens.
  *
- * The budget uses a flat 4 chars/token conversion to derive a character cap
- * from the token share. The comparison side (`getToolResultTextLength`) uses
- * `estimateStringChars` for CJK-aware weighting, so dense CJK content inflates
- * the measured length and triggers truncation at a lower physical character
- * count — correct because CJK text consumes ~1 token per character.
+ * Returns `min(tokenShareEstimated, physicalHardCap)` for doctor/display and
+ * latin-equivalent effective ceilings. Runtime truncation uses
+ * {@link resolveLiveToolResultBudgets} so estimated and physical units stay separate.
  */
 export function calculateMaxToolResultChars(contextWindowTokens: number): number {
   return calculateMaxToolResultCharsWithCap(
@@ -279,22 +305,40 @@ export function calculateMaxToolResultCharsWithCap(
   contextWindowTokens: number,
   hardCapChars: number,
 ): number {
-  const maxTokens = Math.floor(contextWindowTokens * MAX_TOOL_RESULT_CONTEXT_SHARE);
-  // Token-to-char budget: the flat 4x factor produces an estimated-char cap.
-  // getToolResultTextLength uses estimateStringChars so CJK content measures
-  // larger against this cap and triggers truncation at the correct token share.
-  const maxChars = maxTokens * 4;
+  // Latin-equivalent effective ceiling for doctor/help: both inputs are treated
+  // as comparable numbers. Live truncation uses dual budgets instead.
+  const maxChars = calculateTokenShareEstimatedChars(contextWindowTokens);
   return Math.min(maxChars, Math.max(1, hardCapChars));
 }
 
+export function resolveLiveToolResultBudgets(params: {
+  contextWindowTokens: number;
+  cfg?: OpenClawConfig;
+  agentId?: string | null;
+}): ToolResultCharBudgets {
+  const configuredCap = resolveAgentContextLimits(params.cfg, params.agentId)?.toolResultMaxChars;
+  const physicalMaxChars = Math.max(
+    1,
+    Math.floor(configuredCap ?? resolveAutoLiveToolResultMaxChars(params.contextWindowTokens)),
+  );
+  return {
+    estimatedMaxChars: calculateTokenShareEstimatedChars(params.contextWindowTokens),
+    physicalMaxChars,
+  };
+}
+
+/**
+ * Single-number resolver kept for mid-turn precheck / doctor-style callers.
+ * Prefer {@link resolveLiveToolResultBudgets} for truncation so physical config
+ * ceilings are not mixed into the estimated token-share unit.
+ */
 export function resolveLiveToolResultMaxChars(params: {
   contextWindowTokens: number;
   cfg?: OpenClawConfig;
   agentId?: string | null;
 }): number {
-  const configuredCap = resolveAgentContextLimits(params.cfg, params.agentId)?.toolResultMaxChars;
-  const cap = configuredCap ?? resolveAutoLiveToolResultMaxChars(params.contextWindowTokens);
-  return calculateMaxToolResultCharsWithCap(params.contextWindowTokens, cap);
+  const budgets = resolveLiveToolResultBudgets(params);
+  return Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars);
 }
 
 export function resolveLiveToolResultAggregateMaxChars(params: {
@@ -303,15 +347,19 @@ export function resolveLiveToolResultAggregateMaxChars(params: {
   cfg?: OpenClawConfig;
   agentId?: string | null;
 }): number {
+  const budgets = resolveLiveToolResultBudgets({
+    contextWindowTokens: params.contextWindowTokens,
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  // Aggregate recovery stays in estimated-char space (token pressure). The
+  // per-result baseline matches the latin-equivalent effective ceiling
+  // (min of token-share and physical hard cap) so aggregate pressure engages
+  // at the same thresholds as before the dual-budget split.
   const perResultMaxChars = Math.max(
     1,
     Math.floor(
-      params.perResultMaxChars ??
-        resolveLiveToolResultMaxChars({
-          contextWindowTokens: params.contextWindowTokens,
-          cfg: params.cfg,
-          agentId: params.agentId,
-        }),
+      params.perResultMaxChars ?? Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     ),
   );
   const contextWindowTokens = Number.isFinite(params.contextWindowTokens)
@@ -329,10 +377,7 @@ export function resolveLiveToolResultAggregateMaxChars(params: {
   );
 }
 
-/**
- * Get the total character count of text content blocks in a tool result message.
- */
-export function getToolResultTextLength(msg: AgentMessage): number {
+function sumToolResultText(msg: AgentMessage, measure: (text: string) => number): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
     return 0;
   }
@@ -345,10 +390,7 @@ export function getToolResultTextLength(msg: AgentMessage): number {
     if (isToolResultTextBlock(block)) {
       const text = block.text;
       if (typeof text === "string") {
-        // Weight CJK/non-Latin so this estimated-char total is comparable to
-        // token-derived maxChars budgets (maxTokens * 4). Physical UTF-16 length
-        // alone undercounts CJK token cost by up to ~4x.
-        totalLength += estimateStringChars(text);
+        totalLength += measure(text);
       }
     }
   }
@@ -356,33 +398,71 @@ export function getToolResultTextLength(msg: AgentMessage): number {
 }
 
 /**
- * Truncate a tool result message's text content blocks to fit within maxChars.
- * Returns a new message (does not mutate the original).
+ * Physical UTF-16 length of tool-result text blocks (config ceiling unit).
+ */
+export function getToolResultPhysicalTextLength(msg: AgentMessage): number {
+  return sumToolResultText(msg, (text) => text.length);
+}
+
+/**
+ * CJK-weighted estimated length of tool-result text blocks (token-share unit).
+ * Alias kept as `getToolResultTextLength` for existing call sites.
+ */
+export function getToolResultTextLength(msg: AgentMessage): number {
+  return sumToolResultText(msg, estimateStringChars);
+}
+
+function normalizeToolResultCharBudgets(
+  maxChars: number | ToolResultCharBudgets,
+  options: ToolResultTruncationOptions = {},
+): ToolResultCharBudgets {
+  if (typeof maxChars === "object" && maxChars !== null) {
+    return {
+      estimatedMaxChars: Math.max(1, Math.floor(maxChars.estimatedMaxChars)),
+      physicalMaxChars: Math.max(1, Math.floor(maxChars.physicalMaxChars)),
+    };
+  }
+  const estimatedMaxChars = Math.max(1, Math.floor(maxChars));
+  // Single number (tests / legacy): treat as estimated budget only so CJK
+  // weighting applies. Physical ceiling is unlimited unless options override.
+  const physicalMaxChars = Math.max(
+    1,
+    Math.floor(options.physicalMaxChars ?? Number.MAX_SAFE_INTEGER),
+  );
+  return { estimatedMaxChars, physicalMaxChars };
+}
+
+/**
+ * Truncate a tool result message's text content blocks to fit within budgets.
+ * `maxChars` may be a single estimated-char budget (legacy/tests) or dual
+ * {@link ToolResultCharBudgets}. Returns a new message (does not mutate).
  */
 export function truncateToolResultMessage(
   msg: AgentMessage,
-  maxChars: number,
+  maxChars: number | ToolResultCharBudgets,
   options: ToolResultTruncationOptions = {},
 ): AgentMessage {
+  const budgets = normalizeToolResultCharBudgets(maxChars, options);
+  const { estimatedMaxChars, physicalMaxChars } = budgets;
+  // minKeep is resolved against the tighter physical-facing budget so small
+  // estimated allocations are not forced upward past the CJK-adjusted keep.
+  const minKeepReference = Math.min(estimatedMaxChars, physicalMaxChars);
+  const requestedMinKeep = options.minKeepChars ?? MIN_KEEP_CHARS;
   const suffixFactory = resolveSuffixFactory(options.suffix);
-  const minKeepChars = resolveEffectiveMinKeepChars({
-    maxChars,
-    minKeepChars: options.minKeepChars ?? MIN_KEEP_CHARS,
-    suffixFactory,
-  });
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return msg;
   }
 
-  // Calculate total text size
-  const totalTextChars = getToolResultTextLength(msg);
-  if (totalTextChars <= maxChars) {
+  const totalEstimatedChars = getToolResultTextLength(msg);
+  const totalPhysicalChars = getToolResultPhysicalTextLength(msg);
+  if (totalEstimatedChars <= estimatedMaxChars && totalPhysicalChars <= physicalMaxChars) {
     return msg;
   }
 
-  // Distribute the estimated-char budget proportionally among text blocks,
-  // then convert each share back to a physical UTF-16 slice budget.
+  // Distribute budgets proportionally, then convert estimated shares to physical
+  // UTF-16 slice budgets. Clamp min-keep to each block's adjusted allocation so
+  // dense CJK under small caps cannot retain more estimated chars than budgeted.
   const newContent = content.map((block: unknown) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
@@ -391,24 +471,40 @@ export function truncateToolResultMessage(
     if (typeof textBlock.text !== "string" || textBlock.text.length === 0) {
       return block;
     }
-    // CJK-aware proportional budget: estimateStringChars inflates CJK chars so
-    // they consume a proportional share of the token-derived character budget.
     const blockEstimatedChars = estimateStringChars(textBlock.text);
-    const blockShare = blockEstimatedChars / totalTextChars;
-    // Convert the estimated-char budget back to a physical-char budget that
-    // truncateToolResultText can use for UTF-16 slicing. Dense CJK text gets a
-    // smaller physical budget (≈ budget/4) because each char costs ~1 token;
-    // pure ASCII keeps budget ≈ proportionalEstimatedBudget.
-    const inflationRatio = blockEstimatedChars / textBlock.text.length;
-    const proportionalEstimatedBudget = Math.floor(maxChars * blockShare);
-    const physicalBudget = Math.floor(proportionalEstimatedBudget / Math.max(1, inflationRatio));
-    const blockBudget = Math.max(
-      1,
-      Math.min(textBlock.text.length, Math.max(minKeepChars, physicalBudget)),
+    const blockPhysicalChars = textBlock.text.length;
+    const estimatedShare = totalEstimatedChars > 0 ? blockEstimatedChars / totalEstimatedChars : 0;
+    const physicalShare = totalPhysicalChars > 0 ? blockPhysicalChars / totalPhysicalChars : 0;
+    const inflationRatio = blockEstimatedChars / Math.max(1, blockPhysicalChars);
+    const proportionalEstimatedBudget = Math.floor(estimatedMaxChars * estimatedShare);
+    const physicalFromEstimated = Math.floor(
+      proportionalEstimatedBudget / Math.max(1, inflationRatio),
     );
+    const physicalFromCap = Math.floor(physicalMaxChars * physicalShare);
+    // Keep short marker/status blocks intact; large siblings absorb the cut.
+    // Flooring proportional shares otherwise shreds e.g. "Image reading is disabled."
+    // next to a multi-KB payload under a shared estimated budget.
+    const isSmallSiblingBlock =
+      blockPhysicalChars <= 512 &&
+      totalEstimatedChars > 0 &&
+      blockEstimatedChars / totalEstimatedChars <= 0.05 &&
+      blockPhysicalChars <= physicalFromCap;
+    if (isSmallSiblingBlock) {
+      return block;
+    }
+    const rawPhysicalBudget = Math.max(
+      1,
+      Math.min(blockPhysicalChars, physicalFromEstimated, physicalFromCap),
+    );
+    const effectiveMinKeep = resolveEffectiveMinKeepChars({
+      maxChars: rawPhysicalBudget,
+      minKeepChars: Math.min(requestedMinKeep, minKeepReference, rawPhysicalBudget),
+      suffixFactory,
+    });
+    const blockBudget = rawPhysicalBudget;
     const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
       suffix: suffixFactory,
-      minKeepChars,
+      minKeepChars: effectiveMinKeep,
     });
     const nextBlock = Object.assign({}, textBlock, { text: truncatedText });
     if (typeof textBlock.content === "string") {
@@ -543,10 +639,35 @@ function formatAggregateElisionText(
  * This is used as a pre-emptive guard before sending messages to the LLM,
  * without modifying the session file.
  */
+function resolveBudgetsForContext(params: {
+  contextWindowTokens: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
+  cfg?: OpenClawConfig;
+  agentId?: string | null;
+}): ToolResultCharBudgets {
+  if (params.maxCharsOverride != null && typeof params.maxCharsOverride === "object") {
+    return normalizeToolResultCharBudgets(params.maxCharsOverride);
+  }
+  if (typeof params.maxCharsOverride === "number") {
+    // Legacy single number: estimated-only budget (tests / callers that have not
+    // migrated to dual budgets). Physical ceiling is left open so CJK weighting
+    // on the estimated side is not re-clamped by the same number as physical.
+    return {
+      estimatedMaxChars: Math.max(1, Math.floor(params.maxCharsOverride)),
+      physicalMaxChars: Number.MAX_SAFE_INTEGER,
+    };
+  }
+  return resolveLiveToolResultBudgets({
+    contextWindowTokens: params.contextWindowTokens,
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+}
+
 export function truncateOversizedToolResultsInMessages(
   messages: AgentMessage[],
   contextWindowTokens: number,
-  maxCharsOverride?: number,
+  maxCharsOverride?: number | ToolResultCharBudgets,
   aggregateMaxCharsOverride?: number,
   projectionState?: ToolResultPromptProjectionState,
 ): {
@@ -556,13 +677,13 @@ export function truncateOversizedToolResultsInMessages(
   aggregatePressureEngaged: boolean;
   aggregateBudgetChars: number;
 } {
-  const maxChars = Math.max(
-    1,
-    maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
+  const budgets = resolveBudgetsForContext({
+    contextWindowTokens,
+    maxCharsOverride,
+  });
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
     contextWindowTokens,
-    maxChars,
+    Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     aggregateMaxCharsOverride,
   );
   const projectionKeys = projectionState
@@ -595,7 +716,7 @@ export function truncateOversizedToolResultsInMessages(
   });
   const plan = buildToolResultReplacementPlan({
     branch,
-    maxChars,
+    budgets,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
     protectTrailingToolResults: Boolean(projectionState),
@@ -990,12 +1111,13 @@ function clearToolResultText(
 
 function buildOversizedToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
-  maxChars: number;
+  budgets: ToolResultCharBudgets;
   minKeepChars?: number;
   protectedEntryIds?: Set<string>;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const replacements: ToolResultReplacement[] = [];
+  const { estimatedMaxChars, physicalMaxChars } = params.budgets;
 
   for (const entry of params.branch) {
     if (entry.type !== "message" || !entry.message) {
@@ -1005,7 +1127,9 @@ function buildOversizedToolResultReplacements(params: {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
-    if (getToolResultTextLength(msg) <= params.maxChars) {
+    const estimatedLen = getToolResultTextLength(msg);
+    const physicalLen = getToolResultPhysicalTextLength(msg);
+    if (estimatedLen <= estimatedMaxChars && physicalLen <= physicalMaxChars) {
       continue;
     }
     const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
@@ -1013,10 +1137,14 @@ function buildOversizedToolResultReplacements(params: {
       : minKeepChars;
     const spillMarkers = resolveAggregateElisionMarkers(msg);
     const suffixFactory = spillMarkers?.truncationSuffix;
-    const maxChars = Math.max(params.maxChars, suffixFactory?.(1).length ?? 0);
+    const suffixFloor = suffixFactory?.(1).length ?? 0;
+    const budgets: ToolResultCharBudgets = {
+      estimatedMaxChars: Math.max(estimatedMaxChars, suffixFloor),
+      physicalMaxChars: Math.max(physicalMaxChars, suffixFloor),
+    };
     replacements.push({
       entryId: entry.id,
-      message: truncateToolResultMessage(msg, maxChars, {
+      message: truncateToolResultMessage(msg, budgets, {
         minKeepChars: replacementMinKeepChars,
         ...(suffixFactory ? { suffix: suffixFactory } : {}),
       }),
@@ -1074,7 +1202,7 @@ function applyToolResultReplacementsToBranch(
 
 function buildToolResultReplacementPlan(params: {
   branch: ToolResultBranchEntry[];
-  maxChars: number;
+  budgets: ToolResultCharBudgets;
   aggregateBudgetChars: number;
   minKeepChars?: number;
   protectTrailingToolResults?: boolean;
@@ -1092,7 +1220,7 @@ function buildToolResultReplacementPlan(params: {
     : undefined;
   const oversizedReplacements = buildOversizedToolResultReplacements({
     branch: params.branch,
-    maxChars: params.maxChars,
+    budgets: params.budgets,
     minKeepChars,
     protectedEntryIds,
   });
@@ -1129,17 +1257,17 @@ function buildToolResultReplacementPlan(params: {
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
   aggregateMaxCharsOverride?: number;
 }): ToolResultReductionPotential {
   const { messages, contextWindowTokens } = params;
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
+  const budgets = resolveBudgetsForContext({
+    contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+  });
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
     contextWindowTokens,
-    maxChars,
+    Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     params.aggregateMaxCharsOverride,
   );
   const branch = messages.map((message, index) => ({
@@ -1163,14 +1291,14 @@ export function estimateToolResultReductionPotential(params: {
   }
   const plan = buildToolResultReplacementPlan({
     branch,
-    maxChars,
+    budgets,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   const maxReducibleChars = plan.oversizedReducibleChars + plan.aggregateReducibleChars;
 
   return {
-    maxChars,
+    maxChars: Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     aggregateBudgetChars,
     toolResultCount,
     totalToolResultChars,
@@ -1184,7 +1312,7 @@ export function estimateToolResultReductionPotential(params: {
 function truncateOversizedToolResultsInExistingSessionManager(params: {
   sessionManager: SessionManager;
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
   aggregateMaxCharsOverride?: number;
   protectTrailingToolResults?: boolean;
   sessionFile?: string;
@@ -1193,13 +1321,14 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   agentId?: string;
 }): { truncated: boolean; truncatedCount: number; reason?: string } {
   const { sessionManager, contextWindowTokens } = params;
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
+  const budgets = resolveBudgetsForContext({
+    contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    agentId: params.agentId,
+  });
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
     contextWindowTokens,
-    maxChars,
+    Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     params.aggregateMaxCharsOverride,
   );
   const branch = sessionManager.getBranch() as ToolResultBranchEntry[];
@@ -1210,7 +1339,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
 
   const plan = buildToolResultReplacementPlan({
     branch,
-    maxChars,
+    budgets,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
     protectTrailingToolResults: params.protectTrailingToolResults,
@@ -1246,7 +1375,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   logToolResultSessionTruncation({
     rewrittenEntries: rewriteResult.rewrittenEntries,
     contextWindowTokens,
-    maxChars,
+    maxChars: Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     aggregateBudgetChars,
     oversizedReplacementCount: plan.oversizedReplacementCount,
     aggregateReplacementCount: plan.aggregateReplacementCount,
@@ -1265,7 +1394,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   state: TranscriptFileState;
   sessionFile: string;
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
   aggregateMaxCharsOverride?: number;
   protectTrailingToolResults?: boolean;
   sessionId?: string;
@@ -1274,13 +1403,14 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   config?: SessionWriteLockAcquireTimeoutConfig;
 }): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
   const { state, contextWindowTokens } = params;
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
+  const budgets = resolveBudgetsForContext({
+    contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    agentId: params.agentId,
+  });
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
     contextWindowTokens,
-    maxChars,
+    Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     params.aggregateMaxCharsOverride,
   );
   const branch = state.getBranch() as ToolResultBranchEntry[];
@@ -1291,7 +1421,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
 
   const plan = buildToolResultReplacementPlan({
     branch,
-    maxChars,
+    budgets,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
     protectTrailingToolResults: params.protectTrailingToolResults,
@@ -1332,7 +1462,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   logToolResultSessionTruncation({
     rewrittenEntries: rewriteResult.rewrittenEntries,
     contextWindowTokens,
-    maxChars,
+    maxChars: Math.min(budgets.estimatedMaxChars, budgets.physicalMaxChars),
     aggregateBudgetChars,
     oversizedReplacementCount: plan.oversizedReplacementCount,
     aggregateReplacementCount: plan.aggregateReplacementCount,
@@ -1350,7 +1480,7 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
 export function truncateOversizedToolResultsInSessionManager(params: {
   sessionManager: SessionManager;
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
   aggregateMaxCharsOverride?: number;
   protectTrailingToolResults?: boolean;
   sessionFile?: string;
@@ -1373,7 +1503,7 @@ export function truncateOversizedToolResultsInSessionManager(params: {
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
   aggregateMaxCharsOverride?: number;
   protectTrailingToolResults?: boolean;
   sessionId?: string;
@@ -1413,7 +1543,7 @@ export async function truncateOversizedToolResultsInSession(params: {
 export function sessionLikelyHasOversizedToolResults(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
-  maxCharsOverride?: number;
+  maxCharsOverride?: number | ToolResultCharBudgets;
 }): boolean {
   const estimate = estimateToolResultReductionPotential(params);
   return estimate.oversizedCount > 0 || estimate.aggregateReducibleChars > 0;

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -460,10 +460,81 @@ export function truncateToolResultMessage(
     return msg;
   }
 
-  // Distribute budgets proportionally, then convert estimated shares to physical
-  // UTF-16 slice budgets. Clamp min-keep to each block's adjusted allocation so
-  // dense CJK under small caps cannot retain more estimated chars than budgeted.
-  const newContent = content.map((block: unknown) => {
+  // First pass: measure text blocks and classify short siblings that stay intact.
+  // Intact blocks must reserve both estimated and physical capacity before the
+  // remaining shared budgets are distributed; otherwise a short ASCII marker
+  // rides free on top of a dense CJK block's full-budget allocation and the
+  // completed message can exceed the token-share cap.
+  type TextBlockPlan = {
+    index: number;
+    text: string;
+    estimatedChars: number;
+    physicalChars: number;
+    keepIntact: boolean;
+  };
+  const textPlans: TextBlockPlan[] = [];
+  for (let index = 0; index < content.length; index += 1) {
+    const block = content[index];
+    if (!isToolResultTextBlock(block)) {
+      continue;
+    }
+    const text = block.text;
+    if (typeof text !== "string" || text.length === 0) {
+      continue;
+    }
+    const estimatedChars = estimateStringChars(text);
+    const physicalChars = text.length;
+    textPlans.push({
+      index,
+      text,
+      estimatedChars,
+      physicalChars,
+      keepIntact: false,
+    });
+  }
+
+  let reservedEstimated = 0;
+  let reservedPhysical = 0;
+  for (const plan of textPlans) {
+    const estimatedShare = totalEstimatedChars > 0 ? plan.estimatedChars / totalEstimatedChars : 0;
+    const physicalShare = totalPhysicalChars > 0 ? plan.physicalChars / totalPhysicalChars : 0;
+    const physicalFromCap = Math.floor(physicalMaxChars * physicalShare);
+    // Keep short marker/status blocks intact; large siblings absorb the cut.
+    // Flooring proportional shares otherwise shreds e.g. "Image reading is disabled."
+    // next to a multi-KB payload under a shared estimated budget.
+    const isSmallSiblingBlock =
+      plan.physicalChars <= 512 &&
+      totalEstimatedChars > 0 &&
+      estimatedShare <= 0.05 &&
+      plan.physicalChars <= physicalFromCap &&
+      reservedEstimated + plan.estimatedChars <= estimatedMaxChars &&
+      reservedPhysical + plan.physicalChars <= physicalMaxChars;
+    if (isSmallSiblingBlock) {
+      plan.keepIntact = true;
+      reservedEstimated += plan.estimatedChars;
+      reservedPhysical += plan.physicalChars;
+    }
+  }
+
+  const remainingEstimatedBudget = Math.max(0, estimatedMaxChars - reservedEstimated);
+  const remainingPhysicalBudget = Math.max(0, physicalMaxChars - reservedPhysical);
+  let truncatableEstimatedTotal = 0;
+  let truncatablePhysicalTotal = 0;
+  for (const plan of textPlans) {
+    if (plan.keepIntact) {
+      continue;
+    }
+    truncatableEstimatedTotal += plan.estimatedChars;
+    truncatablePhysicalTotal += plan.physicalChars;
+  }
+
+  const planByIndex = new Map(textPlans.map((plan) => [plan.index, plan]));
+
+  // Distribute remaining budgets proportionally among truncatable blocks, then
+  // convert estimated shares to physical UTF-16 slice budgets. Clamp min-keep
+  // to each block's adjusted allocation so dense CJK under small caps cannot
+  // retain more estimated chars than budgeted.
+  const newContent = content.map((block: unknown, index: number) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
     }
@@ -471,38 +542,33 @@ export function truncateToolResultMessage(
     if (typeof textBlock.text !== "string" || textBlock.text.length === 0) {
       return block;
     }
-    const blockEstimatedChars = estimateStringChars(textBlock.text);
-    const blockPhysicalChars = textBlock.text.length;
-    const estimatedShare = totalEstimatedChars > 0 ? blockEstimatedChars / totalEstimatedChars : 0;
-    const physicalShare = totalPhysicalChars > 0 ? blockPhysicalChars / totalPhysicalChars : 0;
-    const inflationRatio = blockEstimatedChars / Math.max(1, blockPhysicalChars);
-    const proportionalEstimatedBudget = Math.floor(estimatedMaxChars * estimatedShare);
+    const plan = planByIndex.get(index);
+    if (!plan) {
+      return block;
+    }
+    if (plan.keepIntact) {
+      return block;
+    }
+    const estimatedShare =
+      truncatableEstimatedTotal > 0 ? plan.estimatedChars / truncatableEstimatedTotal : 0;
+    const physicalShare =
+      truncatablePhysicalTotal > 0 ? plan.physicalChars / truncatablePhysicalTotal : 0;
+    const inflationRatio = plan.estimatedChars / Math.max(1, plan.physicalChars);
+    const proportionalEstimatedBudget = Math.floor(remainingEstimatedBudget * estimatedShare);
     const physicalFromEstimated = Math.floor(
       proportionalEstimatedBudget / Math.max(1, inflationRatio),
     );
-    const physicalFromCap = Math.floor(physicalMaxChars * physicalShare);
-    // Keep short marker/status blocks intact; large siblings absorb the cut.
-    // Flooring proportional shares otherwise shreds e.g. "Image reading is disabled."
-    // next to a multi-KB payload under a shared estimated budget.
-    const isSmallSiblingBlock =
-      blockPhysicalChars <= 512 &&
-      totalEstimatedChars > 0 &&
-      blockEstimatedChars / totalEstimatedChars <= 0.05 &&
-      blockPhysicalChars <= physicalFromCap;
-    if (isSmallSiblingBlock) {
-      return block;
-    }
+    const physicalFromCap = Math.floor(remainingPhysicalBudget * physicalShare);
     const rawPhysicalBudget = Math.max(
       1,
-      Math.min(blockPhysicalChars, physicalFromEstimated, physicalFromCap),
+      Math.min(plan.physicalChars, physicalFromEstimated, physicalFromCap),
     );
     const effectiveMinKeep = resolveEffectiveMinKeepChars({
       maxChars: rawPhysicalBudget,
       minKeepChars: Math.min(requestedMinKeep, minKeepReference, rawPhysicalBudget),
       suffixFactory,
     });
-    const blockBudget = rawPhysicalBudget;
-    const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
+    const truncatedText = truncateToolResultText(textBlock.text, rawPhysicalBudget, {
       suffix: suffixFactory,
       minKeepChars: effectiveMinKeep,
     });

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { estimateStringChars } from "../../utils/cjk-chars.js";
 import { resolveAgentContextLimits } from "../agent-scope.js";
 import type { AgentMessage } from "../runtime/index.js";
 import {
@@ -247,8 +248,11 @@ export function truncateToolResultText(
  * Calculate the maximum allowed characters for a single tool result
  * based on the model's context window tokens.
  *
- * Uses a rough 4 chars ≈ 1 token heuristic (conservative for English text;
- * actual ratio varies by tokenizer).
+ * The budget uses a flat 4 chars/token conversion to derive a character cap
+ * from the token share. The comparison side (`getToolResultTextLength`) uses
+ * `estimateStringChars` for CJK-aware weighting, so dense CJK content inflates
+ * the measured length and triggers truncation at a lower physical character
+ * count — correct because CJK text consumes ~1 token per character.
  */
 export function calculateMaxToolResultChars(contextWindowTokens: number): number {
   return calculateMaxToolResultCharsWithCap(
@@ -276,7 +280,9 @@ export function calculateMaxToolResultCharsWithCap(
   hardCapChars: number,
 ): number {
   const maxTokens = Math.floor(contextWindowTokens * MAX_TOOL_RESULT_CONTEXT_SHARE);
-  // Rough conversion: ~4 chars per token on average
+  // Token-to-char budget: the flat 4x factor produces an estimated-char cap.
+  // getToolResultTextLength uses estimateStringChars so CJK content measures
+  // larger against this cap and triggers truncation at the correct token share.
   const maxChars = maxTokens * 4;
   return Math.min(maxChars, Math.max(1, hardCapChars));
 }
@@ -339,7 +345,10 @@ export function getToolResultTextLength(msg: AgentMessage): number {
     if (isToolResultTextBlock(block)) {
       const text = block.text;
       if (typeof text === "string") {
-        totalLength += text.length;
+        // Weight CJK/non-Latin so this estimated-char total is comparable to
+        // token-derived maxChars budgets (maxTokens * 4). Physical UTF-16 length
+        // alone undercounts CJK token cost by up to ~4x.
+        totalLength += estimateStringChars(text);
       }
     }
   }
@@ -372,24 +381,30 @@ export function truncateToolResultMessage(
     return msg;
   }
 
-  // Distribute the budget proportionally among text blocks
+  // Distribute the estimated-char budget proportionally among text blocks,
+  // then convert each share back to a physical UTF-16 slice budget.
   const newContent = content.map((block: unknown) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
     }
     const textBlock = block;
-    if (typeof textBlock.text !== "string") {
+    if (typeof textBlock.text !== "string" || textBlock.text.length === 0) {
       return block;
     }
-    // Proportional budget for this block
-    const blockShare = textBlock.text.length / totalTextChars;
-    const defaultSuffix = suffixFactory(
-      Math.max(1, textBlock.text.length - Math.floor(maxChars * blockShare)),
-    );
-    const proportionalBudget = Math.floor(maxChars * blockShare);
+    // CJK-aware proportional budget: estimateStringChars inflates CJK chars so
+    // they consume a proportional share of the token-derived character budget.
+    const blockEstimatedChars = estimateStringChars(textBlock.text);
+    const blockShare = blockEstimatedChars / totalTextChars;
+    // Convert the estimated-char budget back to a physical-char budget that
+    // truncateToolResultText can use for UTF-16 slicing. Dense CJK text gets a
+    // smaller physical budget (≈ budget/4) because each char costs ~1 token;
+    // pure ASCII keeps budget ≈ proportionalEstimatedBudget.
+    const inflationRatio = blockEstimatedChars / textBlock.text.length;
+    const proportionalEstimatedBudget = Math.floor(maxChars * blockShare);
+    const physicalBudget = Math.floor(proportionalEstimatedBudget / Math.max(1, inflationRatio));
     const blockBudget = Math.max(
       1,
-      Math.min(maxChars, Math.max(minKeepChars + defaultSuffix.length, proportionalBudget)),
+      Math.min(textBlock.text.length, Math.max(minKeepChars, physicalBudget)),
     );
     const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
       suffix: suffixFactory,

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -20,7 +20,7 @@ import {
   type PersistedUserTurnMessage,
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
-import { resolveLiveToolResultMaxChars } from "./embedded-agent-runner/tool-result-truncation.js";
+import { resolveLiveToolResultBudgets } from "./embedded-agent-runner/tool-result-truncation.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import type { SessionManager } from "./sessions/index.js";
@@ -160,9 +160,9 @@ export function guardSessionManager(
     allowedToolNames: opts?.allowedToolNames,
     beforeMessageWriteHook: beforeMessageWrite,
     redactLoggingConfig: opts?.config?.logging,
-    maxToolResultChars:
+    toolResultCharBudgets:
       typeof opts?.contextWindowTokens === "number"
-        ? resolveLiveToolResultMaxChars({
+        ? resolveLiveToolResultBudgets({
             contextWindowTokens: opts.contextWindowTokens,
             cfg: opts.config,
             agentId: opts.agentId,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -25,6 +25,7 @@ import { isTranscriptOnlyOpenClawAssistantModel } from "../shared/transcript-onl
 import { formatContextLimitTruncationNotice } from "./embedded-agent-runner/context-truncation-notice.js";
 import {
   DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+  type ToolResultCharBudgets,
   truncateToolResultMessage,
 } from "./embedded-agent-runner/tool-result-truncation.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -42,11 +43,11 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
  * Returns the original message if under the limit, or a new message with
  * truncated text blocks otherwise.
  */
-function capToolResultSize(msg: AgentMessage, maxChars: number): AgentMessage {
+function capToolResultSize(msg: AgentMessage, budgets: ToolResultCharBudgets): AgentMessage {
   if ((msg as { role?: string }).role !== "toolResult") {
     return msg;
   }
-  return truncateToolResultMessage(msg, maxChars, {
+  return truncateToolResultMessage(msg, budgets, {
     suffix: (truncatedChars) => formatContextLimitTruncationNotice(truncatedChars),
     minKeepChars: 2_000,
   });
@@ -56,6 +57,24 @@ function resolveMaxToolResultChars(opts?: { maxToolResultChars?: number }): numb
   return resolveIntegerOption(opts?.maxToolResultChars, DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS, {
     min: 1,
   });
+}
+
+function resolveToolResultCharBudgets(opts?: {
+  maxToolResultChars?: number;
+  toolResultCharBudgets?: ToolResultCharBudgets;
+}): ToolResultCharBudgets {
+  if (opts?.toolResultCharBudgets) {
+    return {
+      estimatedMaxChars: Math.max(1, Math.floor(opts.toolResultCharBudgets.estimatedMaxChars)),
+      physicalMaxChars: Math.max(1, Math.floor(opts.toolResultCharBudgets.physicalMaxChars)),
+    };
+  }
+  const single = resolveMaxToolResultChars(opts);
+  // Legacy single-number path: estimated-only (physical open).
+  return {
+    estimatedMaxChars: single,
+    physicalMaxChars: Number.MAX_SAFE_INTEGER,
+  };
 }
 
 type UserAgentMessage = Extract<AgentMessage, { role: "user" }>;
@@ -532,10 +551,10 @@ function capToolResultDetails(
 
 function capToolResultForPersistence(
   msg: AgentMessage,
-  maxChars: number,
+  budgets: ToolResultCharBudgets,
   redactionConfig?: ToolResultDetailRedactionConfig,
 ): AgentMessage {
-  return capToolResultDetails(capToolResultSize(msg, maxChars), redactionConfig);
+  return capToolResultDetails(capToolResultSize(msg, budgets), redactionConfig);
 }
 
 function normalizePersistedToolResultName(
@@ -615,6 +634,7 @@ export function installSessionToolResultGuard(
     ) => PluginHookBeforeMessageWriteResult | undefined;
     redactLoggingConfig?: ToolResultDetailRedactionConfig;
     maxToolResultChars?: number;
+    toolResultCharBudgets?: ToolResultCharBudgets;
     suppressNextUserMessagePersistence?: boolean;
     suppressTranscriptOnlyAssistantPersistence?: boolean;
     suppressAssistantErrorPersistence?: boolean;
@@ -657,7 +677,7 @@ export function installSessionToolResultGuard(
   const beforeWrite = opts?.beforeMessageWriteHook;
   const toolResultTransformerMayMutate = opts?.transformToolResultForPersistence !== undefined;
   const redactionConfig = opts?.redactLoggingConfig;
-  const maxToolResultChars = resolveMaxToolResultChars(opts);
+  const toolResultCharBudgets = resolveToolResultCharBudgets(opts);
   const transcriptSeqByEntryId: TranscriptSeqByEntryId = new Map();
   let suppressNextUserMessagePersistence = opts?.suppressNextUserMessagePersistence === true;
 
@@ -736,7 +756,7 @@ export function installSessionToolResultGuard(
         const flushed = applyBeforeWriteHook(transformed);
         if (flushed) {
           appendMessageAndCacheTranscriptSeq(
-            capToolResultForPersistence(flushed.message, maxToolResultChars, redactionConfig),
+            capToolResultForPersistence(flushed.message, toolResultCharBudgets, redactionConfig),
             {
               invalidateSerializedPrefixCache:
                 persistedSynthetic !== synthetic ||
@@ -784,7 +804,7 @@ export function installSessionToolResultGuard(
       const persistedToolResult = persistMessage(normalizedToolResult);
       const capped = capToolResultForPersistence(
         persistedToolResult,
-        maxToolResultChars,
+        toolResultCharBudgets,
         redactionConfig,
       );
       const transformed = persistToolResult(capped, {
@@ -797,7 +817,7 @@ export function installSessionToolResultGuard(
         return undefined;
       }
       return appendMessageAndCacheTranscriptSeq(
-        capToolResultForPersistence(persisted.message, maxToolResultChars, redactionConfig),
+        capToolResultForPersistence(persisted.message, toolResultCharBudgets, redactionConfig),
         {
           invalidateSerializedPrefixCache:
             callerInvalidatesCache ||


### PR DESCRIPTION
Closes #103847

## What Problem This Solves

Fixes an issue where users with CJK-heavy tool results (Chinese, Japanese, Korean text) would keep oversized tool payloads in the agent context even though those results already consumed far more tokens than the live truncation budget intended. Dense CJK was measured by raw UTF-16 length while the budget assumed ~4 Latin characters per token, so content could under-count by up to ~4× and skip truncation.

## Why This Change Was Made

Split live tool-result budgets into two units:

1. **Estimated / token-share** (`maxTokens * 4`) — compared with CJK-aware `estimateStringChars` so dense CJK triggers truncation at the intended token share.
2. **Physical UTF-16 ceiling** — configured `toolResultMaxChars` and the auto hard-cap ladder stay physical-character contracts (not re-interpreted as estimated chars).

When truncating multi-block results, convert each block’s estimated share back to a physical UTF-16 slice budget, clamp `minKeep` to that adjusted allocation (so small caps cannot retain more estimated cost than budgeted), keep short sibling marker blocks intact, and skip empty text blocks so inflation ratios never become NaN. Runtime paths (`run` / `attempt` / session tool-result guard) pass dual budgets via `resolveLiveToolResultBudgets`.

## User Impact

- CJK-heavy tool sessions truncate at the intended context share instead of retaining near-full CJK payloads that pressure the model window.
- Existing `toolResultMaxChars` config remains a **physical** character ceiling (upgrade-compatible).
- Pure ASCII behavior stays the same under the dual-budget path.

## Evidence

Verification host: local macOS (Crabbox bypass)

Head: `b30d7c138` (`fix(agents): charge intact siblings in dual-budget truncation`)

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/tool-result-truncation.test.ts \
  src/utils/cjk-chars.test.ts \
  src/agents/session-tool-result-guard.test.ts
# agents: 72/72 (tool-result-truncation, including dual-budget / minKeep / config ceiling cases)
# unit-fast: 18/18 (cjk-chars) + 35/35 (session-tool-result-guard)
```

Focused cases added/updated for ClawSweeper unit-boundary findings:

- configured physical ceiling not treated as estimated (CJK keep > ~config/4)
- full CJK payload kept when estimated budget is loose and physical config allows
- small-cap CJK clamps `minKeep` to adjusted physical allocation
- `resolveLiveToolResultBudgets` separates estimated token-share vs physical config

Main-contrast measurement (16000 estimated-char token-share budget):

```json
{
  "ascii_physical": 8000,
  "ascii_estimated": 8000,
  "cjk_physical": 8000,
  "cjk_estimated": 32000,
  "cjk_would_truncate_main": false,
  "cjk_would_truncate_fixed": true
}
```

## Real behavior proof

- Behavior addressed: Live tool-result truncation weights dense CJK for automatic token-share budgets while preserving configured physical character ceilings; min-keep no longer defeats CJK-adjusted physical allocations under small caps.
- Environment: local macOS openclaw checkout on branch `fix/103847-cjk-tool-result-truncation` @ `879763fc08a9`, Node + `node scripts/run-vitest.mjs`.
- Current-main contrast: On main, `getToolResultTextLength` sums `text.length`, so 8000 CJK chars measure as 8000 against a 16000 estimated-char cap and are **not** truncated despite ~token-share overshoot. After this patch the same content measures as 32000 estimated chars and is truncated under the token-share path. Configured `toolResultMaxChars: 8000` remains a physical ceiling (dual budgets), not an estimated-char reinterpretation.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts`
  2. `node scripts/run-vitest.mjs src/agents/session-tool-result-guard.test.ts src/utils/cjk-chars.test.ts`
- Evidence after fix: 72/72 + 35/35 + 18/18 green; dual-budget and minKeep regressions assert ClawSweeper P1/P2 unit boundaries.
- Control check: Existing ASCII truncation, aggregate recovery, projection, and head/tail strategy tests still pass.
- Observed result after fix: CJK auto path truncates; physical config ceiling preserved; small-cap minKeep clamped.
- ClawSweeper P1 follow-up (`b30d7c138`): intact short ASCII siblings reserved against both dual budgets before dense CJK truncation; mixed-block unit regression + allocator math show composed next-request-visible estimated chars stay ≤ token-share budget (~15935 / 16000).
- What was not tested: Live multi-turn embedded agent run against a real provider with production CJK tool output (provider transcript redaction); non-macOS hosts; full rebase onto latest main (additive-only push).

## Follow-up to ClawSweeper review

Addressed on `b30d7c138` (on top of prior dual-budget work):

1. **P1** Charge preserved/intact sibling blocks against shared dual budgets — reserve estimated + physical capacity for short intact markers first, then distribute only remaining budgets to truncatable siblings (`src/agents/embedded-agent-runner/tool-result-truncation.ts`).
2. Mixed short-ASCII + dense-CJK regression asserts the completed multi-block tool result stays within the estimated token-share cap while keeping the marker intact.
3. Focused proof: `node scripts/run-vitest.mjs` tool-result-truncation **73/73**, cjk-chars **18/18**, session-tool-result-guard **35/35**.

Allocator measurement (short ASCII marker + 8000 CJK under estimated 16000 / physical 64000):

```json
{
  "case": "short_ascii_sibling_plus_dense_cjk_allocator_math",
  "estimatedBudget": 16000,
  "physicalBudget": 64000,
  "marker_intact": true,
  "marker_physical": 26,
  "marker_estimated": 26,
  "cjk_original_physical": 8000,
  "cjk_physical_budget_after_reserve": 3993,
  "total_estimated_after_approx": 15935,
  "within_estimated_budget": true,
  "next_request_visible_estimated_chars_approx": 15935
}
```

Requesting re-review.


## AI disclosure

This fix was implemented with AI assistance (Grok). Human review of the diff, tests, and proof is still expected before merge.

