### PR TITLE
improve(ui): replace background tasks rail chips with a quiet status line

### DIFF
--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -18,7 +18,6 @@ import {
   sortTasks,
   taskDetail,
   taskRuntimeLabel,
-  taskStatusChipClass,
   taskStatusLabel,
   taskTimestampMs,
   taskTitle,
@@ -337,6 +336,17 @@ export function renderBackgroundTasksToggle(
   `;
 }
 
+// Status tone drives the meta line's colored word and the running pulse dot;
+// pill chips read too heavy at rail width, so tone is typographic only.
+const STATUS_TONES = {
+  queued: "warn",
+  running: "warn",
+  completed: "ok",
+  failed: "danger",
+  cancelled: "muted",
+  timed_out: "danger",
+} as const satisfies Record<TaskSummary["status"], string>;
+
 function renderTaskRow(task: TaskSummary, props: BackgroundTasksProps): TemplateResult {
   const active = isActiveTask(task);
   const title = taskTitle(task);
@@ -346,9 +356,13 @@ function renderTaskRow(task: TaskSummary, props: BackgroundTasksProps): Template
   );
   const transcriptSessionKey = task.childSessionKey ?? task.sessionKey;
   const cancelling = props.cancellingTaskIds.has(task.id);
+  const tone = STATUS_TONES[task.status];
   return html`
     <div class="chat-tasks-rail__task" role="listitem" data-task-id=${task.id}>
       <div class="chat-tasks-rail__task-head">
+        ${task.status === "running"
+          ? html`<span class="chat-tasks-rail__task-pulse" aria-hidden="true"></span>`
+          : nothing}
         <openclaw-tooltip .content=${title}>
           <span class="chat-tasks-rail__task-title">${title}</span>
         </openclaw-tooltip>
@@ -369,28 +383,28 @@ function renderTaskRow(task: TaskSummary, props: BackgroundTasksProps): Template
           : nothing}
       </div>
       <div class="chat-tasks-rail__task-meta">
-        <span class="chip ${taskStatusChipClass(task.status)}"
+        <span class="chat-tasks-rail__task-status chat-tasks-rail__task-status--${tone}"
           >${taskStatusLabel(task.status)}</span
         >
-        <span class="chip">${taskRuntimeLabel(task)}</span>
+        <span class="chat-tasks-rail__task-sep" aria-hidden="true">·</span>
+        <span>${taskRuntimeLabel(task)}</span>
         ${timestamp > 0
-          ? html`<span class="chat-tasks-rail__task-time" title=${formatMs(timestamp)}
-              >${formatRelativeTimestamp(timestamp)}</span
-            >`
+          ? html`<span class="chat-tasks-rail__task-sep" aria-hidden="true">·</span>
+              <span title=${formatMs(timestamp)}>${formatRelativeTimestamp(timestamp)}</span>`
+          : nothing}
+        ${transcriptSessionKey
+          ? html`
+              <button
+                class="chat-tasks-rail__task-transcript"
+                type="button"
+                @click=${() => props.onOpenSession(transcriptSessionKey)}
+              >
+                ${t("chat.backgroundTasks.viewTranscript")}
+              </button>
+            `
           : nothing}
       </div>
       ${detail ? html`<div class="chat-tasks-rail__task-detail">${detail}</div>` : nothing}
-      ${transcriptSessionKey
-        ? html`
-            <button
-              class="chat-tasks-rail__task-transcript"
-              type="button"
-              @click=${() => props.onOpenSession(transcriptSessionKey)}
-            >
-              ${t("chat.backgroundTasks.viewTranscript")}
-            </button>
-          `
-        : nothing}
     </div>
   `;
 }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -740,28 +740,64 @@
 .chat-tasks-rail__task {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg-elevated) 46%, transparent);
+  gap: 3px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-elevated) 62%, transparent);
+}
+
+.chat-tasks-rail__task:hover,
+.chat-tasks-rail__task:focus-within {
+  border-color: color-mix(in srgb, var(--border-strong) 45%, transparent);
 }
 
 .chat-tasks-rail__task-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 6px;
   min-width: 0;
 }
 
+/* openclaw-tooltip is display:contents, so the title span itself is the flex
+   item; growing it pins the stop button to the card's right edge even for
+   short titles. */
 .chat-tasks-rail__task-title {
+  display: block;
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--control-ui-text-sm);
+  font-weight: 550;
   line-height: 1.25;
+}
+
+/* Live-run indicator: replaces the old status pill for running rows. */
+.chat-tasks-rail__task-pulse {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  background: var(--warn, #f59e0b);
+  animation: chat-tasks-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes chat-tasks-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-tasks-rail__task-pulse {
+    animation: none;
+  }
 }
 
 .chat-tasks-rail__task-stop {
@@ -791,17 +827,40 @@
   stroke-width: 1.8px;
 }
 
+/* One quiet text line replaces the status/runtime pill chips: colored status
+   word, runtime, relative time, trailing transcript link. */
 .chat-tasks-rail__task-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-}
-
-.chat-tasks-rail__task-time {
+  align-items: baseline;
+  gap: 5px;
   color: var(--muted);
   font-size: var(--control-ui-text-xs);
-  line-height: 1.2;
+  line-height: 1.3;
+}
+
+.chat-tasks-rail__task-status {
+  font-weight: 560;
+}
+
+.chat-tasks-rail__task-status--ok {
+  color: var(--ok, #22c55e);
+}
+
+.chat-tasks-rail__task-status--warn {
+  color: var(--warn, #f59e0b);
+}
+
+.chat-tasks-rail__task-status--danger {
+  color: var(--danger, #ef4444);
+}
+
+.chat-tasks-rail__task-status--muted {
+  color: var(--muted);
+}
+
+.chat-tasks-rail__task-sep {
+  opacity: 0.6;
 }
 
 .chat-tasks-rail__task-detail {
@@ -815,21 +874,27 @@
   overflow-wrap: anywhere;
 }
 
+/* Quiet by default so a column of rows is not a column of accent links;
+   pushed right to end the meta line like a row action. */
 .chat-tasks-rail__task-transcript {
-  align-self: flex-start;
+  margin-left: auto;
   padding: 0;
   border: 0;
   background: transparent;
-  color: var(--accent);
+  color: var(--muted);
   font: inherit;
   font-size: var(--control-ui-text-xs);
-  line-height: 1.2;
+  line-height: 1.3;
   cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--muted) 45%, transparent);
+  text-underline-offset: 2px;
 }
 
 .chat-tasks-rail__task-transcript:hover,
 .chat-tasks-rail__task-transcript:focus-visible {
-  text-decoration: underline;
+  color: var(--accent);
+  text-decoration-color: currentColor;
 }
 
 @keyframes chat-sidebar-fade-in {


### PR DESCRIPTION
Related: #104010 (follow-up visual polish requested by maintainer)

## What Problem This Solves

The background tasks rail landed in #104010 with two pill chips per row (status + runtime). At rail width the stacked bubbles read heavy and repetitive — the status pill also duplicates what the Running/Finished section header already says.

## Why This Change Was Made

Replaces the chips with a single quiet meta line per row: a colored status word (ok/warn/danger/muted tone), runtime label, and relative time separated by middle dots, with the View transcript link tucked to the line's right edge in muted styling (accent only on hover). Running rows get a small amber pulse dot before the title (static under prefers-reduced-motion), the stop control pins to the card's right edge, and the cards drop their border for a soft fill with a hover outline. Rendering structure, data flow, and behavior are unchanged; the Tasks page keeps its chips.

## User Impact

The rail is visually calmer and scans faster: one glance separates running from finished work by section, dot, and status color instead of parsing pill labels. No behavior changes.

## Evidence

- Before/after screenshots in the PR comment below (mocked-gateway Playwright e2e artifacts).
- `pnpm test ui/src/pages/chat/components/chat-background-tasks.test.ts` (9 passed), `pnpm test ui/src/pages/chat/background-tasks.e2e.test.ts` (passed), `pnpm tsgo:test:ui` clean, scoped oxlint clean.
- Codex autoreview run on the branch diff (result noted in comments).
