### PR TITLE
fix(google-meet): align DTMF delay metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Google Meet DTMF metadata:** report the same 12-second pre-PIN delay default in plugin metadata that the runtime and docs apply, keeping manifest-driven setup and config surfaces aligned. (#103613) Thanks @llagy007.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Google Meet DTMF metadata:** report the same 12-second pre-PIN delay default in plugin metadata that the runtime and docs apply, keeping manifest-driven setup and config surfaces aligned. (#103613) Thanks @llagy007.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -679,6 +679,7 @@ describe("google-meet plugin", () => {
       "chrome.bargeInRmsThreshold",
       "chrome.bargeInPeakThreshold",
       "chrome.bargeInCooldownMs",
+      "voiceCall.dtmfDelayMs",
       "voiceCall.postDtmfSpeechDelayMs",
     ]) {
       expect(entry.configSchema.uiHints?.[key]).toHaveProperty("advanced", true);
@@ -704,6 +705,14 @@ describe("google-meet plugin", () => {
     expect(requireConfigProperty(chromeProperties, "bargeInCooldownMs")).toEqual({
       type: "number",
       default: 900,
+    });
+    const defaultConfig = resolveGoogleMeetConfig({});
+    expect(defaultConfig.voiceCall.dtmfDelayMs).toBe(12000);
+    expect(
+      requireConfigProperty(configSchema.properties?.voiceCall?.properties, "dtmfDelayMs"),
+    ).toEqual({
+      type: "number",
+      default: defaultConfig.voiceCall.dtmfDelayMs,
     });
     expect(
       requireConfigProperty(

--- a/extensions/google-meet/openclaw.plugin.json
+++ b/extensions/google-meet/openclaw.plugin.json
@@ -425,7 +425,7 @@
           },
           "dtmfDelayMs": {
             "type": "number",
-            "default": 2500
+            "default": 12000
           },
           "postDtmfSpeechDelayMs": {
             "type": "number",


### PR DESCRIPTION
## What Problem This Solves

Google Meet runtime configuration and public docs use a 12-second `voiceCall.dtmfDelayMs` default, but the plugin manifest advertised 2.5 seconds. Manifest-driven setup and configuration surfaces could therefore show an effective default that the runtime never used.

Replaces #103613 because GitHub rejected the maintainer changelog push to the contributor fork despite `maintainer_can_modify=true`.

## Why This Change Was Made

The plugin-owned static manifest now matches the existing runtime contract. A resolver-to-manifest regression assertion compares the metadata default with the real resolved default, so the two sources cannot silently drift again. No new config key, runtime fallback, or compatibility path is added.

The original contributor change is preserved with a `Co-authored-by` trailer and changelog credit for @llagy007.

## User Impact

Google Meet setup and config UIs now report the same 12-second pre-PIN DTMF wait that the runtime and documentation already apply.

## Evidence

- Blacksmith Testbox `tbx_01kx7jty3bkfdn92q666kdwvb7`: `corepack pnpm test extensions/google-meet/index.test.ts extensions/google-meet/src/config.test.ts` passed, 2 files / 118 tests.
- Structured autoreview: clean, patch correct with 0.99 confidence.
- `oxfmt --check CHANGELOG.md extensions/google-meet/index.test.ts`: passed.
- `git diff --check`: passed.
- Source audit: `extensions/google-meet/src/config.ts` resolves 12000; `extensions/google-meet/src/runtime.ts` consumes it for PIN-derived waits; `docs/plugins/google-meet.md` documents 12000; only `openclaw.plugin.json` held 2500.

No browser or carrier call is required for this static metadata contract; the runtime behavior is intentionally unchanged.
