### PR TITLE
fix(codex): preserve UTF-16 pairs in tool output delta truncation

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -3705,7 +3705,7 @@ describe("CodexAppServerEventProjector", () => {
 
       expect(onToolResult).toHaveBeenCalledTimes(1);
       expect(onToolResult).toHaveBeenCalledWith({
-        text: `🛠️ \`bash\`\n\`\`\`txt\n${expectedChunk}...(truncated)...\n\`\`\``,
+        text: `🛠️ Bash\n\`\`\`txt\n${expectedChunk}...(truncated)...\n\`\`\``,
       });
       const text = (mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string }).text;
       expect(text).not.toMatch(

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -3676,127 +3676,43 @@ describe("CodexAppServerEventProjector", () => {
     expect(item.content).toContain("showing 10000");
   });
 
-  it("keeps streamed progress output UTF-16 safe at the 8,000-char progress message cap", async () => {
-    const onToolResult = vi.fn();
-    const projector = await createProjector({
-      ...(await createParams()),
-      verboseLevel: "full",
-      onToolResult,
-    });
+  it.each([
+    { prefixLength: 7_999, delta: "😀tail", expectedChunk: "" },
+    { prefixLength: 7_998, delta: "x😀tail", expectedChunk: "x\n" },
+  ])(
+    "keeps streamed progress UTF-16 safe with $prefixLength chars already emitted",
+    async ({ prefixLength, delta, expectedChunk }) => {
+      const onToolResult = vi.fn();
+      const projector = await createProjector({
+        ...(await createParams()),
+        verboseLevel: "full",
+        onToolResult,
+      });
 
-    // Case 1: remainingChars=1, delta starts with a non-BMP emoji.
-    // Old .slice(0, 1) would cut after the HIGH surrogate → lone surrogate.
-    // Fixed truncateUtf16Safe backs off → chunk is empty, no corrupt text emitted.
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: {
-          type: "commandExecution",
-          id: "cmd-progress-utf16-1",
-          command: "echo emoji",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "inProgress",
-          commandActions: [],
-          aggregatedOutput: null,
-          exitCode: null,
-          durationMs: null,
-        },
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-utf16-1",
-        delta: "a".repeat(7_999),
-      }),
-    );
-    // remainingChars = 1, delta starts with 😀 (surrogate pair U+D83D U+DE00)
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-utf16-1",
-        delta: "😀hello",
-      }),
-    );
+      await projector.handleNotification(
+        forCurrentTurn("item/commandExecution/outputDelta", {
+          itemId: "cmd-progress-utf16",
+          delta: "a".repeat(prefixLength),
+        }),
+      );
+      onToolResult.mockClear();
+      await projector.handleNotification(
+        forCurrentTurn("item/commandExecution/outputDelta", {
+          itemId: "cmd-progress-utf16",
+          delta,
+        }),
+      );
 
-    // Case 2: remainingChars=2, delta="x😀y" — cut lands on the HIGH surrogate.
-    // Old .slice(0, 2) → "x\uD83D" (lone HIGH surrogate).
-    // Fixed truncateUtf16Safe → "x" (backs off before the emoji).
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: {
-          type: "commandExecution",
-          id: "cmd-progress-utf16-2",
-          command: "echo emoji2",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "inProgress",
-          commandActions: [],
-          aggregatedOutput: null,
-          exitCode: null,
-          durationMs: null,
-        },
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-utf16-2",
-        delta: "a".repeat(7_998),
-      }),
-    );
-    // remainingChars = 2, emoji at positions 1-2 of "x😀y"
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-utf16-2",
-        delta: "x😀y",
-      }),
-    );
-
-    // Case 3: ASCII-only delta at the boundary — must not regress.
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: {
-          type: "commandExecution",
-          id: "cmd-progress-ascii",
-          command: "echo ascii",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "inProgress",
-          commandActions: [],
-          aggregatedOutput: null,
-          exitCode: null,
-          durationMs: null,
-        },
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-ascii",
-        delta: "0".repeat(7_990),
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("item/commandExecution/outputDelta", {
-        itemId: "cmd-progress-ascii",
-        delta: "0123456789",
-      }),
-    );
-
-    // Collect all emitted progress texts and verify no lone surrogates.
-    const LONE_SURROGATE =
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
-    const allTexts = onToolResult.mock.calls
-      .flat()
-      .filter((c): c is { text?: string } => typeof c === "object" && c !== null)
-      .map((c) => c.text)
-      .filter((t): t is string => typeof t === "string");
-
-    expect(allTexts.length).toBeGreaterThan(0);
-    for (const text of allTexts) {
-      expect(text).not.toMatch(LONE_SURROGATE);
-    }
-  });
+      expect(onToolResult).toHaveBeenCalledTimes(1);
+      expect(onToolResult).toHaveBeenCalledWith({
+        text: `🛠️ \`bash\`\n\`\`\`txt\n${expectedChunk}...(truncated)...\n\`\`\``,
+      });
+      const text = (mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string }).text;
+      expect(text).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
+      );
+    },
+  );
 
   it("freezes streamed raw prefix after UTF-16-safe truncation so full-output echoes stay suppressed", async () => {
     const projector = await createProjector();

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -3676,6 +3676,128 @@ describe("CodexAppServerEventProjector", () => {
     expect(item.content).toContain("showing 10000");
   });
 
+  it("keeps streamed progress output UTF-16 safe at the 8,000-char progress message cap", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "full",
+      onToolResult,
+    });
+
+    // Case 1: remainingChars=1, delta starts with a non-BMP emoji.
+    // Old .slice(0, 1) would cut after the HIGH surrogate → lone surrogate.
+    // Fixed truncateUtf16Safe backs off → chunk is empty, no corrupt text emitted.
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-progress-utf16-1",
+          command: "echo emoji",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-utf16-1",
+        delta: "a".repeat(7_999),
+      }),
+    );
+    // remainingChars = 1, delta starts with 😀 (surrogate pair U+D83D U+DE00)
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-utf16-1",
+        delta: "😀hello",
+      }),
+    );
+
+    // Case 2: remainingChars=2, delta="x😀y" — cut lands on the HIGH surrogate.
+    // Old .slice(0, 2) → "x\uD83D" (lone HIGH surrogate).
+    // Fixed truncateUtf16Safe → "x" (backs off before the emoji).
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-progress-utf16-2",
+          command: "echo emoji2",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-utf16-2",
+        delta: "a".repeat(7_998),
+      }),
+    );
+    // remainingChars = 2, emoji at positions 1-2 of "x😀y"
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-utf16-2",
+        delta: "x😀y",
+      }),
+    );
+
+    // Case 3: ASCII-only delta at the boundary — must not regress.
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-progress-ascii",
+          command: "echo ascii",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-ascii",
+        delta: "0".repeat(7_990),
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-progress-ascii",
+        delta: "0123456789",
+      }),
+    );
+
+    // Collect all emitted progress texts and verify no lone surrogates.
+    const LONE_SURROGATE =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+    const allTexts = onToolResult.mock.calls
+      .flat()
+      .filter((c): c is { text?: string } => typeof c === "object" && c !== null)
+      .map((c) => c.text)
+      .filter((t): t is string => typeof t === "string");
+
+    expect(allTexts.length).toBeGreaterThan(0);
+    for (const text of allTexts) {
+      expect(text).not.toMatch(LONE_SURROGATE);
+    }
+  });
+
   it("freezes streamed raw prefix after UTF-16-safe truncation so full-output echoes stay suppressed", async () => {
     const projector = await createProjector();
     // First over-cap delta ends mid-surrogate: truncateUtf16Safe backs up and

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1444,7 +1444,7 @@ export class CodexAppServerEventProjector {
       });
       return;
     }
-    const chunk = delta.length > remainingChars ? delta.slice(0, remainingChars) : delta;
+    const chunk = delta.length > remainingChars ? truncateUtf16Safe(delta, remainingChars) : delta;
     state.chars += chunk.length;
     state.messages += 1;
     const reachedLimit =


### PR DESCRIPTION
## What Problem This Solves

Codex command-output progress used a raw UTF-16 `slice` at the 8,000-code-unit display cap. When the boundary fell between the two code units of a non-BMP character, OpenClaw emitted a lone surrogate and rendered a corrupted replacement glyph.

## Why This Change Was Made

The projector already uses the shared `truncateUtf16Safe` helper for its sibling 10,000-code-unit transcript paths. This change applies the same established maximum-code-unit contract to the one missed progress path; it does not change message caps, ordinary output, or truncation notices.

## User Impact

Codex streaming tool output no longer renders a corrupted glyph when emoji or another non-BMP character straddles the progress-output truncation boundary.

## Evidence

- Production change: one helper substitution in `CodexAppServerEventProjector.handleOutputDelta`.
- Regression: two table-driven cases cover one and two remaining code units, assert the exact emitted progress payload, and reject lone surrogates.
- Sanitized AWS Crabbox `cbx_6b230760c967`, run `run_942f3e8b8b42`, exact head `441a17f98d494ba8e7ded547e7b169ff43bd4e47`: `pnpm test extensions/codex/src/app-server/event-projector.test.ts` passed 148/148 on Linux Node 24.
- Fresh full-branch autoreview against `origin/main`: clean, no accepted/actionable findings.
- Upstream Codex emits command output deltas as valid strings; OpenClaw remains responsible for preserving UTF-16 pairs when applying its local display cap.

## What Was Not Tested

- A live Codex session whose command output happens to place a non-BMP character at exactly code unit 7,999. The isolated proof drives the real projector notification path deterministically, which is the owner of this truncation behavior.
