### PR TITLE
fix(scripts): make clawlog default behavior match documented usage

### DIFF
--- a/scripts/clawlog.sh
+++ b/scripts/clawlog.sh
@@ -146,12 +146,6 @@ escape_predicate_literal() {
     printf '%s' "$value"
 }
 
-# Show help if no arguments provided
-if [[ $# -eq 0 ]]; then
-    show_usage
-    exit 0
-fi
-
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -165,14 +159,26 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -n|--lines)
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                echo -e "${RED}Error: $1 requires a value${NC}" >&2
+                exit 1
+            fi
             TAIL_LINES="$2"
             shift 2
             ;;
         -l|--last)
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                echo -e "${RED}Error: $1 requires a value${NC}" >&2
+                exit 1
+            fi
             TIME_RANGE="$2"
             shift 2
             ;;
         -c|--category)
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                echo -e "${RED}Error: $1 requires a value${NC}" >&2
+                exit 1
+            fi
             CATEGORY="$2"
             shift 2
             ;;
@@ -185,10 +191,18 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -s|--search)
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                echo -e "${RED}Error: $1 requires a value${NC}" >&2
+                exit 1
+            fi
             SEARCH_TEXT="$2"
             shift 2
             ;;
         -o|--output)
+            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+                echo -e "${RED}Error: $1 requires a value${NC}" >&2
+                exit 1
+            fi
             OUTPUT_FILE="$2"
             shift 2
             ;;

--- a/scripts/clawlog.sh
+++ b/scripts/clawlog.sh
@@ -159,7 +159,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -n|--lines)
-            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo -e "${RED}Error: $1 requires a value${NC}" >&2
                 exit 1
             fi
@@ -167,7 +167,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -l|--last)
-            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo -e "${RED}Error: $1 requires a value${NC}" >&2
                 exit 1
             fi
@@ -175,7 +175,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -c|--category)
-            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo -e "${RED}Error: $1 requires a value${NC}" >&2
                 exit 1
             fi
@@ -191,7 +191,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -s|--search)
-            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo -e "${RED}Error: $1 requires a value${NC}" >&2
                 exit 1
             fi
@@ -199,7 +199,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -o|--output)
-            if [[ $# -lt 2 || "${2:-}" == -* ]]; then
+            if [[ $# -lt 2 ]]; then
                 echo -e "${RED}Error: $1 requires a value${NC}" >&2
                 exit 1
             fi

--- a/test/scripts/clawlog.test.ts
+++ b/test/scripts/clawlog.test.ts
@@ -1,0 +1,60 @@
+// Clawlog tests cover argument parsing contracts in the macOS logging helper.
+// These tests do not require a real macOS log(1) binary; they verify that the
+// script reaches the expected code paths before any platform-specific command.
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/clawlog.sh";
+
+function runClawlog(args: string[] = []) {
+  return spawnSync("bash", [SCRIPT_PATH, ...args], {
+    encoding: "utf8",
+    env: process.env,
+  });
+}
+
+describe("clawlog.sh argument parsing", () => {
+  it("uses the documented default view when run without arguments", () => {
+    const result = runClawlog();
+    const output = result.stdout + result.stderr;
+
+    // Should reach the default log-view path, not print usage.
+    expect(output).toContain("Showing last 50 log lines from the past 5m");
+    expect(output).not.toContain("USAGE:");
+  });
+
+  it("still prints usage for --help", () => {
+    const result = runClawlog(["--help"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toContain("USAGE:");
+  });
+
+  const valueOptions = ["-n", "-l", "-c", "-s", "-o"];
+  for (const option of valueOptions) {
+    it(`reports a clear error when ${option} is missing a value`, () => {
+      const result = runClawlog([option]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`Error: ${option} requires a value`);
+    });
+  }
+
+  it("accepts dash-prefixed search text", () => {
+    const result = runClawlog(["-s", "-failed"]);
+
+    expect(result.stderr).not.toContain("requires a value");
+  });
+
+  it("accepts dash-prefixed category", () => {
+    const result = runClawlog(["-c", "-ServerManager"]);
+
+    expect(result.stderr).not.toContain("requires a value");
+  });
+
+  it("accepts dash-prefixed output path", () => {
+    const result = runClawlog(["-o", "-debug.log"]);
+
+    expect(result.stderr).not.toContain("requires a value");
+  });
+});

--- a/test/scripts/clawlog.test.ts
+++ b/test/scripts/clawlog.test.ts
@@ -2,34 +2,31 @@
 // These tests do not require a real macOS log(1) binary; they verify that the
 // script reaches the expected code paths before any platform-specific command.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = fileURLToPath(new URL("../../scripts/clawlog.sh", import.meta.url));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runClawlog(args: string[] = []) {
-  const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-clawlog-test-"));
+  const cwd = tempDirs.make("openclaw-clawlog-test-");
   const binDir = path.join(cwd, "bin");
   mkdirSync(binDir);
   const sudoPath = path.join(binDir, "sudo");
   writeFileSync(sudoPath, "#!/bin/sh\nexit 0\n");
   chmodSync(sudoPath, 0o755);
 
-  try {
-    return spawnSync("bash", [SCRIPT_PATH, ...args], {
-      cwd,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
-    });
-  } finally {
-    rmSync(cwd, { recursive: true, force: true });
-  }
+  return spawnSync("bash", [SCRIPT_PATH, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
 }
 
 describe("clawlog.sh argument parsing", () => {

--- a/test/scripts/clawlog.test.ts
+++ b/test/scripts/clawlog.test.ts
@@ -2,15 +2,34 @@
 // These tests do not require a real macOS log(1) binary; they verify that the
 // script reaches the expected code paths before any platform-specific command.
 import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const SCRIPT_PATH = "scripts/clawlog.sh";
+const SCRIPT_PATH = fileURLToPath(new URL("../../scripts/clawlog.sh", import.meta.url));
 
 function runClawlog(args: string[] = []) {
-  return spawnSync("bash", [SCRIPT_PATH, ...args], {
-    encoding: "utf8",
-    env: process.env,
-  });
+  const cwd = mkdtempSync(path.join(tmpdir(), "openclaw-clawlog-test-"));
+  const binDir = path.join(cwd, "bin");
+  mkdirSync(binDir);
+  const sudoPath = path.join(binDir, "sudo");
+  writeFileSync(sudoPath, "#!/bin/sh\nexit 0\n");
+  chmodSync(sudoPath, 0o755);
+
+  try {
+    return spawnSync("bash", [SCRIPT_PATH, ...args], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 }
 
 describe("clawlog.sh argument parsing", () => {


### PR DESCRIPTION
Closes #104058

## What Problem This Solves

Fixes an issue where `scripts/clawlog.sh` printed the full usage help when invoked with no arguments, even though its own help text documents `clawlog` (no options) as "Show last 50 lines from past 5 minutes (default)."

It also fixes a secondary issue where options that require a value (`-n`, `-l`, `-c`, `-s`, `-o`) crashed with an unbound-variable error when the value was omitted, instead of printing a clear error.

## Why This Change Was Made

The script had an early branch that short-circuited to `show_usage` whenever `$# -eq 0`, before the default `TIME_RANGE="5m"` and `TAIL_LINES=50` values could be used. That branch is removed so the argument parser runs with the documented defaults.

Value validation is added to every option that consumes `$2`, so a bare flag like `clawlog -n` now reports `Error: -n requires a value` and exits cleanly instead of failing on an unbound variable under `set -u`.

## User Impact

Users running `clawlog` without arguments now get the expected default log view (last 50 lines from the past 5 minutes) on macOS, matching the documented behavior. Users who omit a required option value get a clear error message.

## Evidence

Before the fix:

```text
$ ./scripts/clawlog.sh
clawlog - OpenClaw Logging Utility
USAGE:
    clawlog [OPTIONS]
...

$ ./scripts/clawlog.sh -n
scripts/clawlog.sh:行168: $2: 未绑定的变量
```

After the fix:

```text
$ ./scripts/clawlog.sh
Showing last 50 log lines from the past 5m

$ ./scripts/clawlog.sh -n
Error: -n requires a value
```

`bash -n scripts/clawlog.sh` and `git diff --check` both pass.