### PR TITLE
fix(browser): refresh target after guarded existing-session actions

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -150,6 +150,43 @@ describe("existing-session interaction navigation guard", () => {
     expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
   });
 
+  it("resolves current target after guarded non-click interactions", async () => {
+    const guardedActions = [
+      { kind: "hover", ref: "btn-1" },
+      { kind: "scrollIntoView", ref: "btn-1" },
+      { kind: "drag", startRef: "item-1", endRef: "slot-1" },
+      { kind: "select", ref: "menu-1", values: ["alpha"] },
+      { kind: "fill", fields: [{ ref: "input-1", value: "Ada" }] },
+    ] as const;
+
+    for (const [index, body] of guardedActions.entries()) {
+      const nextTargetId = `new-${index}`;
+      routeState.profileCtx.listTabs
+        .mockResolvedValueOnce([
+          {
+            targetId: "7",
+            url: "https://example.com",
+          },
+        ])
+        .mockResolvedValue([
+          {
+            targetId: nextTargetId,
+            url: "https://example.com",
+          },
+        ]);
+
+      const response = await runAction(body);
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        targetId: nextTargetId,
+        url: "https://example.com",
+      });
+      routeState.profileCtx.listTabs.mockReset();
+    }
+  });
+
   it("threads one request budget through coordinate actions and navigation probes", async () => {
     const handler = getActPostHandler();
     const response = createBrowserRouteResponse();

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -43,12 +43,13 @@ vi.mock("../navigation-guard.js", () => navigationGuardMocks);
 vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
 
 const DEFAULT_SSRF_POLICY = { allowPrivateNetwork: false } as const;
-const GUARDED_NON_CLICK_ACTIONS = [
+const GUARDED_TARGET_REFRESH_ACTIONS = [
   { kind: "hover", ref: "btn-1" },
   { kind: "scrollIntoView", ref: "btn-1" },
   { kind: "drag", startRef: "item-1", endRef: "slot-1" },
   { kind: "select", ref: "menu-1", values: ["alpha"] },
   { kind: "fill", fields: [{ ref: "input-1", value: "Ada" }] },
+  { kind: "evaluate", fn: "() => document.title" },
 ] as const;
 
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
@@ -157,7 +158,7 @@ describe("existing-session interaction navigation guard", () => {
     expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
   });
 
-  it.each(GUARDED_NON_CLICK_ACTIONS)(
+  it.each(GUARDED_TARGET_REFRESH_ACTIONS)(
     "resolves current target after guarded $kind interaction",
     async (body) => {
       routeState.profileCtx.listTabs.mockResolvedValueOnce([routeState.tab]).mockResolvedValue([

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -43,6 +43,13 @@ vi.mock("../navigation-guard.js", () => navigationGuardMocks);
 vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
 
 const DEFAULT_SSRF_POLICY = { allowPrivateNetwork: false } as const;
+const GUARDED_NON_CLICK_ACTIONS = [
+  { kind: "hover", ref: "btn-1" },
+  { kind: "scrollIntoView", ref: "btn-1" },
+  { kind: "drag", startRef: "item-1", endRef: "slot-1" },
+  { kind: "select", ref: "menu-1", values: ["alpha"] },
+  { kind: "fill", fields: [{ ref: "input-1", value: "Ada" }] },
+] as const;
 
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
 const routeState = existingSessionRouteState;
@@ -150,42 +157,23 @@ describe("existing-session interaction navigation guard", () => {
     expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
   });
 
-  it("resolves current target after guarded non-click interactions", async () => {
-    const guardedActions = [
-      { kind: "hover", ref: "btn-1" },
-      { kind: "scrollIntoView", ref: "btn-1" },
-      { kind: "drag", startRef: "item-1", endRef: "slot-1" },
-      { kind: "select", ref: "menu-1", values: ["alpha"] },
-      { kind: "fill", fields: [{ ref: "input-1", value: "Ada" }] },
-    ] as const;
-
-    for (const [index, body] of guardedActions.entries()) {
-      const nextTargetId = `new-${index}`;
-      routeState.profileCtx.listTabs
-        .mockResolvedValueOnce([
-          {
-            targetId: "7",
-            url: "https://example.com",
-          },
-        ])
-        .mockResolvedValue([
-          {
-            targetId: nextTargetId,
-            url: "https://example.com",
-          },
-        ]);
+  it.each(GUARDED_NON_CLICK_ACTIONS)(
+    "resolves current target after guarded $kind interaction",
+    async (body) => {
+      routeState.profileCtx.listTabs.mockResolvedValueOnce([routeState.tab]).mockResolvedValue([
+        { targetId: "new-target", url: routeState.tab.url },
+      ]);
 
       const response = await runAction(body);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toMatchObject({
         ok: true,
-        targetId: nextTargetId,
-        url: "https://example.com",
+        targetId: "new-target",
+        url: routeState.tab.url,
       });
-      routeState.profileCtx.listTabs.mockReset();
-    }
-  });
+    },
+  );
 
   it("threads one request budget through coordinate actions and navigation probes", async () => {
     const handler = getActPostHandler();

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -161,9 +161,9 @@ describe("existing-session interaction navigation guard", () => {
   it.each(GUARDED_TARGET_REFRESH_ACTIONS)(
     "resolves current target after guarded $kind interaction",
     async (body) => {
-      routeState.profileCtx.listTabs.mockResolvedValueOnce([routeState.tab]).mockResolvedValue([
-        { targetId: "new-target", url: routeState.tab.url },
-      ]);
+      routeState.profileCtx.listTabs
+        .mockResolvedValueOnce([routeState.tab])
+        .mockResolvedValue([{ targetId: "new-target", url: routeState.tab.url }]);
 
       const response = await runAction(body);
 

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -539,7 +539,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk();
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "scrollIntoView":
                 await runExistingSessionActionWithNavigationGuard({
                   execute: () =>
@@ -550,7 +550,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk();
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "drag":
                 await runExistingSessionActionWithNavigationGuard({
                   execute: () =>
@@ -561,7 +561,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk();
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "select":
                 await runExistingSessionActionWithNavigationGuard({
                   execute: () =>
@@ -572,7 +572,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk();
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "fill":
                 await runExistingSessionActionWithNavigationGuard({
                   execute: () =>
@@ -585,7 +585,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk();
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "resize":
                 await resizeChromeMcpPage({
                   ...existingSessionTarget,

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -618,7 +618,7 @@ export function registerBrowserAgentActRoutes(
                     }),
                   guard: existingSessionNavigationGuard,
                 });
-                return await jsonOk({ result });
+                return await jsonOk({ result }, { resolveCurrentTarget: true });
               }
               case "close":
                 await profileCtx.closeTab(tab.targetId, {

--- a/extensions/browser/src/browser/routes/existing-session.test-support.ts
+++ b/extensions/browser/src/browser/routes/existing-session.test-support.ts
@@ -54,6 +54,16 @@ export function createExistingSessionAgentSharedModule() {
       throw new Error("Playwright should not be used for existing-session tests");
     }),
     resolveProfileContext: vi.fn(() => existingSessionRouteState.profileCtx),
+    resolveSafeRouteTabUrl: vi.fn(
+      async (params: {
+        profileCtx: typeof existingSessionRouteState.profileCtx;
+        targetId: string;
+        fallbackUrl?: string;
+      }) => {
+        const tabs = await params.profileCtx.listTabs();
+        return tabs.find((tab) => tab.targetId === params.targetId)?.url ?? params.fallbackUrl;
+      },
+    ),
     resolveTargetIdFromBody: vi.fn((body: Record<string, unknown>) =>
       typeof body.targetId === "string" ? body.targetId : undefined,
     ),


### PR DESCRIPTION
## What Problem This Solves
Existing-session `hover`, `scrollIntoView`, `drag`, `select`, `fill`, and `evaluate` actions already run the post-interaction navigation guard, but their success responses kept the pre-action `targetId`. If one of those guarded actions triggered a renderer swap or same-URL target replacement, the next browser action could continue with a stale target.

## Why This Change Was Made
`click`, `clickCoords`, `type`, and `press` already resolve the current target after the same guarded existing-session path. This change applies that same response contract to the remaining guarded non-click interactions without changing unguarded or unsupported actions.

## User Impact
Browser agents using existing-session profiles get the current tab target after guarded hover, scroll, drag, select, fill, and evaluate interactions. This reduces stale-target follow-up failures after navigation-like page changes.

## Evidence
- Added isolated regression cases that simulate each guarded interaction replacing the old target and verify the response returns the replacement target.
- Repaired the route-support mock so target URL safety resolution is exercised instead of bypassed.
- Focused tests:
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts`
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/routes/agent.existing-session.test.ts`
- Touched-file checks:
  - `oxfmt --check extensions/browser/src/browser/routes/agent.act.ts extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts`
  - `node scripts/run-oxlint.mjs extensions/browser/src/browser/routes/agent.act.ts extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts`
  - `git diff --check`

## Live Existing-Session Browser Proof
Original live-proof head: `e809e5a2f8183fd683b66eabff185fe055d0f43c`.

I ran a local live proof with real Chrome, real `chrome-devtools-mcp@latest`, and the real OpenClaw Browser HTTP routes. The proof launched temporary `/usr/bin/google-chrome --headless=new --remote-debugging-port=<redacted>`, started `startBrowserBridgeServer` with an existing-session profile using `cdpUrl: http://127.0.0.1:<redacted>` and `ssrfPolicy: { dangerouslyAllowPrivateNetwork: true }`, then used only public Browser routes:

1. `POST /tabs/open` opened a launcher page.
2. `POST /act` with `kind: "evaluate"` opened a script-owned child tab.
3. `GET /snapshot?format=ai&targetId=<old>` captured refs from the child tab.
4. The child tab opened an same-URL replacement tab and closed itself after the guarded action passed URL stability checks.
5. `POST /act` ran each guarded action, and `POST /act` with `kind: "wait"` used the returned target to prove the next action succeeds.

Redacted live output summary:

```text
hover:          delay=1350 actStatus=200 old=chrome-mcp:<session>:...:5  returned=chrome-mcp:<session>:...:6  replaced=true waitStatus=200 waitOk=true
scrollIntoView: delay=1450 actStatus=200 old=chrome-mcp:<session>:...:11 returned=chrome-mcp:<session>:...:12 replaced=true waitStatus=200 waitOk=true
drag:           delay=1450 actStatus=200 old=chrome-mcp:<session>:...:7  returned=chrome-mcp:<session>:...:8  replaced=true waitStatus=200 waitOk=true
select:         delay=1350 actStatus=200 old=chrome-mcp:<session>:...:5  returned=chrome-mcp:<session>:...:6  replaced=true waitStatus=200 waitOk=true
fill:           delay=1350 actStatus=200 old=chrome-mcp:<session>:...:9  returned=chrome-mcp:<session>:...:10 replaced=true waitStatus=200 waitOk=true
```

This proof uses the real existing-session `/act` route for `hover`, `scrollIntoView`, `drag`, `select`, and `fill`; every success response returned a replacement target, and the immediate follow-up `wait` action succeeded on that returned target. The maintainer-added `evaluate` sibling fix is covered by the isolated regression matrix and will receive separate exact-final-head live proof before merge.
