### PR TITLE
fix(transcripts): stop live capture when the agent run is canceled

### DIFF
--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
@@ -184,6 +184,7 @@ describe("discord live qa runtime", () => {
 
     expect(next.channels?.discord?.voice).toEqual({
       enabled: true,
+      mode: "stt-tts",
       autoJoin: [
         {
           guildId: "123456789012345678",

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -449,7 +449,6 @@ function buildDiscordQaConfig(
     ...baseCfg.plugins?.entries,
     discord: { enabled: true },
   };
-  const requireMention = !options.statusReactionsToolOnly;
   const messages = options.statusReactionsToolOnly
     ? {
         ...baseCfg.messages,
@@ -479,6 +478,7 @@ function buildDiscordQaConfig(
     ? {
         ...baseCfg.channels?.discord?.voice,
         enabled: true,
+        mode: "stt-tts" as const,
         autoJoin: [options.voiceAutoJoin],
       }
     : undefined;
@@ -504,12 +504,12 @@ function buildDiscordQaConfig(
             groupPolicy: "allowlist",
             guilds: {
               [params.guildId]: {
-                requireMention,
+                requireMention: !options.statusReactionsToolOnly,
                 users: [params.driverBotId],
                 channels: {
                   [params.channelId]: {
                     enabled: true,
-                    requireMention,
+                    requireMention: !options.statusReactionsToolOnly,
                     users: [params.driverBotId],
                   },
                 },

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from "node:crypto";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
+import { getTranscriptSourceProvider } from "../../transcripts/provider-registry.js";
+import type {
+  TranscriptSessionDescriptor,
+  TranscriptSourceLocator,
+  TranscriptSourceProvider,
+  TranscriptsStartResult,
+} from "../../transcripts/provider-types.js";
+import type { TranscriptsStore } from "../../transcripts/store.js";
+
+export type TranscriptsLogger = {
+  warn: (message: string) => void;
+};
+
+export type TranscriptsRuntimeContext = {
+  config?: OpenClawConfig;
+  stateDir: string;
+  logger: TranscriptsLogger;
+};
+
+export type ActiveTranscriptsSession = {
+  session: TranscriptSessionDescriptor;
+  providerId: string;
+  // Aborted starts stay active until a later stop confirms provider cleanup.
+  cleanupPending?: true;
+};
+
+// Process-local ownership shared by tool-driven and configured transcript captures.
+export const activeSessions = new Map<string, ActiveTranscriptsSession>();
+// Reserve ids across async provider startup so overlapping starts cannot
+// replace the only cleanup owner for an existing or still-starting capture.
+const startingSessionIds = new Set<string>();
+
+function createStartupAbortScope(parent?: AbortSignal): {
+  signal?: AbortSignal;
+  detach: () => void;
+} {
+  if (!parent) {
+    return { signal: undefined, detach: () => {} };
+  }
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(parent.reason);
+  if (parent.aborted) {
+    abortFromParent();
+  } else {
+    parent.addEventListener("abort", abortFromParent, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    // Provider startup owns this scoped signal only until start settles.
+    // Detaching prevents a later agent-run abort from ending live capture.
+    detach: () => parent.removeEventListener("abort", abortFromParent),
+  };
+}
+
+export function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required: true; trim?: boolean },
+): string;
+export function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options?: { required?: false; trim?: boolean },
+): string | undefined;
+export function readStringParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required?: boolean; trim?: boolean } = {},
+): string | undefined {
+  const value = params[key];
+  if (typeof value !== "string") {
+    if (options.required) {
+      throw new Error(`${key} required`);
+    }
+    return undefined;
+  }
+  const normalized = options.trim === false ? value : value.trim();
+  if (!normalized && options.required) {
+    throw new Error(`${key} required`);
+  }
+  return normalized || undefined;
+}
+
+export function createSessionId(): string {
+  return `transcript-${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+}
+
+// Provider routing comes from tool params so manual imports and live providers
+// share one persisted source descriptor.
+export function sourceFromParams(params: Record<string, unknown>): TranscriptSourceLocator {
+  const providerId = readStringParam(params, "providerId", { trim: true }) ?? "manual-transcript";
+  return {
+    providerId,
+    accountId: readStringParam(params, "accountId", { trim: true }),
+    guildId: readStringParam(params, "guildId", { trim: true }),
+    channelId: readStringParam(params, "channelId", { trim: true }),
+    meetingUrl: readStringParam(params, "meetingUrl", { trim: true }),
+  };
+}
+
+export function resolveSourceProvider(providerId: string, ctx: TranscriptsRuntimeContext) {
+  return providerId === manualTranscriptSourceProvider.id
+    ? manualTranscriptSourceProvider
+    : getTranscriptSourceProvider(providerId, ctx.config);
+}
+
+export function toolText(text: string, details?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: details ?? {},
+  };
+}
+
+export async function stopPendingTranscriptCapture(params: {
+  ctx: TranscriptsRuntimeContext;
+  provider: TranscriptSourceProvider | undefined;
+  session: TranscriptSessionDescriptor;
+  reason: string;
+}): Promise<string | undefined> {
+  if (!params.provider?.stop) {
+    return `transcripts provider ${params.session.source.providerId} cannot stop live capture`;
+  }
+  try {
+    const result = await params.provider.stop({
+      cfg: params.ctx.config,
+      sessionId: params.session.sessionId,
+      source: params.session.source,
+      reason: params.reason,
+    });
+    return result.ok ? undefined : result.error;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+export async function startTranscripts(params: {
+  ctx: TranscriptsRuntimeContext;
+  store: TranscriptsStore;
+  rawParams: Record<string, unknown>;
+  abortSignal?: AbortSignal;
+  startupWaitMs?: number;
+}) {
+  if (params.abortSignal?.aborted) {
+    throw new Error("transcripts start aborted");
+  }
+  const source = sourceFromParams(params.rawParams);
+  const provider = resolveSourceProvider(source.providerId, params.ctx);
+  if (!provider?.start) {
+    throw new Error(`transcripts provider ${source.providerId} cannot start live capture`);
+  }
+  const session: TranscriptSessionDescriptor = {
+    sessionId: readStringParam(params.rawParams, "sessionId", { trim: true }) ?? createSessionId(),
+    title: readStringParam(params.rawParams, "title", { trim: true }),
+    source,
+    startedAt: new Date().toISOString(),
+  };
+  if (activeSessions.has(session.sessionId) || startingSessionIds.has(session.sessionId)) {
+    throw new Error(`transcripts session already active: ${session.sessionId}`);
+  }
+  startingSessionIds.add(session.sessionId);
+  try {
+    await params.store.writeSession(session);
+    let startupPending = true;
+    const startupAbort = createStartupAbortScope(params.abortSignal);
+    let result: TranscriptsStartResult;
+    try {
+      result = await provider.start({
+        cfg: params.ctx.config,
+        session,
+        abortSignal: startupAbort.signal,
+        startupWaitMs: params.startupWaitMs,
+        onUtterance: async (utterance) => {
+          // Provider callbacks can race abort cleanup; never persist that late startup audio.
+          if (startupPending && startupAbort.signal?.aborted) {
+            return;
+          }
+          await params.store.appendUtteranceForSession(session, utterance);
+        },
+      });
+    } finally {
+      startupAbort.detach();
+    }
+    // Provider failures retain cleanup ownership; only a successful result can
+    // transfer a live capture to this lifecycle for abort/stop retry handling.
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    if (startupAbort.signal?.aborted) {
+      const cleanupError = await stopPendingTranscriptCapture({
+        ctx: params.ctx,
+        provider,
+        session,
+        reason: "service-stop",
+      });
+      if (cleanupError) {
+        activeSessions.set(session.sessionId, {
+          session,
+          providerId: provider.id,
+          cleanupPending: true,
+        });
+        throw new Error(`transcripts start aborted; provider cleanup failed: ${cleanupError}`);
+      }
+      throw new Error("transcripts start aborted");
+    }
+    startupPending = false;
+    activeSessions.set(session.sessionId, { session, providerId: provider.id });
+    return toolText(`Transcripts started: ${session.sessionId}`, {
+      sessionId: session.sessionId,
+      providerId: provider.id,
+    });
+  } finally {
+    startingSessionIds.delete(session.sessionId);
+  }
+}

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -20,7 +20,7 @@ export type TranscriptsRuntimeContext = {
   logger: TranscriptsLogger;
 };
 
-export type ActiveTranscriptsSession = {
+type ActiveTranscriptsSession = {
   session: TranscriptSessionDescriptor;
   providerId: string;
   // Aborted starts stay active until a later stop confirms provider cleanup.

--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -58,6 +58,168 @@ describe("transcripts tool", () => {
     );
   });
 
+  it("cancels a pending live capture when the agent run is aborted", async () => {
+    const stateDir = await makeStateDir();
+    const controller = new AbortController();
+    const stop = vi.fn(async () => ({ ok: true, sessionId: "cancelled-meeting" }));
+    const start = vi.fn(async (request) => {
+      expect(request.abortSignal).toBe(controller.signal);
+      controller.abort();
+      return { ok: true, session: request.session };
+    });
+    getTranscriptSourceProviderMock.mockReturnValue({
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+      stop,
+    });
+    const { tool } = await createHarness(stateDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          action: "start",
+          providerId: "proof-live",
+          sessionId: "cancelled-meeting",
+        },
+        controller.signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts start aborted");
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "cancelled-meeting",
+        reason: "service-stop",
+      }),
+    );
+  });
+
+  it("keeps capturing after a successfully started agent run is later aborted", async () => {
+    const stateDir = await makeStateDir();
+    const controller = new AbortController();
+    let emitAfterStart: (() => Promise<void>) | undefined;
+    const start = vi.fn(async (request) => {
+      emitAfterStart = async () => {
+        await request.onUtterance({
+          text: "captured after the start action completed",
+          final: true,
+        });
+      };
+      return { ok: true, session: request.session };
+    });
+    const stop = vi.fn(async () => ({ ok: true, sessionId: "ongoing-meeting" }));
+    getTranscriptSourceProviderMock.mockReturnValue({
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+      stop,
+    });
+    const { tool } = await createHarness(stateDir);
+
+    await tool.execute(
+      "call-1",
+      {
+        action: "start",
+        providerId: "proof-live",
+        sessionId: "ongoing-meeting",
+      },
+      controller.signal,
+      vi.fn(),
+    );
+    controller.abort();
+    await emitAfterStart?.();
+
+    await expect(
+      fs.readFile(
+        path.join(stateDir, "transcripts", currentDateDir(), "ongoing-meeting", "transcript.jsonl"),
+        "utf8",
+      ),
+    ).resolves.toContain("captured after the start action completed");
+    await tool.execute(
+      "call-2",
+      { action: "stop", sessionId: "ongoing-meeting" },
+      undefined,
+      vi.fn(),
+    );
+  });
+
+  it("drops late utterances and keeps repeated abort cleanup failures retryable", async () => {
+    const stateDir = await makeStateDir();
+    const controller = new AbortController();
+    let cleanupFailuresRemaining = 2;
+    const stop = vi.fn(async () =>
+      cleanupFailuresRemaining-- > 0
+        ? { ok: false, error: "voice cleanup failed" }
+        : { ok: true, sessionId: "cancelled-meeting-retry" },
+    );
+    const start = vi.fn(async (request) => {
+      controller.abort();
+      await request.onUtterance({
+        text: "captured after agent cancellation",
+        final: true,
+      });
+      return { ok: true, session: request.session };
+    });
+    getTranscriptSourceProviderMock.mockReturnValue({
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+      stop,
+    });
+    const { tool } = await createHarness(stateDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          action: "start",
+          providerId: "proof-live",
+          sessionId: "cancelled-meeting-retry",
+        },
+        controller.signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts start aborted; provider cleanup failed: voice cleanup failed");
+
+    await expect(
+      fs.readFile(
+        path.join(
+          stateDir,
+          "transcripts",
+          currentDateDir(),
+          "cancelled-meeting-retry",
+          "transcript.jsonl",
+        ),
+        "utf8",
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(stop).toHaveBeenCalledOnce();
+
+    await expect(
+      tool.execute(
+        "call-2",
+        { action: "stop", sessionId: "cancelled-meeting-retry" },
+        undefined,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts provider cleanup failed: voice cleanup failed");
+    expect(stop).toHaveBeenCalledTimes(2);
+
+    await tool.execute(
+      "call-3",
+      { action: "stop", sessionId: "cancelled-meeting-retry" },
+      undefined,
+      vi.fn(),
+    );
+    expect(stop).toHaveBeenCalledTimes(3);
+  });
+
   it("imports a speaker transcript and writes summary artifacts", async () => {
     const stateDir = await makeStateDir();
     const { tool } = await createHarness(stateDir);

--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TranscriptStopRequest } from "../../transcripts/provider-types.js";
 import { TranscriptsStore } from "../../transcripts/store.js";
 import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
 
@@ -63,8 +64,10 @@ describe("transcripts tool", () => {
     const controller = new AbortController();
     const stop = vi.fn(async () => ({ ok: true, sessionId: "cancelled-meeting" }));
     const start = vi.fn(async (request) => {
-      expect(request.abortSignal).toBe(controller.signal);
+      expect(request.abortSignal).not.toBe(controller.signal);
+      expect(request.abortSignal?.aborted).toBe(false);
       controller.abort();
+      expect(request.abortSignal?.aborted).toBe(true);
       return { ok: true, session: request.session };
     });
     getTranscriptSourceProviderMock.mockReturnValue({
@@ -102,7 +105,9 @@ describe("transcripts tool", () => {
     const stateDir = await makeStateDir();
     const controller = new AbortController();
     let emitAfterStart: (() => Promise<void>) | undefined;
+    let startupSignal: AbortSignal | undefined;
     const start = vi.fn(async (request) => {
+      startupSignal = request.abortSignal;
       emitAfterStart = async () => {
         await request.onUtterance({
           text: "captured after the start action completed",
@@ -131,7 +136,9 @@ describe("transcripts tool", () => {
       controller.signal,
       vi.fn(),
     );
+    expect(startupSignal).not.toBe(controller.signal);
     controller.abort();
+    expect(startupSignal?.aborted).toBe(false);
     await emitAfterStart?.();
 
     await expect(
@@ -203,6 +210,20 @@ describe("transcripts tool", () => {
 
     await expect(
       tool.execute(
+        "call-retry-start",
+        {
+          action: "start",
+          providerId: "proof-live",
+          sessionId: "cancelled-meeting-retry",
+        },
+        undefined,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts session already active: cancelled-meeting-retry");
+    expect(start).toHaveBeenCalledOnce();
+
+    await expect(
+      tool.execute(
         "call-2",
         { action: "stop", sessionId: "cancelled-meeting-retry" },
         undefined,
@@ -218,6 +239,163 @@ describe("transcripts tool", () => {
       vi.fn(),
     );
     expect(stop).toHaveBeenCalledTimes(3);
+  });
+
+  it("reserves a session id while provider startup is pending", async () => {
+    const stateDir = await makeStateDir();
+    let releaseStart: (() => void) | undefined;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const start = vi.fn(async (request) => {
+      await startGate;
+      return { ok: true as const, session: request.session };
+    });
+    const stop = vi.fn(async () => ({ ok: true as const, sessionId: "shared-session" }));
+    getTranscriptSourceProviderMock.mockReturnValue({
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+      stop,
+    });
+    const { tool } = await createHarness(stateDir);
+
+    const firstStart = tool.execute(
+      "call-1",
+      { action: "start", providerId: "proof-live", sessionId: "shared-session" },
+      undefined,
+      vi.fn(),
+    );
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledOnce();
+    });
+
+    await expect(
+      tool.execute(
+        "call-2",
+        { action: "start", providerId: "proof-live", sessionId: "shared-session" },
+        undefined,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts session already active: shared-session");
+    releaseStart?.();
+    await firstStart;
+    await tool.execute(
+      "call-3",
+      { action: "stop", sessionId: "shared-session" },
+      undefined,
+      vi.fn(),
+    );
+
+    expect(start).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("keeps thrown abort cleanup failures retryable", async () => {
+    const stateDir = await makeStateDir();
+    const controller = new AbortController();
+    let stopAttempts = 0;
+    const stop = vi.fn(async (_request: TranscriptStopRequest) => {
+      stopAttempts += 1;
+      if (stopAttempts === 1) {
+        throw new Error("voice cleanup threw");
+      }
+      return { ok: true as const, sessionId: "cancelled-meeting-thrown" };
+    });
+    const start = vi.fn(async (request) => {
+      await request.onUtterance({ text: "captured before abort", final: true });
+      controller.abort();
+      return { ok: true as const, session: request.session };
+    });
+    getTranscriptSourceProviderMock.mockReturnValue({
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+      stop,
+    });
+    const { tool } = await createHarness(stateDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          action: "start",
+          providerId: "proof-live",
+          sessionId: "cancelled-meeting-thrown",
+        },
+        controller.signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow("transcripts start aborted; provider cleanup failed: voice cleanup threw");
+    await tool.execute(
+      "call-2",
+      { action: "stop", sessionId: "cancelled-meeting-thrown" },
+      undefined,
+      vi.fn(),
+    );
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(stop.mock.calls.map(([request]) => request.reason)).toEqual([
+      "service-stop",
+      "tool-stop",
+    ]);
+  });
+
+  it("keeps missing abort cleanup hooks visible until the provider can stop", async () => {
+    const stateDir = await makeStateDir();
+    const controller = new AbortController();
+    const start = vi.fn(async (request) => {
+      controller.abort();
+      return { ok: true as const, session: request.session };
+    });
+    const provider = {
+      id: "proof-live",
+      name: "Proof Live",
+      sourceKinds: ["live-caption"],
+      start,
+    };
+    getTranscriptSourceProviderMock.mockReturnValue(provider);
+    const { tool } = await createHarness(stateDir);
+
+    await expect(
+      tool.execute(
+        "call-1",
+        {
+          action: "start",
+          providerId: "proof-live",
+          sessionId: "cancelled-meeting-no-stop",
+        },
+        controller.signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow(
+      "transcripts start aborted; provider cleanup failed: transcripts provider proof-live cannot stop live capture",
+    );
+
+    await expect(
+      tool.execute(
+        "call-2",
+        { action: "stop", sessionId: "cancelled-meeting-no-stop" },
+        undefined,
+        vi.fn(),
+      ),
+    ).rejects.toThrow(
+      "transcripts provider cleanup failed: transcripts provider proof-live cannot stop live capture",
+    );
+    const stop = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: "cancelled-meeting-no-stop",
+    }));
+    getTranscriptSourceProviderMock.mockReturnValue({ ...provider, stop });
+    await tool.execute(
+      "call-3",
+      { action: "stop", sessionId: "cancelled-meeting-no-stop" },
+      undefined,
+      vi.fn(),
+    );
+    expect(stop).toHaveBeenCalledOnce();
   });
 
   it("imports a speaker transcript and writes summary artifacts", async () => {
@@ -514,11 +692,13 @@ describe("transcripts tool", () => {
   it("auto-starts configured live meeting sources", async () => {
     const stateDir = await makeStateDir();
     const start = vi.fn(async (request) => ({ ok: true, session: request.session }));
+    const stop = vi.fn(async () => ({ ok: true as const, sessionId: "standup" }));
     getTranscriptSourceProviderMock.mockReturnValue({
       id: "discord-voice",
       name: "Discord Voice",
       sourceKinds: ["live-audio"],
       start,
+      stop,
     });
     const { service } = await createHarness(stateDir, {
       autoStart: [
@@ -564,6 +744,8 @@ describe("transcripts tool", () => {
         "utf8",
       ),
     ).resolves.toContain("Standup");
+    await service.stop();
+    expect(stop).toHaveBeenCalledOnce();
   });
 
   it("aborts pending auto-starts when the service stops", async () => {

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -3,7 +3,6 @@
  *
  * Manages live capture, manual import, summarization, and process-local transcript sessions.
  */
-import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";
@@ -14,35 +13,23 @@ import {
   resolveTranscriptsConfig,
 } from "../../transcripts/config.js";
 import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
-import {
-  getTranscriptSourceProvider,
-  listTranscriptSourceProviders,
-} from "../../transcripts/provider-registry.js";
-import type {
-  TranscriptSessionDescriptor,
-  TranscriptSourceLocator,
-} from "../../transcripts/provider-types.js";
+import { listTranscriptSourceProviders } from "../../transcripts/provider-registry.js";
+import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
 import { TranscriptsStore, type TranscriptsSessionEntry } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
 import type { AnyAgentTool } from "./common.js";
-
-type TranscriptsLogger = {
-  warn: (message: string) => void;
-};
-
-type TranscriptsRuntimeContext = {
-  config?: OpenClawConfig;
-  stateDir: string;
-  logger: TranscriptsLogger;
-};
-
-type ActiveTranscriptsSession = {
-  session: TranscriptSessionDescriptor;
-  providerId: string;
-  cleanupPending?: boolean;
-};
-
-const activeSessions = new Map<string, ActiveTranscriptsSession>();
+import {
+  activeSessions,
+  createSessionId,
+  readStringParam,
+  resolveSourceProvider,
+  sourceFromParams,
+  startTranscripts,
+  stopPendingTranscriptCapture,
+  toolText,
+  type TranscriptsLogger,
+  type TranscriptsRuntimeContext,
+} from "./transcripts-tool-runtime.js";
 const AUTO_START_RETRY_ATTEMPTS = 12;
 const AUTO_START_RETRY_MS = 5_000;
 const AUTO_START_STOP_TIMEOUT_MS = 5_000;
@@ -59,35 +46,6 @@ function asParamsRecord(params: unknown): Record<string, unknown> {
   return params && typeof params === "object" && !Array.isArray(params)
     ? (params as Record<string, unknown>)
     : {};
-}
-
-function readStringParam(
-  params: Record<string, unknown>,
-  key: string,
-  options: { required: true; trim?: boolean },
-): string;
-function readStringParam(
-  params: Record<string, unknown>,
-  key: string,
-  options?: { required?: false; trim?: boolean },
-): string | undefined;
-function readStringParam(
-  params: Record<string, unknown>,
-  key: string,
-  options: { required?: boolean; trim?: boolean } = {},
-): string | undefined {
-  const value = params[key];
-  if (typeof value !== "string") {
-    if (options.required) {
-      throw new Error(`${key} required`);
-    }
-    return undefined;
-  }
-  const normalized = options.trim === false ? value : value.trim();
-  if (!normalized && options.required) {
-    throw new Error(`${key} required`);
-  }
-  return normalized || undefined;
 }
 
 const TranscriptsSchema = Type.Object(
@@ -107,10 +65,6 @@ const TranscriptsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
-
-function createSessionId(): string {
-  return `transcript-${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
-}
 
 function createStore(ctx: TranscriptsRuntimeContext): TranscriptsStore {
   return new TranscriptsStore(path.join(ctx.stateDir, "transcripts"));
@@ -138,32 +92,6 @@ async function waitForPendingAutoStartsToSettle(
   }
 }
 
-// Provider routing comes from tool params so manual imports and live providers
-// share one persisted source descriptor.
-function sourceFromParams(params: Record<string, unknown>): TranscriptSourceLocator {
-  const providerId = readStringParam(params, "providerId", { trim: true }) ?? "manual-transcript";
-  return {
-    providerId,
-    accountId: readStringParam(params, "accountId", { trim: true }),
-    guildId: readStringParam(params, "guildId", { trim: true }),
-    channelId: readStringParam(params, "channelId", { trim: true }),
-    meetingUrl: readStringParam(params, "meetingUrl", { trim: true }),
-  };
-}
-
-function resolveSourceProvider(providerId: string, ctx: TranscriptsRuntimeContext) {
-  return providerId === manualTranscriptSourceProvider.id
-    ? manualTranscriptSourceProvider
-    : getTranscriptSourceProvider(providerId, ctx.config);
-}
-
-function toolText(text: string, details?: Record<string, unknown>) {
-  return {
-    content: [{ type: "text" as const, text }],
-    details: details ?? {},
-  };
-}
-
 // Summaries are persisted beside the session so stop/import/summarize actions
 // return both model-readable details and a durable artifact path.
 async function summarizeAndPersist(params: {
@@ -186,81 +114,6 @@ async function summarizeAndPersist(params: {
       ? await params.store.writeSummaryToDir(summary, params.sessionDir)
       : await params.store.writeSummary(summary, params.session);
   return { summary, summaryPath };
-}
-
-async function startTranscripts(params: {
-  ctx: TranscriptsRuntimeContext;
-  store: TranscriptsStore;
-  rawParams: Record<string, unknown>;
-  abortSignal?: AbortSignal;
-  startupWaitMs?: number;
-}) {
-  if (params.abortSignal?.aborted) {
-    throw new Error("transcripts start aborted");
-  }
-  const source = sourceFromParams(params.rawParams);
-  const provider = resolveSourceProvider(source.providerId, params.ctx);
-  if (!provider?.start) {
-    throw new Error(`transcripts provider ${source.providerId} cannot start live capture`);
-  }
-  const session: TranscriptSessionDescriptor = {
-    sessionId: readStringParam(params.rawParams, "sessionId", { trim: true }) ?? createSessionId(),
-    title: readStringParam(params.rawParams, "title", { trim: true }),
-    source,
-    startedAt: new Date().toISOString(),
-  };
-  await params.store.writeSession(session);
-  let startupPending = true;
-  const result = await provider.start({
-    cfg: params.ctx.config,
-    session,
-    abortSignal: params.abortSignal,
-    startupWaitMs: params.startupWaitMs,
-    onUtterance: async (utterance) => {
-      if (startupPending && params.abortSignal?.aborted) {
-        return;
-      }
-      await params.store.appendUtteranceForSession(session, utterance);
-    },
-  });
-  if (!result.ok) {
-    throw new Error(result.error);
-  }
-  if (params.abortSignal?.aborted) {
-    let cleanupError: string | undefined;
-    if (!provider.stop) {
-      cleanupError = `transcripts provider ${provider.id} cannot stop live capture`;
-    } else {
-      try {
-        const cleanupResult = await provider.stop({
-          cfg: params.ctx.config,
-          sessionId: session.sessionId,
-          source: session.source,
-          reason: "service-stop",
-        });
-        if (!cleanupResult.ok) {
-          cleanupError = cleanupResult.error;
-        }
-      } catch (error) {
-        cleanupError = error instanceof Error ? error.message : String(error);
-      }
-    }
-    if (cleanupError) {
-      activeSessions.set(session.sessionId, {
-        session,
-        providerId: provider.id,
-        cleanupPending: true,
-      });
-      throw new Error(`transcripts start aborted; provider cleanup failed: ${cleanupError}`);
-    }
-    throw new Error("transcripts start aborted");
-  }
-  startupPending = false;
-  activeSessions.set(session.sessionId, { session, providerId: provider.id });
-  return toolText(`Transcripts started: ${session.sessionId}`, {
-    sessionId: session.sessionId,
-    providerId: provider.id,
-  });
 }
 
 async function stopTranscripts(params: {
@@ -292,7 +145,17 @@ async function stopTranscripts(params: {
   const providerId = selectedActive?.providerId ?? session.source.providerId;
   const provider = resolveSourceProvider(providerId, params.ctx);
   let providerStopError: string | undefined;
-  if (selectedActive && provider?.stop) {
+  if (selectedActive?.cleanupPending) {
+    providerStopError = await stopPendingTranscriptCapture({
+      ctx: params.ctx,
+      provider,
+      session,
+      reason: "tool-stop",
+    });
+    if (providerStopError) {
+      throw new Error(`transcripts provider cleanup failed: ${providerStopError}`);
+    }
+  } else if (selectedActive && provider?.stop) {
     const result = await provider.stop({
       cfg: params.ctx.config,
       sessionId,
@@ -302,11 +165,6 @@ async function stopTranscripts(params: {
     if (!result.ok) {
       providerStopError = result.error;
     }
-  } else if (selectedActive?.cleanupPending) {
-    providerStopError = `transcripts provider ${providerId} cannot stop live capture`;
-  }
-  if (selectedActive?.cleanupPending && providerStopError) {
-    throw new Error(`transcripts provider cleanup failed: ${providerStopError}`);
   }
   const stoppedAt = new Date().toISOString();
   if (selectedActive) {

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -39,6 +39,7 @@ type TranscriptsRuntimeContext = {
 type ActiveTranscriptsSession = {
   session: TranscriptSessionDescriptor;
   providerId: string;
+  cleanupPending?: boolean;
 };
 
 const activeSessions = new Map<string, ActiveTranscriptsSession>();
@@ -209,25 +210,52 @@ async function startTranscripts(params: {
     startedAt: new Date().toISOString(),
   };
   await params.store.writeSession(session);
+  let startupPending = true;
   const result = await provider.start({
     cfg: params.ctx.config,
     session,
     abortSignal: params.abortSignal,
     startupWaitMs: params.startupWaitMs,
-    onUtterance: (utterance) => params.store.appendUtteranceForSession(session, utterance),
+    onUtterance: async (utterance) => {
+      if (startupPending && params.abortSignal?.aborted) {
+        return;
+      }
+      await params.store.appendUtteranceForSession(session, utterance);
+    },
   });
   if (!result.ok) {
     throw new Error(result.error);
   }
   if (params.abortSignal?.aborted) {
-    await provider.stop?.({
-      cfg: params.ctx.config,
-      sessionId: session.sessionId,
-      source: session.source,
-      reason: "service-stop",
-    });
+    let cleanupError: string | undefined;
+    if (!provider.stop) {
+      cleanupError = `transcripts provider ${provider.id} cannot stop live capture`;
+    } else {
+      try {
+        const cleanupResult = await provider.stop({
+          cfg: params.ctx.config,
+          sessionId: session.sessionId,
+          source: session.source,
+          reason: "service-stop",
+        });
+        if (!cleanupResult.ok) {
+          cleanupError = cleanupResult.error;
+        }
+      } catch (error) {
+        cleanupError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    if (cleanupError) {
+      activeSessions.set(session.sessionId, {
+        session,
+        providerId: provider.id,
+        cleanupPending: true,
+      });
+      throw new Error(`transcripts start aborted; provider cleanup failed: ${cleanupError}`);
+    }
     throw new Error("transcripts start aborted");
   }
+  startupPending = false;
   activeSessions.set(session.sessionId, { session, providerId: provider.id });
   return toolText(`Transcripts started: ${session.sessionId}`, {
     sessionId: session.sessionId,
@@ -274,6 +302,11 @@ async function stopTranscripts(params: {
     if (!result.ok) {
       providerStopError = result.error;
     }
+  } else if (selectedActive?.cleanupPending) {
+    providerStopError = `transcripts provider ${providerId} cannot stop live capture`;
+  }
+  if (selectedActive?.cleanupPending && providerStopError) {
+    throw new Error(`transcripts provider cleanup failed: ${providerStopError}`);
   }
   const stoppedAt = new Date().toISOString();
   if (selectedActive) {
@@ -392,6 +425,7 @@ async function statusTranscripts(ctx: TranscriptsRuntimeContext) {
     providerId: entry.providerId,
     title: entry.session.title,
     source: entry.session.source,
+    cleanupPending: entry.cleanupPending === true,
   }));
   return toolText(
     [
@@ -419,7 +453,7 @@ export function createTranscriptsTool(options?: {
     description:
       "Start/stop/import/summarize/status meeting transcripts: Discord, Google Meet, Slack huddles, others.",
     parameters: TranscriptsSchema,
-    async execute(_toolCallId, rawParams) {
+    async execute(_toolCallId, rawParams, signal) {
       const config = resolveTranscriptsConfig(ctx.config?.transcripts);
       if (!config.enabled) {
         throw new Error("transcripts are disabled");
@@ -429,7 +463,7 @@ export function createTranscriptsTool(options?: {
       const store = createStore(ctx);
       switch (action) {
         case "start":
-          return await startTranscripts({ ctx, store, rawParams: params });
+          return await startTranscripts({ ctx, store, rawParams: params, abortSignal: signal });
         case "stop":
           return await stopTranscripts({ ctx, store, rawParams: params });
         case "import":

--- a/src/transcripts/provider-types.ts
+++ b/src/transcripts/provider-types.ts
@@ -65,7 +65,12 @@ export type TranscriptStartRequest = {
   onStatus?: (status: TranscriptSourceStatus) => void | Promise<void>;
 };
 
-/** Result from starting a transcript source provider. */
+/**
+ * Result from starting a transcript source provider.
+ *
+ * Providers retain cleanup ownership until they return `ok: true`. A failed or
+ * rejected start must release any partial capture before it settles.
+ */
 export type TranscriptsStartResult =
   | {
       ok: true;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Canceling an agent run while live transcript capture is starting can still let the provider finish, persist late utterances, and remain active after the run has ended.

## Why This Change Was Made

The transcripts tool now forwards the agent run's cancellation signal into provider startup. While startup is pending, it suppresses utterances delivered after cancellation and cleans up a provider that nevertheless starts successfully. Failed, thrown, or temporarily unavailable cleanup remains visible and retryable until a later stop confirms release.

The process-local capture registry and startup cleanup now live in a focused runtime module, keeping the agent tool under the repository LOC ratchet. The provider contract also makes ownership explicit: providers retain cleanup responsibility until a successful start transfers ownership to core.

Discord QA auto-join explicitly selects `stt-tts`, so the transport smoke path does not depend on optional realtime voice-provider credentials.

## User Impact

Stopping an agent run now prevents a pending transcript capture from writing late content or becoming an untracked background capture. Successfully started captures remain independent of later cancellation of the run that created them.

## Evidence

- Blacksmith Testbox: 50/50 focused tests passed on the final patch (`16` core transcript lifecycle, `4` Discord provider, `30` Discord QA runtime), plus `tsgo:core` and `tsgo:core:test`. Run: https://github.com/openclaw/openclaw/actions/runs/29228977125
- Exact rebased head `3eed95c349692eaf73c62d5324c6254e2bb8cd1f`: hosted CI run https://github.com/openclaw/openclaw/actions/runs/29241130171 completed with 44 successful and 12 skipped jobs and no failures.
- Patch-identical prepared head `061cc5dc6f0788868723c830fa37ce7b14c9bb7f`: hosted CI run https://github.com/openclaw/openclaw/actions/runs/29231802684 passed with 50 successful checks, 11 skipped, and no failures.
- Live Discord run `run_aef319a1c70e`: real SUT join, agent AbortController cancellation, cleanup leave verified through Discord, second join, 4-second Ogg/Opus playback from the driver bot, SUT capture, and transcript callback. Captured audio: `783404` bytes. A deterministic media-understanding stub isolated the proof to real Discord audio ingress/capture and cancellation lifecycle.
- Provider fault coverage includes successful cleanup, returned cleanup failure, thrown cleanup failure, missing stop support, repeated retry, late utterance suppression, and later cancellation after a successful start.
- `transcripts-tool.ts` reduced from `623` to `461` lines; the extracted runtime module is `177` lines. The TypeScript LOC guard passes on the rebased head.
- Structured autoreview found and repaired two lifecycle ownership gaps (startup-signal detachment and session-id reservation); the required repair-cycle rerun reported no accepted/actionable findings.
