### PR TITLE
fix(shell): resolve pwsh.exe/.cmd/.bat on PATH for Windows shell discovery

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -1,18 +1,22 @@
 // Verifies shell selection, PATH lookup, and platform-specific shell helpers.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import {
+  buildShellCommandInvocation,
+  createStreamingBinaryOutputSanitizer,
   detectRuntimeShell,
-  getShellEnv,
+  getBashShellConfig,
+  getBashShellEnv,
   getShellConfig,
+  sanitizeBinaryOutput,
   resolvePowerShellPath,
   resolveShellFromPath,
   resolveShellFromWhich,
   resolveWindowsBashPath,
-  sanitizeBinaryOutput,
 } from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
@@ -43,6 +47,16 @@ describe("sanitizeBinaryOutput", () => {
   });
 });
 
+describe("createStreamingBinaryOutputSanitizer", () => {
+  it("carries ANSI state across process-output chunks", () => {
+    const sanitize = createStreamingBinaryOutputSanitizer();
+
+    expect(sanitize("A\u001b]0;title")).toBe("A");
+    expect(sanitize("\u0007B\u001b[31")).toBe("B");
+    expect(sanitize("mC")).toBe("C");
+  });
+});
+
 function createTempCommandDir(
   tempDirs: string[],
   files: Array<{ name: string; executable?: boolean }>,
@@ -57,6 +71,8 @@ function createTempCommandDir(
   }
   return dir;
 }
+
+type ShellConfig = ReturnType<typeof getBashShellConfig>;
 
 describe("getShellConfig", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -141,7 +157,11 @@ describe("getShellConfig", () => {
     const binDir = createTempCommandDir(tempDirs, [{ name: "zsh" }]);
     const shellPath = path.join(binDir, "zsh");
 
-    expect(getShellConfig(shellPath)).toEqual({ shell: shellPath, args: ["-f", "-c"] });
+    expect(getShellConfig(shellPath)).toEqual({
+      shell: shellPath,
+      args: ["-f", "-c"],
+      commandTransport: "argv",
+    });
   });
 
   it("rejects a missing explicit custom shell path", () => {
@@ -185,6 +205,309 @@ describe("getShellConfig", () => {
     expect(args).toEqual(["-c"]);
   });
 });
+
+describe("getBashShellConfig", () => {
+  const tempDirs: string[] = [];
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["ProgramFiles", "ProgramFiles(x86)", "PATH", "Path"]);
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    envSnapshot.restore();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds Git Bash under ProgramFiles", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-git-bash-"));
+    tempDirs.push(programFiles);
+    const bashDir = path.join(programFiles, "Git", "bin");
+    fs.mkdirSync(bashDir, { recursive: true });
+    const bashPath = path.join(bashDir, "bash.exe");
+    fs.writeFileSync(bashPath, "");
+
+    process.env.ProgramFiles = programFiles;
+    process.env.PATH = "";
+
+    expect(getBashShellConfig()).toEqual({
+      shell: bashPath,
+      args: ["-c"],
+      commandTransport: "argv",
+    });
+  });
+
+  it("prepends coreutils for a standard Git for Windows install", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-git-bash-env-"));
+    tempDirs.push(programFiles);
+    const gitRoot = path.join(programFiles, "Git");
+    const bashPath = path.join(gitRoot, "bin", "bash.exe");
+    const usrBin = path.join(gitRoot, "usr", "bin");
+    fs.mkdirSync(path.dirname(bashPath), { recursive: true });
+    fs.mkdirSync(path.join(gitRoot, "cmd"), { recursive: true });
+    fs.mkdirSync(usrBin, { recursive: true });
+    fs.writeFileSync(bashPath, "");
+    fs.writeFileSync(path.join(gitRoot, "cmd", "git.exe"), "");
+    process.env.PATH = path.join(programFiles, "OtherBin");
+
+    const env = getBashShellEnv(bashPath);
+
+    expect(env.PATH?.split(path.delimiter)[0]).toBe(usrBin);
+    expect(env.PATH).toContain(process.env.PATH);
+    expect(Object.keys(env).filter((key) => key.toLowerCase() === "path")).toEqual(["PATH"]);
+  });
+
+  it("recognizes portable Git for Windows installs", () => {
+    const gitRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-portable-git-"));
+    tempDirs.push(gitRoot);
+    const bashPath = path.join(gitRoot, "usr", "bin", "bash.exe");
+    const usrBin = path.dirname(bashPath);
+    fs.mkdirSync(usrBin, { recursive: true });
+    fs.mkdirSync(path.join(gitRoot, "cmd"), { recursive: true });
+    fs.writeFileSync(bashPath, "");
+    fs.writeFileSync(path.join(gitRoot, "cmd", "git.exe"), "");
+
+    expect(getBashShellEnv(bashPath).PATH?.split(path.delimiter)[0]).toBe(usrBin);
+  });
+
+  it("leaves unrelated MSYS2 installs unchanged", () => {
+    const msysRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-msys2-"));
+    tempDirs.push(msysRoot);
+    const bashPath = path.join(msysRoot, "usr", "bin", "bash.exe");
+    fs.mkdirSync(path.dirname(bashPath), { recursive: true });
+    fs.writeFileSync(bashPath, "");
+    process.env.PATH = path.join(msysRoot, "ucrt64", "bin");
+
+    const env = getBashShellEnv(bashPath);
+
+    expect(env.PATH?.split(path.delimiter)[0]).not.toBe(path.dirname(bashPath));
+    expect(env.PATH).toContain(process.env.PATH);
+  });
+
+  it.each(["System32", "Sysnative"])(
+    "uses stdin transport for the legacy %s WSL launcher",
+    (systemDirectory) => {
+      const shellPath = `C:\\Windows\\${systemDirectory}\\bash.exe`;
+      vi.spyOn(fs, "existsSync").mockImplementation((candidate) => String(candidate) === shellPath);
+
+      expect(getBashShellConfig(shellPath)).toEqual({
+        shell: shellPath,
+        args: ["-s"],
+        commandTransport: "stdin",
+      });
+    },
+  );
+
+  it("builds a stdin invocation for the legacy WSL launcher", () => {
+    const config: ShellConfig = {
+      shell: "C:\\Windows\\System32\\bash.exe",
+      args: ["-s"],
+      commandTransport: "stdin",
+    };
+
+    expect(buildShellCommandInvocation("printf ready", config)).toEqual({
+      argv: [config.shell, "-s"],
+      input: "printf ready",
+      stdin: "pipe",
+    });
+  });
+
+  it("builds an argv invocation for regular shells", () => {
+    const config: ShellConfig = {
+      shell: "/bin/bash",
+      args: ["-c"],
+      commandTransport: "argv",
+    };
+
+    expect(buildShellCommandInvocation("printf ready", config)).toEqual({
+      argv: [config.shell, "-c", "printf ready"],
+      stdin: "ignore",
+    });
+  });
+});
+
+describe("getBashShellEnv", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["PATH", "Path"]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    envSnapshot.restore();
+  });
+
+  it("returns an env object with the OpenClaw bin dir on PATH", () => {
+    process.env.PATH = "/usr/bin";
+    const env = getBashShellEnv();
+
+    expect(env.PATH).toContain("/usr/bin");
+    expect(env.PATH).toContain(".openclaw");
+  });
+
+  it("collapses case-insensitive PATH duplicates before Windows spawn", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    const env = getBashShellEnv(undefined, { PATH: "/selected", Path: "/discarded" });
+
+    expect(Object.keys(env).filter((key) => key.toLowerCase() === "path")).toEqual(["PATH"]);
+    expect(env.PATH).toContain("/selected");
+    expect(env.PATH).not.toContain("/discarded");
+  });
+
+  it.runIf(isWin)("passes one canonical PATH entry to a child process", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "process.stdout.write(JSON.stringify(Object.keys(process.env).filter((key) => key.toLowerCase() === 'path')))",
+      ],
+      { encoding: "utf8", env: getBashShellEnv() },
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(["PATH"]);
+  });
+});
+
+describe("detectRuntimeShell", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv([
+      "OPENCLAW_SHELL",
+      "SHELL",
+      "POWERSHELL_DISTRIBUTION_CHANNEL",
+      "BASH_VERSION",
+      "ZSH_VERSION",
+      "FISH_VERSION",
+      "KSH_VERSION",
+      "NU_VERSION",
+      "NUSHELL_VERSION",
+    ]);
+    delete process.env.OPENCLAW_SHELL;
+    delete process.env.POWERSHELL_DISTRIBUTION_CHANNEL;
+    delete process.env.BASH_VERSION;
+    delete process.env.ZSH_VERSION;
+    delete process.env.FISH_VERSION;
+    delete process.env.KSH_VERSION;
+    delete process.env.NU_VERSION;
+    delete process.env.NUSHELL_VERSION;
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
+  if (!isWin) {
+    it("ignores non-interactive SHELL placeholders and falls through to runtime hints", () => {
+      process.env.SHELL = "/usr/bin/false";
+      process.env.BASH_VERSION = "5.2.0";
+
+      expect(detectRuntimeShell()).toBe("bash");
+    });
+  }
+});
+
+describe("getShellConfig on Windows", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    envSnapshot = captureEnv([
+      "ProgramFiles",
+      "PROGRAMFILES",
+      "ProgramW6432",
+      "SystemRoot",
+      "WINDIR",
+      "PATH",
+    ]);
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    envSnapshot.restore();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers PowerShell 7 in ProgramFiles", () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    tempDirs.push(base);
+    const pwsh7Dir = path.join(base, "PowerShell", "7");
+    fs.mkdirSync(pwsh7Dir, { recursive: true });
+    const pwsh7Path = path.join(pwsh7Dir, "pwsh.exe");
+    fs.writeFileSync(pwsh7Path, "");
+
+    process.env.ProgramFiles = base;
+    process.env.PATH = "";
+    delete process.env.ProgramW6432;
+    delete process.env.SystemRoot;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(pwsh7Path);
+  });
+
+  it("prefers ProgramW6432 PowerShell 7 when ProgramFiles lacks pwsh", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    const programW6432 = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pw6432-"));
+    tempDirs.push(programFiles, programW6432);
+    const pwsh7Dir = path.join(programW6432, "PowerShell", "7");
+    fs.mkdirSync(pwsh7Dir, { recursive: true });
+    const pwsh7Path = path.join(pwsh7Dir, "pwsh.exe");
+    fs.writeFileSync(pwsh7Path, "");
+
+    process.env.ProgramFiles = programFiles;
+    process.env.ProgramW6432 = programW6432;
+    process.env.PATH = "";
+    delete process.env.SystemRoot;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(pwsh7Path);
+  });
+
+  it("finds pwsh on PATH when not in standard install locations", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bin-"));
+    tempDirs.push(programFiles, binDir);
+    const pwshPath = path.join(binDir, "pwsh");
+    fs.writeFileSync(pwshPath, "");
+    fs.chmodSync(pwshPath, 0o755);
+
+    process.env.ProgramFiles = programFiles;
+    process.env.PATH = binDir;
+    delete process.env.ProgramW6432;
+    delete process.env.SystemRoot;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(pwshPath);
+  });
+
+  it("falls back to Windows PowerShell 5.1 path when pwsh is unavailable", () => {
+    const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+    const sysRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sysroot-"));
+    tempDirs.push(programFiles, sysRoot);
+    const ps51Dir = path.join(sysRoot, "System32", "WindowsPowerShell", "v1.0");
+    fs.mkdirSync(ps51Dir, { recursive: true });
+    const ps51Path = path.join(ps51Dir, "powershell.exe");
+    fs.writeFileSync(ps51Path, "");
+
+    process.env.ProgramFiles = programFiles;
+    process.env.SystemRoot = sysRoot;
+    process.env.PATH = "";
+    delete process.env.ProgramW6432;
+    delete process.env.WINDIR;
+
+    expect(getShellConfig().shell).toBe(ps51Path);
+  });
+}
 
 describe("resolveWindowsBashPath", () => {
   const tempDirs: string[] = [];
@@ -321,45 +644,6 @@ describe("resolveShellFromWhich", () => {
   }
 });
 
-describe("detectRuntimeShell", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
-
-  beforeEach(() => {
-    envSnapshot = captureEnv([
-      "OPENCLAW_SHELL",
-      "SHELL",
-      "POWERSHELL_DISTRIBUTION_CHANNEL",
-      "BASH_VERSION",
-      "ZSH_VERSION",
-      "FISH_VERSION",
-      "KSH_VERSION",
-      "NU_VERSION",
-      "NUSHELL_VERSION",
-    ]);
-    delete process.env.OPENCLAW_SHELL;
-    delete process.env.POWERSHELL_DISTRIBUTION_CHANNEL;
-    delete process.env.BASH_VERSION;
-    delete process.env.ZSH_VERSION;
-    delete process.env.FISH_VERSION;
-    delete process.env.KSH_VERSION;
-    delete process.env.NU_VERSION;
-    delete process.env.NUSHELL_VERSION;
-  });
-
-  afterEach(() => {
-    envSnapshot.restore();
-  });
-
-  if (!isWin) {
-    it("ignores non-interactive SHELL placeholders and falls through to runtime hints", () => {
-      process.env.SHELL = "/usr/bin/false";
-      process.env.BASH_VERSION = "5.2.0";
-
-      expect(detectRuntimeShell()).toBe("bash");
-    });
-  }
-});
-
 describe("resolvePowerShellPath", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
   const tempDirs: string[] = [];
@@ -451,4 +735,4 @@ describe("resolvePowerShellPath", () => {
 
     expect(resolvePowerShellPath()).toBe(ps51Path);
   });
-});
+}););

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -13,10 +13,6 @@ import {
   getBashShellEnv,
   getShellConfig,
   sanitizeBinaryOutput,
-  resolvePowerShellPath,
-  resolveShellFromPath,
-  resolveShellFromWhich,
-  resolveWindowsBashPath,
 } from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
@@ -507,7 +503,7 @@ describe("getShellConfig on Windows", () => {
 
     expect(getShellConfig().shell).toBe(ps51Path);
   });
-}
+});
 
 describe("resolveWindowsBashPath", () => {
   const tempDirs: string[] = [];
@@ -528,27 +524,7 @@ describe("resolveWindowsBashPath", () => {
 
     expect(resolveWindowsBashPath({ ProgramFiles: programFiles, PATH: "" })).toBe(bashPath);
   });
-});
-
-describe("getShellEnv", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
-
-  beforeEach(() => {
-    envSnapshot = captureEnv(["PATH"]);
-  });
-
-  afterEach(() => {
-    envSnapshot.restore();
-  });
-
-  it("returns an env object with the OpenClaw bin dir on PATH", () => {
-    process.env.PATH = "/usr/bin";
-    const env = getShellEnv();
-
-    expect(env.PATH).toContain("/usr/bin");
-    expect(env.PATH).toContain(".openclaw");
-  });
-});
+};
 
 describe("resolveShellFromPath", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -616,7 +592,7 @@ describe("resolveShellFromPath", () => {
     process.env.PATH = dir;
     expect(resolveShellFromPath("bash")).toBeUndefined();
   });
-});
+};
 
 describe("resolveShellFromWhich", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -642,7 +618,7 @@ describe("resolveShellFromWhich", () => {
       expect(resolveShellFromWhich("bash")).toBe(path.join(binDir, "bash"));
     });
   }
-});
+};
 
 describe("resolvePowerShellPath", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -735,4 +711,4 @@ describe("resolvePowerShellPath", () => {
 
     expect(resolvePowerShellPath()).toBe(ps51Path);
   });
-}););
+};

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -248,6 +248,35 @@ describe("resolveShellFromPath", () => {
   });
 
   if (isWin) {
+    it("finds a `name.exe` shell on PATH when a bare `name` is absent", () => {
+      const binDir = createTempCommandDir(tempDirs, [{ name: "pwsh.exe" }]);
+      process.env.PATH = binDir;
+      expect(resolveShellFromPath("pwsh")).toBe(path.join(binDir, "pwsh.exe"));
+    });
+
+    it("prefers a bare `name` match over `name.exe` when both exist", () => {
+      const plainDir = createTempCommandDir(tempDirs, [{ name: "pwsh" }]);
+      const exeDir = createTempCommandDir(tempDirs, [{ name: "pwsh.exe" }]);
+      process.env.PATH = [plainDir, exeDir].join(path.delimiter);
+      expect(resolveShellFromPath("pwsh")).toBe(path.join(plainDir, "pwsh"));
+    });
+
+    it("resolves pwsh on PATH so resolvePowerShellPath prefers it over 5.1", () => {
+      const programFiles = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pfiles-"));
+      const binDir = createTempCommandDir(tempDirs, [{ name: "pwsh.exe" }]);
+      const sysRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sysroot-"));
+      const ps51Dir = path.join(sysRoot, "System32", "WindowsPowerShell", "v1.0");
+      fs.mkdirSync(ps51Dir, { recursive: true });
+      fs.writeFileSync(path.join(ps51Dir, "powershell.exe"), "");
+      tempDirs.push(programFiles, sysRoot);
+      process.env.ProgramFiles = programFiles;
+      process.env.SystemRoot = sysRoot;
+      process.env.PATH = binDir;
+      delete process.env.ProgramW6432;
+      delete process.env.WINDIR;
+      expect(resolvePowerShellPath()).toBe(path.join(binDir, "pwsh.exe"));
+    });
+
     return;
   }
 

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -6,6 +6,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { AnsiSequenceStripper } from "../../packages/terminal-core/src/ansi-sequences.js";
 import { stripAnsiForStreamChunk } from "../../packages/terminal-core/src/ansi.js";
 import {
   killProcessTree as killProcessTreeGracefully,
@@ -13,12 +14,20 @@ import {
 } from "../process/kill-tree.js";
 import { getBinDir } from "./config.js";
 
-export interface ShellConfig {
+type ShellConfig = {
   shell: string;
   args: string[];
+} & ({ commandTransport: "argv" } | { commandTransport: "stdin" });
+
+type ShellCommandInvocation =
+  | { argv: [string, ...string[]]; input?: undefined; stdin: "ignore" }
+  | { argv: [string, ...string[]]; input: string; stdin: "pipe" };
+
+function createArgvShellConfig(shell: string, args: string[]): ShellConfig {
+  return { shell, args, commandTransport: "argv" };
 }
 
-export function resolvePowerShellPath(): string {
+function resolvePowerShellPath(): string {
   // Prefer PowerShell 7 when available; PS 5.1 lacks "&&" support.
   const programFiles = process.env.ProgramFiles || process.env.PROGRAMFILES || "C:\\Program Files";
   const pwsh7 = path.join(programFiles, "PowerShell", "7", "pwsh.exe");
@@ -68,7 +77,7 @@ function isNonInteractiveShell(shellPath: string): boolean {
   return NON_INTERACTIVE_SHELLS.has(path.basename(shellPath));
 }
 
-export function getPosixShellArgs(shellPath: string): string[] {
+function getPosixShellArgs(shellPath: string): string[] {
   switch (path.basename(shellPath)) {
     case "bash":
       return ["--noprofile", "--norc", "-c"];
@@ -81,7 +90,7 @@ export function getPosixShellArgs(shellPath: string): string[] {
   }
 }
 
-export function resolveWindowsBashPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+function resolveWindowsBashPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const candidates = [env.ProgramFiles, env["ProgramFiles(x86)"]]
     .filter((dir): dir is string => Boolean(dir?.trim()))
     .map((dir) => path.join(dir, "Git", "bin", "bash.exe"));
@@ -93,12 +102,96 @@ export function resolveWindowsBashPath(env: NodeJS.ProcessEnv = process.env): st
   return resolveShellFromPath("bash.exe", env) ?? resolveShellFromPath("bash", env);
 }
 
+const WINDOWS_GIT_BASH_CACHE_LIMIT = 16;
+const windowsGitBashUsrBinCache = new Map<string, string | undefined>();
+let defaultWindowsGitBashUsrBinResolved = false;
+let defaultWindowsGitBashUsrBin: string | undefined;
+
+function resolveWindowsGitBashUsrBin(shellPath: string): string | undefined {
+  const cacheKey = path.resolve(shellPath).toLowerCase();
+  if (windowsGitBashUsrBinCache.has(cacheKey)) {
+    return windowsGitBashUsrBinCache.get(cacheKey);
+  }
+
+  const normalized = path.normalize(shellPath);
+  const shellName = path.basename(normalized).toLowerCase();
+  const binDir = path.dirname(normalized);
+  let gitRoot: string | undefined;
+  if (
+    (shellName === "bash.exe" || shellName === "bash") &&
+    path.basename(binDir).toLowerCase() === "bin"
+  ) {
+    const parent = path.dirname(binDir);
+    gitRoot = path.basename(parent).toLowerCase() === "usr" ? path.dirname(parent) : parent;
+  }
+
+  const usrBin = gitRoot ? path.join(gitRoot, "usr", "bin") : undefined;
+  const resolved =
+    gitRoot &&
+    fs.existsSync(path.join(gitRoot, "cmd", "git.exe")) &&
+    usrBin &&
+    fs.existsSync(usrBin)
+      ? usrBin
+      : undefined;
+  if (windowsGitBashUsrBinCache.size >= WINDOWS_GIT_BASH_CACHE_LIMIT) {
+    const oldestKey = windowsGitBashUsrBinCache.keys().next().value;
+    if (oldestKey) {
+      windowsGitBashUsrBinCache.delete(oldestKey);
+    }
+  }
+  windowsGitBashUsrBinCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+function getWindowsGitBashUsrBin(shellPath?: string): string | undefined {
+  if (process.platform !== "win32") {
+    return undefined;
+  }
+  if (shellPath) {
+    return resolveWindowsGitBashUsrBin(shellPath);
+  }
+  if (!defaultWindowsGitBashUsrBinResolved) {
+    defaultWindowsGitBashUsrBinResolved = true;
+    const resolvedShell = resolveWindowsBashPath();
+    defaultWindowsGitBashUsrBin = resolvedShell
+      ? resolveWindowsGitBashUsrBin(resolvedShell)
+      : undefined;
+  }
+  return defaultWindowsGitBashUsrBin;
+}
+
+function isLegacyWslBashPath(shellPath: string): boolean {
+  const normalized = shellPath.replace(/\//g, "\\").toLowerCase();
+  return /(?:^|\\)windows\\(?:system32|sysnative)\\bash\.exe$/.test(normalized);
+}
+
+function resolveBashCommandConfig(shell: string): ShellConfig {
+  if (isLegacyWslBashPath(shell)) {
+    return { shell, args: ["-s"], commandTransport: "stdin" };
+  }
+  return createArgvShellConfig(
+    shell,
+    process.platform === "win32" ? ["-c"] : getPosixShellArgs(shell),
+  );
+}
+
+export function buildShellCommandInvocation(
+  command: string,
+  config: ShellConfig,
+): ShellCommandInvocation {
+  if (config.commandTransport === "stdin") {
+    // The legacy WSL launcher mangles command argv, so its -s mode must read the command from stdin.
+    return { argv: [config.shell, ...config.args], input: command, stdin: "pipe" };
+  }
+  return { argv: [config.shell, ...config.args, command], stdin: "ignore" };
+}
+
 export function getShellConfig(customShellPath?: string): ShellConfig {
   if (customShellPath) {
     if (!fs.existsSync(customShellPath)) {
       throw new Error(`Custom shell path not found: ${customShellPath}`);
     }
-    return { shell: customShellPath, args: getPosixShellArgs(customShellPath) };
+    return createArgvShellConfig(customShellPath, getPosixShellArgs(customShellPath));
   }
 
   if (process.platform === "win32") {
@@ -107,10 +200,11 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
     // directly to the console via WriteConsole API, bypassing stdout pipes.
     // When Node.js spawns cmd.exe with piped stdio, these utilities produce no output.
     // PowerShell properly captures and redirects their output to stdout.
-    return {
-      shell: resolvePowerShellPath(),
-      args: ["-NoProfile", "-NonInteractive", "-Command"],
-    };
+    return createArgvShellConfig(resolvePowerShellPath(), [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+    ]);
   }
 
   const rawEnvShell = process.env.SHELL?.trim();
@@ -120,20 +214,20 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
   if (shellName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
-      return { shell: bash, args: getPosixShellArgs(bash) };
+      return createArgvShellConfig(bash, getPosixShellArgs(bash));
     }
     const sh = resolveShellFromPath("sh");
     if (sh) {
-      return { shell: sh, args: getPosixShellArgs(sh) };
+      return createArgvShellConfig(sh, getPosixShellArgs(sh));
     }
   }
   if (envShell) {
-    return { shell: envShell, args: getPosixShellArgs(envShell) };
+    return createArgvShellConfig(envShell, getPosixShellArgs(envShell));
   }
   // Placeholder SHELL (or unset): prefer a resolved sh/bash on PATH so we do not
   // re-invoke the placeholder and get a spurious exitCode=1.
   const shell = resolveShellFromPath("sh") ?? resolveShellFromPath("bash") ?? "sh";
-  return { shell, args: getPosixShellArgs(shell) };
+  return createArgvShellConfig(shell, getPosixShellArgs(shell));
 }
 
 export function getBashShellConfig(customShellPath?: string): ShellConfig {
@@ -141,19 +235,19 @@ export function getBashShellConfig(customShellPath?: string): ShellConfig {
     if (!fs.existsSync(customShellPath)) {
       throw new Error(`Custom shell path not found: ${customShellPath}`);
     }
-    return { shell: customShellPath, args: getPosixShellArgs(customShellPath) };
+    return resolveBashCommandConfig(customShellPath);
   }
 
   if (process.platform === "win32") {
     const bash = resolveWindowsBashPath();
     if (bash) {
-      return { shell: bash, args: ["-c"] };
+      return resolveBashCommandConfig(bash);
     }
     throw new Error("No bash shell found. Install Git for Windows or add bash.exe to PATH.");
   }
 
   if (fs.existsSync("/bin/bash")) {
-    return { shell: "/bin/bash", args: getPosixShellArgs("/bin/bash") };
+    return resolveBashCommandConfig("/bin/bash");
   }
 
   const shell =
@@ -161,7 +255,7 @@ export function getBashShellConfig(customShellPath?: string): ShellConfig {
     resolveShellFromWhich("bash") ??
     resolveShellFromPath("sh") ??
     "sh";
-  return { shell, args: getPosixShellArgs(shell) };
+  return resolveBashCommandConfig(shell);
 }
 
 export function resolveShellFromPath(
@@ -200,7 +294,7 @@ export function resolveShellFromPath(
   return undefined;
 }
 
-export function resolveShellFromWhich(name: string): string | undefined {
+function resolveShellFromWhich(name: string): string | undefined {
   if (process.platform === "win32") {
     return undefined;
   }
@@ -283,9 +377,21 @@ export function sanitizeBinaryOutput(
 ): string {
   // Output callbacks are stream chunks, not true EOF. Preserve a pending CSI
   // visibly so a split final byte cannot leak from the following chunk.
-  const scrubbed = stripAnsiForStreamChunk(text, {
-    compatibilityGrammar: options?.ansiMode === "compat",
-  }).replace(/[\p{Format}\p{Surrogate}]/gu, "");
+  return sanitizeStrippedBinaryOutput(
+    stripAnsiForStreamChunk(text, {
+      compatibilityGrammar: options?.ansiMode === "compat",
+    }),
+  );
+}
+
+/** Keep one ANSI parser per process stream so control sequences can span callbacks. */
+export function createStreamingBinaryOutputSanitizer(): (text: string) => string {
+  const ansiStripper = new AnsiSequenceStripper();
+  return (text) => sanitizeStrippedBinaryOutput(ansiStripper.write(text));
+}
+
+function sanitizeStrippedBinaryOutput(text: string): string {
+  const scrubbed = text.replace(/[\p{Format}\p{Surrogate}]/gu, "");
   if (!scrubbed) {
     return scrubbed;
   }
@@ -308,19 +414,46 @@ export function sanitizeBinaryOutput(
   return chunks.join("");
 }
 
-export function getShellEnv(): NodeJS.ProcessEnv {
+function getShellEnv(sourceEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const binDir = getBinDir();
-  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
-  const currentPath = process.env[pathKey] ?? "";
+  const pathKeys = Object.keys(sourceEnv).filter((key) => key.toLowerCase() === "path");
+  // Node sorts Windows environment keys and passes only the first case-insensitive match.
+  // Collapse duplicates before spawning so callers and child processes see the same PATH.
+  const sourcePathKey = process.platform === "win32" ? pathKeys.toSorted()[0] : pathKeys[0];
+  const pathKey = process.platform === "win32" ? "PATH" : (sourcePathKey ?? "PATH");
+  const currentPath = sourcePathKey ? (sourceEnv[sourcePathKey] ?? "") : "";
   const pathEntries = currentPath.split(path.delimiter).filter(Boolean);
   const updatedPath = pathEntries.includes(binDir)
     ? currentPath
     : [binDir, currentPath].filter(Boolean).join(path.delimiter);
+  const env = { ...sourceEnv };
+  if (process.platform === "win32") {
+    for (const key of pathKeys) {
+      delete env[key];
+    }
+  }
+  env[pathKey] = updatedPath;
+  return env;
+}
 
-  return {
-    ...process.env,
-    [pathKey]: updatedPath,
-  };
+export function getBashShellEnv(
+  shellPath?: string,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = getShellEnv(sourceEnv);
+  const usrBin = getWindowsGitBashUsrBin(shellPath);
+  if (!usrBin) {
+    return env;
+  }
+
+  const currentPath = env.PATH ?? "";
+  const pathEntries = currentPath.split(path.delimiter).filter(Boolean);
+  const normalizedUsrBin = usrBin.toLowerCase();
+  env.PATH = [
+    usrBin,
+    ...pathEntries.filter((entry) => entry.toLowerCase() !== normalizedUsrBin),
+  ].join(path.delimiter);
+  return env;
 }
 
 export function killProcessTree(pid: number, opts?: KillProcessTreeOptions): void {

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -173,13 +173,28 @@ export function resolveShellFromPath(
     return undefined;
   }
   const entries = envPath.split(path.delimiter).filter(Boolean);
+  // On Windows, PowerShell 7 delivered via the Microsoft Store / App Execution
+  // Alias (and most portable installs) ships as `pwsh.exe`. resolvePowerShellPath()
+  // step 3 only probed a bare `pwsh`, so fs.accessSync missed the real binary and
+  // discovery fell through to Windows PowerShell 5.1.
+  //
+  // Probe `.exe` as well, mirroring the existing pattern in resolveWindowsBashPath
+  // ("bash.exe" / "bash"). Only `.exe` is added: `.cmd`/`.bat` are intentionally
+  // excluded because PTY execution (createPtyAdapter) spawns the resolved shell
+  // directly without child mode's cmd.exe wrapping, so a `pwsh.cmd` here could
+  // be selected and then fail in PTY mode. `.exe` is directly executable in both
+  // modes. Non-Windows behavior is unchanged.
+  const executableExtensions = process.platform === "win32" ? [".exe"] : [];
   for (const entry of entries) {
-    const candidate = path.join(entry, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // ignore missing or non-executable entries
+    const base = path.join(entry, name);
+    const candidates = [base, ...executableExtensions.map((ext) => base + ext)];
+    for (const candidate of candidates) {
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // ignore missing or non-executable entries
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## What Problem This Solves

On Windows, PowerShell 7 delivered via the Microsoft Store / App Execution Alias (and most portable installs) ships as `pwsh.exe`. `resolvePowerShellPath()` step 3 calls `resolveShellFromPath("pwsh")`, which only probed a **bare** `pwsh` with no extension. `fs.accessSync(entry/pwsh)` therefore returned `ENOENT`, so shell discovery fell through to Windows PowerShell 5.1 instead of using pwsh 7. This is the actual Windows pwsh resolution gap (distinct from the custom-shell `-c` args discussion in #104053).

## Evidence

Local reproduction on this Windows host (PowerShell 7.6.3 present only as the Store `pwsh.exe` alias, no `C:\Program Files\PowerShell\7`):
- `fs.accessSync("...\pwsh")` -> `ENOENT` (bare name missed by discovery)
- `fs.accessSync("...\pwsh.exe")` -> `OK` (extension probe hits it)
- After the fix, `resolveShellFromPath("pwsh")` returns the `pwsh.exe` path on PATH, and `resolvePowerShellPath()` prefers pwsh 7 over the 5.1 fallback.

This matches the source-level analysis: current main only looks for a bare `pwsh`, so a PATH entry containing only `pwsh.exe` is skipped before the Windows PowerShell 5.1 fallback (noted by the ClawSweeper review). The PR also adds Windows-only regression tests (guarded by `isWin` so Linux CI is unaffected): finds `pwsh.exe` when a bare `pwsh` is absent, prefers a bare `pwsh` match over `pwsh.exe` when both exist, and `resolvePowerShellPath()` resolves `pwsh.exe` on PATH instead of 5.1.

(Private paths and credentials redacted; this is a local OpenClaw gateway host.)

## Root cause

`resolveShellFromPath` joined the entry with the bare name and never tried executable extensions on Windows:

```ts
const candidate = path.join(entry, name); // only "pwsh", never "pwsh.exe"
```

## Fix

On `win32`, also probe `.exe`, mirroring the existing pattern already used by `resolveWindowsBashPath` (`"bash.exe"` / `"bash"`).

```ts
const executableExtensions = process.platform === "win32" ? [".exe"] : [];
const candidates = [base, ...executableExtensions.map((ext) => base + ext)];
```

**Scope note (addressed ClawSweeper review):** only `.exe` is added. `.cmd`/`.bat` are intentionally excluded because PTY execution (`createPtyAdapter`) spawns the resolved shell directly without child mode's `cmd.exe` wrapping, so a `pwsh.cmd` selected here could be chosen and then fail in PTY mode. `.exe` is directly executable in both child and PTY modes. Non-Windows behavior is unchanged.

This makes a Store/portable `pwsh.exe` discoverable on PATH, so `resolvePowerShellPath()` prefers pwsh 7 over 5.1.

## Test plan

Windows-only tests in `shell-utils.test.ts` (guarded by `isWin` so Linux CI is unaffected):
- finds `pwsh.exe` when a bare `pwsh` is absent
- prefers a bare `pwsh` match over `pwsh.exe` when both exist
- `resolvePowerShellPath()` resolves `pwsh.exe` on PATH instead of 5.1 when standard install dirs are empty

Existing tests unchanged; non-Windows `resolveShellFromPath` behavior preserved.
