### PR TITLE
fix(macos): keep node execution policy on the Mac

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -15123,6 +15123,22 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 36,
+      "path": "apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift",
+      "source": "Local mode needs the CLI so launchd can run the Gateway.",
+      "surface": "apple",
+      "id": "native.apple.aacf7bad691821fd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 36,
+      "path": "apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift",
+      "source": "Mac node command execution needs the matching local CLI helper.",
+      "surface": "apple",
+      "id": "native.apple.c5d4db33f4539b02"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 34,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(version) is ready.",
@@ -18763,7 +18779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 936,
+      "line": 985,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "approvalSource requires matching systemRunPlan",
       "surface": "apple",
@@ -18771,7 +18787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 936,
+      "line": 985,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "explicit approval requires matching systemRunPlan",
       "surface": "apple",
@@ -18803,7 +18819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 236,
+      "line": 234,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -18811,7 +18827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 236,
+      "line": 234,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
@@ -19562,16 +19578,24 @@
       "id": "native.apple.42af85cdf91d0264"
     },
     {
-      "kind": "ui-call-concatenated",
-      "line": 700,
+      "kind": "conditional-branch",
+      "line": 702,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "OpenClaw is setting up its background service on this Mac. This usually takes under a minute — no Terminal, no administrator password.",
+      "source": "OpenClaw is installing its private command helper on this Mac. ",
       "surface": "apple",
-      "id": "native.apple.183aee003b44ede6"
+      "id": "native.apple.5ad444b2642f19b1"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 702,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
+      "source": "OpenClaw is setting up its background service on this Mac. ",
+      "surface": "apple",
+      "id": "native.apple.4532fc1108b20b27"
     },
     {
       "kind": "ui-named-argument",
-      "line": 711,
+      "line": 713,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -19579,7 +19603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 718,
+      "line": 721,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -19587,7 +19611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 719,
+      "line": 722,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -19595,7 +19619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 722,
+      "line": 726,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -19603,7 +19627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 723,
+      "line": 727,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -19611,7 +19635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 728,
+      "line": 732,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -19619,7 +19643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 731,
+      "line": 735,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -19627,7 +19651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 822,
+      "line": 826,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Agent workspace",
       "surface": "apple",
@@ -19635,7 +19659,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 824,
+      "line": 828,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
       "surface": "apple",
@@ -19643,7 +19667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 835,
+      "line": 839,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway detected",
       "surface": "apple",
@@ -19651,7 +19675,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 837,
+      "line": 841,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
       "surface": "apple",
@@ -19659,7 +19683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 843,
+      "line": 847,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copied",
       "surface": "apple",
@@ -19667,7 +19691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 843,
+      "line": 847,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Copy setup command",
       "surface": "apple",
@@ -19675,7 +19699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 849,
+      "line": 853,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Workspace folder",
       "surface": "apple",
@@ -19683,7 +19707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 863,
+      "line": 867,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Create workspace",
       "surface": "apple",
@@ -19691,7 +19715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 869,
+      "line": 873,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open folder",
       "surface": "apple",
@@ -19699,7 +19723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 880,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Save in config",
       "surface": "apple",
@@ -19707,7 +19731,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 897,
+      "line": 901,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
       "surface": "apple",
@@ -19715,7 +19739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 912,
+      "line": 916,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Meet your agent",
       "surface": "apple",
@@ -19723,7 +19747,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 914,
+      "line": 918,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
       "surface": "apple",
@@ -19731,7 +19755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 935,
+      "line": 939,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -19739,7 +19763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 942,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -19747,7 +19771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 946,
+      "line": 950,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -19755,7 +19779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 947,
+      "line": 951,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -19763,7 +19787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 954,
+      "line": 958,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -19771,7 +19795,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 955,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -19779,7 +19803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 964,
+      "line": 968,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -19787,7 +19811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 965,
+      "line": 969,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for quick chat and status.",
       "surface": "apple",
@@ -19795,7 +19819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 968,
+      "line": 972,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -19803,7 +19827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 969,
+      "line": 973,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -19811,7 +19835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 975,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -19819,7 +19843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 976,
+      "line": 980,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -19827,7 +19851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 977,
+      "line": 981,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -19835,7 +19859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 980,
+      "line": 984,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -19843,7 +19867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 981,
+      "line": 985,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel for quick chat; the agent can show previews ",
       "surface": "apple",
@@ -19851,7 +19875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 985,
+      "line": 989,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -19859,7 +19883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 986,
+      "line": 990,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -19867,7 +19891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 988,
+      "line": 992,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -19875,7 +19899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 993,
+      "line": 997,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -19883,7 +19907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1022,
+      "line": 1026,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -19891,7 +19915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1029,
+      "line": 1033,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -19899,7 +19923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1042,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -19907,7 +19931,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1041,
+      "line": 1045,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -19915,7 +19939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1047,
+      "line": 1051,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -19923,7 +19947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1053,
+      "line": 1057,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift
@@ -19,11 +19,12 @@ final class CLIInstallPrompter {
 
     private func checkAndPromptIfNeededAsync(reason: String) async {
         guard AppStateStore.shared.onboardingSeen else { return }
-        guard AppStateStore.shared.connectionMode == .local else { return }
+        guard AppStateStore.shared.connectionMode != .unconfigured else { return }
         guard let version = Self.appVersion() else { return }
         let status = await CLIInstaller.status()
         guard AppStateStore.shared.onboardingSeen else { return }
-        guard AppStateStore.shared.connectionMode == .local else { return }
+        let mode = AppStateStore.shared.connectionMode
+        guard mode != .unconfigured else { return }
         guard !status.isReady else { return }
         let lastPrompt = UserDefaults.standard.string(forKey: cliInstallPromptedVersionKey)
         guard lastPrompt != version else { return }
@@ -31,7 +32,9 @@ final class CLIInstallPrompter {
 
         let alert = NSAlert()
         alert.messageText = "Install OpenClaw CLI?"
-        alert.informativeText = "Local mode needs the CLI so launchd can run the gateway."
+        alert.informativeText = mode == .local
+            ? "Local mode needs the CLI so launchd can run the Gateway."
+            : "Mac node command execution needs the matching local CLI helper."
         alert.addButton(withTitle: "Install CLI")
         alert.addButton(withTitle: "Not now")
         alert.addButton(withTitle: "Open Settings")
@@ -55,17 +58,22 @@ final class CLIInstallPrompter {
             await status.set(message)
         }
         if installed {
-            await status.set("Starting OpenClaw Gateway…")
-            let activation = await CLIInstaller.activateLocalGateway()
-            let message = switch activation {
-            case .ready:
-                "OpenClaw Gateway is ready."
-            case .deferred:
-                "OpenClaw is installed. The Gateway will start when This Mac is active and resumed."
-            case .failed:
-                "OpenClaw was installed, but the Gateway did not start. Open Settings to retry."
+            let currentMode = AppStateStore.shared.connectionMode
+            if currentMode == .local {
+                await status.set("Starting OpenClaw Gateway…")
+                let activation = await CLIInstaller.activateLocalGateway(mode: currentMode)
+                let message = switch activation {
+                case .ready:
+                    "OpenClaw Gateway is ready."
+                case .deferred:
+                    "OpenClaw is installed. The Gateway will start when This Mac is active and resumed."
+                case .failed:
+                    "OpenClaw was installed, but the Gateway did not start. Open Settings to retry."
+                }
+                await status.set(message)
+            } else {
+                await status.set("OpenClaw CLI is ready for Mac node commands.")
             }
-            await status.set(message)
         }
         if let message = await status.get() {
             let alert = NSAlert()

--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -93,6 +93,7 @@ enum CLIInstaller {
             searchPaths: CommandResolver.preferredPaths(),
             fileManager: .default)
         guard !locations.isEmpty else {
+            self.forgetValidatedExecutable()
             return .missing(location: self.managedExecutableLocation())
         }
 
@@ -105,18 +106,22 @@ enum CLIInstaller {
             }
             fallbackStatus = fallbackStatus ?? status
         }
+        self.forgetValidatedExecutable()
         return fallbackStatus ?? .missing(location: self.managedExecutableLocation())
     }
 
     static func managedStatus() async -> Status {
         let location = self.managedExecutableLocation()
         guard FileManager.default.isExecutableFile(atPath: location) else {
+            self.forgetValidatedExecutable(at: location)
             return .missing(location: location)
         }
 
         let status = await self.status(location: location)
         if status.isReady {
             self.rememberValidated(status)
+        } else {
+            self.forgetValidatedExecutable(at: location)
         }
         return status
     }
@@ -199,6 +204,19 @@ enum CLIInstaller {
         guard case let .ready(location, version) = status else { return }
         UserDefaults.standard.set(location, forKey: cliValidatedExecutableKey)
         UserDefaults.standard.set(version, forKey: cliValidatedVersionKey)
+    }
+
+    static func forgetValidatedExecutable(
+        at location: String? = nil,
+        defaults: UserDefaults = .standard)
+    {
+        if let location,
+           defaults.string(forKey: cliValidatedExecutableKey) != location
+        {
+            return
+        }
+        defaults.removeObject(forKey: cliValidatedExecutableKey)
+        defaults.removeObject(forKey: cliValidatedVersionKey)
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -282,6 +282,21 @@ enum CommandResolver {
             return ssh
         }
 
+        return self.localOpenClawCommand(
+            subcommand: subcommand,
+            extraArgs: extraArgs,
+            searchPaths: searchPaths,
+            projectRoot: projectRoot)
+    }
+
+    /// Resolves only the CLI installed beside this app. Node-side preparation
+    /// must happen on the Mac node even when its Gateway connection uses SSH.
+    static func localOpenClawCommand(
+        subcommand: String,
+        extraArgs: [String] = [],
+        searchPaths: [String]? = nil,
+        projectRoot: URL? = nil) -> [String]
+    {
         let root = projectRoot ?? self.projectRoot()
         if let openclawPath = self.projectOpenClawExecutable(projectRoot: root) {
             return [openclawPath, subcommand] + extraArgs
@@ -318,6 +333,48 @@ enum CommandResolver {
         case let .failure(error):
             return self.runtimeErrorCommand(error)
         }
+    }
+
+    static func matchingLocalOpenClawCommand(
+        subcommand: String,
+        extraArgs: [String] = [],
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default,
+        requiredVersion: String? = GatewayEnvironment.expectedGatewayVersionString(),
+        searchPaths: [String]? = nil,
+        projectRoot: URL? = nil) -> [String]
+    {
+        if let executable = self.validatedOpenClawExecutable(
+            defaults: defaults,
+            fileManager: fileManager,
+            requiredVersion: requiredVersion)
+        {
+            return [executable, subcommand] + extraArgs
+        }
+        #if DEBUG
+        return self.localOpenClawCommand(
+            subcommand: subcommand,
+            extraArgs: extraArgs,
+            searchPaths: searchPaths,
+            projectRoot: projectRoot)
+        #else
+        return self.errorCommand(with: "matching local openclaw CLI unavailable; reinstall the CLI from Settings")
+        #endif
+    }
+
+    static func hasMatchingLocalOpenClawCommand() -> Bool {
+        if self.validatedOpenClawExecutable(
+            defaults: .standard,
+            fileManager: .default,
+            requiredVersion: GatewayEnvironment.expectedGatewayVersionString()) != nil
+        {
+            return true
+        }
+        #if DEBUG
+        return self.hasAnyOpenClawInvoker()
+        #else
+        return false
+        #endif
     }
 
     static func openclawCommand(

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -398,7 +398,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 // Validate PATH selection before local startup. Existing installs may not
                 // have the validation cache yet, and a stale external CLI must not win.
-                if state.connectionMode == .local {
+                if state.connectionMode != .unconfigured {
                     _ = await CLIInstaller.status()
                 }
                 await ConnectionModeCoordinator.shared.apply(

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -667,6 +667,7 @@ final class MacNodeModeCoordinator: NSObject {
         var caps: [String] = [
             OpenClawCapability.canvas.rawValue,
             OpenClawCapability.screen.rawValue,
+            OpenClawCapability.system.rawValue,
         ]
         if browserControlEnabled, connectionMode == .local {
             caps.append(OpenClawCapability.browser.rawValue)
@@ -706,7 +707,10 @@ final class MacNodeModeCoordinator: NSObject {
         return Dictionary(uniqueKeysWithValues: statuses.map { ($0.key.rawValue, $0.value) })
     }
 
-    nonisolated static func resolvedCommands(caps: [String]) -> [String] {
+    nonisolated static func resolvedCommands(
+        caps: [String],
+        systemRunPrepareEnabled: Bool = true) -> [String]
+    {
         var commands: [String] = [
             OpenClawCanvasCommand.present.rawValue,
             OpenClawCanvasCommand.hide.rawValue,
@@ -724,6 +728,9 @@ final class MacNodeModeCoordinator: NSObject {
             OpenClawSystemCommand.execApprovalsGet.rawValue,
             OpenClawSystemCommand.execApprovalsSet.rawValue,
         ]
+        if systemRunPrepareEnabled {
+            commands.append(OpenClawSystemCommand.prepareRun.rawValue)
+        }
 
         let capsSet = Set(caps)
         if capsSet.contains(OpenClawCapability.browser.rawValue) {
@@ -748,7 +755,9 @@ final class MacNodeModeCoordinator: NSObject {
     }
 
     private func currentCommands(caps: [String]) -> [String] {
-        Self.resolvedCommands(caps: caps)
+        Self.resolvedCommands(
+            caps: caps,
+            systemRunPrepareEnabled: CommandResolver.hasMatchingLocalOpenClawCommand())
     }
 
     nonisolated static func tlsPinStoreKey(for url: URL) -> String {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -27,6 +27,8 @@ actor MacNodeRuntime {
     private let codexThreadCatalogEnabled: @Sendable () -> Bool
     private let codexThreadListRequest: @Sendable (String?) async throws -> String
     private let execApprovalStoreMutations: ExecApprovalStoreMutations
+    private let systemRunPreparer: @Sendable (
+        _ params: OpenClawSystemRunPrepareParams) async throws -> OpenClawSystemRunPreparedArtifacts
     private let shellRunner: @Sendable (
         _ command: [String],
         _ cwd: String?,
@@ -67,6 +69,10 @@ actor MacNodeRuntime {
             try await MacNodeCodexThreadCatalog.list(paramsJSON: paramsJSON)
         },
         execApprovalStoreMutations: ExecApprovalStoreMutations = .live,
+        systemRunPreparer: @escaping @Sendable (
+            _ params: OpenClawSystemRunPrepareParams) async throws -> OpenClawSystemRunPreparedArtifacts = { params in
+            try await MacSystemRunPreparer.prepare(params)
+        },
         shellRunner: @escaping @Sendable (
             _ command: [String],
             _ cwd: String?,
@@ -84,6 +90,7 @@ actor MacNodeRuntime {
         self.codexThreadCatalogEnabled = codexThreadCatalogEnabled
         self.codexThreadListRequest = codexThreadListRequest
         self.execApprovalStoreMutations = execApprovalStoreMutations
+        self.systemRunPreparer = systemRunPreparer
         self.shellRunner = shellRunner
     }
 
@@ -135,6 +142,8 @@ actor MacNodeRuntime {
                 return try await self.handleComputerActInvoke(req)
             case OpenClawSystemCommand.run.rawValue:
                 return try await self.handleSystemRun(req)
+            case OpenClawSystemCommand.prepareRun.rawValue:
+                return try await self.handleSystemRunPrepare(req)
             case OpenClawSystemCommand.which.rawValue:
                 return try await self.handleSystemWhich(req)
             case OpenClawSystemCommand.notify.rawValue:
@@ -742,6 +751,46 @@ extension MacNodeRuntime {
 // MARK: - System commands
 
 extension MacNodeRuntime {
+    private func handleSystemRunPrepare(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
+        let params = try Self.decodeParams(OpenClawSystemRunPrepareParams.self, from: req.paramsJSON)
+        let prepared = try await self.systemRunPreparer(params)
+        let validated: ExecHostValidatedRequest
+        switch ExecHostRequestEvaluator.validateCommand(
+            command: prepared.plan.argv,
+            rawCommand: prepared.plan.commandText)
+        {
+        case let .success(value):
+            validated = value
+        case let .failure(error):
+            return Self.errorResponse(req, code: .invalidRequest, message: error.message)
+        }
+        guard validated.command == prepared.plan.argv else {
+            return Self.errorResponse(
+                req,
+                code: .invalidRequest,
+                message: "INVALID_REQUEST: local CLI returned an inconsistent system.run plan")
+        }
+        var plan = prepared.plan
+        // The CLI owns argv planning; native owns the display string used to
+        // bind delayed approval back to the exact command at execution time.
+        plan.commandText = validated.displayCommand
+        let evaluation = await ExecApprovalEvaluator.evaluate(
+            command: plan.argv,
+            rawCommand: plan.commandText,
+            displayCommand: plan.commandText,
+            cwd: plan.cwd,
+            envOverrides: params.env,
+            agentId: plan.agentId)
+        plan.policySnapshot = evaluation.policySnapshot.portable
+        let response = OpenClawSystemRunPrepareResponse(
+            plan: plan,
+            execPolicy: .init(
+                security: .init(rawValue: evaluation.security.rawValue)!,
+                ask: .init(rawValue: evaluation.ask.rawValue)!),
+            allowAlwaysCoverage: prepared.allowAlwaysCoverage)
+        return try BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: Self.encodePayload(response))
+    }
+
     private struct SystemRunPreparation {
         let params: OpenClawSystemRunParams
         let approvalSource: ExecApprovalRequestSource?

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacSystemRunPreparer.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacSystemRunPreparer.swift
@@ -1,0 +1,42 @@
+import Foundation
+import OpenClawKit
+
+enum MacSystemRunPreparer {
+    private static let timeoutSeconds = 15.0
+
+    static func prepare(_ params: OpenClawSystemRunPrepareParams) async throws
+        -> OpenClawSystemRunPreparedArtifacts
+    {
+        let input = try JSONEncoder().encode(params)
+        let command = CommandResolver.matchingLocalOpenClawCommand(
+            subcommand: "node",
+            extraArgs: ["_prepare-system-run"])
+        let path = CommandResolver.preferredPaths().joined(separator: ":")
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = path
+        let result = await ShellExecutor.runDetailed(
+            command: command,
+            cwd: nil,
+            env: environment,
+            timeout: self.timeoutSeconds,
+            stdin: input)
+        guard result.success else {
+            let detail = result.timedOut ? "timed out" : (result.errorMessage ?? "failed")
+            throw NSError(domain: "MacSystemRunPreparer", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "SYSTEM_RUN_PREPARE_FAILED: local CLI \(detail)",
+            ])
+        }
+        guard let data = result.stdout.data(using: .utf8) else {
+            throw NSError(domain: "MacSystemRunPreparer", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "SYSTEM_RUN_PREPARE_FAILED: local CLI returned invalid UTF-8",
+            ])
+        }
+        do {
+            return try JSONDecoder().decode(OpenClawSystemRunPreparedArtifacts.self, from: data)
+        } catch {
+            throw NSError(domain: "MacSystemRunPreparer", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "SYSTEM_RUN_PREPARE_FAILED: local CLI returned invalid JSON",
+            ])
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -190,10 +190,8 @@ struct OnboardingView: View {
     {
         switch mode {
         case .remote:
-            // Remote setup doesn't need local gateway/CLI/workspace setup pages,
-            // but the AI check runs against the remote gateway so a broken
-            // remote model surfaces here, not in the first chat.
-            return showOnboardingChat ? [0, 1, 3, 5, 8, 9] : [0, 1, 3, 5, 9]
+            let setupPages = requiresCLIInstall ? [0, 1, 2, 3, 5] : [0, 1, 3, 5]
+            return showOnboardingChat ? setupPages + [8, 9] : setupPages + [9]
         case .unconfigured:
             return showOnboardingChat ? [0, 1, 8, 9] : [0, 1, 9]
         case .local:
@@ -221,7 +219,7 @@ struct OnboardingView: View {
         Self.pageOrder(
             for: self.state.connectionMode,
             showOnboardingChat: self.showOnboardingChat,
-            requiresCLIInstall: self.state.connectionMode == .local && !self.cliInstalled)
+            requiresCLIInstall: self.state.connectionMode != .unconfigured && !self.cliInstalled)
     }
 
     var pageCount: Int {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -52,12 +52,17 @@ extension OnboardingView {
 
     func maybeInstallCLI(for pageIndex: Int) {
         if pageIndex == cliPageIndex, cliExecutableReady {
+            if state.connectionMode == .remote {
+                cliInstalled = true
+                cliStatus = "OpenClaw CLI is ready for Mac node commands."
+                return
+            }
             self.startExistingCLIActivationIfNeeded()
             return
         }
         guard Self.shouldAutoInstallCLI(
             onCLIPage: pageIndex == cliPageIndex,
-            isLocal: state.connectionMode == .local,
+            shouldInstall: state.connectionMode != .unconfigured,
             visible: onboardingVisible,
             statusKnown: cliStatusKnown,
             executableReady: cliExecutableReady,
@@ -69,14 +74,14 @@ extension OnboardingView {
 
     static func shouldAutoInstallCLI(
         onCLIPage: Bool,
-        isLocal: Bool,
+        shouldInstall: Bool,
         visible: Bool,
         statusKnown: Bool,
         executableReady: Bool,
         installed: Bool,
         installing: Bool) -> Bool
     {
-        onCLIPage && isLocal && visible && statusKnown && !executableReady && !installed && !installing
+        onCLIPage && shouldInstall && visible && statusKnown && !executableReady && !installed && !installing
     }
 
     func startExistingCLIActivationIfNeeded() {
@@ -163,6 +168,11 @@ extension OnboardingView {
         guard installed else { return }
         cliExecutableReady = true
         cliInstallLocation = CLIInstaller.managedExecutableLocation()
+        if self.state.connectionMode == .remote {
+            cliStatus = "OpenClaw CLI is ready for Mac node commands."
+            cliInstalled = true
+            return
+        }
         cliStatus = "Starting OpenClaw Gateway…"
         // The step checklist shows one spinner at a time: install first,
         // then the service start.

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -698,7 +698,9 @@ extension OnboardingView {
             Text("Getting things ready")
                 .font(.largeTitle.weight(.semibold))
             Text(
-                "OpenClaw is setting up its background service on this Mac. " +
+                (self.state.connectionMode == .remote
+                    ? "OpenClaw is installing its private command helper on this Mac. "
+                    : "OpenClaw is setting up its background service on this Mac. ") +
                     "This usually takes under a minute — no Terminal, no administrator password.")
                 .font(.body)
                 .foregroundStyle(.secondary)
@@ -714,10 +716,12 @@ extension OnboardingView {
                         : "A private copy inside your user folder.",
                     state: self.installStepStateForInstall,
                     monospacedDetail: self.cliInstalled && self.cliInstallLocation != nil)
-                self.installStepRow(
-                    title: "Start the background service",
-                    detail: "Runs quietly and starts again after a restart.",
-                    state: self.installStepStateForService)
+                if self.state.connectionMode == .local {
+                    self.installStepRow(
+                        title: "Start the background service",
+                        detail: "Runs quietly and starts again after a restart.",
+                        state: self.installStepStateForService)
+                }
                 self.installStepRow(
                     title: "Ready for the next step",
                     detail: "Once the service answers, you’ll connect your AI.",

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import OpenClawIPC
 
@@ -29,6 +30,27 @@ enum ShellExecutor {
         }
     }
 
+    private final class InputWriter: @unchecked Sendable {
+        let pipe = Pipe()
+
+        init() {
+            // Timeout can close the child side while a large request is still
+            // draining. Convert EPIPE into a write error instead of SIGPIPE.
+            _ = fcntl(self.pipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+        }
+
+        func write(_ data: Data) {
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? self.pipe.fileHandleForWriting.write(contentsOf: data)
+                try? self.pipe.fileHandleForWriting.close()
+            }
+        }
+
+        func close() {
+            try? self.pipe.fileHandleForWriting.close()
+        }
+    }
+
     private static func completedResult(
         status: Int,
         outTask: Task<Data, Never>,
@@ -49,7 +71,8 @@ enum ShellExecutor {
         command: [String],
         cwd: String?,
         env: [String: String]?,
-        timeout: Double?) async -> ShellResult
+        timeout: Double?,
+        stdin: Data? = nil) async -> ShellResult
     {
         guard !command.isEmpty else {
             return ShellResult(
@@ -73,8 +96,10 @@ enum ShellExecutor {
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
+        let stdinWriter = stdin == nil ? nil : InputWriter()
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
+        process.standardInput = stdinWriter?.pipe
 
         let outTask = Task { stdoutPipe.fileHandleForReading.readToEndSafely() }
         let errTask = Task { stderrPipe.fileHandleForReading.readToEndSafely() }
@@ -97,6 +122,7 @@ enum ShellExecutor {
                 do {
                     try process.run()
                 } catch {
+                    stdinWriter?.close()
                     completion.finish(
                         ShellResult(
                             stdout: "",
@@ -120,12 +146,17 @@ enum ShellExecutor {
                             success: false,
                             errorMessage: "timeout"))
                 }
+                if let stdin {
+                    stdinWriter?.write(stdin)
+                }
             }
         }
 
         do {
             try process.run()
+            if let stdin { stdinWriter?.write(stdin) }
         } catch {
+            stdinWriter?.close()
             return ShellResult(
                 stdout: "",
                 stderr: "",

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -235,6 +235,19 @@ import Testing
             requiredVersion: "2026.8.0") == nil)
     }
 
+    @Test @MainActor func `failed CLI validation clears only the matching cached executable`() throws {
+        let defaults = self.makeDefaults()
+        defaults.set("/tmp/openclaw", forKey: cliValidatedExecutableKey)
+        defaults.set("2026.7.10", forKey: cliValidatedVersionKey)
+
+        CLIInstaller.forgetValidatedExecutable(at: "/tmp/other", defaults: defaults)
+        #expect(defaults.string(forKey: cliValidatedExecutableKey) == "/tmp/openclaw")
+
+        CLIInstaller.forgetValidatedExecutable(at: "/tmp/openclaw", defaults: defaults)
+        #expect(defaults.string(forKey: cliValidatedExecutableKey) == nil)
+        #expect(defaults.string(forKey: cliValidatedVersionKey) == nil)
+    }
+
     @Test func `builds SSH command for remote mode`() {
         let defaults = self.makeDefaults()
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
@@ -268,6 +281,44 @@ import Testing
             #expect(script.contains("--json"))
             #expect(script.contains("CLI="))
         }
+    }
+
+    @Test func `local command never routes through remote gateway SSH`() throws {
+        let tmp = try makeTempDirForTests()
+        let binDir = tmp.appendingPathComponent("bin")
+        let openclawPath = binDir.appendingPathComponent("openclaw")
+        try makeExecutableForTests(at: openclawPath)
+
+        let cmd = CommandResolver.localOpenClawCommand(
+            subcommand: "node",
+            extraArgs: ["_prepare-system-run"],
+            searchPaths: [binDir.path],
+            projectRoot: tmp)
+
+        #expect(cmd == [openclawPath.path, "node", "_prepare-system-run"])
+        #expect(cmd.first != "/usr/bin/ssh")
+    }
+
+    @Test func `matching local command prefers validated CLI over project checkout`() throws {
+        let defaults = self.makeDefaults()
+        let tmp = try makeTempDirForTests()
+        let validated = tmp.appendingPathComponent("validated/openclaw")
+        let project = tmp.appendingPathComponent("project")
+        let projectCLI = project.appendingPathComponent("node_modules/.bin/openclaw")
+        try makeExecutableForTests(at: validated)
+        try makeExecutableForTests(at: projectCLI)
+        defaults.set(validated.path, forKey: cliValidatedExecutableKey)
+        defaults.set("2026.7.10", forKey: cliValidatedVersionKey)
+
+        let cmd = CommandResolver.matchingLocalOpenClawCommand(
+            subcommand: "node",
+            extraArgs: ["_prepare-system-run"],
+            defaults: defaults,
+            requiredVersion: "2026.7.1",
+            searchPaths: [projectCLI.deletingLastPathComponent().path],
+            projectRoot: project)
+
+        #expect(cmd == [validated.path, "node", "_prepare-system-run"])
     }
 
     @Test func `explicit SSH config host key policy omits strict override`() {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -6,6 +6,68 @@ import Testing
 
 @Suite(.serialized)
 struct ExecApprovalsStoreRefactorTests {
+    @Test
+    func `native prepare attaches current Mac policy to canonical CLI plan`() async throws {
+        try await self.withTempStateDir { _ in
+            _ = try ExecApprovalsStore.updateAgentSettings(agentId: "main") { entry in
+                entry.security = .full
+                entry.ask = .always
+            }.get()
+            let command = ["/usr/bin/printf", "<%s>"]
+            let artifacts = OpenClawSystemRunPreparedArtifacts(
+                plan: OpenClawSystemRunApprovalPlan(
+                    argv: command,
+                    cwd: nil,
+                    commandText: "/usr/bin/printf <%s>",
+                    agentId: "main",
+                    sessionKey: "session-1"),
+                allowAlwaysCoverage: .init(
+                    complete: true,
+                    patterns: [.init(pattern: "/usr/bin/printf")]))
+            let probe = ShellRunProbe()
+            let runtime = MacNodeRuntime(
+                systemRunPreparer: { params in
+                    #expect(params.command == command)
+                    return artifacts
+                },
+                shellRunner: { command, _, _, _ in await probe.run(command) })
+            let params = OpenClawSystemRunPrepareParams(
+                command: command,
+                agentId: "main",
+                sessionKey: "session-1")
+            let json = try String(data: JSONEncoder().encode(params), encoding: .utf8)
+
+            let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "prepare-native-policy",
+                command: OpenClawSystemCommand.prepareRun.rawValue,
+                paramsJSON: json))
+
+            #expect(response.ok)
+            let payload = try #require(response.payloadJSON?.data(using: .utf8))
+            let prepared = try JSONDecoder().decode(OpenClawSystemRunPrepareResponse.self, from: payload)
+            #expect(prepared.execPolicy.security == .full)
+            #expect(prepared.execPolicy.ask == .always)
+            #expect(prepared.plan.policySnapshot?.security == .full)
+            #expect(prepared.plan.commandText == ExecCommandFormatter.displayString(for: command))
+            #expect(prepared.allowAlwaysCoverage.patterns == [.init(pattern: "/usr/bin/printf")])
+
+            let runParams = OpenClawSystemRunParams(
+                command: command,
+                agentId: "main",
+                sessionKey: "session-1",
+                systemRunPlan: prepared.plan,
+                approved: true)
+            let runJSON = try String(data: JSONEncoder().encode(runParams), encoding: .utf8)
+            let runResponse = await runtime.handleInvoke(BridgeInvokeRequest(
+                id: "run-native-policy",
+                command: OpenClawSystemCommand.run.rawValue,
+                paramsJSON: runJSON))
+
+            #expect(runResponse.ok)
+            #expect(await probe.capturedCommands() == [command])
+        }
+    }
+
     private actor ShellRunProbe {
         private var commands: [[String]] = []
 

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -77,6 +77,30 @@ struct LowCoverageHelperTests {
         #expect(result.stderr.contains("stderr-1999"))
     }
 
+    @Test func `shell executor delivers stdin without blocking timeout setup`() async {
+        let input = Data(repeating: 0x61, count: 256 * 1024)
+        let result = await ShellExecutor.runDetailed(
+            command: ["/bin/sh", "-c", "wc -c"],
+            cwd: nil,
+            env: nil,
+            timeout: 2,
+            stdin: input)
+
+        #expect(result.success)
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "262144")
+    }
+
+    @Test func `shell executor times out while child ignores large stdin`() async {
+        let result = await ShellExecutor.runDetailed(
+            command: ["/bin/sleep", "2"],
+            cwd: nil,
+            env: nil,
+            timeout: 0.05,
+            stdin: Data(repeating: 0x61, count: 1024 * 1024))
+
+        #expect(result.timedOut)
+    }
+
     @Test func `node info codable round trip`() throws {
         let info = NodeInfo(
             nodeId: "node-1",

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -431,6 +431,13 @@ struct MacNodeModeCoordinatorTests {
         #expect(!commands.contains(OpenClawBrowserCommand.proxy.rawValue))
         #expect(commands.contains(OpenClawCanvasCommand.present.rawValue))
         #expect(commands.contains(OpenClawSystemCommand.notify.rawValue))
+        #expect(caps.contains(OpenClawCapability.system.rawValue))
+        #expect(commands.contains(OpenClawSystemCommand.prepareRun.rawValue))
+
+        let commandsWithoutHelper = MacNodeModeCoordinator.resolvedCommands(
+            caps: caps,
+            systemRunPrepareEnabled: false)
+        #expect(!commandsWithoutHelper.contains(OpenClawSystemCommand.prepareRun.rawValue))
     }
 
     @Test func `local mode advertises browser proxy when enabled`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -112,7 +112,7 @@ struct OnboardingViewSmokeTests {
     @Test func `automatic CLI setup waits for the initial status probe`() {
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
+            shouldInstall: true,
             visible: true,
             statusKnown: false,
             executableReady: false,
@@ -120,7 +120,7 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
+            shouldInstall: true,
             visible: true,
             statusKnown: true,
             executableReady: false,
@@ -128,7 +128,7 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
+            shouldInstall: true,
             visible: false,
             statusKnown: true,
             executableReady: false,
@@ -157,6 +157,25 @@ struct OnboardingViewSmokeTests {
             isLocal: true,
             executableReady: true,
             installing: true))
+    }
+
+    @Test func `fresh remote setup installs CLI helper before inference setup`() {
+        let order = OnboardingView.pageOrder(
+            for: .remote,
+            showOnboardingChat: false,
+            requiresCLIInstall: true)
+
+        #expect(order.firstIndex(of: 2) == 2)
+        #expect(order.firstIndex(of: 3) == 3)
+    }
+
+    @Test func `live remote onboarding includes missing CLI helper page`() {
+        let state = AppState(preview: true)
+        state.connectionMode = .remote
+        let view = OnboardingView(state: state)
+        view.cliInstalled = false
+
+        #expect(view.pageOrder.contains(2))
     }
 
     @Test func `connection mode change restarts full page monitoring`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -136,7 +136,7 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
+            shouldInstall: true,
             visible: true,
             statusKnown: true,
             executableReady: true,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Capabilities.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Capabilities.swift
@@ -5,6 +5,7 @@ public enum OpenClawCapability: String, Codable, Sendable {
     case browser
     case camera
     case screen
+    case system
     case computer
     case voiceWake
     case talk

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
@@ -2,10 +2,101 @@ import Foundation
 
 public enum OpenClawSystemCommand: String, Codable, Sendable {
     case run = "system.run"
+    case prepareRun = "system.run.prepare"
     case which = "system.which"
     case notify = "system.notify"
     case execApprovalsGet = "system.execApprovals.get"
     case execApprovalsSet = "system.execApprovals.set"
+}
+
+public struct OpenClawSystemRunPrepareParams: Codable, Sendable, Equatable {
+    public var command: [String]
+    public var rawCommand: String?
+    public var cwd: String?
+    public var env: [String: String]?
+    public var agentId: String?
+    public var sessionKey: String?
+    public var strictInlineEval: Bool?
+
+    public init(
+        command: [String],
+        rawCommand: String? = nil,
+        cwd: String? = nil,
+        env: [String: String]? = nil,
+        agentId: String? = nil,
+        sessionKey: String? = nil,
+        strictInlineEval: Bool? = nil)
+    {
+        self.command = command
+        self.rawCommand = rawCommand
+        self.cwd = cwd
+        self.env = env
+        self.agentId = agentId
+        self.sessionKey = sessionKey
+        self.strictInlineEval = strictInlineEval
+    }
+}
+
+public struct OpenClawSystemRunAllowAlwaysCoverage: Codable, Sendable, Equatable {
+    public struct Pattern: Codable, Sendable, Equatable {
+        public var pattern: String
+        public var argPattern: String?
+
+        public init(pattern: String, argPattern: String? = nil) {
+            self.pattern = pattern
+            self.argPattern = argPattern
+        }
+    }
+
+    public var complete: Bool
+    public var patterns: [Pattern]
+
+    public init(complete: Bool, patterns: [Pattern]) {
+        self.complete = complete
+        self.patterns = patterns
+    }
+}
+
+public struct OpenClawSystemRunPreparedArtifacts: Codable, Sendable, Equatable {
+    public var plan: OpenClawSystemRunApprovalPlan
+    public var allowAlwaysCoverage: OpenClawSystemRunAllowAlwaysCoverage
+
+    public init(
+        plan: OpenClawSystemRunApprovalPlan,
+        allowAlwaysCoverage: OpenClawSystemRunAllowAlwaysCoverage)
+    {
+        self.plan = plan
+        self.allowAlwaysCoverage = allowAlwaysCoverage
+    }
+}
+
+public struct OpenClawSystemRunPrepareResponse: Codable, Sendable, Equatable {
+    public struct ExecPolicy: Codable, Sendable, Equatable {
+        public var security: OpenClawSystemRunApprovalPolicySnapshot.Security
+        public var ask: OpenClawSystemRunApprovalPolicySnapshot.Ask
+
+        public init(
+            security: OpenClawSystemRunApprovalPolicySnapshot.Security,
+            ask: OpenClawSystemRunApprovalPolicySnapshot.Ask)
+        {
+            self.security = security
+            self.ask = ask
+        }
+    }
+
+    public var plan: OpenClawSystemRunApprovalPlan
+    public var execPolicy: ExecPolicy
+    public var allowAlwaysCoverage: OpenClawSystemRunAllowAlwaysCoverage
+
+    public init(
+        plan: OpenClawSystemRunApprovalPlan,
+        execPolicy: ExecPolicy,
+        allowAlwaysCoverage: OpenClawSystemRunAllowAlwaysCoverage)
+    {
+        self.plan = plan
+        self.execPolicy = execPolicy
+        self.allowAlwaysCoverage = allowAlwaysCoverage
+    }
 }
 
 public enum OpenClawNotificationPriority: String, Codable, Sendable {

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -298,6 +298,17 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { networkProxy: "bypass" },
   },
   {
+    commandPath: ["node", "_prepare-system-run"],
+    exact: true,
+    policy: {
+      bypassConfigGuard: true,
+      loadPlugins: "never",
+      ownsProtocolStdout: true,
+      ensureCliPath: false,
+      networkProxy: "bypass",
+    },
+  },
+  {
     commandPath: ["node", "run"],
     exact: true,
     policy: { networkProxy: "default" },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -66,6 +66,16 @@ describe("command-path-policy", () => {
     });
   });
 
+  it("isolates node run preparation as a machine protocol", () => {
+    expectResolvedPolicy(["node", "_prepare-system-run"], {
+      bypassConfigGuard: true,
+      loadPlugins: "never",
+      ownsProtocolStdout: true,
+      ensureCliPath: false,
+      networkProxy: "bypass",
+    });
+  });
+
   it("applies exact overrides after broader channel plugin rules", () => {
     expectResolvedPolicy(["channels", "send"], {
       loadPlugins: "always",

--- a/src/cli/node-cli/prepare-system-run.test.ts
+++ b/src/cli/node-cli/prepare-system-run.test.ts
@@ -1,0 +1,41 @@
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { runNodePrepareSystemRun } from "./prepare-system-run.js";
+
+describe("runNodePrepareSystemRun", () => {
+  it("returns the canonical plan and allow-always coverage", async () => {
+    const output = await runNodePrepareSystemRun(
+      Readable.from([
+        JSON.stringify({
+          command: ["/bin/sh", "-lc", "/bin/echo ok"],
+          rawCommand: "/bin/echo ok",
+          agentId: "main",
+          sessionKey: "session-1",
+        }),
+      ]),
+    );
+
+    expect(JSON.parse(output)).toMatchObject({
+      plan: {
+        argv: ["/bin/sh", "-lc", "/bin/echo ok"],
+        agentId: "main",
+        sessionKey: "session-1",
+      },
+      allowAlwaysCoverage: { complete: true },
+    });
+  });
+
+  it("rejects blocked environment overrides", async () => {
+    await expect(
+      runNodePrepareSystemRun(
+        Readable.from([
+          JSON.stringify({
+            command: ["/bin/sh", "-lc", "/bin/echo ok"],
+            rawCommand: "/bin/echo ok",
+            env: { PATH: "/tmp" },
+          }),
+        ]),
+      ),
+    ).rejects.toThrow("blocked override keys: PATH");
+  });
+});

--- a/src/cli/node-cli/prepare-system-run.ts
+++ b/src/cli/node-cli/prepare-system-run.ts
@@ -1,0 +1,37 @@
+import type { Readable } from "node:stream";
+import {
+  prepareSystemRunApproval,
+  type SystemRunPrepareParams,
+} from "../../node-host/system-run-prepare.js";
+
+const MAX_INPUT_BYTES = 1024 * 1024;
+
+async function readBoundedInput(input: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of input) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_INPUT_BYTES) {
+      throw new Error("system.run.prepare input exceeds 1 MiB");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function runNodePrepareSystemRun(input: Readable = process.stdin): Promise<string> {
+  const raw = await readBoundedInput(input);
+  const params = JSON.parse(raw) as unknown;
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    throw new Error("system.run.prepare input must be a JSON object");
+  }
+  const result = await prepareSystemRunApproval(params as SystemRunPrepareParams);
+  if (!result.ok) {
+    throw new Error(result.message);
+  }
+  return JSON.stringify({
+    plan: result.plan,
+    allowAlwaysCoverage: result.allowAlwaysCoverage,
+  });
+}

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -17,6 +17,7 @@ import {
   runNodeDaemonStop,
   runNodeDaemonUninstall,
 } from "./daemon.js";
+import { runNodePrepareSystemRun } from "./prepare-system-run.js";
 
 function parsePortOption(value: unknown, fallback: number): number | null {
   // Undefined keeps config/default port; invalid explicit input returns null for CLI errors.
@@ -44,6 +45,16 @@ export function registerNodeCli(program: Command) {
           ["openclaw node restart", "Restart the installed node host service."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/node", "docs.openclaw.ai/cli/node")}\n`,
     );
+
+  node.command("_prepare-system-run", { hidden: true }).action(async () => {
+    try {
+      process.stdout.write(`${await runNodePrepareSystemRun()}\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    }
+  });
 
   node
     .command("run")

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -7,44 +7,29 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { GatewayClient } from "../gateway/client.js";
 import {
-  analyzeArgvCommand,
   createExecApprovalPolicySnapshot,
   ensureExecApprovalsSnapshot,
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
-  resolveAllowAlwaysPatternCoverage,
   updateExecApprovals,
   type ExecAsk,
   type ExecApprovalsFile,
   type ExecApprovalsResolved,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
-import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import {
   requestExecHostViaSocket,
   type ExecHostRequest,
   type ExecHostResponse,
 } from "../infra/exec-host.js";
-import {
-  extractShellWrapperCommand,
-  isShellWrapperInvocation,
-} from "../infra/exec-wrapper-resolution.js";
-import {
-  inspectHostExecEnvOverrides,
-  sanitizeHostExecEnv,
-  sanitizeSystemRunEnvOverrides,
-} from "../infra/host-env-security.js";
+import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
 import { logWarn } from "../logger.js";
-import {
-  buildSystemRunApprovalPlan,
-  handleSystemRunInvoke,
-  resolveEffectiveSystemRunExecPolicy,
-} from "./invoke-system-run.js";
+import { handleSystemRunInvoke, resolveEffectiveSystemRunExecPolicy } from "./invoke-system-run.js";
 import type {
   ExecEventPayload,
   ExecFinishedEventParams,
@@ -53,6 +38,7 @@ import type {
   SystemRunParams,
 } from "./invoke-types.js";
 import { invokeRegisteredNodeHostCommand } from "./plugin-node-host.js";
+import { prepareSystemRunApproval, type SystemRunPrepareParams } from "./system-run-prepare.js";
 
 const OUTPUT_CAP = 200_000;
 const OUTPUT_EVENT_TAIL = 20_000;
@@ -73,122 +59,6 @@ type SystemExecApprovalsSetParams = {
   file: ExecApprovalsFile;
   baseHash?: string | null;
 };
-
-type SystemRunPrepareParams = {
-  command?: unknown;
-  rawCommand?: unknown;
-  cwd?: unknown;
-  env?: Record<string, string> | null;
-  agentId?: unknown;
-  sessionKey?: unknown;
-  strictInlineEval?: unknown;
-};
-
-type SystemRunPrepareEnv =
-  | {
-      ok: true;
-      env: Record<string, string>;
-    }
-  | {
-      ok: false;
-      message: string;
-    };
-
-function buildEnvOverrideRejectionMessage(params: {
-  rejectedOverrideBlockedKeys: string[];
-  rejectedOverrideInvalidKeys: string[];
-}): string {
-  const details: string[] = [];
-  if (params.rejectedOverrideBlockedKeys.length > 0) {
-    details.push(`blocked override keys: ${params.rejectedOverrideBlockedKeys.join(", ")}`);
-  }
-  if (params.rejectedOverrideInvalidKeys.length > 0) {
-    details.push(
-      `invalid non-portable override keys: ${params.rejectedOverrideInvalidKeys.join(", ")}`,
-    );
-  }
-  return `SYSTEM_RUN_DENIED: environment override rejected (${details.join("; ")})`;
-}
-
-function buildSystemRunPrepareCoverageEnv(params: {
-  argv: string[];
-  env?: Record<string, string> | null;
-}): SystemRunPrepareEnv {
-  const diagnostics = inspectHostExecEnvOverrides({
-    overrides: params.env ?? undefined,
-    blockPathOverrides: true,
-  });
-  if (
-    diagnostics.rejectedOverrideBlockedKeys.length > 0 ||
-    diagnostics.rejectedOverrideInvalidKeys.length > 0
-  ) {
-    return {
-      ok: false,
-      message: buildEnvOverrideRejectionMessage(diagnostics),
-    };
-  }
-  const envOverrides = sanitizeSystemRunEnvOverrides({
-    overrides: params.env ?? undefined,
-    shellWrapper: isShellWrapperInvocation(params.argv),
-  });
-  return {
-    ok: true,
-    // Prepared coverage is durable approval evidence, so keep this in parity
-    // with the env passed to `system.run` policy and execution.
-    env: sanitizeEnv(envOverrides),
-  };
-}
-
-async function buildSystemRunAllowAlwaysCoverage(params: {
-  argv: string[];
-  rawCommand?: string | null;
-  cwd: string | null | undefined;
-  env: Record<string, string> | undefined;
-  strictInlineEval?: boolean;
-}) {
-  const cwd = params.cwd ?? undefined;
-  const shellWrapper = extractShellWrapperCommand(params.argv, params.rawCommand);
-  if (shellWrapper.isWrapper) {
-    if (!shellWrapper.command) {
-      return { complete: false, patterns: [] };
-    }
-    const authorizationPlan = await planShellAuthorization({
-      command: shellWrapper.command,
-      cwd,
-      env: params.env,
-      platform: process.platform,
-    });
-    if (!authorizationPlan.ok) {
-      return { complete: false, patterns: [] };
-    }
-    const candidates = authorizationPlan.groups.flatMap((group) => group.candidates);
-    const reusableSegments = candidates
-      .filter((candidate) => candidate.allowAlways)
-      .map((candidate) => candidate.sourceSegment);
-    const coverage = resolveAllowAlwaysPatternCoverage({
-      segments: reusableSegments,
-      cwd,
-      env: params.env,
-      platform: process.platform,
-      strictInlineEval: params.strictInlineEval,
-    });
-    return {
-      ...coverage,
-      complete: coverage.complete && reusableSegments.length === candidates.length,
-    };
-  }
-  const analysis = analyzeArgvCommand({ argv: params.argv, cwd, env: params.env });
-  if (!analysis.ok) {
-    return { complete: false, patterns: [] };
-  }
-  return resolveAllowAlwaysPatternCoverage({
-    segments: analysis.segments,
-    cwd,
-    env: params.env,
-    platform: process.platform,
-    strictInlineEval: params.strictInlineEval,
-  });
-}
 
 type ExecApprovalsSnapshot = {
   path: string;
@@ -740,17 +610,9 @@ async function dispatchInvoke(
   if (command === "system.run.prepare") {
     try {
       const params = decodeParams<SystemRunPrepareParams>(frame.paramsJSON);
-      const prepared = buildSystemRunApprovalPlan(params);
+      const prepared = await prepareSystemRunApproval(params);
       if (!prepared.ok) {
         await sendErrorResult(client, frame, "INVALID_REQUEST", prepared.message);
-        return;
-      }
-      const prepareEnv = buildSystemRunPrepareCoverageEnv({
-        argv: prepared.plan.argv,
-        env: params.env ?? undefined,
-      });
-      if (!prepareEnv.ok) {
-        await sendErrorResult(client, frame, "INVALID_REQUEST", prepareEnv.message);
         return;
       }
       const { getRuntimeConfig } = await import("../config/config.js");
@@ -774,13 +636,7 @@ async function dispatchInvoke(
           security: execPolicy.security,
           ask: execPolicy.ask,
         },
-        allowAlwaysCoverage: await buildSystemRunAllowAlwaysCoverage({
-          argv: prepared.plan.argv,
-          rawCommand: typeof params.rawCommand === "string" ? params.rawCommand : null,
-          cwd: prepared.plan.cwd,
-          env: prepareEnv.env,
-          strictInlineEval: params.strictInlineEval === true,
-        }),
+        allowAlwaysCoverage: prepared.allowAlwaysCoverage,
       });
     } catch (err) {
       await sendInvalidRequestResult(client, frame, err);

--- a/src/node-host/system-run-prepare.ts
+++ b/src/node-host/system-run-prepare.ts
@@ -1,0 +1,139 @@
+import { analyzeArgvCommand, resolveAllowAlwaysPatternCoverage } from "../infra/exec-approvals.js";
+import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
+import {
+  extractShellWrapperCommand,
+  isShellWrapperInvocation,
+} from "../infra/exec-wrapper-resolution.js";
+import {
+  inspectHostExecEnvOverrides,
+  sanitizeHostExecEnv,
+  sanitizeSystemRunEnvOverrides,
+} from "../infra/host-env-security.js";
+import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
+
+export type SystemRunPrepareParams = {
+  command?: unknown;
+  rawCommand?: unknown;
+  cwd?: unknown;
+  env?: Record<string, string> | null;
+  agentId?: unknown;
+  sessionKey?: unknown;
+  strictInlineEval?: unknown;
+};
+
+function buildEnvOverrideRejectionMessage(params: {
+  rejectedOverrideBlockedKeys: string[];
+  rejectedOverrideInvalidKeys: string[];
+}): string {
+  const details: string[] = [];
+  if (params.rejectedOverrideBlockedKeys.length > 0) {
+    details.push(`blocked override keys: ${params.rejectedOverrideBlockedKeys.join(", ")}`);
+  }
+  if (params.rejectedOverrideInvalidKeys.length > 0) {
+    details.push(
+      `invalid non-portable override keys: ${params.rejectedOverrideInvalidKeys.join(", ")}`,
+    );
+  }
+  return `SYSTEM_RUN_DENIED: environment override rejected (${details.join("; ")})`;
+}
+
+function buildCoverageEnv(params: {
+  argv: string[];
+  env?: Record<string, string> | null;
+}): { ok: true; env: Record<string, string> } | { ok: false; message: string } {
+  const diagnostics = inspectHostExecEnvOverrides({
+    overrides: params.env ?? undefined,
+    blockPathOverrides: true,
+  });
+  if (
+    diagnostics.rejectedOverrideBlockedKeys.length > 0 ||
+    diagnostics.rejectedOverrideInvalidKeys.length > 0
+  ) {
+    return { ok: false, message: buildEnvOverrideRejectionMessage(diagnostics) };
+  }
+  const envOverrides = sanitizeSystemRunEnvOverrides({
+    overrides: params.env ?? undefined,
+    shellWrapper: isShellWrapperInvocation(params.argv),
+  });
+  return {
+    ok: true,
+    // Durable approval coverage must use the same environment policy as execution.
+    env: sanitizeHostExecEnv({ overrides: envOverrides, blockPathOverrides: true }),
+  };
+}
+
+async function buildAllowAlwaysCoverage(params: {
+  argv: string[];
+  rawCommand?: string | null;
+  cwd: string | null | undefined;
+  env: Record<string, string>;
+  strictInlineEval?: boolean;
+}) {
+  const cwd = params.cwd ?? undefined;
+  const shellWrapper = extractShellWrapperCommand(params.argv, params.rawCommand);
+  if (shellWrapper.isWrapper) {
+    if (!shellWrapper.command) {
+      return { complete: false, patterns: [] };
+    }
+    const authorizationPlan = await planShellAuthorization({
+      command: shellWrapper.command,
+      cwd,
+      env: params.env,
+      platform: process.platform,
+    });
+    if (!authorizationPlan.ok) {
+      return { complete: false, patterns: [] };
+    }
+    const candidates = authorizationPlan.groups.flatMap((group) => group.candidates);
+    const reusableSegments = candidates
+      .filter((candidate) => candidate.allowAlways)
+      .map((candidate) => candidate.sourceSegment);
+    const coverage = resolveAllowAlwaysPatternCoverage({
+      segments: reusableSegments,
+      cwd,
+      env: params.env,
+      platform: process.platform,
+      strictInlineEval: params.strictInlineEval,
+    });
+    return {
+      ...coverage,
+      complete: coverage.complete && reusableSegments.length === candidates.length,
+    };
+  }
+  const analysis = analyzeArgvCommand({ argv: params.argv, cwd, env: params.env });
+  if (!analysis.ok) {
+    return { complete: false, patterns: [] };
+  }
+  return resolveAllowAlwaysPatternCoverage({
+    segments: analysis.segments,
+    cwd,
+    env: params.env,
+    platform: process.platform,
+    strictInlineEval: params.strictInlineEval,
+  });
+}
+
+export async function prepareSystemRunApproval(params: SystemRunPrepareParams) {
+  const prepared = buildSystemRunApprovalPlan(params);
+  if (!prepared.ok) {
+    return prepared;
+  }
+  const prepareEnv = buildCoverageEnv({
+    argv: prepared.plan.argv,
+    env: params.env ?? undefined,
+  });
+  if (!prepareEnv.ok) {
+    return prepareEnv;
+  }
+  return {
+    ok: true as const,
+    plan: prepared.plan,
+    allowAlwaysCoverage: await buildAllowAlwaysCoverage({
+      argv: prepared.plan.argv,
+      rawCommand: typeof params.rawCommand === "string" ? params.rawCommand : null,
+      cwd: prepared.plan.cwd,
+      env: prepareEnv.env,
+      strictInlineEval: params.strictInlineEval === true,
+    }),
+  };
+}

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -6,6 +6,50 @@ import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
 describe("cli json stdout contract", () => {
+  it("keeps node run preparation independent from invalid config and doctor output", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, ".openclaw");
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(path.join(stateDir, "openclaw.json"), "{ invalid", "utf8");
+
+        const env = {
+          ...process.env,
+          HOME: tempHome,
+          USERPROFILE: tempHome,
+          OPENCLAW_TEST_FAST: "1",
+        };
+        delete env.OPENCLAW_HOME;
+        delete env.OPENCLAW_STATE_DIR;
+        delete env.OPENCLAW_CONFIG_PATH;
+        delete env.VITEST;
+
+        const entry = path.resolve(process.cwd(), "src/entry.ts");
+        const result = spawnSync(
+          process.execPath,
+          ["--import", "tsx", entry, "node", "_prepare-system-run"],
+          {
+            cwd: process.cwd(),
+            env,
+            encoding: "utf8",
+            input: JSON.stringify({ command: ["/usr/bin/printf", "<%s>"] }),
+          },
+        );
+
+        expect(result.status).toBe(0);
+        const parsed = JSON.parse(result.stdout.trim()) as {
+          plan?: { argv?: string[] };
+          allowAlwaysCoverage?: unknown;
+        };
+        expect(parsed.plan?.argv).toEqual(["/usr/bin/printf", "<%s>"]);
+        expect(parsed).toHaveProperty("allowAlwaysCoverage");
+        expect(result.stdout).not.toContain("Doctor warnings");
+        expect(result.stdout).not.toContain("Config invalid");
+      },
+      { prefix: "openclaw-prepare-json-e2e-" },
+    );
+  });
+
   it("keeps `update status --json` stdout parseable even with legacy doctor preflight inputs", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
Fixes #103873

## What Problem This Solves

Fixes an issue where users routing agent execution to a macOS app node would lose node-owned execution-policy and reusable allow-always analysis because the app omitted the CLI node's `system` capability and `system.run.prepare` command.

## Why This Change Was Made

The Mac node now exposes the core preparation surface and delegates canonical argv planning and allow-always coverage to an exact-version local OpenClaw CLI helper. Native code remains the authority for the current Mac approval policy, canonical display binding, and execution; helper advertisement fails closed when validation is stale or unavailable. Remote-Gateway onboarding installs the same private helper without starting a local Gateway.

## User Impact

Mac app nodes now provide the Gateway the same core execution preparation facts as headless CLI nodes while retaining their additive native capabilities. Agent execution can use the Mac's current policy and reusable approval coverage instead of the conservative legacy fallback, and mismatched or broken helpers are withheld rather than trusted.

## Evidence

- macOS full package suite on clawmac: 970 tests across 127 suites, all passed.
- macOS focused suites: command resolver/cache 24/24; shell stdin/timeout helpers 23/23; onboarding/coordinator/resolver 63/63.
- macOS prepare-to-run regression: TypeScript-style metacharacter display is normalized by native code, bound as delayed authority, and executes the exact argv.
- TypeScript focused tests: canonical prepare helper and node invoke dispatcher, 21/21 passed.
- Blacksmith Testbox `tbx_01kx7hs0tfyzafj74k0gjf2j6g`: `pnpm check:changed` completed in 11m02s with exit 0 on the final pre-rebase diff; post-rebase onboarding/resolver integration passed 42/42 on clawmac.
- Fresh autoreview completed after lifecycle, stale-cache, stdin/SIGPIPE, and cross-language canonicalization repairs.
