### PR TITLE
fix(release): expose Telegram launcher failures safely

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1639,7 +1639,7 @@ jobs:
           export command_sha256 expected_env_keys_b64 sandbox_payload_b64
 
           launcher_stage=enter-mount-namespace
-          exec /usr/bin/unshare \
+          /usr/bin/unshare \
             --mount \
             --fork \
             --propagation private \

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1137,7 +1137,9 @@ jobs:
 
           sudo tee "$launcher" >/dev/null <<'LAUNCHER'
           #!/bin/bash
-          set -euo pipefail
+          set -Eeuo pipefail
+          launcher_stage=entry
+          trap 'exit_status=$?; trap - ERR; printf "Telegram SUT launcher failed: stage=%s line=%s status=%s\n" "$launcher_stage" "$LINENO" "$exit_status" >&2; exit "$exit_status"' ERR
 
           transport_keys=(
             HOME
@@ -1514,6 +1516,7 @@ jobs:
             exec sudo "${sudo_args[@]}" -- "$0" --root-run "$@"
           fi
           shift
+          launcher_stage=root-run-setup
           [[ "$EUID" == "0" ]]
           source /etc/openclaw-telegram-sut.conf
 
@@ -1635,11 +1638,14 @@ jobs:
           export boundary_mode generation command_file identity_file sandbox_file
           export command_sha256 expected_env_keys_b64 sandbox_payload_b64
 
+          launcher_stage=enter-mount-namespace
           exec /usr/bin/unshare \
             --mount \
             --fork \
             --propagation private \
             /bin/bash -ceu '
+              launcher_stage=mask-host-paths
+              trap "exit_status=\$?; trap - ERR; printf \"Telegram SUT launcher failed: stage=%s line=%s status=%s\\n\" \"\$launcher_stage\" \"\$LINENO\" \"\$exit_status\" >&2; exit \"\$exit_status\"" ERR
               for masked_path in "$RUNNER_HOME" /tmp /var/tmp /dev/shm; do
                 [[ -d "$masked_path" ]]
                 mount \
@@ -1648,8 +1654,10 @@ jobs:
                   openclaw-telegram-mask \
                   "$masked_path"
               done
+              launcher_stage=mount-proc
               mount -t proc proc /proc -o nosuid,nodev,noexec,hidepid=2
               if [[ "$boundary_mode" == "true" ]]; then
+                launcher_stage=write-identity
                 pid="$$"
                 proc_stat="$(cat "/proc/${pid}/stat")"
                 proc_tail="${proc_stat##*) }"

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -190,6 +190,24 @@ describe("monitorQaGatewayChildFailure", () => {
   });
 });
 
+describe("formatQaGatewayProcessBoundaryStartupFailure", () => {
+  it("includes only a bounded, redacted launcher log tail", () => {
+    const prefix = "x".repeat(9_000);
+    const longSecret = "s".repeat(9_000);
+    const message = testing.formatQaGatewayProcessBoundaryStartupFailure(
+      new Error("launcher exited before identity"),
+      `${prefix}\nAuthorization: Bearer ${longSecret}\nlauncher stage=mount-proc`,
+    );
+
+    expect(message).toContain("launcher exited before identity");
+    expect(message).toContain("Gateway logs:");
+    expect(message).toContain("Authorization: Bearer <redacted>");
+    expect(message).toContain("launcher stage=mount-proc");
+    expect(message).not.toContain("s".repeat(100));
+    expect(message).not.toContain(prefix);
+  });
+});
+
 describe("Gateway child fixture helpers", () => {
   it("creates an empty transport config seam", () => {
     expect(testing.createQaGatewayEmptyTransport()).toEqual({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -459,6 +459,13 @@ function monitorQaGatewayChildFailure(child: ChildProcess, output: { push(chunk:
   return () => childFailure;
 }
 
+const QA_GATEWAY_PROCESS_BOUNDARY_LOG_TAIL_CHARS = 8_192;
+
+function formatQaGatewayProcessBoundaryStartupFailure(error: unknown, logs: string) {
+  const logTail = redactQaGatewayDebugText(logs).slice(-QA_GATEWAY_PROCESS_BOUNDARY_LOG_TAIL_CHARS);
+  return `${formatErrorMessage(error)}${formatQaGatewayLogsForError(logTail)}`;
+}
+
 async function fetchLocalGatewayHealth(params: {
   baseUrl: string;
   healthPath: "/readyz" | "/healthz";
@@ -549,6 +556,7 @@ export const testing = {
   createQaGatewayChildLogCollector,
   monitorQaGatewayChildFailure,
   throwQaGatewayChildFailure,
+  formatQaGatewayProcessBoundaryStartupFailure,
   createQaBundledPluginsDir,
   signalQaGatewayChildProcessTree,
   stopQaGatewayChildProcessTree,
@@ -1098,13 +1106,21 @@ export async function startQaGatewayChild(params: {
             cleanupErrors.push(cleanupError);
           }
         }
+        const boundaryFailure = preparedBoundary
+          ? formatQaGatewayProcessBoundaryStartupFailure(error, logs())
+          : null;
         if (cleanupErrors.length > 0) {
           const cleanupFailure = new AggregateError(
             [error, ...cleanupErrors],
-            "qa gateway failed before verified process cleanup completed",
+            boundaryFailure
+              ? `qa gateway failed before verified process cleanup completed: ${boundaryFailure}`
+              : "qa gateway failed before verified process cleanup completed",
             { cause: error },
           );
           throw cleanupFailure;
+        }
+        if (boundaryFailure) {
+          throw new Error(boundaryFailure, { cause: error });
         }
         throw error;
       }

--- a/extensions/telegram/src/send.transport-close-proof.test.ts
+++ b/extensions/telegram/src/send.transport-close-proof.test.ts
@@ -22,7 +22,7 @@ describe("telegram transport cache eviction over real sockets", () => {
     server = createServer((req, res) => {
       let body = "";
       req.on("data", (chunk: Buffer) => {
-        body += chunk;
+        body += chunk.toString("utf8");
       });
       req.on("end", () => {
         const url = req.url ?? "";
@@ -55,7 +55,9 @@ describe("telegram transport cache eviction over real sockets", () => {
         liveSockets.delete(socket);
       });
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
     ({ sendMessageTelegram, resetTelegramClientOptionsCacheForTests } = await import("./send.js"));
   });
@@ -66,7 +68,9 @@ describe("telegram transport cache eviction over real sockets", () => {
     for (const socket of liveSockets) {
       socket.destroy();
     }
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   });
 
   it("closes evicted transports, deferring close for an in-flight send", async () => {

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -509,6 +509,8 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain("launcher_stage=mask-host-paths");
     expect(source).toContain("launcher_stage=mount-proc");
     expect(source).toContain("launcher_stage=write-identity");
+    expect(source).toMatch(/launcher_stage=enter-mount-namespace\n\s+\/usr\/bin\/unshare/u);
+    expect(source).not.toContain("exec /usr/bin/unshare");
     expect(source).not.toContain("set -x");
     expect(source).toContain('temp_root="$(realpath -e "${OPENCLAW_QA_TEMP_ROOT:?}")"');
     expect(source).toContain('proc_stat="$(cat "/proc/${pid}/stat")"');
@@ -520,5 +522,25 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain('export HOME="${temp_root}/home"');
     expect(source).toContain('export XDG_CONFIG_HOME="${temp_root}/xdg-config"');
     expect(source).toContain('if [[ "${1:-}" == "--root-terminate-uid" ]]');
+  });
+
+  it("reports the namespace-entry stage when its supervised child fails", () => {
+    const source = readFileSync(WORKFLOW_PATH, "utf8");
+    const trapLine = source.match(/^\s+(trap 'exit_status=.*' ERR)$/mu)?.[1];
+    expect(trapLine).toBeTruthy();
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -Eeuo pipefail\nlauncher_stage=enter-mount-namespace\n${trapLine}\nbash -c 'exit 23'`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(23);
+    expect(result.stderr).toMatch(
+      /Telegram SUT launcher failed: stage=enter-mount-namespace line=[0-9]+ status=23/u,
+    );
   });
 });

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -503,6 +503,13 @@ describe("release Telegram QA workflow", () => {
 
   it("derives SUT-writable paths from the verified runtime root after sudo", () => {
     const source = readFileSync(WORKFLOW_PATH, "utf8");
+    expect(source).toContain("Telegram SUT launcher failed: stage=%s line=%s status=%s");
+    expect(source).toContain("launcher_stage=root-run-setup");
+    expect(source).toContain("launcher_stage=enter-mount-namespace");
+    expect(source).toContain("launcher_stage=mask-host-paths");
+    expect(source).toContain("launcher_stage=mount-proc");
+    expect(source).toContain("launcher_stage=write-identity");
+    expect(source).not.toContain("set -x");
     expect(source).toContain('temp_root="$(realpath -e "${OPENCLAW_QA_TEMP_ROOT:?}")"');
     expect(source).toContain('proc_stat="$(cat "/proc/${pid}/stat")"');
     expect(source).not.toContain('proc_stat="$(cat /proc/self/stat)"');


### PR DESCRIPTION
## What Problem This Solves

The trusted Telegram release lane can fail before the isolated SUT writes its verified process identity, but the QA harness currently discards launcher stderr. The resulting generic error does not identify which isolation stage failed.

## Why This Change Was Made

- Add metadata-only launcher stage/status diagnostics without shell tracing.
- Propagate only the last 8 KiB of fully redacted Gateway/launcher output when process-boundary startup fails.
- Redact before truncation so a cutoff cannot split a credential prefix from its value.

## User Impact

No product behavior changes. Release maintainers get actionable, secret-safe Telegram SUT startup failures.

## Evidence

- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- targeted formatter and `git diff --check`
- Blacksmith Testbox through Crabbox `tbx_01kx7gqns2kj85xqkr4wbgmhds`: 88 focused tests passed across the QA extension and workflow contract
- Same Testbox: `pnpm check:changed` passed extension typechecks, extension/tooling lint, guards, and import-cycle checks
- Fresh Codex autoreview: clean after fixing redaction-before-truncation

No agent transcript attached.
