### PR TITLE
fix(sessions): prevent maintenance from deleting active sessions

### DIFF
--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -27,7 +27,7 @@ import {
   type SessionEntryLifecycleUpsert,
 } from "./session-accessor.js";
 import { cloneSessionStoreRecord } from "./store-cache.js";
-import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -436,7 +436,11 @@ async function previewStoreCleanup(params: {
           },
         })
       : 0;
-  const preserveSessionKeys = collectSessionMaintenancePreserveKeys([params.activeKey]);
+  const preserveSessionKeys = collectSessionMaintenancePreserveKeysForStore({
+    storePath: params.target.storePath,
+    store: previewStore,
+    baseKeys: [params.activeKey],
+  });
   const modelRunPruned = shouldRunModelRunPrune({
     maintenance: params.maintenance,
     entryCount: Object.keys(previewStore).length,
@@ -668,6 +672,7 @@ export async function runSessionsCleanup(params: {
         removals,
         upserts: missingRepairs,
         activeSessionKey: opts.activeKey,
+        preserveActiveWork: true,
         maintenanceOverride: {
           mode,
         },

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -2117,6 +2117,7 @@ export async function applySessionEntryLifecycleMutation(params: {
   activeSessionKey?: string;
   maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
   skipMaintenance?: boolean;
+  preserveActiveWork?: boolean;
   archiveReason?: "deleted" | "reset";
   restrictArchivedTranscriptsToStoreDir?: boolean;
   cleanupArchivedTranscripts?: {

--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { runSessionRegistryMaintenanceForStore } from "./session-registry-maintenance.js";
 import { loadSessionStore, saveSessionStore } from "./store.js";
@@ -122,5 +123,41 @@ describe("runSessionRegistryMaintenanceForStore", () => {
     const updated = loadSessionStore(storePath, { skipCache: true });
     expect(updated["agent:main:cron:done-job:run:old-run"]).toBeUndefined();
     expect(updated).toHaveProperty(oldOrdinaryKey);
+  });
+
+  it("preserves active cron rows until their admission releases", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:done-job:run:active-run";
+    const sessionId = "active-run";
+    const storePath = await createStore({
+      [sessionKey]: sessionEntry(sessionId, now - 8 * DAY_MS),
+    });
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [sessionId],
+      assertAllowed: () => {},
+    });
+
+    try {
+      const activeResult = await runSessionRegistryMaintenanceForStore({
+        apply: true,
+        retentionMs: 7 * DAY_MS,
+        runningCronJobIds: new Set(),
+        storePath,
+      });
+      expect(activeResult.pruned).toBe(0);
+      expect(loadSessionStore(storePath, { skipCache: true })).toHaveProperty(sessionKey);
+    } finally {
+      admission.release();
+    }
+
+    const releasedResult = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+    expect(releasedResult.pruned).toBe(1);
+    expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
   });
 });

--- a/src/config/sessions/session-registry-maintenance.ts
+++ b/src/config/sessions/session-registry-maintenance.ts
@@ -1,6 +1,7 @@
 // Storage-neutral session registry maintenance for task-owned cron run cleanup.
 import fs from "node:fs";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { collectActiveSessionWorkAdmissionKeys } from "./store-maintenance-preserve.js";
 import { loadSessionStore, pruneStaleEntries, updateSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
@@ -32,9 +33,14 @@ function parseCronRunSessionJobId(sessionKey: string): string | undefined {
 
 function buildSessionRegistryPreserveKeys(params: {
   runningCronJobIds: ReadonlySet<string>;
+  storePath: string;
   store: Record<string, SessionEntry>;
 }): { preserveKeys: Set<string>; preservedRunning: number } {
-  const preserveKeys = new Set<string>();
+  const preserveKeys =
+    collectActiveSessionWorkAdmissionKeys({
+      storePath: params.storePath,
+      store: params.store,
+    }) ?? new Set<string>();
   let preservedRunning = 0;
   for (const key of Object.keys(params.store)) {
     const jobId = parseCronRunSessionJobId(key);
@@ -54,10 +60,12 @@ function buildSessionRegistryPreserveKeys(params: {
 function pruneSessionRegistryStore(params: {
   retentionMs: number;
   runningCronJobIds: ReadonlySet<string>;
+  storePath: string;
   store: Record<string, SessionEntry>;
 }): Omit<SessionRegistryMaintenanceStoreSummary, "beforeCount"> {
   const { preserveKeys, preservedRunning } = buildSessionRegistryPreserveKeys({
     runningCronJobIds: params.runningCronJobIds,
+    storePath: params.storePath,
     store: params.store,
   });
   const pruned = pruneStaleEntries(params.store, params.retentionMs, {
@@ -97,6 +105,7 @@ export async function runSessionRegistryMaintenanceForStore(
       ...pruneSessionRegistryStore({
         retentionMs: params.retentionMs,
         runningCronJobIds: params.runningCronJobIds,
+        storePath: params.storePath,
         store: previewStore,
       }),
     };
@@ -108,6 +117,7 @@ export async function runSessionRegistryMaintenanceForStore(
       pruneSessionRegistryStore({
         retentionMs: params.retentionMs,
         runningCronJobIds: params.runningCronJobIds,
+        storePath: params.storePath,
         store,
       }),
     { skipMaintenance: true },

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -29,7 +29,7 @@ import {
 } from "./store-cache.js";
 import { normalizePersistedSessionEntryShape } from "./store-entry-shape.js";
 import { resolveSessionStoreEntry } from "./store-entry.js";
-import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -447,7 +447,10 @@ export function loadSessionStore(
     let pruned = 0;
     let capped = 0;
     if (maintenance.mode === "enforce") {
-      const preserveSessionKeys = collectSessionMaintenancePreserveKeys();
+      const preserveSessionKeys = collectSessionMaintenancePreserveKeysForStore({
+        storePath,
+        store,
+      });
       if (
         shouldRunModelRunPrune({
           maintenance,
@@ -461,7 +464,10 @@ export function loadSessionStore(
       }
     }
     if (maintenance.mode === "enforce" && Object.keys(store).length > maintenance.maxEntries) {
-      const preserveSessionKeys = collectSessionMaintenancePreserveKeys();
+      const preserveSessionKeys = collectSessionMaintenancePreserveKeysForStore({
+        storePath,
+        store,
+      });
       pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
         log: false,
         preserveKeys: preserveSessionKeys,

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -1,7 +1,7 @@
 // Storage-neutral session maintenance operations for the file-backed session store.
 import path from "node:path";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
-import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -195,9 +195,11 @@ async function applyEnforcedMaintenance(params: {
   beforeCount: number;
   forceMaintenance: boolean;
 }): Promise<FileBackedSessionStoreMaintenanceResult> {
-  const preserveSessionKeys = collectSessionMaintenancePreserveKeys([
-    params.operation.activeSessionKey,
-  ]);
+  const preserveSessionKeys = collectSessionMaintenancePreserveKeysForStore({
+    storePath: params.operation.storePath,
+    store: params.operation.store,
+    baseKeys: [params.operation.activeSessionKey],
+  });
   const removedSessionFiles = new Map<string, string | undefined>();
   const modelRunPruned = shouldRunModelRunPrune({
     maintenance: params.maintenance,

--- a/src/config/sessions/store-maintenance-preserve.ts
+++ b/src/config/sessions/store-maintenance-preserve.ts
@@ -1,5 +1,7 @@
 // Maintenance preserve providers protect runtime-owned sessions from pruning/capping.
+import { collectActiveSessionWorkAdmissionIdentities } from "../../sessions/session-lifecycle-admission.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
+import type { SessionEntry } from "./types.js";
 
 /** Provider hook for session keys that maintenance/pruning should preserve. */
 export type SessionMaintenancePreserveKeysProvider = () => Iterable<string> | undefined;
@@ -47,6 +49,49 @@ export function collectSessionMaintenancePreserveKeys(
     } catch {
       // Maintenance must remain best-effort if a runtime provider is temporarily unavailable.
     }
+  }
+  return keys.size > 0 ? keys : undefined;
+}
+
+/** Resolves store keys owned by active work, including aliases sharing a backing session id. */
+export function collectActiveSessionWorkAdmissionKeys(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+}): Set<string> | undefined {
+  const activeIdentities = collectActiveSessionWorkAdmissionIdentities(params.storePath);
+  if (activeIdentities.size === 0) {
+    return undefined;
+  }
+  const normalizedIdentities = new Set(
+    Array.from(activeIdentities, (identity) => normalizeStoreSessionKey(identity)),
+  );
+  const keys = new Set<string>();
+  for (const [key, entry] of Object.entries(params.store)) {
+    if (
+      normalizedIdentities.has(normalizeStoreSessionKey(key)) ||
+      activeIdentities.has(entry.sessionId)
+    ) {
+      // Maintenance iterates the persisted keys verbatim, while admissions
+      // normally use canonical identities. Preserve both representations.
+      keys.add(key);
+      keys.add(normalizeStoreSessionKey(key));
+    }
+  }
+  return keys.size > 0 ? keys : undefined;
+}
+
+/** Collects every runtime and active-work key protected from automatic maintenance. */
+export function collectSessionMaintenancePreserveKeysForStore(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  baseKeys?: Iterable<string | undefined>;
+}): Set<string> | undefined {
+  const keys = collectSessionMaintenancePreserveKeys(params.baseKeys) ?? new Set<string>();
+  for (const key of collectActiveSessionWorkAdmissionKeys({
+    storePath: params.storePath,
+    store: params.store,
+  }) ?? []) {
+    keys.add(key);
   }
   return keys.size > 0 ? keys : undefined;
 }

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -1,6 +1,7 @@
 // Session store pruning tests cover pruning decisions and retention ordering.
 import crypto from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { applyFileBackedSessionStoreMaintenance } from "./store-maintenance-operations.js";
 import {
@@ -41,6 +42,14 @@ function makeEntry(updatedAt: number): SessionEntry {
 
 function makeStore(entries: Array<[string, SessionEntry]>): Record<string, SessionEntry> {
   return Object.fromEntries(entries);
+}
+
+function createMaintenanceArtifacts() {
+  return {
+    archiveRemovedSessionTranscripts: async () => new Set<string>(),
+    removeRemovedSessionTrajectoryArtifacts: async () => {},
+    cleanupArchivedSessionTranscripts: async () => {},
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +278,189 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
     expect(Object.keys(store)).toHaveLength(50);
     for (let i = 0; i < 50; i++) {
       expect(store).toHaveProperty(`agent:main:explicit:real-${i}`);
+    }
+  });
+
+  it("preserves every active admission instead of only the writer session", async () => {
+    const now = Date.now();
+    const storePath = "/tmp/openclaw-sessions/active-admissions.json";
+    const activeKey = "agent:main:cron:job:run:active";
+    const store = makeStore([
+      [activeKey, { sessionId: "active-session", updatedAt: now - 3 }],
+      ["removable", { sessionId: "removable-session", updatedAt: now - 2 }],
+      ["writer", { sessionId: "writer-session", updatedAt: now - 1 }],
+    ]);
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [activeKey, "active-session"],
+      assertAllowed: () => {},
+    });
+
+    try {
+      await applyFileBackedSessionStoreMaintenance({
+        storePath,
+        store,
+        activeSessionKey: "writer",
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 30 * DAY_MS,
+          maxEntries: 1,
+          modelRunPruneAfterMs: DAY_MS,
+          resetArchiveRetentionMs: null,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+
+      expect(store).toHaveProperty(activeKey);
+      expect(store).toHaveProperty("writer");
+      expect(store.removable).toBeUndefined();
+    } finally {
+      admission.release();
+    }
+  });
+
+  it("preserves every store alias backed by an active session id", async () => {
+    const now = Date.now();
+    const storePath = "/tmp/openclaw-sessions/active-aliases.json";
+    const activeSessionId = "active-alias-session";
+    const firstAlias = "agent:main:cron:job:run:active";
+    const secondAlias = "agent:main:cron:job:run:active:thread:reply";
+    const store = makeStore([
+      [firstAlias, { sessionId: activeSessionId, updatedAt: now - 3 }],
+      [secondAlias, { sessionId: activeSessionId, updatedAt: now - 2 }],
+      ["removable", { sessionId: "removable-session", updatedAt: now - 1 }],
+    ]);
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [activeSessionId],
+      assertAllowed: () => {},
+    });
+
+    try {
+      await applyFileBackedSessionStoreMaintenance({
+        storePath,
+        store,
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 30 * DAY_MS,
+          maxEntries: 1,
+          modelRunPruneAfterMs: DAY_MS,
+          resetArchiveRetentionMs: null,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+
+      expect(store).toHaveProperty(firstAlias);
+      expect(store).toHaveProperty(secondAlias);
+      expect(store.removable).toBeUndefined();
+    } finally {
+      admission.release();
+    }
+  });
+
+  it("preserves a raw legacy store key matched by a canonical admission identity", async () => {
+    const now = Date.now();
+    const storePath = "/tmp/openclaw-sessions/active-legacy-key.json";
+    const rawActiveKey = "Agent:Main:Subagent:CHILD";
+    const canonicalActiveKey = "agent:main:subagent:child";
+    const store = makeStore([
+      [rawActiveKey, { sessionId: "active-legacy-session", updatedAt: now - 2 }],
+      ["removable", { sessionId: "removable-session", updatedAt: now - 1 }],
+    ]);
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: [canonicalActiveKey],
+      assertAllowed: () => {},
+    });
+
+    try {
+      await applyFileBackedSessionStoreMaintenance({
+        storePath,
+        store,
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 30 * DAY_MS,
+          maxEntries: 1,
+          modelRunPruneAfterMs: DAY_MS,
+          resetArchiveRetentionMs: null,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+
+      expect(store).toHaveProperty(rawActiveKey);
+      expect(store.removable).toBeUndefined();
+    } finally {
+      admission.release();
+    }
+  });
+
+  it("scopes active preservation by store and releases rows back to maintenance", async () => {
+    const now = Date.now();
+    const activeStorePath = "/tmp/openclaw-sessions/active-store.json";
+    const maintainedStorePath = "/tmp/openclaw-sessions/maintained-store.json";
+    const activeSessionId = "shared-session-id";
+    const admission = await beginSessionWorkAdmission({
+      scope: activeStorePath,
+      identities: [activeSessionId],
+      assertAllowed: () => {},
+    });
+    const maintenanceConfig = {
+      mode: "enforce" as const,
+      pruneAfterMs: 30 * DAY_MS,
+      maxEntries: 1,
+      modelRunPruneAfterMs: DAY_MS,
+      resetArchiveRetentionMs: null,
+      maxDiskBytes: null,
+      highWaterBytes: null,
+    };
+
+    try {
+      const otherStore = makeStore([
+        ["old", { sessionId: activeSessionId, updatedAt: now - 31 * DAY_MS }],
+        ["new", { sessionId: "new-session", updatedAt: now - 1 }],
+      ]);
+      await applyFileBackedSessionStoreMaintenance({
+        storePath: maintainedStorePath,
+        store: otherStore,
+        maintenanceConfig,
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+      expect(otherStore.old).toBeUndefined();
+
+      const activeStore = makeStore([
+        ["old", { sessionId: activeSessionId, updatedAt: now - 31 * DAY_MS }],
+        ["new", { sessionId: "new-session", updatedAt: now - 1 }],
+      ]);
+      await applyFileBackedSessionStoreMaintenance({
+        storePath: activeStorePath,
+        store: activeStore,
+        maintenanceConfig,
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+      expect(activeStore).toHaveProperty("old");
+
+      admission.release();
+      await applyFileBackedSessionStoreMaintenance({
+        storePath: activeStorePath,
+        store: activeStore,
+        maintenanceConfig,
+        log: { warn: () => {}, info: () => {} },
+        artifacts: createMaintenanceArtifacts(),
+      });
+      expect(activeStore.old).toBeUndefined();
+    } finally {
+      admission.release();
     }
   });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -59,6 +59,7 @@ import {
   applyFileBackedSessionStoreMaintenance,
   type SessionMaintenanceApplyReport,
 } from "./store-maintenance-operations.js";
+import { collectActiveSessionWorkAdmissionKeys } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -1343,6 +1344,7 @@ export async function applySessionEntryLifecycleMutation(params: {
   activeSessionKey?: string;
   maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
   skipMaintenance?: boolean;
+  preserveActiveWork?: boolean;
   archiveReason?: "deleted" | "reset";
   restrictArchivedTranscriptsToStoreDir?: boolean;
   cleanupArchivedTranscripts?: {
@@ -1366,9 +1368,13 @@ export async function applySessionEntryLifecycleMutation(params: {
 
   await runExclusiveSessionStoreWrite(storePath, async () => {
     const store = loadMutableSessionStoreForWriter(storePath);
+    const activeWorkKeys =
+      params.preserveActiveWork === true
+        ? collectActiveSessionWorkAdmissionKeys({ storePath, store })
+        : undefined;
     for (const removal of params.removals ?? []) {
       const sessionKey = removal.sessionKey.trim();
-      if (!sessionKey) {
+      if (!sessionKey || activeWorkKeys?.has(sessionKey)) {
         continue;
       }
       const entry = store[sessionKey];

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -3,8 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import type { Logger } from "./service/state.js";
 import { sweepCronRunSessions, resolveRetentionMs, resetReaperThrottle } from "./session-reaper.js";
 
@@ -246,38 +248,51 @@ describe("sweepCronRunSessions", () => {
     expect(JSON.parse(fs.readFileSync(storePath, "utf-8"))).toEqual({});
   });
 
-  it("preserves an expired continuation while its gateway owner is active", async () => {
+  it("preserves an expired run when work is admitted before writer-owned removal", async () => {
     const now = Date.now();
-    const sessionKey = "agent:main:cron:job1:run:continuing-run";
+    const sessionKey = "agent:main:cron:job1:run:active-run";
     const store = {
       [sessionKey]: {
-        sessionId: "continuing-run",
+        sessionId: "active-run",
         updatedAt: now - 25 * 3_600_000,
-        cronRunContinuation: {
-          lifecycleRevision: "revision-1",
-          phase: "continuing",
-          ownerRunId: "gateway-run",
-        },
       },
     };
     fs.writeFileSync(storePath, JSON.stringify(store));
-    const admission = await beginSessionWorkAdmission({
-      scope: storePath,
-      identities: [sessionKey],
-      assertAllowed: () => {},
+    const writerStarted = createDeferred();
+    const releaseWriter = createDeferred();
+    const firstValidation = createDeferred();
+    const writer = runExclusiveSessionStoreWrite(storePath, async () => {
+      writerStarted.resolve();
+      await releaseWriter.promise;
     });
+    await writerStarted.promise;
+
+    const sweep = sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+    const admissionPromise = beginSessionWorkAdmission({
+      scope: storePath,
+      identities: ["active-run"],
+      assertAllowed: () => {
+        firstValidation.resolve();
+      },
+    });
+    await firstValidation.promise;
+
     try {
-      const result = await sweepCronRunSessions({
-        sessionStorePath: storePath,
-        nowMs: now,
-        log,
-        force: true,
-      });
+      releaseWriter.resolve();
+      const result = await sweep;
+      const admission = await admissionPromise;
 
       expect(result.pruned).toBe(0);
       expect(JSON.parse(fs.readFileSync(storePath, "utf-8"))).toEqual(store);
-    } finally {
       admission.release();
+    } finally {
+      releaseWriter.resolve();
+      await Promise.allSettled([writer, sweep, admissionPromise]);
     }
   });
 

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -8,7 +8,6 @@ import {
 import type { CronConfig } from "../config/types.cron.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
-import { isSessionWorkAdmissionActive } from "../sessions/session-lifecycle-admission.js";
 import { hasPendingGeneratedMediaTaskForSessionKey } from "../tasks/task-status-access.js";
 import type { Logger } from "./service/state.js";
 
@@ -81,14 +80,10 @@ export async function sweepCronRunSessions(params: {
         continue;
       }
       const continuation = entry.cronRunContinuation;
-      const activeContinuationOwner = isSessionWorkAdmissionActive(storePath, [
-        sessionKey,
-        entry.sessionId,
-      ]);
       const hasPendingMedia = Boolean(
         continuation && hasPendingGeneratedMediaTaskForSessionKey(sessionKey),
       );
-      if (continuation && (hasPendingMedia || activeContinuationOwner)) {
+      if (continuation && hasPendingMedia) {
         continue;
       }
       const updatedAt = entry.updatedAt ?? 0;
@@ -106,6 +101,7 @@ export async function sweepCronRunSessions(params: {
       const result = await applySessionEntryLifecycleMutation({
         storePath,
         removals,
+        preserveActiveWork: true,
         restrictArchivedTranscriptsToStoreDir: true,
         cleanupArchivedTranscripts: {
           rules: [{ reason: "deleted", olderThanMs: retentionMs }],

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -2165,7 +2165,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         resolvedSessionKey === "global"
           ? (resolvedSessionAgentId ?? agentId ?? resolveDefaultAgentId(cfgForAgent ?? cfg))
           : undefined;
-      const assertGatewayWorkAdmissionAllowed = () => {
+      const assertGatewayWorkAdmissionAllowed = (commitOutcome = true) => {
         const latestPreRegistrationAbort = readGatewayDedupeEntry({
           dedupe: context.dedupe,
           keys: agentDedupeKeys,
@@ -2178,38 +2178,46 @@ export const agentHandlers: GatewayRequestHandlers = {
             alternateSessionKeys: [preAcceptedReservedSessionKey, requestedSessionKey],
           })
         ) {
-          postAdmissionAbort = latestPreRegistrationAbort;
+          if (commitOutcome) {
+            postAdmissionAbort = latestPreRegistrationAbort;
+          }
           return;
         }
         if (agentDedupeReserved) {
           if (!latestPreRegistrationAbort) {
-            postAdmissionTimeout = {
-              runId,
-              status: "timeout",
-              summary: "aborted",
-              stopReason: "timeout",
-              timeoutPhase: "queue",
-              providerStarted: false,
-            };
-            setAbortedAgentDedupeEntries({
-              dedupe: context.dedupe,
-              keys: agentDedupeKeys,
-              agentId: admissionAgentId(),
-              sessionKey: resolvedSessionKey,
-              runId,
-              stopReason: "timeout",
-            });
+            if (commitOutcome) {
+              postAdmissionTimeout = {
+                runId,
+                status: "timeout",
+                summary: "aborted",
+                stopReason: "timeout",
+                timeoutPhase: "queue",
+                providerStarted: false,
+              };
+              setAbortedAgentDedupeEntries({
+                dedupe: context.dedupe,
+                keys: agentDedupeKeys,
+                agentId: admissionAgentId(),
+                sessionKey: resolvedSessionKey,
+                runId,
+                stopReason: "timeout",
+              });
+            }
             return;
           }
           if (
             !latestPreRegistrationAbort.ok ||
             !isAcceptedAgentDedupePayload(latestPreRegistrationAbort.payload)
           ) {
-            postAdmissionAbort = latestPreRegistrationAbort;
+            if (commitOutcome) {
+              postAdmissionAbort = latestPreRegistrationAbort;
+            }
             return;
           }
           if (latestPreRegistrationAbort.payload.reservationId !== agentReservationId) {
-            postAdmissionSuperseded = true;
+            if (commitOutcome) {
+              postAdmissionSuperseded = true;
+            }
             return;
           }
           if (
@@ -2217,30 +2225,37 @@ export const agentHandlers: GatewayRequestHandlers = {
               nowMs: Date.now(),
             })
           ) {
-            postAdmissionTimeout = {
-              runId,
-              status: "timeout",
-              summary: "aborted",
-              stopReason: "timeout",
-              timeoutPhase: "queue",
-              providerStarted: false,
-            };
-            setAbortedAgentDedupeEntries({
-              dedupe: context.dedupe,
-              keys: agentDedupeKeys,
-              agentId: admissionAgentId(),
-              sessionKey: resolvedSessionKey,
-              runId,
-              stopReason: "timeout",
-            });
+            if (commitOutcome) {
+              postAdmissionTimeout = {
+                runId,
+                status: "timeout",
+                summary: "aborted",
+                stopReason: "timeout",
+                timeoutPhase: "queue",
+                providerStarted: false,
+              };
+              setAbortedAgentDedupeEntries({
+                dedupe: context.dedupe,
+                keys: agentDedupeKeys,
+                agentId: admissionAgentId(),
+                sessionKey: resolvedSessionKey,
+                runId,
+                stopReason: "timeout",
+              });
+            }
             return;
           }
         }
-        lifecycleRotatedDuringAdmission = abortForLifecycleRotation({
-          sessionKey: resolvedSessionKey,
-          agentId: admissionAgentId(),
-        });
-        if (lifecycleRotatedDuringAdmission || !resolvedSessionKey) {
+        if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
+          if (commitOutcome) {
+            lifecycleRotatedDuringAdmission = abortForLifecycleRotation({
+              sessionKey: resolvedSessionKey,
+              agentId: admissionAgentId(),
+            });
+          }
+          return;
+        }
+        if (!resolvedSessionKey) {
           return;
         }
         let latestEntry = loadSessionEntry(resolvedSessionKey, {
@@ -2262,7 +2277,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         if (archivedError) {
           throw new Error(archivedError);
         }
-        if (latestEntry?.sessionId && latestEntry.sessionId !== supersededSessionId) {
+        if (
+          commitOutcome &&
+          latestEntry?.sessionId &&
+          latestEntry.sessionId !== supersededSessionId
+        ) {
           admittedSessionId = latestEntry.sessionId;
         }
       };
@@ -2300,7 +2319,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         gatewayWorkAdmission = await beginSessionWorkAdmission({
           scope,
           identities: [resolvedSessionKey, resolvedSessionId],
-          assertAllowed: assertGatewayWorkAdmissionAllowed,
+          assertAllowed: () => assertGatewayWorkAdmissionAllowed(false),
+          revalidateAllowed: assertGatewayWorkAdmissionAllowed,
           onInterrupt: interruptGatewayWorkAdmission,
         });
       };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -4136,97 +4136,110 @@ export const chatHandlers: GatewayRequestHandlers = {
     let admittedRunAbort: ReturnType<typeof registerChatAbortController> | undefined;
     let reservationSuperseded = false;
     let supersedingResult: DedupeEntry | undefined;
+    const assertChatWorkAdmissionAllowed = (commitOutcome: boolean) => {
+      if (context.chatAbortedRuns.has(clientRunId)) {
+        return;
+      }
+      const pendingReservation = readPreRegisteredRun({
+        key: pendingChatSendKey,
+        entry: context.dedupe.get(pendingChatSendKey),
+        keyPrefix: PENDING_CHAT_SEND_DEDUPE_PREFIX,
+      });
+      if (
+        pendingReservation &&
+        normalizeUnknownText(pendingReservation.payload.attemptId) !== pendingAttemptId
+      ) {
+        if (commitOutcome) {
+          reservationSuperseded = true;
+        }
+        return;
+      }
+      if (!pendingReservation) {
+        const terminalResult = context.dedupe.get(`chat:${clientRunId}`);
+        if (terminalResult || context.chatAbortControllers.has(clientRunId)) {
+          if (commitOutcome) {
+            reservationSuperseded = true;
+            supersedingResult = terminalResult;
+          }
+          return;
+        }
+      }
+      if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
+        if (commitOutcome) {
+          writePreRegisteredChatAbort({
+            context,
+            runId: clientRunId,
+            stopReason: "restart",
+            attemptId: pendingAttemptId,
+          });
+        }
+        return;
+      }
+      if (
+        !pendingReservation ||
+        !isFutureDateTimestampMs(pendingReservation.payload.expiresAtMs, {
+          nowMs: Date.now(),
+        })
+      ) {
+        if (commitOutcome) {
+          writePreRegisteredChatAbort({
+            context,
+            runId: clientRunId,
+            stopReason: "timeout",
+            attemptId: pendingAttemptId,
+          });
+        }
+        return;
+      }
+      const latestSession = loadSessionEntry(rawSessionKey, sessionLoadOptions);
+      if (sessionRoutingChanged(latestSession.cfg)) {
+        throw new Error(SESSION_ROUTING_CHANGED_ERROR_REASON);
+      }
+      const latestEntry = latestSession.entry;
+      if (entry && !latestEntry) {
+        throw new Error(`Session "${sessionKey}" was deleted while starting work. Retry.`);
+      }
+      // Admission can queue behind reset. Never route a request captured
+      // against the old session into the replacement transcript.
+      if (
+        backingSessionId &&
+        latestEntry?.sessionId &&
+        latestEntry.sessionId !== backingSessionId
+      ) {
+        throw new Error(`Session "${sessionKey}" changed while starting work. Retry.`);
+      }
+      const archivedError = resolveSessionWorkStartError(sessionKey, latestEntry);
+      if (archivedError) {
+        throw new Error(archivedError);
+      }
+      if (!commitOutcome) {
+        return;
+      }
+      admittedSessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
+      admittedRunAbort = registerChatAbortController({
+        chatAbortControllers: context.chatAbortControllers,
+        runId: clientRunId,
+        sessionId: admittedSessionId,
+        sessionKey,
+        agentId: selectedAgent.agentId,
+        timeoutMs,
+        now,
+        ownerConnId: normalizeOptionalText(client?.connId),
+        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+        providerId: resolvedSessionModel.provider,
+        authProviderId: resolvedSessionAuthProvider,
+        isAbortable: (active) => isReplyRunAbortableForSignal(active.controller.signal),
+        kind: "chat-send",
+        turnKind,
+        lifecycleGeneration,
+      });
+    };
     try {
       gatewayWorkAdmission = await beginSessionWorkAdmission({
         scope: storePath,
         identities: [sessionKey, backingSessionId],
-        assertAllowed: () => {
-          if (context.chatAbortedRuns.has(clientRunId)) {
-            return;
-          }
-          const pendingReservation = readPreRegisteredRun({
-            key: pendingChatSendKey,
-            entry: context.dedupe.get(pendingChatSendKey),
-            keyPrefix: PENDING_CHAT_SEND_DEDUPE_PREFIX,
-          });
-          if (
-            pendingReservation &&
-            normalizeUnknownText(pendingReservation.payload.attemptId) !== pendingAttemptId
-          ) {
-            reservationSuperseded = true;
-            return;
-          }
-          if (!pendingReservation) {
-            const terminalResult = context.dedupe.get(`chat:${clientRunId}`);
-            if (terminalResult || context.chatAbortControllers.has(clientRunId)) {
-              reservationSuperseded = true;
-              supersedingResult = terminalResult;
-              return;
-            }
-          }
-          if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
-            writePreRegisteredChatAbort({
-              context,
-              runId: clientRunId,
-              stopReason: "restart",
-              attemptId: pendingAttemptId,
-            });
-            return;
-          }
-          if (
-            !pendingReservation ||
-            !isFutureDateTimestampMs(pendingReservation.payload.expiresAtMs, {
-              nowMs: Date.now(),
-            })
-          ) {
-            writePreRegisteredChatAbort({
-              context,
-              runId: clientRunId,
-              stopReason: "timeout",
-              attemptId: pendingAttemptId,
-            });
-            return;
-          }
-          const latestSession = loadSessionEntry(rawSessionKey, sessionLoadOptions);
-          if (sessionRoutingChanged(latestSession.cfg)) {
-            throw new Error(SESSION_ROUTING_CHANGED_ERROR_REASON);
-          }
-          const latestEntry = latestSession.entry;
-          if (entry && !latestEntry) {
-            throw new Error(`Session "${sessionKey}" was deleted while starting work. Retry.`);
-          }
-          // Admission can queue behind reset. Never route a request captured
-          // against the old session into the replacement transcript.
-          if (
-            backingSessionId &&
-            latestEntry?.sessionId &&
-            latestEntry.sessionId !== backingSessionId
-          ) {
-            throw new Error(`Session "${sessionKey}" changed while starting work. Retry.`);
-          }
-          const archivedError = resolveSessionWorkStartError(sessionKey, latestEntry);
-          if (archivedError) {
-            throw new Error(archivedError);
-          }
-          admittedSessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-          admittedRunAbort = registerChatAbortController({
-            chatAbortControllers: context.chatAbortControllers,
-            runId: clientRunId,
-            sessionId: admittedSessionId,
-            sessionKey,
-            agentId: selectedAgent.agentId,
-            timeoutMs,
-            now,
-            ownerConnId: normalizeOptionalText(client?.connId),
-            ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-            providerId: resolvedSessionModel.provider,
-            authProviderId: resolvedSessionAuthProvider,
-            isAbortable: (active) => isReplyRunAbortableForSignal(active.controller.signal),
-            kind: "chat-send",
-            turnKind,
-            lifecycleGeneration,
-          });
-        },
+        assertAllowed: () => assertChatWorkAdmissionAllowed(false),
+        revalidateAllowed: () => assertChatWorkAdmissionAllowed(true),
         onInterrupt: () => {
           if (admittedRunAbort?.entry) {
             admittedRunAbort.entry.abortStopReason = "restart";

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1734,6 +1734,7 @@ export async function runHeartbeatOnce(opts: {
     const lifecycleResult = await applySessionEntryLifecycleMutation({
       storePath: isolatedStorePath,
       removals,
+      preserveActiveWork: true,
       upserts: [
         {
           sessionKey: isolatedSessionKey,

--- a/src/sessions/session-lifecycle-admission.test.ts
+++ b/src/sessions/session-lifecycle-admission.test.ts
@@ -1,6 +1,7 @@
 // Tests lifecycle/work admission ordering across canonical keys and backing ids.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { expect, it } from "vitest";
+import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import {
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
@@ -130,6 +131,205 @@ it("lets an admitted root enter session work while suspension preparation refuse
   } finally {
     suspension?.rollback();
     root?.release();
+    resetGatewayWorkAdmission();
+  }
+});
+
+it("registers active work before waiting for the store writer barrier", async () => {
+  const storePath = "store-writer-barrier";
+  const writerStarted = createDeferred();
+  const releaseWriter = createDeferred();
+  const firstValidation = createDeferred();
+  let validationCount = 0;
+  const writer = runExclusiveSessionStoreWrite(storePath, async () => {
+    writerStarted.resolve();
+    await releaseWriter.promise;
+  });
+  await writerStarted.promise;
+
+  const admissionPromise = beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["agent:main:child", "session-writer-barrier"],
+    assertAllowed: () => {
+      validationCount += 1;
+      if (validationCount === 1) {
+        firstValidation.resolve();
+      }
+    },
+  });
+  await firstValidation.promise;
+  await Promise.resolve();
+
+  expect(isSessionWorkAdmissionActive(storePath, ["session-writer-barrier"])).toBe(true);
+
+  releaseWriter.resolve();
+  const admission = await admissionPromise;
+  try {
+    expect(validationCount).toBe(2);
+  } finally {
+    admission.release();
+    await writer;
+  }
+});
+
+it("revalidates inline when admission begins inside the active store writer", async () => {
+  const storePath = "store-writer-reentrant-admission";
+  const order: string[] = [];
+  const admission = await runExclusiveSessionStoreWrite(storePath, async () => {
+    order.push("writer:start");
+    const lease = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: ["session-writer-reentrant-admission"],
+      assertAllowed: () => {
+        order.push("validate");
+      },
+    });
+    order.push("writer:end");
+    return lease;
+  });
+
+  try {
+    expect(order).toEqual(["writer:start", "validate", "validate", "writer:end"]);
+    expect(isSessionWorkAdmissionActive(storePath, ["session-writer-reentrant-admission"])).toBe(
+      true,
+    );
+  } finally {
+    admission.release();
+  }
+});
+
+it("runs one-time admission work only during writer-barrier revalidation", async () => {
+  let initialChecks = 0;
+  let finalChecks = 0;
+  const admission = await beginSessionWorkAdmission({
+    scope: "store-dedicated-revalidation",
+    identities: ["session-dedicated-revalidation"],
+    assertAllowed: () => {
+      initialChecks += 1;
+    },
+    revalidateAllowed: () => {
+      finalChecks += 1;
+    },
+  });
+
+  try {
+    expect(initialChecks).toBe(1);
+    expect(finalChecks).toBe(1);
+  } finally {
+    admission.release();
+  }
+});
+
+it("rejects and releases an admission invalidated by an earlier store writer", async () => {
+  const storePath = "store-writer-revalidation";
+  const writerStarted = createDeferred();
+  const releaseWriter = createDeferred();
+  const firstValidation = createDeferred();
+  let allowed = true;
+  let validationCount = 0;
+  const writer = runExclusiveSessionStoreWrite(storePath, async () => {
+    writerStarted.resolve();
+    await releaseWriter.promise;
+    allowed = false;
+  });
+  await writerStarted.promise;
+
+  const admission = beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["agent:main:child", "session-writer-revalidation"],
+    assertAllowed: () => {
+      validationCount += 1;
+      if (validationCount === 1) {
+        firstValidation.resolve();
+      }
+      if (!allowed) {
+        throw new Error("session changed");
+      }
+    },
+  });
+  await firstValidation.promise;
+  await Promise.resolve();
+  expect(isSessionWorkAdmissionActive(storePath, ["session-writer-revalidation"])).toBe(true);
+
+  releaseWriter.resolve();
+  await writer;
+  await expect(admission).rejects.toThrow("session changed");
+  expect(validationCount).toBe(2);
+  expect(isSessionWorkAdmissionActive(storePath, ["session-writer-revalidation"])).toBe(false);
+});
+
+it("releases an admission aborted while waiting for the store writer barrier", async () => {
+  const storePath = "store-writer-abort";
+  const writerStarted = createDeferred();
+  const releaseWriter = createDeferred();
+  const firstValidation = createDeferred();
+  const controller = new AbortController();
+  const abortError = new Error("admission aborted behind writer");
+  const writer = runExclusiveSessionStoreWrite(storePath, async () => {
+    writerStarted.resolve();
+    await releaseWriter.promise;
+  });
+  await writerStarted.promise;
+
+  const admission = beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["session-writer-abort"],
+    signal: controller.signal,
+    assertAllowed: () => {
+      firstValidation.resolve();
+    },
+  });
+  await firstValidation.promise;
+  controller.abort(abortError);
+
+  await expect(admission).rejects.toBe(abortError);
+  expect(isSessionWorkAdmissionActive(storePath, ["session-writer-abort"])).toBe(false);
+
+  releaseWriter.resolve();
+  await writer;
+});
+
+it("revalidates without inheriting a released gateway root from the writer queue", async () => {
+  resetGatewayWorkAdmission();
+  const storePath = "store-released-gateway-root";
+  const writerStarted = createDeferred();
+  const releaseWriter = createDeferred();
+  const firstValidation = createDeferred();
+  const root = tryBeginGatewayRootWorkAdmission();
+  expect(root).not.toBeNull();
+  if (!root) {
+    throw new Error("gateway root admission unavailable");
+  }
+  const writer = root.run(
+    async () =>
+      await runExclusiveSessionStoreWrite(storePath, async () => {
+        writerStarted.resolve();
+        await releaseWriter.promise;
+      }),
+  );
+  await writerStarted.promise;
+
+  let validationCount = 0;
+  const admissionPromise = beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["session-released-gateway-root"],
+    assertAllowed: () => {
+      validationCount += 1;
+      if (validationCount === 1) {
+        firstValidation.resolve();
+      }
+    },
+  });
+  await firstValidation.promise;
+
+  root.release();
+  releaseWriter.resolve();
+  const admission = await admissionPromise;
+  try {
+    expect(validationCount).toBe(2);
+  } finally {
+    admission.release();
+    await writer;
     resetGatewayWorkAdmission();
   }
 });

--- a/src/sessions/session-lifecycle-admission.ts
+++ b/src/sessions/session-lifecycle-admission.ts
@@ -1,5 +1,6 @@
 // Serializes lifecycle mutations and work admission for logical session identities.
 import { AsyncLocalStorage } from "node:async_hooks";
+import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import {
   GatewayDrainingError,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -76,6 +77,25 @@ function normalizeSessionIdentities(
   )
     .map((identity) => JSON.stringify([normalizedScope, identity]))
     .toSorted();
+}
+
+function decodeSessionIdentity(
+  normalizedIdentity: string,
+): { scope: string; identity: string } | undefined {
+  try {
+    const decoded: unknown = JSON.parse(normalizedIdentity);
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 2 ||
+      typeof decoded[0] !== "string" ||
+      typeof decoded[1] !== "string"
+    ) {
+      return undefined;
+    }
+    return { scope: decoded[0], identity: decoded[1] };
+  } catch {
+    return undefined;
+  }
 }
 
 async function runWithSessionIdentityLocks<T>(
@@ -336,6 +356,25 @@ export function isSessionWorkAdmissionActive(
   );
 }
 
+/** Active session identities for one store/lifecycle scope. */
+export function collectActiveSessionWorkAdmissionIdentities(scope: string): Set<string> {
+  const normalizedScope = scope.trim();
+  if (!normalizedScope) {
+    throw new Error("session lifecycle scope is required");
+  }
+  const identities = new Set<string>();
+  for (const [normalizedIdentity, admissions] of ACTIVE_SESSION_WORK_ADMISSIONS) {
+    if (admissions.size === 0) {
+      continue;
+    }
+    const decoded = decodeSessionIdentity(normalizedIdentity);
+    if (decoded?.scope === normalizedScope) {
+      identities.add(decoded.identity);
+    }
+  }
+  return identities;
+}
+
 /** Unique admitted turns; one lease can be indexed under several identities. */
 export function getActiveSessionWorkAdmissionCount(): number {
   const admissions = new Set<SessionWorkAdmission>();
@@ -360,6 +399,8 @@ export async function beginSessionWorkAdmission(params: {
   scope: string;
   identities: Iterable<string | undefined>;
   assertAllowed: () => Promise<void> | void;
+  /** Final writer-ordered validation; use when one-time effects must not run during the first check. */
+  revalidateAllowed?: () => Promise<void> | void;
   onInterrupt?: () => void;
   signal?: AbortSignal;
 }): Promise<SessionWorkAdmissionLease> {
@@ -405,7 +446,7 @@ export async function beginSessionWorkAdmission(params: {
         }
         resolveReleased();
       };
-      return {
+      const lease: SessionWorkAdmissionLease = {
         release,
         run: async <T>(run: () => Promise<T>) => {
           const current = new Set(CURRENT_SESSION_WORK_ADMISSIONS.getStore());
@@ -413,6 +454,50 @@ export async function beginSessionWorkAdmission(params: {
           return await CURRENT_SESSION_WORK_ADMISSIONS.run(current, run);
         },
       };
+      const signal = params.signal;
+      let writerBarrierStarted = false;
+      let removeAbortListener = () => {};
+      try {
+        const queuedAbort = signal
+          ? new Promise<never>((_, reject) => {
+              const onAbort = () => {
+                if (writerBarrierStarted) {
+                  return;
+                }
+                reject(
+                  signal.reason instanceof Error
+                    ? signal.reason
+                    : new Error("session work admission aborted"),
+                );
+              };
+              removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+              signal.addEventListener("abort", onAbort, { once: true });
+              if (signal.aborted) {
+                onAbort();
+              }
+            })
+          : undefined;
+        // Register before crossing the writer barrier. Earlier maintenance then
+        // either preserves this admission or commits first and fails revalidation.
+        const writerBarrier = runExclusiveSessionStoreWrite(
+          params.scope,
+          async () => {
+            writerBarrierStarted = true;
+            params.signal?.throwIfAborted();
+            await (params.revalidateAllowed ?? params.assertAllowed)();
+          },
+          // Writer-owned rollover callbacks can open replacement admissions.
+          // Reenter that lane or the writer waits on work queued behind itself.
+          { reentrant: true },
+        );
+        await (queuedAbort ? Promise.race([writerBarrier, queuedAbort]) : writerBarrier);
+        return lease;
+      } catch (error) {
+        release();
+        throw error;
+      } finally {
+        removeAbortListener();
+      }
     },
   });
 }


### PR DESCRIPTION
Closes #102064

## What Problem This Solves

Fixes an issue where scheduled agent work could lose its session state and final delivery when automatic session maintenance pruned or archived the session while the run was still active.

## Why This Change Was Made

Automatic maintenance now preserves every session identity covered by an active session-work admission, including aliases that resolve to the same session. Admission also crosses the session-store writer boundary and performs a final lifecycle revalidation, so maintenance cannot race between validation and active-work registration.

Explicit user-driven reset and deletion behavior is unchanged.

## User Impact

Long-running scheduled and gateway agent work can complete without automatic maintenance deleting its active session or causing an `EmbeddedAttemptSessionTakeoverError`.

## Evidence

### Live scheduled-cron before/after proof

Run on July 11, 2026 using Blacksmith Testbox through Crabbox:

- Testbox: `tbx_01kx7py7cw0j3v5cgxyde14xgv` (`golden-crayfish`)
- Before fix: `9bfecf46ee3eb08173c97dd7d307363f67483edf`
- After fix: `c5a68cabe6aa45ec91a21279be42cfb64a374bd6`

The same scenario was run at both revisions:

1. Start a real OpenClaw Gateway with isolated state.
2. Add a scheduled isolated `agentTurn` cron job through the CLI.
3. Hold the turn at its second model request after `session_status` has run.
4. Force automatic maintenance by creating four additional sessions with `session.maintenance.maxEntries=2`.
5. Release the response and inspect cron terminal history.

The loopback model server only makes the race deterministic. Gateway startup, cron scheduling, CLI/RPC calls, session storage, automatic maintenance, transcript locking, and cron terminal history use production paths. No external credentials were used.

<details>
<summary>Before fix: active aliases deleted and takeover error reproduced</summary>

```text
commit=9bfecf46ee3eb08173c97dd7d307363f67483edf
provider=blacksmith-testbox
leaseId=tbx_01kx7py7cw0j3v5cgxyde14xgv

{"ok":true,"expectation":"broken","jobId":"<redacted-job-id>","modelRequestCount":2,"activeBefore":["agent:main:cron:<redacted-job-id>","agent:main:cron:<redacted-job-id>:run:<redacted-run-id>"],"activeAfter":[],"entryCountAfterMaintenance":2,"status":"error","takeoverObserved":true,"runError":"EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: <redacted-temp-state>/agents/main/sessions/<redacted-session-id>.jsonl"}
ISSUE_102064_E2E_REPRO_OK

blacksmith run summary sync=delegated command=2m24.107s total=2m24.122s exit=0
```

</details>

<details>
<summary>After fix: active aliases preserved and scheduled run completed</summary>

```text
commit=c5a68cabe6aa45ec91a21279be42cfb64a374bd6
provider=blacksmith-testbox
leaseId=tbx_01kx7py7cw0j3v5cgxyde14xgv

{"ok":true,"expectation":"fixed","jobId":"<redacted-job-id>","modelRequestCount":2,"activeBefore":["agent:main:cron:<redacted-job-id>","agent:main:cron:<redacted-job-id>:run:<redacted-run-id>"],"activeAfter":["agent:main:cron:<redacted-job-id>","agent:main:cron:<redacted-job-id>:run:<redacted-run-id>"],"entryCountAfterMaintenance":2,"status":"ok","takeoverObserved":false}
ISSUE_102064_E2E_FIX_OK

blacksmith run summary sync=delegated command=2m15.869s total=2m15.884s exit=0
```

</details>

### Automated validation

- session lifecycle admission: 20 tests
- reply-session rollover: 136 tests
- session-store pruning: 31 tests
- cron session reaper: 21 tests
- session registry maintenance: 4 tests
- `pnpm check:changed` passed
- Fresh autoreview against current `origin/main`: no findings

AI-assisted implementation and validation. I reviewed and understand the resulting lifecycle and maintenance behavior.
