### PR TITLE
fix(agents): keep scp stderr tail UTF-16 safe

### DIFF
--- a/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
+++ b/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
@@ -98,6 +98,15 @@ describe("stageSandboxMedia scp remote paths", () => {
     expect(stderr).not.toContain("start-");
   });
 
+  it("keeps scp stderr tail UTF-16 safe when the boundary bisects an emoji", () => {
+    const stderr = appendScpStderrTail("prefix", "🤖tail", 5);
+
+    expect(stderr).toBe("tail");
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(stderr),
+    ).toBe(false);
+  });
+
   it("rejects remote attachment filenames with shell metacharacters before spawning scp", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const { cfg, workspaceDir, sessionKey, remoteCacheDir } = createRemoteStageParams(home);

--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -1,7 +1,10 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { testing } from "./stage-sandbox-media.js";
+import { SCP_STDERR_TAIL_CHARS, testing } from "./stage-sandbox-media.js";
+
+const hasUnpairedUtf16Surrogate = (text: string): boolean =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text);
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
 
@@ -46,6 +49,31 @@ describe("scpFile", () => {
     child.emit("close", 1);
 
     await expect(resultPromise).rejects.toThrow("scp failed (1): stderr EPIPE");
+  });
+
+  it("surfaces UTF-16 safe scp stderr when transfer fails with emoji at tail boundary", async () => {
+    const { child, stderr } = createChild();
+    // Place the retained tail window on the emoji's low surrogate so raw slicing
+    // would keep a lone surrogate half before the thrown error is built.
+    const lowSurrogateTailStart = 100;
+    const padding = "n".repeat(lowSurrogateTailStart - 1);
+    const recent = "🤖" + "n".repeat(SCP_STDERR_TAIL_CHARS - 5) + "fail";
+
+    const resultPromise = testing.scpFile("host", "/remote/path", "/local/path");
+    stderr.emit("data", padding);
+    stderr.emit("data", recent);
+    child.emit("close", 1);
+
+    let message = "";
+    try {
+      await resultPromise;
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toMatch(/^scp failed \(1\):/);
+    expect(message).toContain("fail");
+    expect(message).not.toContain("🤖");
+    expect(hasUnpairedUtf16Surrogate(message)).toBe(false);
   });
 
   it("does not terminate scp again when spawning fails", async () => {

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isInboundPathAllowed } from "@openclaw/media-core/inbound-path-policy";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { assertSandboxPath } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { slugifySessionKey } from "../../agents/sandbox/shared.js";
@@ -427,7 +428,7 @@ export function appendScpStderrTail(
   if (combined.length <= maxChars) {
     return combined;
   }
-  return combined.slice(-maxChars);
+  return sliceUtf16Safe(combined, Math.max(0, combined.length - maxChars));
 }
 
 export const testing = { scpFile } as const;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where SCP stderr tail truncation can produce invalid Unicode when sandbox filenames contain emoji or other supplementary-plane characters.

`appendScpStderrTail()` caps raw `child.stderr` output with `combined.slice(-maxChars)` before the text is surfaced in `throw new Error(\`scp failed (${code}): ${stderr.trim()}\`)`. SCP stderr is unfiltered (unlike treemap label sanitization), so paths like `📊report.csv` can land on a UTF-16 surrogate boundary and leave a lone high/low surrogate in operator/agent-visible errors.

**Concrete example:** when the retained 16,384-code-unit window starts on `🤖`'s low surrogate (`U+DD16`), current `main` surfaces `scp failed (1): �nnn…MARK` with `unpaired_surrogates=true`.

## Why This Change Was Made

Replace the raw tail slice with `sliceUtf16Safe(combined, Math.max(0, combined.length - maxChars))` from `@openclaw/normalization-core/utf16-slice`, matching the established tail-truncation pattern in `src/infra/restart-sentinel.ts` (#103757) and `src/node-host/invoke.ts`. Ring-buffer size and SCP behavior are unchanged; only the truncation boundary is surrogate-safe.

## User Impact

**Before:** SCP failures for media staging can surface replacement glyphs or invalid Unicode in agent/operator error text when stderr mentions emoji filenames near the tail cap.

**After:** SCP stderr tails remain well-formed Unicode; boundary emoji are dropped whole instead of split.

## Evidence

- `src/auto-reply/reply/stage-sandbox-media.ts` — `appendScpStderrTail` uses `sliceUtf16Safe` for the tail cap
- `packages/normalization-core/src/utf16-slice.ts` — shared surrogate backoff helper
- Helper regression: `src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts`
- Caller-path regression: `src/auto-reply/reply/stage-sandbox-media.scp.test.ts` (`testing.scpFile` mocked `spawn` stderr bisect case)
- Exact-boundary live subprocess proof: PATH-injected real `scp` binary writes 16,585 UTF-16 code units so the retained window starts on `🤖`'s low surrogate; production `testing.scpFile` (no `spawn` mock) surfaces the truncated error

## Real behavior proof

- **Behavior or issue addressed:** SCP stderr tail truncation no longer leaves unpaired UTF-16 surrogates when an emoji filename crosses the 16,384-code-unit tail cap before the error is thrown to the agent/operator.
- **Canonical reachability path:** `stageSandboxMedia` remote attachment staging → `scpFile` spawns `scp` → `child.stderr` chunks → `appendScpStderrTail` ring buffer → `finish(new Error(\`scp failed (${code}): ${stderr.trim()}\`))` on non-zero exit.
- **Boundary crossed:** local-runtime; real Node child process named `scp` on `PATH` (stdio stderr pipe + utf8 encoding), invoked through production `testing.scpFile` with no `spawn` mock. Payload places the retained-tail start on `U+DD16` (emoji low surrogate).
- **Shared helper / provider constraint check:** Reused `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice`; provider/channel constraints N/A because this is sandbox media staging stderr handling.
- **Real environment tested:** macOS (darwin 24.3.0), Node 22, branch `fix/scp-stderr-tail-utf16` @ `36b2600a8e0`, PATH-injected `scp` at `/tmp/scp-utf16-proof-*/bin/scp`.
- **Exact steps or command run after this patch:**

```text
$ # Install a PATH-shadowing scp that writes 16585 UTF-16 code units with 🤖
$ # positioned so raw slice(-16384) starts on low surrogate U+DD16, then exits 1.
$ export PATH="/tmp/scp-utf16-proof-*/bin:$PATH"
$ node --import tsx /tmp/scp-utf16-proof-*/run.mjs
$ node scripts/run-vitest.mjs \
    src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts \
    src/auto-reply/reply/stage-sandbox-media.scp.test.ts \
    -t "UTF-16|scp stderr tail|scpFile" --reporter=verbose
```

- **Evidence after fix:**

```text
# BEFORE (current main raw slice through the same production scpFile + fake scp):
prepared_stderr_code_units=16585
raw_tail_lone_surrogate=true
raw_tail_first_codeunit=0xDD16
production_retained_stderr_code_units=16384
production_unpaired_surrogates=true
production_first_stderr_codeunit=0xDD16
scp failed (1): �nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn…(16400 cu)…nnnnnnnnnnnnnnnnMARK

# AFTER (this PR):
prepared_stderr_code_units=16585
raw_tail_lone_surrogate=true
raw_tail_first_codeunit=0xDD16
safe_tail_lone_surrogate=false
safe_tail_first_codeunit=0x6E
safe_tail_length=16383
production_error_ok=true
production_retained_stderr_code_units=16383
production_unpaired_surrogates=false
production_contains_MARK=true
production_contains_emoji=false
production_first_stderr_codeunit=0x6E
spawned_scp=/tmp/scp-utf16-proof-x0XoEj/bin/scp
scp failed (1): nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn…(16399 cu)…nnnnnnnnnnnnnnnnMARK

$ node scripts/run-vitest.mjs … -t "UTF-16|scp stderr tail|scpFile" --reporter=verbose
 ✓ keeps scp stderr tail UTF-16 safe when the boundary bisects an emoji
 ✓ surfaces UTF-16 safe scp stderr when transfer fails with emoji at tail boundary

Test Files  2 passed (2)
     Tests  5 passed | 5 skipped (10)
```

- **Observed result after fix:** Same PATH-injected real `scp` subprocess wrote >16,384 stderr code units with the retained-tail start on `U+DD16`. On current main that production path keeps the lone low surrogate (`�…MARK`, `unpaired_surrogates=true`, retained 16384). After this patch the same production `scpFile` path drops the split pair (`unpaired_surrogates=false`, first code unit `0x6E`, retained 16383, `MARK` preserved). Supplemental mocked caller regression still covers the same boundary.
- **What was not tested:** Live OpenSSH `scp` against a reachable operator sandbox host that naturally emits >16,384 stderr code units; full gateway/iMessage inbound delivery roundtrip.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
