### PR TITLE
fix(ui): resolve global-alias session kinds for chat avatar mode

### DIFF
--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -15,7 +15,7 @@ export const DEFAULT_MAIN_KEY = "main";
 
 export type UiSessionDefaultsHost = {
   assistantAgentId?: string | null;
-  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
+  agentsList?: { defaultId?: string | null; mainKey?: string | null; scope?: string | null } | null;
   hello?: { snapshot?: unknown } | null;
 };
 
@@ -172,6 +172,17 @@ function resolveUiMainAliasAgentId(
   const rest = normalizeLowercaseStringOrEmpty(parsed.rest);
   const mainKey = resolveUiConfiguredMainKey(host);
   return rest === DEFAULT_MAIN_KEY || rest === mainKey ? normalizeAgentId(parsed.agentId) : null;
+}
+
+/** True when the configured main session routes to the global stream (session.scope="global"). */
+export function isUiGlobalScopeConfigured(
+  host: Pick<UiSessionDefaultsHost, "agentsList" | "hello">,
+): boolean {
+  const scope = normalizeOptionalLowercaseString(host.agentsList?.scope);
+  if (scope) {
+    return scope === "global";
+  }
+  return isUiGlobalSessionKey(resolveUiCanonicalMainSessionKey(host));
 }
 
 function resolveUiCanonicalMainSessionKey(

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1325,6 +1325,7 @@ class ChatPane extends OpenClawLightDomElement {
       disabledReason,
       error: state.lastError,
       sessions: state.sessionsResult,
+      sessionHost: { agentsList: state.agentsList, hello: state.hello },
       providerUsage: {
         basePath: state.basePath,
         modelAuthStatusResult: state.modelAuthStatusResult,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -687,7 +687,7 @@ describe("chat compaction divider", () => {
 });
 
 describe("direct thread avatar mode", () => {
-  function sessionsListWithKind(sessionKey: string, kind: "direct" | "group") {
+  function sessionsListWithKind(sessionKey: string, kind: "direct" | "group" | "global") {
     return {
       ts: 0,
       path: "",
@@ -771,6 +771,58 @@ describe("direct thread avatar mode", () => {
     });
     expect(
       requireElement(group, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps avatars when a main alias selects the canonical global row", () => {
+    // scope=global: sessions.list only carries the literal "global" row while
+    // the pane navigates via agent:<id>:main; the host resolves the alias.
+    const aliasedGlobal = renderChatView({
+      sessionKey: "agent:work:main",
+      sessions: sessionsListWithKind("global", "global"),
+      sessionHost: { agentsList: { defaultId: "work", mainKey: "main" }, hello: null },
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(aliasedGlobal, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
+  it("prefers the equivalent direct row over a global row for main aliases", () => {
+    const sessions = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: 200_000 },
+      sessions: [
+        { key: "global", kind: "global", updatedAt: 2 },
+        { key: "agent:work:main", kind: "direct", updatedAt: 1 },
+      ],
+    };
+    const direct = renderChatView({
+      sessionKey: "agent:work:main",
+      sessions,
+      sessionHost: { agentsList: { defaultId: "work", mainKey: "main" }, hello: null },
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats explicit agent global keys as global even without a session row", () => {
+    const globalAlias = renderChatView({
+      sessionKey: "agent:work:global",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(globalAlias, ".chat-thread", "chat thread").classList.contains(
         "chat-thread--direct",
       ),
     ).toBe(false);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -782,7 +782,10 @@ describe("direct thread avatar mode", () => {
     const aliasedGlobal = renderChatView({
       sessionKey: "agent:work:main",
       sessions: sessionsListWithKind("global", "global"),
-      sessionHost: { agentsList: { defaultId: "work", mainKey: "main" }, hello: null },
+      sessionHost: {
+        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
+        hello: null,
+      },
       messages: [{ role: "user", content: "hi", timestamp: 1 }],
     });
     expect(
@@ -792,6 +795,25 @@ describe("direct thread avatar mode", () => {
     ).toBe(false);
   });
 
+  it("ignores stray global rows for main aliases outside global scope", () => {
+    // per-sender scope: a listed global row must not reclassify a direct main
+    // thread whose exact row is missing from the capped list.
+    const direct = renderChatView({
+      sessionKey: "agent:work:main",
+      sessions: sessionsListWithKind("global", "global"),
+      sessionHost: {
+        agentsList: { defaultId: "work", mainKey: "main", scope: "per-sender" },
+        hello: null,
+      },
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(direct, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(true);
+  });
+
   it("prefers the equivalent direct row over a global row for main aliases", () => {
     const sessions = {
       ts: 0,
@@ -799,14 +821,17 @@ describe("direct thread avatar mode", () => {
       count: 2,
       defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: 200_000 },
       sessions: [
-        { key: "global", kind: "global", updatedAt: 2 },
-        { key: "agent:work:main", kind: "direct", updatedAt: 1 },
+        { key: "global", kind: "global" as const, updatedAt: 2 },
+        { key: "agent:work:main", kind: "direct" as const, updatedAt: 1 },
       ],
     };
     const direct = renderChatView({
       sessionKey: "agent:work:main",
       sessions,
-      sessionHost: { agentsList: { defaultId: "work", mainKey: "main" }, hello: null },
+      sessionHost: {
+        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
+        hello: null,
+      },
       messages: [{ role: "user", content: "hi", timestamp: 1 }],
     });
     expect(

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -795,6 +795,24 @@ describe("direct thread avatar mode", () => {
     ).toBe(false);
   });
 
+  it("classifies global-scope main aliases without a listed global row", () => {
+    // The capped list can omit the canonical global row (or it may not exist
+    // before the first persisted turn); configured scope alone decides.
+    const aliased = renderChatView({
+      sessionKey: "agent:work:main",
+      sessionHost: {
+        agentsList: { defaultId: "work", mainKey: "main", scope: "global" },
+        hello: null,
+      },
+      messages: [{ role: "user", content: "hi", timestamp: 1 }],
+    });
+    expect(
+      requireElement(aliased, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
   it("ignores stray global rows for main aliases outside global scope", () => {
     // per-sender scope: a listed global row must not reclassify a direct main
     // thread whose exact row is missing from the capped list.

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -17,6 +17,7 @@ import type {
 import type { ChatSideResult } from "../../lib/chat/side-result.ts";
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary.ts";
+import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
 import {
   renderBackgroundTasksRail,
   renderBackgroundTasksToggle,
@@ -88,6 +89,8 @@ export type ChatProps = {
   disabledReason: string | null;
   error: string | null;
   sessions: SessionsListResult | null;
+  /** Host context resolving global-alias session keys (scope=global fleets). */
+  sessionHost?: Pick<UiSessionDefaultsHost, "agentsList" | "hello"> | null;
   providerUsage?: ProviderUsageDisplayProps;
   focusMode?: boolean;
   onLoadSidebarFullMessage?: (
@@ -206,6 +209,7 @@ export function renderChat(props: ChatProps) {
     showToolCalls: props.showToolCalls,
     runActive: Boolean(props.canAbort),
     sessions: props.sessions,
+    sessionHost: props.sessionHost,
     assistantName: props.assistantName,
     assistantAvatar: props.assistantAvatar,
     assistantAvatarUrl: props.assistantAvatarUrl,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -689,14 +689,18 @@ export function renderChatThread(props: ChatThreadProps) {
   const displayStream = props.stream ?? null;
   const sessionHost = props.sessionHost ?? null;
   // Equivalence, not exact match: the default session travels under alias
-  // keys ("main" vs "agent:main:main") depending on the caller. Global-scope
-  // fleets additionally select the canonical "global" row via alias keys
-  // (agent:<id>:global, or the configured main alias while the global row
-  // exists); the strict opts mirror chat-history's subscription matching.
-  const activeSession =
-    props.sessions?.sessions?.find((row) =>
-      areUiSessionKeysEquivalent(row.key, props.sessionKey),
-    ) ??
+  // keys ("main" vs "agent:main:main") depending on the caller.
+  const activeSession = props.sessions?.sessions?.find((row) =>
+    areUiSessionKeysEquivalent(row.key, props.sessionKey),
+  );
+  // Kind-only fallback: global-scope fleets select the canonical "global" row
+  // via alias keys (agent:<id>:global, or the configured main alias while the
+  // global row exists); strict opts mirror chat-history's subscription
+  // matching. Kept separate from activeSession because the shared sessions
+  // list can belong to another agent's scope — the kind is safe to borrow,
+  // reasoning/context metadata is not.
+  const sessionKindRow =
+    activeSession ??
     (sessionHost
       ? props.sessions?.sessions?.find(
           (row) =>
@@ -742,7 +746,7 @@ export function renderChatThread(props: ChatThreadProps) {
   // agent:<id>:global keys are the global stream even without a row, the rest
   // uses the same core helper the gateway uses. Message senderLabels are not a
   // signal here: gateway sanitization labels 1:1 channel DM rows too.
-  const rowKind = activeSession?.kind;
+  const rowKind = sessionKindRow?.kind;
   const sessionKind =
     rowKind && rowKind !== "unknown"
       ? rowKind

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -17,7 +17,13 @@ import { CHAT_HISTORY_RENDER_LIMIT } from "../../../lib/chat/chat-types.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
-import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  isUiGlobalSessionKey,
+  parseAgentSessionKey,
+  resolveUiGlobalAliasAgentId,
+  type UiSessionDefaultsHost,
+} from "../../../lib/sessions/session-key.ts";
 import {
   buildCachedChatItems,
   coalesceStreamRuns,
@@ -88,6 +94,8 @@ type ChatThreadProps = {
   /** True while the session has an abortable live run (marks running tool rows). */
   runActive?: boolean;
   sessions: SessionsListResult | null;
+  /** Host context resolving global-alias session keys (scope=global fleets). */
+  sessionHost?: Pick<UiSessionDefaultsHost, "agentsList" | "hello"> | null;
   assistantName: string;
   assistantAvatar: string | null;
   assistantAvatarUrl?: string | null;
@@ -679,11 +687,26 @@ export function renderChatThread(props: ChatThreadProps) {
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   ensureRelativeTimeRefresh(state, requestUpdate);
   const displayStream = props.stream ?? null;
+  const sessionHost = props.sessionHost ?? null;
   // Equivalence, not exact match: the default session travels under alias
-  // keys ("main" vs "agent:main:main") depending on the caller.
-  const activeSession = props.sessions?.sessions?.find((row) =>
-    areUiSessionKeysEquivalent(row.key, props.sessionKey),
-  );
+  // keys ("main" vs "agent:main:main") depending on the caller. Global-scope
+  // fleets additionally select the canonical "global" row via alias keys
+  // (agent:<id>:global, or the configured main alias while the global row
+  // exists); the strict opts mirror chat-history's subscription matching.
+  const activeSession =
+    props.sessions?.sessions?.find((row) =>
+      areUiSessionKeysEquivalent(row.key, props.sessionKey),
+    ) ??
+    (sessionHost
+      ? props.sessions?.sessions?.find(
+          (row) =>
+            isUiGlobalSessionKey(row.key) &&
+            resolveUiGlobalAliasAgentId(sessionHost, props.sessionKey, {
+              rowKind: row.kind,
+              requireGlobalRowForMainAlias: true,
+            }) !== null,
+        )
+      : undefined);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
@@ -715,17 +738,20 @@ export function renderChatThread(props: ChatThreadProps) {
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
   // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
   // as the always-visible identity marker. The canonical session kind decides;
-  // the sessions list is capped, so absent/unknown rows classify by key shape
-  // via the same core helper the gateway uses. Message senderLabels are not a
+  // the sessions list is capped, so absent/unknown rows classify by key shape:
+  // agent:<id>:global keys are the global stream even without a row, the rest
+  // uses the same core helper the gateway uses. Message senderLabels are not a
   // signal here: gateway sanitization labels 1:1 channel DM rows too.
   const rowKind = activeSession?.kind;
   const sessionKind =
-    rowKind && rowKind !== "unknown" ? rowKind : classifySessionKind(props.sessionKey);
+    rowKind && rowKind !== "unknown"
+      ? rowKind
+      : parseAgentSessionKey(props.sessionKey)?.rest === "global"
+        ? "global"
+        : classifySessionKind(props.sessionKey);
   // Only agent-solo kinds qualify: "global" aggregates every inbound context
   // under session.scope="global" (including group/channel senders), so it
-  // keeps avatars like "group" and "unknown" do. Known limitation: global
-  // aliases (agent:<id>:main under scope=global) need host context to detect
-  // (resolveUiGlobalAliasAgentId) and classify as direct here; follow-up.
+  // keeps avatars like "group" and "unknown" do.
   const isDirectThread =
     sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child";
   const showLoadingSkeleton = props.loading && chatItems.length === 0;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -19,6 +19,7 @@ import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import {
   areUiSessionKeysEquivalent,
+  isUiGlobalScopeConfigured,
   isUiGlobalSessionKey,
   parseAgentSessionKey,
   resolveUiGlobalAliasAgentId,
@@ -694,14 +695,15 @@ export function renderChatThread(props: ChatThreadProps) {
     areUiSessionKeysEquivalent(row.key, props.sessionKey),
   );
   // Kind-only fallback: global-scope fleets select the canonical "global" row
-  // via alias keys (agent:<id>:global, or the configured main alias while the
-  // global row exists); strict opts mirror chat-history's subscription
-  // matching. Kept separate from activeSession because the shared sessions
-  // list can belong to another agent's scope — the kind is safe to borrow,
-  // reasoning/context metadata is not.
+  // via alias keys (agent:<id>:global, or the configured main alias); strict
+  // opts mirror chat-history's subscription matching. Gated on configured
+  // global scope because stray global rows can coexist with per-sender
+  // sessions, and kept separate from activeSession because the shared
+  // sessions list can belong to another agent's scope — the kind is safe to
+  // borrow, reasoning/context metadata is not.
   const sessionKindRow =
     activeSession ??
-    (sessionHost
+    (sessionHost && isUiGlobalScopeConfigured(sessionHost)
       ? props.sessions?.sessions?.find(
           (row) =>
             isUiGlobalSessionKey(row.key) &&

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -20,7 +20,6 @@ import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalScopeConfigured,
-  isUiGlobalSessionKey,
   parseAgentSessionKey,
   resolveUiGlobalAliasAgentId,
   type UiSessionDefaultsHost,
@@ -694,25 +693,15 @@ export function renderChatThread(props: ChatThreadProps) {
   const activeSession = props.sessions?.sessions?.find((row) =>
     areUiSessionKeysEquivalent(row.key, props.sessionKey),
   );
-  // Kind-only fallback: global-scope fleets select the canonical "global" row
-  // via alias keys (agent:<id>:global, or the configured main alias); strict
-  // opts mirror chat-history's subscription matching. Gated on configured
-  // global scope because stray global rows can coexist with per-sender
-  // sessions, and kept separate from activeSession because the shared
-  // sessions list can belong to another agent's scope — the kind is safe to
-  // borrow, reasoning/context metadata is not.
-  const sessionKindRow =
-    activeSession ??
-    (sessionHost && isUiGlobalScopeConfigured(sessionHost)
-      ? props.sessions?.sessions?.find(
-          (row) =>
-            isUiGlobalSessionKey(row.key) &&
-            resolveUiGlobalAliasAgentId(sessionHost, props.sessionKey, {
-              rowKind: row.kind,
-              requireGlobalRowForMainAlias: true,
-            }) !== null,
-        )
-      : undefined);
+  // Global-alias detection needs no session row: under configured global
+  // scope, agent:<id>:global and configured-main aliases route to the global
+  // stream even when the capped sessions list omits the canonical row (or it
+  // does not exist yet). The scope gate keeps per-sender main threads direct.
+  const isGlobalAliasKey =
+    parseAgentSessionKey(props.sessionKey)?.rest === "global" ||
+    (sessionHost !== null &&
+      isUiGlobalScopeConfigured(sessionHost) &&
+      resolveUiGlobalAliasAgentId(sessionHost, props.sessionKey) !== null);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
@@ -744,15 +733,15 @@ export function renderChatThread(props: ChatThreadProps) {
   const isEmpty = chatItems.length === 0 && !props.loading && !hasRealtimeTalkConversation;
   // 1:1 sessions drop the avatar gutter entirely; group threads keep avatars
   // as the always-visible identity marker. The canonical session kind decides;
-  // the sessions list is capped, so absent/unknown rows classify by key shape:
-  // agent:<id>:global keys are the global stream even without a row, the rest
-  // uses the same core helper the gateway uses. Message senderLabels are not a
-  // signal here: gateway sanitization labels 1:1 channel DM rows too.
-  const rowKind = sessionKindRow?.kind;
+  // the sessions list is capped, so absent/unknown rows classify by key:
+  // global aliases first, then the same core key-shape helper the gateway
+  // uses. Message senderLabels are not a signal here: gateway sanitization
+  // labels 1:1 channel DM rows too.
+  const rowKind = activeSession?.kind;
   const sessionKind =
     rowKind && rowKind !== "unknown"
       ? rowKind
-      : parseAgentSessionKey(props.sessionKey)?.rest === "global"
+      : isGlobalAliasKey
         ? "global"
         : classifySessionKind(props.sessionKey);
   // Only agent-solo kinds qualify: "global" aggregates every inbound context


### PR DESCRIPTION
## What Problem This Solves

Resolves the limitation documented in #104092: under `session.scope="global"`, the web chat can select the global stream through alias keys (`agent:<id>:main`, a configured main key, or `agent:<id>:global`) while `sessions.list` only carries the canonical `global` row. The thread's avatar-mode classification could not resolve those aliases, classified them as direct, and hid sender avatars in a thread that aggregates group/channel senders.

## Why This Change Was Made

The pane now threads a narrow `sessionHost` (`{agentsList, hello}` — data it already owns) into the chat thread. The equivalence-matched session row still exclusively owns per-session metadata (reasoning level, context tokens), because the shared sessions list can belong to another agent's scope. Kind classification adds one prepared fact: a new `isUiGlobalScopeConfigured` helper (agents-list `scope`, falling back to the hello snapshot's configured main session key) gates `resolveUiGlobalAliasAgentId`, so global-scope aliases classify as `global` with **no session row required** — the capped list may omit the canonical row, or it may not exist before the first persisted turn. Per-sender scopes ignore stray global rows entirely, and explicit `agent:<id>:global` keys classify as global even without host context. Web (Control UI) only.

## User Impact

Global-scope fleets keep sender avatars on aliased global views (multi-sender identity stays visible); per-sender setups — the default — are unchanged, and their direct sessions still render the clean avatar-free stream even when the capped session list omits their row.

## Evidence

- Five new regression tests in `ui/src/pages/chat/chat-view.test.ts`: global-scope main alias with the canonical row, the same alias with **no** listed row, stray global rows under per-sender scope staying direct, equivalent-direct-row precedence, and explicit `agent:<id>:global` keys without host context.
- Chat suites green on Blacksmith Testbox (3198/3198 including the sessions lib on the initial run, 241/241 focused reruns after each review fix); `pnpm check:changed` green at the final head (run 29139137668).
- Codex autoreview, four rounds: three findings verified and fixed (cross-agent metadata isolation, scope-gating stray global rows, row-independent alias classification — each strictly simplified the logic); the remaining "add a CHANGELOG entry" finding is rejected per repo policy (CHANGELOG.md is release-only; this section carries the release-note context).
