### PR TITLE
fix(restart): fail closed when pending inspection throws instead of emitting restart

### DIFF
--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -1283,7 +1283,9 @@ describe("infra runtime", () => {
       }
     });
 
-    it("emits SIGUSR1 if deferral check throws", async () => {
+    // #104064: an inspection failure means active-work state is unknown;
+    // fail closed by deferring instead of emitting (old behavior emitted).
+    it("defers restart if deferral check throws", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};
       process.on("SIGUSR1", handler);
@@ -1293,6 +1295,33 @@ describe("infra runtime", () => {
         });
         scheduleGatewaySigusr1Restart({ delayMs: 0 });
         await vi.advanceTimersByTimeAsync(0);
+        // Must NOT emit — state is unknown, so fail closed
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("emits restart after deferral check recovers from error", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      let callCount = 0;
+      try {
+        setPreRestartDeferralCheck(() => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error("boom");
+          }
+          return 0;
+        });
+        scheduleGatewaySigusr1Restart({ delayMs: 0 });
+        await vi.advanceTimersByTimeAsync(0);
+        // First check threw: no emission
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        // Next poll interval: check returns 0, emit restart
+        await vi.advanceTimersByTimeAsync(500);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -214,10 +214,14 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     expect(hooks.onTimeout).not.toHaveBeenCalled();
   });
 
-  it("handles getPendingCount error by restarting immediately", () => {
+  // #104064: an inspection exception means active-work state is unknown;
+  // fail closed by entering the deferred poll and retrying instead of
+  // emitting a restart (the old fail-open behavior).
+  it("defers restart when initial getPendingCount throws", () => {
     const hooks: RestartDeferralHooks = {
       onCheckError: vi.fn(),
       onReady: vi.fn(),
+      onDeferring: vi.fn(),
     };
 
     deferGatewayRestartUntilIdle({
@@ -228,6 +232,71 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     });
 
     expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    // Must enter deferred state, not emit a restart
+    expect(hooks.onDeferring).toHaveBeenCalled();
     expect(hooks.onReady).not.toHaveBeenCalled();
+  });
+
+  it("retries on the next poll after initial getPendingCount throws, then emits when zero", async () => {
+    let callCount = 0;
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+      onDeferring: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("transient");
+        }
+        return 0;
+      },
+      hooks,
+    });
+
+    // Initial inspection threw: deferred, no restart
+    expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+
+    // Next poll succeeds with zero: emit restart
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hooks.onReady).toHaveBeenCalledOnce();
+  });
+
+  it("preserves active poll when polling getPendingCount throws", async () => {
+    let callCount = 0;
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        callCount++;
+        if (callCount <= 2) {
+          return 1; // initial + first poll: pending
+        }
+        if (callCount === 3) {
+          throw new Error("transient"); // second poll: throw
+        }
+        return 0; // third poll: drained
+      },
+      hooks,
+    });
+
+    // First poll: still pending
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hooks.onReady).not.toHaveBeenCalled();
+
+    // Second poll: throws — poll must remain active
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+
+    // Third poll: zero — restart emitted
+    await vi.advanceTimersByTimeAsync(500);
+    expect(hooks.onReady).toHaveBeenCalledOnce();
   });
 });

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -299,4 +299,33 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     await vi.advanceTimersByTimeAsync(500);
     expect(hooks.onReady).toHaveBeenCalledOnce();
   });
+
+  it("fires force timeout when polling getPendingCount keeps throwing", async () => {
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+      onTimeout: vi.fn(),
+    };
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        throw new Error("persistent");
+      },
+      maxWaitMs: 1_000,
+      hooks,
+      timeoutIntent: { force: true, reason: "gateway.restart.deferral-timeout" },
+    });
+
+    // Elapsed time has not yet reached the force timeout
+    vi.advanceTimersByTime(999);
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+
+    // Force timeout fires even though every inspection throws
+    vi.advanceTimersByTime(1);
+    expect(hooks.onTimeout).toHaveBeenCalledOnce();
+    expect(consumeGatewaySigusr1RestartIntent()).toEqual({
+      force: true,
+      reason: "gateway.restart.deferral-timeout",
+    });
+  });
 });

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -774,9 +774,10 @@ export function deferGatewayRestartUntilIdle(opts: {
     try {
       current = opts.getPendingCount();
     } catch (err) {
-      stopPoll();
       opts.hooks?.onCheckError?.(err);
-      void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
+      // Preserve the active poll and retry on the next interval — an
+      // inspection exception is not a confirmed-zero result, so fail
+      // closed by deferring instead of emitting a restart (#104064).
       return;
     }
     if (current <= 0) {
@@ -798,22 +799,23 @@ export function deferGatewayRestartUntilIdle(opts: {
       });
     }
   };
-  let pending: number;
+  // Inspection failure means active-work state is unknown; fail closed by
+  // entering the deferred poll instead of emitting a restart (#104064).
+  let pending: number | undefined;
   try {
     pending = opts.getPendingCount();
   } catch (err) {
     opts.hooks?.onCheckError?.(err);
-    void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
+  }
+  if (pending !== undefined && pending <= 0) {
+    attemptEmission({ notifyReady: true });
     return handle;
   }
-  if (pending > 0) {
-    opts.hooks?.onDeferring?.(pending);
-  }
+  // When the initial inspection throws, we enter deferral with an unknown
+  // count so the poll retries on the next interval.
+  opts.hooks?.onDeferring?.(pending ?? 0);
   poll = setInterval(inspectPending, pollMs);
   activeDeferralPolls.add(poll);
-  if (pending <= 0) {
-    attemptEmission({ notifyReady: true });
-  }
   return handle;
 }
 

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -775,9 +775,19 @@ export function deferGatewayRestartUntilIdle(opts: {
       current = opts.getPendingCount();
     } catch (err) {
       opts.hooks?.onCheckError?.(err);
-      // Preserve the active poll and retry on the next interval — an
-      // inspection exception is not a confirmed-zero result, so fail
-      // closed by deferring instead of emitting a restart (#104064).
+      // Inspection failure means active-work state is unknown; fail closed by
+      // retrying on the next interval. But if the force timeout has elapsed,
+      // the configured bounded bypass must still fire (#104064).
+      const elapsedMs = Date.now() - startedAt;
+      if (maxWaitMs !== undefined && elapsedMs >= maxWaitMs) {
+        stopPoll();
+        opts.hooks?.onTimeout?.(0, elapsedMs);
+        attemptEmission({
+          intent: opts.timeoutIntent,
+          notifyReady: false,
+          skipIdleCheck: true,
+        });
+      }
       return;
     }
     if (current <= 0) {


### PR DESCRIPTION
## What Problem This Solves

When the pre-restart deferral check throws, the gateway immediately emits `SIGUSR1` to restart. But an inspection failure means the active-work state is unknown — restarting with unknown state could disrupt active work. The safer behavior is to fail closed by deferring the restart.

## Fix

Change the deferral check error handling from emit-immediately to defer. If the check throws, the restart is deferred (fail-closed). If the check recovers on a subsequent call, the restart proceeds.

## Evidence

### Before fix: unknown state triggers immediate restart

```
Before fix: inspection throw emits SIGUSR1 restart immediately
Unknown state → restart could disrupt active work
```

### After fix: unknown state defers restart

```
After fix: inspection throw defers restart (fail-closed, unknown state = don't restart)
If check recovers on next call, restart proceeds normally
```

## Test plan

- [x] New test: deferral check throw no longer emits SIGUSR1
- [x] New test: restart proceeds after deferral check recovers from error
- [x] Normal deferral (returning count) still works