### PR TITLE
fix(ui): keep raw ids out of sidebar session rows and stop WebKit section overlap

### DIFF
--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -33,6 +33,8 @@ function sessionRow(
     hasActiveRun?: boolean;
     status?: string;
     spawnedBy?: string;
+    execNode?: string;
+    worktree?: { branch?: string; repoRoot?: string };
   } = {},
 ) {
   return {
@@ -964,6 +966,119 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       });
       await expect.poll(() => pinnedGroup.locator(".sidebar-recent-session").count()).toBe(0);
       await expect.poll(() => chatsGroup.locator(".sidebar-recent-session").count()).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps raw ids out of work rows and survives rows growing subtitles in place", async () => {
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const nodeHash = "11c38726acc6fac280357576c87acc6fac280357";
+    const rows = (withWork: boolean) => {
+      const ts = baseTime + (withWork ? 5_000 : 0);
+      return [
+        sessionRow("agent:main:main", "Main", ts),
+        sessionRow(
+          "agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d",
+          "",
+          ts - 60_000,
+          withWork ? { execNode: nodeHash } : {},
+        ),
+        sessionRow(
+          "agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6e",
+          "",
+          ts - 120_000,
+          withWork
+            ? {
+                execNode: nodeHash,
+                worktree: { branch: "openclaw/wt-1", repoRoot: "/Users/dev/Projects/clawdbot" },
+              }
+            : {},
+        ),
+        sessionRow("agent:main:node-mcp-debug-4de003fbff138fcb9239c9378b2e", "", ts - 180_000),
+      ];
+    };
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse(rows(false)),
+      },
+      // Defer every list request; the test resolves them per phase so rows
+      // first paint single-line and only then grow a subtitle line in place.
+      deferredMethods: Array.from({ length: 12 }, () => "sessions.list"),
+      sessionKey: "agent:main:main",
+    });
+    const resolveNextList = async (withWork: boolean) => {
+      try {
+        await gateway.resolveDeferred("sessions.list", sessionsListResponse(rows(withWork)));
+      } catch {
+        // No list request queued yet; the poll below retries.
+      }
+    };
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await expect
+        .poll(
+          async () => {
+            await resolveNextList(false);
+            return page.locator(".sidebar-recent-session").count();
+          },
+          { timeout: 15_000 },
+        )
+        .toBeGreaterThan(0);
+      // Rows grow a second subtitle line only after first layout: the WebKit
+      // overlap regression needs in-place growth, not a static two-line list.
+      await gateway.emitGatewayEvent("sessions.changed", {});
+      await expect
+        .poll(
+          async () => {
+            await resolveNextList(true);
+            return page.locator(".sidebar-recent-session__subtitle").count();
+          },
+          { timeout: 15_000 },
+        )
+        .toBeGreaterThan(0);
+
+      // Names and subtitles never show raw node ids or raw agent keys.
+      const names = await trimmedTextContents(page.locator(".sidebar-recent-session__name"));
+      expect(names).toContain("New session");
+      expect(names).toContain("clawdbot ⎇ wt-1 · …0357");
+      expect(names).toContain("node-mcp-debug-…8b2e");
+      const subtitles = await trimmedTextContents(
+        page.locator(".sidebar-recent-session__subtitle"),
+      );
+      expect(subtitles).toContain("…0357");
+      for (const text of [...names, ...subtitles]) {
+        expect(text).not.toContain(nodeHash);
+        expect(text).not.toContain("agent:main:");
+      }
+
+      // Sections must lay out below the rows above them, not paint over them.
+      const overlaps = await page.evaluate(() => {
+        const rects = [
+          ...document.querySelectorAll(".sidebar-recent-session, .sidebar-recent-sessions__head"),
+        ]
+          .map((element) => {
+            const rect = element.getBoundingClientRect();
+            return { top: rect.top, bottom: rect.bottom };
+          })
+          .filter((rect) => rect.bottom > rect.top)
+          .toSorted((a, b) => a.top - b.top);
+        let bad = 0;
+        for (let index = 1; index < rects.length; index += 1) {
+          if (rects[index].top < rects[index - 1].bottom - 2) {
+            bad += 1;
+          }
+        }
+        return bad;
+      });
+      expect(overlaps).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -39,6 +39,19 @@ describe("resolveSessionDisplayName", () => {
       }),
     ).toBe("clawdbot ⎇ wt-3f2a");
   });
+
+  it("names named subsessions after their slug, never the raw agent key", () => {
+    expect(resolveSessionDisplayName("agent:main:node-proof-claude")).toBe("node-proof-claude");
+    expect(resolveSessionDisplayName("agent:main:explicit:node-mcp-debug")).toBe("node-mcp-debug");
+    expect(
+      resolveSessionDisplayName(
+        "agent:main:explicit:model-run-0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d",
+      ),
+    ).toBe("model-run-…5c6d");
+    expect(resolveSessionDisplayName("agent:main:node-fleet-4de003fbff138fcb9239c9378b2e")).toBe(
+      "node-fleet-…8b2e",
+    );
+  });
 });
 
 describe("resolveSessionWorkSubtitle", () => {
@@ -53,9 +66,21 @@ describe("resolveSessionWorkSubtitle", () => {
         worktree: { branch: "feature/x", repoRoot: "/repo/clawdbot" },
         execNode: "macbook",
       }),
-    ).toBe("macbook · clawdbot ⎇ feature/x");
+    ).toBe("clawdbot ⎇ feature/x · macbook");
     expect(resolveSessionWorkSubtitle({ execNode: "macbook" })).toBe("macbook");
     expect(resolveSessionWorkSubtitle({})).toBeUndefined();
+  });
+
+  it("shortens opaque node ids instead of rendering raw hashes", () => {
+    expect(
+      resolveSessionWorkSubtitle({ execNode: "11c38726acc6fac280357576c87acc6fac280357" }),
+    ).toBe("…0357");
+    expect(
+      resolveSessionWorkSubtitle({
+        worktree: { branch: "openclaw/wt-1", repoRoot: "/repo/clawdbot" },
+        execNode: "11c38726acc6fac280357576c87acc6fac280357",
+      }),
+    ).toBe("clawdbot ⎇ wt-1 · …0357");
   });
 });
 

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -25,6 +25,15 @@ function shortenPeerId(identifier: string): string {
   return trimmed.length <= 10 ? trimmed : `…${trimmed.slice(-6)}`;
 }
 
+// Long hex/uuid runs inside keys and node ids are machine ids, not names;
+// keep a short recognizable tail so rows never fill with opaque hashes.
+const OPAQUE_ID_RUN_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{10,}/gi;
+
+function shortenOpaqueIdRuns(text: string): string {
+  return text.replace(OPAQUE_ID_RUN_RE, (match) => `…${match.slice(-4)}`);
+}
+
 const WORKTREE_BRANCH_PREFIX = "openclaw/";
 
 const CHANNEL_SESSION_KEY_RE = /^agent:[^:]+:([^:]+)(?::[^:]+)?:(?:direct|group|channel|thread):/;
@@ -58,14 +67,17 @@ type SessionWorktreeDisplayRow = {
 export function resolveSessionWorkSubtitle(row: SessionWorktreeDisplayRow): string | undefined {
   const repoRoot = normalizeOptionalString(row.worktree?.repoRoot);
   const branch = normalizeOptionalString(row.worktree?.branch);
-  const node = normalizeOptionalString(row.execNode);
+  // execNode is often a raw node id (long hex); never render it in full.
+  const rawNode = normalizeOptionalString(row.execNode);
+  const node = rawNode ? shortenOpaqueIdRuns(rawNode) : undefined;
   const repoName = repoRoot ? (repoRoot.split(/[\\/]/).findLast(Boolean) ?? repoRoot) : undefined;
   const shortBranch = branch?.startsWith(WORKTREE_BRANCH_PREFIX)
     ? branch.slice(WORKTREE_BRANCH_PREFIX.length)
     : branch;
   const checkout = repoName ? (shortBranch ? `${repoName} ⎇ ${shortBranch}` : repoName) : undefined;
   if (checkout && node) {
-    return `${node} · ${checkout}`;
+    // Checkout first: it names the work; the node is routing detail.
+    return `${checkout} · ${node}`;
   }
   return checkout ?? node;
 }
@@ -140,6 +152,14 @@ function parseSessionKey(key: string): SessionKeyInfo {
   // must not flash in the sidebar while that title is pending.
   if (/^agent:[^:]+:dashboard:/.test(key)) {
     return { prefix: "", fallbackName: "New session" };
+  }
+
+  // Remaining agent keys are named subsessions (CLI --session-id and friends):
+  // drop the agent:<id>: routing boilerplate and shorten opaque id runs so the
+  // slug reads as a name instead of a raw key.
+  const agentKeyMatch = key.match(/^agent:[^:]+:(?:explicit:)?(.+)$/);
+  if (agentKeyMatch) {
+    return { prefix: "", fallbackName: shortenOpaqueIdRuns(agentKeyMatch[1]) };
   }
 
   // Unknown: return key as-is.

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1098,8 +1098,12 @@ html.openclaw-native-macos .shell-nav-expand {
   opacity: 0.85;
 }
 
+/* Flex, not grid: WebKit does not re-run a grid flex-item's intrinsic sizing
+   when rows stream in or grow a second subtitle line after first layout, so a
+   grid list keeps a stale height and the next section paints over its rows. */
 .sidebar-recent-sessions__list {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2px;
   min-height: 12px;
 }


### PR DESCRIPTION
## What Problem This Solves

The sessions sidebar fills with opaque gray machine ids and, in the Mac app (WKWebView), sections can paint on top of each other (user screenshot: WORK rows and the CHATS section overlapping, with times like "51m/1h" doubled up):

- Work rows render the raw exec-node id (`11c38726acc6fac280357576c87…`) as their subtitle, and unnamed worktree rows even get it as their *title* (the old subtitle format was `node · checkout`, so the 40-char hash led the line).
- Unnamed named-subsessions (CLI `--session-id` and friends) fall back to the full raw key (`agent:main:node-proof-cla…`) as their row name, despite the redesign's "session names never show raw keys or peer ids" contract.
- The session list used `display: grid`; WebKit does not re-run a grid flex-item's intrinsic sizing when rows stream in or grow a second subtitle line after first layout (same WKWebView bug class as the voice-turn fix in #102573), so the list keeps a stale height and the next section paints over its rows.

## Why This Change Was Made

- `ui/src/lib/session-display.ts`: opaque hex/uuid runs in node ids and session-key slugs shorten to a `…tail` (`shortenOpaqueIdRuns`); the work subtitle leads with the checkout (`clawdbot ⎇ wt-1 · …0357`) since that names the work and the node is routing detail; unnamed `agent:<id>:` subsession keys drop the routing boilerplate and render their slug (`node-mcp-debug-…8b2e`) instead of the raw key.
- `ui/src/styles/layout.css`: `.sidebar-recent-sessions__list` moves from `grid` to a flex column (visually identical in Chromium) to remove the WebKit stale-intrinsic-height overlap by construction.
- New e2e regression: rows first paint single-line, then grow subtitles in place via a `sessions.changed` refresh; asserts no raw node hash or `agent:main:` text in any row name/subtitle and that no row/section rects overlap after the growth.

## User Impact

Sidebar rows read as names again — "New session" with a `…0357` node tail, `clawdbot ⎇ wt-1 · …0357` for worktree sessions, `node-mcp-debug-…8b2e` for named subsessions — and sections no longer paint over each other in the Mac app. No API, config, or i18n changes.

## Evidence

- Before/after under Playwright WebKit against the real Control UI (mock gateway): before, WORK titles/subtitles showed full 40-char hashes and CHATS titles showed raw `agent:main:…` keys; after, all rows render the shortened forms above with clean layout in both WebKit and Chromium.
- `node scripts/run-vitest.mjs ui/src/e2e/session-management.e2e.test.ts` → 10/10 pass (includes the new grow-in-place/no-raw-ids/no-overlap regression test).
- `node scripts/run-vitest.mjs ui/src/lib/session-display.test.ts ui/src/components/app-sidebar.test.ts` → pass (new unit coverage for id shortening, subtitle order, and subsession slug fallbacks).
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` lanes green (Testbox leases still dying mid-hydration; local per documented fallback); `lint core` shard exit 0; `oxfmt --check` clean on touched files.
- Codex autoreview (gpt-5.5, xhigh): clean, no actionable findings.
- Note: the section overlap itself did not reproduce under Playwright's WebKit build (it is WKWebView-specific, per the #102573 bug class); the grid→flex change removes the trigger construct and the new e2e guards the streamed-growth layout invariant in CI.
