### PR TITLE
fix(signal): surface daemon errors split across output chunks

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -48,7 +48,7 @@ describe("signal daemon log classification", () => {
     expect(testApi.classifySignalCliLogLine("SEVERE Manager - database exception")).toBe("error");
   });
 
-  it("preserves log lines across output chunk boundaries", async () => {
+  it("preserves log lines and UTF-8 across output chunk boundaries", async () => {
     const stream = new PassThrough();
     const logs: string[] = [];
     const errors: string[] = [];
@@ -63,10 +63,18 @@ describe("signal daemon log classification", () => {
     stream.write(
       Buffer.from("ROR DaemonCommand - startup failed\r\nWARN Manager - retrying\npartial"),
     );
-    stream.end(" warning");
+    stream.write(" warning\n");
+    const utf8Line = Buffer.from("INFO Manager - café ready");
+    const splitCodePointAt = utf8Line.indexOf(0xc3) + 1;
+    stream.write(utf8Line.subarray(0, splitCodePointAt));
+    stream.end(utf8Line.subarray(splitCodePointAt));
     await ended;
 
     expect(errors).toEqual(["signal-cli: ERROR DaemonCommand - startup failed"]);
-    expect(logs).toEqual(["signal-cli: WARN Manager - retrying", "signal-cli: partial warning"]);
+    expect(logs).toEqual([
+      "signal-cli: WARN Manager - retrying",
+      "signal-cli: partial warning",
+      "signal-cli: INFO Manager - café ready",
+    ]);
   });
 });

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,6 +1,8 @@
 // Signal tests cover daemon plugin behavior.
+import { once } from "node:events";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { testApi } from "./daemon.js";
 
@@ -44,5 +46,27 @@ describe("signal daemon log classification", () => {
   it("still surfaces signal-cli failures as errors", () => {
     expect(testApi.classifySignalCliLogLine("ERROR DaemonCommand - startup failed")).toBe("error");
     expect(testApi.classifySignalCliLogLine("SEVERE Manager - database exception")).toBe("error");
+  });
+
+  it("preserves log lines across output chunk boundaries", async () => {
+    const stream = new PassThrough();
+    const logs: string[] = [];
+    const errors: string[] = [];
+    testApi.bindSignalCliOutput({
+      stream,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    });
+
+    const ended = once(stream, "end");
+    stream.write(Buffer.from("ER"));
+    stream.write(
+      Buffer.from("ROR DaemonCommand - startup failed\r\nWARN Manager - retrying\npartial"),
+    );
+    stream.end(" warning");
+    await ended;
+
+    expect(errors).toEqual(["signal-cli: ERROR DaemonCommand - startup failed"]);
+    expect(logs).toEqual(["signal-cli: WARN Manager - retrying", "signal-cli: partial warning"]);
   });
 });

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 
 type SignalDaemonOpts = {
@@ -63,14 +64,16 @@ function bindSignalCliOutput(params: {
   log: (message: string) => void;
   error: (message: string) => void;
 }): void {
-  params.stream?.on("data", (data) => {
-    for (const line of data.toString().split(/\r?\n/)) {
-      const kind = classifySignalCliLogLine(line);
-      if (kind === "log") {
-        params.log(`signal-cli: ${line.trim()}`);
-      } else if (kind === "error") {
-        params.error(`signal-cli: ${line.trim()}`);
-      }
+  if (!params.stream) {
+    return;
+  }
+  const lines = createInterface({ input: params.stream });
+  lines.on("line", (line) => {
+    const kind = classifySignalCliLogLine(line);
+    if (kind === "log") {
+      params.log(`signal-cli: ${line.trim()}`);
+    } else if (kind === "error") {
+      params.error(`signal-cli: ${line.trim()}`);
     }
   });
 }
@@ -175,6 +178,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
 }
 
 export const testApi = {
+  bindSignalCliOutput,
   buildDaemonArgs,
   classifySignalCliLogLine,
   resolveSignalCliConfigPath,

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -67,6 +67,8 @@ function bindSignalCliOutput(params: {
   if (!params.stream) {
     return;
   }
+  // Process pipe chunks can split both log lines and UTF-8 code points. Readline owns that
+  // framing so classification sees complete text, including the final unterminated line.
   const lines = createInterface({ input: params.stream });
   lines.on("line", (line) => {
     const kind = classifySignalCliLogLine(line);


### PR DESCRIPTION
## What Problem This Solves

Fixes Signal daemon diagnostics being classified from arbitrary stdout/stderr chunks instead of complete text lines. A real error such as `ERROR` or `Failed to initialize HTTP Server` could be split across pipe reads and emitted as ordinary fragments; a multibyte UTF-8 character split at the same boundary could also be corrupted.

## Why This Change Was Made

The shared Signal daemon output boundary now delegates UTF-8 decoding, line framing, CRLF/LF handling, and the final unterminated line to Node's `readline` interface before applying the existing severity classifier. This is the narrow owner-boundary fix for both stdout and stderr and leaves daemon lifecycle, configuration, and channel delivery unchanged.

Maintainer refactor:

- documented the line-framing and UTF-8 invariant at the process-pipe seam;
- extended the regression to split a real UTF-8 code point as well as the `ERROR` token;
- rebased the contributor's implementation onto current main while preserving authorship.

## User Impact

Signal operators get one correctly classified daemon diagnostic even when the operating system splits a line or UTF-8 code point across reads. Routine warnings remain logs; error-like lines still update error state.

## Evidence

- Exact reviewed head: `9c54b4515123ba0459bf058a8ba16a458553cacb`.
- Blacksmith Testbox `tbx_01kxbxzfw904j2hn0nfnt48ndg`: focused unit suite passed 5/5; official `signal-cli 0.14.5` live fault run passed with stderr relayed in at most two-byte writes.
- Independent live result: one `signal-cli: Failed to initialize HTTP Server` error record, zero ordinary fragments.
- Fresh post-rebase Testbox `tbx_01kxby4m86gdtr7zmeht8ff2g4`: focused suite passed 5/5; conflict, attribution, extension-boundary, dependency-pin, duplicate-target, and format gates passed.
- The remaining `plugin-sdk-api-baseline.sha256` changed-gate failure is unrelated moving-main drift: this PR changes only two Signal-private files and no Plugin SDK/API inputs.
- Fresh branch-wide autoreview: no actionable findings; correctness confidence 0.95.
- Current exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29206739588 — running.
- Current exact-head Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/29206738875 — running.

## Best-Fix Judgment

Best bounded fix. A custom chunk buffer would need to reimplement UTF-8 decoding, CRLF handling, and final-line flushing; changing severity policy would address the wrong layer. One `readline` interface per child stream gives the existing classifier the complete lines it already expects.

Provenance: the per-chunk classification behavior traces to `eefbf3dc5a995ea6a1a3eb66f90a5f76dbff3ae7` (2026-02-22) and was carried into the Signal plugin boundary by #45531; it has shipped since v2026.3.22.

AI-assisted: yes. Maintainer review covered the complete daemon module, both child streams, classifier policy, process lifecycle, adjacent tests, Signal docs, Node's installed `readline` implementation contract, current main, shipped tags, real `signal-cli`, and fresh autoreview.
