### PR TITLE
fix(workboard): check active claim before dependency guard in claim()

### DIFF
--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1310,6 +1310,25 @@ describe("WorkboardStore", () => {
     await expect(store.linkCards(lateParent.id, child.id)).rejects.toThrow(/active child/);
   });
 
+  it("reports already claimed for dependency-backed cards on repeat claim", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent", status: "todo" });
+    const child = await store.create({
+      title: "Child",
+      status: "todo",
+      parents: [parent.id],
+    });
+
+    await store.complete(parent.id, { summary: "Parent done." });
+    await store.dispatch();
+
+    const claimed = await store.claim(child.id, { ownerId: "main" });
+    expect(claimed.card.status).toBe("running");
+    expect(claimed.card.metadata?.claim).toMatchObject({ ownerId: "main" });
+
+    await expect(store.claim(child.id, { ownerId: "other" })).rejects.toThrow(/already claimed/);
+  });
+
   it("rejects terminal children with incomplete dependency parents", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const runningParent = await store.create({ title: "Running parent", status: "running" });

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -3401,6 +3401,10 @@ export class WorkboardStore {
         ttlSeconds ? secondsToDurationMs(ttlSeconds) : DEFAULT_CLAIM_TTL_MS,
       );
       const guarded = await this.promoteDependencyReady(id, now);
+      const existingClaim = guarded.metadata?.claim;
+      if (existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })) {
+        throw new Error(`card already claimed by ${existingClaim.ownerId}.`);
+      }
       if (cardParentIds(guarded).length > 0 && guarded.status !== "ready") {
         throw new Error("card dependencies are not done.");
       }
@@ -3409,10 +3413,6 @@ export class WorkboardStore {
       }
       if (retryBudgetExhausted(guarded)) {
         throw new Error("card exhausted its retry budget.");
-      }
-      const existingClaim = guarded.metadata?.claim;
-      if (existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })) {
-        throw new Error(`card already claimed by ${existingClaim.ownerId}.`);
       }
       const metadata = clearDiagnostics(guarded.metadata, ["stranded_ready"]);
       const card = await this.updateCard(id, {


### PR DESCRIPTION
## Summary

`claim()` on a dependency-backed card that is already claimed returns "card dependencies are not done" instead of "card already claimed by ...". The existingClaim check now runs before the dependency readiness guard so the correct error is surfaced.

- Problem: `claim()` tests the card's status against dependency readiness before checking for an active claim. A successful first claim moves the card to `running`, so any repeat claim hits the dependency guard's `status !== "ready"` branch before the existingClaim check is reached.
- Solution: Reorder the guard checks so existingClaim is evaluated first, restoring the established "already claimed by <owner>" behavior for cards with parents.
- What changed: `extensions/workboard/src/store.ts` (move existingClaim check before dependency guard), `extensions/workboard/src/store.test.ts` (add regression test for dependency-backed repeat claim)
- What did NOT change: Same-owner token replay, dependency error message content, dispatch diagnostics, CLI surface — all out of scope per ClawSweeper review.

## Change Type & Scope

### Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Related to #104050
- [x] This PR fixes a bug or regression

## Motivation

The misleading error "card dependencies are not done" sends agents into dependency-debugging loops when the card is in fact claimed and healthy. ClawSweeper confirmed the defect is shipped, narrowly owned, source-reproducible, and has clear fix boundaries with no open canonical fix.

## Review Contract

```text
Ref: #104050
Surface: workboard store (extensions/workboard)
Bug: claim() returns "card dependencies are not done" for already-claimed cards with parents
Cause: The existingClaim check runs after the dependency guard. The first claim changes
  the card status to "running", so the second claim's dependency guard rejects
  (status !== "ready") before the "already claimed" check is reached.
Provenance:
  introduced by: fc463e3b61a — current blame carries forward from earlier implementation
  Confidence: likely
Best fix: Yes — reordering the two guard blocks is the minimal, correct fix at the owning
  store boundary. The existingClaim check now runs first, restoring the established
  "already claimed by <owner>" behavior for cards with parents.
Refactor: No
Proof: live store exercise (node --import tsx) + unit tests (80/80 passing, including new regression test)
Risk: None — the dependency guard and claim check are independent invariants; reordering
  them does not weaken dependency enforcement. Existing tests for dependency-blocked
  claims continue to pass.
```

## Real Behavior Proof

**Behavior addressed**: Repeat claim on a dependency-backed card that is already claimed returns misleading "card dependencies are not done." error instead of "card already claimed by ...".

**Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node 22.19, branch `fix/workboard-claim-order-104050`, live store exercise via `node --import tsx` directly exercising `WorkboardStore.claim()` with parent/child dependencies, plus full Vitest suite.

**Exact steps or command run after this patch**:

```bash
# Run the workboard store test suite (80 tests including the new regression test)
node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts --run
```

**Evidence after fix**:

```console
$ node --import tsx scripts/workboard-claim-proof.ts

============================================================
Scenario 1: claimed dependency-backed card → repeat claim
============================================================
Parent: 91ab3dfd (todo) | Child: 6047aaea (todo, parent→91ab3dfd)
After parent done + dispatch: child status = ready
First claim: ok, status=running, owner=main
Repeat claim error: card already claimed by main.
✅ PASS

============================================================
Scenario 2: unfinished parent — still blocks claim
============================================================
Parent: 6843d08c (todo) | Child: 6a666172 (todo)
Claim error: card dependencies are not done.
✅ PASS
```

Live store exercise above confirms the fix end-to-end:
- A dependency-backed child ready after parent completion is claimable, then correctly reports "already claimed" on a repeat attempt.
- An unfinished parent still correctly blocks the child with "dependencies are not done".

Unit test suite also passes cleanly:

```console
$ node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts --run

 RUN  v4.1.9 /home/0668000999/OpenClaw
 Test Files  1 passed (1)
      Tests  80 passed (80)
```

**Observed result after fix**:

- Live store exercise: repeat claim on dependency-backed `running` card → `card already claimed by main.` (correct, was "dependencies are not done" before)
- Live store exercise: claim on child with unfinished parent → `card dependencies are not done.` (unchanged, dependency enforcement preserved)
- All 80 unit tests pass, including the new regression test "reports already claimed for dependency-backed cards on repeat claim"
- Existing tests for dependency-blocked claims (store.test.ts lines 1258, 1286) and parentless repeat claim (store.test.ts line 995) continue to pass
- The fix is a pure reorder: 4 lines moved, zero semantic changes to either guard

**What was not tested**:

- Real agent session using workboard MCP tools through a configured agent (requires full gateway setup with model/provider/auth)

## Risks and Mitigations

- **Highest risk area**: None — the two guard checks are independent. The dependency guard only fires when `cardParentIds(guarded).length > 0 && guarded.status !== "ready"`, and the existingClaim guard only fires when there is an unexpired claim. Reordering them does not change either condition.
- **Mitigation**: Existing tests for both guards pass unchanged. The new regression test explicitly covers the intersection case (claimed + dependency-backed).
- **Compatibility impact**: None — no public API, config, or storage schema changes. The error message for genuinely blocked cards ("card dependencies are not done.") is unchanged.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- **Verified scenarios**: Claim on dependency-backed card with completed parent (success), repeat claim on same card (correct "already claimed" error), claim on card with incomplete parent (correct "dependencies" error), claim on parentless card (unchanged behavior)
- **Edge cases checked**: Card with parents and existing claim, card with parents and no claim, card without parents and existing claim
- **What you did NOT verify**: Real agent session using workboard MCP tools, multi-owner claim scenarios via live gateway

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Issue #104050 analysis → identified misordered guard checks in `claim()` at store.ts L3403-3416 → proposed and implemented reorder + regression test
