### PR TITLE
fix(agents): count CJK tool-result text by token-equivalent length

### DIFF
--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -81,8 +81,12 @@ limits.
 `toolResultMaxChars` is unset by default, so OpenClaw derives the live
 tool-result cap from the effective model context window: `16000` chars below
 100K tokens, `32000` chars at 100K+ tokens, `64000` chars at 200K+ tokens.
-The runtime context-share guard still caps a single tool result at 30% of the
-context window even when a larger explicit ceiling is configured.
+`toolResultMaxChars` is a physical UTF-16 character ceiling. Independently, a
+token-equivalent context-share guard caps a single tool result at 30% of the
+context window; that guard counts CJK and other East Asian scripts covered by
+the character-width estimator at roughly its real per-character token cost, so a
+CJK-heavy result cannot exceed its share of
+the window even though the physical ceiling is measured in raw characters.
 
 For images, OpenClaw downscales transcript/tool image payloads before
 provider calls. Tune with `agents.defaults.imageMaxDimensionPx` (default:

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -4,7 +4,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -12,6 +12,7 @@ import { createDedupeCache } from "../../infra/dedupe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { estimateStringChars } from "../../utils/cjk-chars.js";
 import { resolveAgentContextLimits } from "../agent-scope.js";
 import type { AgentMessage } from "../runtime/index.js";
 import {
@@ -80,7 +81,51 @@ export const toolResultWarningDedupe = {
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
+  /**
+   * Optional token-equivalent budget applied in addition to the physical
+   * `maxChars` ceiling. When set, the retained result must satisfy BOTH the raw
+   * UTF-16 `maxChars` limit and `estimateStringChars(result) <= estimatedMaxChars`.
+   * Defaults to no estimated limit (physical-only), which keeps persistence-path
+   * callers unchanged.
+   */
+  estimatedMaxChars?: number;
 };
+
+/**
+ * Token-equivalent budget for a single tool result: the context-share limit
+ * expressed in CJK-aware characters (the unit `estimateStringChars` returns).
+ * This is the estimated half of the two-budget contract; the physical half is
+ * the raw UTF-16 `toolResultMaxChars` ceiling, kept separate on purpose.
+ */
+function resolveEstimatedToolResultBudget(contextWindowTokens: number): number {
+  if (!Number.isFinite(contextWindowTokens)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(1, Math.floor(contextWindowTokens * MAX_TOOL_RESULT_CONTEXT_SHARE) * 4);
+}
+
+/**
+ * Largest raw UTF-16 cut index whose retained prefix satisfies the
+ * token-equivalent budget: `estimateStringChars(text.slice(0, i)) <= budget`.
+ * Measured on the actual prefix (not a whole-input average) so a compositionally
+ * uneven slice cannot exceed the token budget.
+ */
+function rawCutForEstimatedBudget(text: string, estimatedBudget: number): number {
+  if (!Number.isFinite(estimatedBudget) || estimateStringChars(text) <= estimatedBudget) {
+    return text.length;
+  }
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (estimateStringChars(sliceUtf16Safe(text, 0, mid)) <= estimatedBudget) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return low;
+}
 
 const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
@@ -160,23 +205,41 @@ function resolveEffectiveMinKeepChars(params: {
 function appendBoundedTruncationSuffix(params: {
   keptText: string;
   originalTextLength: number;
-  maxChars: number;
+  rawMaxChars: number;
+  estimatedMaxChars: number;
   suffixFactory: (truncatedChars: number) => string;
 }): string {
   const build = (keptText: string) =>
     keptText + params.suffixFactory(Math.max(1, params.originalTextLength - keptText.length));
+  // The complete assembled result (kept prefix/tail/marker + suffix) must fit
+  // both the raw ceiling and the token-equivalent budget. Measuring the actual
+  // assembled text — not a per-input average — is what keeps an uneven CJK/ASCII
+  // slice from exceeding the estimated budget.
+  const fitsBudgets = (finalText: string) =>
+    finalText.length <= params.rawMaxChars &&
+    estimateStringChars(finalText) <= params.estimatedMaxChars;
 
   let keptText = params.keptText;
   while (true) {
     const finalText = build(keptText);
-    if (finalText.length <= params.maxChars) {
+    if (fitsBudgets(finalText)) {
       return finalText;
     }
     if (keptText.length === 0) {
-      return truncateUtf16Safe(finalText, params.maxChars);
+      const rawCeil = Math.min(
+        params.rawMaxChars,
+        rawCutForEstimatedBudget(finalText, params.estimatedMaxChars),
+      );
+      return sliceUtf16Safe(finalText, 0, Math.max(0, rawCeil));
     }
-    const overflow = finalText.length - params.maxChars;
-    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
+    const rawOverflow = Math.max(0, finalText.length - params.rawMaxChars);
+    const estimatedOverflow = Number.isFinite(params.estimatedMaxChars)
+      ? Math.max(0, estimateStringChars(finalText) - params.estimatedMaxChars)
+      : 0;
+    // Each removed UTF-16 unit drops the estimate by at least 1, so shrinking by
+    // the larger overflow converges without overshooting into an empty result.
+    const shrinkBy = Math.max(1, rawOverflow, estimatedOverflow);
+    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - shrinkBy));
     keptText =
       nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
   }
@@ -205,7 +268,17 @@ function hasImportantTail(text: string): boolean {
 }
 
 /**
- * Truncate a single text string to fit within maxChars.
+ * Truncate a single text string to fit within two independent budgets:
+ * a physical raw UTF-16 ceiling (`physicalMaxChars`) and an optional
+ * token-equivalent budget (`options.estimatedMaxChars`, default unbounded).
+ *
+ * The physical ceiling keeps the raw output bounded; the estimated budget keeps
+ * the token cost bounded so CJK-heavy content cannot silently exceed its share
+ * of the context window. Both are enforced on the actual retained result, so a
+ * compositionally uneven slice cannot exceed the token budget.
+ *
+ * For pure ASCII (`estimateStringChars === text.length`) with no estimated
+ * budget the behavior is identical to a plain raw-length truncation.
  *
  * Uses a head+tail strategy when the tail contains important content
  * (errors, results, JSON structure), otherwise preserves the beginning.
@@ -214,20 +287,30 @@ function hasImportantTail(text: string): boolean {
  */
 function truncateToolResultText(
   text: string,
-  maxChars: number,
+  physicalMaxChars: number,
   options: ToolResultTruncationOptions = {},
 ): string {
   const suffixFactory = resolveSuffixFactory(options.suffix);
+  const estimatedMaxChars = options.estimatedMaxChars ?? Number.POSITIVE_INFINITY;
+  // Short-circuit when the text already fits both the physical and estimated
+  // budgets.
+  if (text.length <= physicalMaxChars && estimateStringChars(text) <= estimatedMaxChars) {
+    return text;
+  }
+  // Internal slicing works on raw UTF-16 indices. The effective raw budget is
+  // the largest prefix length that fits BOTH the physical ceiling and the
+  // token-equivalent budget for this specific text.
+  const rawMaxChars = Math.max(
+    1,
+    Math.min(physicalMaxChars, rawCutForEstimatedBudget(text, estimatedMaxChars)),
+  );
   const minKeepChars = resolveEffectiveMinKeepChars({
-    maxChars,
+    maxChars: rawMaxChars,
     minKeepChars: options.minKeepChars ?? MIN_KEEP_CHARS,
     suffixFactory,
   });
-  if (text.length <= maxChars) {
-    return text;
-  }
-  const defaultSuffix = suffixFactory(Math.max(1, text.length - maxChars));
-  const budget = Math.max(minKeepChars, maxChars - defaultSuffix.length);
+  const defaultSuffix = suffixFactory(Math.max(1, text.length - rawMaxChars));
+  const budget = Math.max(minKeepChars, rawMaxChars - defaultSuffix.length);
 
   // If tail looks important, split budget between head and tail
   if (hasImportantTail(text) && budget > minKeepChars * 2) {
@@ -253,7 +336,8 @@ function truncateToolResultText(
       return appendBoundedTruncationSuffix({
         keptText,
         originalTextLength: text.length,
-        maxChars,
+        rawMaxChars,
+        estimatedMaxChars,
         suffixFactory,
       });
     }
@@ -269,7 +353,8 @@ function truncateToolResultText(
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,
-    maxChars,
+    rawMaxChars,
+    estimatedMaxChars,
     suffixFactory,
   });
 }
@@ -355,7 +440,9 @@ export function resolveLiveToolResultAggregateMaxChars(params: {
 }
 
 /**
- * Get the total character count of text content blocks in a tool result message.
+ * Get the total raw UTF-16 length of text content blocks in a tool result
+ * message. This is the physical measurement enforced against the physical
+ * `toolResultMaxChars` ceiling and the aggregate raw budget.
  */
 function getToolResultTextLength(msg: AgentMessage): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
@@ -378,17 +465,46 @@ function getToolResultTextLength(msg: AgentMessage): number {
 }
 
 /**
- * Truncate a tool result message's text content blocks to fit within maxChars.
- * Returns a new message (does not mutate the original).
+ * Get the total token-equivalent (CJK-aware) length of text content blocks in a
+ * tool result message. This is the estimated measurement enforced against the
+ * per-result token-share budget, so CJK-heavy results are not undercounted by
+ * up to 4x against the physical-character cap.
+ */
+function getToolResultEstimatedTextLength(msg: AgentMessage): number {
+  if (!msg || (msg as { role?: string }).role !== "toolResult") {
+    return 0;
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let totalLength = 0;
+  for (const block of content) {
+    if (isToolResultTextBlock(block)) {
+      const text = block.text;
+      if (typeof text === "string") {
+        totalLength += estimateStringChars(text);
+      }
+    }
+  }
+  return totalLength;
+}
+
+/**
+ * Truncate a tool result message's text content blocks to fit within the
+ * physical `physicalMaxChars` ceiling and, when supplied, the token-equivalent
+ * `options.estimatedMaxChars` budget. Returns a new message (does not mutate the
+ * original).
  */
 export function truncateToolResultMessage(
   msg: AgentMessage,
-  maxChars: number,
+  physicalMaxChars: number,
   options: ToolResultTruncationOptions = {},
 ): AgentMessage {
   const suffixFactory = resolveSuffixFactory(options.suffix);
+  const estimatedMaxChars = options.estimatedMaxChars ?? Number.POSITIVE_INFINITY;
   const minKeepChars = resolveEffectiveMinKeepChars({
-    maxChars,
+    maxChars: physicalMaxChars,
     minKeepChars: options.minKeepChars ?? MIN_KEEP_CHARS,
     suffixFactory,
   });
@@ -397,13 +513,15 @@ export function truncateToolResultMessage(
     return msg;
   }
 
-  // Calculate total text size
-  const totalTextChars = getToolResultTextLength(msg);
-  if (totalTextChars <= maxChars) {
+  // Fits both budgets? Physical is raw UTF-16 length; estimated is token-equivalent.
+  const totalRawChars = getToolResultTextLength(msg);
+  const totalEstimatedChars = getToolResultEstimatedTextLength(msg);
+  if (totalRawChars <= physicalMaxChars && totalEstimatedChars <= estimatedMaxChars) {
     return msg;
   }
 
-  // Distribute the budget proportionally among text blocks
+  // Distribute each budget proportionally among text blocks: the physical budget
+  // by raw share, the estimated budget by token-equivalent share.
   const newContent = content.map((block: unknown) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
@@ -412,19 +530,26 @@ export function truncateToolResultMessage(
     if (typeof textBlock.text !== "string") {
       return block;
     }
-    // Proportional budget for this block
-    const blockShare = textBlock.text.length / totalTextChars;
-    const defaultSuffix = suffixFactory(
-      Math.max(1, textBlock.text.length - Math.floor(maxChars * blockShare)),
-    );
-    const proportionalBudget = Math.floor(maxChars * blockShare);
-    const blockBudget = Math.max(
+    const blockRawChars = textBlock.text.length;
+    const blockEstimatedChars = estimateStringChars(textBlock.text);
+    const physicalShare = totalRawChars > 0 ? blockRawChars / totalRawChars : 1;
+    const estimatedShare = totalEstimatedChars > 0 ? blockEstimatedChars / totalEstimatedChars : 1;
+    const proportionalPhysicalBudget = Math.floor(physicalMaxChars * physicalShare);
+    const defaultSuffix = suffixFactory(Math.max(1, blockRawChars - proportionalPhysicalBudget));
+    const blockPhysicalBudget = Math.max(
       1,
-      Math.min(maxChars, Math.max(minKeepChars + defaultSuffix.length, proportionalBudget)),
+      Math.min(
+        physicalMaxChars,
+        Math.max(minKeepChars + defaultSuffix.length, proportionalPhysicalBudget),
+      ),
     );
-    const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
+    const blockEstimatedBudget = Number.isFinite(estimatedMaxChars)
+      ? Math.max(1, Math.floor(estimatedMaxChars * estimatedShare))
+      : Number.POSITIVE_INFINITY;
+    const truncatedText = truncateToolResultText(textBlock.text, blockPhysicalBudget, {
       suffix: suffixFactory,
       minKeepChars,
+      estimatedMaxChars: blockEstimatedBudget,
     });
     const nextBlock = Object.assign({}, textBlock, { text: truncatedText });
     if (typeof textBlock.content === "string") {
@@ -620,6 +745,7 @@ export function truncateOversizedToolResultsInMessages(
   const plan = buildToolResultReplacementPlan({
     branch,
     maxChars,
+    estimatedMaxChars: resolveEstimatedToolResultBudget(contextWindowTokens),
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
     protectTrailingToolResults: Boolean(projectionState),
@@ -1015,10 +1141,12 @@ function clearToolResultText(
 function buildOversizedToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   maxChars: number;
+  estimatedMaxChars?: number;
   minKeepChars?: number;
   protectedEntryIds?: Set<string>;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const estimatedMaxChars = params.estimatedMaxChars ?? Number.POSITIVE_INFINITY;
   const replacements: ToolResultReplacement[] = [];
 
   for (const entry of params.branch) {
@@ -1029,7 +1157,12 @@ function buildOversizedToolResultReplacements(params: {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
-    if (getToolResultTextLength(msg) <= params.maxChars) {
+    // Oversized if it exceeds either budget: the physical raw ceiling or the
+    // token-equivalent budget.
+    if (
+      getToolResultTextLength(msg) <= params.maxChars &&
+      getToolResultEstimatedTextLength(msg) <= estimatedMaxChars
+    ) {
       continue;
     }
     const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
@@ -1042,6 +1175,7 @@ function buildOversizedToolResultReplacements(params: {
       entryId: entry.id,
       message: truncateToolResultMessage(msg, maxChars, {
         minKeepChars: replacementMinKeepChars,
+        estimatedMaxChars,
         ...(suffixFactory ? { suffix: suffixFactory } : {}),
       }),
     });
@@ -1099,6 +1233,7 @@ function applyToolResultReplacementsToBranch(
 function buildToolResultReplacementPlan(params: {
   branch: ToolResultBranchEntry[];
   maxChars: number;
+  estimatedMaxChars?: number;
   aggregateBudgetChars: number;
   minKeepChars?: number;
   protectTrailingToolResults?: boolean;
@@ -1117,6 +1252,7 @@ function buildToolResultReplacementPlan(params: {
   const oversizedReplacements = buildOversizedToolResultReplacements({
     branch: params.branch,
     maxChars: params.maxChars,
+    estimatedMaxChars: params.estimatedMaxChars,
     minKeepChars,
     protectedEntryIds,
   });
@@ -1177,6 +1313,7 @@ function buildRecoveryToolResultReplacementPlan(params: {
     plan: buildToolResultReplacementPlan({
       branch: params.branch,
       maxChars,
+      estimatedMaxChars: resolveEstimatedToolResultBudget(params.contextWindowTokens),
       aggregateBudgetChars,
       minKeepChars: RECOVERY_MIN_KEEP_CHARS,
       protectTrailingToolResults: params.protectTrailingToolResults,
@@ -1222,6 +1359,7 @@ export function estimateToolResultReductionPotential(params: {
   const plan = buildToolResultReplacementPlan({
     branch,
     maxChars,
+    estimatedMaxChars: resolveEstimatedToolResultBudget(contextWindowTokens),
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });


### PR DESCRIPTION
## Summary

**Problem**: The live per-turn tool-result truncation cap converts token budgets to character budgets with a flat 4-chars-per-token heuristic but measured tool-result text with raw UTF-16 `text.length`. A result made mostly of CJK text was accepted under the cap while its real token count was up to 4x the budget the cap exists to enforce.

**Solution**: Keep `toolResultMaxChars` as an independent **physical** UTF-16 ceiling and add a separate **token-equivalent** budget (the 30% context-share limit) measured with the existing CJK-aware `estimateStringChars` helper. The complete retained result must satisfy BOTH limits.

**What changed**: `getToolResultTextLength` stays a raw measurement (physical cap); a new `getToolResultEstimatedTextLength` measures token-equivalent length. `truncateToolResultText` gates on both budgets and re-checks the fully assembled prefix/tail/marker/suffix against the estimated budget, shrinking Unicode-safely. Plus tests and a docs note.

**What did NOT change**: The estimated budget is opt-in, so the persistence guard keeps its physical-only cap and pure ASCII behavior is byte-for-byte identical. The `maxChars` formula, the `toolResultMaxChars` config contract, and the output format are unchanged.

Fixes #103847

## What Problem This Solves

**Problem**: `calculateMaxToolResultCharsWithCap` derives a token budget (`maxTokens * 4`) but the truncation compared/sliced against it using raw `text.length`. For CJK text (encoded at ~1 token/char, not ~1 token/4 chars) a 16000-char result reported 16000 against a 16000 cap and was never truncated, while its real cost was ~16000 tokens.

**Why This Change Was Made**: A maintainer's prior decision on this issue defined a two-budget contract — keep the configured cap as a physical UTF-16 ceiling and enforce a separate token-derived budget. This PR implements exactly that, reusing `estimateStringChars` (already used by `preemptive-compaction.ts`, `pruner.ts`, and `openai-transport-stream.ts`) rather than reinterpreting the physical config ceiling as a CJK-weighted one.

**User Impact**: CJK-heavy tool results are bounded to their real share of the context window without over-truncating results that already fit both budgets. ASCII/Latin content and the physical `toolResultMaxChars` ceiling are unaffected.

## Root Cause

**Trigger condition**: A tool result whose text is dense CJK (or other non-Latin) content whose raw UTF-16 length fits the physical cap but whose token-equivalent length exceeds the context-share budget.

**Root cause analysis**: The physical cap and the token budget were collapsed into one number and measured with raw `text.length`, so CJK content bypassed the token budget. A whole-input inflation ratio also cannot bound a compositionally different retained slice.

**Affected scope**: `src/agents/embedded-agent-runner/tool-result-truncation.ts` — the live tool-result truncation path wired into `run.ts`, `run/attempt.ts`, and `session-tool-result-guard.ts`.

## Real behavior proof

**Behavior addressed**: Enforce a separate token-equivalent budget on the actual retained tool-result text while keeping `toolResultMaxChars` a physical UTF-16 ceiling.

**Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node.js 22.x, OpenClaw main @ 7ac8e2e227, real exported functions driven directly via `node --import tsx` (not mocked).

**Exact steps or command run after this patch**:

Drive the real exported functions with the mixed-script counterexample and the physical-cap / live-path cases:
```bash
node --import tsx -e "
import { truncateToolResultText, truncateOversizedToolResultsInMessages } from './src/agents/embedded-agent-runner/tool-result-truncation.js';
import { estimateStringChars } from './src/utils/cjk-chars.js';
const mixed = '字'.repeat(5000) + 'a'.repeat(15000);
const r = truncateToolResultText(mixed, 1000000, { estimatedMaxChars: 16000 });
console.log('mixed retained est', estimateStringChars(r), '<=16000', estimateStringChars(r) <= 16000);
const cjk8k = [{ role: 'toolResult', content: [{ type: 'text', text: '字'.repeat(8000) }], id: 'a', timestamp: 1, toolCallId: 't' }];
console.log('8000 CJK truncatedCount', truncateOversizedToolResultsInMessages(cjk8k, 50000).truncatedCount);
"
```

**After-fix evidence**:
```
== P1-2 mixed-script counterexample (old code emitted ~24142) ==
input estimated: 35000
retained estimated: 15781 | <= 16000: true

== P1-1 physical cap NOT CJK-weighted: 8000 CJK, physical 16000, ctx 50000 ==
truncatedCount: 0 (0 = not over-truncated)

== live path bounds large CJK to 30% token share ==
truncatedCount: 1 | retained est: 59781 | <= E(60000): true

== ASCII unchanged ==
8000 ASCII truncatedCount: 0 (0)
```

**Observed result after the fix**: The mixed-script counterexample (CJK-heavy prefix + ASCII tail) retains 15781 estimated chars — within the 16000 budget — because the actual retained text is measured, not a whole-input average. An 8000-char CJK result that fits both budgets is not truncated (physical cap is not CJK-weighted). A 30000-char CJK result is bounded to 59781 estimated chars (the 30% share of a 50K context). ASCII is unchanged.

**What was not tested**: I did not run against a real provider tokenizer (no tokenizer library is bundled); the estimate uses the codebase's own `estimateStringChars`, already relied on in four sibling paths as the corrected estimate for this undercount class.

## Tests and validation

### Unit tests

```
pnpm test -- src/agents/embedded-agent-runner/tool-result-truncation.test.ts

 Test Files  1 passed (1)
      Tests  73 passed (73)
   Duration  5.81s
```

Adds two-budget coverage: physical/estimated separation, the mixed-script overflow counterexample, CJK Extension B surrogate safety, and live-path integration (configured-cap no-op, large-CJK share bound, mixed-script, 50K/128K tiers). Related suites pass unchanged (`session-tool-result-guard` 35, `preemptive-compaction` 22). Also validated with `pnpm tsgo:core` (clean) and oxlint (clean).

## Linked context

- **Issue**: #103847
- **Related PRs**: #104055 (competing candidate for the same issue), #103901 (earlier attempt, closed after the two-budget design was defined)
- **In scope**: Per-result live truncation two-budget enforcement in `tool-result-truncation.ts`
- **Out of scope**: The separate aggregate tool-result budget (kept on its existing raw measurement)

## Risk checklist

merge-risk: Low

- [x] This change is backwards compatible — ASCII behavior is byte-for-byte identical; the physical `toolResultMaxChars` ceiling is unchanged
- [x] This change has been tested with existing configurations — all 73 tests pass, config contract unchanged
- [x] No breaking changes — estimated budget is opt-in; persistence guard stays physical-only
- [x] Mitigation: reuses the already-tested shared `estimateStringChars` helper; the retained result is verified against both budgets
- [x] Documentation updated — `docs/reference/token-use.md` describes the physical ceiling plus the separate token-share guard
