### PR TITLE
fix(memory-core): defer dreaming sweep when main session has active runs

### DIFF
--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -2880,4 +2880,33 @@ describe("short-term dreaming trigger", () => {
       "memory-core: dreaming promotion complete (workspaces=3, candidates=3, applied=3, failed=0).",
     );
   });
+
+  it("defers dreaming when active embedded runs exist (#103911)", async () => {
+    const logger = createLogger();
+    const workspaceDir = await createTempWorkspace("memory-dreaming-defer-");
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_MEMORY_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+      getActiveEmbeddedRunCount: () => 1, // simulate main session active
+    });
+
+    expect(result?.handled).toBe(true);
+    expect(result?.reason).toBe("memory-core: short-term dreaming deferred (active runs)");
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("deferred"),
+    );
+  });
 });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -502,6 +502,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
   config: ShortTermPromotionDreamingConfig;
   logger: Logger;
   subagent?: OpenClawPluginApi["runtime"]["subagent"];
+  getActiveEmbeddedRunCount?: () => number;
 }): Promise<{ handled: true; reason: string } | undefined> {
   if (params.trigger !== "heartbeat" && params.trigger !== "cron") {
     return undefined;
@@ -511,6 +512,19 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
   }
   if (!params.config.enabled) {
     return { handled: true, reason: "memory-core: short-term dreaming disabled" };
+  }
+
+  // Defer dreaming when the main session has active embedded runs to avoid
+  // provider rate-limit contention and session-file takeover errors (#103911).
+  const activeRunCount = params.getActiveEmbeddedRunCount?.() ?? 0;
+  if (activeRunCount > 0) {
+    params.logger.info(
+      "memory-core: short-term dreaming deferred — main session has active runs",
+    );
+    return {
+      handled: true,
+      reason: "memory-core: short-term dreaming deferred (active runs)",
+    };
   }
 
   const recencyHalfLifeDays =
@@ -976,6 +990,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
         config,
         logger: api.logger,
         subagent: config.enabled ? api.runtime?.subagent : undefined,
+        getActiveEmbeddedRunCount: api.runtime?.getActiveEmbeddedRunCount,
       });
     } catch (err) {
       api.logger.error(`memory-core: dreaming trigger failed: ${formatErrorMessage(err)}`);

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -33,6 +33,7 @@ import { createRuntimeMedia } from "./runtime-media.js";
 import { createRuntimeSystem } from "./runtime-system.js";
 import { createRuntimeTaskFlow } from "./runtime-taskflow.js";
 import { createRuntimeTasks } from "./runtime-tasks.js";
+import { getActiveEmbeddedRunCount } from "../../agents/embedded-agent-runner/run-state.js";
 import type { CreatePluginRuntimeOptions, PluginRuntime } from "./types.js";
 
 export type { CreatePluginRuntimeOptions } from "./types.js";
@@ -269,6 +270,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     // Sourced from the shared OpenClaw version resolver (#52899) so plugins
     // always see the same version the CLI reports, avoiding API-version drift.
     version: VERSION,
+    getActiveEmbeddedRunCount,
     gateway: createRuntimeGateway(),
     config: createRuntimeConfig(),
     agent: createRuntimeAgent(),

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -430,4 +430,6 @@ export type PluginRuntimeCore = {
       workspaceDir?: string;
     }) => Promise<import("../../agents/model-auth-runtime-shared.js").ResolvedProviderAuth>;
   };
+  /** Count of active embedded agent runs. >0 means the main session is busy. */
+  getActiveEmbeddedRunCount: () => number;
 };


### PR DESCRIPTION
## What Problem This Solves

Dreaming sweep narrative subagents compete for the same provider rate limit as the active main session, causing 429 errors, phantom user message replays, and `EmbeddedAttemptSessionTakeoverError`. Deferring the sweep when the main session has active runs prevents the entire failure chain at the source.

- Problem: Dreaming sweep fires on a fixed cron schedule regardless of user activity. Narrative subagents use the same default model/provider as the main session. Both compete for the same rate limit → main session 429 → model fallback loop replays user messages into the transcript → concurrent session file change triggers takeover error → conversation context cleared.
- Solution: Check `getActiveEmbeddedRunCount()` before running the sweep. If > 0 (main session is busy), defer to the next cron cycle.
- What changed: `src/plugins/runtime/types-core.ts` (add `getActiveEmbeddedRunCount` to `PluginRuntimeCore`), `src/plugins/runtime/index.ts` (wire to `run-state.ts`), `extensions/memory-core/src/dreaming.ts` (deferral check + pass runtime method), `extensions/memory-core/src/dreaming.test.ts` (new test case).
- What did NOT change: Dreaming sweep logic, config schema, session lock mechanism, failover classification, model fallback behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #103911
- Related #84583 (same `EmbeddedAttemptSessionTakeoverError` class, different trigger)
- [x] This PR fixes a bug or regression

## Motivation

The dreaming sweep runs on a default cron schedule (0 3 * * *). When the user is awake and chatting at that time, the sweep's narrative subagents consume the same provider API rate limit as the main session. This causes the main session's model call to fail with a 429 error, which triggers a model-fallback loop. Each fallback iteration opens a new SessionManager and re-persists the user message, creating phantom duplicates. Concurrently, the embedded prompt lock detects the session file change as a takeover, clearing the conversation context.

The fix is minimal and targeted: defer the sweep when any embedded agent run is active. The sweep is a background maintenance task with no real-time requirements — skipping one cron cycle is harmless.

## Evidence

- Behavior addressed: Dreaming sweep defers when main session has active embedded runs, preventing rate-limit contention and takeover errors.

- Real environment tested: Local OpenClaw source checkout, Node 22.19, Linux (WSL2).

- Exact steps or command run after this patch:

```
node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
node scripts/run-vitest.mjs src/plugins/runtime/index.test.ts
```

- Evidence after fix:

```console
$ node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts
 RUN  v4.1.9
 Test Files  1 passed (1)
      Tests  53 passed (53)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
 RUN  v4.1.9
 Test Files  1 passed (1)
      Tests  114 passed (114)

$ node scripts/run-vitest.mjs src/plugins/runtime/index.test.ts
 RUN  v4.1.9
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

- Observed result after fix:
  - When `getActiveEmbeddedRunCount() > 0`: dreaming sweep returns immediately with `"memory-core: short-term dreaming deferred (active runs)"`
  - When `getActiveEmbeddedRunCount() === 0`: dreaming sweep proceeds normally
  - All 190 existing tests across 3 test suites continue to pass
  - New test verifies deferral behavior explicitly

- What was not tested: Real gateway E2E with concurrent sessions (requires provider API keys). The deferral mechanism is pure code logic verified at the unit level.

- Fix completeness preflight (4 questions):
  - Authorization guard: N/A — preventive check, not a new code path. Existing `before_agent_reply` hook guards non-cron/heartbeat triggers.
  - Enumeration completeness: All three trigger scenarios covered — cron (defer when active), heartbeat (defer when active), other triggers (existing guard).
  - Path coverage: N/A — no config reference form changes.
  - Cleanup symmetry: N/A — function is idempotent, no state to clean up on deferral.

## Root Cause (if applicable)

The full root cause chain (verified through source-code tracing and a focused reproduction test):

1. Dreaming sweep fires on cron → creates narrative subagent runs
2. Narrative subagents use the **same** model/provider as the main session by default (`subagent.run()` without explicit `model` → `resolveDefaultModelForAgent()`)
3. Both compete for the same provider rate limit → main session gets 429
4. 429 triggers model fallback loop → each iteration opens new `SessionManager` with `suppressNextUserMessagePersistence: false` → re-persists user message to transcript
5. The 429/failover triggers WebChat reconnect, which writes replayed messages and prompt-error entries to the main session's own transcript file (not written by dreaming — dreaming uses isolated session files)
6. When the embedded prompt lock reacquires (`reacquireAfterPrompt`), `assertSessionFileFence()` detects the external file change as a takeover → `EmbeddedAttemptSessionTakeoverError`
7. The takeover error wraps the 429 promptError → `resolveModelFallbackError()` classifies it as `failover` (not `coordination`) → fallback loop continues → phantom messages amplified (reported as 5x)

## Regression Test Plan (if applicable)

N/A — existing test suites cover all affected paths.

## User-visible / Behavior Changes

- **Fix**: When the user is actively chatting at dreaming sweep time, the sweep is silently deferred. The user's session is not interrupted.
- **No change** when the user is idle: dreaming runs as normal.
- **No new config options** — the fix is automatic and transparent.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — no config changes; deferral is transparent.
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: This PR is a mitigation that covers the common case. A full architectural fix (background maintenance lease) is identified and scoped for follow-up.
- **Refactor needed**: The ideal solution is a process-wide `BackgroundMaintenanceLease` that prevents foreground work from starting during background maintenance, or allows dreaming to yield when foreground work arrives. This requires changes to the centralized run dispatcher in `run.ts` (`enqueueCommandInLane`) plus a new lease module, estimated at ~250-350 lines. This PR intentionally keeps the scope limited to the snapshot check at the dreaming entry point.
- **Known limitation (TOCTOU)**: The check snapshots `getActiveEmbeddedRunCount()` once at sweep start. A foreground run that begins immediately after the check, during the long async sweep, could still overlap. The window is small (seconds) and rare (default 3 AM cron), but real. A follow-up PR can address this with the lease mechanism described above.
- **Alternative considered**:
  - `BackgroundMaintenanceLease` (atomic foreground/background admission): The correct architectural fix. Moved to follow-up to avoid touching the hot-path run scheduler in this change.
  - Reclassifying takeover+429 as coordination error in `failover-error.ts`: Would stop the phantom-message amplification, but changes error classification semantics and needs maintainer product decision.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Risk**: Deferred dreaming may never run if the user is continuously active for extended periods.
  - **Mitigation**: Default cron fires once per day; one skipped cycle is acceptable. The sweep executes on the next scheduled cycle when the user is idle.
- **Risk**: `getActiveEmbeddedRunCount()` includes all active runs, not just the main session.
  - **Mitigation**: Intentionally conservative — any active embedded run means the system is under load and background maintenance should wait.
- **Risk (known TOCTOU)**: A foreground run that starts immediately after the snapshot check, during the long async sweep, can still overlap and cause rate-limit contention.
  - **Mitigation**: The overlap window is small. A follow-up PR with a `BackgroundMaintenanceLease` mechanism can eliminate this window entirely by making foreground runs wait during background maintenance or allowing dreaming to yield.

---

Fixes #103911
