### PR TITLE
fix(tool-call-repair): bound serialized stream normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plain-text XML tool calls:** repair zero-argument calls and keep byte/character-bounded stream normalization from leaking incomplete or oversized tool syntax while preserving visible suffix text. (#98984, #102240, #102933, #102975, #103220, #103585) Thanks @wangyan2026, @qingminglong, @wuqxuan, and @ZOOWH.
 - **QQBot token requests:** bound token acquisition with the shared 30-second guarded-fetch deadline so stalled singleflight callers fail together, clean up, and can retry. (#102897) Thanks @maweibin.
 - **Canvas A2UI validation:** reject malformed or unsupported JSONL at CLI, agent-tool, and final node-invoke boundaries while preserving native v0.8 dispatch. (#103713) Thanks @qingminglong.
 - **Twilio RCS inbound routing:** normalize RCS consumer addresses only after signed webhook validation so sender matching and sessions work without changing outbound RCS semantics. (#102373) Thanks @clawSean.

--- a/packages/tool-call-repair/src/grammar.test.ts
+++ b/packages/tool-call-repair/src/grammar.test.ts
@@ -1,14 +1,150 @@
 import { describe, expect, it } from "vitest";
-import { findXmlishToolCallEnd } from "./grammar.js";
+import { scanXmlishToolCall, utf8ByteLengthWithinLimit } from "./grammar.js";
 
-describe("findXmlishToolCallEnd", () => {
+describe("scanXmlishToolCall", () => {
   it.each([
-    ["<function=get_system_info>\n</function>", true],
-    ["<function=get_system_info>\n</function>\n", true],
-    ["<function=get_weather><parameter=city>Tokyo</parameter></function>", true],
-    ["[tool:get_system_info]</function>", false],
-    ["[get_system_info]\n</function>", false],
-  ] as const)("classifies %s", (raw, complete) => {
-    expect(findXmlishToolCallEnd(raw)).toBe(complete ? raw.length : null);
+    "<function=read>",
+    "<function=read></func",
+    "<function=read><parameter=path>/tmp/file",
+    "[tool:read]<parameter=path>/tmp/file",
+    "[read]\n<parameter=path>/tmp/file",
+  ])("keeps incomplete syntax as a prefix: %s", (raw) => {
+    expect(scanXmlishToolCall(raw).kind).toBe("prefix");
+  });
+
+  it.each([
+    "<function=get_system_info></function>",
+    "<function=read><parameter=path>/tmp/file</parameter></function>",
+    "[tool:read]<parameter=path>/tmp/file</parameter>",
+    "[read]\n<parameter=path>/tmp/file</parameter></function>",
+  ])("accepts the supported complete forms: %s", (raw) => {
+    const scan = scanXmlishToolCall(`${raw}\nvisible`);
+    expect(scan.kind).toBe("complete");
+    if (scan.kind !== "complete") {
+      return;
+    }
+    expect(scan.end).toBe(raw.length);
+  });
+
+  it("accepts 120-character names at both XML boundaries", () => {
+    const name = "x".repeat(120);
+    expect(
+      scanXmlishToolCall(`<function=${name}><parameter=${name}>value</parameter></function>`).kind,
+    ).toBe("complete");
+  });
+
+  it("preserves name case while matching XML tags case-insensitively", () => {
+    const raw = "<FuNcTiOn=Read><PaRaMeTeR=Path>value</pArAmEtEr></fUnCtIoN>";
+    const scan = scanXmlishToolCall(raw);
+
+    expect(scan.kind).toBe("complete");
+    if (scan.kind !== "complete") {
+      return;
+    }
+    expect(raw.slice(scan.name.start, scan.name.end)).toBe("Read");
+    const parameter = scan.parameters[0];
+    expect(parameter && raw.slice(parameter.name.start, parameter.name.end)).toBe("Path");
+  });
+
+  it.each([
+    "[tool:get_system_info]</function>",
+    "[get_system_info]\n</function>",
+    `<function=${"x".repeat(121)}></function>`,
+    `<function=${"x".repeat(121)}`,
+    `<function=read><parameter=${"x".repeat(121)}>value</parameter></function>`,
+    `<function=read><parameter=${"x".repeat(121)}`,
+  ])("rejects invalid or ambiguous executable forms: %s", (raw) => {
+    expect(scanXmlishToolCall(raw).kind).toBe("invalid");
+  });
+
+  it("returns absolute name, parameter, payload, and call spans", () => {
+    const call = [
+      "<function=write>",
+      "<parameter=content>",
+      "  hello",
+      "</parameter>",
+      "</function>",
+    ].join("\n");
+    const raw = `  ${call}\nvisible`;
+    const scan = scanXmlishToolCall(raw, 2);
+
+    expect(scan.kind).toBe("complete");
+    if (scan.kind !== "complete") {
+      return;
+    }
+    expect(raw.slice(scan.name.start, scan.name.end)).toBe("write");
+    expect(raw.slice(scan.payload.start, scan.payload.end)).toBe(
+      "\n<parameter=content>\n  hello\n</parameter>\n",
+    );
+    expect(scan.parameters).toHaveLength(1);
+    const parameter = scan.parameters[0];
+    expect(parameter && raw.slice(parameter.name.start, parameter.name.end)).toBe("content");
+    expect(parameter && raw.slice(parameter.value.start, parameter.value.end)).toBe("\n  hello\n");
+    expect(scan.end).toBe(2 + call.length);
+  });
+
+  it("exposes an incomplete body span for UTF-8 limit enforcement", () => {
+    const raw = `<function=read>${"\u00a0".repeat(128_001)}`;
+    const scan = scanXmlishToolCall(raw);
+
+    expect(scan.kind).toBe("prefix");
+    if (scan.kind !== "prefix" || !scan.candidate?.payload) {
+      return;
+    }
+    expect(raw.length).toBeLessThan(256_000);
+    expect(
+      utf8ByteLengthWithinLimit(
+        raw,
+        scan.candidate.payload.start,
+        scan.candidate.payload.end,
+        256_000,
+      ),
+    ).toBeNull();
+  });
+
+  it("excludes a partial function close from the payload cap", () => {
+    const body = " ".repeat(255_999);
+    const prefix = `<function=read>${body}</func`;
+    const scan = scanXmlishToolCall(prefix);
+
+    expect(scan.kind).toBe("prefix");
+    if (scan.kind !== "prefix" || !scan.candidate?.payload) {
+      return;
+    }
+    expect(
+      utf8ByteLengthWithinLimit(
+        prefix,
+        scan.candidate.payload.start,
+        scan.candidate.payload.end,
+        256_000,
+      ),
+    ).toBe(255_999);
+    expect(scanXmlishToolCall(`${prefix}tion>`).kind).toBe("complete");
+  });
+
+  it.each(["</func", "<param"])(
+    "retains the complete optional-close call before an ambiguous %s prefix",
+    (suffix) => {
+      const complete = "[tool:read]<parameter=path>/tmp/file</parameter>";
+      const scan = scanXmlishToolCall(`${complete}${suffix}`);
+
+      expect(scan.kind).toBe("prefix");
+      if (scan.kind !== "prefix") {
+        return;
+      }
+      expect(scan.completeEnd).toBe(complete.length);
+    },
+  );
+
+  it("retains the first visible byte after an invalid over-cap body prefix", () => {
+    const visible = "Visible answer";
+    const raw = `<function=read>${"\u00a0".repeat(128_001)}${visible}`;
+    const scan = scanXmlishToolCall(raw);
+
+    expect(scan.kind).toBe("invalid");
+    if (scan.kind !== "invalid") {
+      return;
+    }
+    expect(raw.slice(scan.at)).toBe(visible);
   });
 });

--- a/packages/tool-call-repair/src/grammar.ts
+++ b/packages/tool-call-repair/src/grammar.ts
@@ -7,11 +7,6 @@ export const HARMONY_MESSAGE_MARKER = "<|message|>";
 /** Harmony stream marker that may close a serialized tool-call payload. */
 export const HARMONY_CALL_MARKER = "<|call|>";
 
-/** Accepts either a complete literal or a still-streaming prefix of that literal. */
-export function matchesLiteralPrefix(text: string, literal: string): boolean {
-  return literal.startsWith(text) || text.startsWith(literal);
-}
-
 /** Tool names in bracket/plain-text repairs intentionally match provider-safe ids only. */
 export function isPlainTextToolNameChar(char: string | undefined): boolean {
   return Boolean(char && /[A-Za-z0-9_-]/.test(char));
@@ -26,6 +21,15 @@ export function isXmlishNameChar(char: string | undefined): boolean {
 export function skipHorizontalWhitespace(text: string, start: number): number {
   let index = start;
   while (index < text.length && (text[index] === " " || text[index] === "\t")) {
+    index += 1;
+  }
+  return index;
+}
+
+/** Skips indentation whitespace without crossing the current line boundary. */
+export function skipLineIndentation(text: string, start: number): number {
+  let index = start;
+  while (index < text.length && /[^\S\r\n]/u.test(text[index] ?? "")) {
     index += 1;
   }
   return index;
@@ -51,187 +55,267 @@ export function consumeLineBreak(text: string, start: number): number | null {
   return null;
 }
 
-/** Finds the exclusive end offset of a balanced JSON object starting at `start`. */
-export function findJsonObjectEnd(
+export type StructuralLineBreakOptions = {
+  lineBreakOffsets: ReadonlySet<number>;
+  usedLineBreakOffsets?: Set<number>;
+};
+
+export function consumeStructuralLineBreakAfterHorizontalWhitespace(
   text: string,
   start: number,
-  maxPayloadBytes?: number,
+  options?: StructuralLineBreakOptions,
 ): number | null {
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let index = start; index < text.length; index += 1) {
-    if (maxPayloadBytes !== undefined && index + 1 - start > maxPayloadBytes) {
-      return null;
-    }
-    const char = text[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return index + 1;
-      }
+  const right = skipHorizontalWhitespace(text, start);
+  const actual = consumeLineBreak(text, right);
+  if (actual !== null) {
+    return actual;
+  }
+  for (let offset = start; offset <= right; offset += 1) {
+    if (options?.lineBreakOffsets.has(offset)) {
+      options.usedLineBreakOffsets?.add(offset);
+      return offset;
     }
   }
   return null;
 }
 
-/** Consumes one optional line break after a repaired serialized tool-call fragment. */
-function skipSerializedToolCallTrailingLineBreak(text: string, cursor: number): number {
-  const afterLineBreak = consumeLineBreak(text, cursor);
-  return afterLineBreak ?? cursor;
+const utf8Encoder = new TextEncoder();
+
+/** Returns the encoded byte length when a source span stays within its serialized limit. */
+export function utf8ByteLengthWithinLimit(
+  text: string,
+  start: number,
+  end: number,
+  maxBytes: number,
+): number | null {
+  if (end - start > maxBytes) {
+    return null;
+  }
+  const byteLength = utf8Encoder.encode(text.slice(start, end)).byteLength;
+  return byteLength <= maxBytes ? byteLength : null;
 }
 
-/** Accepts the legacy closing markers models append after JSON tool-call payloads. */
-export function consumeJsonToolClosingMarker(text: string, cursor: number): number {
-  let markerStart = cursor;
-  while (markerStart < text.length && /\s/.test(text[markerStart] ?? "")) {
-    markerStart += 1;
-  }
-  const rest = text.slice(markerStart);
-  if (rest.startsWith(END_TOOL_REQUEST)) {
-    return skipSerializedToolCallTrailingLineBreak(text, markerStart + END_TOOL_REQUEST.length);
-  }
-  const bracketClose = /^\[\/[A-Za-z0-9_-]+\]/.exec(rest);
-  if (bracketClose) {
-    return skipSerializedToolCallTrailingLineBreak(text, markerStart + bracketClose[0].length);
-  }
-  if (rest.startsWith(HARMONY_CALL_MARKER)) {
-    return skipSerializedToolCallTrailingLineBreak(text, markerStart + HARMONY_CALL_MARKER.length);
-  }
-  return skipSerializedToolCallTrailingLineBreak(text, cursor);
-}
+export type XmlishToolCallSpan = { end: number; start: number };
+export type XmlishToolCallParameterSpan = {
+  name: XmlishToolCallSpan;
+  value: XmlishToolCallSpan;
+};
+type XmlishToolCallCandidate = {
+  activeParameterOpenEnd?: number;
+  name: XmlishToolCallSpan;
+  nameComplete: boolean;
+  parameters: readonly XmlishToolCallParameterSpan[];
+  payload?: XmlishToolCallSpan;
+  syntax: "function" | "named-bracket" | "tool-bracket";
+};
+export type XmlishToolCallScan =
+  | { at: number; candidate?: XmlishToolCallCandidate; kind: "invalid" }
+  // `completeEnd` is safe for static stripping only; the prefix remains non-executable.
+  | { candidate?: XmlishToolCallCandidate; completeEnd?: number; kind: "prefix" }
+  | (XmlishToolCallCandidate & {
+      end: number;
+      kind: "complete";
+      payload: XmlishToolCallSpan;
+    });
 
-/** Finds JSON after bracketed tool syntax such as `[tool_name]\n{...}`. */
-export function findBracketedJsonPayloadStart(text: string): number | null {
-  if (!text.startsWith("[")) {
-    return null;
-  }
-  const close = text.indexOf("]");
-  if (close === -1) {
-    return null;
-  }
-  let cursor = close + 1;
-  cursor = skipHorizontalWhitespace(text, cursor);
-  cursor = skipSerializedToolCallTrailingLineBreak(text, cursor);
-  cursor = skipHorizontalWhitespace(text, cursor);
-  return text[cursor] === "{" ? cursor : null;
-}
+const FUNCTION_OPEN = "<function=";
+const FUNCTION_CLOSE = "</function>";
+const PARAMETER_OPEN = "<parameter=";
+const PARAMETER_CLOSE = "</parameter>";
 
-/** Finds JSON after Harmony channel/tool headers while tolerating optional message markers. */
-export function findHarmonyJsonPayloadStart(text: string): number | null {
-  let cursor = 0;
-  if (text.startsWith(HARMONY_CHANNEL_MARKER)) {
-    cursor = HARMONY_CHANNEL_MARKER.length;
-  }
-  const rest = text.slice(cursor);
-  const channel = ["commentary", "analysis", "final"].find((candidate) =>
-    rest.startsWith(candidate),
-  );
-  if (!channel) {
-    return null;
-  }
-  cursor += channel.length;
-  cursor = skipHorizontalWhitespace(text, cursor);
-  if (!text.slice(cursor).startsWith("to=")) {
-    return null;
-  }
-  cursor += "to=".length;
-  const nameStart = cursor;
-  while (isPlainTextToolNameChar(text[cursor])) {
-    cursor += 1;
-  }
-  if (cursor === nameStart) {
-    return null;
-  }
-  cursor = skipHorizontalWhitespace(text, cursor);
-  if (!text.slice(cursor).startsWith("code")) {
-    return null;
-  }
-  cursor += "code".length;
-  cursor = skipWhitespace(text, cursor);
-  if (text.slice(cursor).startsWith(HARMONY_MESSAGE_MARKER)) {
-    cursor = skipWhitespace(text, cursor + HARMONY_MESSAGE_MARKER.length);
-  }
-  return text[cursor] === "{" ? cursor : null;
-}
-
-/** Case-insensitive marker compare for ASCII protocol tags without locale rules. */
-function startsWithAsciiMarkerIgnoreCase(text: string, cursor: number, marker: string): boolean {
+export function startsWithAsciiMarkerIgnoreCase(
+  text: string,
+  cursor: number,
+  marker: string,
+): boolean {
   return text.slice(cursor, cursor + marker.length).toLowerCase() === marker;
 }
 
-/** Case-insensitive marker search for ASCII protocol tags without allocating regexes. */
-function indexOfAsciiMarkerIgnoreCase(text: string, marker: string, start: number): number {
-  let cursor = start;
-  while (cursor < text.length) {
-    const next = text.indexOf(marker[0] ?? "", cursor);
-    if (next === -1) {
-      return -1;
+export function isAsciiMarkerPrefixIgnoreCase(
+  text: string,
+  cursor: number,
+  marker: string,
+): boolean {
+  const rest = text.slice(cursor, cursor + marker.length).toLowerCase();
+  return rest.length < marker.length && marker.startsWith(rest);
+}
+
+export function indexOfAsciiMarkerIgnoreCase(text: string, marker: string, start: number): number {
+  for (
+    let cursor = text.indexOf("<", start);
+    cursor !== -1;
+    cursor = text.indexOf("<", cursor + 1)
+  ) {
+    if (startsWithAsciiMarkerIgnoreCase(text, cursor, marker)) {
+      return cursor;
     }
-    if (startsWithAsciiMarkerIgnoreCase(text, next, marker)) {
-      return next;
-    }
-    cursor = next + 1;
   }
   return -1;
 }
 
-/** Returns the end offset for a complete XML-ish or bracketed plain-text tool call. */
-export function findXmlishToolCallEnd(text: string): number | null {
-  let cursor: number;
-  // Explicit <function=...> openings may close with zero parameters.
-  // Bracketed openings still require at least one <parameter=...> body.
-  const xmlFunction = /^<function=[A-Za-z0-9_.:-]+>/i.exec(text);
-  if (xmlFunction) {
-    cursor = xmlFunction[0].length;
+/** Uncapped structural scan shared by parsing, stripping, and stream buffering. */
+export function scanXmlishToolCall(
+  text: string,
+  start = 0,
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): XmlishToolCallScan {
+  let cursor = start;
+  let syntax: XmlishToolCallCandidate["syntax"];
+  let name: XmlishToolCallSpan;
+
+  if (text[cursor] === "<") {
+    if (
+      !startsWithAsciiMarkerIgnoreCase(text, cursor, FUNCTION_OPEN) &&
+      !isAsciiMarkerPrefixIgnoreCase(text, cursor, FUNCTION_OPEN)
+    ) {
+      return { kind: "invalid", at: start };
+    }
+    if (text.length - cursor < FUNCTION_OPEN.length) {
+      return { kind: "prefix" };
+    }
+    cursor += FUNCTION_OPEN.length;
+    const nameStart = cursor;
+    while (isXmlishNameChar(text[cursor]) && cursor - nameStart < 121) {
+      cursor += 1;
+    }
+    name = { start: nameStart, end: cursor };
+    syntax = "function";
+    if (cursor - nameStart > 120) {
+      return { kind: "invalid", at: cursor };
+    }
+    if (cursor === text.length) {
+      return { kind: "prefix", candidate: { syntax, name, nameComplete: false, parameters: [] } };
+    }
+    if (cursor === nameStart || text[cursor] !== ">") {
+      return { kind: "invalid", at: cursor };
+    }
+    cursor += 1;
+  } else if (text[cursor] === "[") {
+    cursor += 1;
+    const firstNameStart = cursor;
+    while (isPlainTextToolNameChar(text[cursor]) && cursor - firstNameStart < 121) {
+      cursor += 1;
+    }
+    if (cursor - firstNameStart > 120) {
+      return { kind: "invalid", at: cursor };
+    }
+    const firstName = text.slice(firstNameStart, cursor);
+    if (cursor === text.length && "tool".startsWith(firstName)) {
+      return { kind: "prefix" };
+    }
+    syntax = "named-bracket";
+    name = { start: firstNameStart, end: cursor };
+    if (text[cursor] === ":" && firstName === "tool") {
+      syntax = "tool-bracket";
+      cursor += 1;
+      const nameStart = cursor;
+      while (isPlainTextToolNameChar(text[cursor]) && cursor - nameStart < 121) {
+        cursor += 1;
+      }
+      name = { start: nameStart, end: cursor };
+      if (cursor - nameStart > 120) {
+        return { kind: "invalid", at: cursor };
+      }
+    }
+    if (cursor === text.length) {
+      return { kind: "prefix", candidate: { syntax, name, nameComplete: false, parameters: [] } };
+    }
+    if (name.start === name.end || text[cursor] !== "]") {
+      return { kind: "invalid", at: cursor };
+    }
+    cursor += 1;
+    if (syntax === "named-bracket") {
+      if (cursor === text.length) {
+        return { kind: "prefix", candidate: { syntax, name, nameComplete: true, parameters: [] } };
+      }
+      const afterLineBreak = consumeStructuralLineBreakAfterHorizontalWhitespace(
+        text,
+        cursor,
+        structuralLineBreaks,
+      );
+      if (afterLineBreak === null) {
+        return { kind: "invalid", at: cursor };
+      }
+      cursor = afterLineBreak;
+    }
   } else {
-    const bracketed = /^\[(?:tool:)?[A-Za-z0-9_-]+\]/.exec(text);
-    if (!bracketed) {
-      return null;
-    }
-    cursor = bracketed[0].length;
-    cursor = skipHorizontalWhitespace(text, cursor);
-    cursor = skipSerializedToolCallTrailingLineBreak(text, cursor);
+    return { kind: "invalid", at: start };
   }
 
-  cursor = skipWhitespace(text, cursor);
-  if (xmlFunction && startsWithAsciiMarkerIgnoreCase(text, cursor, "</function>")) {
-    return skipSerializedToolCallTrailingLineBreak(text, cursor + "</function>".length);
-  }
-  if (!startsWithAsciiMarkerIgnoreCase(text, cursor, "<parameter=")) {
-    return null;
-  }
-
-  while (cursor < text.length) {
-    const parameterClose = indexOfAsciiMarkerIgnoreCase(text, "</parameter>", cursor);
-    if (parameterClose === -1) {
-      return null;
+  const bodyStart = cursor;
+  const parameters: XmlishToolCallParameterSpan[] = [];
+  const candidate = (
+    payloadEnd: number,
+    activeParameterOpenEnd?: number,
+  ): XmlishToolCallCandidate & { payload: XmlishToolCallSpan } => ({
+    syntax,
+    name,
+    nameComplete: true,
+    parameters,
+    payload: { start: bodyStart, end: payloadEnd },
+    ...(activeParameterOpenEnd === undefined ? {} : { activeParameterOpenEnd }),
+  });
+  let lastParameterEnd: number | undefined;
+  const prefix = (payloadEnd: number, activeParameterOpenEnd?: number): XmlishToolCallScan => ({
+    kind: "prefix",
+    candidate: candidate(payloadEnd, activeParameterOpenEnd),
+    completeEnd: syntax === "tool-bracket" ? lastParameterEnd : undefined,
+  });
+  const complete = (payloadEnd: number, end = payloadEnd): XmlishToolCallScan => ({
+    kind: "complete",
+    ...candidate(payloadEnd),
+    end,
+  });
+  while (true) {
+    const markerStart = skipWhitespace(text, cursor);
+    if (markerStart === text.length) {
+      return syntax === "tool-bracket" && lastParameterEnd !== undefined
+        ? complete(lastParameterEnd)
+        : { kind: "prefix", candidate: candidate(text.length) };
     }
-    cursor = skipWhitespace(text, parameterClose + "</parameter>".length);
-    if (startsWithAsciiMarkerIgnoreCase(text, cursor, "</function>")) {
-      return skipSerializedToolCallTrailingLineBreak(text, cursor + "</function>".length);
+    if (startsWithAsciiMarkerIgnoreCase(text, markerStart, FUNCTION_CLOSE)) {
+      return syntax !== "function" && parameters.length === 0
+        ? { kind: "invalid", at: markerStart, candidate: candidate(markerStart) }
+        : complete(markerStart, markerStart + FUNCTION_CLOSE.length);
     }
-    if (!startsWithAsciiMarkerIgnoreCase(text, cursor, "<parameter=")) {
-      return skipSerializedToolCallTrailingLineBreak(text, cursor);
+    if (isAsciiMarkerPrefixIgnoreCase(text, markerStart, FUNCTION_CLOSE)) {
+      return prefix(markerStart);
     }
+    if (startsWithAsciiMarkerIgnoreCase(text, markerStart, PARAMETER_OPEN)) {
+      const nameStart = markerStart + PARAMETER_OPEN.length;
+      let nameEnd = nameStart;
+      while (isXmlishNameChar(text[nameEnd]) && nameEnd - nameStart < 121) {
+        nameEnd += 1;
+      }
+      if (nameEnd - nameStart > 120) {
+        return { kind: "invalid", at: markerStart, candidate: candidate(markerStart) };
+      }
+      if (nameEnd === text.length) {
+        return prefix(markerStart);
+      }
+      if (nameEnd === nameStart || text[nameEnd] !== ">") {
+        return { kind: "invalid", at: markerStart, candidate: candidate(markerStart) };
+      }
+      const valueStart = nameEnd + 1;
+      const closeStart = indexOfAsciiMarkerIgnoreCase(text, PARAMETER_CLOSE, valueStart);
+      if (closeStart === -1) {
+        return prefix(text.length, valueStart);
+      }
+      const end = closeStart + PARAMETER_CLOSE.length;
+      parameters.push({
+        name: { start: nameStart, end: nameEnd },
+        value: { start: valueStart, end: closeStart },
+      });
+      cursor = end;
+      lastParameterEnd = end;
+      continue;
+    }
+    if (isAsciiMarkerPrefixIgnoreCase(text, markerStart, PARAMETER_OPEN)) {
+      return prefix(markerStart);
+    }
+    if (syntax === "tool-bracket" && lastParameterEnd !== undefined) {
+      return complete(lastParameterEnd);
+    }
+    return { kind: "invalid", at: markerStart, candidate: candidate(markerStart) };
   }
-  return null;
 }

--- a/packages/tool-call-repair/src/index.ts
+++ b/packages/tool-call-repair/src/index.ts
@@ -7,14 +7,16 @@ export {
 } from "./payload.js";
 export {
   normalizePlainTextToolCallStreamEvents,
-  scrubOverCapPlainTextToolCallMessage,
+  projectScrubbedPlainTextToolCallMessage,
   type PlainTextToolCallMessageNormalization,
   type PlainTextToolCallNameMatcher,
   type PlainTextToolCallStreamNormalizerOptions,
 } from "./stream-normalizer.js";
 export {
-  extractStandalonePlainTextToolCallText,
-  promoteStandalonePlainTextToolCallMessage,
+  createPromotedPlainTextToolCallBlock,
+  createPromotedPlainTextToolCallEvents,
+  projectStandalonePlainTextToolCallMessage,
+  type PlainTextToolCallMessageProjection,
   type PlainTextToolCallPromotionOptions,
   type PromotedPlainTextToolCallBlockFactory,
   type ToolCallRepairNameResolver,

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { scanXmlishToolCall } from "./grammar.js";
+import { scanPlainTextJsonToolCall, stripPlainTextToolCallBlocks } from "./payload.js";
+
+function trackStringOperations(value: string) {
+  let indexedReads = 0;
+  let indexOfCalls = 0;
+  const source = Object(value) as object;
+  const text = new Proxy(source, {
+    get(target, property) {
+      if (typeof property === "string" && /^(?:0|[1-9]\d*)$/.test(property)) {
+        indexedReads += 1;
+      }
+      if (property === "indexOf") {
+        return (searchString: string, position?: number) => {
+          indexOfCalls += 1;
+          return value.indexOf(searchString, position);
+        };
+      }
+      const member = Reflect.get(target, property, target) as unknown;
+      return typeof member === "function" ? member.bind(target) : member;
+    },
+  });
+  return {
+    get indexedReads() {
+      return indexedReads;
+    },
+    get indexOfCalls() {
+      return indexOfCalls;
+    },
+    text: text as unknown as string,
+  };
+}
+
+describe("scanPlainTextJsonToolCall", () => {
+  it.each([
+    ["named", '[read]\n{"path":"/tmp/file"}[/read]visible'],
+    ["legacy", '[read]\n{"path":"/tmp/file"}[END_TOOL_REQUEST]visible'],
+    ["Harmony", '<|channel|>commentary to=read code<|message|>{"path":"/tmp/file"}<|call|>visible'],
+  ])("returns the complete %s call before a visible suffix", (_syntax, raw) => {
+    const scan = scanPlainTextJsonToolCall(raw);
+
+    expect(scan.kind).toBe("complete");
+    if (scan.kind !== "complete") {
+      return;
+    }
+    expect(raw.slice(scan.end)).toBe("visible");
+    expect(raw.slice(scan.name.start, scan.name.end)).toBe("read");
+    expect(raw.slice(scan.payload.start, scan.payload.end)).toBe('{"path":"/tmp/file"}');
+  });
+
+  it.each([
+    ["[", undefined, undefined, undefined],
+    ["[tool", undefined, undefined, undefined],
+    ["[tool:re", "tool-bracket", "re", false],
+    ["[read]", "named-bracket", "read", true],
+    ["comment", undefined, undefined, undefined],
+    ["commentary to=read co", "harmony", "read", true],
+    ['[read]\n{"path":1}[/re', "named-bracket", "read", true],
+  ] as const)("classifies the streaming prefix %s", (raw, syntax, name, nameComplete) => {
+    const scan = scanPlainTextJsonToolCall(raw);
+
+    expect(scan.kind).toBe("prefix");
+    if (scan.kind !== "prefix") {
+      return;
+    }
+    expect(scan.candidate?.syntax).toBe(syntax);
+    expect(scan.candidate?.nameComplete).toBe(nameComplete);
+    expect(
+      scan.candidate?.name
+        ? raw.slice(scan.candidate.name.start, scan.candidate.name.end)
+        : undefined,
+    ).toBe(name);
+  });
+
+  it("exposes lexical continuation state for an incomplete JSON object", () => {
+    const raw = '[tool:read]{"value":"still open';
+    const scan = scanPlainTextJsonToolCall(raw);
+
+    expect(scan.kind).toBe("prefix");
+    if (scan.kind !== "prefix") {
+      return;
+    }
+    expect(scan.candidate?.json).toEqual({ depth: 1, escaped: false, inString: true });
+    expect(
+      scan.candidate?.payload &&
+        raw.slice(scan.candidate.payload.start, scan.candidate.payload.end),
+    ).toBe('{"value":"still open');
+  });
+
+  it("uses a virtual text-part boundary as the named-header line break", () => {
+    const raw = '[read]{"path":"/tmp/file"}[/read]';
+    const usedLineBreakOffsets = new Set<number>();
+    const scan = scanPlainTextJsonToolCall(raw, 0, {
+      lineBreakOffsets: new Set(["[read]".length]),
+      usedLineBreakOffsets,
+    });
+
+    expect(scan.kind).toBe("complete");
+    expect([...usedLineBreakOffsets]).toEqual(["[read]".length]);
+  });
+
+  it.each([
+    (name: string) => `[${name}]\n{}[/${name}]`,
+    (name: string) => `[tool:${name}] {}`,
+    (name: string) => `analysis to=${name} code {}`,
+  ])("accepts 120-character names and rejects the 121st character", (build) => {
+    expect(scanPlainTextJsonToolCall(build("x".repeat(120))).kind).toBe("complete");
+    const oversized = scanPlainTextJsonToolCall(build("x".repeat(121)));
+    expect(oversized.kind).toBe("invalid");
+    if (oversized.kind === "invalid") {
+      expect(oversized.at).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns invalid progress without consuming a wrong named closer", () => {
+    const raw = '[read]\n{"path":"/tmp/file"}[/write] visible';
+    const scan = scanPlainTextJsonToolCall(raw);
+
+    expect(scan.kind).toBe("invalid");
+    if (scan.kind !== "invalid") {
+      return;
+    }
+    expect(raw.slice(scan.at)).toBe("[/write] visible");
+    expect(
+      scan.candidate?.payload &&
+        raw.slice(scan.candidate.payload.start, scan.candidate.payload.end),
+    ).toBe('{"path":"/tmp/file"}');
+  });
+
+  it.each([
+    ["tool bracket", '[tool:read]{"path":"/tmp/file"}'],
+    ["Harmony", 'analysis to=read code {"path":"/tmp/file"}'],
+  ])("buffers every partial optional closer for %s syntax", (_name, call) => {
+    for (const marker of ["<|call|>", "[END_TOOL_REQUEST]", "[/read]"]) {
+      for (let split = 1; split < marker.length; split += 1) {
+        expect(scanPlainTextJsonToolCall(call + marker.slice(0, split)).kind).toBe("prefix");
+      }
+
+      const complete = scanPlainTextJsonToolCall(call + marker);
+      expect(complete).toMatchObject({ kind: "complete", end: call.length + marker.length });
+    }
+    const mismatch = scanPlainTextJsonToolCall(`${call}<|cap`);
+    expect(mismatch).toMatchObject({ kind: "complete", end: call.length });
+  });
+});
+
+describe("stripPlainTextToolCallBlocks", () => {
+  it("preserves a balanced tool block whose JSON is invalid", () => {
+    const raw = '[read]\n{"path":}\n[/read]';
+
+    expect(stripPlainTextToolCallBlocks(raw)).toBe(raw);
+  });
+
+  it.each([
+    ["JSON", "[tool:read] {\n", scanPlainTextJsonToolCall],
+    ["XML", "<function=read><parameter=x>x\n", scanXmlishToolCall],
+  ] as const)(
+    "preserves a long repeated incomplete %s candidate in one scan",
+    (_name, line, scan) => {
+      const raw = line.repeat(20_000);
+      const result = scan(raw);
+
+      expect(result.kind).toBe("prefix");
+      if (result.kind !== "prefix") {
+        return;
+      }
+      expect(result.candidate?.payload?.end).toBe(raw.length);
+      expect(stripPlainTextToolCallBlocks(raw)).toBe(raw);
+    },
+  );
+
+  it("advances once through a far-invalid XML parameter", () => {
+    const repeats = 256;
+    const raw = "<function=read><parameter=x>x\n".repeat(repeats) + "</parameter>X";
+    const tracked = trackStringOperations(raw);
+
+    expect(stripPlainTextToolCallBlocks(tracked.text)).toBe(raw);
+    expect(tracked.indexOfCalls).toBeLessThan(repeats * 8);
+  });
+
+  it("advances once through a far-invalid named JSON payload", () => {
+    const repeats = 256;
+    const raw = "[read]\n{\n".repeat(repeats) + "}".repeat(repeats) + "[/wrong]";
+    const tracked = trackStringOperations(raw);
+
+    expect(stripPlainTextToolCallBlocks(tracked.text)).toBe(raw);
+    expect(tracked.indexedReads).toBeLessThan(raw.length * 16);
+  });
+});

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -1,14 +1,18 @@
 // Tool Call Repair module implements payload behavior.
 import {
   consumeLineBreak,
+  consumeStructuralLineBreakAfterHorizontalWhitespace,
   END_TOOL_REQUEST,
-  findJsonObjectEnd,
   HARMONY_CALL_MARKER,
   HARMONY_CHANNEL_MARKER,
   HARMONY_MESSAGE_MARKER,
   isPlainTextToolNameChar,
+  scanXmlishToolCall,
   skipHorizontalWhitespace,
+  skipLineIndentation,
   skipWhitespace,
+  type StructuralLineBreakOptions,
+  utf8ByteLengthWithinLimit,
 } from "./grammar.js";
 
 /** Parsed standalone plain-text tool call block with source offsets for repair. */
@@ -33,370 +37,592 @@ export type PlainTextToolCallParseOptions = {
   maxPayloadBytes?: number;
 };
 
+type NormalizedPlainTextToolCallParseOptions = Omit<
+  PlainTextToolCallParseOptions,
+  "allowedToolNames"
+> & { allowedToolNames?: ReadonlySet<string> };
+
 const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
-const utf8Encoder = new TextEncoder();
+const MAX_PLAIN_TEXT_TOOL_NAME_CHARS = 120;
+const HARMONY_CHANNELS = ["commentary", "analysis", "final"] as const;
 
-function utf8ByteLengthWithinLimit(
-  text: string,
-  start: number,
-  end: number,
-  maxBytes: number,
-): number | null {
-  if (end - start > maxBytes) {
-    return null;
-  }
-  const byteLength = utf8Encoder.encode(text.slice(start, end)).byteLength;
-  return byteLength <= maxBytes ? byteLength : null;
-}
+export type PlainTextJsonToolCallSpan = { end: number; start: number };
+export type PlainTextJsonToolCallSyntax = "harmony" | "named-bracket" | "tool-bracket";
+export type PlainTextJsonToolCallState = {
+  depth: number;
+  escaped: boolean;
+  inString: boolean;
+};
+export type PlainTextJsonToolCallCandidate = {
+  json?: PlainTextJsonToolCallState;
+  name: PlainTextJsonToolCallSpan;
+  nameComplete: boolean;
+  payload?: PlainTextJsonToolCallSpan;
+  syntax: PlainTextJsonToolCallSyntax;
+};
+export type PlainTextJsonToolCallScan =
+  | { at: number; candidate?: PlainTextJsonToolCallCandidate; kind: "invalid" }
+  | { candidate?: PlainTextJsonToolCallCandidate; kind: "prefix" }
+  | (PlainTextJsonToolCallCandidate & {
+      end: number;
+      kind: "complete";
+      nameComplete: true;
+      payload: PlainTextJsonToolCallSpan;
+    });
 
-type PlainTextToolCallOpening = {
-  end: number;
-  kind: "bracket" | "harmony" | "tool-bracket" | "xml-function";
-  name: string;
+export type PlainTextToolCallNameMatcher = {
+  hasExactName(name: string): boolean;
+  hasNamePrefix(prefix: string): boolean;
 };
 
-function parseBracketOpening(text: string, start: number): PlainTextToolCallOpening | null {
-  if (text[start] !== "[") {
-    return null;
-  }
-  let cursor = start + 1;
-  if (text.startsWith("tool:", cursor)) {
-    cursor += "tool:".length;
-    const nameStart = cursor;
-    while (isPlainTextToolNameChar(text[cursor])) {
-      cursor += 1;
-    }
-    if (cursor === nameStart || text[cursor] !== "]") {
-      return null;
-    }
-    return {
-      end: cursor + 1,
-      kind: "tool-bracket",
-      name: text.slice(nameStart, cursor),
-    };
-  }
-  const nameStart = cursor;
-  while (isPlainTextToolNameChar(text[cursor])) {
-    cursor += 1;
-  }
-  if (cursor === nameStart || text[cursor] !== "]") {
-    return null;
-  }
-  const name = text.slice(nameStart, cursor);
-  cursor += 1;
-  cursor = skipHorizontalWhitespace(text, cursor);
-  const afterLineBreak = consumeLineBreak(text, cursor);
-  if (afterLineBreak === null) {
-    return null;
-  }
-  return { end: afterLineBreak, kind: "bracket", name };
+type PlainTextToolCallScanBranches = {
+  json: PlainTextJsonToolCallScan;
+  matches: { json: boolean; xmlish: boolean };
+  xmlish: ReturnType<typeof scanXmlishToolCall>;
+};
+
+export type PlainTextToolCallScan = PlainTextToolCallScanBranches &
+  (
+    | {
+        end: number;
+        kind: "complete";
+        next: number;
+        overCap: boolean;
+        payloadStart: number;
+      }
+    | {
+        completeEnd?: number;
+        kind: "prefix";
+        next: number;
+        overCap: boolean;
+        payloadStart?: number;
+      }
+    | {
+        at: number;
+        kind: "invalid";
+        next: number;
+        overCap: boolean;
+        payloadStart?: number;
+      }
+  );
+
+type PlainTextToolCallScanCandidate = {
+  name: PlainTextJsonToolCallSpan;
+  nameComplete: boolean;
+  payload?: PlainTextJsonToolCallSpan;
+};
+
+type PlainTextToolCallScanBranch =
+  | ({
+      end: number;
+      kind: "complete";
+      payload: PlainTextJsonToolCallSpan;
+    } & PlainTextToolCallScanCandidate)
+  | { candidate?: PlainTextToolCallScanCandidate; kind: "prefix" }
+  | { at: number; candidate?: PlainTextToolCallScanCandidate; kind: "invalid" };
+
+type PlainTextJsonToolCallOpening = {
+  cursor: number;
+  kind: "complete";
+  value: PlainTextJsonToolCallCandidate & { nameComplete: true };
+};
+type PlainTextJsonToolCallOpeningScan =
+  | PlainTextJsonToolCallOpening
+  | Extract<PlainTextJsonToolCallScan, { kind: "invalid" | "prefix" }>;
+
+function isLiteralPrefixAt(text: string, start: number, literal: string): boolean {
+  const available = text.length - start;
+  return start >= 0 && available < literal.length && literal.startsWith(text.slice(start));
 }
 
-function parseHarmonyOpening(text: string, start: number): PlainTextToolCallOpening | null {
+function scanToolNameEnd(text: string, start: number): number | null {
+  let end = start;
+  while (isPlainTextToolNameChar(text[end])) {
+    if (end - start === MAX_PLAIN_TEXT_TOOL_NAME_CHARS) {
+      return null;
+    }
+    end += 1;
+  }
+  return end;
+}
+
+function candidate<NameComplete extends boolean>(
+  syntax: PlainTextJsonToolCallSyntax,
+  name: PlainTextJsonToolCallSpan,
+  nameComplete: NameComplete,
+  payload?: PlainTextJsonToolCallSpan,
+  json?: PlainTextJsonToolCallState,
+): PlainTextJsonToolCallCandidate & { nameComplete: NameComplete } {
+  return { syntax, name, nameComplete, ...(payload ? { payload } : {}), ...(json ? { json } : {}) };
+}
+
+function scanBracketOpening(
+  text: string,
+  start: number,
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): PlainTextJsonToolCallOpeningScan {
+  let cursor = start + 1;
+  let syntax: PlainTextJsonToolCallSyntax = "named-bracket";
+  if (text.startsWith("tool:", cursor)) {
+    syntax = "tool-bracket";
+    cursor += "tool:".length;
+  } else if (isLiteralPrefixAt(text, cursor, "tool:")) {
+    return { kind: "prefix" };
+  }
+  const nameStart = cursor;
+  const nameEnd = scanToolNameEnd(text, nameStart);
+  if (nameEnd === null) {
+    return { kind: "invalid", at: nameStart + MAX_PLAIN_TEXT_TOOL_NAME_CHARS };
+  }
+  const name = { start: nameStart, end: nameEnd };
+  cursor = nameEnd;
+  if (cursor === text.length) {
+    return {
+      kind: "prefix",
+      ...(nameStart === nameEnd ? {} : { candidate: candidate(syntax, name, false) }),
+    };
+  }
+  if (nameStart === nameEnd || text[cursor] !== "]") {
+    return { kind: "invalid", at: cursor };
+  }
+  cursor += 1;
+  const value = candidate(syntax, name, true);
+  if (syntax === "named-bracket") {
+    const horizontalEnd = skipHorizontalWhitespace(text, cursor);
+    if (horizontalEnd === text.length) {
+      return { kind: "prefix", candidate: value };
+    }
+    const afterLineBreak = consumeStructuralLineBreakAfterHorizontalWhitespace(
+      text,
+      cursor,
+      structuralLineBreaks,
+    );
+    if (afterLineBreak === null) {
+      return { kind: "invalid", at: horizontalEnd, candidate: value };
+    }
+    cursor = afterLineBreak;
+  }
+  return { kind: "complete", cursor, value };
+}
+
+function scanHarmonyOpening(text: string, start: number): PlainTextJsonToolCallOpeningScan {
   let cursor = start;
   if (text.startsWith(HARMONY_CHANNEL_MARKER, cursor)) {
     cursor += HARMONY_CHANNEL_MARKER.length;
+  } else if (isLiteralPrefixAt(text, cursor, HARMONY_CHANNEL_MARKER)) {
+    return { kind: "prefix" };
+  } else if (text[cursor] === "<") {
+    return { kind: "invalid", at: cursor };
   }
-  const channelStart = cursor;
-  while (/[A-Za-z_]/.test(text[cursor] ?? "")) {
-    cursor += 1;
+
+  const channel = HARMONY_CHANNELS.find((value) => text.startsWith(value, cursor));
+  if (!channel) {
+    return HARMONY_CHANNELS.some((value) => isLiteralPrefixAt(text, cursor, value))
+      ? { kind: "prefix" }
+      : { kind: "invalid", at: cursor };
   }
-  const channel = text.slice(channelStart, cursor);
-  if (channel !== "commentary" && channel !== "analysis" && channel !== "final") {
-    return null;
+  cursor += channel.length;
+  if (cursor === text.length) {
+    return { kind: "prefix" };
+  }
+  if (text[cursor] !== " " && text[cursor] !== "\t") {
+    return { kind: "invalid", at: cursor };
   }
   cursor = skipHorizontalWhitespace(text, cursor);
   if (!text.startsWith("to=", cursor)) {
-    return null;
+    return isLiteralPrefixAt(text, cursor, "to=")
+      ? { kind: "prefix" }
+      : { kind: "invalid", at: cursor };
   }
-  cursor += 3;
+  cursor += "to=".length;
+
   const nameStart = cursor;
-  while (isPlainTextToolNameChar(text[cursor])) {
-    cursor += 1;
+  const nameEnd = scanToolNameEnd(text, nameStart);
+  if (nameEnd === null) {
+    return { kind: "invalid", at: nameStart + MAX_PLAIN_TEXT_TOOL_NAME_CHARS };
   }
-  if (cursor === nameStart) {
-    return null;
+  const name = { start: nameStart, end: nameEnd };
+  cursor = nameEnd;
+  if (cursor === text.length) {
+    return {
+      kind: "prefix",
+      ...(nameStart === nameEnd ? {} : { candidate: candidate("harmony", name, false) }),
+    };
   }
-  const name = text.slice(nameStart, cursor);
+  if (nameStart === nameEnd || (text[cursor] !== " " && text[cursor] !== "\t")) {
+    return { kind: "invalid", at: cursor };
+  }
   cursor = skipHorizontalWhitespace(text, cursor);
+  const value = candidate("harmony", name, true);
   if (!text.startsWith("code", cursor)) {
-    return null;
+    return isLiteralPrefixAt(text, cursor, "code")
+      ? { kind: "prefix", candidate: value }
+      : { kind: "invalid", at: cursor, candidate: value };
   }
-  cursor += 4;
-  cursor = skipWhitespace(text, cursor);
+  cursor = skipWhitespace(text, cursor + "code".length);
   if (text.startsWith(HARMONY_MESSAGE_MARKER, cursor)) {
     cursor = skipWhitespace(text, cursor + HARMONY_MESSAGE_MARKER.length);
+  } else if (isLiteralPrefixAt(text, cursor, HARMONY_MESSAGE_MARKER)) {
+    return { kind: "prefix", candidate: value };
+  } else if (text[cursor] === "<") {
+    return { kind: "invalid", at: cursor, candidate: value };
   }
-  return { end: cursor, kind: "harmony", name };
+  return { kind: "complete", cursor, value };
 }
 
-function parseXmlishFunctionOpening(text: string, start: number): PlainTextToolCallOpening | null {
-  const match = /^<function=([A-Za-z0-9_.:-]{1,120})>/i.exec(text.slice(start));
-  if (!match?.[1]) {
-    return null;
-  }
-  return {
-    end: start + match[0].length,
-    kind: "xml-function",
-    name: match[1],
-  };
-}
-
-function parseOpening(text: string, start: number): PlainTextToolCallOpening | null {
-  return parseBracketOpening(text, start) ?? parseHarmonyOpening(text, start);
-}
-
-function consumeJsonObject(
+function scanJsonObject(
   text: string,
   start: number,
-  maxPayloadBytes: number,
-): { end: number; value: Record<string, unknown> } | null {
-  const cursor = skipWhitespace(text, start);
-  if (text[cursor] !== "{") {
-    return null;
-  }
-  const end = findJsonObjectEnd(text, cursor, maxPayloadBytes);
-  if (end === null || utf8ByteLengthWithinLimit(text, cursor, end, maxPayloadBytes) === null) {
-    return null;
-  }
-  const rawJson = text.slice(cursor, end);
-  try {
-    const parsed = JSON.parse(rawJson) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
+): {
+  end: number;
+  kind: "complete" | "prefix";
+  state: PlainTextJsonToolCallState;
+} {
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
     }
-    return { end, value: parsed as Record<string, unknown> };
-  } catch {
-    return null;
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          kind: "complete",
+          end: index + 1,
+          state: { depth, escaped, inString },
+        };
+      }
+    }
   }
+  return { kind: "prefix", end: text.length, state: { depth, escaped, inString } };
 }
 
-function parseClosing(text: string, start: number, name: string): number | null {
-  const cursor = skipWhitespace(text, start);
-  if (text.startsWith(END_TOOL_REQUEST, cursor)) {
-    return cursor + END_TOOL_REQUEST.length;
+/** Uncapped structural scan shared by parsing, stripping, and stream buffering. */
+export function scanPlainTextJsonToolCall(
+  text: string,
+  start = 0,
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): PlainTextJsonToolCallScan {
+  const opening =
+    text[start] === "["
+      ? scanBracketOpening(text, start, structuralLineBreaks)
+      : scanHarmonyOpening(text, start);
+  if (opening.kind !== "complete") {
+    return opening;
   }
-  const namedClosing = `[/${name}]`;
-  if (text.startsWith(namedClosing, cursor)) {
-    return cursor + namedClosing.length;
+
+  const value = opening.value;
+  const payloadStart = skipWhitespace(text, opening.cursor);
+  if (payloadStart === text.length) {
+    return { kind: "prefix", candidate: value };
   }
-  return null;
+  if (text[payloadStart] !== "{") {
+    return { kind: "invalid", at: payloadStart, candidate: value };
+  }
+
+  const json = scanJsonObject(text, payloadStart);
+  const payload = { start: payloadStart, end: json.end };
+  if (json.kind === "prefix") {
+    return {
+      kind: "prefix",
+      candidate: candidate(value.syntax, value.name, true, payload, json.state),
+    };
+  }
+
+  const closingCandidate = candidate(value.syntax, value.name, true, payload, json.state);
+  if (value.syntax !== "named-bracket") {
+    const markerStart = skipWhitespace(text, json.end);
+    const name = text.slice(value.name.start, value.name.end);
+    const closings = [HARMONY_CALL_MARKER, END_TOOL_REQUEST, `[/${name}]`];
+    for (const closing of closings) {
+      if (text.startsWith(closing, markerStart)) {
+        return {
+          ...value,
+          kind: "complete",
+          payload,
+          end: markerStart + closing.length,
+        };
+      }
+      if (markerStart < text.length && isLiteralPrefixAt(text, markerStart, closing)) {
+        return { kind: "prefix", candidate: closingCandidate };
+      }
+    }
+    return {
+      ...value,
+      kind: "complete",
+      payload,
+      end: json.end,
+    };
+  }
+
+  const closingStart = skipWhitespace(text, json.end);
+  if (closingStart === text.length) {
+    return { kind: "prefix", candidate: closingCandidate };
+  }
+  const name = text.slice(value.name.start, value.name.end);
+  const closings = [END_TOOL_REQUEST, `[/${name}]`];
+  for (const closing of closings) {
+    if (text.startsWith(closing, closingStart)) {
+      return {
+        ...value,
+        payload,
+        kind: "complete",
+        end: closingStart + closing.length,
+      };
+    }
+    if (isLiteralPrefixAt(text, closingStart, closing)) {
+      return { kind: "prefix", candidate: closingCandidate };
+    }
+  }
+  return { kind: "invalid", at: closingStart, candidate: closingCandidate };
 }
 
-function parseOptionalHarmonyClosing(text: string, start: number): number {
-  const cursor = skipWhitespace(text, start);
-  if (text.startsWith(HARMONY_CALL_MARKER, cursor)) {
-    return cursor + HARMONY_CALL_MARKER.length;
+/** Classifies one JSON/XML call candidate and provides monotonic scan progress. */
+export function scanPlainTextToolCall(
+  text: string,
+  start = 0,
+  options?: {
+    matcher?: PlainTextToolCallNameMatcher;
+    maxPayloadBytes?: number;
+    structuralLineBreaks?: StructuralLineBreakOptions;
+  },
+): PlainTextToolCallScan {
+  const xmlish = scanXmlishToolCall(text, start, options?.structuralLineBreaks);
+  const json = scanPlainTextJsonToolCall(text, start, options?.structuralLineBreaks);
+  const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
+  const allowed = (scan: PlainTextToolCallScanBranch) => {
+    const value = scan.kind === "complete" ? scan : scan.candidate;
+    if (!value) {
+      return { accepted: scan.kind === "prefix" };
+    }
+    const name = text.slice(value.name.start, value.name.end);
+    const matches = value.nameComplete
+      ? (options?.matcher?.hasExactName(name) ?? true)
+      : (options?.matcher?.hasNamePrefix(name) ?? true);
+    return matches
+      ? { accepted: true, value, ...(value.payload ? { payload: value.payload } : {}) }
+      : { accepted: false };
+  };
+  const xml = allowed(xmlish);
+  const jsonValue = allowed(json);
+  const branches = {
+    json,
+    matches: { json: jsonValue.accepted, xmlish: xml.accepted },
+    xmlish,
+  };
+  const overCap = (payload?: PlainTextJsonToolCallSpan) =>
+    Boolean(
+      payload &&
+      utf8ByteLengthWithinLimit(text, payload.start, payload.end, maxPayloadBytes) === null,
+    );
+  const xmlOverCap = overCap(xml.payload);
+  const jsonOverCap = overCap(jsonValue.payload);
+
+  if (xml.accepted && xmlish.kind === "complete") {
+    return {
+      ...branches,
+      end: xmlish.end,
+      kind: "complete",
+      next: xmlish.end,
+      overCap: xmlOverCap,
+      payloadStart: xmlish.payload.start,
+    };
   }
-  return start;
+  if (jsonValue.accepted && json.kind === "complete") {
+    if (jsonOverCap || parseJsonArguments(text, json.payload)) {
+      return {
+        ...branches,
+        end: json.end,
+        kind: "complete",
+        next: json.end,
+        overCap: jsonOverCap,
+        payloadStart: json.payload.start,
+      };
+    }
+    return {
+      ...branches,
+      at: json.end,
+      kind: "invalid",
+      next: json.end,
+      overCap: false,
+      payloadStart: json.payload.start,
+    };
+  }
+
+  if (xml.accepted && xmlish.kind === "invalid" && xmlOverCap && xml.payload) {
+    return {
+      ...branches,
+      at: xmlish.at,
+      kind: "invalid",
+      next: xmlish.at,
+      overCap: true,
+      payloadStart: xml.payload.start,
+    };
+  }
+  if (jsonValue.accepted && json.kind === "invalid" && jsonOverCap && jsonValue.payload) {
+    return {
+      ...branches,
+      at: json.at,
+      kind: "invalid",
+      next: json.at,
+      overCap: true,
+      payloadStart: jsonValue.payload.start,
+    };
+  }
+
+  const xmlPrefix = xml.accepted && xmlish.kind === "prefix";
+  const jsonPrefix = jsonValue.accepted && json.kind === "prefix";
+  if (xmlPrefix || jsonPrefix) {
+    const payload = xmlPrefix ? xml.payload : jsonValue.payload;
+    return {
+      ...branches,
+      ...(xmlish.kind === "prefix" && xmlish.completeEnd !== undefined
+        ? { completeEnd: xmlish.completeEnd }
+        : {}),
+      kind: "prefix",
+      next: text.length,
+      overCap: overCap(payload),
+      ...(payload ? { payloadStart: payload.start } : {}),
+    };
+  }
+
+  let next = start + 1;
+  if (xml.accepted) {
+    next = Math.max(next, xmlish.kind === "invalid" ? xmlish.at : text.length);
+  }
+  if (jsonValue.accepted) {
+    next = Math.max(
+      next,
+      json.kind === "complete" ? json.end : json.kind === "invalid" ? json.at : text.length,
+    );
+  }
+  return { ...branches, at: next, kind: "invalid", next, overCap: false };
 }
 
 function parsePlainTextToolCallBlockAt(
   text: string,
   start: number,
-  options?: PlainTextToolCallParseOptions,
+  options?: NormalizedPlainTextToolCallParseOptions,
+  structuralLineBreaks?: StructuralLineBreakOptions,
 ): PlainTextToolCallBlock | null {
-  const opening = parseOpening(text, start);
-  if (!opening) {
+  const scan = scanPlainTextJsonToolCall(text, start, structuralLineBreaks);
+  if (scan.kind !== "complete") {
     return null;
   }
-  const allowedToolNames = options?.allowedToolNames
-    ? new Set(options.allowedToolNames)
-    : undefined;
-  if (allowedToolNames && !allowedToolNames.has(opening.name)) {
+  const name = text.slice(scan.name.start, scan.name.end);
+  if (options?.allowedToolNames && !options.allowedToolNames.has(name)) {
     return null;
   }
-  const payload = consumeJsonObject(
-    text,
-    opening.end,
-    options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES,
-  );
-  if (!payload) {
+  const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
+  if (
+    utf8ByteLengthWithinLimit(text, scan.payload.start, scan.payload.end, maxPayloadBytes) === null
+  ) {
     return null;
   }
-  const closingEnd =
-    opening.kind === "bracket"
-      ? parseClosing(text, payload.end, opening.name)
-      : parseOptionalHarmonyClosing(text, payload.end);
-  if (closingEnd === null) {
+  const argumentsValue = parseJsonArguments(text, scan.payload);
+  if (!argumentsValue) {
     return null;
   }
   return {
-    arguments: payload.value,
-    end: closingEnd,
-    name: opening.name,
-    raw: text.slice(start, closingEnd),
+    arguments: argumentsValue,
+    end: scan.end,
+    name,
+    raw: text.slice(start, scan.end),
     start,
   };
 }
 
-type XmlishParameterBlockBounds = {
-  closeStart: number;
-  end: number;
-  name: string;
-  payloadStart: number;
-  start: number;
-};
-
-function findXmlishParameterBlock(text: string, start: number): XmlishParameterBlockBounds | null {
-  const cursor = skipWhitespace(text, start);
-  const openMatch = /^<parameter=([A-Za-z0-9_.:-]{1,120})>/i.exec(text.slice(cursor));
-  if (!openMatch?.[1]) {
-    return null;
-  }
-  const payloadStart = cursor + openMatch[0].length;
-  const closeMatch = /<\/parameter>/i.exec(text.slice(payloadStart));
-  if (!closeMatch) {
-    return null;
-  }
-  const closeStart = payloadStart + closeMatch.index;
-  const closeEnd = closeStart + closeMatch[0].length;
-  return {
-    closeStart,
-    end: closeEnd,
-    name: openMatch[1],
-    payloadStart,
-    start: cursor,
-  };
-}
-
-function consumeXmlishParameterBlock(
+function parseJsonArguments(
   text: string,
-  start: number,
-  maxPayloadBytes: number,
-): { byteLength: number; end: number; name: string; value: string } | null {
-  const bounds = findXmlishParameterBlock(text, start);
-  if (!bounds) {
+  payload: PlainTextJsonToolCallSpan,
+): Record<string, unknown> | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(text.slice(payload.start, payload.end)) as unknown;
+  } catch {
     return null;
   }
-  const byteLength = utf8ByteLengthWithinLimit(text, start, bounds.end, maxPayloadBytes);
-  if (byteLength === null) {
-    return null;
-  }
-  return {
-    byteLength,
-    end: bounds.end,
-    name: bounds.name,
-    value: extractXmlishParameterValue(text, bounds.payloadStart, bounds.closeStart),
-  };
-}
-
-function extractXmlishParameterValue(text: string, start: number, end: number): string {
-  let payloadStart = start;
-  let payloadEnd = end;
-  const afterOpeningLineBreak = consumeLineBreak(text, payloadStart);
-  if (afterOpeningLineBreak !== null) {
-    payloadStart = afterOpeningLineBreak;
-    if (payloadEnd > payloadStart && text[payloadEnd - 1] === "\n") {
-      payloadEnd -= 1;
-      if (payloadEnd > payloadStart && text[payloadEnd - 1] === "\r") {
-        payloadEnd -= 1;
-      }
-    } else if (payloadEnd > payloadStart && text[payloadEnd - 1] === "\r") {
-      payloadEnd -= 1;
-    }
-  }
-  return text.slice(payloadStart, payloadEnd);
-}
-
-function findXmlishFunctionClose(
-  text: string,
-  start: number,
-): { closeStart: number; end: number } | null {
-  const closeStart = skipWhitespace(text, start);
-  return text.slice(closeStart).toLowerCase().startsWith("</function>")
-    ? { closeStart, end: closeStart + "</function>".length }
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
     : null;
 }
 
-function parseXmlishPlainTextToolCallBlockEndAt(text: string, start: number): number | null {
-  const opening = parseXmlishOpening(text, start);
-  if (!opening) {
-    return null;
-  }
-
-  let cursor = opening.end;
-  let hasParameters = false;
-  while (true) {
-    const parameter = findXmlishParameterBlock(text, cursor);
-    if (!parameter) {
-      break;
+function extractXmlishParameterValue(
+  text: string,
+  start: number,
+  end: number,
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): string {
+  let value = text.slice(start, end);
+  if (consumeLineBreak(text, skipHorizontalWhitespace(text, start)) === null) {
+    const boundary = consumeStructuralLineBreakAfterHorizontalWhitespace(
+      text,
+      start,
+      structuralLineBreaks,
+    );
+    if (boundary !== null) {
+      const offset = boundary - start;
+      value = `${value.slice(0, offset)}\n${value.slice(offset)}`;
     }
-    hasParameters = true;
-    cursor = parameter.end;
   }
-  if (!hasParameters && opening.kind !== "xml-function") {
-    return null;
+  const payloadStart = consumeLineBreak(value, 0);
+  if (payloadStart === null) {
+    return value;
   }
-  const close = findXmlishFunctionClose(text, cursor);
-  return close?.end ?? (opening.kind === "tool-bracket" ? cursor : null);
-}
-
-function parseXmlishOpening(text: string, start: number): PlainTextToolCallOpening | null {
-  return parseBracketOpening(text, start) ?? parseXmlishFunctionOpening(text, start);
+  return value.slice(payloadStart).replace(/(?:\r\n|[\r\n])$/u, "");
 }
 
 function parseXmlishPlainTextToolCallBlockAt(
   text: string,
   start: number,
-  options?: PlainTextToolCallParseOptions,
+  options?: NormalizedPlainTextToolCallParseOptions,
+  structuralLineBreaks?: StructuralLineBreakOptions,
 ): PlainTextToolCallBlock | null {
-  const opening = parseXmlishOpening(text, start);
-  if (!opening) {
+  const scan = scanXmlishToolCall(text, start, structuralLineBreaks);
+  if (scan.kind !== "complete") {
     return null;
   }
-  const allowedToolNames = options?.allowedToolNames
-    ? new Set(options.allowedToolNames)
-    : undefined;
-  if (allowedToolNames && !allowedToolNames.has(opening.name)) {
+  const name = text.slice(scan.name.start, scan.name.end);
+  if (options?.allowedToolNames && !options.allowedToolNames.has(name)) {
     return null;
   }
 
   const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
-  const args: Record<string, unknown> = {};
-  let cursor = opening.end;
-  let hasParameters = false;
-  let payloadBytes = 0;
-  while (true) {
-    const parameter = consumeXmlishParameterBlock(text, cursor, maxPayloadBytes);
-    if (!parameter) {
-      break;
-    }
-    payloadBytes += parameter.byteLength;
-    if (payloadBytes > maxPayloadBytes) {
-      return null;
-    }
-    args[parameter.name] = parameter.value;
-    hasParameters = true;
-    cursor = parameter.end;
-  }
-  if (!hasParameters && opening.kind !== "xml-function") {
+  if (
+    utf8ByteLengthWithinLimit(text, scan.payload.start, scan.payload.end, maxPayloadBytes) === null
+  ) {
     return null;
   }
-
-  const close = findXmlishFunctionClose(text, cursor);
-  if (!close && opening.kind !== "tool-bracket") {
-    return null;
-  }
-  if (close) {
-    // Whitespace before the close shares the serialized body budget. Otherwise an empty
-    // XML call can bypass the cap in owners that promote before over-cap scrubbing.
-    const trailingBytes = utf8ByteLengthWithinLimit(
-      text,
-      cursor,
-      close.closeStart,
-      maxPayloadBytes - payloadBytes,
-    );
-    if (trailingBytes === null) {
-      return null;
-    }
-  }
-  const end = close?.end ?? cursor;
+  const args = Object.fromEntries(
+    scan.parameters.map((parameter) => [
+      text.slice(parameter.name.start, parameter.name.end),
+      extractXmlishParameterValue(
+        text,
+        parameter.value.start,
+        parameter.value.end,
+        structuralLineBreaks,
+      ),
+    ]),
+  );
   return {
     arguments: args,
-    end,
-    name: opening.name,
-    raw: text.slice(start, end),
+    end: scan.end,
+    name,
+    raw: text.slice(start, scan.end),
     start,
   };
 }
@@ -404,22 +630,56 @@ function parseXmlishPlainTextToolCallBlockAt(
 function parsePlainTextToolCallBlockAtAnySyntax(
   text: string,
   start: number,
-  options?: PlainTextToolCallParseOptions,
+  options?: NormalizedPlainTextToolCallParseOptions,
+  structuralLineBreaks?: StructuralLineBreakOptions,
 ): PlainTextToolCallBlock | null {
   return (
-    parsePlainTextToolCallBlockAt(text, start, options) ??
-    parseXmlishPlainTextToolCallBlockAt(text, start, options)
+    parsePlainTextToolCallBlockAt(text, start, options, structuralLineBreaks) ??
+    parseXmlishPlainTextToolCallBlockAt(text, start, options, structuralLineBreaks)
+  );
+}
+
+function normalizeParseOptions(
+  options?: PlainTextToolCallParseOptions,
+): NormalizedPlainTextToolCallParseOptions | undefined {
+  return options
+    ? {
+        ...options,
+        allowedToolNames: options.allowedToolNames ? new Set(options.allowedToolNames) : undefined,
+      }
+    : undefined;
+}
+
+/** Parses one canonical call prefix while allowing unrelated visible suffix text. */
+export function parsePlainTextToolCallPrefix(
+  text: string,
+  start = 0,
+  options?: PlainTextToolCallParseOptions,
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): PlainTextToolCallBlock | null {
+  return parsePlainTextToolCallBlockAtAnySyntax(
+    text,
+    start,
+    normalizeParseOptions(options),
+    structuralLineBreaks,
   );
 }
 
 export function parseStandalonePlainTextToolCallBlocks(
   text: string,
   options?: PlainTextToolCallParseOptions,
+  structuralLineBreaks?: StructuralLineBreakOptions,
 ): PlainTextToolCallBlock[] | null {
   const blocks: PlainTextToolCallBlock[] = [];
+  const normalizedOptions = normalizeParseOptions(options);
   let cursor = skipWhitespace(text, 0);
   while (cursor < text.length) {
-    const block = parsePlainTextToolCallBlockAtAnySyntax(text, cursor, options);
+    const block = parsePlainTextToolCallBlockAtAnySyntax(
+      text,
+      cursor,
+      normalizedOptions,
+      structuralLineBreaks,
+    );
     if (!block) {
       return null;
     }
@@ -429,49 +689,15 @@ export function parseStandalonePlainTextToolCallBlocks(
   return blocks.length > 0 ? blocks : null;
 }
 
-export type OverCapPlainTextToolCallPrefix = {
-  visibleText: string;
-};
-
-/** Finds complete leading blocks when at least one exceeds the default payload cap. */
-export function parseOverCapPlainTextToolCallPrefix(
-  text: string,
-  options?: { isAllowedName?: (name: string) => boolean },
-): OverCapPlainTextToolCallPrefix | null {
-  let cursor = skipWhitespace(text, 0);
-  let hasOverCapBlock = false;
-  let parsedBlockCount = 0;
-  let visibleTextStart = cursor;
-  while (cursor < text.length) {
-    const block = parsePlainTextToolCallBlockAtAnySyntax(text, cursor, {
-      maxPayloadBytes: Number.POSITIVE_INFINITY,
-    });
-    if (!block) {
-      break;
-    }
-    if (options?.isAllowedName && !options.isAllowedName(block.name)) {
-      break;
-    }
-    // Optional-close syntax can cap out after an earlier parameter yet still parse a shorter
-    // block. Matching end offsets proves both parsers consumed the same serialized call.
-    const cappedBlock = parsePlainTextToolCallBlockAtAnySyntax(text, cursor);
-    hasOverCapBlock ||= !cappedBlock || cappedBlock.end !== block.end;
-    parsedBlockCount += 1;
-    visibleTextStart = consumeLineBreak(text, block.end) ?? block.end;
-    cursor = skipWhitespace(text, visibleTextStart);
-  }
-  return hasOverCapBlock && parsedBlockCount > 0
-    ? { visibleText: text.slice(visibleTextStart) }
-    : null;
-}
-
 /** Removes full-line standalone plain-text tool-call blocks from user-visible text. */
 export function stripPlainTextToolCallBlocks(text: string): string {
   if (
     !text ||
     (!/\[(?:tool:)?[A-Za-z0-9_-]+\]/.test(text) &&
-      !/(?:^|\n)\s*(?:<\|channel\|>)?(?:commentary|analysis|final)\s+to=/.test(text) &&
-      !/(?:^|\n)\s*<function=[A-Za-z0-9_.:-]{1,120}>/i.test(text))
+      !/(?:^|[\r\n])[^\S\r\n]*(?:<\|channel\|>)?(?:commentary|analysis|final)[ \t]+to=/.test(
+        text,
+      ) &&
+      !/(?:^|[\r\n])[^\S\r\n]*<function=/i.test(text))
   ) {
     return text;
   }
@@ -479,24 +705,43 @@ export function stripPlainTextToolCallBlocks(text: string): string {
   let cursor = 0;
   let index = 0;
   while (index < text.length) {
-    const lineStart = index === 0 || text[index - 1] === "\n";
+    const lineStart = index === 0 || text[index - 1] === "\n" || text[index - 1] === "\r";
     if (!lineStart) {
       index += 1;
       continue;
     }
-    const blockStart = skipHorizontalWhitespace(text, index);
-    const block = parsePlainTextToolCallBlockAt(text, blockStart);
-    const blockEnd = block?.end ?? parseXmlishPlainTextToolCallBlockEndAt(text, blockStart);
-    if (blockEnd === null) {
-      index += 1;
+    const blockStart = skipLineIndentation(text, index);
+    const scan = scanPlainTextToolCall(text, blockStart);
+    if (scan.kind === "prefix" && scan.completeEnd === undefined) {
+      return result + text.slice(cursor);
+    }
+    if (scan.kind === "invalid") {
+      // The scanner owns everything before `at` as one malformed candidate. Honor that
+      // progress so nested line starts inside its payload are not rescanned quadratically.
+      index = Math.max(index + 1, scan.next);
       continue;
     }
+    let blockEnd = scan.kind === "complete" ? scan.end : scan.completeEnd;
     result += text.slice(cursor, index);
-    cursor = blockEnd;
-    const afterBlockLineBreak = consumeLineBreak(text, cursor);
-    if (afterBlockLineBreak !== null) {
-      cursor = afterBlockLineBreak;
+    while (true) {
+      const adjacentStart = skipLineIndentation(text, blockEnd);
+      const adjacent = scanPlainTextToolCall(text, adjacentStart);
+      const adjacentEnd =
+        adjacent.kind === "complete"
+          ? adjacent.end
+          : adjacent.kind === "prefix"
+            ? adjacent.completeEnd
+            : undefined;
+      if (adjacentEnd === undefined || adjacentEnd <= blockEnd) {
+        break;
+      }
+      blockEnd = adjacentEnd;
     }
+    const lineBreakStart = skipLineIndentation(text, blockEnd);
+    cursor =
+      lineBreakStart === text.length
+        ? lineBreakStart
+        : (consumeLineBreak(text, lineBreakStart) ?? blockEnd);
     index = cursor;
   }
   result += text.slice(cursor);

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -404,7 +404,13 @@ export function scanPlainTextToolCall(
   const xmlish = scanXmlishToolCall(text, start, options?.structuralLineBreaks);
   const json = scanPlainTextJsonToolCall(text, start, options?.structuralLineBreaks);
   const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
-  const allowed = (scan: PlainTextToolCallScanBranch) => {
+  const allowed = (
+    scan: PlainTextToolCallScanBranch,
+  ): {
+    accepted: boolean;
+    payload?: PlainTextJsonToolCallSpan;
+    value?: PlainTextToolCallScanCandidate;
+  } => {
     const value = scan.kind === "complete" ? scan : scan.candidate;
     if (!value) {
       return { accepted: scan.kind === "prefix" };
@@ -722,6 +728,9 @@ export function stripPlainTextToolCallBlocks(text: string): string {
       continue;
     }
     let blockEnd = scan.kind === "complete" ? scan.end : scan.completeEnd;
+    if (blockEnd === undefined) {
+      return result + text.slice(cursor);
+    }
     result += text.slice(cursor, index);
     while (true) {
       const adjacentStart = skipLineIndentation(text, blockEnd);

--- a/packages/tool-call-repair/src/promote.ts
+++ b/packages/tool-call-repair/src/promote.ts
@@ -24,8 +24,50 @@ export type PlainTextToolCallPromotionOptions = {
   resolveToolName?: ToolCallRepairNameResolver;
 };
 
+export type PlainTextToolCallMessageProjection = {
+  message: Record<string, unknown>;
+  sourceToProjectedContentIndex: ReadonlyMap<number, number>;
+};
+
+/** Builds the shared assistant-message shape for a repaired text tool call. */
+export function createPromotedPlainTextToolCallBlock(
+  block: PlainTextToolCallBlock,
+  name: string,
+): Record<string, unknown> {
+  return {
+    type: "toolCall",
+    id: `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`,
+    name,
+    arguments: block.arguments,
+    partialArgs: JSON.stringify(block.arguments),
+  };
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+/** Emits the complete provider-neutral lifecycle for promoted tool-call blocks. */
+export function createPromotedPlainTextToolCallEvents(
+  message: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const content = Array.isArray(message.content) ? message.content : [];
+  return content.flatMap((block, contentIndex) => {
+    const toolCall = asRecord(block);
+    if (toolCall?.type !== "toolCall") {
+      return [];
+    }
+    return [
+      { type: "toolcall_start", contentIndex, partial: message },
+      {
+        type: "toolcall_delta",
+        contentIndex,
+        delta: typeof toolCall.partialArgs === "string" ? toolCall.partialArgs : "{}",
+        partial: message,
+      },
+      { type: "toolcall_end", contentIndex, toolCall, partial: message },
+    ];
+  });
 }
 
 function resolveExactToolName(rawName: string, allowedToolNames: Set<string>): string | null {
@@ -35,8 +77,13 @@ function resolveExactToolName(rawName: string, allowedToolNames: Set<string>): s
 function createPromotedToolCallBlocks(
   text: string,
   options: PlainTextToolCallPromotionOptions,
+  lineBreakOffsets?: ReadonlySet<number>,
 ): Record<string, unknown>[] | undefined {
-  const parsedBlocks = parseStandalonePlainTextToolCallBlocks(text);
+  const parsedBlocks = parseStandalonePlainTextToolCallBlocks(
+    text,
+    undefined,
+    lineBreakOffsets ? { lineBreakOffsets } : undefined,
+  );
   if (!parsedBlocks) {
     return undefined;
   }
@@ -57,145 +104,50 @@ function createPromotedToolCallBlocksFromTextParts(
   textParts: readonly string[],
   options: PlainTextToolCallPromotionOptions,
 ): Record<string, unknown>[] | undefined {
-  const exactText = textParts.join("").trim();
-  if (!exactText) {
+  const text = textParts.join("");
+  if (!text.trim()) {
     return [];
   }
-  for (const text of createTextPartPromotionCandidates(textParts, exactText)) {
-    const toolCalls = createPromotedToolCallBlocks(text, options);
-    if (toolCalls) {
-      return toolCalls;
-    }
-  }
-  return undefined;
-}
-
-function createTextPartPromotionCandidates(
-  textParts: readonly string[],
-  exactText: string,
-): string[] {
-  // Some providers split structural markers across text parts; try repaired and exact joins
-  // before falling back to newline joins so valid payloads promote without changing content.
-  const repairedText = joinTextPartsWithStructuralLineBreaks(textParts).trim();
-  const newlineJoinedText = textParts.join("\n").trim();
-  return [...new Set([repairedText, exactText, newlineJoinedText].filter(Boolean))];
-}
-
-function joinTextPartsWithStructuralLineBreaks(textParts: readonly string[]): string {
-  let text = "";
-  for (const part of textParts) {
-    if (text && shouldInsertStructuralLineBreak(text, part)) {
-      text += "\n";
-    }
-    text += part;
-  }
-  return text;
-}
-
-function shouldInsertStructuralLineBreak(left: string, right: string): boolean {
-  if (!left || !right || /[\r\n]$/u.test(left) || /^\s/u.test(right)) {
-    return false;
-  }
-  const trimmedLeft = left.trimEnd();
-  return (
-    /<parameter=[A-Za-z0-9_.:-]{1,120}>$/iu.test(trimmedLeft) ||
-    /^\[[A-Za-z0-9_-]+\]$/u.test(trimmedLeft)
+  let offset = 0;
+  const lineBreakOffsets = new Set(
+    textParts.slice(0, -1).map((part) => {
+      offset += part.length;
+      return offset;
+    }),
   );
+  if (lineBreakOffsets.has(text.length)) {
+    lineBreakOffsets.delete(text.length);
+  }
+  return createPromotedToolCallBlocks(text, options, lineBreakOffsets);
 }
 
-function shouldPromoteMessage(options: PlainTextToolCallPromotionOptions): boolean {
-  if (options.allowedToolNames.size === 0) {
-    return false;
-  }
-  const messageRecord = asRecord(options.message);
-  if (!messageRecord) {
-    return false;
-  }
-  if (options.requireAssistantRole && messageRecord.role !== "assistant") {
-    return false;
-  }
-  return !options.allowedStopReasons || options.allowedStopReasons.has(messageRecord.stopReason);
-}
-
-/** Extracts candidate standalone tool-call text while rejecting mixed unsafe content. */
-export function extractStandalonePlainTextToolCallText(params: {
-  allowOtherNonTextBlocks?: boolean;
-  allowedStopReasons?: ReadonlySet<unknown>;
-  isRetainableNonTextBlock?: (block: Record<string, unknown>) => boolean;
-  message: unknown;
-  requireAssistantRole?: boolean;
-}): string | undefined {
-  const record = asRecord(params.message);
-  if (!record) {
-    return undefined;
-  }
-  if (params.requireAssistantRole && record.role !== "assistant") {
-    return undefined;
-  }
-  if (params.allowedStopReasons && !params.allowedStopReasons.has(record.stopReason)) {
-    return undefined;
-  }
-
-  const content = record.content;
-  if (typeof content === "string") {
-    const text = content.trim();
-    return text || undefined;
-  }
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-
-  const textParts: string[] = [];
-  for (const block of content) {
-    const blockRecord = asRecord(block);
-    if (!blockRecord) {
-      return undefined;
-    }
-    if (blockRecord.type === "text") {
-      if (typeof blockRecord.text !== "string") {
-        return undefined;
-      }
-      if (blockRecord.text.trim()) {
-        textParts.push(blockRecord.text);
-      }
-      continue;
-    }
-    if (params.isRetainableNonTextBlock?.(blockRecord) || params.allowOtherNonTextBlocks) {
-      continue;
-    }
-    return undefined;
-  }
-
-  const text = textParts.join("").trim();
-  return text || undefined;
-}
-
-/** Promotes standalone plain-text tool-call messages into provider-native content blocks. */
-export function promoteStandalonePlainTextToolCallMessage(
+/** Promotes text calls and maps source blocks retained in the projected message. */
+export function projectStandalonePlainTextToolCallMessage(
   options: PlainTextToolCallPromotionOptions,
-): Record<string, unknown> | undefined {
-  if (!shouldPromoteMessage(options)) {
-    return undefined;
-  }
+): PlainTextToolCallMessageProjection | undefined {
   const messageRecord = asRecord(options.message);
-  if (!messageRecord) {
+  if (
+    !messageRecord ||
+    options.allowedToolNames.size === 0 ||
+    (options.requireAssistantRole && messageRecord.role !== "assistant") ||
+    (options.allowedStopReasons && !options.allowedStopReasons.has(messageRecord.stopReason))
+  ) {
     return undefined;
   }
 
   const originalContent = messageRecord.content;
   if (typeof originalContent === "string") {
-    const text = originalContent.trim();
-    if (!text) {
-      return undefined;
-    }
-    const toolCalls = createPromotedToolCallBlocks(text, options);
+    const toolCalls = createPromotedToolCallBlocks(originalContent.trim(), options);
     if (!toolCalls) {
       return undefined;
     }
     return {
-      ...messageRecord,
-      content: toolCalls,
-      stopReason: "toolUse",
+      message: {
+        ...messageRecord,
+        content: toolCalls,
+        stopReason: "toolUse",
+      },
+      sourceToProjectedContentIndex: new Map(),
     };
   }
 
@@ -204,25 +156,21 @@ export function promoteStandalonePlainTextToolCallMessage(
   }
 
   const content: Array<Record<string, unknown>> = [];
+  const sourceToProjectedContentIndex = new Map<number, number>();
   let promotedTextBlock = false;
   let textParts: string[] = [];
-  const flushTextParts = (): boolean | undefined => {
-    if (textParts.length === 0) {
-      return false;
-    }
+  const flushTextParts = (): boolean => {
     const toolCalls = createPromotedToolCallBlocksFromTextParts(textParts, options);
     textParts = [];
-    if (toolCalls?.length === 0) {
+    if (!toolCalls) {
       return false;
     }
-    if (!toolCalls) {
-      return undefined;
-    }
     content.push(...toolCalls);
+    promotedTextBlock ||= toolCalls.length > 0;
     return true;
   };
 
-  for (const block of originalContent) {
+  for (const [sourceIndex, block] of originalContent.entries()) {
     const blockRecord = asRecord(block);
     if (!blockRecord) {
       return undefined;
@@ -231,35 +179,33 @@ export function promoteStandalonePlainTextToolCallMessage(
       if (typeof blockRecord.text !== "string") {
         return undefined;
       }
-      if (blockRecord.text.trim()) {
-        textParts.push(blockRecord.text);
-      }
+      textParts.push(blockRecord.text);
       continue;
     }
-    const promotedTextRun = flushTextParts();
-    if (promotedTextRun === undefined) {
+    if (!flushTextParts()) {
       return undefined;
     }
-    promotedTextBlock ||= promotedTextRun;
     if (options.isRetainableNonTextBlock?.(blockRecord)) {
+      sourceToProjectedContentIndex.set(sourceIndex, content.length);
       content.push(blockRecord);
       continue;
     }
     return undefined;
   }
 
-  const promotedTrailingTextRun = flushTextParts();
-  if (promotedTrailingTextRun === undefined) {
+  if (!flushTextParts()) {
     return undefined;
   }
-  promotedTextBlock ||= promotedTrailingTextRun;
   if (!promotedTextBlock) {
     return undefined;
   }
 
   return {
-    ...messageRecord,
-    content,
-    stopReason: "toolUse",
+    message: {
+      ...messageRecord,
+      content,
+      stopReason: "toolUse",
+    },
+    sourceToProjectedContentIndex,
   };
 }

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -685,6 +685,19 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(JSON.stringify(events)).not.toContain("[read]");
   });
 
+  it("bounds blank-line buffering after a complete call", async () => {
+    const call = "<function=read></function>\n";
+    const whitespaceChunks = Array.from({ length: 65 }, () => "\n".repeat(4096));
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      ...whitespaceChunks.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+      { type: "text_delta", contentIndex: 0, delta: "Visible" },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["Visible"]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
   it("preserves visible whitespace when an optional JSON closer is absent", async () => {
     const prefix = `[tool:read] {"path":"${"x".repeat(256_001)}`;
     const suffix = '"}\n\nVisible';

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -694,7 +694,9 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
       { type: "text_delta", contentIndex: 0, delta: "Visible" },
     ]);
 
-    expect(textDeltas(events)).toEqual(["Visible"]);
+    const deltas = textDeltas(events);
+    expect(deltas.at(-1)).toBe("Visible");
+    expect(deltas.slice(0, -1).join("").length).toBeLessThanOrEqual(2 * 4096);
     expect(JSON.stringify(events)).not.toContain("<function=read>");
   });
 

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -1,0 +1,1159 @@
+import { describe, expect, it } from "vitest";
+import { parseStandalonePlainTextToolCallBlocks } from "./payload.js";
+import {
+  normalizePlainTextToolCallStreamEvents,
+  projectScrubbedPlainTextToolCallMessage,
+  type PlainTextToolCallMessageNormalization,
+  type PlainTextToolCallNameMatcher,
+} from "./stream-normalizer.js";
+
+const matcher: PlainTextToolCallNameMatcher = {
+  hasExactName: (name) => name === "read",
+  hasNamePrefix: (prefix) => "read".startsWith(prefix),
+};
+
+type Terminal = "done" | "eof" | "error";
+
+function parseSplitCall(parts: readonly string[]) {
+  let offset = 0;
+  const lineBreakOffsets = new Set(
+    parts.slice(0, -1).map((part) => {
+      offset += part.length;
+      return offset;
+    }),
+  );
+  return parseStandalonePlainTextToolCallBlocks(parts.join(""), undefined, {
+    lineBreakOffsets,
+  });
+}
+
+function textContent(text: string) {
+  return [{ type: "text", text }];
+}
+
+function textDelta(delta: string, snapshot: string) {
+  return {
+    type: "text_delta",
+    contentIndex: 0,
+    delta,
+    partial: { role: "assistant", content: textContent(snapshot) },
+  };
+}
+
+async function normalize(events: readonly unknown[]): Promise<Record<string, unknown>[]> {
+  async function* source() {
+    yield* events;
+  }
+  const normalized: Record<string, unknown>[] = [];
+  const scrubMessage = (message: unknown, options?: { preserveEmptyTextBlocks?: boolean }) =>
+    projectScrubbedPlainTextToolCallMessage({
+      matcher,
+      message,
+      preserveEmptyTextBlocks: options?.preserveEmptyTextBlocks,
+    });
+  for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+    matcher,
+    createPromotedToolCallEvents: () => [],
+    normalizeTerminalMessage: ({
+      message,
+      preserveEmptyTextBlocks,
+    }): PlainTextToolCallMessageNormalization => {
+      const scrubbed = scrubMessage(message, { preserveEmptyTextBlocks });
+      return scrubbed ? { kind: "scrubbed", ...scrubbed } : undefined;
+    },
+  })) {
+    if (event && typeof event === "object") {
+      normalized.push(event as Record<string, unknown>);
+    }
+  }
+  return normalized;
+}
+
+function withTerminal(
+  deltas: readonly Record<string, unknown>[],
+  terminal: Terminal,
+  snapshot: string,
+): Record<string, unknown>[] {
+  if (terminal === "eof") {
+    return [...deltas];
+  }
+  const message = { role: "assistant", content: textContent(snapshot), stopReason: "length" };
+  return terminal === "done"
+    ? [...deltas, { type: "done", reason: "length", message }]
+    : [...deltas, { type: "error", partial: message, error: { content: textContent(snapshot) } }];
+}
+
+function textDeltas(events: readonly Record<string, unknown>[]): unknown[] {
+  return events.filter((event) => event.type === "text_delta").map((event) => event.delta);
+}
+
+function expectTerminalContent(
+  events: readonly Record<string, unknown>[],
+  terminal: Terminal,
+  content: unknown,
+) {
+  if (terminal === "done") {
+    expect(events.at(-1)?.message).toMatchObject({ content });
+  } else if (terminal === "error") {
+    const partialContent =
+      Array.isArray(content) && content.length === 0 ? textContent("") : content;
+    expect(events.at(-1)?.partial).toMatchObject({ content: partialContent });
+    expect(events.at(-1)?.error).toMatchObject({ content });
+  }
+}
+
+describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
+  it.each<Terminal>(["done", "error", "eof"])(
+    "suppresses an incomplete multibyte prefix at %s",
+    async (terminal) => {
+      const raw = `<function=read>${"\u00a0".repeat(128_001)}`;
+      const events = await normalize(withTerminal([textDelta(raw, raw)], terminal, raw));
+
+      expect(textDeltas(events)).toEqual([]);
+      expect(JSON.stringify(events)).not.toContain("<function=read>");
+      expectTerminalContent(events, terminal, []);
+    },
+  );
+
+  it.each<Terminal>(["done", "error", "eof"])(
+    "preserves visible text that invalidates an incomplete over-cap prefix at %s",
+    async (terminal) => {
+      const prefix = `<function=read>${"\u00a0".repeat(128_001)}`;
+      const visible = "Visible answer";
+      const events = await normalize(
+        withTerminal(
+          [textDelta(prefix, prefix), textDelta(visible, `${prefix}${visible}`)],
+          terminal,
+          `${prefix}${visible}`,
+        ),
+      );
+
+      expect(textDeltas(events)).toEqual([visible]);
+      expect(JSON.stringify(events)).not.toContain("<function=read>");
+      if (terminal !== "eof") {
+        expectTerminalContent(events, terminal, textContent(visible));
+      }
+    },
+  );
+
+  it.each<Terminal>(["done", "error", "eof"])(
+    "preserves a 400k suffix after a complete byte-over-cap call at %s",
+    async (terminal) => {
+      const call = `<function=read>${"\u00a0".repeat(128_001)}</function>`;
+      const visible = `${"a".repeat(150_000)}MIDDLE${"b".repeat(250_000)}`;
+      const raw = `${call}\n${visible}`;
+      const events = await normalize(withTerminal([textDelta(raw, raw)], terminal, raw));
+
+      expect(textDeltas(events)).toEqual([visible]);
+      expect(String(textDeltas(events)[0])).toHaveLength(visible.length);
+      expect(String(textDeltas(events)[0])).toContain("MIDDLE");
+      expect(JSON.stringify(events)).not.toContain("<function=read>");
+      expectTerminalContent(events, terminal, textContent(visible));
+    },
+  );
+
+  it("does not leak a complete parameter tail before a split function close", async () => {
+    const prefix = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter>`;
+    const raw = `${prefix}</function>`;
+    const events = await normalize([textDelta(prefix, prefix), textDelta("</function>", raw)]);
+
+    expect(events).toEqual([]);
+  });
+
+  it("suppresses XML-punctuated parameter names after the byte cap", async () => {
+    const prefix = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter>`;
+    const tail = "<parameter=foo.bar>SECRET</parameter></function>";
+    const events = await normalize([
+      textDelta(prefix, prefix),
+      textDelta(tail, `${prefix}${tail}`),
+    ]);
+
+    expect(events).toEqual([]);
+  });
+
+  it("uses repaired text-block joins for done-only byte-over-cap calls", async () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "[read]" },
+        {
+          type: "text",
+          text: `<parameter=path>${"\u00a0".repeat(128_001)}</parameter></function>`,
+        },
+      ],
+      stopReason: "length",
+    };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events).toEqual([
+      { type: "done", reason: "length", message: { ...message, content: [] } },
+    ]);
+  });
+
+  it.each([
+    `<parameter=path>${"x".repeat(256_001)}`,
+    `{"path":"${"x".repeat(256_001)}`,
+    `{"path":"${"x".repeat(256_001)}"}`,
+    `{"path":"${"x".repeat(256_001)}"}\n[END_TOOL_REQU`,
+  ])("scrubs incomplete split named calls", async (payload) => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "[read]" },
+        { type: "text", text: payload },
+      ],
+      stopReason: "length",
+    };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events.at(-1)?.message).toMatchObject({ content: [] });
+    expect(JSON.stringify(events)).not.toContain("[read]");
+  });
+
+  it("scrubs an incomplete named call from a done-only snapshot", async () => {
+    const raw = "<function=read><parameter=path>SECRET";
+    const message = { role: "assistant", content: textContent(raw), stopReason: "length" };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events).toEqual([
+      { type: "done", reason: "length", message: { ...message, content: [] } },
+    ]);
+  });
+
+  it("repairs split calls after visible text", async () => {
+    const payload = `<parameter=path>${"x".repeat(256_001)}</parameter></function>`;
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Visible\n[read]" },
+        { type: "text", text: payload },
+      ],
+      stopReason: "length",
+    };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events.at(-1)?.message).toMatchObject({ content: textContent("Visible\n") });
+  });
+
+  it("merges exact and repaired over-cap ranges", async () => {
+    const exact = `<function=read>${"\u00a0".repeat(128_001)}</function>\n`;
+    const split = `<parameter=path>${"y".repeat(256_001)}</parameter></function>`;
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: exact },
+        { type: "text", text: "[read]" },
+        { type: "text", text: split },
+      ],
+      stopReason: "length",
+    };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events.at(-1)?.message).toMatchObject({ content: [] });
+  });
+
+  it("keeps literal close markers inside split parameter values", () => {
+    const parts = ["[write]", "<parameter=content>literal </function> tail</parameter></function>"];
+
+    expect(parseSplitCall(parts)?.[0]?.arguments).toEqual({
+      content: "literal </function> tail",
+    });
+  });
+
+  it.each([
+    ["<function=read><parameter=path> ", "/tmp</parameter></function>"],
+    ["[read]", '  {"path":"/tmp"}[/read]'],
+  ])("repairs a boundary inside leading horizontal whitespace", (first, second) => {
+    expect(parseSplitCall([first, second])?.[0]?.name).toBe("read");
+  });
+
+  it.each(["\n", "\r\n"])("does not duplicate an existing parameter line break %j", (lineBreak) => {
+    const first = "<function=read><parameter=path>";
+    const second = `  ${lineBreak}/tmp</parameter></function>`;
+
+    expect(parseSplitCall([first, second])?.[0]?.arguments).toEqual({ path: `  ${lineBreak}/tmp` });
+  });
+
+  it("preserves non-text ordering around the visible suffix", async () => {
+    const call = `<function=read>${"\u00a0".repeat(128_001)}</function>`;
+    const image = { type: "image", data: "opaque" };
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: call }, image, { type: "text", text: "Visible" }],
+      stopReason: "length",
+    };
+    const events = await normalize([{ type: "done", reason: "length", message }]);
+
+    expect(events.at(-1)?.message).toMatchObject({
+      content: [image, { type: "text", text: "Visible" }],
+    });
+  });
+
+  it("strips every leading serialized call after the first over-cap call", async () => {
+    const overCap = `<function=read>${"\u00a0".repeat(128_001)}</function>`;
+    const second = "<function=read></function>";
+    const raw = `${overCap}\n${second}\nVisible`;
+    const events = await normalize([
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(events.at(-1)?.message).toMatchObject({ content: textContent("Visible") });
+  });
+
+  it("suppresses an incomplete follow-on call prefix", async () => {
+    const raw = `<function=read>${"\u00a0".repeat(128_001)}</function>\n[tool:read`;
+    const events = await normalize([textDelta(raw, raw)]);
+
+    expect(events).toEqual([]);
+  });
+
+  it("keeps an incomplete follow-on call private until terminal promotion", async () => {
+    const raw = "<function=read></function>\n<function=read><parameter=path>SECRET";
+    async function* source() {
+      yield textDelta(raw, raw);
+      yield {
+        type: "done",
+        reason: "stop",
+        message: { role: "assistant", content: textContent(raw), stopReason: "stop" },
+      };
+    }
+    const message = {
+      role: "assistant",
+      content: [{ type: "toolCall", name: "read", arguments: { path: "SECRET" } }],
+      stopReason: "toolUse",
+    };
+    const events: Record<string, unknown>[] = [];
+    for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+      matcher,
+      createPromotedToolCallEvents: () => [],
+      normalizeTerminalMessage: () => ({
+        kind: "promoted",
+        message,
+        sourceToProjectedContentIndex: new Map(),
+      }),
+    })) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect(events.map((event) => event.type)).toEqual(["start", "done"]);
+    expect(JSON.stringify(events.slice(0, -1))).not.toContain("SECRET");
+  });
+
+  it.each(['[tool:read] {"path":"SECRET"}', 'analysis to=read code {"path":"SECRET"}'])(
+    "keeps every split optional closer private for %s",
+    async (call) => {
+      const marker = "<|call|>";
+      for (let split = 1; split < marker.length; split += 1) {
+        const first = call + marker.slice(0, split);
+        const raw = call + marker;
+        async function* source() {
+          yield textDelta(first, first);
+          yield textDelta(marker.slice(split), raw);
+          yield {
+            type: "done",
+            reason: "stop",
+            message: { role: "assistant", content: textContent(raw), stopReason: "stop" },
+          };
+        }
+        const message = {
+          role: "assistant",
+          content: [{ type: "toolCall", name: "read", arguments: {} }],
+          stopReason: "toolUse",
+        };
+        const events: Record<string, unknown>[] = [];
+        for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+          matcher,
+          createPromotedToolCallEvents: () => [],
+          normalizeTerminalMessage: () => ({
+            kind: "promoted",
+            message,
+            sourceToProjectedContentIndex: new Map(),
+          }),
+        })) {
+          events.push(event as Record<string, unknown>);
+        }
+
+        expect(events.map((event) => event.type)).toEqual(["start", "done"]);
+        expect(JSON.stringify(events.slice(0, -1))).not.toContain(marker.slice(0, split));
+      }
+    },
+  );
+
+  it.each([
+    ["tool bracket", (payload: string) => `[tool:read] ${payload}`, "<|call|>"],
+    ["tool bracket legacy", (payload: string) => `[tool:read] ${payload}`, "[END_TOOL_REQUEST]"],
+    ["tool bracket named", (payload: string) => `[tool:read] ${payload}`, "[/read]"],
+    ["Harmony", (payload: string) => `analysis to=read code ${payload}`, "<|call|>"],
+    ["named bracket", (payload: string) => `[read]\n${payload}`, "[/read]"],
+    ["legacy named bracket", (payload: string) => `[read]\n${payload}`, "[END_TOOL_REQUEST]"],
+  ])("keeps split over-cap closing markers private for %s", async (_name, build, marker) => {
+    const call = build(`{"path":"${"x".repeat(256_001)}"}`);
+    const visible = "Visible";
+    for (let split = 1; split < marker.length; split += 1) {
+      const events = await normalize([
+        { type: "text_delta", contentIndex: 0, delta: call + marker.slice(0, split) },
+        { type: "text_delta", contentIndex: 0, delta: marker.slice(split) + `\n${visible}` },
+      ]);
+
+      expect(textDeltas(events)).toEqual([visible]);
+      expect(JSON.stringify(events)).not.toContain(marker);
+    }
+  });
+
+  it("keeps an optional closer private when it starts after the over-cap payload", async () => {
+    const call = `[tool:read] {"path":"${"x".repeat(256_001)}"}`;
+    const marker = "<|call|>";
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      { type: "text_delta", contentIndex: 0, delta: `${marker}\nVisible` },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["Visible"]);
+    expect(JSON.stringify(events)).not.toContain(marker);
+  });
+
+  it("preserves a follow-on named JSON call invalidated by visible tail text", async () => {
+    const overCap = `<function=read>${"\u00a0".repeat(128_001)}</function>`;
+    const visible = '[read]\n{"path":"/tmp"} visible';
+    const raw = `${overCap}\n${visible}`;
+    const events = await normalize([
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(events.at(-1)?.message).toMatchObject({ content: textContent(visible) });
+  });
+
+  it("preserves equal visible suffixes from independent calls", async () => {
+    const call = `<function=read>${"\u00a0".repeat(128_001)}</function>\nOK\n`;
+    const events = await normalize([textDelta(call, call), textDelta(call, `${call}${call}`)]);
+
+    expect(textDeltas(events)).toEqual(["OK\n", "OK\n"]);
+  });
+
+  it("remaps buffered auxiliary indexes after compact terminal scrubbing", async () => {
+    const raw = `[tool:read]\n<parameter=path>\n${"x".repeat(256_001)}`;
+    const thinking = { type: "thinking", thinking: "checking" };
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: raw }, thinking],
+      stopReason: "length",
+    };
+    const events = await normalize([
+      textDelta(raw, raw),
+      {
+        type: "thinking_delta",
+        contentIndex: 1,
+        delta: "checking",
+        partial: { role: "assistant", content: [{ type: "text", text: raw }, thinking] },
+      },
+      { type: "done", reason: "length", message },
+    ]);
+
+    expect(events.map((event) => event.type)).toEqual(["thinking_delta", "done"]);
+    expect(events[0]).toMatchObject({ contentIndex: 0, partial: { content: [thinking] } });
+    expect(events[1]?.message).toMatchObject({ content: [thinking] });
+    expect(JSON.stringify(events)).not.toContain("[tool:read]");
+  });
+
+  it("uses the compact error projection when no partial is present", async () => {
+    const raw = `[tool:read]\n<parameter=path>\n${"x".repeat(256_001)}`;
+    const thinking = { type: "thinking", thinking: "checking" };
+    const error = { role: "assistant", content: [{ type: "text", text: raw }, thinking] };
+    const events = await normalize([
+      textDelta(raw, raw),
+      {
+        type: "thinking_delta",
+        contentIndex: 1,
+        delta: "checking",
+        partial: error,
+      },
+      { type: "error", error },
+    ]);
+
+    expect(events[0]).toMatchObject({ contentIndex: 0, partial: { content: [thinking] } });
+    expect(events.at(-1)?.error).toMatchObject({ content: [thinking] });
+    expect(JSON.stringify(events)).not.toContain("[tool:read]");
+  });
+
+  it.each(["thinking_delta", "text_delta"])(
+    "scrubs raw cumulative snapshots from later %s events",
+    async (type) => {
+      const call = `<function=read>${"\u00a0".repeat(128_001)}</function>`;
+      const visible = type === "thinking_delta" ? "checking" : "Visible";
+      const block =
+        type === "thinking_delta"
+          ? { type: "thinking", thinking: visible }
+          : { type: "text", text: `${call}${visible}` };
+      const later = {
+        type,
+        contentIndex: type === "thinking_delta" ? 1 : 0,
+        delta: visible,
+        partial: {
+          role: "assistant",
+          content: type === "thinking_delta" ? [{ type: "text", text: call }, block] : [block],
+        },
+      };
+      const events = await normalize([textDelta(call, call), later]);
+
+      expect(JSON.stringify(events)).not.toContain("<function=read>");
+      expect(events.at(-1)?.delta).toBe(visible);
+    },
+  );
+
+  it("drains every unique auxiliary lifecycle event at the queue cap", async () => {
+    const candidate = '[tool:read] {"path":"SECRET"';
+    const lifecycles = Array.from({ length: 129 }, (_, index) => [
+      { type: "thinking_start", contentIndex: index + 1 },
+      { type: "thinking_end", contentIndex: index + 1, content: "" },
+    ]).flat();
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: candidate },
+      ...lifecycles,
+    ]);
+
+    expect(events[0]?.type).toBe("start");
+    expect(events.filter((event) => event.type === "thinking_start")).toHaveLength(129);
+    expect(events.filter((event) => event.type === "thinking_end")).toHaveLength(129);
+    expect(events.slice(1)).toMatchObject(lifecycles);
+    expect(JSON.stringify(events)).not.toContain("SECRET");
+  });
+
+  it("drains merged auxiliary deltas at the queue byte cap", async () => {
+    const candidate = '[tool:read] {"path":"SECRET"';
+    const chunk = "x".repeat(128_001);
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: candidate },
+      { type: "thinking_delta", contentIndex: 1, delta: chunk },
+      { type: "thinking_delta", contentIndex: 1, delta: chunk },
+      { type: "thinking_delta", contentIndex: 1, delta: chunk },
+    ]);
+
+    expect(events[0]?.type).toBe("start");
+    expect(events.filter((event) => event.type === "thinking_delta")).toHaveLength(2);
+    expect(JSON.stringify(events)).not.toContain("SECRET");
+  });
+
+  it("preserves clean required partials after scrubbing a call", async () => {
+    const call = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter></function>`;
+    const partial = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Visible" },
+        { type: "thinking", thinking: "checking" },
+      ],
+    };
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: `${call}\nVisible` },
+      { type: "thinking_start", contentIndex: 1, partial },
+    ]);
+
+    expect(events.at(-1)).toEqual({ type: "thinking_start", contentIndex: 1, partial });
+  });
+
+  it("preserves clean required partials while draining buffered auxiliary events", async () => {
+    const partial = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "checking" }],
+    };
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: '[tool:read] {"path":"SECRET"' },
+      { type: "thinking_start", contentIndex: 1, partial },
+    ]);
+
+    expect(events).toEqual([{ type: "thinking_start", contentIndex: 1, partial }]);
+  });
+
+  it("replays a false prefix after auxiliary queue compaction", async () => {
+    const prefix = "[tool:re";
+    const visible = `${prefix} nope`;
+    const sourceEvents = [
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      ...Array.from({ length: 257 }, () => ({
+        type: "thinking_delta",
+        contentIndex: 1,
+        delta: "x",
+      })),
+      { type: "text_delta", contentIndex: 0, delta: " nope" },
+    ];
+    const events = await normalize(sourceEvents);
+
+    expect(textDeltas(events).join("")).toBe(visible);
+  });
+
+  it("scans complete under-cap call sequences linearly", () => {
+    const callCount = 64;
+    let exactNameChecks = 0;
+    const countingMatcher: PlainTextToolCallNameMatcher = {
+      hasExactName: (name) => {
+        exactNameChecks += 1;
+        return name === "read";
+      },
+      hasNamePrefix: (prefix) => "read".startsWith(prefix),
+    };
+    const text = Array.from({ length: callCount }, () => "<function=read></function>").join("\n");
+
+    expect(
+      projectScrubbedPlainTextToolCallMessage({
+        matcher: countingMatcher,
+        message: { role: "assistant", content: text },
+      }),
+    ).toBeUndefined();
+    expect(exactNameChecks).toBeLessThanOrEqual(callCount * 3);
+  });
+
+  it("scrubs an under-cap call after visible terminal text", () => {
+    const message = {
+      role: "assistant",
+      content: "Visible answer\n<function=read></function>",
+    };
+
+    expect(projectScrubbedPlainTextToolCallMessage({ matcher, message })?.message).toEqual({
+      ...message,
+      content: "Visible answer\n",
+    });
+  });
+
+  it.each(["comment", "analysis", "final", "<", "["])(
+    "preserves the unnamed protocol prefix %s in terminal prose",
+    (prefix) => {
+      const message = { role: "assistant", content: `Visible answer\n${prefix}` };
+      expect(projectScrubbedPlainTextToolCallMessage({ matcher, message })).toBeUndefined();
+    },
+  );
+
+  it("suppresses a complete call sequence over the aggregate byte budget", async () => {
+    const call = "<function=read></function>\n";
+    const raw = call.repeat(10_000);
+
+    expect(new TextEncoder().encode(raw).byteLength).toBeGreaterThan(256_000);
+    expect(await normalize([textDelta(raw, raw)])).toEqual([]);
+  });
+
+  it("hands an aggregate-over-cap active tail to bounded suppression", async () => {
+    const prefix = "<function=read></function>\n".repeat(9_500);
+    const active = "<function=read><parameter=path>secret";
+    const close = "</parameter></function>\nVisible";
+    const events = await normalize([
+      textDelta(`${prefix}${active}`, `${prefix}${active}`),
+      textDelta(close, `${prefix}${active}${close}`),
+    ]);
+
+    expect(textDeltas(events)).toEqual(["Visible"]);
+    expect(JSON.stringify(events)).not.toContain("secret");
+  });
+
+  it("keeps only a bounded active marker after an aggregate-over-cap prefix", async () => {
+    const prefix = "<function=read></function>\n".repeat(9_500);
+    const marker = "[tool:re";
+    const visible = `${marker} nope`;
+    const events = await normalize([
+      textDelta(`${prefix}${marker}`, `${prefix}${marker}`),
+      textDelta(" nope", `${prefix}${visible}`),
+    ]);
+
+    expect(textDeltas(events)).toEqual([visible]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("keeps post-JSON structural whitespace private without accumulating it", async () => {
+    const prefix = `[read]\n{"path":"${"x".repeat(256_001)}`;
+    const whitespaceChunks = Array.from({ length: 64 }, () => " ".repeat(4096));
+    const tail = "[/read]\nVisible";
+    const raw = `${prefix}"}${whitespaceChunks.join("")}${tail}`;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      { type: "text_delta", contentIndex: 0, delta: '"}' },
+      ...whitespaceChunks.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+      { type: "text_delta", contentIndex: 0, delta: tail },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["Visible"]);
+    expectTerminalContent(events, "done", textContent("Visible"));
+    expect(JSON.stringify(events)).not.toContain("[read]");
+  });
+
+  it("preserves visible whitespace when an optional JSON closer is absent", async () => {
+    const prefix = `[tool:read] {"path":"${"x".repeat(256_001)}`;
+    const suffix = '"}\n\nVisible';
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      { type: "text_delta", contentIndex: 0, delta: suffix },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["\nVisible"]);
+  });
+
+  it("retains a later text start when a buffered call leaves visible text", async () => {
+    const call = "<function=read></function>\n";
+    const suffix = "Visible";
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      { type: "text_start", contentIndex: 1, content: "" },
+      { type: "text_delta", contentIndex: 1, delta: suffix },
+    ]);
+
+    expect(events).toMatchObject([
+      { type: "text_start", contentIndex: 1 },
+      { type: "text_delta", contentIndex: 1, delta: suffix },
+    ]);
+  });
+
+  it("retains a new block supplied only by its authoritative text end", async () => {
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: "[read]" },
+      { type: "text_end", contentIndex: 1, content: "Visible answer" },
+    ]);
+
+    expect(events).toEqual([
+      { type: "text_delta", contentIndex: 0, delta: "[read]" },
+      { type: "text_end", contentIndex: 1, content: "Visible answer" },
+    ]);
+  });
+
+  it("keeps an incomplete call private across a cumulative text end", async () => {
+    const visible = "Hello\n";
+    const call = "<function=read><parameter=path>SECRET";
+    const raw = visible + call;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: raw },
+      { type: "text_end", contentIndex: 0, content: raw },
+    ]);
+
+    expect(textDeltas(events)).toEqual([visible]);
+    expect(JSON.stringify(events)).not.toContain("SECRET");
+  });
+
+  it("projects sanitized text across the original terminal content indexes", async () => {
+    const intro = "Visible intro.\n";
+    const call = "<function=read></function>\n";
+    const suffix = "Visible suffix.";
+    const content = [
+      { type: "text", text: intro },
+      { type: "text", text: call },
+      { type: "text", text: suffix },
+    ];
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: intro },
+      { type: "text_delta", contentIndex: 1, delta: call },
+      { type: "text_delta", contentIndex: 2, delta: suffix },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content, stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual([intro, suffix]);
+    expect(events.at(-1)?.message).toMatchObject({
+      content: [content[0], { type: "text", text: "" }, content[2]],
+    });
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("preserves a later content index after a separately scrubbed over-cap call", async () => {
+    const call = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter></function>`;
+    const suffix = "Visible suffix.";
+    const content = [
+      { type: "text", text: call },
+      { type: "text", text: suffix },
+    ];
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      { type: "text_delta", contentIndex: 1, delta: suffix },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content, stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual([suffix]);
+    expect(events.at(-1)?.message).toMatchObject({
+      content: [{ type: "text", text: "" }, content[1]],
+    });
+  });
+
+  it("preserves streamed content indexes in terminal error snapshots", async () => {
+    const call = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter></function>`;
+    const thinking = { type: "thinking", thinking: "checking" };
+    const suffix = { type: "text", text: "Visible suffix." };
+    const error = { role: "assistant", content: [{ type: "text", text: call }, thinking, suffix] };
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      { type: "text_delta", contentIndex: 2, delta: suffix.text },
+      { type: "error", error },
+    ]);
+
+    expect(textDeltas(events)).toEqual([suffix.text]);
+    expect(events.at(-1)?.error).toMatchObject({
+      content: [{ type: "text", text: "" }, thinking, suffix],
+    });
+  });
+
+  it("keeps earlier visible text when scrubbing a later same-index call", async () => {
+    const intro = "Visible intro.\n";
+    const call = "<function=read></function>\n";
+    const suffix = "Visible suffix.";
+    const raw = `${intro}${call}${suffix}`;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: intro },
+      { type: "text_delta", contentIndex: 0, delta: `${call}${suffix}` },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual([intro, suffix]);
+    expectTerminalContent(events, "done", textContent(`${intro}${suffix}`));
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("emits each visible segment once across multiple stripped calls and cumulative text_end", async () => {
+    const call = `<function=read>${"\u00a0".repeat(128_001)}</function>\n`;
+    const first = `${call}ONE\n`;
+    const second = `TWO\n${call}THREE`;
+    const raw = first + second;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: first },
+      { type: "text_delta", contentIndex: 0, delta: second },
+      { type: "text_end", contentIndex: 0, content: raw },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "text_delta",
+      "text_delta",
+      "text_delta",
+      "done",
+    ]);
+    expect(textDeltas(events)).toEqual(["ONE\n", "TWO\n", "THREE"]);
+    expectTerminalContent(events, "done", textContent("ONE\nTWO\nTHREE"));
+  });
+
+  it.each([
+    ["delta omits the index", {}, { contentIndex: 0 }],
+    ["text_end omits the index", { contentIndex: 0 }, {}],
+  ])("canonicalizes index zero when the %s", async (_name, deltaIndex, endIndex) => {
+    const call = `<function=read>${"\u00a0".repeat(128_001)}</function>\n`;
+    const visible = "Visible once.";
+    const raw = call + visible;
+    const events = await normalize([
+      { type: "text_delta", ...deltaIndex, delta: raw },
+      { type: "text_end", ...endIndex, content: raw },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual([visible]);
+    expectTerminalContent(events, "done", textContent(visible));
+  });
+
+  it.each([false, true])(
+    "tracks many stripped segments by emitted offset (text_end partial: %s)",
+    async (withPartial) => {
+      const call = "<function=read></function>\n";
+      const segments = Array.from({ length: 64 }, (_, index) => `SEG-${index}\n`);
+      const chunks = segments.map((segment) => call + segment);
+      const raw = chunks.join("");
+      const events = await normalize([
+        ...chunks.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+        {
+          type: "text_end",
+          contentIndex: 0,
+          content: raw,
+          ...(withPartial ? { partial: { role: "assistant", content: textContent(raw) } } : {}),
+        },
+        {
+          type: "done",
+          reason: "length",
+          message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+        },
+      ]);
+
+      expect(textDeltas(events)).toEqual(segments);
+      expectTerminalContent(events, "done", textContent(segments.join("")));
+    },
+  );
+
+  it("bounds cumulative dedupe state to offsets for multi-megabyte visible text", async () => {
+    const call = "<function=read></function>\n";
+    const chunks = Array.from({ length: 512 }, () => "x".repeat(4_096));
+    const visible = chunks.join("");
+    const raw = call + visible;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: call },
+      ...chunks.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+      { type: "text_end", contentIndex: 0, content: raw },
+      {
+        type: "done",
+        reason: "length",
+        message: { role: "assistant", content: textContent(raw), stopReason: "length" },
+      },
+    ]);
+
+    expect(textDeltas(events)).toEqual(chunks);
+    expectTerminalContent(events, "done", textContent(visible));
+  });
+
+  it("emits buffered auxiliary events exactly once on unsanitized errors", async () => {
+    const call = "<function=read></function>";
+    const thinking = { type: "thinking", thinking: "checking" };
+    const events = await normalize([
+      textDelta(call, call),
+      {
+        type: "thinking_delta",
+        contentIndex: 1,
+        delta: "checking",
+        partial: { role: "assistant", content: [{ type: "text", text: call }, thinking] },
+      },
+      { type: "error", error: { message: "stream failed" } },
+    ]);
+
+    expect(events.filter((event) => event.type === "thinking_delta")).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: "error" });
+  });
+
+  it("preserves earlier cumulative text in replayed false-positive partials", async () => {
+    const visible = "Hello\n";
+    const prefix = "[tool:re";
+    const thinking = { type: "thinking", thinking: "x" };
+    const events = await normalize([
+      textDelta(visible, visible),
+      textDelta(prefix, `${visible}${prefix}`),
+      {
+        type: "thinking_delta",
+        contentIndex: 1,
+        delta: "x",
+        partial: {
+          role: "assistant",
+          content: [{ type: "text", text: `${visible}${prefix}` }, thinking],
+        },
+      },
+      textDelta(" nope", `${visible}${prefix} nope`),
+    ]);
+
+    expect(events.find((event) => event.type === "thinking_delta")).toMatchObject({
+      partial: { content: [{ type: "text", text: `${visible}${prefix}` }, thinking] },
+    });
+  });
+
+  it.each(["analysis", "commentary", "final"])(
+    "replays the bare Harmony channel word %s at EOF",
+    async (word) => {
+      expect(
+        textDeltas(await normalize([{ type: "text_delta", contentIndex: 0, delta: word }])),
+      ).toEqual([word]);
+    },
+  );
+
+  it("reconciles false-prefix prose completed by text_end", async () => {
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: "analysis" },
+      { type: "text_end", contentIndex: 0, content: "analysis is ordinary prose" },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["analysis is ordinary prose"]);
+    expect(events.map((event) => event.type)).toEqual(["text_delta", "text_end"]);
+  });
+
+  it("bounds unnamed Harmony prefixes before EOF", async () => {
+    const raw = `analysis${" ".repeat(256_001)}`;
+    const events = await normalize([{ type: "text_delta", contentIndex: 0, delta: raw }]);
+
+    expect(textDeltas(events)).toEqual([raw]);
+  });
+
+  it("preserves a malformed parameter marker after over-cap XML", async () => {
+    const prefix = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter>`;
+    const suffix = "<parameter=x!>Visible answer";
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      { type: "text_delta", contentIndex: 0, delta: suffix },
+    ]);
+
+    expect(textDeltas(events)).toEqual([suffix]);
+  });
+
+  it("recovers a visible suffix delivered only by an over-cap text_end", async () => {
+    const prefix = `<function=read><parameter=path>${"x".repeat(256_001)}`;
+    const complete = `${prefix}</parameter></function>\nVisible answer`;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      { type: "text_end", contentIndex: 0, content: complete },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["Visible answer"]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("fails closed on an unresolved authoritative tool-name prefix", async () => {
+    const content = "Hello\n[tool:re";
+    const event = { type: "text_end", contentIndex: 0, content };
+
+    expect(textDeltas(await normalize([event]))).toEqual(["Hello\n"]);
+  });
+
+  it("emits a held text start before a synthetic visible prefix", async () => {
+    const visible = "Visible\n";
+    const candidate = "[tool:re nope";
+    const raw = visible + candidate;
+    const events = await normalize([
+      {
+        type: "text_start",
+        contentIndex: 0,
+        content: "",
+        partial: { role: "assistant", content: textContent("") },
+      },
+      textDelta(`${visible}[tool:re`, `${visible}[tool:re`),
+      textDelta(" nope", raw),
+    ]);
+
+    expect(events.map((event) => event.type)).toEqual(["text_start", "text_delta", "text_delta"]);
+    expect(textDeltas(events)).toEqual([visible, candidate]);
+  });
+
+  it.each(["[tool:read]", "analysis to=read code"])(
+    "suppresses over-cap whitespace before a split JSON payload for %s",
+    async (header) => {
+      const prefix = header + " ".repeat(256_001);
+      const payload = '{"path":"SECRET"}<|call|>';
+      const events = await normalize([
+        { type: "text_delta", contentIndex: 0, delta: prefix },
+        { type: "text_delta", contentIndex: 0, delta: payload },
+      ]);
+
+      expect(events).toEqual([]);
+    },
+  );
+
+  it.each(
+    [
+      "<function=read><parameter=path>SECRET",
+      "<function=read><parameter=path>SECRET</parameter></function>",
+    ].flatMap((raw) =>
+      (["done", "error", "eof"] as const).map((terminal) => [raw, terminal] as const),
+    ),
+  )("fails closed on a known %s candidate at %s", async (raw, terminal) => {
+    const events = await normalize(
+      withTerminal([{ type: "text_delta", contentIndex: 0, delta: raw }], terminal, raw),
+    );
+
+    expect(textDeltas(events)).toEqual([]);
+    expect(JSON.stringify(events)).not.toContain("SECRET");
+  });
+
+  it.each(["[tool:read] {}", "analysis to=read code {}"])(
+    "scrubs a cumulative partial before emitting a visible prefix for %s",
+    async (call) => {
+      const visible = "Visible\n";
+      const first = `${visible}${call}<`;
+      const raw = `${visible}${call}<|call|>`;
+      const events = await normalize([textDelta(first, first), textDelta("|call|>", raw)]);
+
+      expect(textDeltas(events)).toEqual([visible]);
+      expect(events[0]?.partial).toMatchObject({ content: textContent(visible) });
+      expect(JSON.stringify(events[0])).not.toContain("SECRET");
+      expect(JSON.stringify(events)).not.toContain("<|call|>");
+    },
+  );
+
+  it("keeps block-local text_end checkpoints out of the candidate buffer", async () => {
+    const header = "[read]";
+    const payload = '{"path":"SECRET"}[/read]';
+    const rawMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: header },
+        { type: "text", text: payload },
+      ],
+      stopReason: "stop",
+    };
+    const promotedMessage = {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "call_repaired", name: "read", arguments: { path: "SECRET" } },
+      ],
+      stopReason: "toolUse",
+    };
+    async function* source() {
+      yield { type: "text_start", contentIndex: 0, content: "" };
+      yield { type: "text_delta", contentIndex: 0, delta: header };
+      yield { type: "text_end", contentIndex: 0, content: header };
+      yield { type: "text_start", contentIndex: 1, content: "" };
+      yield { type: "text_delta", contentIndex: 1, delta: payload };
+      yield { type: "text_end", contentIndex: 1, content: payload };
+      yield { type: "done", reason: "stop", message: rawMessage };
+    }
+    const events: Record<string, unknown>[] = [];
+    for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+      matcher,
+      createPromotedToolCallEvents: (message) => [
+        { type: "toolcall_start", contentIndex: 0, partial: message },
+        { type: "toolcall_end", contentIndex: 0, partial: message },
+      ],
+      normalizeTerminalMessage: () => ({
+        kind: "promoted",
+        message: promotedMessage,
+        sourceToProjectedContentIndex: new Map(),
+      }),
+    })) {
+      events.push(event as Record<string, unknown>);
+    }
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_end",
+      "done",
+    ]);
+    expect(events.at(-1)).toMatchObject({ reason: "toolUse", message: promotedMessage });
+    expect(JSON.stringify(events)).not.toContain("[/read]");
+  });
+
+  it("preserves native tool-call partials while replaying a false-positive prefix", async () => {
+    const prefix = "[tool:re";
+    const toolCall = { type: "toolCall", id: "call_native", name: "other", arguments: {} };
+    const partial = {
+      role: "assistant",
+      content: [{ type: "text", text: prefix }, toolCall],
+    };
+    const events = await normalize([
+      textDelta(prefix, prefix),
+      { type: "toolcall_start", contentIndex: 1, partial },
+      textDelta(" nope", `${prefix} nope`),
+    ]);
+
+    expect(events.find((event) => event.type === "toolcall_start")?.partial).toEqual(partial);
+  });
+
+  it("does not allocate a synthetic partial from a hostile content index", async () => {
+    const raw = `<function=read><parameter=path>${"x".repeat(256_001)}</parameter></function>`;
+    const events = await normalize([
+      { ...textDelta(raw, raw), contentIndex: Number.MAX_SAFE_INTEGER },
+    ]);
+
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -696,6 +696,18 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     expect(textDeltas(events)).toEqual(["\nVisible"]);
   });
 
+  it("preserves split visible whitespace when an optional JSON closer is absent", async () => {
+    const prefix = `[tool:read] {"path":"${"x".repeat(256_001)}`;
+    const events = await normalize([
+      { type: "text_delta", contentIndex: 0, delta: prefix },
+      { type: "text_delta", contentIndex: 0, delta: '"}' },
+      { type: "text_delta", contentIndex: 0, delta: "\n\n" },
+      { type: "text_delta", contentIndex: 0, delta: "Visible" },
+    ]);
+
+    expect(textDeltas(events)).toEqual(["\nVisible"]);
+  });
+
   it("retains a later text start when a buffered call leaves visible text", async () => {
     const call = "<function=read></function>\n";
     const suffix = "Visible";

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -801,7 +801,9 @@ function classifyPending(
     return { kind: "stripped", text: createRangeRemover([leading])(candidate.text) };
   }
   if (leading && leading.activeStart === undefined) {
-    return pending.sequenceOverCap ? { kind: "stripped", text: "" } : { kind: "complete" };
+    return pending.sequenceOverCap || pending.bufferBytes > MAX_PAYLOAD_BYTES
+      ? { kind: "stripped", text: "" }
+      : { kind: "complete" };
   }
   if (leading?.activeStart !== undefined) {
     return !hasNamedCandidate && finalize ? { kind: "false-positive" } : { kind: "incomplete" };

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -950,8 +950,12 @@ function consumeJsonSuppressor(
     const end = consumeRemovedLineEnd(rest, optionalClosing.length);
     return { complete: true, suffix: rest.slice(end) };
   }
-  if (suppressor.optionalClosings?.some((marker) => marker.startsWith(rest))) {
-    suppressor.carry = rest;
+  const optionalClosings = suppressor.optionalClosings ?? [];
+  if (optionalClosings.some((marker) => marker.startsWith(rest))) {
+    const maxCarryChars = Math.max(...optionalClosings.map((marker) => marker.length));
+    // Keep bounded leading whitespace with a split optional closer. If the next
+    // chunk disproves the closer, it remains part of the visible suffix.
+    suppressor.carry = text.slice(-maxCarryChars);
     return { complete: false };
   }
   const end = consumeRemovedLineEnd(text, 0);

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1,31 +1,28 @@
-// Tool Call Repair helper module supports stream normalizer behavior.
-import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
-  consumeJsonToolClosingMarker,
+  consumeLineBreak,
   END_TOOL_REQUEST,
-  findBracketedJsonPayloadStart,
-  findHarmonyJsonPayloadStart,
-  findJsonObjectEnd,
-  findXmlishToolCallEnd,
-  isPlainTextToolNameChar,
+  HARMONY_CALL_MARKER,
+  indexOfAsciiMarkerIgnoreCase,
+  isAsciiMarkerPrefixIgnoreCase,
   isXmlishNameChar,
-  matchesLiteralPrefix,
+  skipLineIndentation,
+  skipWhitespace,
+  startsWithAsciiMarkerIgnoreCase,
+  type StructuralLineBreakOptions,
+  utf8ByteLengthWithinLimit,
 } from "./grammar.js";
 import {
-  parseOverCapPlainTextToolCallPrefix,
-  type OverCapPlainTextToolCallPrefix,
+  scanPlainTextToolCall,
+  type PlainTextToolCallNameMatcher,
+  type PlainTextToolCallScan,
 } from "./payload.js";
+import type { PlainTextToolCallMessageProjection } from "./promote.js";
 
-export type PlainTextToolCallNameMatcher = {
-  /** True only when the candidate is a complete tool name this request may repair. */
-  hasExactName(name: string): boolean;
-  /** True while streamed bytes still match at least one repairable tool name prefix. */
-  hasNamePrefix(prefix: string): boolean;
-};
+export type { PlainTextToolCallNameMatcher } from "./payload.js";
 
 /** Result of repairing the final message carried by a provider stream `done` event. */
 export type PlainTextToolCallMessageNormalization =
-  | { kind: "promoted" | "scrubbed"; message: Record<string, unknown> }
+  | (PlainTextToolCallMessageProjection & { kind: "promoted" | "scrubbed" })
   | undefined;
 
 /** Stream-level hooks used to promote leaked text tool calls into provider events. */
@@ -34,1547 +31,1595 @@ export type PlainTextToolCallStreamNormalizerOptions = {
   createPromotedToolCallEvents(message: Record<string, unknown>): Iterable<unknown>;
   /** Tool-name matcher scoped to the exact request being normalized. */
   matcher: PlainTextToolCallNameMatcher;
-  /** Repairs or scrubs the final done-message snapshot after text buffering completes. */
-  normalizeDoneMessage(params: {
+  /** Promotes an eligible terminal snapshot or scrubs every recognized candidate. */
+  normalizeTerminalMessage(params: {
+    allowPromotion: boolean;
     message: unknown;
+    preserveEmptyTextBlocks?: boolean;
     reason: unknown;
   }): PlainTextToolCallMessageNormalization;
   /** Stop after the first normalized done event when the wrapped provider has completed. */
   stopAfterDone?: boolean;
 };
 
-const TEXT_TOOL_CALL_BUFFER_MAX_CHARS = 256_000;
+const MAX_PAYLOAD_BYTES = 256_000;
+const MAX_PENDING_EVENTS = 256;
+const MAX_TOOL_NAME_CHARS = 120;
 
-// Keep a bounded prefix plus enough tail to notice closing markers after the cap;
-// otherwise a huge leaked payload could either grow unbounded or lose the visible suffix.
-const TEXT_TOOL_CALL_SUPPRESSED_SCAN_MAX_CHARS = TEXT_TOOL_CALL_BUFFER_MAX_CHARS + 64_000;
-const TEXT_TOOL_CALL_SUPPRESSED_TAIL_CHARS =
-  TEXT_TOOL_CALL_SUPPRESSED_SCAN_MAX_CHARS - TEXT_TOOL_CALL_BUFFER_MAX_CHARS;
-const TEXT_TOOL_CALL_SUPPRESSED_MARKER_SCAN_CHARS = 2_048;
+type TextRange = { end: number; start: number };
+type StandalonePlainTextToolCallCandidate = {
+  parts: Array<{ contentIndex: number; end: number; start: number }>;
+  text: string;
+};
+type ScannedCallSequence = TextRange & { activeStart?: number; overCap: boolean };
+type XmlSuppressor = { carry: string; kind: "xml"; phase: "body" | "parameter" };
 
-type PlainTextToolCallBufferState = "possible" | "impossible" | "over-cap";
+type JsonSuppressor = {
+  carry: string;
+  depth: number;
+  escaped: boolean;
+  inString: boolean;
+  kind: "json";
+  optionalClosings?: readonly string[];
+  phase: "closing" | "opening" | "payload";
+  requiredClosing?: string;
+};
 
-// Compaction joins a distant tail onto the safe prefix. Preserve that exact boundary so
-// terminal snapshots are scrubbed without inferring it from a UTF-16-shortened buffer length.
-type TextToolCallBuffer =
-  | { kind: "full"; text: string }
-  | { kind: "compacted"; prefixLength: number; text: string };
+type OpeningSuppressor = {
+  allowXml: boolean;
+  carry: string;
+  choice?: JsonSuppressor | XmlSuppressor;
+  json: JsonSuppressor;
+  kind: "opening";
+};
 
-function createFullTextToolCallBuffer(text = ""): TextToolCallBuffer {
-  return { kind: "full", text };
-}
+type OverCapSuppressor = JsonSuppressor | OpeningSuppressor | XmlSuppressor;
+
+type CandidatePendingState = {
+  buffer: string;
+  bufferBytes: number;
+  entryBytes: number;
+  entries?: Record<string, unknown>[];
+  kind: "candidate";
+  nextScanChars: number;
+  parts: StandalonePlainTextToolCallCandidate["parts"];
+  sequenceOverCap: boolean;
+  snapshotOffset: number;
+  template: Record<string, unknown>;
+};
+
+type SuppressingPendingState = {
+  entryBytes: number;
+  entries?: Record<string, unknown>[];
+  kind: "suppressing";
+  suppressor?: OverCapSuppressor;
+};
+
+type PendingState = CandidatePendingState | SuppressingPendingState;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
 
-function couldStillBeJsonPayload(text: string, start: number): boolean {
-  let cursor = start;
-  while (cursor < text.length && /\s/.test(text[cursor] ?? "")) {
-    cursor += 1;
-  }
-  return cursor >= text.length || text[cursor] === "{";
+function eventContentIndex(event: Record<string, unknown>): number {
+  const index = event.contentIndex;
+  return typeof index === "number" && Number.isInteger(index) && index >= 0 ? index : 0;
 }
 
-function couldStillBeXmlishParameterPayload(text: string, start: number): boolean {
-  let cursor = start;
-  while (cursor < text.length && /\s/.test(text[cursor] ?? "")) {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  return matchesLiteralPrefix(text.slice(cursor).toLowerCase(), "<parameter=");
+function isTextStreamEvent(event: Record<string, unknown>): boolean {
+  return event.type === "text_start" || event.type === "text_delta" || event.type === "text_end";
 }
 
-/** True while bytes can still complete a zero-argument `</function>` close. */
-function couldStillBeXmlishFunctionClose(text: string, start: number): boolean {
-  let cursor = start;
-  while (cursor < text.length && /\s/.test(text[cursor] ?? "")) {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  return matchesLiteralPrefix(text.slice(cursor).toLowerCase(), "</function>");
-}
-
-function couldStillBeBracketedStandaloneToolCall(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): boolean {
-  if (!text.startsWith("[")) {
-    return false;
-  }
-
-  const toolPrefix = "[tool:";
-  if (matchesLiteralPrefix(text, toolPrefix)) {
-    if (text.length <= toolPrefix.length) {
-      return true;
-    }
-    let cursor = toolPrefix.length;
-    while (isPlainTextToolNameChar(text[cursor])) {
-      cursor += 1;
-    }
-    const name = text.slice(toolPrefix.length, cursor);
-    if (!name || !matcher.hasNamePrefix(name)) {
-      return false;
-    }
-    if (cursor >= text.length) {
-      return true;
-    }
-    if (text[cursor] !== "]") {
-      return false;
-    }
-    if (!matcher.hasExactName(name)) {
-      return false;
-    }
-    return (
-      couldStillBeJsonPayload(text, cursor + 1) ||
-      couldStillBeXmlishParameterPayload(text, cursor + 1)
-    );
-  }
-
-  let cursor = 1;
-  while (isPlainTextToolNameChar(text[cursor])) {
-    cursor += 1;
-  }
-  const name = text.slice(1, cursor);
-  if (!name || !matcher.hasNamePrefix(name)) {
-    return false;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  if (text[cursor] !== "]") {
-    return false;
-  }
-  if (!matcher.hasExactName(name)) {
-    return false;
-  }
-
-  cursor += 1;
-  while (text[cursor] === " " || text[cursor] === "\t") {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  if (text[cursor] === "\r") {
-    if (cursor + 1 >= text.length) {
-      return true;
-    }
-    const payloadStart = text[cursor + 1] === "\n" ? cursor + 2 : cursor + 1;
-    return (
-      couldStillBeJsonPayload(text, payloadStart) ||
-      couldStillBeXmlishParameterPayload(text, payloadStart)
-    );
-  }
-  if (text[cursor] !== "\n") {
-    return false;
-  }
-  return (
-    couldStillBeJsonPayload(text, cursor + 1) ||
-    couldStillBeXmlishParameterPayload(text, cursor + 1)
-  );
-}
-
-function couldStillBeXmlishFunctionToolCall(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): boolean {
-  const marker = "<function=";
-  const lowerText = text.toLowerCase();
-  if (!matchesLiteralPrefix(lowerText, marker)) {
-    return false;
-  }
-  if (text.length <= marker.length) {
-    return true;
-  }
-
-  let cursor = marker.length;
-  while (isXmlishNameChar(text[cursor])) {
-    cursor += 1;
-  }
-  const name = text.slice(marker.length, cursor);
-  if (!name || !matcher.hasNamePrefix(name)) {
-    return false;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  if (text[cursor] !== ">") {
-    return false;
-  }
-  if (!matcher.hasExactName(name)) {
-    return false;
-  }
-  // Zero-argument XML calls close immediately with </function>; keep buffering
-  // that path instead of treating the close tag as an impossible non-tool suffix.
-  return (
-    couldStillBeXmlishParameterPayload(text, cursor + 1) ||
-    couldStillBeXmlishFunctionClose(text, cursor + 1)
-  );
-}
-
-function couldStillBeHarmonyStandaloneToolCall(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): boolean {
-  const channelMarker = "<|channel|>";
-  let cursor = 0;
-  if (matchesLiteralPrefix(text, channelMarker)) {
-    if (text.length <= channelMarker.length) {
-      return true;
-    }
-    cursor = channelMarker.length;
-  }
-
-  const rest = text.slice(cursor);
-  const channel = ["commentary", "analysis", "final"].find((candidate) =>
-    matchesLiteralPrefix(rest, candidate),
-  );
-  if (!channel) {
-    return false;
-  }
-  if (rest.length <= channel.length) {
-    return true;
-  }
-
-  cursor += channel.length;
-  while (text[cursor] === " " || text[cursor] === "\t") {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-
-  const toMarker = "to=";
-  const toRest = text.slice(cursor);
-  if (!matchesLiteralPrefix(toRest, toMarker)) {
-    return false;
-  }
-  if (toRest.length <= toMarker.length) {
-    return true;
-  }
-
-  cursor += toMarker.length;
-  const nameStart = cursor;
-  while (isPlainTextToolNameChar(text[cursor])) {
-    cursor += 1;
-  }
-  const name = text.slice(nameStart, cursor);
-  if (!name || !matcher.hasNamePrefix(name)) {
-    return false;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-
-  while (text[cursor] === " " || text[cursor] === "\t") {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-  if (!matcher.hasExactName(name)) {
-    return false;
-  }
-
-  const codeMarker = "code";
-  const codeRest = text.slice(cursor);
-  if (!matchesLiteralPrefix(codeRest, codeMarker)) {
-    return false;
-  }
-  if (codeRest.length <= codeMarker.length) {
-    return true;
-  }
-
-  cursor += codeMarker.length;
-  while (cursor < text.length && /\s/.test(text[cursor] ?? "")) {
-    cursor += 1;
-  }
-  if (cursor >= text.length) {
-    return true;
-  }
-
-  const messageMarker = "<|message|>";
-  const messageRest = text.slice(cursor);
-  if (matchesLiteralPrefix(messageRest, messageMarker)) {
-    return true;
-  }
-  return text[cursor] === "{";
-}
-
-function hasExactSerializedToolCallPrefix(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): boolean {
-  const bracketed = /^\[(?:tool:)?([A-Za-z0-9_-]+)\]/.exec(text);
-  if (bracketed?.[1]) {
-    return matcher.hasExactName(bracketed[1]);
-  }
-  const xmlish = /^<function=([A-Za-z0-9_.:-]+)>/i.exec(text);
-  if (xmlish?.[1]) {
-    return matcher.hasExactName(xmlish[1]);
-  }
-  const harmony =
-    /^(?:<\|channel\|>)?(?:commentary|analysis|final)\s+to=([A-Za-z0-9_-]+)\s+code\b/.exec(text);
-  return Boolean(harmony?.[1] && matcher.hasExactName(harmony[1]));
-}
-
-function stripCompleteSerializedToolCallPrefix(
-  text: string,
-  matcher?: PlainTextToolCallNameMatcher,
-): string | null {
-  if (matcher && !hasExactSerializedToolCallPrefix(text, matcher)) {
-    return null;
-  }
-  const xmlishEnd = findXmlishToolCallEnd(text);
-  if (xmlishEnd !== null) {
-    return text.slice(xmlishEnd);
-  }
-  const jsonStart = findBracketedJsonPayloadStart(text) ?? findHarmonyJsonPayloadStart(text);
-  if (jsonStart === null) {
-    return null;
-  }
-  const jsonEnd = findJsonObjectEnd(text, jsonStart);
-  if (jsonEnd === null) {
-    return null;
-  }
-  return text.slice(consumeJsonToolClosingMarker(text, jsonEnd));
-}
-
-function stripSerializedToolCallPrefixes(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): string | null {
-  let current = text;
-  let changed = false;
-  for (let count = 0; count < 32; count += 1) {
-    const next = stripCompleteSerializedToolCallPrefix(current.trimStart(), matcher);
-    if (next === null) {
-      if (changed && hasExactSerializedToolCallPrefix(current.trimStart(), matcher)) {
-        return "";
-      }
-      return changed ? current : null;
-    }
-    changed = true;
-    current = next;
-    if (!current.trim()) {
-      return current;
-    }
-  }
-  return hasExactSerializedToolCallPrefix(current.trimStart(), matcher) ? "" : current;
-}
-
-function getPlainTextToolCallBufferState(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): PlainTextToolCallBufferState {
-  const trimmed = text.trimStart();
-  if (trimmed.length === 0) {
-    return text.length > TEXT_TOOL_CALL_BUFFER_MAX_CHARS ? "impossible" : "possible";
-  }
-  const toolCallLike =
-    couldStillBeBracketedStandaloneToolCall(trimmed, matcher) ||
-    couldStillBeXmlishFunctionToolCall(trimmed, matcher) ||
-    couldStillBeHarmonyStandaloneToolCall(trimmed, matcher);
-  if (!toolCallLike) {
-    return "impossible";
-  }
-  if (text.length <= TEXT_TOOL_CALL_BUFFER_MAX_CHARS) {
-    return "possible";
-  }
-  const textAfterCompleteToolBlocks = stripSerializedToolCallPrefixes(trimmed, matcher);
-  return textAfterCompleteToolBlocks !== null && textAfterCompleteToolBlocks.trim()
-    ? "impossible"
-    : "over-cap";
-}
-
-function getTextToolCallEventText(event: Record<string, unknown>): string | undefined {
-  if (typeof event.delta === "string") {
-    return event.delta;
-  }
-  return typeof event.content === "string" ? event.content : undefined;
-}
-
-function appendTextToolCallBuffer(bufferedText: string, event: Record<string, unknown>): string {
-  const text = getTextToolCallEventText(event);
-  if (text === undefined) {
-    return bufferedText;
-  }
-  if (typeof event.content === "string" && !bufferedText) {
-    return text;
-  }
-  return typeof event.delta === "string" ? bufferedText + text : bufferedText;
-}
-
-function hasSuppressedToolCallClosingMarker(text: string): boolean {
-  if (!text) {
-    return false;
-  }
-  const lowerText = text.toLowerCase();
-  return (
-    lowerText.includes("</parameter>") ||
-    lowerText.includes("</function>") ||
-    text.includes(END_TOOL_REQUEST) ||
-    text.includes("<|call|>") ||
-    text.includes("}") ||
-    /\[\/[A-Za-z0-9_.:-]+\]/.test(text)
-  );
-}
-
-function shouldRescanSuppressedTextToolCallBuffer(
-  previousBufferedText: string,
-  event: Record<string, unknown>,
-): boolean {
-  const eventText = getTextToolCallEventText(event);
-  if (!eventText) {
-    return false;
-  }
-  return hasSuppressedToolCallClosingMarker(
-    previousBufferedText.slice(-TEXT_TOOL_CALL_SUPPRESSED_MARKER_SCAN_CHARS) + eventText,
-  );
-}
-
-function truncateSuppressedTextToolCallBuffer(
-  text: string,
-  previous: TextToolCallBuffer,
-): TextToolCallBuffer {
-  const previousPrefixLength = previous.kind === "compacted" ? previous.prefixLength : undefined;
-  if (text.length <= TEXT_TOOL_CALL_SUPPRESSED_SCAN_MAX_CHARS) {
-    return previousPrefixLength === undefined
-      ? createFullTextToolCallBuffer(text)
-      : { kind: "compacted", prefixLength: previousPrefixLength, text };
-  }
-  const prefix =
-    previousPrefixLength === undefined
-      ? sliceUtf16Safe(text, 0, TEXT_TOOL_CALL_BUFFER_MAX_CHARS)
-      : text.slice(0, previousPrefixLength);
-  return {
-    kind: "compacted",
-    prefixLength: prefix.length,
-    text: prefix + sliceUtf16Safe(text, -TEXT_TOOL_CALL_SUPPRESSED_TAIL_CHARS),
-  };
-}
-
-function appendSuppressedTextToolCallBuffer(
-  buffer: TextToolCallBuffer,
-  event: Record<string, unknown>,
-): { buffer: TextToolCallBuffer; changed: boolean; scanText: string } {
-  const nextText = appendTextToolCallBuffer(buffer.text, event);
-  if (nextText === buffer.text) {
-    return { buffer, changed: false, scanText: buffer.text };
-  }
-  return {
-    buffer: truncateSuppressedTextToolCallBuffer(nextText, buffer),
-    changed: true,
-    scanText: nextText,
-  };
-}
-
-function shouldSuppressBufferedTextBlock(blockText: string, buffer: TextToolCallBuffer): boolean {
-  const normalizedBlock = blockText.trim();
-  const normalizedBuffer = buffer.text.trim();
-  const normalizedSuppressedPrefix =
-    buffer.kind === "compacted" ? buffer.text.slice(0, buffer.prefixLength).trim() : "";
-  return (
-    Boolean(normalizedBlock && normalizedBuffer) &&
-    (normalizedBuffer.startsWith(normalizedBlock) ||
-      normalizedBlock.startsWith(normalizedBuffer) ||
-      (buffer.kind === "compacted" &&
-        Boolean(normalizedSuppressedPrefix) &&
-        normalizedBlock.startsWith(normalizedSuppressedPrefix)))
-  );
-}
-
-function scrubBufferedTextFromContent(
-  content: unknown,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { onlyTextIndex?: unknown; preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  if (Array.isArray(content)) {
-    if (typeof options?.onlyTextIndex === "number") {
-      const block = content[options.onlyTextIndex];
-      const record = asRecord(block);
-      if (
-        record?.type !== "text" ||
-        typeof record.text !== "string" ||
-        !shouldSuppressBufferedTextBlock(record.text, bufferedText)
-      ) {
-        return { changed: false, content };
-      }
-      const nextContent = [...content];
-      if (options.preserveEmptyTextBlocks) {
-        nextContent[options.onlyTextIndex] = { ...record, text: "" };
-      } else {
-        nextContent.splice(options.onlyTextIndex, 1);
-      }
-      return { changed: true, content: nextContent };
-    }
-
-    const overCapPrefix = scrubOverCapTextPrefixFromContent(content, matcher, options);
-    if (overCapPrefix.changed) {
-      return overCapPrefix;
-    }
-
-    let changed = false;
-    const nextContent = content.flatMap((block) => {
-      const record = asRecord(block);
-      if (
-        record?.type === "text" &&
-        typeof record.text === "string" &&
-        shouldSuppressBufferedTextBlock(record.text, bufferedText)
-      ) {
-        changed = true;
-        return options?.preserveEmptyTextBlocks ? [{ ...record, text: "" }] : [];
-      }
-      return [block];
-    });
-    return changed ? { changed, content: nextContent } : { changed: false, content };
-  }
-  if (typeof content === "string" && shouldSuppressBufferedTextBlock(content, bufferedText)) {
-    return { changed: true, content: "" };
-  }
-  return { changed: false, content };
-}
-
-function scrubOverCapTextPrefixFromContent(
-  content: readonly unknown[],
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  let currentContent: readonly unknown[] = content;
-  let changed = false;
-  for (let count = 0; count < 32; count += 1) {
-    const scrubbed = scrubFirstOverCapTextPrefixFromContent(currentContent, matcher, options);
-    if (!scrubbed.changed || !Array.isArray(scrubbed.content)) {
-      return changed ? { changed: true, content: currentContent } : scrubbed;
-    }
-    currentContent = scrubbed.content;
-    changed = true;
-  }
-  return { changed, content: currentContent };
-}
-
-function scrubFirstOverCapTextPrefixFromContent(
-  content: readonly unknown[],
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  const suppressedTextIndexes = new Set<number>();
-  let accumulated = "";
-  let reachedOverCap = false;
-  for (let index = 0; index < content.length; index += 1) {
-    const record = asRecord(content[index]);
-    if (record?.type !== "text" || typeof record.text !== "string") {
-      continue;
-    }
-    if (!record.text.trim()) {
-      continue;
-    }
-    if (!accumulated && !hasExactSerializedToolCallPrefix(record.text.trimStart(), matcher)) {
-      continue;
-    }
-    if (reachedOverCap && hasExactSerializedToolCallPrefix(record.text.trimStart(), matcher)) {
-      break;
-    }
-    if (
-      reachedOverCap &&
-      suppressedTextIndexes.size === 1 &&
-      !hasSuppressedToolCallClosingMarker(record.text)
-    ) {
-      break;
-    }
-
-    accumulated = accumulated ? `${accumulated}\n${record.text}` : record.text;
-    suppressedTextIndexes.add(index);
-
-    const state = getPlainTextToolCallBufferState(accumulated, matcher);
-    const byteOverCapPrefix =
-      state === "possible" && hasSuppressedToolCallClosingMarker(accumulated)
-        ? parseAllowedOverCapPlainTextToolCallPrefix(accumulated, matcher)
-        : null;
-    if (byteOverCapPrefix) {
-      return scrubSuppressedTextIndexesFromContent(
-        content,
-        suppressedTextIndexes,
-        options,
-        byteOverCapPrefix.visibleText,
-        index,
-      );
-    }
-    if (state === "over-cap") {
-      reachedOverCap = true;
-      const strippedSuffix = stripSerializedToolCallPrefixes(accumulated, matcher);
-      if (strippedSuffix !== null) {
-        return scrubSuppressedTextIndexesFromContent(
-          content,
-          suppressedTextIndexes,
-          options,
-          strippedSuffix,
-          index,
-        );
-      }
-      continue;
-    }
-    if (state === "impossible") {
-      if (reachedOverCap) {
-        const strippedSuffix = stripSerializedToolCallPrefixes(accumulated, matcher);
-        if (strippedSuffix !== null) {
-          return scrubSuppressedTextIndexesFromContent(
-            content,
-            suppressedTextIndexes,
-            options,
-            strippedSuffix,
-            index,
-          );
-        }
-        return scrubSuppressedTextIndexesFromContent(content, suppressedTextIndexes, options);
-      }
-      accumulated = "";
-      suppressedTextIndexes.clear();
-      reachedOverCap = false;
-    }
-  }
-  if (reachedOverCap) {
-    return scrubSuppressedTextIndexesFromContent(content, suppressedTextIndexes, options);
-  }
-  return { changed: false, content };
-}
-
-function scrubSuppressedTextIndexesFromContent(
-  content: readonly unknown[],
-  suppressedTextIndexes: ReadonlySet<number>,
-  options?: { preserveEmptyTextBlocks?: boolean },
-  visibleSuffix?: string,
-  visibleSuffixIndex?: number,
-): { changed: boolean; content: unknown } {
-  const nextContent = content.flatMap((block, blockIndex) => {
-    if (!suppressedTextIndexes.has(blockIndex)) {
-      return [block];
-    }
-    const blockRecord = asRecord(block);
-    if (
-      visibleSuffixIndex === blockIndex &&
-      visibleSuffix !== undefined &&
-      visibleSuffix.trim() &&
-      blockRecord
-    ) {
-      return [{ ...blockRecord, text: visibleSuffix }];
-    }
-    return options?.preserveEmptyTextBlocks && blockRecord ? [{ ...blockRecord, text: "" }] : [];
-  });
-  return { changed: true, content: nextContent };
-}
-
-function stripPlainTextToolCallsFromContent(
-  content: unknown,
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  if (Array.isArray(content)) {
-    const textBlocks = content
-      .map((block, index) => ({ index, record: asRecord(block) }))
-      .filter(
-        (entry): entry is { index: number; record: Record<string, unknown> } =>
-          entry.record?.type === "text" && typeof entry.record.text === "string",
-      );
-    const joinedText = textBlocks.map((entry) => String(entry.record.text)).join("\n");
-    if (joinedText.trim()) {
-      const strippedJoined = stripSerializedToolCallPrefixes(joinedText.trim(), matcher);
-      if (strippedJoined !== null && strippedJoined !== joinedText) {
-        const firstTextIndex = textBlocks[0]?.index;
-        const nextContent = content.flatMap((block, index) => {
-          const record = asRecord(block);
-          if (record?.type !== "text" || typeof record.text !== "string") {
-            return [block];
-          }
-          if (options?.preserveEmptyTextBlocks) {
-            return [
-              {
-                ...record,
-                text: index === firstTextIndex && strippedJoined.trim() ? strippedJoined : "",
-              },
-            ];
-          }
-          return index === firstTextIndex && strippedJoined.trim()
-            ? [{ ...record, text: strippedJoined }]
-            : [];
-        });
-        return { changed: true, content: nextContent };
-      }
-    }
-
-    let changed = false;
-    const nextContent: unknown[] = [];
-    for (const block of content) {
-      const record = asRecord(block);
-      if (record?.type !== "text" || typeof record.text !== "string") {
-        nextContent.push(block);
-        continue;
-      }
-      const strippedText = stripSerializedToolCallPrefixes(record.text, matcher);
-      if (strippedText === null || strippedText === record.text) {
-        nextContent.push(block);
-        continue;
-      }
-      changed = true;
-      if (strippedText.trim()) {
-        nextContent.push({ ...record, text: strippedText });
-      } else if (options?.preserveEmptyTextBlocks) {
-        nextContent.push({ ...record, text: "" });
-      }
-    }
-    return changed ? { changed, content: nextContent } : { changed: false, content };
-  }
-  if (typeof content === "string") {
-    const strippedText = stripSerializedToolCallPrefixes(content, matcher);
-    if (strippedText !== null && strippedText !== content) {
-      return { changed: true, content: strippedText };
-    }
-  }
-  return { changed: false, content };
-}
-
-function stripOverCapPlainTextToolCallsFromContent(
-  content: unknown,
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  if (Array.isArray(content)) {
-    let changed = false;
-    const nextContent: unknown[] = [];
-    for (const block of content) {
-      const record = asRecord(block);
-      if (
-        record?.type !== "text" ||
-        typeof record.text !== "string" ||
-        record.text.length <= TEXT_TOOL_CALL_BUFFER_MAX_CHARS
-      ) {
-        nextContent.push(block);
-        continue;
-      }
-      const strippedText = stripSerializedToolCallPrefixes(record.text, matcher);
-      if (strippedText === null || strippedText === record.text) {
-        nextContent.push(block);
-        continue;
-      }
-      changed = true;
-      if (strippedText.trim()) {
-        nextContent.push({ ...record, text: strippedText });
-      } else if (options?.preserveEmptyTextBlocks) {
-        nextContent.push({ ...record, text: "" });
-      }
-    }
-    return changed ? { changed, content: nextContent } : { changed: false, content };
-  }
-  if (typeof content === "string" && content.length > TEXT_TOOL_CALL_BUFFER_MAX_CHARS) {
-    const strippedText = stripSerializedToolCallPrefixes(content, matcher);
-    if (strippedText !== null && strippedText !== content) {
-      return { changed: true, content: strippedText };
-    }
-  }
-  return { changed: false, content };
-}
-
-function scrubPlainTextToolCallContent(
-  content: unknown,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  options?: { onlyTextIndex?: unknown; preserveEmptyTextBlocks?: boolean },
-): { changed: boolean; content: unknown } {
-  const scrubbed = scrubBufferedTextFromContent(content, bufferedText, matcher, options);
-  const stripped =
-    options?.onlyTextIndex === undefined
-      ? stripPlainTextToolCallsFromContent(scrubbed.content, matcher, options)
-      : { changed: false, content: scrubbed.content };
-  return stripped.changed ? stripped : scrubbed;
-}
-
-function shouldPreserveEmptyTextBlocksForEventIndex(
-  content: unknown,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  eventContentIndex: unknown,
-): boolean {
-  if (
-    typeof eventContentIndex !== "number" ||
-    !Number.isInteger(eventContentIndex) ||
-    eventContentIndex < 0 ||
-    !Array.isArray(content)
-  ) {
-    return false;
-  }
-  const currentBlock = content[eventContentIndex];
-  if (currentBlock === undefined) {
-    return false;
-  }
-  const scrubbed = scrubPlainTextToolCallContent(content, bufferedText, matcher);
-  return (
-    scrubbed.changed &&
-    Array.isArray(scrubbed.content) &&
-    scrubbed.content[eventContentIndex] !== currentBlock
-  );
-}
-
-function scrubBufferedTextFromPartial(
-  event: Record<string, unknown>,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  contentIndex?: unknown,
-  options?: { preserveEmptyTextBlocks?: boolean },
-): Record<string, unknown> {
-  const partial = asRecord(event.partial);
-  if (!partial) {
-    return event;
-  }
-  const preserveEmptyTextBlocks =
-    options?.preserveEmptyTextBlocks === true ||
-    shouldPreserveEmptyTextBlocksForEventIndex(
-      partial.content,
-      bufferedText,
-      matcher,
-      event.contentIndex,
-    );
-  const scrubbed = scrubPlainTextToolCallContent(partial.content, bufferedText, matcher, {
-    onlyTextIndex: contentIndex,
-    preserveEmptyTextBlocks,
-  });
-  if (!scrubbed.changed) {
-    return event;
-  }
-  return {
-    ...event,
-    partial: {
-      ...partial,
-      content: scrubbed.content,
-    },
-  };
-}
-
-function scrubBufferedTextFromMessage(
-  event: Record<string, unknown>,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  contentIndex?: unknown,
-): Record<string, unknown> {
-  const message = asRecord(event.message);
-  if (!message) {
-    return event;
-  }
-  const scrubbed = scrubPlainTextToolCallContent(message.content, bufferedText, matcher, {
-    onlyTextIndex: contentIndex,
-  });
-  if (!scrubbed.changed) {
-    return event;
-  }
-  return {
-    ...event,
-    message: {
-      ...message,
-      content: scrubbed.content,
-    },
-  };
-}
-
-function scrubBufferedTextFromError(
-  event: Record<string, unknown>,
-  bufferedText: TextToolCallBuffer,
-  matcher: PlainTextToolCallNameMatcher,
-  contentIndex?: unknown,
-): Record<string, unknown> {
-  const error = asRecord(event.error);
-  if (!error) {
-    return event;
-  }
-  const scrubbed = scrubPlainTextToolCallContent(error.content, bufferedText, matcher, {
-    onlyTextIndex: contentIndex,
-  });
-  if (!scrubbed.changed) {
-    return event;
-  }
-  return {
-    ...event,
-    error: {
-      ...error,
-      content: scrubbed.content,
-    },
-  };
-}
-
-function replaceTextContentWithVisibleSuffix(
-  record: Record<string, unknown>,
-  visibleText: string,
-  contentIndex?: unknown,
-  matcher?: PlainTextToolCallNameMatcher,
-): Record<string, unknown> {
-  if (typeof record.content === "string") {
-    return { ...record, content: visibleText };
-  }
-  if (!Array.isArray(record.content)) {
-    return record;
-  }
-  const originalContent = record.content;
-  if (typeof contentIndex === "number") {
-    const content = originalContent.flatMap((block, index) => {
-      if (index !== contentIndex) {
-        return [block];
-      }
-      const blockRecord = asRecord(block);
-      if (blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
-        return [block];
-      }
-      if (matcher && !hasExactSerializedToolCallPrefix(blockRecord.text.trimStart(), matcher)) {
-        return [block];
-      }
-      return visibleText.trim() ? [{ ...blockRecord, text: visibleText }] : [];
-    });
-    if (matcher && content.every((block, index) => block === originalContent[index])) {
-      return replaceTextContentWithVisibleSuffix(record, visibleText, undefined, matcher);
-    }
-    return { ...record, content };
-  }
-  const textBlockCount = originalContent.filter((block) => {
-    const blockRecord = asRecord(block);
-    return blockRecord?.type === "text" && typeof blockRecord.text === "string";
-  }).length;
-  if (textBlockCount !== 1) {
-    if (!matcher) {
-      return record;
-    }
-    let replaced = false;
-    const content = originalContent.flatMap((block) => {
-      const blockRecord = asRecord(block);
-      if (blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
-        return [block];
-      }
-      if (replaced) {
-        return [block];
-      }
-      if (!hasExactSerializedToolCallPrefix(blockRecord.text.trimStart(), matcher)) {
-        return [block];
-      }
-      replaced = true;
-      return visibleText.trim() ? [{ ...blockRecord, text: visibleText }] : [];
-    });
-    return replaced ? { ...record, content } : record;
-  }
-  let replaced = false;
-  const content = originalContent.flatMap((block) => {
-    const blockRecord = asRecord(block);
-    if (blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
-      return [block];
-    }
-    if (replaced) {
-      return [];
-    }
-    replaced = true;
-    return visibleText.trim() ? [{ ...blockRecord, text: visibleText }] : [];
-  });
-  return { ...record, content };
-}
-
-function scrubReclassifiedMixedTextFromPartial(
-  event: Record<string, unknown>,
-  visibleText: string,
-  contentIndex?: unknown,
-  matcher?: PlainTextToolCallNameMatcher,
-): Record<string, unknown> {
-  const partial = asRecord(event.partial);
-  if (!partial) {
-    return event;
-  }
-  return {
-    ...event,
-    partial: replaceTextContentWithVisibleSuffix(partial, visibleText, contentIndex, matcher),
-  };
-}
-
-function scrubReclassifiedMixedTextFromError(
-  event: Record<string, unknown>,
-  visibleText: string,
-  contentIndex?: unknown,
-  matcher?: PlainTextToolCallNameMatcher,
-): Record<string, unknown> {
-  const error = asRecord(event.error);
-  if (!error) {
-    return event;
-  }
-  return {
-    ...event,
-    error: replaceTextContentWithVisibleSuffix(error, visibleText, contentIndex, matcher),
-  };
-}
-
-function parseAllowedOverCapPlainTextToolCallPrefix(
-  text: string,
-  matcher: PlainTextToolCallNameMatcher,
-): OverCapPlainTextToolCallPrefix | null {
-  if (text.length > TEXT_TOOL_CALL_BUFFER_MAX_CHARS) {
-    return null;
-  }
-  return parseOverCapPlainTextToolCallPrefix(text, {
-    isAllowedName: (name) => matcher.hasExactName(name),
-  });
-}
-
-function replacePlainTextToolCallCandidateWithVisibleText(
-  record: Record<string, unknown>,
-  candidateText: string,
-  visibleText: string,
-): Record<string, unknown> {
-  if (typeof record.content === "string") {
-    return { ...record, content: visibleText };
-  }
-  if (!Array.isArray(record.content)) {
-    return record;
-  }
-  if (!visibleText.trim()) {
-    return {
-      ...record,
-      content: record.content.filter((block) => asRecord(block)?.type !== "text"),
-    };
-  }
-  // Terminal snapshots must preserve the content indexes already emitted by stream events.
-  // Project the recovered suffix back onto the original text blocks instead of collapsing it.
-  const textParts = record.content.flatMap((block) => {
-    const blockRecord = asRecord(block);
-    return blockRecord?.type === "text" && typeof blockRecord.text === "string"
-      ? [blockRecord.text]
-      : [];
-  });
-  const joinedText = textParts.filter((text) => text.trim()).join("");
-  const candidateStart = joinedText.length - joinedText.trimStart().length;
-  const visibleStart = candidateStart + candidateText.length - visibleText.length;
-  const visibleEnd = candidateStart + candidateText.length;
-  let textOffset = 0;
-  const content = record.content.map((block) => {
-    const blockRecord = asRecord(block);
-    if (blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
-      return block;
-    }
-    if (!blockRecord.text.trim()) {
-      return { ...blockRecord, text: "" };
-    }
-    const blockStart = textOffset;
-    textOffset += blockRecord.text.length;
-    const sliceStart = Math.max(blockStart, visibleStart);
-    const sliceEnd = Math.min(textOffset, visibleEnd);
-    return {
-      ...blockRecord,
-      text:
-        sliceStart < sliceEnd
-          ? visibleText.slice(sliceStart - visibleStart, sliceEnd - visibleStart)
-          : "",
-    };
-  });
-  return { ...record, content };
-}
-
-/** Scrubs final messages whose streamed plain-text tool-call prefix exceeded the buffer cap. */
-export function scrubOverCapPlainTextToolCallMessage(params: {
-  candidateText: string | undefined;
-  matcher: PlainTextToolCallNameMatcher;
-  message: unknown;
-}): Record<string, unknown> | undefined {
-  const record = asRecord(params.message);
-  const candidateText = params.candidateText;
-  if (!record || !candidateText) {
+function extractStandaloneCandidate(
+  message: unknown,
+  requireAssistantRole = false,
+): StandalonePlainTextToolCallCandidate | undefined {
+  const record = asRecord(message);
+  if (!record || (requireAssistantRole && record.role !== "assistant")) {
     return undefined;
   }
-  const bufferState = getPlainTextToolCallBufferState(candidateText, params.matcher);
-  // Parser bytes can exceed the limit while the UTF-16 stream buffer stays under its char cap.
-  // Reuse parser classification so marker bytes and per-block budgets remain canonical.
-  const byteOverCapPrefix =
-    bufferState === "possible"
-      ? parseAllowedOverCapPlainTextToolCallPrefix(candidateText, params.matcher)
-      : null;
-  if (bufferState === "impossible") {
-    if (candidateText.length <= TEXT_TOOL_CALL_BUFFER_MAX_CHARS) {
+  if (typeof record.content === "string") {
+    return record.content.trim() ? { text: record.content, parts: [] } : undefined;
+  }
+  if (!Array.isArray(record.content)) {
+    return undefined;
+  }
+  const candidate: StandalonePlainTextToolCallCandidate = { text: "", parts: [] };
+  for (const [contentIndex, block] of record.content.entries()) {
+    const value = asRecord(block);
+    if (!value) {
       return undefined;
     }
-    const visibleText = stripSerializedToolCallPrefixes(candidateText, params.matcher);
-    if (visibleText?.trim() && !Array.isArray(record.content)) {
-      const replaced = replaceTextContentWithVisibleSuffix(
-        record,
-        visibleText,
-        undefined,
-        params.matcher,
-      );
-      if (replaced !== record) {
-        return replaced;
-      }
+    if (value.type !== "text") {
+      continue;
     }
-    if (Array.isArray(record.content)) {
-      const overCap = scrubOverCapTextPrefixFromContent(record.content, params.matcher);
-      const stripped = stripOverCapPlainTextToolCallsFromContent(overCap.content, params.matcher);
-      if (!overCap.changed && !stripped.changed) {
-        return undefined;
-      }
-      return {
-        ...record,
-        content: stripped.changed ? stripped.content : overCap.content,
-      };
+    if (typeof value.text !== "string") {
+      return undefined;
     }
-    return undefined;
+    const start = candidate.text.length;
+    candidate.text += value.text;
+    candidate.parts.push({ contentIndex, start, end: candidate.text.length });
   }
-  if (byteOverCapPrefix) {
-    return replacePlainTextToolCallCandidateWithVisibleText(
-      record,
-      candidateText,
-      byteOverCapPrefix.visibleText,
-    );
+  return candidate.text.trim() ? candidate : undefined;
+}
+
+function scannedCall(scan: PlainTextToolCallScan) {
+  if (scan.kind === "complete") {
+    return {
+      end: scan.end,
+      incomplete: false,
+      overCap: scan.overCap,
+      payloadStart: scan.payloadStart,
+    };
   }
-  if (bufferState !== "over-cap") {
-    return undefined;
+  if (scan.overCap && scan.payloadStart !== undefined) {
+    return {
+      end: scan.kind === "prefix" ? scan.next : scan.at,
+      incomplete: scan.kind === "prefix",
+      overCap: true,
+      payloadStart: scan.payloadStart,
+    };
   }
-  const scrubbed = scrubPlainTextToolCallContent(
-    record.content,
-    createFullTextToolCallBuffer(candidateText),
-    params.matcher,
-  );
+  return null;
+}
+
+function scanHasNamedCandidate(scan: PlainTextToolCallScan): boolean {
+  const branches = [scan.json, scan.xmlish] as Array<{
+    candidate?: { name?: TextRange };
+    name?: TextRange;
+  }>;
+  return branches.some((branch) => {
+    const name = branch.candidate?.name ?? branch.name;
+    return name !== undefined && name.end > name.start;
+  });
+}
+
+function consumeRemovedLineEnd(text: string, end: number): number {
+  const lineBreakStart = skipLineIndentation(text, end);
+  if (lineBreakStart === text.length) {
+    return lineBreakStart;
+  }
+  return consumeLineBreak(text, lineBreakStart) ?? end;
+}
+
+function findUtf8OverCapOffset(text: string, start: number): number | null {
+  let bytes = 0;
+  for (let index = start; index < text.length; ) {
+    const code = text.codePointAt(index) ?? 0;
+    index += code > 0xffff ? 2 : 1;
+    bytes += code <= 0x7f ? 1 : code <= 0x7ff ? 2 : code <= 0xffff ? 3 : 4;
+    if (bytes > MAX_PAYLOAD_BYTES) {
+      return index;
+    }
+  }
+  return null;
+}
+
+function findCallSequences(
+  text: string,
+  matcher: PlainTextToolCallNameMatcher,
+  structuralBoundaries: readonly number[] = [],
+  structuralLineBreaks?: StructuralLineBreakOptions,
+): ScannedCallSequence[] {
+  const sequences: ScannedCallSequence[] = [];
+  const structuralBoundarySet = new Set(structuralBoundaries);
+  let structuralBoundaryIndex = 0;
+  let index = 0;
+  while (index < text.length) {
+    const lineStart =
+      index === 0 ||
+      text[index - 1] === "\n" ||
+      text[index - 1] === "\r" ||
+      structuralBoundarySet.has(index);
+    if (!lineStart) {
+      index += 1;
+      continue;
+    }
+    const sequenceStart = index;
+    let callStart = skipLineIndentation(text, index);
+    let sequenceEnd = callStart;
+    let hasOverCap = false;
+    let activeStart: number | undefined;
+    let callCount = 0;
+    const first = scanPlainTextToolCall(text, callStart, {
+      matcher,
+      maxPayloadBytes: MAX_PAYLOAD_BYTES,
+      structuralLineBreaks,
+    });
+    let call = scannedCall(first);
+    if (!call && first.kind === "prefix" && scanHasNamedCandidate(first)) {
+      activeStart = callStart;
+      callCount = 1;
+      sequenceEnd = text.length;
+    }
+    while (call && callStart < text.length) {
+      if (call.incomplete && call.overCap) {
+        const overCapOffset = findUtf8OverCapOffset(text, call.payloadStart);
+        while (
+          structuralBoundaryIndex < structuralBoundaries.length &&
+          (structuralBoundaries[structuralBoundaryIndex] ?? 0) < (overCapOffset ?? Infinity)
+        ) {
+          structuralBoundaryIndex += 1;
+        }
+        let boundary: number | undefined;
+        while (structuralBoundaryIndex < structuralBoundaries.length) {
+          const offset = structuralBoundaries[structuralBoundaryIndex];
+          structuralBoundaryIndex += 1;
+          const boundaryScan =
+            offset === undefined
+              ? undefined
+              : scanPlainTextToolCall(text, skipLineIndentation(text, offset), {
+                  matcher,
+                  maxPayloadBytes: MAX_PAYLOAD_BYTES,
+                  structuralLineBreaks,
+                });
+          if (boundaryScan && scannedCall(boundaryScan)) {
+            boundary = offset;
+            break;
+          }
+        }
+        if (boundary !== undefined) {
+          call.end = boundary;
+          call.incomplete = false;
+        }
+      }
+      callCount += 1;
+      hasOverCap ||= call.overCap;
+      sequenceEnd = consumeRemovedLineEnd(text, call.end);
+      if (call.incomplete) {
+        activeStart = callStart;
+        break;
+      }
+      const nextStart = skipWhitespace(text, call.end);
+      if (nextStart >= text.length) {
+        break;
+      }
+      const nextScan = scanPlainTextToolCall(text, nextStart, {
+        matcher,
+        maxPayloadBytes: MAX_PAYLOAD_BYTES,
+        structuralLineBreaks,
+      });
+      const next = scannedCall(nextScan);
+      if (!next) {
+        if (nextScan.kind === "prefix" && scanHasNamedCandidate(nextScan)) {
+          activeStart = nextStart;
+          sequenceEnd = text.length;
+        }
+        break;
+      }
+      callStart = nextStart;
+      call = next;
+    }
+    if (callCount > 0) {
+      const aggregateOverCap =
+        utf8ByteLengthWithinLimit(text, sequenceStart, sequenceEnd, MAX_PAYLOAD_BYTES) === null;
+      sequences.push({
+        start: sequenceStart,
+        end: sequenceEnd,
+        ...(activeStart === undefined ? {} : { activeStart }),
+        overCap: hasOverCap || aggregateOverCap,
+      });
+      index = Math.max(sequenceEnd, index + 1);
+      continue;
+    }
+    index = Math.max(index + 1, first.next);
+  }
+  return sequences;
+}
+
+function createCandidateScanView(candidate: StandalonePlainTextToolCallCandidate) {
+  const boundaries = candidate.parts.slice(1).map((part) => part.start);
   return {
-    ...record,
-    content: scrubbed.content,
+    boundaries,
+    text: candidate.text,
+    ...(boundaries.length > 0
+      ? { structuralLineBreaks: { lineBreakOffsets: new Set(boundaries) } }
+      : {}),
   };
 }
 
-function createScrubbedTextDeltaEvent(
-  event: Record<string, unknown>,
+function findCandidateCallSequences(
+  candidate: StandalonePlainTextToolCallCandidate,
+  matcher: PlainTextToolCallNameMatcher,
+): ScannedCallSequence[] {
+  const view = createCandidateScanView(candidate);
+  return findCallSequences(view.text, matcher, view.boundaries, view.structuralLineBreaks);
+}
+
+function createRangeRemover(ranges: readonly TextRange[]) {
+  let rangeIndex = 0;
+  return (text: string, offset = 0): string => {
+    let result = "";
+    let cursor = 0;
+    const endOffset = offset + text.length;
+    while ((ranges[rangeIndex]?.end ?? Infinity) <= offset) {
+      rangeIndex += 1;
+    }
+    for (
+      let range = ranges[rangeIndex];
+      range && range.start < endOffset;
+      range = ranges[rangeIndex]
+    ) {
+      const start = Math.max(0, range.start - offset);
+      const end = Math.min(text.length, range.end - offset);
+      if (end > start) {
+        result += text.slice(cursor, Math.max(cursor, start));
+        cursor = Math.max(cursor, end);
+      }
+      if (range.end > endOffset) {
+        break;
+      }
+      rangeIndex += 1;
+    }
+    return cursor ? result + text.slice(cursor) : text;
+  };
+}
+
+function projectRangesOntoMessage(
+  record: Record<string, unknown>,
+  candidate: StandalonePlainTextToolCallCandidate,
+  ranges: readonly TextRange[],
+  preserveEmptyTextBlocks: boolean,
+): PlainTextToolCallMessageProjection {
+  const removeRanges = createRangeRemover(ranges);
+  if (typeof record.content === "string") {
+    return {
+      message: { ...record, content: removeRanges(record.content) },
+      sourceToProjectedContentIndex: new Map([[0, 0]]),
+    };
+  }
+  if (!Array.isArray(record.content)) {
+    return { message: record, sourceToProjectedContentIndex: new Map() };
+  }
+  const parts = new Map(candidate.parts.map((part) => [part.contentIndex, part]));
+  const content: unknown[] = [];
+  const sourceToProjectedContentIndex = new Map<number, number>();
+  for (const [index, block] of record.content.entries()) {
+    const part = parts.get(index);
+    const blockRecord = asRecord(block);
+    if (!part || blockRecord?.type !== "text" || typeof blockRecord.text !== "string") {
+      sourceToProjectedContentIndex.set(index, content.length);
+      content.push(block);
+      continue;
+    }
+    const text = removeRanges(blockRecord.text, part.start);
+    if (text || preserveEmptyTextBlocks) {
+      sourceToProjectedContentIndex.set(index, content.length);
+      content.push({ ...blockRecord, text });
+    }
+  }
+  return { message: { ...record, content }, sourceToProjectedContentIndex };
+}
+
+/** Scrubs unsafe or mixed calls and maps each retained source content block. */
+export function projectScrubbedPlainTextToolCallMessage(params: {
+  forceIncompleteCandidates?: boolean;
+  forceKnownCandidates?: boolean;
+  matcher: PlainTextToolCallNameMatcher;
+  message: unknown;
+  preserveEmptyTextBlocks?: boolean;
+  requireAssistantRole?: boolean;
+}): PlainTextToolCallMessageProjection | undefined {
+  const record = asRecord(params.message);
+  const candidate = extractStandaloneCandidate(
+    params.message,
+    params.requireAssistantRole === true,
+  );
+  if (!record || !candidate) {
+    return undefined;
+  }
+  const sequences = findCandidateCallSequences(candidate, params.matcher);
+  const visibleOutsideCalls = Boolean(createRangeRemover(sequences)(candidate.text).trim());
+  const ranges = sequences.filter(
+    (sequence) =>
+      params.forceKnownCandidates ||
+      sequence.overCap ||
+      visibleOutsideCalls ||
+      (params.forceIncompleteCandidates && sequence.activeStart !== undefined),
+  );
+  return ranges.length > 0
+    ? projectRangesOntoMessage(record, candidate, ranges, params.preserveEmptyTextBlocks === true)
+    : undefined;
+}
+
+function findPotentialCallStart(
   text: string,
-  options?: {
-    bufferedText: TextToolCallBuffer;
-    matcher: PlainTextToolCallNameMatcher;
-  },
+  atLineStart: boolean,
+  matcher: PlainTextToolCallNameMatcher,
+): number | null {
+  for (let index = 0; index < text.length; ) {
+    const lineStart =
+      (index === 0 && atLineStart) || text[index - 1] === "\n" || text[index - 1] === "\r";
+    if (!lineStart) {
+      index += 1;
+      continue;
+    }
+    const start = skipLineIndentation(text, index);
+    const scan = scanPlainTextToolCall(text, start, {
+      matcher,
+      maxPayloadBytes: MAX_PAYLOAD_BYTES,
+    });
+    if (scan.kind === "prefix" || scannedCall(scan)) {
+      return index;
+    }
+    index = Math.max(index + 1, scan.next);
+  }
+  return null;
+}
+
+function nextAtLineStart(previous: boolean, text: string): boolean {
+  if (!text) {
+    return previous;
+  }
+  return text.endsWith("\n") || text.endsWith("\r");
+}
+
+function eventTemplate(event: Record<string, unknown>): Record<string, unknown> {
+  const template = { ...event };
+  delete template.content;
+  delete template.delta;
+  delete template.partial;
+  return template;
+}
+
+function createSyntheticTextDelta(
+  template: Record<string, unknown>,
+  text: string,
+  partial?: Record<string, unknown>,
 ): Record<string, unknown> {
-  const scrubbedEvent = options
-    ? scrubBufferedTextFromPartial(event, options.bufferedText, options.matcher, undefined, {
-        preserveEmptyTextBlocks: true,
-      })
-    : event;
-  const partial = asRecord(scrubbedEvent.partial);
-  const syntheticContent =
-    typeof scrubbedEvent.contentIndex === "number"
-      ? Array.from({ length: scrubbedEvent.contentIndex + 1 }, (_, index) => ({
-          type: "text",
-          text: index === scrubbedEvent.contentIndex ? text : "",
-        }))
-      : [{ type: "text", text }];
-  const scrubbedPartial = partial
-    ? replaceTextContentWithVisibleSuffix(partial, text, scrubbedEvent.contentIndex)
-    : { role: "assistant", content: syntheticContent };
-  const eventWithoutTextEndContent = { ...scrubbedEvent };
-  delete eventWithoutTextEndContent.content;
+  const event = eventTemplate(template);
   return {
-    ...eventWithoutTextEndContent,
+    ...event,
     type: "text_delta",
     delta: text,
-    partial: scrubbedPartial,
+    ...(partial ? { partial } : {}),
   };
 }
 
-function appendReclassifiedVisibleDelta(
-  visibleText: string,
-  event: Record<string, unknown>,
-): string {
-  return typeof event.delta === "string" ? `${visibleText}${event.delta}` : visibleText;
-}
-
-function isAllowedTextToolCallLikeEvent(
-  event: Record<string, unknown>,
-  matcher: PlainTextToolCallNameMatcher,
-): boolean {
-  const text = getTextToolCallEventText(event);
-  return Boolean(text?.trim() && getPlainTextToolCallBufferState(text, matcher) !== "impossible");
-}
-
-function isBufferedTextEvent(bufferedEvent: unknown): boolean {
-  const bufferedRecord = asRecord(bufferedEvent);
-  const bufferedType = typeof bufferedRecord?.type === "string" ? bufferedRecord.type : "";
+function cappedUtf8ByteLength(text: string): number {
   return (
-    bufferedType === "text_start" || bufferedType === "text_delta" || bufferedType === "text_end"
+    utf8ByteLengthWithinLimit(text, 0, text.length, MAX_PAYLOAD_BYTES) ?? MAX_PAYLOAD_BYTES + 1
   );
 }
 
-/** Buffers provider stream text long enough to promote or hide leaked plain-text tool calls. */
+function pendingEventBytes(record: Record<string, unknown>): number {
+  const delta = typeof record.delta === "string" ? cappedUtf8ByteLength(record.delta) : 0;
+  const content = typeof record.content === "string" ? cappedUtf8ByteLength(record.content) : 0;
+  return Math.min(MAX_PAYLOAD_BYTES + 1, delta + content);
+}
+
+function pendingQueueOverCap(pending: CandidatePendingState | SuppressingPendingState): boolean {
+  return (
+    pending.entryBytes > MAX_PAYLOAD_BYTES || (pending.entries?.length ?? 0) > MAX_PENDING_EVENTS
+  );
+}
+
+function createPendingState(
+  record: Record<string, unknown>,
+  text: string,
+  heldStart?: Record<string, unknown>,
+  sequenceOverCap = false,
+  snapshotOffset = 0,
+): CandidatePendingState {
+  const entries = [...(heldStart ? [{ ...heldStart }] : []), { ...record }];
+  return {
+    buffer: text,
+    bufferBytes: cappedUtf8ByteLength(text),
+    entries,
+    entryBytes: entries.reduce((total, entry) => {
+      return Math.min(MAX_PAYLOAD_BYTES + 1, total + pendingEventBytes(entry));
+    }, 0),
+    kind: "candidate",
+    nextScanChars: 256,
+    parts: [
+      {
+        contentIndex: eventContentIndex(record),
+        start: 0,
+        end: text.length,
+      },
+    ],
+    sequenceOverCap,
+    snapshotOffset,
+    template: eventTemplate(record),
+  };
+}
+
+function queuePendingEvent(
+  pending: CandidatePendingState | SuppressingPendingState,
+  record: Record<string, unknown>,
+): void {
+  if (!pending.entries) {
+    return;
+  }
+  const event = { ...record };
+  pending.entryBytes = Math.min(
+    MAX_PAYLOAD_BYTES + 1,
+    pending.entryBytes + pendingEventBytes(event),
+  );
+  const previous = pending.entries.at(-1);
+  const canMerge =
+    typeof previous?.delta === "string" &&
+    typeof event.delta === "string" &&
+    previous.type === event.type &&
+    eventContentIndex(previous) === eventContentIndex(event);
+  if (!canMerge || !previous) {
+    pending.entries.push(event);
+    return;
+  }
+  previous.delta = (previous.delta as string) + (event.delta as string);
+  if (Object.hasOwn(event, "partial")) {
+    previous.partial = event.partial;
+  }
+}
+
+function appendPendingText(
+  pending: CandidatePendingState,
+  text: string,
+  record: Record<string, unknown>,
+): void {
+  queuePendingEvent(pending, record);
+  if (text) {
+    const start = pending.buffer.length;
+    const high = pending.buffer.charCodeAt(pending.buffer.length - 1);
+    const low = text.charCodeAt(0);
+    const joinedPair = high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+    pending.bufferBytes = Math.min(
+      MAX_PAYLOAD_BYTES + 1,
+      pending.bufferBytes + cappedUtf8ByteLength(text) - (joinedPair ? 2 : 0),
+    );
+    pending.buffer += text;
+    const contentIndex = eventContentIndex(record);
+    const previous = pending.parts.at(-1);
+    if (previous?.contentIndex === contentIndex) {
+      previous.end = pending.buffer.length;
+    } else {
+      pending.parts.push({ contentIndex, start, end: pending.buffer.length });
+    }
+  }
+  pending.template = eventTemplate(record);
+}
+
+function replayFalsePositiveCandidate(pending: CandidatePendingState): Record<string, unknown>[] {
+  return pending.entries ?? [createSyntheticTextDelta(pending.template, pending.buffer)];
+}
+
+function projectPendingAuxEvents(
+  pending: CandidatePendingState | SuppressingPendingState,
+  projection?: PlainTextToolCallMessageProjection,
+  projectPartial?: (message: unknown) => PlainTextToolCallMessageProjection | undefined,
+  retainedTextContentIndex?: number,
+): Record<string, unknown>[] {
+  return (pending.entries ?? []).flatMap((event) => {
+    if (isTextStreamEvent(event)) {
+      if (event.type !== "text_start" || eventContentIndex(event) !== retainedTextContentIndex) {
+        return [];
+      }
+    }
+    let eventProjection = projection ?? projectPartial?.(event.partial);
+    const projectedEvent = { ...event };
+    if (eventProjection && typeof event.contentIndex === "number") {
+      let contentIndex = eventProjection.sourceToProjectedContentIndex.get(event.contentIndex);
+      if (contentIndex === undefined && projection) {
+        const partialProjection = projectPartial?.(event.partial);
+        const partialContentIndex = partialProjection?.sourceToProjectedContentIndex.get(
+          event.contentIndex,
+        );
+        if (partialProjection && partialContentIndex !== undefined) {
+          eventProjection = partialProjection;
+          contentIndex = partialContentIndex;
+        }
+      }
+      if (contentIndex === undefined) {
+        return [];
+      }
+      projectedEvent.contentIndex = contentIndex;
+    }
+    if (Object.hasOwn(projectedEvent, "partial")) {
+      if (eventProjection) {
+        projectedEvent.partial = eventProjection.message;
+      }
+    }
+    return [projectedEvent];
+  });
+}
+
+function projectEventIndex(
+  event: Record<string, unknown>,
+  projection: PlainTextToolCallMessageProjection,
+): Record<string, unknown> | undefined {
+  if (typeof event.contentIndex !== "number") {
+    return event;
+  }
+  const contentIndex = projection.sourceToProjectedContentIndex.get(event.contentIndex);
+  return contentIndex === undefined ? undefined : { ...event, contentIndex };
+}
+
+function projectedTextForEvent(
+  event: Record<string, unknown>,
+  projection: PlainTextToolCallMessageProjection,
+): string | undefined {
+  const content = asRecord(projection.message)?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  const projectedIndex = projection.sourceToProjectedContentIndex.get(eventContentIndex(event));
+  const block =
+    Array.isArray(content) && projectedIndex !== undefined
+      ? asRecord(content[projectedIndex])
+      : undefined;
+  return block?.type === "text" && typeof block.text === "string" ? block.text : undefined;
+}
+
+type PendingClassification =
+  | { kind: "complete" }
+  | { kind: "false-positive" }
+  | { kind: "incomplete" }
+  | { kind: "stripped"; text: string }
+  | { kind: "suppress"; suppressor: OverCapSuppressor }
+  | { candidate: StandalonePlainTextToolCallCandidate; kind: "trim" };
+
+const XML_PARAMETER_CLOSE = "</parameter>";
+const XML_FUNCTION_CLOSE = "</function>";
+const XML_PARAMETER_OPEN = "<parameter=";
+
+function createOverCapSuppressor(
+  candidate: StandalonePlainTextToolCallCandidate,
+  matcher: PlainTextToolCallNameMatcher,
+  force = false,
+): OverCapSuppressor | undefined {
+  const view = createCandidateScanView(candidate);
+  const start = skipLineIndentation(view.text, 0);
+  const scan = scanPlainTextToolCall(view.text, start, {
+    matcher,
+    maxPayloadBytes: MAX_PAYLOAD_BYTES,
+    structuralLineBreaks: view.structuralLineBreaks,
+  });
+  const { json, matches, xmlish } = scan;
+  const value =
+    json.kind === "prefix" ? json.candidate : json.kind === "complete" ? json : undefined;
+  const state =
+    value?.json ??
+    (json.kind === "complete" ? { depth: 0, escaped: false, inString: false } : undefined);
+  const name = value ? view.text.slice(value.name.start, value.name.end) : "";
+  const jsonSuppressor: JsonSuppressor | undefined = value
+    ? {
+        kind: "json",
+        carry:
+          value.payload && state?.depth === 0
+            ? view.text.slice(skipWhitespace(view.text, value.payload.end))
+            : "",
+        depth: state?.depth ?? 0,
+        escaped: state?.escaped ?? false,
+        inString: state?.inString ?? false,
+        phase: !value.payload ? "opening" : state?.depth === 0 ? "closing" : "payload",
+        ...(value.syntax === "named-bracket"
+          ? { requiredClosing: `[/${name}]` }
+          : { optionalClosings: [HARMONY_CALL_MARKER, END_TOOL_REQUEST, `[/${name}]`] }),
+      }
+    : undefined;
+  if (force && jsonSuppressor && value?.nameComplete === true && !value.payload && matches.json) {
+    return {
+      allowXml: xmlish.kind === "prefix" && matches.xmlish,
+      carry: "",
+      json: jsonSuppressor,
+      kind: "opening",
+    };
+  }
+  if (
+    xmlish.kind === "prefix" &&
+    matches.xmlish &&
+    xmlish.candidate?.payload &&
+    (force ||
+      utf8ByteLengthWithinLimit(
+        view.text,
+        xmlish.candidate.payload.start,
+        xmlish.candidate.payload.end,
+        MAX_PAYLOAD_BYTES,
+      ) === null)
+  ) {
+    const phase = xmlish.candidate.activeParameterOpenEnd === undefined ? "body" : "parameter";
+    const markers =
+      phase === "parameter" ? [XML_PARAMETER_CLOSE] : [XML_PARAMETER_OPEN, XML_FUNCTION_CLOSE];
+    const markerStart = view.text.lastIndexOf("<");
+    const carry =
+      markerStart !== -1 &&
+      markers.some((marker) => isAsciiMarkerPrefixIgnoreCase(view.text, markerStart, marker))
+        ? view.text.slice(markerStart)
+        : "";
+    return {
+      kind: "xml",
+      carry,
+      phase,
+    };
+  }
+  if (
+    !value ||
+    !jsonSuppressor ||
+    (!value.nameComplete && !value.payload) ||
+    !matches.json ||
+    (!state && !force) ||
+    (!value.payload && !force) ||
+    (!force &&
+      value.payload &&
+      utf8ByteLengthWithinLimit(
+        view.text,
+        value.payload.start,
+        value.payload.end,
+        MAX_PAYLOAD_BYTES,
+      ) !== null)
+  ) {
+    return undefined;
+  }
+  return jsonSuppressor;
+}
+
+function classifyPending(
+  pending: CandidatePendingState,
+  matcher: PlainTextToolCallNameMatcher,
+  finalize = false,
+): PendingClassification {
+  const candidate = { text: pending.buffer, parts: pending.parts };
+  const view = createCandidateScanView(candidate);
+  const terminalScan = scanPlainTextToolCall(view.text, skipLineIndentation(view.text, 0), {
+    matcher,
+    maxPayloadBytes: MAX_PAYLOAD_BYTES,
+    structuralLineBreaks: view.structuralLineBreaks,
+  });
+  const hasNamedCandidate = scanHasNamedCandidate(terminalScan);
+  const sequences = findCandidateCallSequences(candidate, matcher);
+  const overCapRanges = sequences.filter(({ overCap }) => overCap);
+  const leading = sequences[0]?.start === 0 ? sequences[0] : undefined;
+  if (leading?.activeStart !== undefined && (pending.sequenceOverCap || overCapRanges.length > 0)) {
+    const activeCandidate = {
+      text: candidate.text.slice(leading.activeStart),
+      parts: candidate.parts
+        .filter((part) => part.end > (leading.activeStart ?? 0))
+        .map((part) => ({
+          contentIndex: part.contentIndex,
+          start: Math.max(0, part.start - (leading.activeStart ?? 0)),
+          end: part.end - (leading.activeStart ?? 0),
+        })),
+    };
+    const suppressor = createOverCapSuppressor(activeCandidate, matcher, true);
+    if (suppressor) {
+      return { kind: "suppress", suppressor };
+    }
+    if (leading.activeStart > 0) {
+      return { kind: "trim", candidate: activeCandidate };
+    }
+  }
+  if (overCapRanges.length > 0) {
+    const text = createRangeRemover(overCapRanges)(candidate.text);
+    const suppressor = text ? undefined : createOverCapSuppressor(candidate, matcher);
+    return suppressor ? { kind: "suppress", suppressor } : { kind: "stripped", text };
+  }
+  if (
+    leading &&
+    leading.activeStart === undefined &&
+    skipWhitespace(candidate.text, leading.end) < candidate.text.length
+  ) {
+    return { kind: "stripped", text: createRangeRemover([leading])(candidate.text) };
+  }
+  if (leading && leading.activeStart === undefined) {
+    return pending.sequenceOverCap ? { kind: "stripped", text: "" } : { kind: "complete" };
+  }
+  if (leading?.activeStart !== undefined) {
+    return !hasNamedCandidate && finalize ? { kind: "false-positive" } : { kind: "incomplete" };
+  }
+  if (
+    terminalScan.kind === "prefix" &&
+    !hasNamedCandidate &&
+    pending.bufferBytes > MAX_PAYLOAD_BYTES
+  ) {
+    return { kind: "false-positive" };
+  }
+  if (terminalScan.kind === "prefix" && (!finalize || hasNamedCandidate)) {
+    return { kind: "incomplete" };
+  }
+  return pending.sequenceOverCap
+    ? { kind: "stripped", text: candidate.text }
+    : { kind: "false-positive" };
+}
+
+function consumeXmlSuppressor(
+  suppressor: XmlSuppressor,
+  chunk: string,
+): { complete: false } | { complete: true; suffix: string } {
+  const text = suppressor.carry + chunk;
+  suppressor.carry = "";
+  let cursor = 0;
+  while (true) {
+    if (suppressor.phase === "parameter") {
+      const close = indexOfAsciiMarkerIgnoreCase(text, XML_PARAMETER_CLOSE, cursor);
+      if (close === -1) {
+        suppressor.carry = text.slice(-(XML_PARAMETER_CLOSE.length - 1));
+        return { complete: false };
+      }
+      cursor = close + XML_PARAMETER_CLOSE.length;
+      suppressor.phase = "body";
+    }
+    const markerStart = skipWhitespace(text, cursor);
+    if (markerStart === text.length) {
+      return { complete: false };
+    }
+    if (startsWithAsciiMarkerIgnoreCase(text, markerStart, XML_FUNCTION_CLOSE)) {
+      const end = consumeRemovedLineEnd(text, markerStart + XML_FUNCTION_CLOSE.length);
+      return { complete: true, suffix: text.slice(end) };
+    }
+    const markerPrefix =
+      isAsciiMarkerPrefixIgnoreCase(text, markerStart, XML_FUNCTION_CLOSE) ||
+      isAsciiMarkerPrefixIgnoreCase(text, markerStart, XML_PARAMETER_OPEN);
+    if (markerPrefix) {
+      suppressor.carry = text.slice(markerStart);
+      return { complete: false };
+    }
+    if (startsWithAsciiMarkerIgnoreCase(text, markerStart, XML_PARAMETER_OPEN)) {
+      const restLength = text.length - markerStart;
+      const close = text.indexOf(">", markerStart + XML_PARAMETER_OPEN.length);
+      if (close === -1 && restLength <= XML_PARAMETER_OPEN.length + 120) {
+        suppressor.carry = text.slice(markerStart);
+        return { complete: false };
+      }
+      if (close === -1) {
+        return { complete: true, suffix: text.slice(markerStart) };
+      }
+      const name = text.slice(markerStart + XML_PARAMETER_OPEN.length, close);
+      if (
+        !name ||
+        name.length > MAX_TOOL_NAME_CHARS ||
+        [...name].some((character) => !isXmlishNameChar(character))
+      ) {
+        return { complete: true, suffix: text.slice(markerStart) };
+      }
+      suppressor.phase = "parameter";
+      cursor = close + 1;
+      continue;
+    }
+    return { complete: true, suffix: text.slice(markerStart) };
+  }
+}
+
+function consumeJsonSuppressor(
+  suppressor: JsonSuppressor,
+  chunk: string,
+): { complete: false } | { complete: true; suffix: string } {
+  let text = suppressor.carry + chunk;
+  suppressor.carry = "";
+  let cursor = 0;
+  if (suppressor.phase === "opening") {
+    cursor = skipWhitespace(text, cursor);
+    if (cursor === text.length) {
+      return { complete: false };
+    }
+    if (text[cursor] !== "{") {
+      return { complete: true, suffix: text.slice(cursor) };
+    }
+    suppressor.depth = 1;
+    suppressor.phase = "payload";
+    cursor += 1;
+  }
+  if (suppressor.phase === "payload") {
+    for (; cursor < text.length; cursor += 1) {
+      const char = text[cursor];
+      if (suppressor.inString) {
+        if (suppressor.escaped) {
+          suppressor.escaped = false;
+        } else if (char === "\\") {
+          suppressor.escaped = true;
+        } else if (char === '"') {
+          suppressor.inString = false;
+        }
+        continue;
+      }
+      if (char === '"') {
+        suppressor.inString = true;
+      } else if (char === "{") {
+        suppressor.depth += 1;
+      } else if (char === "}") {
+        suppressor.depth -= 1;
+        if (suppressor.depth === 0) {
+          suppressor.phase = "closing";
+          cursor += 1;
+          break;
+        }
+      }
+    }
+    if (suppressor.phase === "payload") {
+      return { complete: false };
+    }
+    text = text.slice(cursor);
+  }
+
+  const markerStart = skipWhitespace(text, 0);
+  const rest = text.slice(markerStart);
+  if (suppressor.requiredClosing) {
+    const markers = [suppressor.requiredClosing, END_TOOL_REQUEST];
+    const closing = markers.find((marker) => rest.startsWith(marker));
+    if (closing) {
+      const end = consumeRemovedLineEnd(rest, closing.length);
+      return { complete: true, suffix: rest.slice(end) };
+    }
+    if (markers.some((marker) => marker.startsWith(rest))) {
+      suppressor.carry = rest;
+      return { complete: false };
+    }
+    return { complete: true, suffix: rest };
+  }
+  const optionalClosing = suppressor.optionalClosings?.find((marker) => rest.startsWith(marker));
+  if (optionalClosing) {
+    const end = consumeRemovedLineEnd(rest, optionalClosing.length);
+    return { complete: true, suffix: rest.slice(end) };
+  }
+  if (suppressor.optionalClosings?.some((marker) => marker.startsWith(rest))) {
+    suppressor.carry = rest;
+    return { complete: false };
+  }
+  const end = consumeRemovedLineEnd(text, 0);
+  return { complete: true, suffix: text.slice(end) };
+}
+
+function consumeOpeningSuppressor(
+  suppressor: OpeningSuppressor,
+  chunk: string,
+): { complete: false } | { complete: true; suffix: string } {
+  if (suppressor.choice) {
+    return suppressor.choice.kind === "xml"
+      ? consumeXmlSuppressor(suppressor.choice, chunk)
+      : consumeJsonSuppressor(suppressor.choice, chunk);
+  }
+  const text = suppressor.carry + chunk;
+  suppressor.carry = "";
+  const start = skipWhitespace(text, 0);
+  if (start === text.length) {
+    return { complete: false };
+  }
+  const rest = text.slice(start);
+  if (rest[0] === "{") {
+    suppressor.choice = suppressor.json;
+    return consumeJsonSuppressor(suppressor.choice, rest);
+  }
+  if (suppressor.allowXml) {
+    if (isAsciiMarkerPrefixIgnoreCase(rest, 0, XML_PARAMETER_OPEN)) {
+      suppressor.carry = rest;
+      return { complete: false };
+    }
+    if (startsWithAsciiMarkerIgnoreCase(rest, 0, XML_PARAMETER_OPEN)) {
+      suppressor.choice = { carry: "", kind: "xml", phase: "body" };
+      return consumeXmlSuppressor(suppressor.choice, rest);
+    }
+  }
+  return { complete: true, suffix: rest };
+}
+
+function consumeOverCapSuppressor(
+  suppressor: OverCapSuppressor,
+  chunk: string,
+): { complete: false } | { complete: true; suffix: string } {
+  return suppressor.kind === "xml"
+    ? consumeXmlSuppressor(suppressor, chunk)
+    : suppressor.kind === "json"
+      ? consumeJsonSuppressor(suppressor, chunk)
+      : consumeOpeningSuppressor(suppressor, chunk);
+}
+
+function orderByContentIndex(
+  events: readonly unknown[],
+  message: Record<string, unknown>,
+): unknown[] {
+  const contentLength = Array.isArray(message.content) ? message.content.length : 0;
+  const order = (event: unknown) => {
+    const index = asRecord(event)?.contentIndex;
+    return typeof index === "number" &&
+      Number.isInteger(index) &&
+      index >= 0 &&
+      index < contentLength
+      ? index
+      : contentLength;
+  };
+  return events.toSorted((left, right) => order(left) - order(right));
+}
+
+/** Coordinates bounded candidate buffering; terminal snapshots remain the source of truth. */
 export async function* normalizePlainTextToolCallStreamEvents(
   source: AsyncIterable<unknown>,
   options: PlainTextToolCallStreamNormalizerOptions,
 ): AsyncGenerator {
-  const bufferedEvents: unknown[] = [];
-  let bufferedText = createFullTextToolCallBuffer();
-  let suppressingOverCapTextToolCall = false;
-  let suppressedTextContentIndex: unknown;
-  let hasSuppressedTextContentIndex = false;
-  let scrubAllSuppressedTextContentIndexes = false;
-  let reclassifiedMixedTextContentIndex: unknown;
-  let hasReclassifiedMixedTextContentIndex = false;
-  let scrubReclassifiedMixedTextFromDone = false;
-  let reclassifiedMixedVisibleText: string | undefined;
+  let pending: PendingState | undefined;
+  let overCapSequenceOpen = false;
+  let scrubFuturePartials = false;
+  let forceScrubTerminal = false;
+  let sawStreamStart = false;
+  let preserveTerminalContentIndexes = false;
+  const heldTextStarts = new Map<string, Record<string, unknown>>();
+  const lineStarts = new Map<string, boolean>();
+  const emittedTextUnits = new Map<string, number>();
 
-  const suppressedTextContentIndexForScrub = () =>
-    hasSuppressedTextContentIndex && !scrubAllSuppressedTextContentIndexes
-      ? suppressedTextContentIndex
+  const scrubSnapshot = (
+    value: unknown,
+    preserveEmptyTextBlocks = false,
+    forceKnownCandidates = false,
+  ) => {
+    const forced = forceKnownCandidates
+      ? projectScrubbedPlainTextToolCallMessage({
+          forceKnownCandidates: true,
+          matcher: options.matcher,
+          message: value,
+          preserveEmptyTextBlocks,
+        })
       : undefined;
-
-  const flushBufferedEvents = () => {
-    const events = bufferedEvents.splice(0);
-    bufferedText = createFullTextToolCallBuffer();
-    return events;
+    if (forced) {
+      return forced;
+    }
+    const normalized = options.normalizeTerminalMessage({
+      allowPromotion: false,
+      message: value,
+      preserveEmptyTextBlocks,
+      reason: "error",
+    });
+    return normalized?.kind === "scrubbed" ? normalized : undefined;
   };
-
-  function* flushScrubbedBufferedNonTextEvents(resetBufferedText: boolean) {
-    const events = bufferedEvents.splice(0);
-    const textToScrub = bufferedText;
-    if (resetBufferedText) {
-      bufferedText = createFullTextToolCallBuffer();
+  const eventKey = (record: Record<string, unknown>) => String(eventContentIndex(record));
+  const sanitizeEventPartial = (
+    record: Record<string, unknown>,
+    forceKnownCandidates = false,
+  ): Record<string, unknown> | undefined => {
+    if (record.partial === undefined) {
+      return record;
     }
-    for (const bufferedEvent of events) {
-      if (isBufferedTextEvent(bufferedEvent)) {
+    const projection = scrubSnapshot(record.partial, true, forceKnownCandidates);
+    if (!projection) {
+      return record;
+    }
+    const projected = projectEventIndex(record, projection);
+    return projected ? { ...projected, partial: projection.message } : undefined;
+  };
+  const forceProjectPendingAux = (
+    candidate: CandidatePendingState | SuppressingPendingState,
+    projection?: PlainTextToolCallMessageProjection,
+    retainedTextContentIndex?: number,
+  ) =>
+    projectPendingAuxEvents(
+      candidate,
+      projection,
+      (message) => scrubSnapshot(message, true, true),
+      retainedTextContentIndex,
+    );
+
+  async function* normalizeEvents() {
+    for await (const sourceEvent of source) {
+      let record = asRecord(sourceEvent);
+      if (!record) {
+        yield sourceEvent;
         continue;
       }
-      const bufferedRecord = asRecord(bufferedEvent);
-      yield bufferedRecord
-        ? scrubBufferedTextFromPartial(
-            bufferedRecord,
-            textToScrub,
-            options.matcher,
-            suppressedTextContentIndexForScrub(),
-            { preserveEmptyTextBlocks: suppressingOverCapTextToolCall },
-          )
-        : bufferedEvent;
-    }
-  }
-
-  function* suppressBufferedTextEvents() {
-    suppressingOverCapTextToolCall = true;
-    yield* flushScrubbedBufferedNonTextEvents(false);
-  }
-
-  for await (const event of source) {
-    const record = asRecord(event);
-    if (!record) {
-      yield event;
-      continue;
-    }
-    const type = typeof record.type === "string" ? record.type : "";
-    if (type === "text_start" || type === "text_delta" || type === "text_end") {
+      const type = typeof record.type === "string" ? record.type : "";
+      sawStreamStart ||= type === "start";
       if (
-        type === "text_end" &&
-        hasReclassifiedMixedTextContentIndex &&
-        record.contentIndex === reclassifiedMixedTextContentIndex
+        scrubFuturePartials &&
+        !pending &&
+        type !== "done" &&
+        type !== "error" &&
+        record.partial !== undefined
       ) {
-        continue;
-      }
-      if (
-        scrubReclassifiedMixedTextFromDone &&
-        reclassifiedMixedVisibleText !== undefined &&
-        hasReclassifiedMixedTextContentIndex &&
-        record.contentIndex === reclassifiedMixedTextContentIndex
-      ) {
-        reclassifiedMixedVisibleText = appendReclassifiedVisibleDelta(
-          reclassifiedMixedVisibleText,
-          record,
-        );
-        yield scrubReclassifiedMixedTextFromPartial(
-          record,
-          reclassifiedMixedVisibleText,
-          reclassifiedMixedTextContentIndex,
-          options.matcher,
-        );
-        continue;
-      }
-      if (suppressingOverCapTextToolCall) {
-        // Once the tentative tool call exceeds the cap, suppress text deltas until a closing
-        // marker proves whether the buffered prefix was a hidden call or mixed visible text.
-        if (hasSuppressedTextContentIndex && record.contentIndex !== suppressedTextContentIndex) {
-          if (isAllowedTextToolCallLikeEvent(record, options.matcher)) {
-            continue;
-          }
-          yield scrubBufferedTextFromPartial(
-            record,
-            bufferedText,
-            options.matcher,
-            suppressedTextContentIndexForScrub(),
-            { preserveEmptyTextBlocks: true },
-          );
+        const projection = scrubSnapshot(record.partial, true, true);
+        const projectedEvent = projection ? projectEventIndex(record, projection) : record;
+        if (!projectedEvent) {
           continue;
         }
-        const previousBufferedText = bufferedText.text;
-        const appended = appendSuppressedTextToolCallBuffer(bufferedText, record);
-        bufferedText = appended.buffer;
-        const shouldRescan =
-          appended.changed &&
-          shouldRescanSuppressedTextToolCallBuffer(previousBufferedText, record);
-        const bufferState = shouldRescan
-          ? getPlainTextToolCallBufferState(appended.scanText, options.matcher)
-          : "over-cap";
-        const byteOverCapPrefix =
-          bufferState === "possible" && hasSuppressedToolCallClosingMarker(appended.scanText)
-            ? parseAllowedOverCapPlainTextToolCallPrefix(appended.scanText, options.matcher)
-            : null;
-        if (byteOverCapPrefix?.visibleText.trim()) {
-          const reclassifiedBufferedText = bufferedText;
-          yield* flushScrubbedBufferedNonTextEvents(true);
-          suppressingOverCapTextToolCall = false;
-          suppressedTextContentIndex = undefined;
-          hasSuppressedTextContentIndex = false;
-          scrubAllSuppressedTextContentIndexes = false;
-          reclassifiedMixedTextContentIndex = record.contentIndex;
-          hasReclassifiedMixedTextContentIndex = true;
-          scrubReclassifiedMixedTextFromDone = true;
-          reclassifiedMixedVisibleText = byteOverCapPrefix.visibleText;
-          yield createScrubbedTextDeltaEvent(record, byteOverCapPrefix.visibleText, {
-            bufferedText: reclassifiedBufferedText,
-            matcher: options.matcher,
-          });
-        } else if (bufferState === "impossible") {
-          const visibleText =
-            stripSerializedToolCallPrefixes(appended.scanText, options.matcher) ?? "";
-          yield* flushScrubbedBufferedNonTextEvents(true);
-          suppressingOverCapTextToolCall = false;
-          suppressedTextContentIndex = undefined;
-          hasSuppressedTextContentIndex = false;
-          scrubAllSuppressedTextContentIndexes = false;
-          reclassifiedMixedTextContentIndex = record.contentIndex;
-          hasReclassifiedMixedTextContentIndex = true;
-          scrubReclassifiedMixedTextFromDone = true;
-          reclassifiedMixedVisibleText = visibleText;
-          if (visibleText.trim()) {
-            yield createScrubbedTextDeltaEvent(record, visibleText);
-          }
-        }
-        continue;
+        record = projection
+          ? { ...projectedEvent, partial: projection.message }
+          : (sanitizeEventPartial(projectedEvent, true) ?? projectedEvent);
       }
-      bufferedEvents.push(event);
-      bufferedText = createFullTextToolCallBuffer(
-        appendTextToolCallBuffer(bufferedText.text, record),
-      );
-      const scanBufferedText = truncateSuppressedTextToolCallBuffer(
-        bufferedText.text,
-        bufferedText,
-      );
-      const scanWasTruncated = scanBufferedText.kind === "compacted";
-      const bufferState = getPlainTextToolCallBufferState(scanBufferedText.text, options.matcher);
-      const byteOverCapPrefix =
-        bufferState === "possible" && hasSuppressedToolCallClosingMarker(bufferedText.text)
-          ? parseAllowedOverCapPlainTextToolCallPrefix(bufferedText.text, options.matcher)
-          : null;
-      if (byteOverCapPrefix) {
-        if (byteOverCapPrefix.visibleText.trim()) {
-          // Byte-sized payloads can cross the parser cap before the UTF-16 stream cap. Once a
-          // complete prefix proves that case, expose only its visible suffix like the char path.
-          const reclassifiedBufferedText = bufferedText;
-          yield* flushScrubbedBufferedNonTextEvents(true);
-          reclassifiedMixedTextContentIndex = record.contentIndex;
-          hasReclassifiedMixedTextContentIndex = true;
-          scrubReclassifiedMixedTextFromDone = true;
-          reclassifiedMixedVisibleText = byteOverCapPrefix.visibleText;
-          yield createScrubbedTextDeltaEvent(record, byteOverCapPrefix.visibleText, {
-            bufferedText: reclassifiedBufferedText,
-            matcher: options.matcher,
-          });
-        } else {
-          bufferedText = scanBufferedText;
-          suppressedTextContentIndex = record.contentIndex;
-          hasSuppressedTextContentIndex = true;
-          scrubAllSuppressedTextContentIndexes = true;
-          yield* suppressBufferedTextEvents();
-        }
-      } else if (bufferState === "impossible") {
-        const visibleText =
-          !scanWasTruncated && bufferedText.text.length > TEXT_TOOL_CALL_BUFFER_MAX_CHARS
-            ? stripSerializedToolCallPrefixes(bufferedText.text.trimStart(), options.matcher)
-            : null;
-        if (visibleText?.trim()) {
-          // A tool-call prefix followed by visible text must be reclassified: emit only the
-          // suffix now, then scrub the final done/error snapshots to match that stream history.
-          yield* flushScrubbedBufferedNonTextEvents(true);
-          reclassifiedMixedTextContentIndex = record.contentIndex;
-          hasReclassifiedMixedTextContentIndex = true;
-          scrubReclassifiedMixedTextFromDone = true;
-          reclassifiedMixedVisibleText = visibleText;
-          yield createScrubbedTextDeltaEvent(record, visibleText);
-        } else if (
-          scanWasTruncated &&
-          stripSerializedToolCallPrefixes(scanBufferedText.text.trimStart(), options.matcher) !==
-            null
-        ) {
-          bufferedText = scanBufferedText;
-          suppressedTextContentIndex = record.contentIndex;
-          hasSuppressedTextContentIndex = true;
-          scrubAllSuppressedTextContentIndexes = false;
-          yield* suppressBufferedTextEvents();
-        } else {
-          yield* flushBufferedEvents();
-        }
-      } else if (bufferState === "over-cap") {
-        bufferedText = scanBufferedText;
-        suppressedTextContentIndex = record.contentIndex;
-        hasSuppressedTextContentIndex = true;
-        scrubAllSuppressedTextContentIndexes = false;
-        yield* suppressBufferedTextEvents();
-      }
-      continue;
-    }
 
-    if (type === "done") {
-      const normalizedMessage = options.normalizeDoneMessage({
-        message: record.message,
-        reason: record.reason,
-      });
-      if (normalizedMessage?.kind === "promoted") {
-        yield* flushScrubbedBufferedNonTextEvents(true);
-        suppressingOverCapTextToolCall = false;
-        suppressedTextContentIndex = undefined;
-        hasSuppressedTextContentIndex = false;
-        scrubAllSuppressedTextContentIndexes = false;
-        scrubReclassifiedMixedTextFromDone = false;
-        reclassifiedMixedTextContentIndex = undefined;
-        hasReclassifiedMixedTextContentIndex = false;
-        reclassifiedMixedVisibleText = undefined;
-        yield* options.createPromotedToolCallEvents(normalizedMessage.message);
-        yield { ...record, reason: "toolUse", message: normalizedMessage.message };
-        if (options.stopAfterDone) {
-          return;
+      if (type === "text_start" || type === "text_delta" || type === "text_end") {
+        const text =
+          typeof record.delta === "string"
+            ? record.delta
+            : typeof record.content === "string"
+              ? record.content
+              : undefined;
+        const key = eventKey(record);
+        if (type === "text_start" && (text === undefined || text === "") && !pending) {
+          const previous = heldTextStarts.get(key);
+          if (previous) {
+            yield previous;
+          }
+          heldTextStarts.set(key, record);
+          continue;
+        }
+
+        if (text === undefined) {
+          if (pending?.kind === "candidate") {
+            queuePendingEvent(pending, record);
+          } else if (!pending) {
+            const held = heldTextStarts.get(key);
+            if (held) {
+              yield held;
+              heldTextStarts.delete(key);
+            }
+            yield record;
+          }
+          continue;
+        }
+
+        let incoming = text;
+        let incomingRecord = record;
+        const closesText = type === "text_end";
+        let authoritative = closesText;
+        let sequenceOverCap = false;
+        while (true) {
+          if (pending?.kind === "suppressing") {
+            if (closesText) {
+              const projection = scrubSnapshot(
+                record.partial ?? { role: "assistant", content: incoming },
+                true,
+                true,
+              );
+              yield* forceProjectPendingAux(pending, projection);
+              const projectedText = projection && projectedTextForEvent(record, projection);
+              const novelText = projectedText?.slice(emittedTextUnits.get(key) ?? 0);
+              if (novelText) {
+                yield createSyntheticTextDelta(record, novelText, projection.message);
+              }
+              pending = undefined;
+              scrubFuturePartials = true;
+              break;
+            }
+            if (!pending.suppressor) {
+              const projection = scrubSnapshot(record.partial, true, true);
+              yield* forceProjectPendingAux(pending, projection);
+              pending = undefined;
+              continue;
+            }
+            const consumed = consumeOverCapSuppressor(pending.suppressor, incoming);
+            if (!consumed.complete) {
+              break;
+            }
+            scrubFuturePartials = true;
+            overCapSequenceOpen = true;
+            const partialProjection = scrubSnapshot(record.partial, true, true);
+            const partial = partialProjection?.message;
+            yield* forceProjectPendingAux(pending, partialProjection);
+            incoming = consumed.suffix;
+            sequenceOverCap = true;
+            if (!incoming) {
+              pending = { entryBytes: 0, kind: "suppressing" };
+              break;
+            }
+            pending = undefined;
+            incomingRecord = {
+              ...eventTemplate(record),
+              type: "text_delta",
+              delta: incoming,
+              ...(partial ? { partial } : {}),
+            };
+            authoritative = false;
+          }
+
+          if (!pending) {
+            const atLineStart =
+              authoritative ||
+              sequenceOverCap ||
+              overCapSequenceOpen ||
+              (lineStarts.get(key) ?? true);
+            const callStart = findPotentialCallStart(incoming, atLineStart, options.matcher);
+            if (callStart === null) {
+              const held = heldTextStarts.get(key);
+              if (held) {
+                yield held;
+                heldTextStarts.delete(key);
+              }
+              yield incomingRecord;
+              if (incoming) {
+                const continuesScrubbedSequence = overCapSequenceOpen;
+                overCapSequenceOpen = false;
+                const contentIndex = eventContentIndex(incomingRecord);
+                preserveTerminalContentIndexes ||=
+                  (sequenceOverCap || continuesScrubbedSequence) && contentIndex > 0;
+              }
+              lineStarts.set(key, nextAtLineStart(atLineStart, incoming));
+              break;
+            }
+            const visiblePrefix = incoming.slice(0, callStart);
+            const emittedUnits = emittedTextUnits.get(key) ?? 0;
+            const emittedPrefixUnits = authoritative ? emittedUnits : 0;
+            const novelVisiblePrefix = visiblePrefix.slice(emittedPrefixUnits);
+            if (novelVisiblePrefix) {
+              const held = heldTextStarts.get(key);
+              if (held) {
+                yield held;
+                heldTextStarts.delete(key);
+              }
+              const visibleProjection = scrubSnapshot(incomingRecord.partial, true, true);
+              const visibleTemplate = visibleProjection
+                ? projectEventIndex(incomingRecord, visibleProjection)
+                : incomingRecord;
+              if (visibleTemplate) {
+                yield createSyntheticTextDelta(
+                  visibleTemplate,
+                  novelVisiblePrefix,
+                  asRecord(visibleProjection?.message),
+                );
+              }
+            }
+            const candidateText = incoming.slice(callStart);
+            const candidateRecord =
+              typeof incomingRecord.delta === "string"
+                ? { ...incomingRecord, delta: candidateText }
+                : authoritative
+                  ? incomingRecord
+                  : { ...incomingRecord, content: candidateText };
+            const held = heldTextStarts.get(key);
+            heldTextStarts.delete(key);
+            pending = createPendingState(
+              candidateRecord,
+              candidateText,
+              held,
+              sequenceOverCap || overCapSequenceOpen,
+              authoritative ? callStart : emittedUnits + callStart,
+            );
+            overCapSequenceOpen = false;
+          } else if (pending.kind === "candidate") {
+            if (authoritative) {
+              const contentIndex = eventContentIndex(incomingRecord);
+              const partIndex = pending.parts.findLastIndex(
+                (part) => part.contentIndex === contentIndex,
+              );
+              const part = pending.parts[partIndex];
+              if (part) {
+                const blockOffset = part.start === 0 ? pending.snapshotOffset : 0;
+                const blockText = incoming.slice(blockOffset);
+                const previousLength = part.end - part.start;
+                const lengthDelta = blockText.length - previousLength;
+                const candidateText =
+                  pending.buffer.slice(0, part.start) + blockText + pending.buffer.slice(part.end);
+                const retained = pending.entries?.filter(
+                  (event) => !isTextStreamEvent(event) || event.type === "text_start",
+                );
+                pending.buffer = candidateText;
+                pending.bufferBytes = cappedUtf8ByteLength(candidateText);
+                pending.entries = [
+                  ...(retained ?? []),
+                  createSyntheticTextDelta(
+                    pending.template,
+                    candidateText,
+                    asRecord(record.partial),
+                  ),
+                  { ...incomingRecord, content: incoming },
+                ];
+                pending.parts = pending.parts.map((entry, index) =>
+                  index < partIndex
+                    ? entry
+                    : index === partIndex
+                      ? { ...entry, end: entry.start + blockText.length }
+                      : {
+                          ...entry,
+                          start: entry.start + lengthDelta,
+                          end: entry.end + lengthDelta,
+                        },
+                );
+                if (part.start === 0) {
+                  pending.snapshotOffset = 0;
+                }
+                pending.template = eventTemplate(incomingRecord);
+              } else {
+                // A text_end snapshot is authoritative for its own content block. Carry a
+                // newly observed block into classification or visible text can vanish at EOF.
+                appendPendingText(pending, incoming, incomingRecord);
+              }
+            } else {
+              appendPendingText(pending, incoming, incomingRecord);
+            }
+            if (!incoming && !authoritative) {
+              break;
+            }
+          }
+
+          if (pending.kind !== "candidate") {
+            break;
+          }
+          const shouldClassify =
+            authoritative ||
+            pending.bufferBytes > MAX_PAYLOAD_BYTES ||
+            pending.buffer.length <= 256 ||
+            pending.buffer.length >= pending.nextScanChars;
+          if (!shouldClassify) {
+            break;
+          }
+          const classification = classifyPending(pending, options.matcher);
+          pending.nextScanChars = Math.max(pending.buffer.length + 1, pending.nextScanChars * 2);
+          if (classification.kind === "complete" || classification.kind === "incomplete") {
+            break;
+          }
+          if (classification.kind === "trim") {
+            scrubFuturePartials = true;
+            const partialProjection = scrubSnapshot(record.partial, true, true);
+            yield* forceProjectPendingAux(pending, partialProjection);
+            const candidate = classification.candidate;
+            pending.buffer = candidate.text;
+            pending.bufferBytes = cappedUtf8ByteLength(candidate.text);
+            pending.entries = undefined;
+            pending.entryBytes = 0;
+            pending.nextScanChars = 256;
+            pending.parts = candidate.parts;
+            pending.sequenceOverCap = true;
+            pending.snapshotOffset = 0;
+            pending.template = {
+              ...pending.template,
+              contentIndex: candidate.parts[0]?.contentIndex ?? pending.template.contentIndex,
+            };
+            break;
+          }
+          if (classification.kind === "suppress") {
+            const entries = pending.entries?.filter((event) => !isTextStreamEvent(event));
+            scrubFuturePartials = true;
+            pending = {
+              entries,
+              entryBytes:
+                entries?.reduce((total, entry) => {
+                  return Math.min(MAX_PAYLOAD_BYTES + 1, total + pendingEventBytes(entry));
+                }, 0) ?? 0,
+              kind: "suppressing",
+              suppressor: classification.suppressor,
+            };
+            break;
+          }
+          if (classification.kind === "false-positive") {
+            yield* replayFalsePositiveCandidate(pending);
+            const replayText = pending.buffer;
+            pending = undefined;
+            if (replayText) {
+              overCapSequenceOpen = false;
+              lineStarts.set(key, nextAtLineStart(lineStarts.get(key) ?? true, replayText));
+            }
+            break;
+          }
+
+          scrubFuturePartials = true;
+          const partialProjection = scrubSnapshot(record.partial, true, true);
+          const authoritativeProjection =
+            partialProjection ??
+            (authoritative
+              ? scrubSnapshot({ role: "assistant", content: pending.buffer }, true, true)
+              : undefined);
+          const projectedText =
+            authoritativeProjection &&
+            projectedTextForEvent(pending.template, authoritativeProjection);
+          const sanitizedText = projectedText ?? classification.text;
+          overCapSequenceOpen = sanitizedText.length === 0;
+          const outputProjection = partialProjection;
+          const contentIndex = eventContentIndex(pending.template);
+          const partial =
+            outputProjection?.message ??
+            (contentIndex === 0
+              ? { role: "assistant", content: [{ type: "text", text: sanitizedText }] }
+              : undefined);
+          yield* forceProjectPendingAux(
+            pending,
+            outputProjection,
+            sanitizedText ? contentIndex : undefined,
+          );
+          // Provider text deltas append to the cumulative text_end snapshot. Count UTF-16
+          // units so slicing uses the same offsets without retaining streamed text.
+          const emittedUnits = emittedTextUnits.get(key) ?? 0;
+          const novelOffset = projectedText
+            ? emittedUnits
+            : authoritative
+              ? Math.max(0, emittedUnits - pending.snapshotOffset)
+              : 0;
+          const novelText = sanitizedText.slice(novelOffset);
+          preserveTerminalContentIndexes ||= sanitizedText.length > 0 && contentIndex > 0;
+          if (novelText) {
+            yield createSyntheticTextDelta(pending.template, novelText, partial);
+          }
+          lineStarts.set(key, nextAtLineStart(lineStarts.get(key) ?? true, sanitizedText));
+          pending = undefined;
+          break;
+        }
+        if (closesText) {
+          emittedTextUnits.delete(key);
         }
         continue;
       }
-      if (normalizedMessage?.kind === "scrubbed") {
-        yield* flushScrubbedBufferedNonTextEvents(true);
-        suppressingOverCapTextToolCall = false;
-        suppressedTextContentIndex = undefined;
-        hasSuppressedTextContentIndex = false;
-        scrubAllSuppressedTextContentIndexes = false;
-        scrubReclassifiedMixedTextFromDone = false;
-        reclassifiedMixedTextContentIndex = undefined;
-        hasReclassifiedMixedTextContentIndex = false;
-        reclassifiedMixedVisibleText = undefined;
-        yield { ...record, message: normalizedMessage.message };
-        if (options.stopAfterDone) {
-          return;
-        }
-        continue;
-      }
-      const mixedMessageRecord = scrubReclassifiedMixedTextFromDone
-        ? asRecord(record.message)
-        : undefined;
-      const strippedMixedMessage =
-        mixedMessageRecord && reclassifiedMixedVisibleText !== undefined
-          ? replaceTextContentWithVisibleSuffix(
-              mixedMessageRecord,
-              reclassifiedMixedVisibleText,
-              hasReclassifiedMixedTextContentIndex ? reclassifiedMixedTextContentIndex : undefined,
-              options.matcher,
-            )
+
+      if (type === "done") {
+        // Keep a later visible suffix at the content index used by its streamed delta.
+        const requestedNormalization = options.normalizeTerminalMessage({
+          allowPromotion: record.reason === "stop" || record.reason === "toolUse",
+          message: record.message,
+          preserveEmptyTextBlocks: preserveTerminalContentIndexes,
+          reason: record.reason,
+        });
+        const forcedProjection = forceScrubTerminal
+          ? scrubSnapshot(record.message, preserveTerminalContentIndexes, true)
           : undefined;
-      if (strippedMixedMessage) {
-        yield* flushScrubbedBufferedNonTextEvents(true);
-        scrubReclassifiedMixedTextFromDone = false;
-        reclassifiedMixedTextContentIndex = undefined;
-        hasReclassifiedMixedTextContentIndex = false;
-        reclassifiedMixedVisibleText = undefined;
-        yield { ...record, message: strippedMixedMessage };
+        const terminalCandidate = requestedNormalization
+          ? undefined
+          : extractStandaloneCandidate(record.message, false);
+        const terminalHasIncompleteCandidate =
+          terminalCandidate &&
+          findCandidateCallSequences(terminalCandidate, options.matcher).some(
+            (sequence) => sequence.activeStart !== undefined,
+          );
+        const terminalCandidateProjection = terminalHasIncompleteCandidate
+          ? scrubSnapshot(record.message, preserveTerminalContentIndexes, true)
+          : undefined;
+        const normalized = forcedProjection
+          ? ({ kind: "scrubbed", ...forcedProjection } as const)
+          : forceScrubTerminal
+            ? undefined
+            : (requestedNormalization ??
+              (terminalCandidateProjection
+                ? ({ kind: "scrubbed", ...terminalCandidateProjection } as const)
+                : undefined));
+        if (normalized?.kind === "promoted") {
+          if (!sawStreamStart) {
+            yield { type: "start", partial: { role: "assistant", content: [] } };
+            sawStreamStart = true;
+          }
+          const promoted = [...options.createPromotedToolCallEvents(normalized.message)];
+          const auxiliary =
+            pending?.kind === "candidate" ? forceProjectPendingAux(pending, normalized) : [];
+          yield* orderByContentIndex([...promoted, ...auxiliary], normalized.message);
+          yield { ...record, reason: "toolUse", message: normalized.message };
+        } else if (normalized?.kind === "scrubbed") {
+          if (pending?.kind === "candidate") {
+            const classification = classifyPending(pending, options.matcher, true);
+            if (classification.kind === "stripped" && classification.text) {
+              const template = projectEventIndex(pending.template, normalized);
+              if (template) {
+                const projectedText = projectedTextForEvent(pending.template, normalized);
+                const sanitizedText = projectedText ?? classification.text;
+                const emittedUnits = emittedTextUnits.get(eventKey(pending.template)) ?? 0;
+                const novelText = sanitizedText.slice(projectedText ? emittedUnits : 0);
+                if (novelText) {
+                  yield createSyntheticTextDelta(template, novelText, normalized.message);
+                }
+              }
+            }
+            yield* forceProjectPendingAux(pending, normalized);
+          } else if (pending?.kind === "suppressing") {
+            yield* forceProjectPendingAux(pending, normalized);
+          }
+          yield { ...record, message: normalized.message };
+        } else {
+          let message = record.message;
+          if (pending?.kind === "candidate") {
+            const classification = classifyPending(pending, options.matcher, true);
+            if (classification.kind === "false-positive") {
+              yield* replayFalsePositiveCandidate(pending);
+            } else {
+              const projection = scrubSnapshot(record.message, true, true);
+              yield* forceProjectPendingAux(pending, projection);
+              message = projection?.message ?? message;
+            }
+          } else if (pending?.kind === "suppressing") {
+            const projection = scrubSnapshot(record.message, true, true);
+            yield* forceProjectPendingAux(pending, projection);
+            message = projection?.message ?? message;
+          }
+          yield message === record.message ? record : { ...record, message };
+        }
+        pending = undefined;
+        forceScrubTerminal = false;
+        heldTextStarts.clear();
+        emittedTextUnits.clear();
         if (options.stopAfterDone) {
           return;
         }
         continue;
       }
-      if (suppressingOverCapTextToolCall) {
-        const scrubbedDoneEvent = scrubBufferedTextFromMessage(
-          record,
-          bufferedText,
-          options.matcher,
-          suppressedTextContentIndexForScrub(),
+
+      if (type === "error") {
+        const knownCandidate =
+          pending?.kind === "suppressing" ||
+          (pending?.kind === "candidate" &&
+            classifyPending(pending, options.matcher, true).kind !== "false-positive");
+        if (pending?.kind === "candidate" && !knownCandidate) {
+          yield* replayFalsePositiveCandidate(pending);
+        }
+        const streamedPartial = scrubSnapshot(record.partial, true, knownCandidate);
+        const streamedError = scrubSnapshot(
+          record.error,
+          preserveTerminalContentIndexes,
+          knownCandidate,
         );
-        yield* flushScrubbedBufferedNonTextEvents(true);
-        suppressingOverCapTextToolCall = false;
-        suppressedTextContentIndex = undefined;
-        hasSuppressedTextContentIndex = false;
-        scrubAllSuppressedTextContentIndexes = false;
-        scrubReclassifiedMixedTextFromDone = false;
-        reclassifiedMixedTextContentIndex = undefined;
-        hasReclassifiedMixedTextContentIndex = false;
-        reclassifiedMixedVisibleText = undefined;
-        yield scrubbedDoneEvent;
-        if (options.stopAfterDone) {
-          return;
+        const projection = streamedPartial ?? streamedError;
+        if (pending?.kind === "candidate" && knownCandidate) {
+          yield* forceProjectPendingAux(pending, projection);
+        } else if (pending?.kind === "suppressing") {
+          yield* forceProjectPendingAux(pending, projection);
         }
-        continue;
-      }
-      yield* flushBufferedEvents();
-      yield event;
-      if (options.stopAfterDone) {
+        yield {
+          ...record,
+          ...(streamedPartial ? { partial: streamedPartial.message } : {}),
+          ...(streamedError ? { error: streamedError.message } : {}),
+        };
         return;
       }
-      continue;
-    }
 
-    if (type === "error") {
-      if (!suppressingOverCapTextToolCall) {
-        yield* flushBufferedEvents();
+      if (pending?.kind === "suppressing") {
+        if (!pending.entries) {
+          const sanitized = sanitizeEventPartial(record, true);
+          if (sanitized) {
+            yield sanitized;
+          }
+          continue;
+        }
+        queuePendingEvent(pending, record);
+        if (pendingQueueOverCap(pending)) {
+          forceScrubTerminal = true;
+          if (!sawStreamStart) {
+            yield { type: "start", partial: { role: "assistant", content: [] } };
+            sawStreamStart = true;
+          }
+          yield* forceProjectPendingAux(pending);
+          pending.entries = undefined;
+          pending.entryBytes = 0;
+        }
+      } else if (pending?.kind === "candidate") {
+        if (!pending.entries) {
+          const sanitized = sanitizeEventPartial(record, true);
+          if (sanitized) {
+            yield sanitized;
+          }
+          continue;
+        }
+        queuePendingEvent(pending, record);
+        if (pendingQueueOverCap(pending)) {
+          const classification = classifyPending(pending, options.matcher);
+          if (classification.kind === "false-positive") {
+            yield* replayFalsePositiveCandidate(pending);
+            pending = undefined;
+            continue;
+          }
+          forceScrubTerminal = true;
+          scrubFuturePartials = true;
+          if (!sawStreamStart) {
+            yield { type: "start", partial: { role: "assistant", content: [] } };
+            sawStreamStart = true;
+          }
+          yield* forceProjectPendingAux(pending);
+          pending.entries = undefined;
+          pending.entryBytes = 0;
+          if (classification.kind === "suppress") {
+            pending = {
+              entryBytes: 0,
+              kind: "suppressing",
+              suppressor: classification.suppressor,
+            };
+          }
+        }
+      } else {
+        for (const held of heldTextStarts.values()) {
+          yield held;
+        }
+        heldTextStarts.clear();
+        yield record;
       }
-      yield suppressingOverCapTextToolCall
-        ? scrubBufferedTextFromError(
-            scrubBufferedTextFromPartial(
-              record,
-              bufferedText,
-              options.matcher,
-              suppressedTextContentIndexForScrub(),
-              { preserveEmptyTextBlocks: true },
-            ),
-            bufferedText,
-            options.matcher,
-            suppressedTextContentIndexForScrub(),
-          )
-        : scrubReclassifiedMixedTextFromDone && reclassifiedMixedVisibleText !== undefined
-          ? scrubReclassifiedMixedTextFromError(
-              scrubReclassifiedMixedTextFromPartial(
-                record,
-                reclassifiedMixedVisibleText,
-                hasReclassifiedMixedTextContentIndex
-                  ? reclassifiedMixedTextContentIndex
-                  : undefined,
-                options.matcher,
-              ),
-              reclassifiedMixedVisibleText,
-              hasReclassifiedMixedTextContentIndex ? reclassifiedMixedTextContentIndex : undefined,
-              options.matcher,
-            )
-          : event;
-      return;
     }
 
-    if (scrubReclassifiedMixedTextFromDone && reclassifiedMixedVisibleText !== undefined) {
-      yield scrubReclassifiedMixedTextFromPartial(
-        record,
-        reclassifiedMixedVisibleText,
-        hasReclassifiedMixedTextContentIndex ? reclassifiedMixedTextContentIndex : undefined,
-        options.matcher,
-      );
-      continue;
+    if (pending?.kind === "candidate") {
+      const classification = classifyPending(pending, options.matcher, true);
+      if (classification.kind === "false-positive") {
+        yield* replayFalsePositiveCandidate(pending);
+      } else {
+        yield* forceProjectPendingAux(pending);
+      }
+    } else if (pending?.kind === "suppressing") {
+      yield* forceProjectPendingAux(pending);
     }
-
-    if (bufferedEvents.length > 0 && !suppressingOverCapTextToolCall) {
-      bufferedEvents.push(event);
-      continue;
+    for (const held of heldTextStarts.values()) {
+      yield held;
     }
-
-    yield suppressingOverCapTextToolCall
-      ? scrubBufferedTextFromPartial(
-          record,
-          bufferedText,
-          options.matcher,
-          suppressedTextContentIndexForScrub(),
-          { preserveEmptyTextBlocks: suppressingOverCapTextToolCall },
-        )
-      : event;
   }
-
-  if (!suppressingOverCapTextToolCall) {
-    yield* flushBufferedEvents();
+  for await (const event of normalizeEvents()) {
+    const record = asRecord(event);
+    if (record?.type === "text_delta" && typeof record.delta === "string") {
+      const key = eventKey(record);
+      const previous = emittedTextUnits.get(key) ?? 0;
+      emittedTextUnits.set(key, previous + record.delta.length);
+    }
+    yield event;
   }
 }

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1158,7 +1158,7 @@ export async function* normalizePlainTextToolCallStreamEvents(
               yield* forceProjectPendingAux(pending, projection);
               const projectedText = projection && projectedTextForEvent(record, projection);
               const novelText = projectedText?.slice(emittedTextUnits.get(key) ?? 0);
-              if (novelText) {
+              if (novelText && projection) {
                 yield createSyntheticTextDelta(record, novelText, projection.message);
               }
               pending = undefined;

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -867,7 +867,7 @@ function consumeXmlSuppressor(
       if (
         !name ||
         name.length > MAX_TOOL_NAME_CHARS ||
-        [...name].some((character) => !isXmlishNameChar(character))
+        Array.from(name).some((character) => !isXmlishNameChar(character))
       ) {
         return { complete: true, suffix: text.slice(markerStart) };
       }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
@@ -146,8 +146,10 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
       "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     expect(requireRecord(events.at(-1), "done").reason).toBe("toolUse");
@@ -167,6 +169,76 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
       name: "exec",
       arguments: { command: "find / -maxdepth 4 -type d 2>/dev/null | head -20" },
     });
+  });
+
+  it("reuses promoted ids across cloned result and done messages", async () => {
+    const rawToolText = "<function=exec></function>";
+    const createMessage = () => ({
+      role: "assistant",
+      content: [{ type: "text", text: rawToolText }],
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          { type: "text_delta", contentIndex: 0, delta: rawToolText },
+          { type: "done", reason: "stop", message: createMessage() },
+        ],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["exec"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const result = requireRecord(await stream.result(), "result message");
+    const events = await collectStreamEvents(stream);
+    const resultToolCall = requireRecord((result.content as unknown[])[0], "result tool call");
+    const done = requireRecord(events.at(-1), "done event");
+    const doneMessage = requireRecord(done.message, "done message");
+    const doneToolCall = requireRecord((doneMessage.content as unknown[])[0], "done tool call");
+    const lifecycle = events
+      .map((event) => requireRecord(event, "event"))
+      .filter((event) => String(event.type).startsWith("toolcall_"));
+
+    expect(doneToolCall.id).toBe(resultToolCall.id);
+    expect(lifecycle).toHaveLength(3);
+    for (const event of lifecycle) {
+      const partial = requireRecord(event.partial, "tool-call partial");
+      expect(requireRecord((partial.content as unknown[])[0], "partial tool call").id).toBe(
+        resultToolCall.id,
+      );
+    }
+  });
+
+  it("scrubs aggregate-over-cap call sequences before result promotion", async () => {
+    const rawToolText = "<function=exec></function>\n".repeat(9_500);
+    const createMessage = () => ({
+      role: "assistant",
+      content: [{ type: "text", text: rawToolText }],
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [{ type: "done", reason: "stop", message: createMessage() }],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["exec"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const result = requireRecord(await stream.result(), "result message");
+    const events = await collectStreamEvents(stream);
+
+    expect(new TextEncoder().encode(rawToolText).byteLength).toBeGreaterThan(256_000);
+    expect(result.content).toEqual([]);
+    expect(requireRecord(requireRecord(events[0], "done").message, "done message").content).toEqual(
+      [],
+    );
+    expect(JSON.stringify({ events, result })).not.toContain("<function=exec>");
   });
 
   it("promotes deferred directory tool names from the live callable set", async () => {
@@ -245,12 +317,14 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const result = requireRecord(await stream.result(), "result message");
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
-      "thinking_delta",
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
+      "thinking_delta",
       "done",
     ]);
-    expect(requireRecord(events[0], "thinking event").contentIndex).toBe(1);
+    expect(requireRecord(events[4], "thinking event").contentIndex).toBe(1);
     expect(requireRecord(events[1], "toolcall start").contentIndex).toBe(0);
     expect((result.content as Array<Record<string, unknown>>).map((block) => block.type)).toEqual([
       "toolCall",
@@ -313,16 +387,19 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const result = requireRecord(await stream.result(), "result message");
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
       "thinking_delta",
       "toolcall_start",
       "toolcall_delta",
-      "toolcall_start",
-      "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
-    expect(requireRecord(events[0], "thinking event").contentIndex).toBe(1);
+    expect(requireRecord(events[4], "thinking event").contentIndex).toBe(1);
     expect(requireRecord(events[1], "first toolcall start").contentIndex).toBe(0);
-    expect(requireRecord(events[3], "second toolcall start").contentIndex).toBe(2);
+    expect(requireRecord(events[5], "second toolcall start").contentIndex).toBe(2);
     expect((result.content as Array<Record<string, unknown>>).map((block) => block.type)).toEqual([
       "toolCall",
       "thinking",
@@ -373,12 +450,14 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const result = requireRecord(await stream.result(), "result message");
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
-      "thinking_delta",
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
+      "thinking_delta",
       "done",
     ]);
-    expect(requireRecord(events[0], "thinking event").contentIndex).toBe(2);
+    expect(requireRecord(events[4], "thinking event").contentIndex).toBe(1);
     expect(requireRecord(events[1], "toolcall start").contentIndex).toBe(0);
     expect((result.content as Array<Record<string, unknown>>).map((block) => block.type)).toEqual([
       "toolCall",
@@ -422,8 +501,10 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const result = requireRecord(await stream.result(), "result message");
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     expect(result.stopReason).toBe("toolUse");
@@ -466,8 +547,10 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const result = requireRecord(await stream.result(), "result message");
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     expect(requireRecord((result.content as unknown[])[0], "tool call")).toMatchObject({
@@ -476,6 +559,92 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
       arguments: { command: "pwd" },
     });
   });
+
+  it.each([
+    {
+      label: "case-insensitive name",
+      allowedToolName: "Read",
+      emittedToolName: "READ",
+      expectedToolName: "Read",
+      parameterName: "path",
+      parameterValue: "src/index.ts",
+    },
+    {
+      label: "normalized alias",
+      allowedToolName: "exec",
+      emittedToolName: "bash",
+      expectedToolName: "exec",
+      parameterName: "command",
+      parameterValue: "pwd",
+    },
+  ])(
+    "promotes $label XML consistently when the terminal reason is toolUse",
+    async ({
+      allowedToolName,
+      emittedToolName,
+      expectedToolName,
+      parameterName,
+      parameterValue,
+    }) => {
+      const rawToolText = [
+        `<function=${emittedToolName}>`,
+        `<parameter=${parameterName}>`,
+        parameterValue,
+        "</parameter>",
+        "</function>",
+      ].join("\n");
+      const resultMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: rawToolText }],
+        stopReason: "toolUse",
+      };
+      const baseFn = vi.fn(() =>
+        createFakeStream({
+          events: [
+            { type: "text_delta", contentIndex: 0, delta: rawToolText },
+            { type: "done", reason: "toolUse", message: resultMessage },
+          ],
+          resultMessage,
+        }),
+      );
+      const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(
+        baseFn as never,
+        new Set([allowedToolName]),
+      );
+      const stream = (await Promise.resolve(
+        wrapped({} as never, {} as never, {} as never),
+      )) as FakeWrappedStream;
+
+      const events = await collectStreamEvents(stream);
+      const result = requireRecord(await stream.result(), "result message");
+      const expectedArguments = { [parameterName]: parameterValue };
+      const expectedContent = [
+        {
+          type: "toolCall",
+          id: expect.stringMatching(/^call_[a-f0-9]{24}$/),
+          name: expectedToolName,
+          arguments: expectedArguments,
+          partialArgs: JSON.stringify(expectedArguments),
+        },
+      ];
+
+      expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+        "start",
+        "toolcall_start",
+        "toolcall_delta",
+        "toolcall_end",
+        "done",
+      ]);
+      expect(requireRecord(events[2], "toolcall delta").delta).toBe(
+        JSON.stringify(expectedArguments),
+      );
+      const doneEvent = requireRecord(events[4], "done event");
+      expect(doneEvent.reason).toBe("toolUse");
+      expect(requireRecord(doneEvent.message, "done message").content).toEqual(expectedContent);
+      expect(result).toMatchObject({ role: "assistant", stopReason: "toolUse" });
+      expect(result.content).toEqual(expectedContent);
+    },
+  );
 
   it("keeps possible tool-call text buffered across interleaved non-text events", async () => {
     const rawToolText = [
@@ -521,14 +690,21 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const events = await collectStreamEvents(stream);
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "start",
       "thinking_delta",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
-    const thinkingEvent = requireRecord(events[0], "thinking event");
+    const thinkingEvent = requireRecord(events[1], "thinking event");
     expect(requireRecord(thinkingEvent.partial, "thinking partial").content).toEqual([
       { type: "thinking", thinking: "Need shell state." },
+      expect.objectContaining({
+        type: "toolCall",
+        name: "exec",
+        arguments: { command: "pwd" },
+      }),
     ]);
     expect(JSON.stringify(events)).not.toContain(rawToolText);
   });
@@ -577,15 +753,21 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const events = await collectStreamEvents(stream);
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
-      "thinking_delta",
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
+      "thinking_delta",
       "done",
     ]);
-    const thinkingEvent = requireRecord(events[0], "thinking event");
+    const thinkingEvent = requireRecord(events[4], "thinking event");
     expect(thinkingEvent.contentIndex).toBe(1);
     expect(requireRecord(thinkingEvent.partial, "thinking partial").content).toEqual([
-      { type: "text", text: "" },
+      expect.objectContaining({
+        type: "toolCall",
+        name: "exec",
+        arguments: { command: "pwd" },
+      }),
       { type: "thinking", thinking: "Need shell state." },
     ]);
     expect(JSON.stringify(events)).not.toContain(rawToolText);
@@ -623,7 +805,7 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     expect(returnIterator).toHaveBeenCalledTimes(1);
   });
 
-  it("flushes buffered text before terminal error events", async () => {
+  it("fails closed on buffered known-tool text before terminal errors", async () => {
     const rawToolText = "[tool:exec]";
     const errorEvent = { type: "error", error: new Error("stream failed") };
     const baseFn = vi.fn(() =>
@@ -639,10 +821,7 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
 
     const events = await collectStreamEvents(stream);
 
-    expect(events).toEqual([
-      { type: "text_delta", contentIndex: 0, delta: rawToolText },
-      errorEvent,
-    ]);
+    expect(events).toEqual([errorEvent]);
   });
 
   it("buffers split XML function markers until final promotion", async () => {
@@ -676,8 +855,10 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     const events = await collectStreamEvents(stream);
 
     expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
   });
@@ -698,6 +879,11 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
       label: "zero-argument XML text over the byte cap",
       marker: "<function=exec>",
       rawToolText: `<function=exec>${"\u00a0".repeat(128_001)}</function>`,
+    },
+    {
+      label: "incomplete XML text over the byte cap",
+      marker: "<function=exec>",
+      rawToolText: `<function=exec>${"\u00a0".repeat(128_001)}`,
     },
   ])("suppresses $label instead of flushing it", async ({ marker, rawToolText }) => {
     const resultMessage = {
@@ -796,6 +982,82 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
     expect(JSON.stringify(result)).not.toContain("</parameter>");
   });
 
+  it("scrubs an over-cap whitespace-only XML body split into its own text block", async () => {
+    const resultMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "<function=exec>" },
+        { type: "text", text: "\u00a0".repeat(128_001) },
+        { type: "text", text: "</function>" },
+      ],
+      stopReason: "stop",
+    };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [{ type: "done", reason: "stop", message: resultMessage }],
+        resultMessage,
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["exec"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const events = await collectStreamEvents(stream);
+    const result = requireRecord(await stream.result(), "result message");
+    const expectedMessage = { role: "assistant", content: [], stopReason: "stop" };
+
+    expect(events).toHaveLength(1);
+    const doneEvent = requireRecord(events[0], "done event");
+    expect(doneEvent.type).toBe("done");
+    expect(doneEvent.reason).toBe("stop");
+    expect(doneEvent.message).toEqual(expectedMessage);
+    expect(result).toEqual(expectedMessage);
+  });
+
+  it.each(["error", "aborted"])(
+    "scrubs over-cap XML from stream.result() when stopReason is %s",
+    async (stopReason) => {
+      const rawToolText = `<function=exec>${"\u00a0".repeat(128_001)}</function>`;
+      const resultMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: rawToolText }],
+        stopReason,
+      };
+      const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage }));
+      const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(
+        baseFn as never,
+        new Set(["exec"]),
+      );
+      const stream = (await Promise.resolve(
+        wrapped({} as never, {} as never, {} as never),
+      )) as FakeWrappedStream;
+
+      const result = requireRecord(await stream.result(), "result message");
+
+      expect(result).toEqual({ role: "assistant", content: [], stopReason });
+      expect(JSON.stringify(result)).not.toContain("<function=exec>");
+    },
+  );
+
+  it("scrubs an incomplete named call from stream.result()", async () => {
+    const rawToolText = "<function=exec><parameter=command>SECRET";
+    const resultMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: rawToolText }],
+      stopReason: "stop",
+    };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage }));
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["exec"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const result = requireRecord(await stream.result(), "result message");
+
+    expect(result).toEqual({ role: "assistant", content: [], stopReason: "stop" });
+  });
+
   it("preserves visible suffix text after an over-cap JSON tool payload", async () => {
     const visibleSuffix = "Visible answer after oversized JSON.";
     const rawText = [`[tool:exec] {"command":"${"x".repeat(256_001)}"}`, visibleSuffix].join("\n");
@@ -830,6 +1092,48 @@ describe("wrapStreamFnPromoteStandaloneTextToolCalls", () => {
       { type: "text", text: visibleSuffix },
     ]);
     expect(JSON.stringify(events)).not.toContain("[tool:exec]");
+  });
+
+  it("scrubs mixed under-cap calls from pre-iteration results and multi-block done events", async () => {
+    const rawCall = "<function=exec></function>";
+    const visibleText = "Visible answer after the leaked call.";
+    const rawText = `${rawCall}\n${visibleText}`;
+    const createMessage = () => ({
+      role: "assistant",
+      content: [
+        { type: "text", text: rawCall },
+        { type: "text", text: visibleText },
+      ],
+      stopReason: "stop",
+    });
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          { type: "text_delta", contentIndex: 0, delta: rawText },
+          { type: "done", reason: "stop", message: createMessage() },
+        ],
+        resultMessage: createMessage(),
+      }),
+    );
+    const wrapped = wrapStreamFnPromoteStandaloneTextToolCalls(baseFn as never, new Set(["exec"]));
+    const stream = (await Promise.resolve(
+      wrapped({} as never, {} as never, {} as never),
+    )) as FakeWrappedStream;
+
+    const result = requireRecord(await stream.result(), "result message");
+    const events = await collectStreamEvents(stream);
+    const expectedContent = [{ type: "text", text: visibleText }];
+
+    expect(result.content).toEqual(expectedContent);
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    expect(requireRecord(events[0], "text event").delta).toBe(visibleText);
+    expect(
+      requireRecord(requireRecord(events[1], "done event").message, "done message").content,
+    ).toEqual(expectedContent);
+    expect(JSON.stringify({ events, result })).not.toContain("<function=exec>");
   });
 
   it("does not buffer normal prose that starts like a final answer", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -5,11 +5,12 @@ import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { normalizeStringEntries } from "../../../../packages/normalization-core/src/string-normalization.js";
 import {
-  extractStandalonePlainTextToolCallText,
+  createPromotedPlainTextToolCallEvents,
   normalizePlainTextToolCallStreamEvents,
-  promoteStandalonePlainTextToolCallMessage as promotePlainTextToolCallMessage,
-  scrubOverCapPlainTextToolCallMessage,
+  projectScrubbedPlainTextToolCallMessage,
+  projectStandalonePlainTextToolCallMessage as projectPlainTextToolCallMessage,
   type PlainTextToolCallBlock,
+  type PlainTextToolCallMessageNormalization,
   type PlainTextToolCallNameMatcher,
 } from "../../../../packages/tool-call-repair/src/index.js";
 import { visitObjectContentBlocks } from "../../../shared/message-content-blocks.js";
@@ -607,6 +608,10 @@ function stripTrailingAssistantPrefillTurns(messages: AgentMessage[]): AgentMess
   return end === messages.length ? messages : messages.slice(0, end);
 }
 
+function createStandaloneTextToolCallId(): string {
+  return `call_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+}
+
 function normalizeToolCallIdsInMessage(message: unknown, fallbackIdByContentIndex: string[]): void {
   if (!message || typeof message !== "object") {
     return;
@@ -859,97 +864,11 @@ function guardUnknownToolLoopInMessage(
   return true;
 }
 
-type PromotedTextToolCallBlock = {
-  type: "toolCall";
-  id: string;
-  name: string;
-  arguments: Record<string, unknown>;
-  partialArgs: string;
-};
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
-}
-
-function createStandaloneTextToolCallId(): string {
-  return `call_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
-}
-
-function createPromotedTextToolCallBlock(
-  block: PlainTextToolCallBlock,
-  name: string,
-): PromotedTextToolCallBlock {
-  return {
-    type: "toolCall",
-    id: createStandaloneTextToolCallId(),
-    name,
-    arguments: block.arguments,
-    partialArgs: JSON.stringify(block.arguments),
-  };
-}
-
 function isRetainableNonVisibleBlock(block: Record<string, unknown>): boolean {
   return block.type === "thinking" || block.type === "redacted_thinking";
 }
 
-const STANDALONE_TEXT_TOOL_CALL_PROMOTION_STOP_REASONS = new Set<unknown>(["stop"]);
-const STANDALONE_TEXT_TOOL_CALL_SCRUB_STOP_REASONS = new Set<unknown>(["stop", "length"]);
-
-function extractStandaloneTextToolCallCandidateForStopReasons(
-  message: unknown,
-  allowedStopReasons: ReadonlySet<unknown>,
-):
-  | {
-      text: string;
-    }
-  | undefined {
-  const text = extractStandalonePlainTextToolCallText({
-    allowedStopReasons,
-    isRetainableNonTextBlock: isRetainableNonVisibleBlock,
-    message,
-    requireAssistantRole: true,
-  });
-  return text ? { text } : undefined;
-}
-
-function promoteStandaloneTextToolCallMessage(
-  message: unknown,
-  allowedToolNames?: Set<string>,
-): Record<string, unknown> | undefined {
-  if (!allowedToolNames) {
-    return undefined;
-  }
-  return promotePlainTextToolCallMessage({
-    allowedStopReasons: STANDALONE_TEXT_TOOL_CALL_PROMOTION_STOP_REASONS,
-    allowedToolNames,
-    createToolCallBlock: createPromotedTextToolCallBlock,
-    isRetainableNonTextBlock: isRetainableNonVisibleBlock,
-    message,
-    requireAssistantRole: true,
-    resolveToolName: resolveExactAllowedToolName,
-  });
-}
-
-function createPromotedToolCallEvents(
-  message: Record<string, unknown>,
-): Array<Record<string, unknown>> {
-  const content = Array.isArray(message.content) ? message.content : [];
-  const events: Array<Record<string, unknown>> = [];
-  content.forEach((block, contentIndex) => {
-    const record = asRecord(block);
-    if (record?.type !== "toolCall") {
-      return;
-    }
-    events.push({ type: "toolcall_start", contentIndex, partial: message });
-    events.push({
-      type: "toolcall_delta",
-      contentIndex,
-      delta: typeof record.partialArgs === "string" ? record.partialArgs : "{}",
-      partial: message,
-    });
-  });
-  return events;
-}
+const STANDALONE_TEXT_TOOL_CALL_PROMOTION_STOP_REASONS = new Set<unknown>(["stop", "toolUse"]);
 
 function createStandaloneToolCallNameMatcher(
   allowedToolNames: Set<string>,
@@ -965,48 +884,68 @@ function wrapStreamPromoteStandaloneTextToolCalls(
   allowedToolNames: Set<string>,
 ): AssistantStream {
   const matcher = createStandaloneToolCallNameMatcher(allowedToolNames);
-  const normalizedMessages = new WeakMap<
-    object,
-    { kind: "promoted" | "scrubbed"; message: Record<string, unknown> }
-  >();
-  const normalizeMessage = (
-    message: unknown,
-  ): { kind: "promoted" | "scrubbed"; message: Record<string, unknown> } | undefined => {
-    if (!message || typeof message !== "object") {
-      return undefined;
-    }
-    const cached = normalizedMessages.get(message);
-    if (cached) {
-      return cached;
-    }
-    const promoted = promoteStandaloneTextToolCallMessage(message, allowedToolNames);
-    if (promoted) {
-      const result = { kind: "promoted" as const, message: promoted };
-      normalizedMessages.set(message, result);
-      return result;
-    }
-    const scrubbed = scrubOverCapPlainTextToolCallMessage({
-      candidateText: extractStandaloneTextToolCallCandidateForStopReasons(
-        message,
-        STANDALONE_TEXT_TOOL_CALL_SCRUB_STOP_REASONS,
-      )?.text,
+  const promotedIdBySource = new Map<string, string>();
+  const normalizeTerminalMessage = (params: {
+    allowPromotion: boolean;
+    message: unknown;
+    preserveEmptyTextBlocks?: boolean;
+  }): PlainTextToolCallMessageNormalization => {
+    const scrubbed = projectScrubbedPlainTextToolCallMessage({
+      forceIncompleteCandidates: true,
       matcher,
-      message,
+      message: params.message,
+      preserveEmptyTextBlocks: params.preserveEmptyTextBlocks,
+      requireAssistantRole: true,
     });
     if (scrubbed) {
-      const result = { kind: "scrubbed" as const, message: scrubbed };
-      normalizedMessages.set(message, result);
-      return result;
+      return { kind: "scrubbed", ...scrubbed };
     }
-    return undefined;
+    if (!params.allowPromotion) {
+      return undefined;
+    }
+    let ordinal = 0;
+    const createStableToolCallBlock = (
+      block: PlainTextToolCallBlock,
+      name: string,
+    ): Record<string, unknown> => {
+      const sourceKey = `${ordinal}:${block.start}:${block.end}`;
+      ordinal += 1;
+      let id = promotedIdBySource.get(sourceKey);
+      if (!id) {
+        id = createStandaloneTextToolCallId();
+        promotedIdBySource.set(sourceKey, id);
+      }
+      return {
+        type: "toolCall",
+        id,
+        name,
+        arguments: block.arguments,
+        partialArgs: JSON.stringify(block.arguments),
+      };
+    };
+    const promoted = projectPlainTextToolCallMessage({
+      allowedStopReasons: STANDALONE_TEXT_TOOL_CALL_PROMOTION_STOP_REASONS,
+      allowedToolNames,
+      createToolCallBlock: createStableToolCallBlock,
+      isRetainableNonTextBlock: isRetainableNonVisibleBlock,
+      message: params.message,
+      requireAssistantRole: true,
+      resolveToolName: resolveExactAllowedToolName,
+    });
+    return promoted ? { kind: "promoted", ...promoted } : undefined;
   };
 
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
-    return (normalizeMessage(message)?.message ?? message) as Awaited<
-      ReturnType<typeof originalResult>
-    >;
+    const reason =
+      message && typeof message === "object"
+        ? (message as { stopReason?: unknown }).stopReason
+        : undefined;
+    return (normalizeTerminalMessage({
+      allowPromotion: STANDALONE_TEXT_TOOL_CALL_PROMOTION_STOP_REASONS.has(reason),
+      message,
+    })?.message ?? message) as Awaited<ReturnType<typeof originalResult>>;
   };
 
   const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
@@ -1017,22 +956,9 @@ function wrapStreamPromoteStandaloneTextToolCalls(
       [Symbol.asyncIterator]: originalAsyncIterator,
     } as AsyncIterable<unknown>;
     yield* normalizePlainTextToolCallStreamEvents(source, {
-      createPromotedToolCallEvents,
+      createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
       matcher,
-      normalizeDoneMessage: ({ message, reason }) => {
-        if (reason === "stop") {
-          return normalizeMessage(message);
-        }
-        const scrubbed = scrubOverCapPlainTextToolCallMessage({
-          candidateText: extractStandaloneTextToolCallCandidateForStopReasons(
-            message,
-            STANDALONE_TEXT_TOOL_CALL_SCRUB_STOP_REASONS,
-          )?.text,
-          matcher,
-          message,
-        });
-        return scrubbed ? { kind: "scrubbed", message: scrubbed } : undefined;
-      },
+      normalizeTerminalMessage,
     });
   };
 

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -93,6 +93,19 @@ function createByteOverCapZeroArgumentXmlCall(name: string): string {
   return `<function=${name}>${"\u00a0".repeat(128_001)}</function>`;
 }
 
+async function collectPlainTextToolCallCompatEvents(events: unknown[]): Promise<StreamEvent[]> {
+  const baseStreamFn: StreamFn = () => createEventStream(events);
+  const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+  const stream = await resolveStream(
+    wrapped({} as never, { tools: [{ name: "read" }] } as never, {}),
+  );
+  const output: StreamEvent[] = [];
+  for await (const event of stream as AsyncIterable<unknown>) {
+    output.push(event as StreamEvent);
+  }
+  return output;
+}
+
 async function resolveStream(stream: ReturnType<StreamFn>) {
   return stream instanceof Promise ? await stream : stream;
 }
@@ -382,8 +395,10 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     }
 
     expect(events.map((event) => (event as { type?: string }).type)).toEqual([
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const done = events.at(-1) as { message?: { content?: unknown; stopReason?: unknown } };
@@ -630,14 +645,17 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     }
 
     expect(events.map((event) => (event as { type?: string }).type)).toEqual([
+      "start",
       "thinking_delta",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
-    const thinkingEvent = requireRecord(events[0], "thinking event");
+    const thinkingEvent = requireRecord(events[1], "thinking event");
     expect(requireRecord(thinkingEvent.partial, "thinking partial").content).toEqual([
       { type: "thinking", thinking: "Need file contents." },
+      expect.objectContaining({ type: "toolCall", name: "read" }),
     ]);
     expect(JSON.stringify(events)).not.toContain(rawToolText);
   });
@@ -688,15 +706,17 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     }
 
     expect(events.map((event) => (event as { type?: string }).type)).toEqual([
-      "thinking_delta",
+      "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
+      "thinking_delta",
       "done",
     ]);
-    const thinkingEvent = requireRecord(events[0], "thinking event");
+    const thinkingEvent = requireRecord(events[4], "thinking event");
     expect(thinkingEvent.contentIndex).toBe(1);
     expect(requireRecord(thinkingEvent.partial, "thinking partial").content).toEqual([
-      { type: "text", text: "" },
+      expect.objectContaining({ type: "toolCall", name: "read" }),
       { type: "thinking", thinking: "Need file contents." },
     ]);
     expect(JSON.stringify(events)).not.toContain(rawToolText);
@@ -848,6 +868,12 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     },
     {
       byteOnly: true,
+      label: "incomplete XML text over the byte cap",
+      marker: "<function=read>",
+      rawToolText: `<function=read>${"\u00a0".repeat(128_001)}`,
+    },
+    {
+      byteOnly: true,
       label: "a later bracketed XML parameter over the byte cap",
       marker: "[tool:read]",
       rawToolText: [
@@ -862,7 +888,8 @@ describe("createPlainTextToolCallCompatWrapper", () => {
       expect(rawToolText.length).toBeLessThan(256_000);
     }
     if (marker === "<function=read>") {
-      const payload = rawToolText.slice(marker.length, -"</function>".length);
+      const payloadEnd = rawToolText.endsWith("</function>") ? -"</function>".length : undefined;
+      const payload = rawToolText.slice(marker.length, payloadEnd);
       expect(new TextEncoder().encode(payload).byteLength).toBe(256_002);
     }
     const baseStreamFn: StreamFn = () =>
@@ -962,6 +989,61 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     });
     expect(requireRecord(events[1], "done event").message).toMatchObject({
       content: [{ type: "text", text: visibleText }],
+    });
+    expect(JSON.stringify(events)).not.toContain(marker);
+  });
+
+  it("keeps a byte-over-cap visible suffix at its streamed content index in done messages", async () => {
+    const marker = "<function=read>";
+    const visibleText = "Visible answer";
+    const firstChunk = `${marker}${"\u00a0".repeat(100_000)}`;
+    const secondChunk = `${"\u00a0".repeat(28_001)}</function>\n${visibleText}`;
+    const content = [
+      { type: "text", text: firstChunk },
+      { type: "thinking", thinking: "checking" },
+      { type: "text", text: secondChunk },
+    ];
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: firstChunk },
+        {
+          type: "text_delta",
+          contentIndex: 2,
+          delta: secondChunk,
+          partial: { role: "assistant", content },
+        },
+        {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content, stopReason: "stop" },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    const expectedContent = [
+      { type: "text", text: "" },
+      { type: "thinking", thinking: "checking" },
+      { type: "text", text: visibleText },
+    ];
+    expect(requireRecord(events[0], "text event")).toMatchObject({
+      delta: visibleText,
+      partial: { content: expectedContent },
+    });
+    expect(requireRecord(events[1], "done event").message).toMatchObject({
+      content: expectedContent,
     });
     expect(JSON.stringify(events)).not.toContain(marker);
   });
@@ -1171,6 +1253,177 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     }
 
     expect(events).toEqual([]);
+  });
+
+  it.each(["EOF", "error"] as const)(
+    "scrubs authoritative text_end byte-over-cap XML at %s",
+    async (terminal) => {
+      const rawToolText = createByteOverCapZeroArgumentXmlCall("read");
+      const events = await collectPlainTextToolCallCompatEvents([
+        { type: "text_delta", contentIndex: 0, delta: "<function=read>" },
+        { type: "text_end", contentIndex: 0, content: rawToolText },
+        ...(terminal === "error"
+          ? [
+              {
+                type: "error",
+                partial: {
+                  role: "assistant",
+                  content: [{ type: "text", text: rawToolText }],
+                },
+                error: {
+                  role: "assistant",
+                  content: [{ type: "text", text: rawToolText }],
+                  errorMessage: "stream failed",
+                },
+              },
+            ]
+          : []),
+      ]);
+
+      if (terminal === "EOF") {
+        expect(events).toEqual([]);
+        return;
+      }
+      expect(events.map((event) => event.type)).toEqual(["error"]);
+      const errorEvent = requireRecord(events[0], "error event");
+      expect(requireRecord(errorEvent.partial, "error partial").content).toEqual([
+        { type: "text", text: "" },
+      ]);
+      expect(requireRecord(errorEvent.error, "error body").content).toEqual([]);
+      expect(JSON.stringify(events)).not.toContain("<function=read>");
+    },
+  );
+
+  it("scrubs byte-over-cap XML from error-only terminal snapshots", async () => {
+    const rawToolText = createByteOverCapZeroArgumentXmlCall("read");
+    const events = await collectPlainTextToolCallCompatEvents([
+      {
+        type: "error",
+        partial: { role: "assistant", content: rawToolText },
+        error: {
+          role: "assistant",
+          content: [{ type: "text", text: rawToolText }],
+          errorMessage: "stream failed",
+        },
+      },
+    ]);
+
+    expect(events.map((event) => event.type)).toEqual(["error"]);
+    const errorEvent = requireRecord(events[0], "error event");
+    expect(requireRecord(errorEvent.partial, "error partial").content).toBe("");
+    expect(requireRecord(errorEvent.error, "error body")).toMatchObject({
+      content: [],
+      errorMessage: "stream failed",
+    });
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("scrubs terminal XML split inside its function markers", async () => {
+    const body = "\u00a0".repeat(128_001);
+    const parts = ["<func", `tion=read>${body}</func`, "tion>"];
+    const events = await collectPlainTextToolCallCompatEvents([
+      {
+        type: "done",
+        reason: "length",
+        message: {
+          role: "assistant",
+          content: parts.map((text) => ({ type: "text", text })),
+          stopReason: "length",
+        },
+      },
+    ]);
+
+    expect(requireRecord(events[0], "done event")).toMatchObject({
+      type: "done",
+      reason: "length",
+      message: { role: "assistant", content: [], stopReason: "length" },
+    });
+    expect(JSON.stringify(events)).not.toContain("<func");
+    expect(JSON.stringify(events)).not.toContain("tion>");
+  });
+
+  it("retains non-text blocks in order around an over-cap XML call suffix", async () => {
+    const visibleText = "Visible suffix";
+    const thinkingBefore = { type: "thinking", thinking: "Before image." };
+    const image = { type: "image", data: "aW1n", mimeType: "image/png" };
+    const thinkingAfter = { type: "thinking", thinking: "After suffix." };
+    const events = await collectPlainTextToolCallCompatEvents([
+      {
+        type: "done",
+        reason: "length",
+        message: {
+          role: "assistant",
+          content: [
+            thinkingBefore,
+            { type: "text", text: `<function=read>${"\u00a0".repeat(128_001)}` },
+            image,
+            { type: "text", text: `</function>\n${visibleText}` },
+            thinkingAfter,
+          ],
+          stopReason: "length",
+        },
+      },
+    ]);
+
+    const doneMessage = requireRecord(requireRecord(events[0], "done event").message, "message");
+    expect(doneMessage.content).toEqual([
+      thinkingBefore,
+      image,
+      { type: "text", text: visibleText },
+      thinkingAfter,
+    ]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("strips consecutive byte-over-cap serialized XML calls", async () => {
+    const visibleText = "Visible after both calls";
+    const rawText = [
+      createByteOverCapZeroArgumentXmlCall("read"),
+      createByteOverCapZeroArgumentXmlCall("read"),
+      visibleText,
+    ].join("\n");
+    const events = await collectPlainTextToolCallCompatEvents([
+      {
+        type: "done",
+        reason: "length",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: rawText }],
+          stopReason: "length",
+        },
+      },
+    ]);
+
+    expect(
+      requireRecord(requireRecord(events[0], "done event").message, "message").content,
+    ).toEqual([{ type: "text", text: visibleText }]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
+  });
+
+  it("preserves the exact suffix after a compacted XML prefix and split terminator", async () => {
+    const visibleText = "Visible after compacted XML";
+    const chunks = ["<func", `tion=read>${" ".repeat(330_001)}</func`, `tion>\n${visibleText}`];
+    const rawText = chunks.join("");
+    const events = await collectPlainTextToolCallCompatEvents([
+      ...chunks.map((delta) => ({ type: "text_delta", contentIndex: 0, delta })),
+      {
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: rawText }],
+          stopReason: "stop",
+        },
+      },
+    ]);
+
+    expect(rawText.length).toBeGreaterThan(320_000);
+    expect(events.map((event) => event.type)).toEqual(["text_delta", "done"]);
+    expect(events[0]).toMatchObject({ delta: visibleText });
+    expect(
+      requireRecord(requireRecord(events[1], "done event").message, "message").content,
+    ).toEqual([{ type: "text", text: visibleText }]);
+    expect(JSON.stringify(events)).not.toContain("<func");
   });
 
   it("scrubs compacted error partials when an emoji crosses the safe prefix boundary", async () => {
@@ -1568,7 +1821,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
 
     expect(requireRecord(events[0], "done event").message).toMatchObject({
       role: "assistant",
-      content: [{ type: "text", text: visibleText }],
+      content: [],
       stopReason: "stop",
     });
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
@@ -1654,7 +1907,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain("</parameter>");
   });
 
-  it("preserves small complete tool calls after over-cap visible text", async () => {
+  it("scrubs small complete tool calls after over-cap visible text", async () => {
     const visibleText = `Visible intro ${"x".repeat(256_001)}`;
     const toolText = '[tool:read] {"path":"src/index.ts"}';
     const baseStreamFn: StreamFn = () =>
@@ -1686,12 +1939,10 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(events.map((event) => (event as { type?: string }).type)).toEqual(["done"]);
     expect(requireRecord(events[0], "done event").message).toMatchObject({
       role: "assistant",
-      content: [
-        { type: "text", text: visibleText },
-        { type: "text", text: toolText },
-      ],
+      content: [{ type: "text", text: visibleText }],
       stopReason: "stop",
     });
+    expect(JSON.stringify(events)).not.toContain(toolText);
   });
 
   it("does not leak over-cap buffers when stripped later tool blocks are followed by text", async () => {
@@ -1845,6 +2096,92 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     ]);
     expect(String(requireRecord(events[0], "text event").delta)).toContain("AAAA");
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
+  });
+
+  it("scrubs mixed under-cap calls from multi-block done messages and results", async () => {
+    const rawCall = "<function=read></function>";
+    const visibleText = "Visible answer after the leaked call.";
+    const rawText = `${rawCall}\n${visibleText}`;
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: rawText },
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: rawCall },
+              { type: "text", text: visibleText },
+            ],
+            stopReason: "stop",
+          },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const output = await resolveStream(
+      wrapped({} as never, { tools: [{ name: "read" }] } as never, {}),
+    );
+    const resultPromise = output.result();
+    const events: unknown[] = [];
+
+    for await (const event of output as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+    const result = requireRecord(await resultPromise, "result message");
+    const expectedContent = [{ type: "text", text: visibleText }];
+
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    expect(requireRecord(events[0], "text event").delta).toBe(visibleText);
+    expect(
+      requireRecord(requireRecord(events[1], "done event").message, "done message").content,
+    ).toEqual(expectedContent);
+    expect(result.content).toEqual(expectedContent);
+    expect(JSON.stringify({ events, result })).not.toContain("<function=read>");
+  });
+
+  it("scrubs mixed under-cap calls from multi-block errors without partials", async () => {
+    const rawCall = "<function=read></function>";
+    const visibleText = "Visible answer before the stream error.";
+    const rawText = `${rawCall}\n${visibleText}`;
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: rawText },
+        {
+          type: "error",
+          error: {
+            role: "assistant",
+            content: [
+              { type: "text", text: rawCall },
+              { type: "text", text: visibleText },
+            ],
+            message: "stream failed",
+          },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "error",
+    ]);
+    expect(requireRecord(events[0], "text event").delta).toBe(visibleText);
+    expect(requireRecord(requireRecord(events[1], "error event").error, "error").content).toEqual([
+      { type: "text", text: visibleText },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("<function=read>");
   });
 
   it("preserves visible suffix text after an over-cap JSON tool payload", async () => {
@@ -2054,6 +2391,48 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
   });
 
+  it("preserves a visible suffix after a named over-cap parameter without a function close", async () => {
+    const toolPrefix = ["[read]", "<parameter=path>", "x".repeat(256_001)].join("\n");
+    const visibleSuffix = "Visible answer after the incomplete tool-looking block.";
+    const tail = ["</parameter>", visibleSuffix].join("\n");
+    const rawText = [toolPrefix, tail].join("\n");
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: toolPrefix },
+        { type: "text_delta", contentIndex: 0, delta: tail },
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: rawText }],
+            stopReason: "stop",
+          },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => requireRecord(event, "event").type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    expect(requireRecord(events[0], "text event").delta).toBe(visibleSuffix);
+    expect(
+      requireRecord(requireRecord(events[1], "done event").message, "done message").content,
+    ).toEqual([{ type: "text", text: visibleSuffix }]);
+    expect(JSON.stringify(events)).not.toContain("[read]");
+    expect(JSON.stringify(events)).not.toContain("</parameter>");
+  });
+
   it("preserves visible suffix text when the over-cap terminator is split across chunks", async () => {
     const toolPrefix = ["[tool:read]", "<parameter=path>", "x".repeat(400_000)].join("\n");
     const visibleSuffix = "Visible answer after a split terminator.";
@@ -2137,13 +2516,17 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
   });
 
-  it("does not duplicate visible suffix text when mixed over-cap events omit contentIndex", async () => {
-    const visibleSuffix = "Visible answer from an index-less stream.";
+  it.each([
+    ["both events omit contentIndex", {}, {}],
+    ["only the delta omits contentIndex", {}, { contentIndex: 0 }],
+    ["only text_end omits contentIndex", { contentIndex: 0 }, {}],
+  ])("does not duplicate visible suffix text when %s", async (_name, deltaIndex, endIndex) => {
+    const visibleSuffix = "Visible answer from a mixed-index stream.";
     const rawText = [`[tool:read] {"path":"${"x".repeat(256_001)}"}`, visibleSuffix].join("\n");
     const baseStreamFn: StreamFn = () =>
       createEventStream([
-        { type: "text_delta", delta: rawText },
-        { type: "text_end", content: rawText },
+        { type: "text_delta", ...deltaIndex, delta: rawText },
+        { type: "text_end", ...endIndex, content: rawText },
         {
           type: "done",
           reason: "stop",
@@ -2173,6 +2556,38 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
   });
 
+  it("deduplicates cumulative text_end across multiple stripped calls", async () => {
+    const call = `<function=read>${"\u00a0".repeat(128_001)}</function>\n`;
+    const first = `${call}ONE\n`;
+    const second = `TWO\n${call}THREE`;
+    const rawText = first + second;
+    const events = await collectPlainTextToolCallCompatEvents([
+      { type: "text_delta", contentIndex: 0, delta: first },
+      { type: "text_delta", contentIndex: 0, delta: second },
+      { type: "text_end", contentIndex: 0, content: rawText },
+      {
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: rawText }],
+          stopReason: "stop",
+        },
+      },
+    ]);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "text_delta",
+      "text_delta",
+      "text_delta",
+      "done",
+    ]);
+    expect(events.slice(0, 3).map((event) => event.delta)).toEqual(["ONE\n", "TWO\n", "THREE"]);
+    expect(
+      requireRecord(requireRecord(events.at(-1), "done event").message, "done message").content,
+    ).toEqual([{ type: "text", text: "ONE\nTWO\nTHREE" }]);
+  });
+
   it("keeps partial snapshots current for multi-delta visible suffix text", async () => {
     const firstVisible = "Visible answer ";
     const secondVisible = "continues.";
@@ -2188,6 +2603,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
           delta: secondVisible,
           partial: { content: [{ type: "text", text: rawText }] },
         },
+        { type: "text_end", contentIndex: 0, content: rawText },
         {
           type: "done",
           reason: "stop",
@@ -2419,15 +2835,17 @@ describe("createPlainTextToolCallCompatWrapper", () => {
       const events = [
         await nextEvent(iterator, "zero-argument tool-call start"),
         await nextEvent(iterator, "zero-argument tool-call arguments"),
+        await nextEvent(iterator, "zero-argument tool-call end"),
         await nextEvent(iterator, "zero-argument done event"),
       ];
       expect(events.map((event) => event.type)).toEqual([
         "toolcall_start",
         "toolcall_delta",
+        "toolcall_end",
         "done",
       ]);
       expect(events[1]).toMatchObject({ delta: "{}" });
-      expect(events[2]).toMatchObject({
+      expect(events[3]).toMatchObject({
         reason: "toolUse",
         message: {
           content: [{ type: "toolCall", name: "read", arguments: {} }],

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -1,12 +1,13 @@
 // Provider stream shared helpers implement reusable stream wrappers and payload policies.
-import { randomUUID } from "node:crypto";
 import { resolveOpenAIReasoningEffortForModel } from "@openclaw/ai/internal/openai";
 import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import {
-  extractStandalonePlainTextToolCallText,
+  createPromotedPlainTextToolCallBlock,
+  createPromotedPlainTextToolCallEvents,
   normalizePlainTextToolCallStreamEvents,
-  promoteStandalonePlainTextToolCallMessage,
-  scrubOverCapPlainTextToolCallMessage,
+  projectScrubbedPlainTextToolCallMessage,
+  projectStandalonePlainTextToolCallMessage,
+  type PlainTextToolCallMessageProjection,
   type PlainTextToolCallNameMatcher,
   type PlainTextToolCallMessageNormalization,
 } from "../../packages/tool-call-repair/src/index.js";
@@ -59,27 +60,10 @@ function resolveContextToolNames(context: Parameters<StreamFn>[1]): Set<string> 
   return new Set(names);
 }
 
-function createSyntheticToolCallId(): string {
-  return `call_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
-}
-
-function createPlainTextToolCallBlock(parsed: {
-  arguments: Record<string, unknown>;
-  name: string;
-}): Record<string, unknown> {
-  return {
-    type: "toolCall",
-    id: createSyntheticToolCallId(),
-    name: parsed.name,
-    arguments: parsed.arguments,
-    partialArgs: JSON.stringify(parsed.arguments),
-  };
-}
-
 function promotePlainTextToolCalls(
   message: unknown,
   toolNames: Set<string>,
-): Record<string, unknown> | undefined {
+): PlainTextToolCallMessageProjection | undefined {
   const messageRecord = toRecord(message);
   if (
     Array.isArray(messageRecord?.content) &&
@@ -87,37 +71,10 @@ function promotePlainTextToolCalls(
   ) {
     return undefined;
   }
-  return promoteStandalonePlainTextToolCallMessage({
+  return projectStandalonePlainTextToolCallMessage({
     allowedToolNames: toolNames,
-    createToolCallBlock: (block, name) => createPlainTextToolCallBlock({ ...block, name }),
+    createToolCallBlock: createPromotedPlainTextToolCallBlock,
     isRetainableNonTextBlock: () => true,
-    message,
-  });
-}
-
-function emitPromotedToolCallEvents(
-  stream: { push(event: unknown): void },
-  message: Record<string, unknown>,
-): void {
-  const content = Array.isArray(message.content) ? message.content : [];
-  content.forEach((block, contentIndex) => {
-    const record = toRecord(block);
-    if (record?.type !== "toolCall") {
-      return;
-    }
-    stream.push({ type: "toolcall_start", contentIndex, partial: message });
-    stream.push({
-      type: "toolcall_delta",
-      contentIndex,
-      delta: typeof record.partialArgs === "string" ? record.partialArgs : "{}",
-      partial: message,
-    });
-  });
-}
-
-function extractPlainTextToolCallCandidate(message: unknown): string | undefined {
-  return extractStandalonePlainTextToolCallText({
-    allowOtherNonTextBlocks: true,
     message,
   });
 }
@@ -138,25 +95,36 @@ function createProviderToolNameMatcher(toolNames: Set<string>): PlainTextToolCal
 
 function normalizeProviderDoneMessage(
   message: unknown,
-  reason: unknown,
+  allowPromotion: boolean,
   toolNames: Set<string>,
   matcher: PlainTextToolCallNameMatcher,
+  preserveEmptyTextBlocks = false,
 ): PlainTextToolCallMessageNormalization {
-  const scrubbedMessage = scrubOverCapPlainTextToolCallMessage({
-    candidateText: extractPlainTextToolCallCandidate(message),
-    matcher,
-    message,
-  });
+  const scrubbedMessage = scrubProviderTerminalMessage(message, matcher, preserveEmptyTextBlocks);
   if (scrubbedMessage) {
-    return { kind: "scrubbed", message: scrubbedMessage };
+    return { kind: "scrubbed", ...scrubbedMessage };
   }
   // Token-limit and error terminals can leave complete-looking tool syntax.
   // Only normal completion or explicit tool use may promote it into an executable call.
-  if (reason !== "stop" && reason !== "toolUse") {
+  if (!allowPromotion) {
     return undefined;
   }
   const promotedMessage = promotePlainTextToolCalls(message, toolNames);
-  return promotedMessage ? { kind: "promoted", message: promotedMessage } : undefined;
+  return promotedMessage ? { kind: "promoted", ...promotedMessage } : undefined;
+}
+
+function scrubProviderTerminalMessage(
+  message: unknown,
+  matcher: PlainTextToolCallNameMatcher,
+  preserveEmptyTextBlocks = false,
+  forceKnownCandidates = false,
+): PlainTextToolCallMessageProjection | undefined {
+  return projectScrubbedPlainTextToolCallMessage({
+    forceKnownCandidates,
+    matcher,
+    message,
+    preserveEmptyTextBlocks,
+  });
 }
 
 function wrapPlainTextToolCallStream(
@@ -184,14 +152,16 @@ function wrapPlainTextToolCallStream(
       const normalizedEvents = normalizePlainTextToolCallStreamEvents(
         source as AsyncIterable<unknown>,
         {
-          createPromotedToolCallEvents: (message) => {
-            const events: unknown[] = [];
-            emitPromotedToolCallEvents({ push: (event: unknown) => events.push(event) }, message);
-            return events;
-          },
+          createPromotedToolCallEvents: createPromotedPlainTextToolCallEvents,
           matcher,
-          normalizeDoneMessage: ({ message, reason }) =>
-            normalizeProviderDoneMessage(message, reason, toolNames, matcher),
+          normalizeTerminalMessage: ({ allowPromotion, message, preserveEmptyTextBlocks }) =>
+            normalizeProviderDoneMessage(
+              message,
+              allowPromotion,
+              toolNames,
+              matcher,
+              preserveEmptyTextBlocks,
+            ),
           stopAfterDone: true,
         },
       );

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -245,6 +245,30 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     });
   });
 
+  it("preserves __proto__ as an own XML argument property", () => {
+    const raw = "<function=write><parameter=__proto__>value</parameter></function>";
+    const args = parseStandalonePlainTextToolCallBlocks(raw)?.[0]?.arguments;
+
+    expect(Object.getPrototypeOf(args)).toBe(Object.prototype);
+    expect(Object.hasOwn(args ?? {}, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(args ?? {}, "__proto__")?.value).toBe("value");
+  });
+
+  it("materializes one-shot tool-name iterables once per parse", () => {
+    function* allowedNames() {
+      yield "exec";
+    }
+    const legacy = "[tool:exec]<parameter=command>pwd</parameter>";
+    expect(
+      parseStandalonePlainTextToolCallBlocks(legacy, { allowedToolNames: allowedNames() }),
+    ).toMatchObject([{ name: "exec", arguments: { command: "pwd" } }]);
+
+    const adjacent = "<function=exec></function><function=exec></function>";
+    expect(
+      parseStandalonePlainTextToolCallBlocks(adjacent, { allowedToolNames: allowedNames() }),
+    ).toHaveLength(2);
+  });
+
   it("rejects serialized XML parameter calls without a function close", () => {
     const raw = ["<function=exec>", "<parameter=command>", "pwd", "</parameter>"].join("\n");
 
@@ -433,6 +457,41 @@ describe("stripPlainTextToolCallBlocks", () => {
       ),
     ).toBe("before\nafter");
   });
+
+  it.each(["<function=read></function>", '[tool:read] {"path":"/tmp"}'])(
+    "strips adjacent same-line calls after an initial XML call: %s",
+    (second) => {
+      const calls = `<function=read></function>${second}`;
+      expect(stripPlainTextToolCallBlocks(`before\n${calls}\nafter`)).toBe("before\nafter");
+    },
+  );
+
+  it.each(["\u00a0", "\u000b", "\u000c"])(
+    "strips calls indented with non-linebreak whitespace %#",
+    (indent) => {
+      expect(
+        stripPlainTextToolCallBlocks(`before\n${indent}<function=read></function>\nafter`),
+      ).toBe("before\nafter");
+    },
+  );
+
+  it.each(["x".repeat(256_001), "é".repeat(128_001)])(
+    "strips complete JSON payloads over the UTF-8 cap",
+    (value) => {
+      const call = `[tool:read] ${JSON.stringify({ value })}`;
+      expect(stripPlainTextToolCallBlocks(`before\n${call}\nafter`)).toBe("before\nafter");
+    },
+  );
+
+  it.each(["</func", "<param"])(
+    "strips a complete optional-close call before an ambiguous %s prefix",
+    (suffix) => {
+      const block = ["[tool:exec]", "<parameter=command>", "pwd", "</parameter>"].join("\n");
+      expect(stripPlainTextToolCallBlocks(["before", block, suffix].join("\n"))).toBe(
+        `before\n${suffix}`,
+      );
+    },
+  );
 
   it("strips oversized XML parameter tool calls without promoting them", () => {
     const largeValue = "x".repeat(140_000);


### PR DESCRIPTION
## What Problem This Solves

The zero-argument XML repair merged in #103220 left serialized plain-text tool calls with multiple parser and stream-normalization paths. Incomplete, oversized, or split calls could be exposed in terminal snapshots; mixed text/non-text streams could also lose ordering, native blocks, or visible prefix/suffix text.

This is a maintainer follow-up to #98984, #102240, #102933, #102975, #103220, and #103585.

## Why This Change Was Made

Consolidate serialized-call recognition behind one canonical grammar and one ordered, byte/character-bounded stream projection. Preserve shipped bracket/XML compatibility while making executable zero-argument XML calls explicit, retaining native content blocks and stable content indexes, and keeping recognized incomplete or oversized known-call syntax fail-closed while malformed non-call text remains visible.

The refactor deletes the older duplicated stream-state matrix and keeps provider and embedded-agent terminal behavior aligned.

## User Impact

Models that serialize tool calls as text no longer leak incomplete/oversized syntax or lose surrounding visible text and native blocks. Valid shipped formats continue to execute, including legacy implicit-close parameter calls; explicit zero-argument XML calls now repair consistently across provider streams, terminal snapshots, and embedded runs.

## Evidence

- Focused repair matrix: 315/315 tests passed on Blacksmith Testbox
- Static proof: all changed-surface typecheck lanes passed; exact formatting and targeted lint passed
- Fresh autoreview: clean, no accepted/actionable findings
- Blacksmith Testbox: [run 29136209593](https://github.com/openclaw/openclaw/actions/runs/29136209593)
- Live Gateway/provider proof at `8720b33ccbc90c2f7619e6b7c80f6aee215901aa`: full build; two loopback Responses requests; `session_status` start/result; final `TOOLCALL_LIVE_OK`; raw XML absent from events, history, transcript, and Gateway logs

Contributor credit is retained for @wangyan2026, @qingminglong, @wuqxuan, and @ZOOWH.

No agent transcript is attached.
