### PR TITLE
[AI-assisted] Fix Android workspace filename wrapping

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.FileProvider
@@ -262,7 +263,7 @@ private fun WorkspaceEntryRow(
       modifier = Modifier.size(20.dp),
     )
     Column(modifier = Modifier.weight(1f)) {
-      Text(text = entry.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
+      Text(text = entry.name, style = ClawTheme.type.body.copy(lineBreak = LineBreak.Heading), color = ClawTheme.colors.text)
       workspaceEntryDetail(context, entry)?.let { detail ->
         Text(text = detail, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1)
       }
@@ -316,9 +317,8 @@ private fun WorkspaceFilePreview(
         ClawPlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
         Text(
           text = path.substringAfterLast('/'),
-          style = ClawTheme.type.display.copy(fontSize = 20.sp, lineHeight = 24.sp),
+          style = ClawTheme.type.display.copy(fontSize = 20.sp, lineHeight = 24.sp, lineBreak = LineBreak.Heading),
           color = ClawTheme.colors.text,
-          maxLines = 1,
           modifier = Modifier.weight(1f),
         )
         file?.let { loaded ->

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.FileProvider
@@ -263,7 +262,7 @@ private fun WorkspaceEntryRow(
       modifier = Modifier.size(20.dp),
     )
     Column(modifier = Modifier.weight(1f)) {
-      Text(text = entry.name, style = ClawTheme.type.body.copy(lineBreak = LineBreak.Heading), color = ClawTheme.colors.text)
+      Text(text = entry.name, style = ClawTheme.type.body.copy(lineBreak = androidx.compose.ui.text.style.LineBreak.Heading), color = ClawTheme.colors.text)
       workspaceEntryDetail(context, entry)?.let { detail ->
         Text(text = detail, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1)
       }
@@ -317,8 +316,9 @@ private fun WorkspaceFilePreview(
         ClawPlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
         Text(
           text = path.substringAfterLast('/'),
-          style = ClawTheme.type.display.copy(fontSize = 20.sp, lineHeight = 24.sp, lineBreak = LineBreak.Heading),
+          style = ClawTheme.type.display.copy(fontSize = 20.sp, lineHeight = 24.sp, lineBreak = androidx.compose.ui.text.style.LineBreak.Heading),
           color = ClawTheme.colors.text,
+          softWrap = true,
           modifier = Modifier.weight(1f),
         )
         file?.let { loaded ->


### PR DESCRIPTION
## What Problem This Solves

The Android workspace file browser forced file and directory names, including the file preview title, onto a single line. Long names were hard-clipped, which could hide the filename suffix or extension and make similarly named files difficult to distinguish.

## Why This Change Was Made

Workspace names are dynamic content and need enough space to remain identifiable. The entry label and preview title now wrap naturally using balanced heading line breaking, while the existing metadata, navigation, and file-loading behavior remain unchanged.

## User Impact

Long file and directory names in the Android Files screen can now use multiple balanced lines. The complete name and extension remain visible, and the row grows vertically instead of truncating the label.

## Evidence

- Fresh open-PR overlap checks for `WorkspaceFilesScreen`, `WorkspaceEntryRow`, and Android workspace filename wrapping returned no matches.
- `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.WorkspaceFilesTest` — pass.
- `./gradlew :app:ktlintCheck :benchmark:ktlintCheck` — pass.
- `pnpm native:i18n:check` — pass (`changed=false`).
- Play debug APK build and installation — pass.
- Behavior verified in an Android emulator using the exact patched APK against an isolated, paired OpenClaw gateway: gateway online, one paired emulator node online, no pending approvals.
- Before: the long fixture filename is clipped before its final extension character.
- After: the same filename wraps over two balanced lines and shows the complete `.md` extension.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="260" src="https://github.com/user-attachments/assets/c5531ce0-faa1-446c-9783-acc22c693379" alt="Before: long Android workspace filename clipped on one line" /></td>
    <td><img width="260" src="https://github.com/user-attachments/assets/8e635c31-3d35-437b-b21c-78d9a314e6ad" alt="After: complete Android workspace filename wrapped over two balanced lines" /></td>
  </tr>
</table>
