### PR TITLE
fix(auto-reply): key command-turn reply operations to the source session

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -1099,7 +1099,11 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     expect(getActiveReplyRunCount()).toBe(0);
   });
 
-  it("keys native command pre-dispatch ownership to the command target session", async () => {
+  it("keys native command pre-dispatch ownership to the source session", async () => {
+    // Contract: reply-run admission is source-keyed for native command turns.
+    // Command handlers still resolve the target via CommandTargetSessionKey /
+    // initialSessionStoreEntry; only the reply-operation key is source-owned
+    // so mid-run status/stop/etc. do not wait on the target's active run.
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "before_dispatch",
     );
@@ -1128,7 +1132,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       },
       SessionKey: sourceSessionKey,
       CommandTargetSessionKey: targetSessionKey,
-      BodyForAgent: "hang before command target dispatch",
+      BodyForAgent: "hang before command source dispatch",
     });
     const dispatchPromise = dispatchReplyFromConfig({
       ctx,
@@ -1149,13 +1153,155 @@ describe("dispatchReplyFromConfig ACP abort", () => {
         "pending" as const,
       ),
     ).resolves.toBe("started");
-    expect(replyRunRegistry.abort(sourceSessionKey)).toBe(false);
-    expect(replyRunRegistry.abort(targetSessionKey)).toBe(true);
+    expect(replyRunRegistry.abort(targetSessionKey)).toBe(false);
+    expect(replyRunRegistry.abort(sourceSessionKey)).toBe(true);
 
     await expect(dispatchPromise).resolves.toMatchObject({
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("admits unauthorized native /stop on the source while the target has an active run", async () => {
+    const sourceSessionKey = "agent:main:telegram:slash:user-unauth";
+    const targetSessionKey = "agent:main:telegram:group:target-run";
+    const targetOperation = createReplyOperation({
+      sessionKey: targetSessionKey,
+      sessionId: "target-active-session",
+      resetTriggered: false,
+    });
+    targetOperation.setPhase("running");
+
+    const replyResolver = vi.fn(async () => ({
+      text: "You are not authorized to use this command.",
+    }));
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      CommandSource: "native",
+      CommandAuthorized: false,
+      CommandTurn: {
+        kind: "native",
+        source: "native",
+        authorized: false,
+        commandName: "stop",
+        body: "/stop",
+      },
+      SessionKey: sourceSessionKey,
+      CommandTargetSessionKey: targetSessionKey,
+      Body: "/stop",
+      RawBody: "/stop",
+      CommandBody: "/stop",
+      BodyForAgent: "/stop",
+    });
+
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    type DispatchOutcome =
+      | { status: "settled"; result: Awaited<typeof dispatchPromise> }
+      | { status: "pending" };
+    const outcome = await raceWithTimeoutResult<DispatchOutcome>(
+      dispatchPromise.then((result) => ({ status: "settled" as const, result })),
+      200,
+      { status: "pending" as const },
+    );
+    expect(outcome).toMatchObject({
+      status: "settled",
+      result: {
+        queuedFinal: true,
+      },
+    });
+    expect(replyResolver).toHaveBeenCalledOnce();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: "You are not authorized to use this command.",
+    });
+    // Target run must remain active — command admission is source-keyed.
+    expect(targetOperation.result).toBeNull();
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(targetOperation);
+    expect(replyRunRegistry.get(sourceSessionKey)).toBeUndefined();
+    targetOperation.complete();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("admits authorized native /status on the source while the target has an active run", async () => {
+    const sourceSessionKey = "agent:main:telegram:slash:user-auth";
+    const targetSessionKey = "agent:main:telegram:group:status-target";
+    const targetOperation = createReplyOperation({
+      sessionKey: targetSessionKey,
+      sessionId: "status-target-active-session",
+      resetTriggered: false,
+    });
+    targetOperation.setPhase("running");
+
+    const replyResolver = vi.fn(async () => ({
+      text: "🧠 Model: mock | ⚙️ Status: ok",
+    }));
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      CommandSource: "native",
+      CommandAuthorized: true,
+      CommandTurn: {
+        kind: "native",
+        source: "native",
+        authorized: true,
+        commandName: "status",
+        body: "/status",
+      },
+      SessionKey: sourceSessionKey,
+      CommandTargetSessionKey: targetSessionKey,
+      Body: "/status",
+      RawBody: "/status",
+      CommandBody: "/status",
+      BodyForAgent: "/status",
+    });
+
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    type DispatchOutcome =
+      | { status: "settled"; result: Awaited<typeof dispatchPromise> }
+      | { status: "pending" };
+    const outcome = await raceWithTimeoutResult<DispatchOutcome>(
+      dispatchPromise.then((result) => ({ status: "settled" as const, result })),
+      200,
+      { status: "pending" as const },
+    );
+    expect(outcome).toMatchObject({
+      status: "settled",
+      result: {
+        queuedFinal: true,
+      },
+    });
+    expect(replyResolver).toHaveBeenCalledOnce();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: "🧠 Model: mock | ⚙️ Status: ok",
+    });
+    expect(targetOperation.result).toBeNull();
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(targetOperation);
+    targetOperation.complete();
     expect(getActiveReplyRunCount()).toBe(0);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1311,14 +1311,27 @@ export async function dispatchReplyFromConfig(
   const boundAcpDispatchSessionKey = resolveBoundAcpDispatchSessionKey({ ctx, cfg });
   const acpDispatchSessionKey =
     boundAcpDispatchSessionKey ?? initialSessionStoreEntry.sessionKey ?? sessionKey;
-  // initialSessionStoreEntry is command-target-aware, so native command turns
-  // stay target-keyed here. Bound ACP dispatch remains source-key owned while
-  // ACP routing uses acpDispatchSessionKey.
+  // initialSessionStoreEntry stays command-target-aware for handler/store
+  // lookups (status/stop/model act on the target via CommandTargetSessionKey).
+  // Reply-run ownership must stay SOURCE-keyed: a native command turn must not
+  // wait on or contend with the target's active run. Bound ACP routing uses
+  // acpDispatchSessionKey separately and must not move source admission.
+  const sourceSessionKey = normalizeOptionalString(ctx.SessionKey);
   const dispatchOperationSessionKey =
-    initialSessionStoreEntry.sessionKey ?? sessionKey ?? acpDispatchSessionKey;
-  // Reply-run ownership stays on the inbound/source session. Bound ACP routing
-  // may use another agent's store, but must not move source lifecycle admission.
-  const operationSessionStoreEntry = initialSessionStoreEntry;
+    sourceSessionKey ?? initialSessionStoreEntry.sessionKey ?? sessionKey ?? acpDispatchSessionKey;
+  const operationSessionStoreEntry =
+    sourceSessionKey &&
+    initialSessionStoreEntry.sessionKey &&
+    sourceSessionKey !== initialSessionStoreEntry.sessionKey
+      ? resolveSessionStoreLookup(
+          {
+            ...ctx,
+            // Strip target so store resolution follows the source SessionKey.
+            CommandTargetSessionKey: undefined,
+          },
+          cfg,
+        )
+      : initialSessionStoreEntry;
   const initialDispatchReplyOperation = dispatchOperationSessionKey
     ? replyRunRegistry.get(dispatchOperationSessionKey)
     : undefined;
@@ -1528,8 +1541,7 @@ export async function dispatchReplyFromConfig(
     }
     const operationSessionId =
       dispatchAbortOperation?.sessionId ??
-      initialSessionStoreEntry.entry?.sessionId ??
-      sessionStoreEntry.entry?.sessionId ??
+      operationSessionStoreEntry.entry?.sessionId ??
       crypto.randomUUID();
     const replyTurnKind = resolveReplyTurnKind(params.replyOptions);
     const allowActivePreDispatch = phase === "pre_dispatch" && replyTurnKind === "visible";

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -23,7 +23,7 @@ import {
 } from "./reply-run-registry.js";
 
 /** Kinds of turns that compete for one reply run slot per session. */
-export type ReplyTurnKind = "visible" | "heartbeat" | "queued_followup" | "control_abort";
+export type ReplyTurnKind = "visible" | "heartbeat" | "queued_followup";
 
 /** Admission result for a reply turn attempting to own the session run slot. */
 export type ReplyTurnAdmission =
@@ -282,10 +282,10 @@ export async function admitReplyTurn(params: {
       if (params.kind === "visible" && expireVisibleStaleOperation(activeOperation)) {
         continue;
       }
-      if (params.kind === "heartbeat" || params.kind === "control_abort") {
+      if (params.kind === "heartbeat") {
         return { status: "skipped", reason: "active-run", activeOperation };
       }
-      // Visible and queued turns may wait for active runs; control turns must stay immediate.
+      // Visible and queued turns may wait for active runs when waitForActive is set.
       if (params.waitForActive === false) {
         return { status: "skipped", reason: "active-run", activeOperation };
       }


### PR DESCRIPTION
## What Problem This Solves

Native slash-command turns key their reply operation to the **command-target session**. When the target has an active run, `admitReplyTurn` treats the command turn as `"visible"` and dead-waits on `replyRunRegistry.waitForIdle(target)` (`reply-turn-admission.ts:294`) — `/stop` waits on the very run it is supposed to kill, `/status` waits on the run it should report on. Production incident on 2026-07-11 (Telegram group): a group member's `/stop` — channel-authorized via `groupAllowFrom: ["*"]` but declined by `commands.ownerAllowFrom` at the pre-admission fast-abort — wedged its slash session (`queued_work_without_active_run`), held the per-chat Telegram control lane guarded for 5 minutes, blocked the owner's own `/stop` behind it, and forced a watchdog ingress restart whose backlog drain collaterally aborted an unrelated codex harness startup. The run itself was never stopped. Fixes #104142.

## Why This Change Was Made

The deadlock is latent since #85100 introduced target-aware operation keying, and was masked on Telegram because — until #103664 — any group inbound aborted the active run at the transport fence, so command turns never met a busy target. #103664 correctly removed that transport kill authority; core must now handle command turns while runs are active.

#85100's own contract says "abort ownership stays source-keyed" and "/stop does not self-abort its own command". This PR aligns the reply-operation key with that contract:

- `dispatch-from-config.ts`: `dispatchOperationSessionKey` resolves source-first (`ctx.SessionKey`); the session-store entry used for operation identity follows the source when it diverges from the command target. `initialSessionStoreEntry` stays target-aware for command handlers (status/stop/model act on the target via `CommandTargetSessionKey`).
- `reply-turn-admission.ts`: the `control_abort` turn kind had zero producers (designed seam, never wired) and is now removed.

Command turns admit instantly on their (idle-by-construction) source session; effects on the target keep flowing through the run registry / session store as before.

## User Impact

- `/stop` works during active runs for everyone the config authorizes, and unauthorized senders get an immediate "not authorized" reply instead of a silent 5-minute wedge.
- `/status` (and other native commands) answer immediately mid-run instead of never.
- A wedged command can no longer poison the per-chat Telegram control lane, so one sender's blocked command no longer disables `/stop` for the whole chat or triggers watchdog channel restarts.

## Evidence

- Regression tests (`dispatch-from-config.acp-abort.test.ts`): unauthorized native `/stop` and authorized `/status` against a session with an active run must settle in <200ms with the target run untouched; the #85100 ownership test now asserts the source-keyed contract.
- Testbox (Blacksmith): `run-vitest` on `dispatch-from-config.acp-abort.test.ts`, `abort.test.ts`, `reply-turn-admission.test.ts` — 83/83 passed; `run-tsgo` core + core-test lanes clean; oxlint clean on changed files.
- Live-gateway E2E (mock Telegram Bot API + mock OpenAI provider, 40s streamed turn, command injected mid-turn), before → after on the incident recipes:
  - incident shape (`groupAllowFrom: ["*"]` + `commands.ownerAllowFrom`, non-owner `/stop`): silent wedge, run unaffected → fast reply, no wedge, run unaffected
  - authorized `/status` mid-run: no reply ever → immediate status reply, run survives
  - authorized `/stop` mid-run: abort ~1s (unchanged)
