### PR TITLE
feat(ui): hide chat avatars in direct sessions

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -727,6 +727,18 @@ describe("direct thread avatar mode", () => {
     ).toBe(false);
   });
 
+  it("keeps avatars in global sessions, which can aggregate group senders", () => {
+    const globalThread = renderChatView({
+      sessionKey: "global",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(globalThread, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
   it("matches session metadata across equivalent alias keys", () => {
     // Default session travels as "main" or "agent:main:main" depending on caller.
     const aliased = renderChatView({

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -741,13 +741,11 @@ describe("direct thread avatar mode", () => {
     ).toBe(true);
   });
 
-  it("falls back to sender-label history when session metadata is missing", () => {
+  it("falls back to session-key shape when session metadata is missing", () => {
+    // Labeled DM rows must not flip the mode: sanitization labels 1:1 DMs too.
     const direct = renderChatView({
-      sessionKey: "fallback-direct",
-      messages: [
-        { role: "user", content: "hi", timestamp: 1 },
-        { role: "assistant", content: "hello", timestamp: 2 },
-      ],
+      sessionKey: "agent:main:telegram:direct:2",
+      messages: labeledHistory,
     });
     expect(
       requireElement(direct, ".chat-thread", "chat thread").classList.contains(
@@ -756,8 +754,8 @@ describe("direct thread avatar mode", () => {
     ).toBe(true);
 
     const group = renderChatView({
-      sessionKey: "fallback-group",
-      messages: labeledHistory,
+      sessionKey: "agent:main:telegram:group:42",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
     });
     expect(
       requireElement(group, ".chat-thread", "chat thread").classList.contains(

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -686,6 +686,31 @@ describe("chat compaction divider", () => {
   });
 });
 
+describe("direct thread avatar mode", () => {
+  it("marks label-free threads direct and labeled threads as group", () => {
+    const direct = renderChatView({
+      sessionKey: "direct-avatar-mode",
+      messages: [
+        { role: "user", content: "hi", timestamp: 1 },
+        { role: "assistant", content: "hello", timestamp: 2 },
+      ],
+    });
+    const directThread = requireElement(direct, ".chat-thread", "chat thread");
+    expect(directThread.classList.contains("chat-thread--direct")).toBe(true);
+
+    const group = renderChatView({
+      sessionKey: "group-avatar-mode",
+      messages: [
+        { role: "user", content: "hi", timestamp: 1 },
+        { role: "assistant", content: "hello", timestamp: 2 },
+        { role: "user", content: "me too", senderLabel: "Mario", timestamp: 3 },
+      ],
+    });
+    const groupThread = requireElement(group, ".chat-thread", "chat thread");
+    expect(groupThread.classList.contains("chat-thread--direct")).toBe(false);
+  });
+});
+
 describe("chat code-block copy", () => {
   it("copies decoded QR block-art boundary spaces from the delegated button handler", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -727,6 +727,20 @@ describe("direct thread avatar mode", () => {
     ).toBe(false);
   });
 
+  it("matches session metadata across equivalent alias keys", () => {
+    // Default session travels as "main" or "agent:main:main" depending on caller.
+    const aliased = renderChatView({
+      sessionKey: "main",
+      sessions: sessionsListWithKind("agent:main:main", "direct"),
+      messages: labeledHistory,
+    });
+    expect(
+      requireElement(aliased, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(true);
+  });
+
   it("falls back to sender-label history when session metadata is missing", () => {
     const direct = renderChatView({
       sessionKey: "fallback-direct",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -687,27 +687,69 @@ describe("chat compaction divider", () => {
 });
 
 describe("direct thread avatar mode", () => {
-  it("marks label-free threads direct and labeled threads as group", () => {
+  function sessionsListWithKind(sessionKey: string, kind: "direct" | "group") {
+    return {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: 200_000 },
+      sessions: [{ key: sessionKey, kind, updatedAt: 1 }],
+    };
+  }
+
+  const labeledHistory = [
+    { role: "user", content: "hi", timestamp: 1 },
+    { role: "assistant", content: "hello", timestamp: 2 },
+    { role: "user", content: "me too", senderLabel: "Mario", timestamp: 3 },
+  ];
+
+  it("classifies by canonical session kind even when DM rows carry sender labels", () => {
     const direct = renderChatView({
-      sessionKey: "direct-avatar-mode",
-      messages: [
-        { role: "user", content: "hi", timestamp: 1 },
-        { role: "assistant", content: "hello", timestamp: 2 },
-      ],
+      sessionKey: "kind-direct",
+      sessions: sessionsListWithKind("kind-direct", "direct"),
+      messages: labeledHistory,
     });
-    const directThread = requireElement(direct, ".chat-thread", "chat thread");
-    expect(directThread.classList.contains("chat-thread--direct")).toBe(true);
+    expect(
+      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(true);
 
     const group = renderChatView({
-      sessionKey: "group-avatar-mode",
+      sessionKey: "kind-group",
+      sessions: sessionsListWithKind("kind-group", "group"),
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(group, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to sender-label history when session metadata is missing", () => {
+    const direct = renderChatView({
+      sessionKey: "fallback-direct",
       messages: [
         { role: "user", content: "hi", timestamp: 1 },
         { role: "assistant", content: "hello", timestamp: 2 },
-        { role: "user", content: "me too", senderLabel: "Mario", timestamp: 3 },
       ],
     });
-    const groupThread = requireElement(group, ".chat-thread", "chat thread");
-    expect(groupThread.classList.contains("chat-thread--direct")).toBe(false);
+    expect(
+      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(true);
+
+    const group = renderChatView({
+      sessionKey: "fallback-group",
+      messages: labeledHistory,
+    });
+    expect(
+      requireElement(group, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -721,7 +721,11 @@ export function renderChatThread(props: ChatThreadProps) {
   const rowKind = activeSession?.kind;
   const sessionKind =
     rowKind && rowKind !== "unknown" ? rowKind : classifySessionKind(props.sessionKey);
-  const isDirectThread = sessionKind !== "group";
+  // Only agent-solo kinds qualify: "global" aggregates every inbound context
+  // under session.scope="global" (including group/channel senders), so it
+  // keeps avatars like "group" and "unknown" do.
+  const isDirectThread =
+    sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child";
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -707,6 +707,12 @@ export function renderChatThread(props: ChatThreadProps) {
   };
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
+  // 1:1 sessions (no labeled foreign sender anywhere in the thread) drop the
+  // avatar gutter entirely; group threads keep avatars as the always-visible
+  // identity marker. senderLabel is only populated for non-default senders.
+  const isDirectThread = !chatItems.some(
+    (item) => item.kind === "group" && Boolean(item.senderLabel?.trim()),
+  );
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;
@@ -717,7 +723,7 @@ export function renderChatThread(props: ChatThreadProps) {
 
   return html`
     <div
-      class="chat-thread"
+      class="chat-thread ${isDirectThread ? "chat-thread--direct" : ""}"
       role="log"
       aria-live="polite"
       ${ref((element) => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -16,6 +16,7 @@ import { CHAT_HISTORY_RENDER_LIMIT } from "../../../lib/chat/chat-types.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
+import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import {
   buildCachedChatItems,
   coalesceStreamRuns,
@@ -677,7 +678,11 @@ export function renderChatThread(props: ChatThreadProps) {
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   ensureRelativeTimeRefresh(state, requestUpdate);
   const displayStream = props.stream ?? null;
-  const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
+  // Equivalence, not exact match: the default session travels under alias
+  // keys ("main" vs "agent:main:main") depending on the caller.
+  const activeSession = props.sessions?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, props.sessionKey),
+  );
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -723,7 +723,9 @@ export function renderChatThread(props: ChatThreadProps) {
     rowKind && rowKind !== "unknown" ? rowKind : classifySessionKind(props.sessionKey);
   // Only agent-solo kinds qualify: "global" aggregates every inbound context
   // under session.scope="global" (including group/channel senders), so it
-  // keeps avatars like "group" and "unknown" do.
+  // keeps avatars like "group" and "unknown" do. Known limitation: global
+  // aliases (agent:<id>:main under scope=global) need host context to detect
+  // (resolveUiGlobalAliasAgentId) and classify as direct here; follow-up.
   const isDirectThread =
     sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child";
   const showLoadingSkeleton = props.loading && chatItems.length === 0;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -707,15 +707,22 @@ export function renderChatThread(props: ChatThreadProps) {
   };
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
-  // 1:1 sessions (no labeled foreign sender anywhere in the thread) drop the
-  // avatar gutter entirely; group threads keep avatars as the always-visible
-  // identity marker. Scan the full raw history, not chatItems: the rendered
-  // window (last ~30, search-filtered) could misclassify a group thread whose
-  // labeled senders scrolled out of view and flip the layout mid-scroll.
-  const isDirectThread = !props.messages.some((message) => {
-    const label = (message as { senderLabel?: unknown } | null)?.senderLabel;
-    return typeof label === "string" && label.trim() !== "";
-  });
+  // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
+  // as the always-visible identity marker. The canonical session kind decides:
+  // channel DMs also carry senderLabel on user rows (gateway sanitization), so
+  // message labels alone would misclassify them. Only when session metadata is
+  // missing do we fall back to scanning the full raw history for labeled
+  // senders — chatItems would be wrong here, its render window is truncated.
+  const sessionKind = activeSession?.kind;
+  const isDirectThread =
+    sessionKind === "group"
+      ? false
+      : sessionKind && sessionKind !== "unknown"
+        ? true
+        : !props.messages.some((message) => {
+            const label = (message as { senderLabel?: unknown } | null)?.senderLabel;
+            return typeof label === "string" && label.trim() !== "";
+          });
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -709,10 +709,13 @@ export function renderChatThread(props: ChatThreadProps) {
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
   // 1:1 sessions (no labeled foreign sender anywhere in the thread) drop the
   // avatar gutter entirely; group threads keep avatars as the always-visible
-  // identity marker. senderLabel is only populated for non-default senders.
-  const isDirectThread = !chatItems.some(
-    (item) => item.kind === "group" && Boolean(item.senderLabel?.trim()),
-  );
+  // identity marker. Scan the full raw history, not chatItems: the rendered
+  // window (last ~30, search-filtered) could misclassify a group thread whose
+  // labeled senders scrolled out of view and flip the layout mid-scroll.
+  const isDirectThread = !props.messages.some((message) => {
+    const label = (message as { senderLabel?: unknown } | null)?.senderLabel;
+    return typeof label === "string" && label.trim() !== "";
+  });
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -4,14 +4,15 @@ import { html, nothing, type TemplateResult } from "lit";
 import { guard } from "lit/directives/guard.js";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import type { SessionsListResult } from "../../../api/types.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { icons } from "../../../components/icons.ts";
+import "../../../components/tooltip.ts";
 import {
   handleMarkdownCodeBlockCopy,
   markdownFileLinkFromEvent,
 } from "../../../components/markdown.ts";
-import "../../../components/tooltip.ts";
 import { CHAT_HISTORY_RENDER_LIMIT } from "../../../lib/chat/chat-types.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
@@ -713,21 +714,14 @@ export function renderChatThread(props: ChatThreadProps) {
   const hasRealtimeTalkConversation = (props.realtimeTalkConversation?.length ?? 0) > 0;
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
   // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
-  // as the always-visible identity marker. The canonical session kind decides:
-  // channel DMs also carry senderLabel on user rows (gateway sanitization), so
-  // message labels alone would misclassify them. Only when session metadata is
-  // missing do we fall back to scanning the full raw history for labeled
-  // senders — chatItems would be wrong here, its render window is truncated.
-  const sessionKind = activeSession?.kind;
-  const isDirectThread =
-    sessionKind === "group"
-      ? false
-      : sessionKind && sessionKind !== "unknown"
-        ? true
-        : !props.messages.some((message) => {
-            const label = (message as { senderLabel?: unknown } | null)?.senderLabel;
-            return typeof label === "string" && label.trim() !== "";
-          });
+  // as the always-visible identity marker. The canonical session kind decides;
+  // the sessions list is capped, so absent/unknown rows classify by key shape
+  // via the same core helper the gateway uses. Message senderLabels are not a
+  // signal here: gateway sanitization labels 1:1 channel DM rows too.
+  const rowKind = activeSession?.kind;
+  const sessionKind =
+    rowKind && rowKind !== "unknown" ? rowKind : classifySessionKind(props.sessionKey);
+  const isDirectThread = sessionKind !== "group";
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -295,6 +295,26 @@ img.chat-avatar {
   padding: 10px 0;
 }
 
+/* Direct (1:1) threads drop avatars entirely: one agent plus one user makes
+   the repeated identity icons pure decoration. Group threads (any labeled
+   foreign sender) keep avatars as the always-visible identity marker. */
+.chat-thread--direct .chat-avatar,
+.chat-thread--direct img.chat-avatar {
+  display: none;
+}
+
+.chat-thread--direct .chat-group {
+  margin-left: 8px;
+}
+
+.chat-thread--direct .chat-group.assistant .chat-group-messages {
+  max-width: var(--chat-message-max-width, min(980px, 100%));
+}
+
+.chat-thread--direct .chat-group.tool .chat-group-messages {
+  max-width: min(980px, 100%);
+}
+
 .chat-duplicate-count {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #104016/#104035 (flat assistant stream, hover-only metadata). The avatar column is the last per-message chrome in the web chat thread, and in the common case — a direct 1:1 session with one agent and one user — the repeated lobster/gear/user icons carry zero information while costing a 46px gutter and floating awkwardly next to the now-flat text.

## Why This Change Was Made

The thread classifies itself by the canonical session kind: agent-solo kinds (`direct`, `cron`, `spawn-child`) render as direct threads and hide avatars entirely (one root class, `chat-thread--direct`, plus scoped CSS that also reclaims the gutter width). `group` sessions keep avatars as the always-visible identity marker, and so do `global` and `unknown` sessions — `session.scope="global"` funnels every inbound context (including group/channel senders) into the literal `global` session, so hiding identity there would be wrong. The kind comes from the `sessions.list` row (matched with the existing alias-equivalence helper, since the default session travels as `main` or `agent:main:main`); when the capped list doesn't contain the row, the key shape is classified with the same core `classifySessionKind` helper the gateway uses. Message `senderLabel`s deliberately play no role: gateway display sanitization attaches labels to ordinary 1:1 channel DM rows too, so labels would misclassify DMs. Web (Control UI) only.

## User Impact

Normal 1:1 agent sessions (including channel DMs, cron runs, and sub-agent sessions) read as a clean full-width stream with no repeated identity icons. Group, community, and global-scope threads keep avatars so senders stay distinguishable at a glance.

## Evidence

| Direct session (avatars hidden, labeled DM row present) | Group session (avatars kept) |
|---|---|
| ![direct](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/direct-thread-avatars/direct-kind-light.png) | ![group](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/direct-thread-avatars/group-kind-light.png) |

Dark mode: [direct-kind-dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/direct-thread-avatars/direct-kind-dark.png). Deterministic mock-gateway Playwright renders; both variants seed a `senderLabel: "Mario"` row and differ only in the session `kind` reported by `sessions.list` — proving kind, not labels, decides.

- Regression tests (`chat-view.test.ts`): kind `direct` stays direct even with labeled DM rows; kind `group` keeps avatars; `global` keeps avatars; alias keys (`main` vs `agent:main:main`) match the metadata row; key-shape fallback classifies `agent:main:telegram:direct:2` vs `...:group:42` when the sessions list lacks the row.
- Chat suites (`chat-message`, `chat-view`, `chat-responsive.browser`) green on Blacksmith Testbox; `pnpm check:changed` green; Codex autoreview iterated through five verified findings (render-window subset, sender-label misclassification, alias-key lookup, capped-list fallback, global-session aggregation) — each fixed with the canonical mechanism rather than heuristics.
- Direct-mode lanes override the `calc(100% - 46px)` gutter math at higher specificity, so mobile breakpoints inherit the right widths without new media queries.
- Known limitation (commented at the classification site, follow-up queued): under `session.scope="global"`, sessions opened via agent alias keys (e.g. `agent:work:main`) while only the canonical `global` row is listed classify as direct and hide avatars; detecting those aliases needs the gateway host snapshot (`resolveUiGlobalAliasAgentId`), which the thread renderer doesn't receive today. Literal `global` keys and listed global rows are handled correctly.
