### PR TITLE
fix(mcp): MCP disabled: true silently ignored — gateway spawns server processes anyway

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.test.ts
@@ -9,7 +9,11 @@ describe("mcp.servers.disabled->enabled migration", () => {
 
   it("migrates disabled: true to enabled: false", () => {
     const changes: string[] = [];
-    const raw = {
+    const raw: {
+      mcp: {
+        servers: Record<string, { disabled?: boolean; enabled?: boolean; command?: string }>;
+      };
+    } = {
       mcp: {
         servers: {
           myServer: {
@@ -34,7 +38,11 @@ describe("mcp.servers.disabled->enabled migration", () => {
 
   it("removes disabled: false as a no-op (server enabled by default)", () => {
     const changes: string[] = [];
-    const raw = {
+    const raw: {
+      mcp: {
+        servers: Record<string, { disabled?: boolean; enabled?: boolean; command?: string }>;
+      };
+    } = {
       mcp: {
         servers: {
           myServer: {
@@ -58,7 +66,11 @@ describe("mcp.servers.disabled->enabled migration", () => {
 
   it("preserves explicit enabled: true when disabled is also present", () => {
     const changes: string[] = [];
-    const raw = {
+    const raw: {
+      mcp: {
+        servers: Record<string, { disabled?: boolean; enabled?: boolean; command?: string }>;
+      };
+    } = {
       mcp: {
         servers: {
           myServer: {
@@ -83,7 +95,11 @@ describe("mcp.servers.disabled->enabled migration", () => {
 
   it("preserves explicit enabled: false when disabled is also present", () => {
     const changes: string[] = [];
-    const raw = {
+    const raw: {
+      mcp: {
+        servers: Record<string, { disabled?: boolean; enabled?: boolean; command?: string }>;
+      };
+    } = {
       mcp: {
         servers: {
           myServer: {
@@ -106,7 +122,11 @@ describe("mcp.servers.disabled->enabled migration", () => {
 
   it("handles multiple servers with mixed states", () => {
     const changes: string[] = [];
-    const raw = {
+    const raw: {
+      mcp: {
+        servers: Record<string, { disabled?: boolean; enabled?: boolean; command?: string }>;
+      };
+    } = {
       mcp: {
         servers: {
           serverA: { disabled: true, command: "a" },

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.test.ts
@@ -1,0 +1,181 @@
+// MCP runtime migration tests cover doctor legacy config migrations for MCP server config shape.
+import { describe, it, expect } from "vitest";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP } from "./legacy-config-migrations.runtime.mcp.js";
+
+describe("mcp.servers.disabled->enabled migration", () => {
+  const migration = LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP.find(
+    (m) => m.id === "mcp.servers.disabled->enabled",
+  );
+
+  it("migrates disabled: true to enabled: false", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          myServer: {
+            disabled: true,
+            command: "npx",
+          },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(true);
+
+    migration!.apply(raw, changes);
+
+    expect(raw.mcp.servers.myServer.enabled).toBe(false);
+    expect(raw.mcp.servers.myServer.disabled).toBeUndefined();
+    expect(raw.mcp.servers.myServer.command).toBe("npx");
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain("disabled → enabled: false");
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+
+  it("removes disabled: false as a no-op (server enabled by default)", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          myServer: {
+            disabled: false,
+            command: "npx",
+          },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(true);
+
+    migration!.apply(raw, changes);
+
+    expect(raw.mcp.servers.myServer.enabled).toBeUndefined();
+    expect(raw.mcp.servers.myServer.disabled).toBeUndefined();
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain("no-op, server enabled by default");
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+
+  it("preserves explicit enabled: true when disabled is also present", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          myServer: {
+            disabled: true,
+            enabled: true,
+            command: "npx",
+          },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(true);
+
+    migration!.apply(raw, changes);
+
+    expect(raw.mcp.servers.myServer.enabled).toBe(true);
+    expect(raw.mcp.servers.myServer.disabled).toBeUndefined();
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain("canonical enabled: true preserved");
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+
+  it("preserves explicit enabled: false when disabled is also present", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          myServer: {
+            disabled: false,
+            enabled: false,
+            command: "npx",
+          },
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(raw.mcp.servers.myServer.enabled).toBe(false);
+    expect(raw.mcp.servers.myServer.disabled).toBeUndefined();
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain("canonical enabled: false preserved");
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+
+  it("handles multiple servers with mixed states", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          serverA: { disabled: true, command: "a" },
+          serverB: { disabled: false, command: "b" },
+          serverC: { disabled: true, enabled: false, command: "c" },
+          serverD: { command: "d" },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(true);
+
+    migration!.apply(raw, changes);
+
+    expect(raw.mcp.servers.serverA.enabled).toBe(false);
+    expect(raw.mcp.servers.serverA.disabled).toBeUndefined();
+    expect(raw.mcp.servers.serverB.enabled).toBeUndefined();
+    expect(raw.mcp.servers.serverB.disabled).toBeUndefined();
+    expect(raw.mcp.servers.serverC.enabled).toBe(false);
+    expect(raw.mcp.servers.serverC.disabled).toBeUndefined();
+    expect(raw.mcp.servers.serverD.disabled).toBeUndefined();
+    expect(raw.mcp.servers.serverD.enabled).toBeUndefined();
+    expect(changes).toHaveLength(3);
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+
+  it("handles missing mcp section gracefully", () => {
+    const changes: string[] = [];
+    const raw = {};
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles missing mcp.servers section gracefully", () => {
+    const changes: string[] = [];
+    const raw = { mcp: {} };
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles non-record server entries gracefully", () => {
+    const changes: string[] = [];
+    const raw = {
+      mcp: {
+        servers: {
+          myServer: "string-value",
+        },
+      },
+    };
+
+    migration!.apply(raw, changes);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does not match when no server has disabled key", () => {
+    const raw = {
+      mcp: {
+        servers: {
+          serverA: { command: "a" },
+          serverB: { command: "b" },
+        },
+      },
+    };
+
+    expect(migration!.legacyRules?.[0]?.match?.(raw.mcp.servers, raw)).toBe(false);
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -19,6 +19,14 @@ const MCP_SERVER_TYPE_RULE: LegacyConfigRule = {
     Object.values(value).some((server) => isRecord(server) && isKnownCliMcpTypeAlias(server.type)),
 };
 
+const MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
+  path: ["mcp", "servers"],
+  message: 'mcp.servers entries use "enabled" (not "disabled"). Run "openclaw doctor --fix".',
+  match: (value) =>
+    isRecord(value) &&
+    Object.values(value).some((server) => isRecord(server) && server.disabled !== undefined),
+};
+
 /** Legacy config migration specs for MCP server config compatibility. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] = [
   defineLegacyConfigMigration({
@@ -49,6 +57,41 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] =
           changes.push(`Removed mcp.servers.${serverName}.type "${rawType}".`);
         }
         delete rawServer.type;
+      }
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "mcp.servers.disabled->enabled",
+    describe: "Migrate legacy disabled key to canonical enabled",
+    legacyRules: [MCP_SERVER_DISABLED_RULE],
+    apply: (raw, changes) => {
+      const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
+      const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
+      if (!servers) {
+        return;
+      }
+
+      for (const [serverName, rawServer] of Object.entries(servers)) {
+        if (!isRecord(rawServer) || rawServer.disabled === undefined) {
+          continue;
+        }
+        if (rawServer.enabled === undefined) {
+          rawServer.enabled = rawServer.disabled === true ? false : undefined;
+          if (rawServer.enabled === undefined) {
+            changes.push(
+              `Removed mcp.servers.${serverName}.disabled (no-op, server enabled by default).`,
+            );
+          } else {
+            changes.push(
+              `Migrated mcp.servers.${serverName}.disabled → enabled: ${rawServer.enabled}.`,
+            );
+          }
+        } else {
+          changes.push(
+            `Removed mcp.servers.${serverName}.disabled (canonical enabled: ${rawServer.enabled} preserved).`,
+          );
+        }
+        delete rawServer.disabled;
       }
     },
   }),


### PR DESCRIPTION
## What Problem This Solves

Fixes #103954 — MCP server config with `disabled: true` is silently ignored. The gateway spawns the MCP subprocess anyway because the runtime only reads the canonical `enabled` field.

## Why This Change Was Made

Previous approach (reverted): runtime normalization that rewrote `disabled` → `enabled` on every config load. ClawSweeper rejected this across 3 review cycles — it creates a permanent undocumented inverse config alias that every code path, type definition, schema, and doc would need to account for.

This patch follows the established OpenClaw pattern: **doctor-only migration**, same as the existing `mcp.servers.type->transport` migration in the same file.

- **Runtime stays canonical-only.** `enabled` is the sole activation field. `disabled` is inert at runtime (same as before this PR).
- **Doctor detects and fixes it once.** `openclaw doctor --fix` finds `disabled` keys, transforms them to `enabled`, and writes the corrected config.
- **Existing seam.** The migration lives in `legacy-config-migrations.runtime.mcp.ts` alongside the existing `type->transport` migration.

## Migration Behavior

| Input | Output | Rationale |
|---|---|---|
| `disabled: true` | `enabled: false` | Explicitly disabled |
| `disabled: false` | (removed, no `enabled` key) | No-op — server enabled by default |
| `disabled: true` + `enabled: true` | `enabled: true` (disabled removed) | Canonical `enabled` wins |
| `disabled: true` + `enabled: false` | `enabled: false` (disabled removed) | Canonical `enabled` wins |
| No `disabled` key | No change | Nothing to migrate |

## User Impact

- Users with `disabled: true` in their MCP config will see a doctor warning and can run `openclaw doctor --fix` to migrate automatically.
- No runtime behavior change — `disabled` was already inert before this PR.
- No new undocumented config surface.

## Evidence

- 2 files changed, 224 insertions, 0 deletions
- Rebased onto latest `upstream/main`
- All tests pass:

```
$ pnpm vitest run src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.test.ts
✓ 9 passed (9 migration tests: disabled→enabled, disabled→noop, conflict precedence, mixed servers, edge cases)

$ pnpm vitest run src/commands/doctor/shared/legacy-config-migrate.test.ts
✓ 137 passed (existing migration tests unaffected)

$ pnpm vitest run src/config/mcp-config.test.ts
✓ 8 passed (existing MCP config tests unaffected)
```

- Migration verified with test coverage for all conflict-precedence cases
- No runtime alias remains in `mcp-config-normalize.ts` — `disabled` is not referenced anywhere in the file

Refs: #103954