### PR TITLE
fix(gateway): pass the session liveness predicate on every worktree gc path

### DIFF
--- a/src/cli/worktrees-cli.ts
+++ b/src/cli/worktrees-cli.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
 import type { ManagedWorktreeRecord } from "../agents/worktrees/types.js";
+import { isManagedWorktreeOwnerActive } from "../gateway/worktree-owner-activity.js";
 import { defaultRuntime } from "../runtime.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
@@ -115,7 +116,7 @@ export function registerWorktreesCli(program: Command): void {
     .description("Run managed worktree cleanup now")
     .option("--json", "Output JSON", false)
     .action(async (opts: JsonOption) => {
-      const result = await managedWorktrees.gc();
+      const result = await managedWorktrees.gc({ isOwnerActive: isManagedWorktreeOwnerActive });
       if (opts.json) {
         printJson(result);
       } else {

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,12 +1,7 @@
 // Gateway maintenance timers.
 // Starts periodic health, dedupe, abort, and media cleanup loops.
 import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import {
-  IDLE_GC_MS,
-  managedWorktrees,
-  WORKTREE_GC_INTERVAL_MS,
-} from "../agents/worktrees/service.js";
-import type { ManagedWorktreeOwnerKind } from "../agents/worktrees/types.js";
+import { managedWorktrees, WORKTREE_GC_INTERVAL_MS } from "../agents/worktrees/service.js";
 import type { HealthSummary } from "../commands/health.js";
 import { sweepStaleRunContexts } from "../infra/agent-events.js";
 import { cleanOldMedia } from "../media/store.js";
@@ -31,23 +26,7 @@ import {
 import { PENDING_CHAT_SEND_DEDUPE_PREFIX, type DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
 import { setBroadcastHealthUpdate } from "./server/health-state.js";
-import { loadSessionEntry } from "./session-utils.js";
-
-function isManagedWorktreeOwnerActive(
-  ownerKind: ManagedWorktreeOwnerKind,
-  ownerId: string,
-): boolean {
-  if (ownerKind !== "session") {
-    return false;
-  }
-  try {
-    const entry = loadSessionEntry(ownerId, { clone: false }).entry;
-    const activityAt = Math.max(entry?.lastInteractionAt ?? 0, entry?.updatedAt ?? 0);
-    return activityAt > 0 && Date.now() - activityAt <= IDLE_GC_MS;
-  } catch {
-    return false;
-  }
-}
+import { isManagedWorktreeOwnerActive } from "./worktree-owner-activity.js";
 
 export function startGatewayMaintenanceTimers(params: {
   broadcast: (

--- a/src/gateway/server-methods/worktrees.test.ts
+++ b/src/gateway/server-methods/worktrees.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { WorktreeSnapshotError } from "../../agents/worktrees/service.js";
 import type { ManagedWorktreeRecord } from "../../agents/worktrees/types.js";
+import { isManagedWorktreeOwnerActive } from "../worktree-owner-activity.js";
 import { createWorktreesHandlers } from "./worktrees.js";
 
 const record: ManagedWorktreeRecord = {
@@ -65,6 +66,10 @@ describe("worktrees gateway methods", () => {
       { removed: [record.id], orphansDeleted: 1, snapshotsPruned: 2 },
       undefined,
     ]);
+    // The RPC path must pass the same session-owner liveness predicate the
+    // scheduled maintenance sweep passes; omitting it removes a live session's
+    // worktree (#104108).
+    expect(service.gc).toHaveBeenCalledWith({ isOwnerActive: isManagedWorktreeOwnerActive });
 
     expect(service.create).toHaveBeenCalledWith({
       repoRoot: "/repo",

--- a/src/gateway/server-methods/worktrees.ts
+++ b/src/gateway/server-methods/worktrees.ts
@@ -14,6 +14,7 @@ import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope
 import { managedWorktrees, WorktreeSnapshotError } from "../../agents/worktrees/service.js";
 import type { ManagedWorktreeService } from "../../agents/worktrees/service.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
+import { isManagedWorktreeOwnerActive } from "../worktree-owner-activity.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 type WorktreeService = Pick<
@@ -143,7 +144,7 @@ export function createWorktreesHandlers(service: WorktreeService): GatewayReques
         return;
       }
       try {
-        respond(true, await service.gc(), undefined);
+        respond(true, await service.gc({ isOwnerActive: isManagedWorktreeOwnerActive }), undefined);
       } catch (error) {
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));
       }

--- a/src/gateway/worktree-owner-activity.test.ts
+++ b/src/gateway/worktree-owner-activity.test.ts
@@ -1,0 +1,51 @@
+// Covers the canonical worktree-GC owner liveness predicate (#104108).
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { IDLE_GC_MS } from "../agents/worktrees/service.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { isManagedWorktreeOwnerActive } from "./worktree-owner-activity.js";
+
+afterEach(() => {
+  resetConfigRuntimeState();
+});
+
+describe("isManagedWorktreeOwnerActive", () => {
+  test("keeps live session owners active and idle-expired ones inactive", async () => {
+    await withStateDirEnv("worktree-owner-activity-", async ({ stateDir }) => {
+      const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      const now = Date.now();
+      fs.writeFileSync(
+        path.join(sessionsDir, "sessions.json"),
+        JSON.stringify({
+          "agent:main:live": { sessionId: "sess-live", lastInteractionAt: now, updatedAt: now },
+          "agent:main:stale": {
+            sessionId: "sess-stale",
+            lastInteractionAt: now - IDLE_GC_MS - 60_000,
+            updatedAt: now - IDLE_GC_MS - 60_000,
+          },
+        }),
+        "utf8",
+      );
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+        },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      expect(isManagedWorktreeOwnerActive("session", "agent:main:live")).toBe(true);
+      expect(isManagedWorktreeOwnerActive("session", "agent:main:stale")).toBe(false);
+      // Non-session owners rely on the git-lock fallback inside gc(), never
+      // on session activity.
+      expect(isManagedWorktreeOwnerActive("manual", "agent:main:live")).toBe(false);
+      // Unknown sessions are not treated as live.
+      expect(isManagedWorktreeOwnerActive("session", "agent:main:missing")).toBe(false);
+    });
+  });
+});

--- a/src/gateway/worktree-owner-activity.ts
+++ b/src/gateway/worktree-owner-activity.ts
@@ -1,0 +1,27 @@
+// Canonical GC liveness predicate for managed worktrees.
+import { IDLE_GC_MS } from "../agents/worktrees/service.js";
+import type { ManagedWorktreeOwnerKind } from "../agents/worktrees/types.js";
+import { loadSessionEntry } from "./session-utils.js";
+
+/**
+ * Session-owned worktrees take no git worktree lock (chat runs avoid registry
+ * acquire writes), so recent owning-session activity is their only protection
+ * against idle-expiry removal. Every gc() caller — scheduled maintenance, the
+ * worktrees.gc RPC, and the CLI command — must pass this same predicate;
+ * omitting it lets gc remove a live session's worktree (#104108).
+ */
+export function isManagedWorktreeOwnerActive(
+  ownerKind: ManagedWorktreeOwnerKind,
+  ownerId: string,
+): boolean {
+  if (ownerKind !== "session") {
+    return false;
+  }
+  try {
+    const entry = loadSessionEntry(ownerId, { clone: false }).entry;
+    const activityAt = Math.max(entry?.lastInteractionAt ?? 0, entry?.updatedAt ?? 0);
+    return activityAt > 0 && Date.now() - activityAt <= IDLE_GC_MS;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

#104108 (P0): the `worktrees.gc` RPC handler called `service.gc()` with no parameters, and the CLI `openclaw worktrees gc` did the same — neither passed the `isOwnerActive` liveness callback that the scheduled maintenance sweep passes. Session-owned worktrees deliberately take no git worktree lock (registry activity substitutes; only `service.acquire()` locks, and no session run path calls it), so inside `gc()` the owner-active guard short-circuits to false whenever the callback is absent. Result: a manual/admin `worktrees.gc` RPC or CLI run force-removes an idle-expired worktree **while its owning session is still live**, destroying any uncommitted work — the scheduled sweep, given identical inputs, retains it.

## Why This Change Was Made

Per the triage's best-solution shape ("one canonical session-owner activity predicate for scheduled and RPC-triggered GC … and resolve the CLI sibling without creating a second liveness policy"):

- `isManagedWorktreeOwnerActive` moves verbatim from `server-maintenance.ts` into `src/gateway/worktree-owner-activity.ts` — one canonical implementation (it stays in the gateway layer because it depends on the gateway session-key resolution in `session-utils.loadSessionEntry`, including legacy-key handling; re-deriving it elsewhere would create the second policy the triage warned about).
- All three `gc()` callers now pass it: scheduled maintenance (unchanged behavior, now importing the shared module), the `worktrees.gc` RPC handler, and the CLI `worktrees gc` command.
- Net prod diff is small (predicate moved, two call sites gain the argument); `server-maintenance.ts` shrinks by the moved lines.

## User Impact

An admin running `worktrees.gc` (RPC or CLI) can no longer delete the working tree — including uncommitted changes — of a session that is actively in use. Workboard/manual worktrees are unaffected (they rely on the git-lock fallback on every path already).

## Evidence

**Executed real-git before/after** (real `ManagedWorktreeService` + real `git worktree` + real SQLite registry + real handler from `createWorktreesHandlers`; session store shows the owner interacted *now*, registry idle-expired via injected clock, uncommitted `wip.txt` inside the worktree):

| | `worktrees.gc` RPC result | uncommitted `wip.txt` |
|---|---|---|
| current `main` | `removed: ["c52a19ce-…"]` | **destroyed** |
| this PR | `removed: []` | **survives** |

**Regressions** (all green):
- `worktree-owner-activity.test.ts` (new): live session owner → active; idle-expired session → inactive; non-session owners → false (git-lock fallback owns them); unknown session → false. Forged real session store + runtime config snapshot.
- `server-methods/worktrees.test.ts`: the gc handler now must call `service.gc({ isOwnerActive: isManagedWorktreeOwnerActive })` (asserted by identity) — fails on prior head where `gc()` was called bare.
- `agents/worktrees/service.test.ts` 27/27 (existing owner-activity semantics unchanged).

**Validation:** handler + predicate suites 14/14; `tsgo:core` 0; oxlint/oxfmt clean; session-accessor boundary guard passed.

**Scope:** #103263 (gc-internals leasing rework) is complementary — it re-checks `isOwnerActive` at removal time but still depends on callers supplying it, and does not touch the RPC handler or CLI; this PR closes exactly that supply gap, as the issue's sibling analysis notes.

Fixes #104108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJogTw4aGDiacwqju1uod6
