### PR TITLE
fix(installer): default to Node 22.22.2

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -197,7 +197,7 @@ by default, plus git-checkout installs under the same prefix flow.
 
 <Steps>
   <Step title="Install local Node runtime">
-    Downloads a pinned supported Node LTS tarball (the version is embedded in the script and updated independently, default `22.22.0`) to `<prefix>/tools/node-v<version>` and verifies SHA-256.
+    Downloads a pinned supported Node LTS tarball (the version is embedded in the script and updated independently, default `22.22.2`) to `<prefix>/tools/node-v<version>` and verifies SHA-256.
     On Alpine/musl Linux, where Node does not publish compatible tarballs for the pinned runtime, installs `nodejs` and `npm` with `apk` and links that runtime into the prefix wrapper path. The Alpine repositories must provide a supported Node version (22.19+, 23.11+, or 24+); use Alpine 3.21 or newer if older repositories only provide Node 20 or 21.
   </Step>
   <Step title="Ensure Git">
@@ -256,7 +256,7 @@ by default, plus git-checkout installs under the same prefix flow.
 | `--git \| --github`                     | Shortcut for git method                                                         |
 | `--git-dir \| --dir <path>`             | Git checkout directory (default: `~/openclaw`)                                  |
 | `--version <ver>`                       | OpenClaw version or dist-tag (default: `latest`)                                |
-| `--node-version <ver>`                  | Node version (default: `22.22.0`)                                               |
+| `--node-version <ver>`                  | Node version (default: `22.22.2`)                                               |
 | `--json`                                | Emit NDJSON events                                                              |
 | `--onboard`                             | Run `openclaw onboard` after install                                            |
 | `--no-onboard`                          | Skip onboarding (default)                                                       |

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -64,7 +64,7 @@ resolve_openclaw_effective_home() {
 OPENCLAW_EFFECTIVE_HOME="$(resolve_openclaw_effective_home)"
 PREFIX="${OPENCLAW_PREFIX:-${HOME}/.openclaw}"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-latest}"
-NODE_VERSION="${OPENCLAW_NODE_VERSION:-22.22.0}"
+NODE_VERSION="${OPENCLAW_NODE_VERSION:-22.22.2}"
 NODE_VERSION_REQUESTED=0
 if [[ -n "${OPENCLAW_NODE_VERSION:-}" ]]; then
   NODE_VERSION_REQUESTED=1
@@ -92,7 +92,7 @@ Usage: install-cli.sh [options]
   --git, --github                     Shortcut for --install-method git
   --git-dir, --dir <path>             Checkout directory (default: ~/openclaw, or \$OPENCLAW_HOME/openclaw)
   --version <ver>                     OpenClaw version (default: latest)
-  --node-version <ver>                Node version (default: 22.22.0)
+  --node-version <ver>                Node version (default: 22.22.2)
   --onboard                           Run "openclaw onboard" after install
   --no-onboard                        Skip onboarding (default)
   --set-npm-prefix                    Force npm prefix to ~/.npm-global if current prefix is not writable (Linux)
@@ -863,7 +863,7 @@ install_node() {
     local required_version
     installed_version="$("$(node_bin)" -v 2>/dev/null || echo unknown)"
     required_version="$(required_node_version)"
-    fail "Installed Node ${NODE_VERSION} must provide Node >= ${required_version} with node:sqlite; found ${installed_version}. Re-run with --node-version 22.22.0 (or newer)"
+    fail "Installed Node ${NODE_VERSION} must provide Node >= ${required_version} with node:sqlite; found ${installed_version}. Re-run with --node-version 22.22.2 (or newer)"
   fi
   emit_json "{\"event\":\"step\",\"name\":\"node\",\"status\":\"ok\",\"version\":\"${NODE_VERSION}\"}"
 }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1060,7 +1060,7 @@ describe("install-cli.sh", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-freshness-"));
     const prefix = join(tmp, "prefix");
     const home = join(tmp, "home");
-    const nodeBin = join(prefix, "tools/node-v22.22.0/bin");
+    const nodeBin = join(prefix, "tools/node-v22.22.2/bin");
     const argsLog = join(tmp, "npm-args.log");
     mkdirSync(nodeBin, { recursive: true });
     mkdirSync(home, { recursive: true });
@@ -1096,7 +1096,7 @@ describe("install-cli.sh", () => {
     const prefix = join(tmp, "prefix");
     const home = join(tmp, "home");
     const project = join(tmp, "project");
-    const nodeBin = join(prefix, "tools/node-v22.22.0/bin");
+    const nodeBin = join(prefix, "tools/node-v22.22.2/bin");
     const argsLog = join(tmp, "npm-args.log");
     mkdirSync(nodeBin, { recursive: true });
     mkdirSync(home, { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fresh CLI installation currently downloads Node 22.22.0, but the package's pinned `hosted-git-info@10.1.1` dependency requires `^22.22.2`. npm therefore prints an `EBADENGINE` warning during a normal fresh install.

## Why This Change Was Made

Advance the installer-managed Node 22 runtime to 22.22.2, the first matching patch release. Keep the help text, failure guidance, installer documentation, and default-dependent tests aligned. Explicit older-version fixtures remain unchanged because they exercise override and minimum-version behavior.

## User Impact

Fresh CLI installs no longer show a misleading engine incompatibility warning while installing the current package graph.

## Evidence

- Node's official distribution endpoint serves `node-v22.22.2-darwin-arm64.tar.gz`.
- `npm view hosted-git-info@10.1.1 engines` requires `^22.22.2 || ^24.15.0 || >=26.0.0`.
- Blacksmith Testbox run 29136004776: `test/scripts/install-cli.test.ts` — 25 passed.
- Exact rerun after docs update: 25 passed.
- `git diff --check` passed.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct (0.99).

Post-land proof will repeat the pristine Parallels CLI/Mac onboarding matrix from exact landed artifacts.
