### PR TITLE
fix(release): restore Telegram live QA credentials

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1466,21 +1466,113 @@ jobs:
           retention-days: 14
           if-no-files-found: error
 
+  # The dispatched child owns Telegram evidence/status artifacts; this blocking job
+  # carries its exact conclusion into the parent summary without copying secrets or artifacts.
   qa_live_telegram_release_checks:
     name: Run QA Lab live Telegram lane
     needs: [resolve_target]
     if: contains(fromJSON('["all","qa","qa-live"]'), needs.resolve_target.outputs.rerun_group) && needs.resolve_target.outputs.qa_live_telegram_enabled == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 210
     permissions:
-      actions: read
-      attestations: write
+      actions: write
       contents: read
-      id-token: write
-      pull-requests: read
-    uses: openclaw/openclaw/.github/workflows/openclaw-release-telegram-qa.yml@main
-    with:
-      expected_trusted_workflow_sha: ${{ needs.resolve_target.outputs.trusted_workflow_sha }}
-      target_ref: ${{ needs.resolve_target.outputs.ref }}
-      target_sha: ${{ needs.resolve_target.outputs.revision }}
+    steps:
+      - name: Dispatch and await trusted Telegram QA
+        env:
+          EXPECTED_TRUSTED_WORKFLOW_SHA: ${{ needs.resolve_target.outputs.trusted_workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REF: ${{ needs.resolve_target.outputs.ref }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          workflow="openclaw-release-telegram-qa.yml"
+          dispatch_id="release-checks-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(openssl rand -hex 16)"
+          run_name="OpenClaw Release Telegram QA ${dispatch_id}"
+          current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+          if [[ "$current_main_sha" != "$EXPECTED_TRUSTED_WORKFLOW_SHA" ]]; then
+            echo "Trusted main moved to ${current_main_sha}, expected ${EXPECTED_TRUSTED_WORKFLOW_SHA}; refusing dispatch." >&2
+            exit 1
+          fi
+
+          find_child_runs() {
+            RUN_NAME="$run_name" gh api -X GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/runs" \
+              -F event=workflow_dispatch \
+              -F branch=main \
+              -F per_page=100 \
+              --jq '[.workflow_runs[] | select(.display_title == env.RUN_NAME) | {id, head_sha}]'
+          }
+          run_id=""
+          cancel_child_on_failure() {
+            status="$?"
+            trap - EXIT
+            if [[ "$status" -ne 0 ]]; then
+              set +e
+              # The nonce makes delayed discovery safe after an ambiguous dispatch response.
+              for _ in $(seq 1 6); do
+                matches_json="$(find_child_runs 2>/dev/null)" || matches_json="[]"
+                if [[ "$(jq 'length' <<<"$matches_json" 2>/dev/null)" == "1" ]]; then
+                  run_id="$(jq -r '.[0].id' <<<"$matches_json")"
+                  gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null 2>&1 || true
+                  break
+                fi
+                sleep 2
+              done
+            fi
+            exit "$status"
+          }
+          trap cancel_child_on_failure EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          gh workflow run "$workflow" \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f dispatch_id="$dispatch_id" \
+            -f expected_trusted_workflow_sha="$EXPECTED_TRUSTED_WORKFLOW_SHA" \
+            -f target_ref="$TARGET_REF" \
+            -f target_sha="$TARGET_SHA"
+
+          for _ in $(seq 1 60); do
+            matches_json="$(find_child_runs)"
+            match_count="$(jq 'length' <<<"$matches_json")"
+            if ((match_count > 1)); then
+              echo "Multiple Telegram QA runs matched ${run_name}; refusing to guess." >&2
+              exit 1
+            fi
+            if ((match_count == 1)); then
+              run_id="$(jq -r '.[0].id' <<<"$matches_json")"
+              child_head_sha="$(jq -r '.[0].head_sha' <<<"$matches_json")"
+              [[ "$child_head_sha" == "$EXPECTED_TRUSTED_WORKFLOW_SHA" ]]
+              break
+            fi
+            sleep 5
+          done
+          if [[ -z "$run_id" ]]; then
+            echo "Could not find exact dispatched Telegram QA run ${run_name}." >&2
+            exit 1
+          fi
+
+          child_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+          echo "Dispatched trusted Telegram QA: ${child_url}"
+          for _ in $(seq 1 1080); do
+            run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+            status="$(jq -r .status <<<"$run_json")"
+            if [[ "$status" == "completed" ]]; then
+              conclusion="$(jq -r .conclusion <<<"$run_json")"
+              if [[ "$conclusion" != "success" ]]; then
+                echo "Trusted Telegram QA concluded ${conclusion}: ${child_url}" >&2
+                exit 1
+              fi
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out awaiting trusted Telegram QA: ${child_url}" >&2
+          exit 1
 
   qa_live_discord_release_checks:
     name: Run QA Lab live Discord lane
@@ -1882,7 +1974,6 @@ jobs:
             "qa_lab_parity_report_release_checks=${QA_LAB_PARITY_REPORT_RELEASE_CHECKS_RESULT}"
             "qa_lab_runtime_parity_release_checks=${QA_LAB_RUNTIME_PARITY_RELEASE_CHECKS_RESULT}"
             "qa_live_matrix_release_checks=${QA_LIVE_MATRIX_RELEASE_CHECKS_RESULT}"
-            "qa_live_telegram_release_checks=${QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT}"
             "qa_live_discord_release_checks=${QA_LIVE_DISCORD_RELEASE_CHECKS_RESULT}"
             "qa_live_whatsapp_release_checks=${QA_LIVE_WHATSAPP_RELEASE_CHECKS_RESULT}"
             "qa_live_slack_release_checks=${QA_LIVE_SLACK_RELEASE_CHECKS_RESULT}"
@@ -2036,7 +2127,7 @@ jobs:
           }
           advisory_status_override_allowed() {
             case "$1" in
-              qa_lab_parity_lane_release_checks|qa_lab_parity_report_release_checks|qa_lab_runtime_parity_release_checks|qa_live_matrix_release_checks|qa_live_telegram_release_checks|qa_live_discord_release_checks|qa_live_whatsapp_release_checks|qa_live_slack_release_checks)
+              qa_lab_parity_lane_release_checks|qa_lab_parity_report_release_checks|qa_lab_runtime_parity_release_checks|qa_live_matrix_release_checks|qa_live_discord_release_checks|qa_live_whatsapp_release_checks|qa_live_slack_release_checks)
                 return 0
                 ;;
               *)

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1,10 +1,14 @@
 name: OpenClaw Release Telegram QA
 
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('OpenClaw Release Telegram QA {0}', inputs.dispatch_id) || 'OpenClaw Release Telegram QA' }}
+
 on:
+  # Transitional compatibility for supported release refs whose parent still calls @main.
+  # Current main dispatches this workflow so qa-live-shared secrets stay in this run.
   workflow_call:
     inputs:
       expected_trusted_workflow_sha:
-        description: Resolved main SHA authorized for this trusted reusable workflow
+        description: Resolved main SHA authorized for this trusted workflow
         required: true
         type: string
       target_ref:
@@ -22,6 +26,24 @@ on:
       OPENCLAW_QA_CONVEX_SITE_URL:
         description: Credential-lease coordinator URL supplied by qa-live-shared
         required: false
+  workflow_dispatch:
+    inputs:
+      dispatch_id:
+        description: Unique parent release-check dispatch identifier
+        required: true
+        type: string
+      expected_trusted_workflow_sha:
+        description: Resolved main SHA authorized for this trusted workflow
+        required: true
+        type: string
+      target_ref:
+        description: Trusted release ref whose exact candidate SHA should be validated
+        required: true
+        type: string
+      target_sha:
+        description: Exact full candidate commit SHA
+        required: true
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -31,7 +53,7 @@ env:
 
 jobs:
   trusted_identity:
-    name: Resolve trusted reusable workflow identity
+    name: Resolve trusted dispatched workflow identity
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -43,7 +65,7 @@ jobs:
       workflow_repository: ${{ steps.identity.outputs.workflow_repository }}
       workflow_sha: ${{ steps.identity.outputs.workflow_sha }}
     steps:
-      - name: Verify called-main identity
+      - name: Verify dispatched-main identity
         id: identity
         env:
           CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
@@ -52,6 +74,8 @@ jobs:
           JOB_CONTEXT: ${{ toJSON(job) }}
           TARGET_REF: ${{ inputs.target_ref }}
           TARGET_SHA: ${{ inputs.target_sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -62,9 +86,18 @@ jobs:
                 ! "$EXPECTED_TRUSTED_WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ ||
                 ! "$TARGET_SHA" =~ ^[a-f0-9]{40}$ ||
                 -z "${TARGET_REF// }" ]]; then
-            echo "Reusable Telegram QA identity or target is malformed." >&2
+            echo "Telegram QA identity or target is malformed." >&2
             exit 1
           fi
+          INVOCATION_MODE=reusable
+          if [[ "$WORKFLOW_REF" == "$expected_ref" ]]; then
+            INVOCATION_MODE=dispatch
+            [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" &&
+               "$GITHUB_REF" == "refs/heads/main" &&
+               "$GITHUB_SHA" == "$EXPECTED_TRUSTED_WORKFLOW_SHA" &&
+               "$WORKFLOW_SHA" == "$EXPECTED_TRUSTED_WORKFLOW_SHA" ]]
+          fi
+          export INVOCATION_MODE
 
           oidc_json="$(
             curl --fail --silent --show-error \
@@ -72,7 +105,7 @@ jobs:
               "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=openclaw-release-telegram-qa"
           )"
           oidc_token="$(jq -er '.value' <<<"$oidc_json")"
-          EXPECTED_JOB_WORKFLOW_REF="$expected_ref" OIDC_TOKEN="$oidc_token" \
+          EXPECTED_WORKFLOW_REF="$expected_ref" OIDC_TOKEN="$oidc_token" \
             node --input-type=module <<'NODE'
           import { appendFileSync } from "node:fs";
 
@@ -85,12 +118,12 @@ jobs:
               "utf8",
             ),
           );
-          const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
           const expectedTrustedWorkflowSha = process.env.EXPECTED_TRUSTED_WORKFLOW_SHA;
+          const eventName = process.env.GITHUB_EVENT_NAME;
           const expected = {
             aud: "openclaw-release-telegram-qa",
+            event_name: eventName,
             iss: "https://token.actions.githubusercontent.com",
-            job_workflow_ref: process.env.EXPECTED_JOB_WORKFLOW_REF,
             ref: process.env.GITHUB_REF,
             repository: process.env.GITHUB_REPOSITORY,
             runner_environment: "github-hosted",
@@ -103,28 +136,36 @@ jobs:
               throw new Error(`OIDC ${key} mismatch`);
             }
           }
-          const expectedJob = {
-            workflow_ref: payload.job_workflow_ref,
-            workflow_repository: payload.repository,
-            workflow_sha: expectedTrustedWorkflowSha,
-          };
-          for (const [key, value] of Object.entries(expectedJob)) {
-            if (job[key] !== value) {
-              throw new Error(`job context ${key} mismatch`);
+          if (process.env.INVOCATION_MODE === "reusable") {
+            const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+            const reusableExpected = {
+              job_workflow_ref: process.env.EXPECTED_WORKFLOW_REF,
+              job_workflow_sha: expectedTrustedWorkflowSha,
+            };
+            for (const [key, value] of Object.entries(reusableExpected)) {
+              if (payload[key] !== value) {
+                throw new Error(`OIDC ${key} mismatch`);
+              }
             }
-          }
-          if (!/^[a-f0-9]{40}$/.test(payload.job_workflow_sha ?? "")) {
-            throw new Error("OIDC job_workflow_sha is malformed");
-          }
-          if (payload.job_workflow_sha !== expectedTrustedWorkflowSha) {
-            throw new Error("OIDC job_workflow_sha does not match the frozen trusted workflow SHA");
+            if (
+              job.workflow_ref !== reusableExpected.job_workflow_ref ||
+              job.workflow_repository !== payload.repository ||
+              job.workflow_sha !== expectedTrustedWorkflowSha
+            ) {
+              throw new Error("job context reusable workflow identity mismatch");
+            }
+          } else if (
+            payload.workflow_ref !== process.env.EXPECTED_WORKFLOW_REF ||
+            payload.workflow_sha !== expectedTrustedWorkflowSha
+          ) {
+            throw new Error("OIDC dispatched workflow identity mismatch");
           }
           appendFileSync(
             process.env.GITHUB_OUTPUT,
             [
-              `workflow_ref=${job.workflow_ref}`,
-              `workflow_repository=${job.workflow_repository}`,
-              `workflow_sha=${job.workflow_sha}`,
+              `workflow_ref=${process.env.EXPECTED_WORKFLOW_REF}`,
+              `workflow_repository=${payload.repository}`,
+              `workflow_sha=${expectedTrustedWorkflowSha}`,
               "",
             ].join("\n"),
           );
@@ -164,7 +205,7 @@ jobs:
       manifest_sha256: ${{ steps.archive.outputs.manifest_sha256 }}
       status: ${{ steps.record_status.outputs.status }}
     steps:
-      - name: Require trusted reusable workflow identity
+      - name: Require trusted dispatched workflow identity
         id: require_identity
         env:
           IDENTITY_STATUS: ${{ needs.trusted_identity.outputs.status }}
@@ -1860,7 +1901,7 @@ jobs:
           {
             printf 'trusted_harness_sha=%s\n' "${{ needs.trusted_identity.outputs.workflow_sha }}"
             printf 'candidate_runtime_plugin_sha=%s\n' "$TARGET_SHA"
-            printf 'trusted_scenario_source=oidc.job_workflow_sha\n'
+            printf 'trusted_scenario_source=verified_trusted_workflow_sha\n'
           } >"${output_dir}/source-attestation.txt"
           echo "output_dir=$output_dir" >>"$GITHUB_OUTPUT"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -34,11 +34,7 @@ const PUBLISH_GENERATED_PR_ACTION = ".github/actions/publish-generated-pr/action
 const MATURITY_SCORECARD_WORKFLOW = ".github/workflows/maturity-scorecard.yml";
 const MATURITY_SCORECARD_WORKFLOW_REF =
   "openclaw/openclaw/.github/workflows/maturity-scorecard.yml@refs/heads/main";
-// Reusable-workflow refs cannot use expressions. This exact callee resolves and
-// verifies its main SHA through OIDC before any credentialed work.
-const OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS = new Set([
-  "openclaw/openclaw/.github/workflows/openclaw-release-telegram-qa.yml@main",
-]);
+const OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS = new Set<string>();
 const MATURITY_GENERATED_PR_PATHS = [
   "qa/maturity-scores.yaml",
   "docs/maturity/scorecard.md",
@@ -475,10 +471,8 @@ describe("ci workflow guards", () => {
     expect(findUnpinnedExternalActions()).toEqual([]);
   });
 
-  it("limits moving reusable workflows to the OIDC-bound Telegram QA callee", () => {
-    expect([...OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS]).toEqual([
-      readReleaseChecksWorkflow().jobs.qa_live_telegram_release_checks.uses,
-    ]);
+  it("forbids moving reusable workflow references", () => {
+    expect([...OIDC_BOUND_MAIN_REUSABLE_WORKFLOWS]).toEqual([]);
   });
 
   it("keeps locale refresh matrices alive and publishes each aggregate through a PR", () => {

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -50,33 +50,45 @@ function workflowStep(job: WorkflowJob, name: string) {
 }
 
 function runIdentityVerification(params: {
-  callerWorkflowSha?: string;
   expectedTrustedWorkflowSha: string;
-  jobWorkflowSha: string;
+  invocation?: "dispatch" | "reusable";
+  oidcJobWorkflowSha?: string;
   oidcWorkflowSha?: string;
+  workflowSha?: string;
 }) {
   const repository = "openclaw/openclaw";
-  const workflowRef = `${repository}/.github/workflows/openclaw-release-checks.yml@refs/heads/release-ci/test`;
-  const jobWorkflowRef = `${repository}/.github/workflows/openclaw-release-telegram-qa.yml@refs/heads/main`;
+  const trustedWorkflowRef = `${repository}/.github/workflows/openclaw-release-telegram-qa.yml@refs/heads/main`;
+  const invocation = params.invocation ?? "dispatch";
+  const workflowRef =
+    invocation === "dispatch"
+      ? trustedWorkflowRef
+      : `${repository}/.github/workflows/openclaw-release-checks.yml@refs/heads/release-ci/test`;
+  const workflowRefName =
+    invocation === "dispatch" ? "refs/heads/main" : "refs/heads/release-ci/test";
   const targetSha = "a".repeat(40);
   const workdir = tempDirs.make("openclaw-telegram-identity-");
   const fakeBin = join(workdir, "bin");
   const curlPath = join(fakeBin, "curl");
   const githubOutput = join(workdir, "github-output");
   mkdirSync(fakeBin);
-  const callerWorkflowSha = params.callerWorkflowSha ?? params.expectedTrustedWorkflowSha;
-  const oidcWorkflowSha = params.oidcWorkflowSha ?? params.jobWorkflowSha;
+  const workflowSha = params.workflowSha ?? params.expectedTrustedWorkflowSha;
+  const oidcWorkflowSha = params.oidcWorkflowSha ?? workflowSha;
   const payload = {
     aud: "openclaw-release-telegram-qa",
+    event_name: "workflow_dispatch",
     iss: "https://token.actions.githubusercontent.com",
-    job_workflow_ref: jobWorkflowRef,
-    job_workflow_sha: oidcWorkflowSha,
-    ref: "refs/heads/release-ci/test",
+    ...(invocation === "reusable"
+      ? {
+          job_workflow_ref: trustedWorkflowRef,
+          job_workflow_sha: params.oidcJobWorkflowSha ?? params.expectedTrustedWorkflowSha,
+        }
+      : {}),
+    ref: workflowRefName,
     repository,
     runner_environment: "github-hosted",
-    sha: callerWorkflowSha,
+    sha: workflowSha,
     workflow_ref: workflowRef,
-    workflow_sha: callerWorkflowSha,
+    workflow_sha: oidcWorkflowSha,
   };
   const token = [
     Buffer.from("{}").toString("base64url"),
@@ -86,7 +98,10 @@ function runIdentityVerification(params: {
   writeFileSync(curlPath, "#!/usr/bin/env bash\nprintf '%s\\n' \"$FAKE_OIDC_JSON\"\n", {
     mode: 0o755,
   });
-  const script = workflowStep(workflowJob("trusted_identity"), "Verify called-main identity").run;
+  const script = workflowStep(
+    workflowJob("trusted_identity"),
+    "Verify dispatched-main identity",
+  ).run;
   if (!script) {
     throw new Error("Expected trusted identity script");
   }
@@ -97,21 +112,24 @@ function runIdentityVerification(params: {
       ACTIONS_ID_TOKEN_REQUEST_TOKEN: "test-token",
       ACTIONS_ID_TOKEN_REQUEST_URL: "https://example.invalid/oidc?",
       CALLER_WORKFLOW_REF: workflowRef,
-      CALLER_WORKFLOW_SHA: callerWorkflowSha,
+      CALLER_WORKFLOW_SHA: workflowSha,
       EXPECTED_TRUSTED_WORKFLOW_SHA: params.expectedTrustedWorkflowSha,
       FAKE_OIDC_JSON: JSON.stringify({ value: token }),
+      GITHUB_EVENT_NAME: "workflow_dispatch",
       GITHUB_OUTPUT: githubOutput,
-      GITHUB_REF: "refs/heads/release-ci/test",
+      GITHUB_REF: workflowRefName,
       GITHUB_REPOSITORY: repository,
-      GITHUB_SHA: callerWorkflowSha,
+      GITHUB_SHA: workflowSha,
       JOB_CONTEXT: JSON.stringify({
-        workflow_ref: jobWorkflowRef,
+        workflow_ref: trustedWorkflowRef,
         workflow_repository: repository,
-        workflow_sha: params.jobWorkflowSha,
+        workflow_sha: params.expectedTrustedWorkflowSha,
       }),
       PATH: `${fakeBin}:${process.env.PATH}`,
       TARGET_REF: "refs/heads/release/2026.7.1",
       TARGET_SHA: targetSha,
+      WORKFLOW_REF: workflowRef,
+      WORKFLOW_SHA: workflowSha,
     },
   });
 }
@@ -189,7 +207,7 @@ function runAdvisoryStatus(overrides: Record<string, string> = {}) {
 }
 
 describe("release Telegram QA workflow", () => {
-  it("has exactly one trusted-main caller from release checks", () => {
+  it("dispatches exactly one trusted-main child from release checks", () => {
     const releaseSource = readFileSync(RELEASE_CHECKS_PATH, "utf8");
     const reusableSource = readFileSync(WORKFLOW_PATH, "utf8");
     const releaseWorkflow = parse(releaseSource) as {
@@ -197,44 +215,49 @@ describe("release Telegram QA workflow", () => {
     };
     const caller = releaseWorkflow.jobs?.qa_live_telegram_release_checks;
 
-    expect(caller?.uses).toBe(
-      "openclaw/openclaw/.github/workflows/openclaw-release-telegram-qa.yml@main",
-    );
     expect(caller?.needs).toEqual(["resolve_target"]);
     expect(caller?.if).toContain("needs.resolve_target.outputs.qa_live_telegram_enabled == 'true'");
-    expect(caller?.with).toEqual({
-      expected_trusted_workflow_sha: "${{ needs.resolve_target.outputs.trusted_workflow_sha }}",
-      target_ref: "${{ needs.resolve_target.outputs.ref }}",
-      target_sha: "${{ needs.resolve_target.outputs.revision }}",
-    });
     expect(caller?.permissions).toEqual({
-      actions: "read",
-      attestations: "write",
+      actions: "write",
       contents: "read",
-      "id-token": "write",
-      "pull-requests": "read",
     });
+    expect(caller?.["timeout-minutes"]).toBe(210);
     expect(caller?.["continue-on-error"]).toBeUndefined();
-    expect(caller?.["runs-on"]).toBeUndefined();
+    expect(caller?.["runs-on"]).toBe("ubuntu-24.04");
     expect(caller?.environment).toBeUndefined();
-    expect(caller?.steps).toBeUndefined();
+    const dispatch = caller?.steps?.find(
+      (step) => step.name === "Dispatch and await trusted Telegram QA",
+    );
+    expect(dispatch?.run).toContain('gh workflow run "$workflow"');
+    expect(dispatch?.run).toContain('--repo "$GITHUB_REPOSITORY"');
+    expect(dispatch?.run).toContain("-F event=workflow_dispatch");
+    expect(dispatch?.run).toContain(".display_title == env.RUN_NAME");
+    expect(dispatch?.run).toContain("$(openssl rand -hex 16)");
+    expect(dispatch?.run).toContain("trap cancel_child_on_failure EXIT");
+    expect(dispatch?.run).toContain("for _ in $(seq 1 6)");
+    expect(dispatch?.run).toContain("/actions/runs/${run_id}/cancel");
+    expect(dispatch?.run).toContain('[[ "$child_head_sha" == "$EXPECTED_TRUSTED_WORKFLOW_SHA" ]]');
+    expect(dispatch?.run).toContain("for _ in $(seq 1 1080)");
+    expect(dispatch?.run).toContain("Trusted Telegram QA concluded ${conclusion}");
+    expect(
+      releaseSource.match(
+        /"qa_live_telegram_release_checks=\$\{QA_LIVE_TELEGRAM_RELEASE_CHECKS_RESULT\}"/gu,
+      ),
+    ).toHaveLength(1);
+    expect(releaseSource).not.toContain(
+      "qa_live_matrix_release_checks|qa_live_telegram_release_checks|qa_live_discord_release_checks",
+    );
     expect(releaseSource).not.toContain("persist-credentials: true");
 
-    const callerPattern =
-      /uses:\s*openclaw\/openclaw\/\.github\/workflows\/openclaw-release-telegram-qa\.yml@main/gu;
-    const callers = readdirSync(".github/workflows")
+    const dispatchers = readdirSync(".github/workflows")
       .filter((name) => name.endsWith(".yml"))
       .flatMap((name) => {
         const path = `.github/workflows/${name}`;
-        return Array.from(readFileSync(path, "utf8").matchAll(callerPattern), () => path);
+        return readFileSync(path, "utf8").includes('workflow="openclaw-release-telegram-qa.yml"')
+          ? [path]
+          : [];
       });
-    expect(callers).toEqual([RELEASE_CHECKS_PATH]);
-    expect(
-      readdirSync(".github/workflows")
-        .filter((name) => name.endsWith(".yml"))
-        .map((name) => readFileSync(`.github/workflows/${name}`, "utf8"))
-        .join("\n"),
-    ).not.toContain("uses: ./.github/workflows/openclaw-release-telegram-qa.yml");
+    expect(dispatchers).toEqual([RELEASE_CHECKS_PATH]);
     expect(reusableSource).toContain(
       "openclaw/openclaw/.github/workflows/openclaw-release-telegram-qa.yml@refs/heads/main",
     );
@@ -251,66 +274,75 @@ describe("release Telegram QA workflow", () => {
     );
     expect(resolveTrustedWorkflow?.run).toContain("--ref refs/heads/main");
     expect(resolveTrustedWorkflow?.run).not.toContain("--fallback-ok");
-    const reusableWorkflow = parse(reusableSource) as {
+    const dispatchedWorkflow = parse(reusableSource) as {
       on?: {
         workflow_call?: {
           inputs?: Record<string, { required?: boolean; type?: string }>;
-          secrets?: Record<string, { description?: string; required?: boolean }>;
+          secrets?: Record<string, { required?: boolean }>;
+        };
+        workflow_dispatch?: {
+          inputs?: Record<string, { required?: boolean; type?: string }>;
         };
       };
     };
-    expect(reusableWorkflow.on?.workflow_call?.inputs?.expected_trusted_workflow_sha).toEqual({
-      description: "Resolved main SHA authorized for this trusted reusable workflow",
+    expect(dispatchedWorkflow.on?.workflow_dispatch?.inputs?.expected_trusted_workflow_sha).toEqual(
+      {
+        description: "Resolved main SHA authorized for this trusted workflow",
+        required: true,
+        type: "string",
+      },
+    );
+    expect(dispatchedWorkflow.on?.workflow_dispatch?.inputs?.dispatch_id).toEqual({
+      description: "Unique parent release-check dispatch identifier",
       required: true,
       type: "string",
     });
-    expect(reusableWorkflow.on?.workflow_call?.secrets).toEqual({
-      OPENCLAW_QA_CONVEX_SECRET_CI: {
-        description: "Credential-lease coordinator secret supplied by qa-live-shared",
-        required: false,
-      },
-      OPENCLAW_QA_CONVEX_SITE_URL: {
-        description: "Credential-lease coordinator URL supplied by qa-live-shared",
-        required: false,
-      },
+    expect(dispatchedWorkflow.on?.workflow_call?.inputs?.expected_trusted_workflow_sha).toEqual({
+      description: "Resolved main SHA authorized for this trusted workflow",
+      required: true,
+      type: "string",
     });
+    expect(dispatchedWorkflow.on?.workflow_call?.secrets).toHaveProperty(
+      "OPENCLAW_QA_CONVEX_SECRET_CI",
+    );
   });
 
-  it("binds called-main OIDC and job identity to the resolved main SHA", () => {
+  it("binds dispatched and legacy reusable OIDC identity to the resolved main SHA", () => {
     const trustedSha = "b".repeat(40);
     const success = runIdentityVerification({
-      callerWorkflowSha: "d".repeat(40),
       expectedTrustedWorkflowSha: trustedSha,
-      jobWorkflowSha: trustedSha,
     });
     expect(success.status).toBe(0);
 
     const oidcDrifted = runIdentityVerification({
       expectedTrustedWorkflowSha: trustedSha,
-      jobWorkflowSha: trustedSha,
       oidcWorkflowSha: "c".repeat(40),
     });
     expect(oidcDrifted.status).toBe(1);
-    expect(oidcDrifted.stderr).toContain(
-      "OIDC job_workflow_sha does not match the frozen trusted workflow SHA",
-    );
-
-    const jobDrifted = runIdentityVerification({
-      expectedTrustedWorkflowSha: trustedSha,
-      jobWorkflowSha: "c".repeat(40),
-      oidcWorkflowSha: trustedSha,
-    });
-    expect(jobDrifted.status).toBe(1);
-    expect(jobDrifted.stderr).toContain("job context workflow_sha mismatch");
+    expect(oidcDrifted.stderr).toContain("OIDC workflow_sha mismatch");
 
     const mainMoved = runIdentityVerification({
-      callerWorkflowSha: "d".repeat(40),
       expectedTrustedWorkflowSha: trustedSha,
-      jobWorkflowSha: "c".repeat(40),
-      oidcWorkflowSha: "c".repeat(40),
+      workflowSha: "c".repeat(40),
     });
     expect(mainMoved.status).toBe(1);
-    expect(mainMoved.stderr).toContain("job context workflow_sha mismatch");
+    expect(mainMoved.stderr).toBe("");
+
+    const reusableSuccess = runIdentityVerification({
+      expectedTrustedWorkflowSha: trustedSha,
+      invocation: "reusable",
+      workflowSha: "d".repeat(40),
+    });
+    expect(reusableSuccess.status).toBe(0);
+
+    const reusableDrifted = runIdentityVerification({
+      expectedTrustedWorkflowSha: trustedSha,
+      invocation: "reusable",
+      oidcJobWorkflowSha: "c".repeat(40),
+      workflowSha: "d".repeat(40),
+    });
+    expect(reusableDrifted.status).toBe(1);
+    expect(reusableDrifted.stderr).toContain("OIDC job_workflow_sha mismatch");
   });
 
   it("keeps candidate construction secretless and credentials inside the isolated runner", () => {
@@ -329,6 +361,7 @@ describe("release Telegram QA workflow", () => {
     expect(secretSteps).toEqual(["Validate required QA credential env", "Run Telegram live lane"]);
     expect(source).not.toContain("secrets: inherit");
     expect(source).not.toContain("persist-credentials: true");
+    expect(source).toContain("trusted_scenario_source=verified_trusted_workflow_sha");
 
     for (const [jobName, job] of Object.entries(workflow.jobs ?? {})) {
       for (const step of job.steps ?? []) {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -247,10 +247,8 @@ function runReleasePublishInputValidation(overrides: Record<string, string>) {
 }
 
 function runReleaseChecksSummary(params: {
-  artifactAttempt?: string;
-  artifactStatus?: "cancelled" | "failure" | "skipped" | "success";
   currentAttempt: string;
-  currentResult: "cancelled" | "skipped" | "success";
+  currentResult: "cancelled" | "failure" | "skipped" | "success";
   resolveResult?: "failure" | "success";
   telegramSelected?: boolean;
   workflowRef?: string;
@@ -263,24 +261,6 @@ function runReleaseChecksSummary(params: {
   const runId = "123456";
   const targetSha = "a".repeat(40);
   const workdir = tempDirs.make("openclaw-release-check-status-");
-  const statusDir = join(workdir, ".artifacts", "release-check-status");
-  if (params.artifactAttempt) {
-    mkdirSync(statusDir, { recursive: true });
-    writeFileSync(
-      join(statusDir, `qa_live_telegram_release_checks-${runId}-${params.artifactAttempt}.env`),
-      [
-        `run_id=${runId}`,
-        `run_attempt=${params.artifactAttempt}`,
-        `target_sha=${targetSha}`,
-        "job=qa_live_telegram_release_checks",
-        "variant=",
-        `status=${params.artifactStatus ?? "success"}`,
-        "job_status=success",
-        "step_outcomes=success success",
-        "",
-      ].join("\n"),
-    );
-  }
   return spawnSync("bash", ["-c", script], {
     cwd: workdir,
     encoding: "utf8",
@@ -2633,14 +2613,18 @@ describe("package artifact reuse", () => {
     }
 
     const telegramCaller = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_telegram_release_checks");
-    expect(telegramCaller.uses).toBe(
-      "openclaw/openclaw/.github/workflows/openclaw-release-telegram-qa.yml@main",
+    const telegramDispatch = workflowStep(telegramCaller, "Dispatch and await trusted Telegram QA");
+    expect(telegramDispatch.run).toContain('workflow="openclaw-release-telegram-qa.yml"');
+    expect(telegramDispatch.run).toContain('--repo "$GITHUB_REPOSITORY"');
+    expect(telegramDispatch.run).toContain("--ref main");
+    expect(telegramDispatch.run).toContain(
+      '-f expected_trusted_workflow_sha="$EXPECTED_TRUSTED_WORKFLOW_SHA"',
     );
-    expect(telegramCaller.with?.expected_trusted_workflow_sha).toBe(
-      "${{ needs.resolve_target.outputs.trusted_workflow_sha }}",
+    expect(telegramDispatch.run).toContain(
+      '[[ "$child_head_sha" == "$EXPECTED_TRUSTED_WORKFLOW_SHA" ]]',
     );
     expect(telegramCaller["continue-on-error"]).toBeUndefined();
-    expect(telegramCaller.steps).toBeUndefined();
+    expect(telegramCaller["timeout-minutes"]).toBe(210);
 
     const telegramStatus = workflowJob(RELEASE_TELEGRAM_QA_WORKFLOW, "advisory_status");
     expect(telegramStatus["continue-on-error"]).toBeUndefined();
@@ -2725,28 +2709,8 @@ describe("package artifact reuse", () => {
     );
   });
 
-  it.each(["skipped", "cancelled"] as const)(
-    "rejects attempt-1 advisory success when attempt 2 is %s",
-    (currentResult) => {
-      const result = runReleaseChecksSummary({
-        artifactAttempt: "1",
-        currentAttempt: "2",
-        currentResult,
-      });
-
-      expect(result.status).toBe(1);
-      const output = `${result.stdout}\n${result.stderr}`;
-      if (currentResult === "skipped") {
-        expect(output).toContain("attempt 2");
-      } else {
-        expect(output).toContain("qa_live_telegram_release_checks-123456-2.env");
-      }
-    },
-  );
-
-  it("accepts an exact current-attempt advisory status artifact", () => {
+  it("accepts a successful dispatched Telegram child", () => {
     const result = runReleaseChecksSummary({
-      artifactAttempt: "2",
       currentAttempt: "2",
       currentResult: "success",
     });
@@ -2755,18 +2719,23 @@ describe("package artifact reuse", () => {
     expect(result.stderr).toBe("");
   });
 
-  it("rejects a skipped selected Telegram reusable call", () => {
-    const result = runReleaseChecksSummary({
-      currentAttempt: "2",
-      currentResult: "skipped",
-      telegramSelected: true,
-    });
+  it.each(["cancelled", "failure", "skipped"] as const)(
+    "rejects a %s selected Telegram child",
+    (currentResult) => {
+      const result = runReleaseChecksSummary({
+        currentAttempt: "2",
+        currentResult,
+        telegramSelected: true,
+      });
 
-    expect(result.status).toBe(1);
-    expect(result.stdout).toContain("::error::qa_live_telegram_release_checks ended with skipped");
-  });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        `::error::qa_live_telegram_release_checks ended with ${currentResult}`,
+      );
+    },
+  );
 
-  it("accepts a skipped unselected Telegram reusable call", () => {
+  it("accepts a skipped unselected Telegram dispatch", () => {
     const result = runReleaseChecksSummary({
       currentAttempt: "2",
       currentResult: "skipped",
@@ -2774,19 +2743,6 @@ describe("package artifact reuse", () => {
     });
 
     expect(result.status).toBe(0);
-  });
-
-  it("rejects skipped terminal evidence for a selected Telegram call", () => {
-    const result = runReleaseChecksSummary({
-      artifactAttempt: "2",
-      artifactStatus: "skipped",
-      currentAttempt: "2",
-      currentResult: "success",
-      telegramSelected: true,
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toContain("::error::qa_live_telegram_release_checks ended with skipped");
   });
 
   it("keeps target resolution blocking before release children", () => {
@@ -2801,7 +2757,7 @@ describe("package artifact reuse", () => {
     expect(result.stdout).toContain("::error::resolve_target ended with failure");
   });
 
-  it("keeps missing current-attempt advisory status non-blocking for Tideclaw alpha", () => {
+  it("keeps a cancelled Telegram child non-blocking for Tideclaw alpha", () => {
     const result = runReleaseChecksSummary({
       currentAttempt: "2",
       currentResult: "cancelled",
@@ -2810,7 +2766,7 @@ describe("package artifact reuse", () => {
 
     expect(result.status).toBe(0);
     const output = `${result.stdout}\n${result.stderr}`;
-    expect(output).toContain("Expected 1 advisory status artifacts");
+    expect(output).toContain("qa_live_telegram_release_checks ended with cancelled");
     expect(output).toContain("Tideclaw alpha");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stable release validation could build and attest the Telegram candidate but then fail before live QA because the nested reusable workflow did not receive the `qa-live-shared` lease-coordinator secrets.

## Why This Change Was Made

Release checks now dispatch the trusted Telegram QA workflow from `main`, bind it to the resolved trusted workflow SHA, correlate the child with an unpredictable nonce, wait for its exact conclusion, and cancel it if the parent stops. The credentialed job remains inside `qa-live-shared`; no secrets are forwarded or inherited. The old reusable trigger remains temporarily for supported release refs that still call `@main`.

## User Impact

Release operators can run the required Telegram live gate without an empty-credential failure at the reusable-workflow boundary. No product behavior, release version, registry state, deployment, or credential value changes.

## Evidence

- Before: release child run https://github.com/openclaw/openclaw/actions/runs/29134767995 reached candidate attestation, then failed credential validation in job `86497457531` with both protected environment values unavailable.
- Control: standalone QA run https://github.com/openclaw/openclaw/actions/runs/29135189430 used the same pinned candidate; Telegram job https://github.com/openclaw/openclaw/actions/runs/29135189430/job/86498182510 passed protected credential validation and the live Telegram lane.
- Static workflow proof: `actionlint .github/workflows/openclaw-release-checks.yml .github/workflows/openclaw-release-telegram-qa.yml`
- Syntax/format proof: YAML parse, `oxfmt`, and `git diff --check` clean.
- Fresh structured autoreview: clean, no accepted/actionable findings.
- Hosted PR CI will provide the workflow-contract, package-acceptance, and security proof for this exact head.
