### PR TITLE
fix(plugins): quiet trusted discovery warning

### DIFF
--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -220,6 +220,7 @@ export function warnWhenAllowlistIsOpen(params: {
   allow: string[];
   warningCacheKey: string;
   warningCache: OpenAllowlistWarningCache;
+  explicitlyEnabledPluginIds?: ReadonlySet<string>;
   discoverablePlugins: Array<{ id: string; source: string; origin: PluginRecord["origin"] }>;
 }) {
   if (!params.emitWarning) {
@@ -229,7 +230,9 @@ export function warnWhenAllowlistIsOpen(params: {
     return;
   }
   const autoDiscoverable = params.discoverablePlugins.filter(
-    (entry) => entry.origin === "workspace" || entry.origin === "global",
+    (entry) =>
+      (entry.origin === "workspace" || entry.origin === "global") &&
+      !params.explicitlyEnabledPluginIds?.has(entry.id),
   );
   if (autoDiscoverable.length === 0) {
     return;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8794,6 +8794,28 @@ module.exports = {
     });
   });
 
+  it("stays quiet when every non-bundled plugin is explicitly enabled", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-explicitly-enabled-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          entries: { "warn-explicitly-enabled-plugin": { enabled: true } },
+        },
+      },
+    });
+
+    expect(warnings.join("\n")).not.toContain("plugins.allow is empty");
+  });
+
   it("warns when plugins.allow entries do not match any discovered plugin ids", () => {
     useNoBundledPlugins();
     clearPluginLoaderCache();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2049,6 +2049,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       allow: normalized.allow,
       warningCacheKey: cacheKey,
       warningCache: pluginLoaderCacheState,
+      explicitlyEnabledPluginIds: new Set(
+        Object.entries(normalized.entries)
+          .filter(([, entry]) => entry.enabled === true)
+          .map(([pluginId]) => pluginId),
+      ),
       // Keep warning input scoped as well so partial snapshot loads only mention the
       // plugins that were intentionally requested for this registry.
       discoverablePlugins: manifestRegistry.plugins
@@ -3039,6 +3044,11 @@ export async function loadOpenClawPluginCliRegistry(
     allow: normalized.allow,
     warningCacheKey: `${cacheKey}::cli-metadata`,
     warningCache: pluginLoaderCacheState,
+    explicitlyEnabledPluginIds: new Set(
+      Object.entries(normalized.entries)
+        .filter(([, entry]) => entry.enabled === true)
+        .map(([pluginId]) => pluginId),
+    ),
     discoverablePlugins: manifestRegistry.plugins
       .filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id))
       .map((plugin) => ({


### PR DESCRIPTION
## What Problem This Solves

Fresh OpenAI onboarding installs and explicitly enables the external Codex runtime plugin, but subsequent agent startup still warns that `plugins.allow` is empty and that the same plugin may auto-load. The warning is a false positive for plugins already trusted with `plugins.entries.<id>.enabled=true`, and it appeared twice during a normal real-inference smoke.

## Why This Change Was Made

Exclude explicitly enabled workspace/global plugins from the open-allowlist warning candidates. Keep warning behavior unchanged for every other discovered non-bundled plugin, so a newly discovered untrusted plugin still produces the security guidance.

## User Impact

Normal onboarding no longer prints alarming trust warnings for the exact plugin the user just enabled. Genuine open-discovery risks remain visible.

## Evidence

- Reproduced on exact landed main `4b7a5a4e8b4a5709b402d65753a55a8f4e67e2a5` after a successful real OpenAI inference turn.
- Blacksmith Testbox: `src/plugins/loader.test.ts` — 171 passed.
- `git diff --check` passed.
- Fresh Codex autoreview: no accepted/actionable findings; patch correct (0.91).

Post-land proof will rerun the real-inference and Mac onboarding variants from exact landed artifacts.
