### PR TITLE
fix(workboard): check active claim before dependency status guard in claim()

### DIFF
--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1008,6 +1008,26 @@ describe("WorkboardStore", () => {
     expect(released.metadata?.claim).toBeUndefined();
   });
 
+  it("reports already claimed instead of dependency error for a claimed dependency-backed card", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const parent = await store.create({ title: "Parent", status: "done" });
+    const child = await store.create({
+      title: "Child",
+      status: "ready",
+      metadata: {
+        links: [{ id: "link-1", type: "parent", targetCardId: parent.id, createdAt: Date.now() }],
+      },
+    });
+
+    // First claim succeeds.
+    const first = await store.claim(child.id, { ownerId: "main", ttlSeconds: 60 });
+    expect(first.card.status).toBe("running");
+    expect(first.card.metadata?.claim?.ownerId).toBe("main");
+
+    // Second claim must report "already claimed", not "dependencies not done".
+    await expect(store.claim(child.id, { ownerId: "other" })).rejects.toThrow(/already claimed/);
+  });
+
   it("caps oversized claim TTL seconds to a valid Date timestamp", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1010,21 +1010,30 @@ describe("WorkboardStore", () => {
 
   it("reports already claimed instead of dependency error for a claimed dependency-backed card", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const parent = await store.create({ title: "Parent", status: "done" });
-    const child = await store.create({
-      title: "Child",
-      status: "ready",
-      metadata: {
-        links: [{ id: "link-1", type: "parent", targetCardId: parent.id, createdAt: Date.now() }],
-      },
-    });
+    const parent = await store.create({ title: "Parent", status: "todo" });
+    const child = await store.create({ title: "Child", status: "todo" });
+    // Parent/child dependencies must be built via linkCards; raw metadata.links
+    // of type "parent" are stripped on create, so a hand-built link leaves the
+    // child parentless and never exercises the dependency guard this test covers.
+    await store.linkCards(parent.id, child.id);
+    await store.update(parent.id, { status: "done" });
+    await store.promoteReady();
 
-    // First claim succeeds.
+    // Guard: the dependency is real and the child promoted, otherwise a repeat
+    // claim would never reach the misordered dependency guard.
+    const linked = await store.get(child.id);
+    expect(
+      linked?.metadata?.links?.some((l) => l.type === "parent" && l.targetCardId === parent.id),
+    ).toBe(true);
+    expect(linked?.status).toBe("ready");
+
+    // First claim succeeds and moves the dependency-backed card to running.
     const first = await store.claim(child.id, { ownerId: "main", ttlSeconds: 60 });
     expect(first.card.status).toBe("running");
     expect(first.card.metadata?.claim?.ownerId).toBe("main");
 
-    // Second claim must report "already claimed", not "dependencies not done".
+    // A running card still has an unfinished-by-status parent, so the second
+    // claim must report "already claimed", not "dependencies not done".
     await expect(store.claim(child.id, { ownerId: "other" })).rejects.toThrow(/already claimed/);
   });
 

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -3401,6 +3401,13 @@ export class WorkboardStore {
         ttlSeconds ? secondsToDurationMs(ttlSeconds) : DEFAULT_CLAIM_TTL_MS,
       );
       const guarded = await this.promoteDependencyReady(id, now);
+      // Check outstanding claim before the dependency status guard
+      // so a repeat claim on a card with parents returns "already
+      // claimed" instead of a misleading "dependencies not done".
+      const existingClaim = guarded.metadata?.claim;
+      if (existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })) {
+        throw new Error(`card already claimed by ${existingClaim.ownerId}.`);
+      }
       if (cardParentIds(guarded).length > 0 && guarded.status !== "ready") {
         throw new Error("card dependencies are not done.");
       }
@@ -3409,10 +3416,6 @@ export class WorkboardStore {
       }
       if (retryBudgetExhausted(guarded)) {
         throw new Error("card exhausted its retry budget.");
-      }
-      const existingClaim = guarded.metadata?.claim;
-      if (existingClaim && isFutureDateTimestampMs(existingClaim.expiresAt, { nowMs: now })) {
-        throw new Error(`card already claimed by ${existingClaim.ownerId}.`);
       }
       const metadata = clearDiagnostics(guarded.metadata, ["stranded_ready"]);
       const card = await this.updateCard(id, {


### PR DESCRIPTION
## What Problem This Solves

Fixes #104050 — `claim()` checks the dependency status guard (card status must be `"ready"`) before checking whether the card is already claimed. Since a successful claim moves the card to `"running"`, any repeat claim on a card with parents returns the misleading error `"card dependencies are not done"` instead of `"card already claimed by <owner>"`.

Cards without parents are unaffected — only the misordered dependency guard triggers this false error.

## Why This Change Was Made

Swap the order of two guards in `claim()`: check the active claim lease before the dependency status guard. The existing claim check (`already claimed by`) and dependency check (`dependencies are not done`) each remain correct on their own; the fix is purely about which one runs first.

No status transitions, no new error messages, no API changes — just moving `existingClaim` above `cardParentIds`.

**Test correction (`fbb9293dc5`):** the regression test first pushed here built the parent link through raw `metadata.links`, which `create()` strips (parent/child dependencies must go through `linkCards`). The child was therefore parentless, the dependency guard never fired, and the test passed with *or* without the fix. It now builds a real dependency via `linkCards` + `promoteReady` and asserts the link and promotion, so it genuinely guards the ordering (fails pre-fix, passes post-fix).

## User Impact

Agents that repeat-claim a dependency-backed card now see the correct `"already claimed by <owner>"` error instead of a misleading `"dependencies not done"` that sends them into dependency-debugging loops.

## Evidence

### Real runtime behavior (SQLite-backed `WorkboardStore`)

Reproduced #104050 end-to-end against a real `node:sqlite` store (not the in-memory test double), driving the public store API — build a parent→child dependency with `linkCards`, mark the parent `done`, `promoteReady`, then claim the child twice. `before` = pre-fix (`HEAD~1`), `after` = this fix.

```
########## BEFORE (pre-fix) ##########
setup   child.parents=[<cardId>] child.status=ready
claim#1 owner=main   -> status=running  token=<redacted>
claim#2 owner=other  -> Error: card dependencies are not done.     # misleading

########## AFTER (this fix) ##########
setup   child.parents=[<cardId>] child.status=ready
claim#1 owner=main   -> status=running  token=<redacted>
claim#2 owner=other  -> Error: card already claimed by main.       # correct
```

<details><summary>Repro driver (throwaway, not committed)</summary>

```ts
import { mkdtempSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { WorkboardStore } from "./extensions/workboard/src/store.ts";
import { createWorkboardSqliteStores } from "./extensions/workboard/src/sqlite-store.ts";

const s = createWorkboardSqliteStores({
  dbPath: join(mkdtempSync(join(tmpdir(), "wb-")), "workboard.sqlite"),
});
const store = new WorkboardStore(s.cards, {
  boards: s.boards, subscriptions: s.subscriptions, attachments: s.attachments,
});

const parent = await store.create({ title: "Parent A", status: "todo" });
const child  = await store.create({ title: "Child B",  status: "todo" });
await store.linkCards(parent.id, child.id);          // real parent->child dependency
await store.update(parent.id, { status: "done" });
await store.promoteReady();                          // child -> ready

const first = await store.claim(child.id, { ownerId: "main", ttlSeconds: 60 });
console.log("claim#1 ->", first.card.status);        // running
try { await store.claim(child.id, { ownerId: "other" }); }
catch (e) { console.log("claim#2 ->", e.message); }
```

</details>

### Regression test (now effective)

The corrected test fails on the pre-fix guard order and passes after the fix:

```
# new test @ FIXED store.ts
  Tests  1 passed

# new test @ PRE-FIX store.ts (HEAD~1)
  × reports already claimed instead of dependency error for a claimed dependency-backed card
  AssertionError: expected [Function] to throw error matching /already claimed/
    but got 'card dependencies are not done.'
```

### Full suite + lint

```
$ node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts
  Test Files  1 passed (1)
       Tests  80 passed (80)

$ node scripts/run-oxlint.mjs extensions/workboard/src/store.ts extensions/workboard/src/store.test.ts
  exit 0
```

1 production line moved + 1 effective regression test. Bounded to `extensions/workboard/src/`. No config, SDK, CLI, docs, or changelog surface was added.
