### PR TITLE
fix(outbound): preserve attributed inline formatting

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7070,6 +7070,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /plugins/sdk-channel-outbound
 - Headings:
   - H2: Adapter
+  - H2: Plain-text sanitization
   - H2: Delivery Evidence
   - H2: Existing outbound adapters
   - H2: Durable sends

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -66,6 +66,24 @@ Only declare capabilities the native transport actually preserves. Cover
 each declared send, receipt, live-preview, and receive-ack capability with
 the contract helpers exported from this subpath.
 
+## Plain-text sanitization
+
+Use `sanitizeForPlainText(...)` when an outbound adapter needs to convert the
+supported HTML formatting tags into lightweight text markup. The default keeps
+the existing chat-style bold and strikethrough markers. Pass
+`{ style: "markdown" }` only when the channel reparses the result as Markdown:
+
+```ts
+import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
+
+const chatText = sanitizeForPlainText(text);
+const markdownText = sanitizeForPlainText(text, { style: "markdown" });
+```
+
+The Markdown style uses `**bold**` and `~~strikethrough~~`; italic and inline
+code keep `_italic_` and backtick markers in both styles. Select the style at
+the channel boundary instead of rewriting marker text after sanitization.
+
 ## Delivery Evidence
 
 A `MessageReceipt` records the result returned by a channel adapter. Concrete

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -351,7 +351,9 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
         chunker: chunkTextForOutbound,
         chunkerMode: "text",
         textChunkLimit: 4000,
-        sanitizeText: ({ text }) => sanitizeForPlainText(sanitizeOutboundText(text)),
+        // Native formatting consumes Markdown ranges, so preserve bold and strike semantics.
+        sanitizeText: ({ text }) =>
+          sanitizeForPlainText(sanitizeOutboundText(text), { style: "markdown" }),
         shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
           shouldSuppressLocalIMessageExecApprovalPrompt({ cfg, accountId, payload, hint }),
         deliveryCapabilities: {

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -12,6 +12,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { imessagePlugin } from "./channel.js";
 import { createIMessageTestPlugin } from "./imessage.test-plugin.js";
+import { extractMarkdownFormatRuns } from "./markdown-format.js";
 
 beforeEach(() => {
   resetFacadeRuntimeStateForTest();
@@ -109,6 +110,20 @@ describe("createIMessageTestPlugin", () => {
       media: true,
       replyTo: true,
       messageSendingHooks: true,
+    });
+  });
+
+  it("preserves sanitized HTML formatting as native ranges", () => {
+    const text = `<strong title="b>">bold</strong> <del data-note='s>'>strike</del>`;
+    const sanitized = imessagePlugin.outbound?.sanitizeText?.({ text, payload: { text } });
+
+    expect(sanitized).toBe("**bold** ~~strike~~");
+    expect(extractMarkdownFormatRuns(sanitized ?? "")).toEqual({
+      text: "bold strike",
+      ranges: [
+        { start: 0, length: 4, styles: ["bold"] },
+        { start: 5, length: 6, styles: ["strikethrough"] },
+      ],
     });
   });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -249,7 +249,9 @@ export function createTelegramOutboundAdapter(
     chunkerMode: "markdown",
     extractMarkdownImages: true,
     textChunkLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
-    sanitizeText: ({ text }) => sanitizeForPlainText(sanitizeAssistantVisibleText(text)),
+    // Default Telegram delivery reparses this result as Markdown; use its bold and strike delimiters.
+    sanitizeText: ({ text }) =>
+      sanitizeForPlainText(sanitizeAssistantVisibleText(text), { style: "markdown" }),
     shouldSuppressLocalPayloadPrompt: options.shouldSuppressLocalPayloadPrompt,
     beforeDeliverPayload: options.beforeDeliverPayload,
     shouldTreatDeliveredTextAsVisible: options.shouldTreatDeliveredTextAsVisible,

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -2,7 +2,7 @@ import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 // Telegram tests cover telegram outbound plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { splitTelegramHtmlChunks } from "./format.js";
+import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
 import { telegramOutbound } from "./outbound-adapter.js";
 import { clearTelegramRuntime } from "./runtime.js";
 
@@ -45,6 +45,15 @@ describe("telegramPlugin outbound", () => {
     const text = "The pipeline has 3 deals.";
 
     expect(telegramOutbound.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+
+  it("uses Telegram markdown markers for sanitized HTML formatting", () => {
+    clearTelegramRuntime();
+    const text = `<strong title="b>">bold</strong> <del data-note='s>'>strike</del>`;
+    const sanitized = telegramOutbound.sanitizeText?.({ text, payload: { text } });
+
+    expect(sanitized).toBe("**bold** ~~strike~~");
+    expect(markdownToTelegramHtml(sanitized ?? "")).toBe("<b>bold</b> <s>strike</s>");
   });
 
   it("preserves explicit HTML parse mode before chunking", () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -45,6 +45,7 @@ describe("sanitizeForPlainText", () => {
   it("converts attributed inline tags without matching tag-name prefixes", () => {
     const attributed = `<strong title="b>"><em title='i>'><del data-note="s>"><code class='c>'>x</code></del></em></strong>`;
     expect(sanitizeForPlainText(attributed)).toBe("*_~`x`~_*");
+    expect(sanitizeForPlainText(attributed, { style: "markdown" })).toBe("**_~~`x`~~_**");
     expect(
       sanitizeForPlainText(
         '<bold title="b">b</bold><strikeout title="s">s</strikeout><codebase>c</codebase>',

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -42,6 +42,11 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("<code>foo()</code>")).toBe("`foo()`");
   });
 
+  it("converts <code> with attributes to backtick wrapping", () => {
+    expect(sanitizeForPlainText('<code class="language-ts">foo()</code>')).toBe("`foo()`");
+    expect(sanitizeForPlainText('<code id="x" class="y">bar()</code>')).toBe("`bar()`");
+  });
+
   // --- block elements -----------------------------------------------------
 
   it("converts <p> and <div> to newlines", () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -62,6 +62,9 @@ describe("sanitizeForPlainText", () => {
   it("converts headings to bold text with newlines", () => {
     expect(sanitizeForPlainText("<h1>Title</h1>")).toBe("\n*Title*\n");
     expect(sanitizeForPlainText("<h3>Section</h3>")).toBe("\n*Section*\n");
+    expect(sanitizeForPlainText('<h2 title="section">Markdown</h2>', { style: "markdown" })).toBe(
+      "\n**Markdown**\n",
+    );
   });
 
   it("converts <li> to bullet points", () => {

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -25,26 +25,40 @@ describe("sanitizeForPlainText", () => {
   it("converts <b> and <strong> to WhatsApp bold", () => {
     expect(sanitizeForPlainText("<b>bold</b>")).toBe("*bold*");
     expect(sanitizeForPlainText("<strong>bold</strong>")).toBe("*bold*");
+    expect(sanitizeForPlainText('<strong class="emphasis">bold</strong>')).toBe("*bold*");
   });
 
   it("converts <i> and <em> to WhatsApp italic", () => {
     expect(sanitizeForPlainText("<i>italic</i>")).toBe("_italic_");
     expect(sanitizeForPlainText("<em>italic</em>")).toBe("_italic_");
+    expect(sanitizeForPlainText('<em data-language="en">italic</em>')).toBe("_italic_");
   });
 
   it("converts <s>, <strike>, and <del> to WhatsApp strikethrough", () => {
     expect(sanitizeForPlainText("<s>deleted</s>")).toBe("~deleted~");
     expect(sanitizeForPlainText("<del>removed</del>")).toBe("~removed~");
     expect(sanitizeForPlainText("<strike>old</strike>")).toBe("~old~");
+    expect(sanitizeForPlainText('<del data-revision="3">removed</del>')).toBe("~removed~");
   });
 
   it("converts <code> to backtick wrapping", () => {
     expect(sanitizeForPlainText("<code>foo()</code>")).toBe("`foo()`");
-  });
-
-  it("converts <code> with attributes to backtick wrapping", () => {
     expect(sanitizeForPlainText('<code class="language-ts">foo()</code>')).toBe("`foo()`");
     expect(sanitizeForPlainText('<code id="x" class="y">bar()</code>')).toBe("`bar()`");
+  });
+
+  it("keeps formatting tag boundaries exact", () => {
+    expect(sanitizeForPlainText("<bold>bold</bold>")).toBe("bold");
+    expect(sanitizeForPlainText("<strikeout>old</strikeout>")).toBe("old");
+    expect(sanitizeForPlainText("<codebase>foo()</codebase>")).toBe("foo()");
+  });
+
+  it("converts nested attributed formatting", () => {
+    expect(
+      sanitizeForPlainText(
+        '<strong class="emphasis"><code data-language="ts">foo()</code></strong>',
+      ),
+    ).toBe("*`foo()`*");
   });
 
   // --- block elements -----------------------------------------------------

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -43,11 +43,12 @@ describe("sanitizeForPlainText", () => {
   });
 
   it("converts attributed inline tags without matching tag-name prefixes", () => {
-    const attributed =
-      '<strong class="b"><em id="i"><del title="s"><code class="c">x</code></del></em></strong>';
+    const attributed = `<strong title="b>"><em title='i>'><del data-note="s>"><code class='c>'>x</code></del></em></strong>`;
     expect(sanitizeForPlainText(attributed)).toBe("*_~`x`~_*");
     expect(
-      sanitizeForPlainText("<bold>b</bold><strikeout>s</strikeout><codebase>c</codebase>"),
+      sanitizeForPlainText(
+        '<bold title="b">b</bold><strikeout title="s">s</strikeout><codebase>c</codebase>',
+      ),
     ).toBe("bsc");
   });
 

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -25,40 +25,30 @@ describe("sanitizeForPlainText", () => {
   it("converts <b> and <strong> to WhatsApp bold", () => {
     expect(sanitizeForPlainText("<b>bold</b>")).toBe("*bold*");
     expect(sanitizeForPlainText("<strong>bold</strong>")).toBe("*bold*");
-    expect(sanitizeForPlainText('<strong class="emphasis">bold</strong>')).toBe("*bold*");
   });
 
   it("converts <i> and <em> to WhatsApp italic", () => {
     expect(sanitizeForPlainText("<i>italic</i>")).toBe("_italic_");
     expect(sanitizeForPlainText("<em>italic</em>")).toBe("_italic_");
-    expect(sanitizeForPlainText('<em data-language="en">italic</em>')).toBe("_italic_");
   });
 
   it("converts <s>, <strike>, and <del> to WhatsApp strikethrough", () => {
     expect(sanitizeForPlainText("<s>deleted</s>")).toBe("~deleted~");
     expect(sanitizeForPlainText("<del>removed</del>")).toBe("~removed~");
     expect(sanitizeForPlainText("<strike>old</strike>")).toBe("~old~");
-    expect(sanitizeForPlainText('<del data-revision="3">removed</del>')).toBe("~removed~");
   });
 
   it("converts <code> to backtick wrapping", () => {
     expect(sanitizeForPlainText("<code>foo()</code>")).toBe("`foo()`");
-    expect(sanitizeForPlainText('<code class="language-ts">foo()</code>')).toBe("`foo()`");
-    expect(sanitizeForPlainText('<code id="x" class="y">bar()</code>')).toBe("`bar()`");
   });
 
-  it("keeps formatting tag boundaries exact", () => {
-    expect(sanitizeForPlainText("<bold>bold</bold>")).toBe("bold");
-    expect(sanitizeForPlainText("<strikeout>old</strikeout>")).toBe("old");
-    expect(sanitizeForPlainText("<codebase>foo()</codebase>")).toBe("foo()");
-  });
-
-  it("converts nested attributed formatting", () => {
+  it("converts attributed inline tags without matching tag-name prefixes", () => {
+    const attributed =
+      '<strong class="b"><em id="i"><del title="s"><code class="c">x</code></del></em></strong>';
+    expect(sanitizeForPlainText(attributed)).toBe("*_~`x`~_*");
     expect(
-      sanitizeForPlainText(
-        '<strong class="emphasis"><code data-language="ts">foo()</code></strong>',
-      ),
-    ).toBe("*`foo()`*");
+      sanitizeForPlainText("<bold>b</bold><strikeout>s</strikeout><codebase>c</codebase>"),
+    ).toBe("bsc");
   });
 
   // --- block elements -----------------------------------------------------

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -34,12 +34,12 @@ export function sanitizeForPlainText(text: string): string {
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
     // Bold → WhatsApp/Signal bold
-    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
+    .replace(/<(b|strong)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "*$2*")
     // Italic → WhatsApp/Signal italic
-    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
+    .replace(/<(i|em)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "_$2_")
     // Strikethrough → WhatsApp/Signal strikethrough
-    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
-    // Inline code (allow attributes such as class="language-ts")
+    .replace(/<(s|strike|del)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "~$2~")
+    // Inline code
     .replace(/<code(?:\s[^>]*)?>(.*?)<\/code>/gi, "`$1`")
     // Headings → bold text with newline
     .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -29,7 +29,9 @@ function stripRemainingHtmlTags(text: string): string {
  * are known to produce and avoids false positives on angle brackets in normal
  * prose (e.g. `a < b`).
  */
-export function sanitizeForPlainText(text: string): string {
+export function sanitizeForPlainText(text: string, options: { style?: "markdown" } = {}): string {
+  const boldMarker = options.style === "markdown" ? "**" : "*";
+  const strikeMarker = options.style === "markdown" ? "~~" : "~";
   const converted = stripInternalRuntimeScaffolding(text)
     // Preserve angle-bracket autolinks as plain URLs before tag stripping.
     .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
@@ -39,16 +41,16 @@ export function sanitizeForPlainText(text: string): string {
     .replace(/<br\s*\/?>/gi, "\n")
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
-    // Bold → WhatsApp/Signal bold
-    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
+    // Bold → selected lightweight markup
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, `${boldMarker}$2${boldMarker}`)
     // Italic → WhatsApp/Signal italic
     .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
-    // Strikethrough → WhatsApp/Signal strikethrough
-    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
+    // Strikethrough → selected lightweight markup
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, `${strikeMarker}$2${strikeMarker}`)
     // Inline code
     .replace(/<code>(.*?)<\/code>/gi, "`$1`")
     // Headings → bold text with newline
-    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
+    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, `\n${boldMarker}$1${boldMarker}\n`)
     // List items → bullet points
     .replace(/<li>(.*?)<\/li>/gi, "• $1\n");
 

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -7,7 +7,7 @@ export { stripInternalRuntimeScaffolding };
 
 const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
 
-// Quoted attribute values may contain `>`; consume them atomically so tag text never leaks.
+// Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
   /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -39,8 +39,8 @@ export function sanitizeForPlainText(text: string): string {
     .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
     // Strikethrough → WhatsApp/Signal strikethrough
     .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
-    // Inline code
-    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
+    // Inline code (allow attributes such as class="language-ts")
+    .replace(/<code(?:\s[^>]*)?>(.*?)<\/code>/gi, "`$1`")
     // Headings → bold text with newline
     .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
     // List items → bullet points

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -7,6 +7,10 @@ export { stripInternalRuntimeScaffolding };
 
 const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
 
+// Quoted attribute values may contain `>`; consume them atomically so tag text never leaks.
+const CONVERTIBLE_HTML_OPEN_TAG_RE =
+  /<(b|strong|i|em|s|strike|del|code|h[1-6]|li)(?=\s|>)(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+
 function stripRemainingHtmlTags(text: string): string {
   let previous: string;
   let current = text;
@@ -29,22 +33,24 @@ export function sanitizeForPlainText(text: string): string {
   const converted = stripInternalRuntimeScaffolding(text)
     // Preserve angle-bracket autolinks as plain URLs before tag stripping.
     .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
+    // Normalize attributes once; conversions below only need exact bare tag names.
+    .replace(CONVERTIBLE_HTML_OPEN_TAG_RE, "<$1>")
     // Line breaks
     .replace(/<br\s*\/?>/gi, "\n")
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
     // Bold → WhatsApp/Signal bold
-    .replace(/<(b|strong)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "*$2*")
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
     // Italic → WhatsApp/Signal italic
-    .replace(/<(i|em)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "_$2_")
+    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
     // Strikethrough → WhatsApp/Signal strikethrough
-    .replace(/<(s|strike|del)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "~$2~")
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
     // Inline code
-    .replace(/<code(?:\s[^>]*)?>(.*?)<\/code>/gi, "`$1`")
+    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
     // Headings → bold text with newline
-    .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
+    .replace(/<h[1-6]>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
     // List items → bullet points
-    .replace(/<li[^>]*>(.*?)<\/li>/gi, "• $1\n");
+    .replace(/<li>(.*?)<\/li>/gi, "• $1\n");
 
   return stripRemainingHtmlTags(converted).replace(/\n{3,}/g, "\n\n");
 }


### PR DESCRIPTION
Closes #104117

## What Problem This Solves

Outbound plain-text sanitization preserved lightweight formatting only for bare inline HTML tags. Attributed variants such as `<code class="language-ts">foo()</code>` and `<strong title="label">bold</strong>` fell through to generic tag stripping, so code, bold, italic, and strikethrough semantics disappeared before channel delivery.

The affected channels do not all consume the same lightweight markup. The shared default uses chat-style `*bold*` and `~strike~`, while Telegram and iMessage reparse Markdown and require `**bold**` and `~~strike~~`.

## Why This Change Was Made

The shared sanitizer now normalizes the fixed set of convertible opening tags with quote-aware attribute handling before applying one canonical conversion path. Exact tag-name boundaries keep near-miss tags such as `<codebase>` from being interpreted as formatting, and quoted `>` characters do not leak attribute text.

`sanitizeForPlainText` also accepts an optional Markdown style. Telegram and iMessage opt in at their outbound boundaries; IRC, WhatsApp, Google Chat, and existing SDK callers retain the previous default byte-for-byte. This avoids duplicating HTML parsing or rewriting user-authored marker text inside individual plugins.

## User Impact

Attributed inline code and emphasis now survive outbound delivery. Telegram and iMessage additionally retain the intended bold and strikethrough semantics after their native Markdown renderers consume the sanitized text.

## Evidence

- Shared sanitizer regressions cover nested attributed `strong`, `em`, `del`, and `code` tags; both quote styles; `>` inside quoted attributes; Markdown/default dialects; and tag-name near misses.
- Telegram adapter coverage asserts the sanitized Markdown and final Telegram HTML entities.
- iMessage adapter coverage asserts the sanitized Markdown and final native formatting ranges.
- Fresh autoreview on the final maintainer refactor: clean, confidence 0.93.
- `git diff --check` on exact head `fcfe58c20cc96d3d6e43fccbafd5b28cd7b87625`: pass.

### Exact-head remote validation

- AWS Crabbox `run_5e34256c43b5`: 5 files / 134 focused sanitizer, Telegram, and iMessage tests passed.
- AWS Crabbox `run_d7bcf32d174a`: `check:changed` passed core, core-test, plugin, plugin-test, docs, tsgo, oxlint, dependency, import-cycle, and runtime-policy lanes.
- Both ran through a trusted clean-main bootstrap on a fresh public-network AWS lease with `--fresh-pr`, no Tailscale, no instance profile, no hydration, and exact SHA verification. The lease was released.

### Source-blind transport validation

- IRC `run_699fe48ff261`: three real core CLI sends completed three TCP handshakes and emitted exactly three `PRIVMSG` frames. Attributed and bare nested fixtures were byte-identical; near-miss tags stayed plain; no attributes or duplicate sends leaked.
- Telegram final-head held proof: one attributed durable send (Gateway `44221`, TDLib `46369079296`) and one bare control (Gateway `44222`, TDLib `46370127872`) produced identical device text and identical bold, italic, strikethrough, and code entities. The old head reproduced the prior italic/literal-strike drift. No tag leakage, duplication, truncation, parse fallback, or delivery error occurred; all credential and AWS leases were released.

### Hosted CI

Exact-head CI run `29164064527` and all related checks completed with 70 successes, 29 intentional skips, zero failures, and zero pending jobs.

## Scope

No config, schema, dependency, storage, or protocol changes. Explicit Telegram HTML parse mode remains unchanged; this PR corrects the default Markdown delivery path.
