### PR TITLE
fix(oc-path): reject oversized multibyte JSONC input

### DIFF
--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -267,7 +267,7 @@ describe("openclaw path CLI", () => {
 
       await pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt);
 
-      expect(rt.exitCode).toBe(1);
+      expect(rt.exitCode).toBe(2);
       expect(stdoutText(rt)).toBe("");
       expect(JSON.parse(stderrText(rt))).toMatchObject({
         error: { code: "OC_JSONC_INPUT_TOO_LARGE" },

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -11,6 +11,8 @@ import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerPathCli } from "./cli.js";
 
+const JSONC_INPUT_LIMIT_BYTES = 16 * 1024 * 1024;
+
 type PathCommandOptions = {
   readonly json?: boolean;
   readonly human?: boolean;
@@ -255,6 +257,21 @@ describe("openclaw path CLI", () => {
       await pathResolveCommand(undefined, { json: true }, rt);
       expect(rt.exitCode).toBe(1);
       expect(stderrText(rt)).toContain("missing required argument");
+    });
+
+    it("rejects oversized multibyte JSONC with the typed diagnostic", async () => {
+      const filePath = join(workspaceDir, "oversized.json");
+      const content = `"${"界".repeat(Math.floor(JSONC_INPUT_LIMIT_BYTES / 3) + 1)}"`;
+      writeFileSync(filePath, content, "utf-8");
+      const rt = createTestRuntime();
+
+      await pathResolveCommand("oc://oversized.json/value", { cwd: workspaceDir, json: true }, rt);
+
+      expect(rt.exitCode).toBe(1);
+      expect(stdoutText(rt)).toBe("");
+      expect(JSON.parse(stderrText(rt))).toMatchObject({
+        error: { code: "OC_JSONC_INPUT_TOO_LARGE" },
+      });
     });
   });
 

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -175,7 +175,7 @@ async function loadAst(
     );
     if (sizeDiagnostic) {
       emitError(runtime, mode, sizeDiagnostic.message, sizeDiagnostic.code);
-      runtime.exit(1);
+      runtime.exit(2);
       return null;
     }
     return result.ast;

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -160,11 +160,25 @@ function catchSentinel<T>(
   }
 }
 
-async function loadAst(absPath: string, fileName: string): Promise<OcAst> {
+async function loadAst(
+  absPath: string,
+  fileName: string,
+  runtime: OutputRuntimeEnv,
+  mode: OutputMode,
+): Promise<OcAst | null> {
   const raw = await fs.readFile(absPath, "utf-8");
   const kind = inferKind(fileName);
   if (kind === "jsonc") {
-    return parseJsonc(raw).ast;
+    const result = parseJsonc(raw);
+    const sizeDiagnostic = result.diagnostics.find(
+      (diagnostic) => diagnostic.code === "OC_JSONC_INPUT_TOO_LARGE",
+    );
+    if (sizeDiagnostic) {
+      emitError(runtime, mode, sizeDiagnostic.message, sizeDiagnostic.code);
+      runtime.exit(1);
+      return null;
+    }
+    return result.ast;
   }
   if (kind === "jsonl") {
     return parseJsonl(raw).ast;
@@ -283,7 +297,10 @@ async function pathResolveCommand(
   if (ocPath === null) {
     return;
   }
-  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file);
+  const ast = await loadAst(resolveFsPath(ocPath, options), ocPath.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   let match: OcMatch | null;
   try {
     match = resolveOcPath(ast, ocPath);
@@ -333,7 +350,10 @@ async function pathSetCommand(
   }
   const fsPath = resolveFsPath(ocPath, options);
   const oldBytes = await fs.readFile(fsPath, "utf-8");
-  const ast = await loadAst(fsPath, ocPath.file);
+  const ast = await loadAst(fsPath, ocPath.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
 
   const result = catchSentinel("set", runtime, mode, () =>
     setOcPath(ast, ocPath, value, { valueJson: options.valueJson === true }),
@@ -407,7 +427,10 @@ async function pathFindCommand(
     runtime.exit(2);
     return;
   }
-  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file);
+  const ast = await loadAst(resolveFsPath(pattern, options), pattern.file, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   const matches = findOcPaths(ast, pattern);
   emit(
     runtime,
@@ -506,7 +529,10 @@ async function pathEmitCommand(
       ? resolvePath(options.file)
       : resolvePath(options.cwd ?? process.cwd(), fileArg);
   const fileName = fsPath.split(/[\\/]/).pop() ?? fileArg;
-  const ast = await loadAst(fsPath, fileName);
+  const ast = await loadAst(fsPath, fileName, runtime, mode);
+  if (ast === null) {
+    return;
+  }
   const bytes = catchSentinel("emit", runtime, mode, () => emitForKind(ast, fileName));
   if (bytes === null) {
     return;

--- a/extensions/oc-path/src/oc-path/jsonc/parse.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/parse.ts
@@ -41,26 +41,27 @@ type JsoncParserNode = {
 };
 
 export function parseJsonc(raw: string): JsoncParseResult {
-  if (raw.trim().length === 0) {
-    return { ast: { kind: "jsonc", raw, root: null }, diagnostics: [] };
-  }
-
   // Pre-parse byte-length cap. Symmetric with the post-parse depth cap
   // at `nodeToJsoncValue`. Without this, `parseTree` would allocate the
   // full tree before our walker noticed; bounding at the source keeps
   // memory pressure proportional to input size.
-  if (raw.length > MAX_JSONC_INPUT_BYTES) {
+  const inputBytes = Buffer.byteLength(raw, "utf8");
+  if (inputBytes > MAX_JSONC_INPUT_BYTES) {
     return {
       ast: { kind: "jsonc", raw, root: null },
       diagnostics: [
         {
           line: 1,
-          message: `input exceeds MAX_JSONC_INPUT_BYTES (${MAX_JSONC_INPUT_BYTES} bytes; got ${raw.length})`,
+          message: `input exceeds MAX_JSONC_INPUT_BYTES (${MAX_JSONC_INPUT_BYTES} bytes; got ${inputBytes})`,
           severity: "error",
           code: "OC_JSONC_INPUT_TOO_LARGE",
         },
       ],
     };
+  }
+
+  if (raw.trim().length === 0) {
+    return { ast: { kind: "jsonc", raw, root: null }, diagnostics: [] };
   }
 
   const parseSource = raw.startsWith("\uFEFF") ? raw.slice(1) : raw;

--- a/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
@@ -158,6 +158,17 @@ describe("parseJsonc — soft errors", () => {
     expect(ast.root).toBeNull();
   });
 
+  it("measures the input cap in UTF-8 bytes", () => {
+    const oversized = `"${"界".repeat(Math.floor(MAX_JSONC_INPUT_BYTES / 3) + 1)}"`;
+    expect(oversized.length).toBeLessThan(MAX_JSONC_INPUT_BYTES);
+
+    const { ast, diagnostics } = parseJsonc(oversized);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain(`got ${Buffer.byteLength(oversized, "utf8")}`);
+    expect(diagnostics[0]?.code).toBe("OC_JSONC_INPUT_TOO_LARGE");
+    expect(ast.root).toBeNull();
+  });
+
   it("accepts input up to the cap", () => {
     // Reasonable-shape JSON well within the cap parses normally.
     const { diagnostics, ast } = parseJsonc('{"key": "value"}');

--- a/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
@@ -159,8 +159,8 @@ describe("parseJsonc — soft errors", () => {
   });
 
   it("measures the input cap in UTF-8 bytes", () => {
-    const oversized = `"${"界".repeat(Math.floor(MAX_JSONC_INPUT_BYTES / 3) + 1)}"`;
-    expect(oversized.length).toBeLessThan(MAX_JSONC_INPUT_BYTES);
+    const oversized = `"${"\u754c".repeat(Math.floor(JSONC_INPUT_LIMIT_BYTES / 3) + 1)}"`;
+    expect(oversized.length).toBeLessThan(JSONC_INPUT_LIMIT_BYTES);
 
     const { ast, diagnostics } = parseJsonc(oversized);
     expect(diagnostics).toHaveLength(1);

--- a/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts
@@ -146,16 +146,21 @@ describe("parseJsonc — soft errors", () => {
   });
 
   it("rejects input larger than MAX_JSONC_INPUT_BYTES with a typed diagnostic", () => {
-    // Construct an input one byte over the cap. We don't allocate the
-    // full 16 MiB+ string in memory; `String#repeat` on a one-byte unit
-    // is enough to push past the threshold without exercising the
-    // expensive `parseTree` path (the cap fires before parse runs).
     const oversized = "a".repeat(JSONC_INPUT_LIMIT_BYTES + 1);
     const { ast, diagnostics } = parseJsonc(oversized);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]?.severity).toBe("error");
     expect(diagnostics[0]?.code).toBe("OC_JSONC_INPUT_TOO_LARGE");
     expect(ast.root).toBeNull();
+  });
+
+  it("accepts valid JSONC at the exact UTF-8 byte cap", () => {
+    const exactBoundary = `"${"a".repeat(JSONC_INPUT_LIMIT_BYTES - 2)}"`;
+    expect(Buffer.byteLength(exactBoundary, "utf8")).toBe(JSONC_INPUT_LIMIT_BYTES);
+
+    const { ast, diagnostics } = parseJsonc(exactBoundary);
+    expect(diagnostics).toEqual([]);
+    expect(ast.root?.kind).toBe("string");
   });
 
   it("measures the input cap in UTF-8 bytes", () => {
@@ -169,10 +174,13 @@ describe("parseJsonc — soft errors", () => {
     expect(ast.root).toBeNull();
   });
 
-  it("accepts input up to the cap", () => {
-    // Reasonable-shape JSON well within the cap parses normally.
-    const { diagnostics, ast } = parseJsonc('{"key": "value"}');
-    expect(diagnostics).toEqual([]);
-    expect(ast.root?.kind).toBe("object");
+  it("counts a UTF-8 BOM toward the byte cap", () => {
+    const oversized = `\uFEFF"${"a".repeat(JSONC_INPUT_LIMIT_BYTES - 2)}"`;
+    expect(Buffer.byteLength(oversized, "utf8")).toBe(JSONC_INPUT_LIMIT_BYTES + 3);
+
+    const { ast, diagnostics } = parseJsonc(oversized);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe("OC_JSONC_INPUT_TOO_LARGE");
+    expect(ast.root).toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running OC Path against JSONC input above the 16 MiB byte cap could receive normal empty or not-found output instead of a typed size rejection. Multibyte input could also bypass the intended byte cap because the parser measured UTF-16 code units.

## Why This Change Was Made

The shared JSONC parser now measures UTF-8 bytes before the empty-input shortcut and `parseTree`. The OC Path CLI loader propagates the existing `OC_JSONC_INPUT_TOO_LARGE` diagnostic through its structured parse-error path for every verb that loads JSON/JSONC, without changing other parser-warning behavior or adding another limit.

## User Impact

OC Path now consistently rejects oversized multibyte and whitespace-only JSONC before allocating the parse tree, and CLI callers receive the documented machine-readable parse-error diagnostic instead of a misleading normal result.

## Evidence

- Claim proved: oversized JSONC input returns the typed `OC_JSONC_INPUT_TOO_LARGE` diagnostic with the documented parse-error exit code.
- Current head: `5731ac582af20ab3d552b39433286e0557f51f51`.
- Real CLI behavior: `node --import tsx --input-type=module -` executed the production `registerPathCli` Commander registration as `openclaw path resolve oc://oversized.json/value --cwd <fixture> --json` against a 16,777,220-byte UTF-8 JSON fixture.

```json
{
  "head": "5731ac582af20ab3d552b39433286e0557f51f51",
  "inputBytes": 16777220,
  "stdout": "",
  "stderr": "{\"error\":{\"code\":\"OC_JSONC_INPUT_TOO_LARGE\",\"message\":\"input exceeds MAX_JSONC_INPUT_BYTES (16777216 bytes; got 16777220)\"}}\n",
  "exitCode": 2
}
```

- Focused regressions: `node scripts/run-vitest.mjs extensions/oc-path/src/cli.test.ts extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts` passed with 2 test files and 43 tests passing.
- Diff hygiene: `git diff --check -- extensions/oc-path/src/cli.ts extensions/oc-path/src/cli.test.ts extensions/oc-path/src/oc-path/jsonc/parse.ts extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts` passed.
- Rebase validation: `git diff --exit-code 267a09cdc5d09e444a9d866aa445130224fb264e 5731ac582af20ab3d552b39433286e0557f51f51 -- extensions/oc-path/src/cli.ts extensions/oc-path/src/cli.test.ts extensions/oc-path/src/oc-path/jsonc/parse.ts extensions/oc-path/src/oc-path/tests/jsonc/parse.test.ts` confirmed the OC Path patch files are unchanged from the prior CLI transcript head.
- Exact-head hosted checks: `Real behavior proof`, `openclaw/ci-gate`, `build-artifacts`, `check-test-types`, `check-prod-types`, `check-lint`, `check-dependencies`, `checks-node-changed-1`, and `checks-node-changed-2` passed on current head `5731ac582af20ab3d552b39433286e0557f51f51`.