### PR TITLE
fix(tlon): bound stalled inbound and outbound media header waits

### DIFF
--- a/extensions/tlon/src/media-fetch-timeouts.ts
+++ b/extensions/tlon/src/media-fetch-timeouts.ts
@@ -1,0 +1,6 @@
+// Header wait and body progress are separate failure modes. Keep both Tlon
+// media directions on one policy so attachment and upload fallbacks stay aligned.
+export const TLON_MEDIA_FETCH_TIMEOUTS = {
+  responseHeaderTimeoutMs: 120_000,
+  readIdleTimeoutMs: 30_000,
+} as const;

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -55,6 +55,7 @@ describe("tlon monitor media", () => {
     expect(saveRemoteMediaMock).toHaveBeenCalledWith({
       url: "https://example.com/photo.png",
       maxBytes: MAX_IMAGE_BYTES,
+      responseHeaderTimeoutMs: 120_000,
       readIdleTimeoutMs: 30_000,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -10,10 +10,9 @@ import {
   saveRemoteMedia,
 } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { TLON_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 
 const MAX_IMAGES_PER_MESSAGE = 8;
-const TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
-const TLON_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
 
 interface ExtractedImage {
   url: string;
@@ -71,8 +70,7 @@ export async function downloadMedia(
     const fetchOptions = {
       url,
       maxBytes: MAX_IMAGE_BYTES,
-      responseHeaderTimeoutMs: TLON_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
-      readIdleTimeoutMs: TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS,
+      ...TLON_MEDIA_FETCH_TIMEOUTS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },
     };

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -13,6 +13,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 
 const MAX_IMAGES_PER_MESSAGE = 8;
 const TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
+const TLON_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
 
 interface ExtractedImage {
   url: string;
@@ -70,6 +71,7 @@ export async function downloadMedia(
     const fetchOptions = {
       url,
       maxBytes: MAX_IMAGE_BYTES,
+      responseHeaderTimeoutMs: TLON_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
       readIdleTimeoutMs: TLON_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },

--- a/extensions/tlon/src/urbit/upload.test.ts
+++ b/extensions/tlon/src/urbit/upload.test.ts
@@ -58,6 +58,7 @@ describe("uploadImageFromUrl", () => {
     expect(mockReadRemoteMediaBuffer).toHaveBeenCalledWith({
       url: "https://example.com/image.png",
       maxBytes: MAX_IMAGE_BYTES,
+      responseHeaderTimeoutMs: 120_000,
       readIdleTimeoutMs: 30_000,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -5,6 +5,7 @@ import { MAX_IMAGE_BYTES, readRemoteMediaBuffer } from "openclaw/plugin-sdk/medi
 import { uploadFile } from "../tlon-api.js";
 
 const TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS = 30_000;
+const TLON_UPLOAD_IMAGE_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
 
 /**
  * Fetch an image from a URL and upload it to Tlon storage.
@@ -24,6 +25,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
     const fetched = await readRemoteMediaBuffer({
       url: imageUrl,
       maxBytes: MAX_IMAGE_BYTES,
+      responseHeaderTimeoutMs: TLON_UPLOAD_IMAGE_RESPONSE_HEADER_TIMEOUT_MS,
       readIdleTimeoutMs: TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -2,10 +2,8 @@
  * Upload an image from a URL to Tlon storage.
  */
 import { MAX_IMAGE_BYTES, readRemoteMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { TLON_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 import { uploadFile } from "../tlon-api.js";
-
-const TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS = 30_000;
-const TLON_UPLOAD_IMAGE_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
 
 /**
  * Fetch an image from a URL and upload it to Tlon storage.
@@ -25,8 +23,7 @@ export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
     const fetched = await readRemoteMediaBuffer({
       url: imageUrl,
       maxBytes: MAX_IMAGE_BYTES,
-      responseHeaderTimeoutMs: TLON_UPLOAD_IMAGE_RESPONSE_HEADER_TIMEOUT_MS,
-      readIdleTimeoutMs: TLON_UPLOAD_IMAGE_IDLE_TIMEOUT_MS,
+      ...TLON_MEDIA_FETCH_TIMEOUTS,
       ssrfPolicy: undefined,
       requestInit: { method: "GET" },
     });


### PR DESCRIPTION
## What Problem This Solves

Tlon inbound `downloadMedia` and outbound `uploadImageFromUrl` call `readRemoteMediaBuffer` / `saveRemoteMedia` with only a 30-second body-idle timeout. If the remote server never returns response headers, the idle timeout never starts and the request can hang indefinitely. This is the same root cause as the Telegram media stall fixed in #103020.

## Why This Change Was Made

Add a 120-second response-header deadline (`responseHeaderTimeoutMs`) to both call sites, mirroring the Telegram media timeout policy, so stalled endpoints fail fast without cutting off healthy long transfers.

## User Impact

Tlon media downloads and image uploads time out predictably when a server never sends headers, instead of blocking the channel.

## Evidence

### Unit tests

```bash
pnpm test extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.test.ts --run
```

Result: 2 files, 11 tests passed.

### Type / lint

```bash
pnpm tsgo:extensions   # exit 0
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/tlon/src/monitor/media.ts extensions/tlon/src/monitor/media.test.ts extensions/tlon/src/urbit/upload.ts extensions/tlon/src/urbit/upload.test.ts
```

Both pass.

### Controlled real-runtime proof

A local HTTP server was used: one endpoint returns a small PNG immediately; another endpoint accepts the connection but never sends response headers. The shared media runtime was exercised with the same options this PR now passes from Tlon (`responseHeaderTimeoutMs: 120_000`, `readIdleTimeoutMs: 30_000`). SSRF was relaxed to `dangerouslyAllowPrivateNetwork` only for the loopback test server.

```text
=== Tlon media header-timeout proof ===
Server listening on http://127.0.0.1:46183
Configured responseHeaderTimeoutMs: 120000

[outbound-healthy] ok: contentType=image/png, bytes=13
[inbound-healthy] ok: path=/home/.../.openclaw/media/inbound/e4e4eac5-edab-4834-9859-cba85a575db2.png, contentType=image/png, size=13

Starting parallel stalled-header fetches (will take ~120s each)...
[fetch-timeout] fetch timeout after 120000ms (elapsed 120000ms) operation=media response headers url=http://127.0.0.1:46183/stall
[fetch-timeout] fetch timeout after 120000ms (elapsed 120060ms) operation=media response headers url=http://127.0.0.1:46183/stall
[outbound-stall] rejected after 120076ms: Failed to fetch media from http://127.0.0.1:46183/stall: request timed out
[inbound-stall] rejected after 120076ms: Failed to fetch media from http://127.0.0.1:46183/stall: request timed out
```

Healthy transfers complete; stalled headers abort near the 120-second deadline. In the Tlon channel code the resulting rejection is caught and the message continues without the failed attachment (inbound) or falls back to the original image URL (outbound).

## Release Note

- Tlon: bound stalled inbound/outbound media header waits.
