### PR TITLE
fix(file-transfer): keep bounded stderr tail UTF-16 safe

### DIFF
--- a/extensions/file-transfer/src/shared/append-bounded-text-tail.test.ts
+++ b/extensions/file-transfer/src/shared/append-bounded-text-tail.test.ts
@@ -1,0 +1,25 @@
+// File Transfer tests cover bounded stderr tail UTF-16 safety.
+import { describe, expect, it } from "vitest";
+import { appendBoundedTextTail, projectBoundedTextTail } from "./append-bounded-text-tail.js";
+
+const hasUnpairedUtf16Surrogate = (text: string): boolean =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(text);
+
+describe("appendBoundedTextTail", () => {
+  it("keeps stderr tail UTF-16 safe when the boundary bisects an emoji", () => {
+    const stderr = appendBoundedTextTail("prefix", Buffer.from("🤖tail"), 5);
+
+    expect(stderr).toBe("tail");
+    expect(hasUnpairedUtf16Surrogate(stderr)).toBe(false);
+  });
+});
+
+describe("projectBoundedTextTail", () => {
+  it("keeps final error projection UTF-16 safe when the boundary bisects an emoji", () => {
+    const stderr = "p".repeat(5) + "🤖fail";
+    const projected = projectBoundedTextTail(stderr, 5);
+
+    expect(projected).toBe("fail");
+    expect(hasUnpairedUtf16Surrogate(projected)).toBe(false);
+  });
+});

--- a/extensions/file-transfer/src/shared/append-bounded-text-tail.ts
+++ b/extensions/file-transfer/src/shared/append-bounded-text-tail.ts
@@ -1,0 +1,15 @@
+// Bounded stderr tails must stay UTF-16 safe when tar/dir-fetch paths mention emoji filenames.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export function appendBoundedTextTail(current: string, chunk: Buffer, maxChars: number): string {
+  const next = current + chunk.toString();
+  if (next.length <= maxChars) {
+    return next;
+  }
+  return sliceUtf16Safe(next, Math.max(0, next.length - maxChars));
+}
+
+// Final error projections reuse the ring-buffer tail; raw slice(-N) can still bisect emoji.
+export function projectBoundedTextTail(text: string, maxChars: number): string {
+  return sliceUtf16Safe(text, Math.max(0, text.length - maxChars));
+}

--- a/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
@@ -70,4 +70,32 @@ describe("dir.fetch archive policy output lifecycle", () => {
       }),
     ).resolves.toEqual({ ok: true, entries: ["ok.txt"] });
   });
+
+  it("surfaces UTF-16 safe tar stderr tail when archive listing fails with emoji at projection boundary", async () => {
+    const oldNoise = "n".repeat(250);
+    // Length 201: raw slice(-200) would start on the low surrogate of 🤖.
+    const recent = "🤖" + "f".repeat(199);
+    const spawnMock = mockTarSpawn((child) => {
+      child.stderr.emit("data", Buffer.from(oldNoise));
+      child.stderr.emit("data", Buffer.from(recent));
+      child.emit("close", 2);
+    });
+    const { testing } = await importWithSpawn(spawnMock);
+    const { projectBoundedTextTail } = await import("./append-bounded-text-tail.js");
+
+    const result = await testing.listDirFetchArchiveEntries({
+      tarBase64: Buffer.from("archive").toString("base64"),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain(projectBoundedTextTail(recent, 200));
+      expect(result.reason).toContain("f".repeat(199));
+      expect(result.reason).not.toContain("🤖");
+      expect(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+          result.reason,
+        ),
+      ).toBe(false);
+    }
+  });
 });

--- a/extensions/file-transfer/src/shared/node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.ts
@@ -6,6 +6,7 @@ import type {
   OpenClawPluginNodeInvokePolicyContext,
   OpenClawPluginNodeInvokePolicyResult,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { appendBoundedTextTail, projectBoundedTextTail } from "./append-bounded-text-tail.js";
 import { appendFileTransferAudit, type FileTransferAuditOp } from "./audit.js";
 import { consumeChildOutput } from "./child-output.js";
 import {
@@ -22,6 +23,7 @@ const DIR_FETCH_MAX_ENTRIES = 5000;
 const DIR_FETCH_ARCHIVE_LIST_TIMEOUT_MS = 30_000;
 const DIR_FETCH_ARCHIVE_LIST_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
 const DIR_FETCH_ARCHIVE_LIST_STDERR_TAIL_CHARS = 4096;
+const DIR_FETCH_ARCHIVE_LIST_ERROR_STDERR_CHARS = 200;
 
 type FileTransferCommand = FileTransferNodeInvokeCommand;
 
@@ -29,11 +31,6 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
-}
-
-function appendBoundedTextTail(current: string, chunk: Buffer, maxChars: number): string {
-  const next = current + chunk.toString();
-  return next.length > maxChars ? next.slice(-maxChars) : next;
 }
 
 function readPath(params: Record<string, unknown>): string {
@@ -424,7 +421,7 @@ async function listDirFetchArchiveEntries(
         finish({
           ok: false,
           code: "ARCHIVE_ENTRIES_UNREADABLE",
-          reason: `tar -tzf exited ${code}: ${stderr.slice(-200)}`,
+          reason: `tar -tzf exited ${code}: ${projectBoundedTextTail(stderr, DIR_FETCH_ARCHIVE_LIST_ERROR_STDERR_CHARS)}`,
         });
         return;
       }

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { projectBoundedTextTail } from "../shared/append-bounded-text-tail.js";
 import { validateTarUncompressedBudget } from "./dir-fetch-tool.js";
 
 let tmpRoot: string;
@@ -276,8 +277,45 @@ describe("dir.fetch tar validation", () => {
       const result = await testing.preValidateTarball(Buffer.from("x"));
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.reason).toContain(recent.slice(-200));
+        expect(result.reason).toContain(projectBoundedTextTail(recent, 200));
         expect(result.reason).not.toContain(oldNoise.slice(0, 40));
+      }
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
+  it("surfaces UTF-16 safe tar stderr tail when listing fails with emoji at projection boundary", async () => {
+    vi.resetModules();
+    const oldNoise = "n".repeat(250);
+    // Length 201: raw slice(-200) would start on the low surrogate of 🤖.
+    const recent = "🤖" + "f".repeat(199);
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return {
+        ...actual,
+        spawn: mockTarSpawn((child) => {
+          child.stderr.emit("data", Buffer.from(oldNoise));
+          child.stderr.emit("data", Buffer.from(recent));
+          child.emit("close", 2);
+        }),
+      };
+    });
+
+    try {
+      const { testing } = await import("./dir-fetch-tool.js");
+      const result = await testing.preValidateTarball(Buffer.from("x"));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toContain(projectBoundedTextTail(recent, 200));
+        expect(result.reason).toContain("f".repeat(199));
+        expect(result.reason).not.toContain("🤖");
+        expect(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+            result.reason,
+          ),
+        ).toBe(false);
       }
     } finally {
       vi.doUnmock("node:child_process");

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -5,6 +5,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import {
+  appendBoundedTextTail,
+  projectBoundedTextTail,
+} from "../shared/append-bounded-text-tail.js";
 import { appendFileTransferAudit } from "../shared/audit.js";
 import { consumeChildOutput } from "../shared/child-output.js";
 import { IMAGE_MIME_INLINE_SET, mimeFromExtension } from "../shared/mime.js";
@@ -32,6 +36,8 @@ const TAR_UNPACK_TIMEOUT_MS = 60_000;
 const TAR_UNPACK_MAX_ENTRIES = 5000;
 const TAR_LIST_OUTPUT_MAX_CHARS = 32 * 1024 * 1024;
 const TAR_STDERR_TAIL_CHARS = 4096;
+const TAR_ERROR_REASON_STDERR_CHARS = 200;
+const TAR_UNPACK_ERROR_STDERR_CHARS = 300;
 
 // Hard caps on uncompressed extraction. Defends against decompression-bomb
 // archives that compress to <16MB but expand to gigabytes. Both caps are
@@ -39,11 +45,6 @@ const TAR_STDERR_TAIL_CHARS = 4096;
 // and per-file size to bound any single fs.stat / hash operation.
 const DIR_FETCH_MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
 const DIR_FETCH_MAX_SINGLE_FILE_BYTES = 16 * 1024 * 1024;
-
-function appendBoundedTextTail(current: string, chunk: Buffer, maxChars: number): string {
-  const next = current + chunk.toString();
-  return next.length > maxChars ? next.slice(-maxChars) : next;
-}
 
 async function listTarOutputLines<T>(input: {
   args: string[];
@@ -137,7 +138,10 @@ async function listTarOutputLines<T>(input: {
         return;
       }
       if (code !== 0) {
-        finish({ ok: false, reason: `${input.label} exited ${code}: ${stderr.slice(-200)}` });
+        finish({
+          ok: false,
+          reason: `${input.label} exited ${code}: ${projectBoundedTextTail(stderr, TAR_ERROR_REASON_STDERR_CHARS)}`,
+        });
         return;
       }
       if (pending) {
@@ -350,7 +354,7 @@ export async function validateTarUncompressedBudget(
       if (code !== 0) {
         finish({
           ok: false,
-          reason: `tar uncompressed budget validation exited ${code}: ${stderr.slice(-200)}`,
+          reason: `tar uncompressed budget validation exited ${code}: ${projectBoundedTextTail(stderr, TAR_ERROR_REASON_STDERR_CHARS)}`,
         });
         return;
       }
@@ -455,7 +459,11 @@ async function unpackTar(tarBuffer: Buffer, destDir: string): Promise<void> {
     });
     child.on("close", (code) => {
       if (code !== 0) {
-        fail(new Error(`tar unpack exited ${code}: ${stderrOut.slice(-300)}`));
+        fail(
+          new Error(
+            `tar unpack exited ${code}: ${projectBoundedTextTail(stderrOut, TAR_UNPACK_ERROR_STDERR_CHARS)}`,
+          ),
+        );
         return;
       }
       succeed();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where file-transfer tar/dir-fetch stderr tail truncation can produce invalid Unicode when paths or archive listings contain emoji or other supplementary-plane characters.

`appendBoundedTextTail()` capped raw `child.stderr` chunks with `next.slice(-maxChars)` and failure reasons still used raw `stderr.slice(-200/-300)` at projection time. Tar stderr is unfiltered, so filenames like `📊report.csv` can land on a UTF-16 surrogate boundary and leave a lone high/low surrogate in error text surfaced to agents/operators.

**Concrete example:** with production ring cap `4096` and input `"x"×4095 + "🤖" + "y"×4095`, raw `.slice(-4096)` keeps `U+DD16` (lone low surrogate) without its high half; with reason cap `200` and input `"🤖" + "f"×199`, raw `.slice(-200)` has the same failure.

## Why This Change Was Made

Extract shared helpers in `extensions/file-transfer/src/shared/append-bounded-text-tail.ts`:

- `appendBoundedTextTail` — UTF-16-safe ring buffer for streaming stderr
- `projectBoundedTextTail` — UTF-16-safe final projection for error reasons

Both use `sliceUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`, matching the SCP stderr fix (#103757) pattern. Ring-buffer sizes and tar/dir-fetch behavior are unchanged; only truncation boundaries are surrogate-safe end-to-end.

## User Impact

**Before:** `dir_fetch` / archive-list failures can surface replacement glyphs or invalid Unicode in agent/operator error text when stderr mentions emoji paths near the 4,096-char ring-buffer cap or 200/300-char error projection.

**After:** File-transfer stderr tails and surfaced failure reasons remain well-formed Unicode; boundary emoji are dropped whole instead of split.

## Evidence

- `extensions/file-transfer/src/shared/append-bounded-text-tail.ts` — shared UTF-16-safe ring buffer + projection helpers
- `extensions/file-transfer/src/tools/dir-fetch-tool.ts` — tar list/budget/unpack stderr paths use both helpers
- `extensions/file-transfer/src/shared/node-invoke-policy.ts` — archive list stderr path uses both helpers
- Regression: `append-bounded-text-tail.test.ts`, caller-path tests in `dir-fetch-tool.test.ts` and `node-invoke-policy.stream-errors.test.ts` (fixtures place `🤖` so raw `slice(-200)` starts on the low surrogate)

## Real behavior proof

- **Behavior or issue addressed:** File-transfer bounded stderr tails and final tar failure reasons no longer leave unpaired UTF-16 surrogates when emoji cross the ring-buffer cap or 200/300-char error projection.
- **Canonical reachability path:** `dir_fetch` tool `preValidateTarball` / node `listDirFetchArchiveEntries` → `spawn(tar, …)` → `child.stderr` chunks → `appendBoundedTextTail` ring buffer → `projectBoundedTextTail` in failure reason returned to agent/operator.
- **Boundary crossed:** local-runtime; real Node child using the same stderr EventEmitter wiring as `consumeChildOutput` (production `4096` / `200` caps engineered to bisect `🤖`), plus real `/usr/bin/tar` with an emoji missing path.
- **Shared helper / provider constraint check:** Reused `sliceUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`; provider/channel constraints N/A because this is plugin-local tar stderr handling.
- **Real environment tested:** macOS (darwin), Node v22.22.0, branch `fix/file-transfer-bounded-tail-utf16`, `/usr/bin/tar`.
- **Exact steps or command run after this patch:**

```text
$ pnpm exec tsx .file-transfer-utf16-proof.mjs
$ node scripts/run-vitest.mjs extensions/file-transfer/src/shared/append-bounded-text-tail.test.ts extensions/file-transfer/src/tools/dir-fetch-tool.test.ts extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
=== Real subprocess proof: file-transfer UTF-16 stderr tails ===
platform: darwin, node: v22.22.0

--- Case A: production 4096 ring bisects 🤖 (before/after) ---
payload code units: 8192
production ring cap: 4096, reason cap: 200
raw ring first code unit: U+DD16
raw ring unpaired_surrogates: true
raw reason unpaired_surrogates: false
fixed ring length: 4095
fixed ring first code unit: U+0079
fixed ring unpaired_surrogates: false
fixed reason unpaired_surrogates: false
fixed reason prefix: "tar -tzf exited 1: yyyyyyyyyyyyyyyyyyyyyyyyyyyyy"…
boundary before/after pass: true

--- Case B: production 200 reason projection bisects 🤖 (before/after) ---
payload code units: 201
production ring cap: 4096, reason cap: 200
raw ring first code unit: U+D83E
raw ring unpaired_surrogates: false
raw reason unpaired_surrogates: true
fixed ring length: 201
fixed ring first code unit: U+D83E
fixed ring unpaired_surrogates: false
fixed reason unpaired_surrogates: false
fixed reason prefix: "tar -tzf exited 1: fffffffffffffffffffffffffffff"…
boundary before/after pass: true

--- Case C: real /usr/bin/tar (emoji filename in stderr) ---
tar: /usr/bin/tar
stderr length: 4096
stderr unpaired_surrogates: false
reason unpaired_surrogates: false
reason tail: "e or directory\ntar: 📊missing.csv: Cannot stat: No such file or directory\ntar: Error exit delayed from previous errors.\n"

=== Summary ===
ring boundary before/after: true
reason boundary before/after: true
real tar surrogate-safe: true
all boundary proofs pass: true

$ node scripts/run-vitest.mjs … --reporter=verbose
 ✓ surfaces UTF-16 safe tar stderr tail when listing fails with emoji at projection boundary
 ✓ surfaces UTF-16 safe tar stderr tail when archive listing fails with emoji at projection boundary
 Test Files  3 passed (3)
      Tests  14 passed (14)
```

- **Observed result after fix:** Case A shows raw production `4096` ring starts on lone low surrogate `U+DD16` while patched `appendBoundedTextTail` drops that half and retains a well-formed `y`×4095 tail. Case B shows raw `slice(-200)` reason projection unpaired while `projectBoundedTextTail` drops `🤖` and keeps `f`×199. Case C runs real `/usr/bin/tar` with `📊missing.csv` through the same helpers at the 4,096 ring cap with `unpaired_surrogates=false`.
- **What was not tested:** Live `dir_fetch` / node archive-list on a remote host; Linux GNU tar stderr encoding differences.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
