### PR TITLE
fix(workboard): report active claims before dependency errors

### DIFF
--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1008,6 +1008,47 @@ describe("WorkboardStore", () => {
     expect(released.metadata?.claim).toBeUndefined();
   });
 
+  it("reports an active claim after a dependency-backed card starts running", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent", status: "done" });
+    const child = await store.create({ title: "Child", parents: [parent.id] });
+
+    await store.claim(child.id, { ownerId: "main", ttlSeconds: 60 });
+
+    await expect(store.claim(child.id, { ownerId: "other" })).rejects.toThrow(
+      "card already claimed by main.",
+    );
+  });
+
+  it("preserves scheduled and retry-budget errors when a claim is active", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const store = new WorkboardStore(createMemoryStore());
+      const scheduled = await store.create({ title: "Scheduled", status: "ready" });
+      await store.claim(scheduled.id, { ownerId: "main", ttlSeconds: 60 });
+      await store.update(scheduled.id, { status: "scheduled", scheduledAt: 10_000 });
+
+      const exhausted = await store.create({
+        title: "Exhausted",
+        status: "ready",
+        maxRetries: 1,
+        metadata: { failureCount: 1 },
+      });
+      await store.claim(exhausted.id, { ownerId: "main", ttlSeconds: 60 });
+      await store.update(exhausted.id, { metadata: { failureCount: 2 } });
+
+      await expect(store.claim(scheduled.id, { ownerId: "other" })).rejects.toThrow(
+        "card is scheduled for later.",
+      );
+      await expect(store.claim(exhausted.id, { ownerId: "other" })).rejects.toThrow(
+        "card exhausted its retry budget.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("caps oversized claim TTL seconds to a valid Date timestamp", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -3404,7 +3404,12 @@ export class WorkboardStore {
         ttlSeconds ? secondsToDurationMs(ttlSeconds) : DEFAULT_CLAIM_TTL_MS,
       );
       const guarded = await this.promoteDependencyReady(id, now);
-      if (cardParentIds(guarded).length > 0 && guarded.status !== "ready") {
+      const existingClaim = guarded.metadata?.claim;
+      const activeClaim =
+        existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })
+          ? existingClaim
+          : undefined;
+      if (cardParentIds(guarded).length > 0 && guarded.status !== "ready" && !activeClaim) {
         throw new Error("card dependencies are not done.");
       }
       if (guarded.status === "scheduled") {
@@ -3413,9 +3418,8 @@ export class WorkboardStore {
       if (retryBudgetExhausted(guarded)) {
         throw new Error("card exhausted its retry budget.");
       }
-      const existingClaim = guarded.metadata?.claim;
-      if (existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })) {
-        throw new Error(`card already claimed by ${existingClaim.ownerId}.`);
+      if (activeClaim) {
+        throw new Error(`card already claimed by ${activeClaim.ownerId}.`);
       }
       const metadata = clearDiagnostics(guarded.metadata, ["stranded_ready"]);
       const card = await this.updateCard(id, {


### PR DESCRIPTION
## What Problem This Solves

Repeat `workboard_claim` calls on a dependency-backed card report `card dependencies are not done.` after the first successful claim moves the card to `running`. That diagnosis is false when the parents are complete and an unexpired claim already owns the card.

Closes #104050

## Why This Change Was Made

The store checked dependency readiness before its existing active-claim guard. This change preserves the existing claim contract and moves that guard ahead of dependency/status validation, so dependency-backed and parentless cards report active ownership consistently. It deliberately does not add same-owner token replay or bundle the separate dispatch/CLI UX requests from the issue.

## User Impact

Agents retrying a claim now receive `card already claimed by <owner>.` instead of being sent into dependency troubleshooting for a healthy running card. No storage shape, token behavior, or dependency policy changes.

## Evidence

AI-assisted contribution; I reviewed and understand the two-file change.

Negative control on current `origin/main`:

```text
expected ... "card already claimed by main."
received ... "card dependencies are not done."
1 failed | 79 passed
```

After the fix:

```text
/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts -- --reporter=dot
Test Files 2 passed (2)
Tests 86 passed (86)
```

Real plugin/runtime proof used the production `createWorkboardTools` registration surface with a temporary on-disk workboard SQLite store. Claim tokens were redacted from the captured output:

```text
$ node --import tsx /private/tmp/workboard-104050-proof.mts
{"firstClaim":{"status":"running","ownerId":"main","token":"[redacted]"}}
{"repeatClaim":{"error":"card already claimed by main."}}
{"unfinishedParentClaim":{"error":"card dependencies are not done."}}
```

The proof created a completed parent and dependent child through `workboard_create`, claimed the child through `workboard_claim` as `main`, repeated `workboard_claim` through a separately registered `other` agent context, and separately verified an unfinished parent remains blocked. The temporary state directory and SQLite database were removed after the run.

Additional checks:

- focused `oxfmt --check`: passed
- focused `scripts/run-oxlint.mjs`: passed
- `git diff --check`: passed
- autoreview: `autoreview clean: no accepted/actionable findings reported`

Blacksmith Testbox pre-warm was attempted first but unavailable because the `blacksmith` CLI is not installed, so this narrow deterministic extension regression used the bundled-Node local fallback.
