### PR TITLE
fix(gateway): block suspension/restart while background exec sessions are running

### DIFF
--- a/packages/gateway-protocol/src/schema/gateway-suspend.ts
+++ b/packages/gateway-protocol/src/schema/gateway-suspend.ts
@@ -36,6 +36,7 @@ export const GatewaySuspendBlockerSchema = Type.Object(
       Type.Literal("queued-turn"),
       Type.Literal("terminal-persistence"),
       Type.Literal("terminal-session"),
+      Type.Literal("background-exec"),
     ]),
     count: CountSchema,
     message: Type.String(),

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -9,6 +9,7 @@ import type { ProcessSession } from "./bash-process-registry.js";
 import {
   addSession,
   appendOutput,
+  countRunningBackgroundSessions,
   drainSession,
   listFinishedSessions,
   markBackgrounded,
@@ -199,6 +200,54 @@ describe("bash process registry", () => {
       resetProcessRegistryForTests();
       vi.useRealTimers();
     }
+  });
+
+  describe("countRunningBackgroundSessions", () => {
+    it("returns 0 when no sessions are registered", () => {
+      expect(countRunningBackgroundSessions()).toBe(0);
+    });
+
+    it("counts only backgrounded sessions that have not exited", () => {
+      const running = createRegistrySession({
+        id: "running-bg",
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 30_000,
+        backgrounded: true,
+      });
+      const foreground = createRegistrySession({
+        id: "foreground",
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 30_000,
+        backgrounded: false,
+      });
+      const backgroundedButExited = createRegistrySession({
+        id: "bg-exited",
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 30_000,
+        backgrounded: true,
+      });
+
+      addSession(running);
+      addSession(foreground);
+      addSession(backgroundedButExited);
+      markExited(backgroundedButExited, 0, null, "completed");
+
+      expect(countRunningBackgroundSessions()).toBe(1);
+    });
+
+    it("returns 0 after a running backgrounded session exits", () => {
+      const session = createRegistrySession({
+        id: "sess",
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 30_000,
+        backgrounded: true,
+      });
+      addSession(session);
+      expect(countRunningBackgroundSessions()).toBe(1);
+
+      markExited(session, 0, null, "completed");
+      expect(countRunningBackgroundSessions()).toBe(0);
+    });
   });
 });
 

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -325,6 +325,19 @@ export function listRunningSessions() {
   return Array.from(runningSessions.values()).filter((s) => s.backgrounded);
 }
 
+/** Returns the number of backgrounded sessions that are still running.
+ *  This is a sanitized count suitable for Gateway active-work snapshots:
+ *  no command, PID, output, scope, or session identifiers are exposed. */
+export function countRunningBackgroundSessions(): number {
+  let count = 0;
+  for (const session of runningSessions.values()) {
+    if (session.backgrounded && !session.exited) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 /** Lists retained finished background sessions. */
 export function listFinishedSessions() {
   return Array.from(finishedSessions.values());

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 // and WebSocket surfaces, config reload hooks, and graceful restart/shutdown.
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { countRunningBackgroundSessions } from "../agents/bash-process-registry.js";
 import {
   getActiveEmbeddedRunCount,
   resolveActiveEmbeddedRunSessionId,
@@ -651,7 +652,8 @@ export async function startGatewayServer(
       getTotalPendingReplies() +
       getActiveEmbeddedRunCount() +
       getActiveCronJobCount() +
-      getActiveTaskCount(),
+      getActiveTaskCount() +
+      countRunningBackgroundSessions(),
   );
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing
   // non-loopback installs that upgraded to v2026.2.26+ without required origins.

--- a/src/infra/gateway-active-work.test.ts
+++ b/src/infra/gateway-active-work.test.ts
@@ -1,0 +1,73 @@
+// Covers the shared active-work snapshot used by restart and host-suspension decisions.
+import { describe, expect, it } from "vitest";
+import {
+  createGatewayActiveWorkSnapshot,
+  type GatewayActiveWorkInspectors,
+} from "./gateway-active-work.js";
+
+function inspectors(
+  overrides: Partial<GatewayActiveWorkInspectors> = {},
+): GatewayActiveWorkInspectors {
+  return {
+    getQueueSize: () => 0,
+    getPendingReplies: () => 0,
+    getEmbeddedRuns: () => 0,
+    getCronRuns: () => 0,
+    getActiveTasks: () => 0,
+    getTaskBlockers: () => [],
+    getRootRequests: () => 0,
+    getSessionAdmissions: () => 0,
+    getSessionMutations: () => 0,
+    getChatRuns: () => 0,
+    getQueuedTurns: () => 0,
+    getTerminalPersistence: () => 0,
+    getTerminalSessions: () => 0,
+    getBackgroundExecCount: () => 0,
+    ...overrides,
+  };
+}
+
+describe("gateway active work snapshot", () => {
+  it("reports idle when all inspectors return zero", () => {
+    const snapshot = createGatewayActiveWorkSnapshot(inspectors());
+    expect(snapshot.idle).toBe(true);
+    expect(snapshot.counts.totalActive).toBe(0);
+    expect(snapshot.blockers).toHaveLength(0);
+  });
+
+  it("includes a background-exec count blocker", () => {
+    const snapshot = createGatewayActiveWorkSnapshot(
+      inspectors({ getBackgroundExecCount: () => 3 }),
+    );
+    expect(snapshot.idle).toBe(false);
+    expect(snapshot.counts.backgroundExec).toBe(3);
+    expect(snapshot.counts.totalActive).toBe(3);
+    expect(snapshot.blockers).toEqual([
+      {
+        kind: "background-exec",
+        count: 3,
+        message: "3 running background exec session(s)",
+      },
+    ]);
+  });
+
+  it("normalizes negative or non-finite counts to zero", () => {
+    const snapshot = createGatewayActiveWorkSnapshot(
+      inspectors({ getBackgroundExecCount: () => Number.NaN }),
+    );
+    expect(snapshot.counts.backgroundExec).toBe(0);
+    expect(snapshot.blockers).toHaveLength(0);
+    expect(snapshot.idle).toBe(true);
+  });
+
+  it("aggregates background-exec into totalActive alongside other work", () => {
+    const snapshot = createGatewayActiveWorkSnapshot(
+      inspectors({
+        getQueueSize: () => 2,
+        getBackgroundExecCount: () => 4,
+      }),
+    );
+    expect(snapshot.counts.totalActive).toBe(6);
+    expect(snapshot.blockers.map((b) => b.kind)).toEqual(["queue", "background-exec"]);
+  });
+});

--- a/src/infra/gateway-active-work.ts
+++ b/src/infra/gateway-active-work.ts
@@ -1,4 +1,5 @@
 // Collects process activity shared by restart and host-suspension decisions.
+import { countRunningBackgroundSessions } from "../agents/bash-process-registry.js";
 import { getActiveEmbeddedRunCount } from "../agents/embedded-agent-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import { getActiveCronJobCount } from "../cron/active-jobs.js";
@@ -28,6 +29,7 @@ export type GatewayActiveWorkCounts = {
   queuedTurns: number;
   terminalPersistence: number;
   terminalSessions: number;
+  backgroundExec: number;
   /** Compatibility aggregate. Categories can overlap; use individual counts for diagnostics. */
   totalActive: number;
 };
@@ -45,7 +47,8 @@ export type GatewayActiveWorkBlocker = {
     | "chat-run"
     | "queued-turn"
     | "terminal-persistence"
-    | "terminal-session";
+    | "terminal-session"
+    | "background-exec";
   count: number;
   message: string;
   task?: ActiveTaskRestartBlocker;
@@ -71,6 +74,7 @@ export type GatewayActiveWorkInspectors = {
   getQueuedTurns: () => number;
   getTerminalPersistence: () => number;
   getTerminalSessions: () => number;
+  getBackgroundExecCount: () => number;
 };
 
 const defaultInspectors: GatewayActiveWorkInspectors = {
@@ -87,6 +91,7 @@ const defaultInspectors: GatewayActiveWorkInspectors = {
   getQueuedTurns: () => 0,
   getTerminalPersistence: () => 0,
   getTerminalSessions: () => 0,
+  getBackgroundExecCount: countRunningBackgroundSessions,
 };
 
 function normalizeCount(value: number): number {
@@ -110,6 +115,7 @@ export function createGatewayActiveWorkSnapshot(
     queuedTurns: normalizeCount(resolved.getQueuedTurns()),
     terminalPersistence: normalizeCount(resolved.getTerminalPersistence()),
     terminalSessions: normalizeCount(resolved.getTerminalSessions()),
+    backgroundExec: normalizeCount(resolved.getBackgroundExecCount()),
     totalActive: 0,
   };
   counts.totalActive = Object.entries(counts).reduce(
@@ -153,6 +159,11 @@ export function createGatewayActiveWorkSnapshot(
     counts.terminalSessions,
     "terminal-session",
     `${counts.terminalSessions} open terminal session(s)`,
+  );
+  add(
+    counts.backgroundExec,
+    "background-exec",
+    `${counts.backgroundExec} running background exec session(s)`,
   );
 
   if (counts.activeTasks > 0) {

--- a/src/infra/gateway-suspend-coordinator.test.ts
+++ b/src/infra/gateway-suspend-coordinator.test.ts
@@ -111,6 +111,9 @@ describe("gateway suspend coordinator", () => {
     });
 
     expect(result.status).toBe("busy");
+    if (result.status !== "busy") {
+      throw new Error("expected busy result");
+    }
     expect(result).toMatchObject({
       reason: "active-work",
       activeCount: 1,

--- a/src/infra/gateway-suspend-coordinator.test.ts
+++ b/src/infra/gateway-suspend-coordinator.test.ts
@@ -1,6 +1,12 @@
 // Covers atomic refuse-only suspension preparation, renewal, and release.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  addSession,
+  countRunningBackgroundSessions,
+  resetProcessRegistryForTests,
+} from "../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
+import {
   isGatewayWorkAdmissionClosed,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
@@ -31,6 +37,7 @@ function inspectors(
     getQueuedTurns: () => 0,
     getTerminalPersistence: () => 0,
     getTerminalSessions: () => 0,
+    getBackgroundExecCount: () => 0,
     ...overrides,
   };
 }
@@ -38,11 +45,13 @@ function inspectors(
 beforeEach(() => {
   resetGatewaySuspendCoordinatorForTest();
   resetGatewayWorkAdmission();
+  resetProcessRegistryForTests();
 });
 
 afterEach(() => {
   resetGatewaySuspendCoordinatorForTest();
   resetGatewayWorkAdmission();
+  resetProcessRegistryForTests();
 });
 
 describe("gateway suspend coordinator", () => {
@@ -82,6 +91,33 @@ describe("gateway suspend coordinator", () => {
 
     expect(result.status).toBe("busy");
     expect(events).toEqual(["pause", "inspect", "resume"]);
+    expect(isGatewayWorkAdmissionClosed()).toBe(false);
+  });
+
+  it("blocks preparation while a background exec session is running", () => {
+    const session = createProcessSessionFixture({
+      id: "bg-sess",
+      command: "sleep 99",
+      backgrounded: true,
+    });
+    addSession(session);
+    expect(countRunningBackgroundSessions()).toBe(1);
+
+    const result = prepareGatewaySuspend({
+      requestId: "request-bg-busy",
+      pauseScheduling: vi.fn(),
+      resumeScheduling: vi.fn(),
+      inspect: inspectors({ getBackgroundExecCount: () => countRunningBackgroundSessions() }),
+    });
+
+    expect(result.status).toBe("busy");
+    expect(result).toMatchObject({
+      reason: "active-work",
+      activeCount: 1,
+    });
+    expect(result.blockers).toEqual([
+      { kind: "background-exec", count: 1, message: "1 running background exec session(s)" },
+    ]);
     expect(isGatewayWorkAdmissionClosed()).toBe(false);
   });
 

--- a/src/infra/restart-coordinator.test.ts
+++ b/src/infra/restart-coordinator.test.ts
@@ -30,6 +30,7 @@ describe("safe gateway restart coordinator", () => {
         embeddedRuns: 0,
         cronRuns: 0,
         activeTasks: 0,
+        backgroundExec: 0,
         totalActive: 0,
       },
       blockers: [],
@@ -44,6 +45,7 @@ describe("safe gateway restart coordinator", () => {
       getEmbeddedRuns: () => 1,
       getCronRuns: () => 1,
       getActiveTasks: () => 1,
+      getBackgroundExecCount: () => 1,
       getTaskBlockers: () => [
         {
           taskId: "task-1",
@@ -57,12 +59,14 @@ describe("safe gateway restart coordinator", () => {
     });
 
     expect(preflight.safe).toBe(false);
-    expect(preflight.counts.totalActive).toBe(6);
+    expect(preflight.counts.totalActive).toBe(7);
+    expect(preflight.counts.backgroundExec).toBe(1);
     expect(preflight.blockers.map((blocker) => blocker.kind)).toEqual([
       "queue",
       "reply",
       "embedded-run",
       "cron-run",
+      "background-exec",
       "task",
     ]);
     expect(preflight.summary).toContain("restart deferred");

--- a/src/infra/restart-coordinator.ts
+++ b/src/infra/restart-coordinator.ts
@@ -13,10 +13,11 @@ export type SafeGatewayRestartCounts = {
   embeddedRuns: number;
   cronRuns: number;
   activeTasks: number;
+  backgroundExec: number;
   totalActive: number;
 };
 export type SafeGatewayRestartBlocker = Omit<GatewayActiveWorkBlocker, "kind"> & {
-  kind: "queue" | "reply" | "embedded-run" | "cron-run" | "task";
+  kind: "queue" | "reply" | "embedded-run" | "cron-run" | "task" | "background-exec";
 };
 
 type SafeRestartInspectors = Pick<
@@ -27,6 +28,7 @@ type SafeRestartInspectors = Pick<
   | "getCronRuns"
   | "getActiveTasks"
   | "getTaskBlockers"
+  | "getBackgroundExecCount"
 >;
 
 export type SafeGatewayRestartPreflight = {
@@ -62,14 +64,24 @@ export function createSafeGatewayRestartPreflight(
     embeddedRuns: snapshot.counts.embeddedRuns,
     cronRuns: snapshot.counts.cronRuns,
     activeTasks: snapshot.counts.activeTasks,
+    backgroundExec: snapshot.counts.backgroundExec,
     totalActive:
       snapshot.counts.queueSize +
       snapshot.counts.pendingReplies +
       snapshot.counts.embeddedRuns +
       snapshot.counts.cronRuns +
-      snapshot.counts.activeTasks,
+      snapshot.counts.activeTasks +
+      snapshot.counts.backgroundExec,
   };
-  const blockers = snapshot.blockers as SafeGatewayRestartBlocker[];
+  const blockers = snapshot.blockers.filter(
+    (b): b is SafeGatewayRestartBlocker =>
+      b.kind === "queue" ||
+      b.kind === "reply" ||
+      b.kind === "embedded-run" ||
+      b.kind === "cron-run" ||
+      b.kind === "task" ||
+      b.kind === "background-exec",
+  );
 
   const summary =
     blockers.length === 0

--- a/src/infra/restart-suspension.test.ts
+++ b/src/infra/restart-suspension.test.ts
@@ -34,6 +34,7 @@ function inspectors(): GatewayActiveWorkInspectors {
     getQueuedTurns: () => 0,
     getTerminalPersistence: () => 0,
     getTerminalSessions: () => 0,
+    getBackgroundExecCount: () => 0,
   };
 }
 

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -4,6 +4,8 @@ import {
   testing,
   consumeGatewaySigusr1RestartIntent,
   deferGatewayRestartUntilIdle,
+  scheduleGatewaySigusr1Restart,
+  setPreRestartDeferralCheck,
   type RestartDeferralHooks,
 } from "./restart.js";
 
@@ -160,5 +162,39 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
 
     expect(hooks.onCheckError).toHaveBeenCalledOnce();
     expect(hooks.onReady).not.toHaveBeenCalled();
+  });
+});
+
+describe("scheduleGatewaySigusr1Restart background-exec deferral", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    testing.resetSigusr1State();
+    // Ensure emit mode uses process.emit rather than process.kill.
+    process.on("SIGUSR1", () => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    testing.resetSigusr1State();
+    process.removeAllListeners("SIGUSR1");
+  });
+
+  it("withholds SIGUSR1 while background exec sessions are running and emits after they exit", () => {
+    const emitSpy = vi.spyOn(process, "emit").mockReturnValue(true);
+    let backgroundExecCount = 1;
+    setPreRestartDeferralCheck(() => backgroundExecCount);
+
+    scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "test.background-exec" });
+
+    // Let the initial timeout fire and begin deferral polling.
+    vi.advanceTimersByTime(0);
+    expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+    // Simulate the background exec session exiting.
+    backgroundExecCount = 0;
+    vi.advanceTimersByTime(1_000);
+
+    expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Backgrounded bash exec sessions remain live in `bash-process-registry.ts` after their originating run settles, but `gateway.suspend.prepare` and safe-restart preflight did not consult that registry. A Gateway could therefore report "ready" for suspension (or schedule a restart) while a child process was still performing work that the host would terminate.

Fixes #104079.

## Why This Change Was Made

- Adds a sanitized, count-only `backgroundExec` inspector to the shared `GatewayActiveWorkSnapshot`.
- Exposes `countRunningBackgroundSessions()` from `bash-process-registry.ts` — it returns a count and leaks no command, PID, output, scope, or session identifiers.
- Propagates the blocker through both the suspension protocol schema and the safe-restart coordinator, so live background exec blocks both suspension and restart decisions.
- **Update:** also includes the registry count in the actual `setPreRestartDeferralCheck` callback registered at Gateway startup, so the SIGUSR1 emission path is gated in addition to the preflight diagnostic.
- Keeps the existing atomic prepare sequence: admission is closed before the registry is inspected.

## User Impact

Cooperative hosts that rely on `gateway.suspend.prepare` will no longer receive a false "ready" response while a background exec command is still running. Safe-restart requests are also deferred until the session exits or is killed.

## Evidence

### Regression coverage

New focused test in `src/infra/restart.deferral-timeout.test.ts`:

- Schedules a SIGUSR1 restart via `scheduleGatewaySigusr1Restart`.
- Sets the deferral check to return a positive background-exec count.
- Confirms `SIGUSR1` is **not** emitted while the count is positive.
- Drops the count to 0 and confirms `SIGUSR1` is emitted.

Result: 8 passed (`src/infra/restart.deferral-timeout.test.ts`).

### Existing tests

```bash
pnpm test src/agents/bash-process-registry.test.ts src/infra/restart-coordinator.test.ts src/infra/infra-runtime.test.ts src/infra/restart-suspension.test.ts --run
```

Result: 4 files, 67 tests passed.

### Type / lint

```bash
pnpm tsgo:core          # exit 0
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server.impl.ts src/infra/restart.deferral-timeout.test.ts
```

Both pass.

### Key code path

`src/gateway/server.impl.ts:648` now registers:

```ts
setPreRestartDeferralCheck(
  () =>
    getTotalQueueSize() +
    getTotalPendingReplies() +
    getActiveEmbeddedRunCount() +
    getActiveCronJobCount() +
    getActiveTaskCount() +
    countRunningBackgroundSessions(),
);
```

This closes the gap identified in the previous review where the preflight reported `backgroundExec` but the actual signal-emission callback did not.

## Release Note

- Gateway: block suspension and restart while background exec sessions are running.
