### PR TITLE
fix(agents): prevent local provider sidecars surviving canceled startup

### DIFF
--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -807,7 +807,7 @@ describe("provider local service", () => {
   });
 
   it("does not spawn a local service after its last startup caller aborts", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-service-abort-"));
+    const tempDir = tempDirs.make("openclaw-local-service-abort-");
     const pidPath = path.join(tempDir, "child.pid");
     const controller = new AbortController();
     let probeCount = 0;
@@ -828,13 +828,14 @@ describe("provider local service", () => {
     if (!address || typeof address === "string") {
       throw new Error("missing test server port");
     }
-    const healthUrl = `http://127.0.0.1:${address.port}/v1/models`;
+    const port = address.port;
+    const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const model = attachModelProviderLocalService(
       {
         id: "demo",
         provider: "local-abort-before-spawn",
         api: "openai-completions",
-        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        baseUrl: `http://127.0.0.1:${port}/v1`,
       } as unknown as Model<"openai-completions">,
       {
         command: process.execPath,
@@ -859,7 +860,6 @@ describe("provider local service", () => {
       await expect(
         ensureModelProviderLocalService(model, undefined, controller.signal),
       ).rejects.toThrow("request aborted after unhealthy probe");
-      stopManagedProviderLocalServicesForTest();
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 200);
       });
@@ -880,7 +880,6 @@ describe("provider local service", () => {
           resolve();
         });
       });
-      await fs.rm(tempDir, { force: true, recursive: true });
     }
   });
 });

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -1,6 +1,7 @@
 // Verifies managed local provider services start, lease, probe, and stop safely.
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -803,5 +804,83 @@ describe("provider local service", () => {
     expect(startupError?.message).not.toContain(argumentDiagnosticSecret);
     expect(Buffer.byteLength(startupError?.message ?? "")).toBeLessThanOrEqual(8 * 1024 + 256);
     expect(getManagedProviderLocalServiceDiagnosticsForTest()).toEqual([]);
+  });
+
+  it("does not spawn a local service after its last startup caller aborts", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-service-abort-"));
+    const pidPath = path.join(tempDir, "child.pid");
+    const controller = new AbortController();
+    let probeCount = 0;
+    let childPid: number | undefined;
+    const server = http.createServer((_request, response) => {
+      probeCount += 1;
+      response.writeHead(503, { "content-type": "text/plain" });
+      response.end("not ready");
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing test server port");
+    }
+    const healthUrl = `http://127.0.0.1:${address.port}/v1/models`;
+    const model = attachModelProviderLocalService(
+      {
+        id: "demo",
+        provider: "local-abort-before-spawn",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as unknown as Model<"openai-completions">,
+      {
+        command: process.execPath,
+        args: [
+          "-e",
+          `require("node:fs").writeFileSync(${JSON.stringify(pidPath)},String(process.pid));setInterval(()=>{},1000);`,
+        ],
+        healthUrl,
+        readyTimeoutMs: 60_000,
+      },
+    );
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+      const response = await realFetch(...args);
+      if (response.status === 503 && !controller.signal.aborted) {
+        controller.abort(new Error("request aborted after unhealthy probe"));
+      }
+      return response;
+    });
+
+    try {
+      await expect(
+        ensureModelProviderLocalService(model, undefined, controller.signal),
+      ).rejects.toThrow("request aborted after unhealthy probe");
+      stopManagedProviderLocalServicesForTest();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200);
+      });
+      childPid = await readPidFile(pidPath).catch(() => undefined);
+
+      expect(probeCount).toBe(1);
+      expect(childPid).toBeUndefined();
+    } finally {
+      fetchSpy.mockRestore();
+      childPid ??= await readPidFile(pidPath).catch(() => undefined);
+      killPidIfAlive(childPid);
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
   });
 });

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -217,7 +217,7 @@ export async function ensureProviderLocalService(
 
   validateLocalServiceConfig(service, target.providerId);
   const healthUrl = resolveHealthUrl(service, target.baseUrl);
-  const healthHeaders = filterHealthProbeHeaders(target.headers);
+  const healthHeaders = buildHealthProbeHeaders(target.headers, undefined);
   const key = localServiceKey(target.providerId, service, healthUrl);
   installExitHandler();
   const managed = services.get(key) ?? { active: 0 };
@@ -353,10 +353,6 @@ function buildHealthProbeHeaders(
   appendHeaders(providerHeaders);
   appendHeaders(requestHeaders);
   return [...headers].length > 0 ? headers : undefined;
-}
-
-function filterHealthProbeHeaders(headers: HeadersInit | undefined): Headers | undefined {
-  return buildHealthProbeHeaders(headers, undefined);
 }
 
 async function probeHealth(

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -418,6 +418,9 @@ async function startAndWaitForLocalService(params: {
     stderrTail: "",
   };
   managed.diagnostics = diagnostics;
+  // The last lease can disappear while the health probe or restart settles.
+  // Recheck at the spawn boundary so cleanup cannot orphan a newly created child.
+  throwIfAborted(signal);
   log.info(`starting ${provider} local service: ${service.command}`);
   managed.process = spawn(service.command, service.args ?? [], {
     cwd: service.cwd,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators using a configured local model provider could be left with a detached sidecar process after the final model request was canceled during a cold start. The process survived normal manager cleanup because it started after the service entry had already been removed.

## Why This Change Was Made

The startup owner now rechecks its manager-owned abort signal at the final synchronous boundary before `spawn()`. This preserves shared startup for remaining callers, prevents a child from appearing after the last caller's cleanup, and keeps any child created before a later startup failure visible to the existing manager cleanup path.

The conflict resolution keeps current `main`'s bounded, redacted startup diagnostics and host-owned local-service behavior. It does not change provider configuration, health-check behavior, readiness timeouts, process-tree signaling, schemas, or protocols.

## User Impact

Canceling the last request during a local provider cold start no longer leaks a detached provider process. Concurrent requests that still hold a lease continue sharing the same startup as before.

## Evidence

After rebasing onto current `main`, the exact regression test was run with the final abort check temporarily removed. It failed after observing a real spawned child PID, reproducing the orphan race on the new base.

With the fix restored, the complete local-provider service test file passes:

```text
Test Files  1 passed (1)
Tests       21 passed (21)
```

The independent live proof directly loaded the production manager and used a real loopback HTTP 503 response, native `fetch`, the production detached `spawn()` path, a real Node child PID probe, and real manager cleanup:

```json
{
  "realLoopbackHealthProbeCount": 1,
  "callerAborted": true,
  "error": "Error: user cancelled exactly after unhealthy probe completed",
  "childInfo": null,
  "childSpawnedAfterAbort": false,
  "aliveBeforeCleanup": false,
  "aliveAfterRegistryCleanup": false,
  "orphanedFromManager": false
}
```

Additional checks passed:

- full test TypeScript graph: core, extensions, and root test projects
- `oxfmt --check` on both changed files
- `oxlint --deny-warnings` on both changed files
- `git diff --check`

The broad local `agents-core` config did not report test results before the repository's 180-second no-output watchdog and is not counted as a pass. The owning test file, full test type graph, focused static checks, and issue-specific live process proof passed; hosted CI will re-evaluate the rebased head.
