### PR TITLE
fix(browser): guard permission grant origins

### DIFF
--- a/extensions/browser/src/browser/routes/permissions.test.ts
+++ b/extensions/browser/src/browser/routes/permissions.test.ts
@@ -31,6 +31,21 @@ const pwMocks = vi.hoisted(() => ({
   })),
 }));
 
+const navigationGuardMocks = vi.hoisted(() => ({
+  assertBrowserNavigationAllowed: vi.fn(async (_opts: Record<string, unknown>) => {}),
+  withBrowserNavigationPolicy: vi.fn(
+    (
+      ssrfPolicy?: Record<string, unknown>,
+      opts?: { browserProxyMode?: "direct" | "explicit-browser-proxy" },
+    ) => ({
+      ...(ssrfPolicy ? { ssrfPolicy } : {}),
+      ...(opts?.browserProxyMode && opts.browserProxyMode !== "direct"
+        ? { browserProxyMode: opts.browserProxyMode }
+        : {}),
+    }),
+  ),
+}));
+
 vi.mock("../chrome.js", () => ({
   getChromeWebSocketUrl: cdpMocks.getChromeWebSocketUrl,
 }));
@@ -38,6 +53,8 @@ vi.mock("../chrome.js", () => ({
 vi.mock("../cdp.helpers.js", () => ({
   withCdpSocket: cdpMocks.withCdpSocket,
 }));
+
+vi.mock("../navigation-guard.js", () => navigationGuardMocks);
 
 const { registerBrowserPermissionRoutes, testing } = await import("./permissions.js");
 
@@ -71,7 +88,7 @@ function createRouteContext(
   ssrfPolicy: Record<string, unknown> = { allowPrivateNetwork: false },
 ) {
   return {
-    state: () => ({ resolved: { ssrfPolicy } }),
+    state: () => ({ resolved: { ssrfPolicy, extraArgs: [] } }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
     mapTabError: vi.fn(() => null),
@@ -110,6 +127,8 @@ describe("browser permission routes", () => {
     pwMocks.getPwAiModule.mockReset().mockResolvedValue(null);
     pwMocks.getPageForTargetId.mockClear();
     pwMocks.grantPermissions.mockClear();
+    navigationGuardMocks.assertBrowserNavigationAllowed.mockReset().mockResolvedValue(undefined);
+    navigationGuardMocks.withBrowserNavigationPolicy.mockClear();
   });
 
   it("uses Playwright context permissions for attached pages when available", async () => {
@@ -170,6 +189,28 @@ describe("browser permission routes", () => {
       origin: "https://meet.google.com",
       permissions: ["audioCapture", "videoCapture", "speakerSelection"],
     });
+  });
+
+  it("blocks policy-disallowed origins before granting permissions", async () => {
+    const blockedOriginError = new Error("Navigation blocked: test policy");
+    blockedOriginError.name = "InvalidBrowserNavigationUrlError";
+    navigationGuardMocks.assertBrowserNavigationAllowed.mockRejectedValueOnce(blockedOriginError);
+
+    const { response, profileCtx } = await callGrant({
+      origin: "http://169.254.169.254/latest/meta-data",
+      permissions: ["audioCapture"],
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toStrictEqual({ error: "Navigation blocked: test policy" });
+    expect(navigationGuardMocks.assertBrowserNavigationAllowed).toHaveBeenCalledWith({
+      url: "http://169.254.169.254",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+    expect(profileCtx.ensureBrowserAvailable).not.toHaveBeenCalled();
+    expect(cdpMocks.getChromeWebSocketUrl).not.toHaveBeenCalled();
+    expect(cdpMocks.send).not.toHaveBeenCalled();
+    expect(pwMocks.getPwAiModule).not.toHaveBeenCalled();
   });
 
   it("preserves structured browser availability errors", async () => {

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -7,10 +7,15 @@
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { resolveBrowserNavigationProxyMode } from "../browser-proxy-mode.js";
 import { resolveCdpControlPolicy } from "../cdp-reachability-policy.js";
 import { withCdpSocket } from "../cdp.helpers.js";
 import { getChromeWebSocketUrl } from "../chrome.js";
 import { toBrowserErrorResponse } from "../errors.js";
+import {
+  assertBrowserNavigationAllowed,
+  withBrowserNavigationPolicy,
+} from "../navigation-guard.js";
 import { getPwAiModule } from "../pw-ai-module.js";
 import type { BrowserRouteContext } from "../server-context.js";
 import type { ProfileContext } from "../server-context.js";
@@ -153,6 +158,16 @@ function toPlaywrightPermission(permission: string): string | undefined {
   }
 }
 
+function permissionOriginNavigationPolicy(ctx: BrowserRouteContext, profileCtx: ProfileContext) {
+  const resolved = ctx.state().resolved;
+  return withBrowserNavigationPolicy(resolved.ssrfPolicy, {
+    browserProxyMode: resolveBrowserNavigationProxyMode({
+      resolved,
+      profile: profileCtx.profile,
+    }),
+  });
+}
+
 /** Register permission grant endpoints on the browser control server. */
 export function registerBrowserPermissionRoutes(
   app: BrowserRouteRegistrar,
@@ -185,6 +200,10 @@ export function registerBrowserPermissionRoutes(
       }
 
       try {
+        await assertBrowserNavigationAllowed({
+          url: origin,
+          ...permissionOriginNavigationPolicy(ctx, profileCtx),
+        });
         await profileCtx.ensureBrowserAvailable();
         const cdpPolicy = resolveCdpControlPolicy(
           profileCtx.profile,


### PR DESCRIPTION
## What Problem This Solves

`/permissions/grant` validates the browser CDP control endpoint before granting page permissions, but it did not validate the supplied page origin with the same browser navigation policy used by navigation routes. That allowed permission grants to proceed for origins that the browser SSRF/navigation guard would otherwise reject.

## Why This Change Was Made

Permission grants are page-origin side effects. They should fail before launching or connecting to the browser when the requested origin is not allowed by the profile-aware browser navigation policy.

This change applies the existing browser navigation guard to the normalized permission origin before `ensureBrowserAvailable`, Playwright, or raw CDP grant paths run.

## User Impact

Users keep the existing permission grant behavior for allowed http(s) origins. Disallowed origins now return the existing browser navigation error response instead of granting microphone/camera permissions or touching CDP.

## Evidence

- Added a route regression that makes the navigation guard reject a private-link origin and verifies no browser availability check, CDP WebSocket lookup, raw CDP command, or Playwright grant path is invoked.
- Reused the existing profile-aware browser proxy/navigation policy helpers instead of adding a separate permission-only policy.

## Proof

Base: `upstream/main` at `ffc8051cacb50d1f4b39cc2c6f822083caba1f2a`.

- `node scripts/run-vitest.mjs extensions/browser/src/browser/routes/permissions.test.ts`
- `node_modules/.bin/oxfmt --check extensions/browser/src/browser/routes/permissions.ts extensions/browser/src/browser/routes/permissions.test.ts`
- `node scripts/run-oxlint.mjs extensions/browser/src/browser/routes/permissions.ts extensions/browser/src/browser/routes/permissions.test.ts`
- `git diff --check`
