### PR TITLE
fix(agents): truncate multibyte middleware details at byte limit

### DIFF
--- a/src/agents/harness/tool-result-middleware.test.ts
+++ b/src/agents/harness/tool-result-middleware.test.ts
@@ -550,6 +550,28 @@ describe("createAgentToolResultMiddlewareRunner", () => {
     expect(sanitized.originalSizeBytes ?? 0).toBeGreaterThan(100_000);
   });
 
+  it("measures multibyte incoming details by serialized UTF-8 bytes", async () => {
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      () => undefined,
+    ]);
+    const details = { blob: "é".repeat(60_000) };
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: {},
+      result: {
+        content: [{ type: "text", text: "ok" }],
+        details,
+      },
+    });
+
+    expect(result.details).toEqual({
+      truncated: true,
+      originalSizeBytes: Buffer.byteLength(JSON.stringify(details)),
+    });
+  });
+
   it("snapshots confirmed delivery before oversized details are collapsed", async () => {
     const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" }, [
       () => {

--- a/src/agents/harness/tool-result-middleware.test.ts
+++ b/src/agents/harness/tool-result-middleware.test.ts
@@ -67,14 +67,14 @@ describe("createAgentToolResultMiddlewareRunner", () => {
     expect(result.details).toEqual({ status: "error", middlewareError: true });
   });
 
-  it("rejects oversized middleware details", async () => {
+  it("rejects oversized multibyte middleware details", async () => {
     // Details are serialized into harness/tool payloads; cap them before a
     // middleware result can create unbounded transcript growth.
     const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" }, [
       () => ({
         result: {
           content: [{ type: "text", text: "compacted" }],
-          details: { payload: "x".repeat(100_001) },
+          details: { payload: "é".repeat(60_000) },
         },
       }),
     ]);

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -53,7 +53,7 @@ function isValidMiddlewareContentBlock(value: unknown): boolean {
   return false;
 }
 
-function isValidMiddlewareDetails(
+function hasValidMiddlewareDetailsShape(
   value: unknown,
   state: { keys: number; bytes: number; seen: WeakSet<object> } = {
     keys: 0,
@@ -69,11 +69,11 @@ function isValidMiddlewareDetails(
     return false;
   }
   if (typeof value === "string") {
-    state.bytes += value.length;
+    state.bytes += Buffer.byteLength(value);
     return state.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
   }
   if (typeof value === "number" || typeof value === "boolean") {
-    state.bytes += String(value).length;
+    state.bytes += Buffer.byteLength(String(value));
     return state.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
   }
   if (typeof value !== "object") {
@@ -89,7 +89,7 @@ function isValidMiddlewareDetails(
       return false;
     }
     for (const entry of value) {
-      if (!isValidMiddlewareDetails(entry, state, depth + 1)) {
+      if (!hasValidMiddlewareDetailsShape(entry, state, depth + 1)) {
         return false;
       }
     }
@@ -97,15 +97,32 @@ function isValidMiddlewareDetails(
   }
   for (const [key, entry] of Object.entries(value)) {
     state.keys += 1;
-    state.bytes += key.length;
+    state.bytes += Buffer.byteLength(key);
     if (state.keys > MAX_MIDDLEWARE_DETAILS_KEYS || state.bytes > MAX_MIDDLEWARE_DETAILS_BYTES) {
       return false;
     }
-    if (!isValidMiddlewareDetails(entry, state, depth + 1)) {
+    if (!hasValidMiddlewareDetailsShape(entry, state, depth + 1)) {
       return false;
     }
   }
   return true;
+}
+
+function isValidMiddlewareDetails(value: unknown): boolean {
+  if (!hasValidMiddlewareDetailsShape(value)) {
+    return false;
+  }
+  if (value === undefined) {
+    return true;
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    return (
+      serialized !== undefined && Buffer.byteLength(serialized) <= MAX_MIDDLEWARE_DETAILS_BYTES
+    );
+  } catch {
+    return false;
+  }
 }
 
 function isValidMiddlewareToolResult(value: unknown): value is OpenClawAgentToolResult {
@@ -386,8 +403,9 @@ function sanitizeMiddlewareDetailsValue(value: unknown): unknown {
     if (serialized === undefined) {
       return null;
     }
-    if (serialized.length > MAX_MIDDLEWARE_DETAILS_BYTES) {
-      return { truncated: true, originalSizeBytes: serialized.length };
+    const serializedBytes = Buffer.byteLength(serialized);
+    if (serializedBytes > MAX_MIDDLEWARE_DETAILS_BYTES) {
+      return { truncated: true, originalSizeBytes: serializedBytes };
     }
     return JSON.parse(serialized);
   } catch {

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -2,6 +2,7 @@
  * Runs native harness tool-result middleware around tool execution results.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { boundedJsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   AgentToolResultMiddleware,
@@ -55,9 +56,8 @@ function isValidMiddlewareContentBlock(value: unknown): boolean {
 
 function hasValidMiddlewareDetailsShape(
   value: unknown,
-  state: { keys: number; bytes: number; seen: WeakSet<object> } = {
+  state: { keys: number; seen: WeakSet<object> } = {
     keys: 0,
-    bytes: 0,
     seen: new WeakSet<object>(),
   },
   depth = 0,
@@ -68,13 +68,8 @@ function hasValidMiddlewareDetailsShape(
   if (depth > MAX_MIDDLEWARE_DETAILS_DEPTH) {
     return false;
   }
-  if (typeof value === "string") {
-    state.bytes += Buffer.byteLength(value);
-    return state.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    state.bytes += Buffer.byteLength(String(value));
-    return state.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return true;
   }
   if (typeof value !== "object") {
     return false;
@@ -95,10 +90,9 @@ function hasValidMiddlewareDetailsShape(
     }
     return true;
   }
-  for (const [key, entry] of Object.entries(value)) {
+  for (const entry of Object.values(value)) {
     state.keys += 1;
-    state.bytes += Buffer.byteLength(key);
-    if (state.keys > MAX_MIDDLEWARE_DETAILS_KEYS || state.bytes > MAX_MIDDLEWARE_DETAILS_BYTES) {
+    if (state.keys > MAX_MIDDLEWARE_DETAILS_KEYS) {
       return false;
     }
     if (!hasValidMiddlewareDetailsShape(entry, state, depth + 1)) {
@@ -109,20 +103,14 @@ function hasValidMiddlewareDetailsShape(
 }
 
 function isValidMiddlewareDetails(value: unknown): boolean {
-  if (!hasValidMiddlewareDetailsShape(value)) {
-    return false;
-  }
   if (value === undefined) {
     return true;
   }
-  try {
-    const serialized = JSON.stringify(value);
-    return (
-      serialized !== undefined && Buffer.byteLength(serialized) <= MAX_MIDDLEWARE_DETAILS_BYTES
-    );
-  } catch {
+  if (!hasValidMiddlewareDetailsShape(value)) {
     return false;
   }
+  const size = boundedJsonUtf8Bytes(value, MAX_MIDDLEWARE_DETAILS_BYTES);
+  return size.complete && size.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
 }
 
 function isValidMiddlewareToolResult(value: unknown): value is OpenClawAgentToolResult {
@@ -403,7 +391,7 @@ function sanitizeMiddlewareDetailsValue(value: unknown): unknown {
     if (serialized === undefined) {
       return null;
     }
-    const serializedBytes = Buffer.byteLength(serialized);
+    const serializedBytes = Buffer.byteLength(serialized, "utf8");
     if (serializedBytes > MAX_MIDDLEWARE_DETAILS_BYTES) {
       return { truncated: true, originalSizeBytes: serializedBytes };
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tools returning non-ASCII result details could send more than the 100 KB details limit into agent tool-result middleware because the limit was measured in UTF-16 code units instead of serialized UTF-8 bytes.

## Why This Change Was Made

The middleware details validator now delegates exact JSON UTF-8 accounting to the shared bounded byte walker while retaining the current type, depth, cycle, and key-count checks. This avoids both the old code-unit undercount and an unbounded preflight serialization. The incoming-details sanitizer measures its already-serialized value in UTF-8 and reports the accurate original byte size.

## User Impact

Agent tool-result middleware now receives consistently bounded details for multibyte payloads, and oversized details are replaced with an accurate truncation marker instead of bypassing the configured byte limit.

## Evidence

Validated at head `ffecfa240e892ac02c97d4f8d8a6b55b556b3b51`.

Claim proved: the production OpenClaw tool-result middleware runner replaces an actual multibyte details payload with the accurate truncation marker before a registered middleware observes it.

Direct runtime command: `node --import tsx --input-type=module -`, importing `src/agents/harness/tool-result-middleware.ts` and calling `createAgentToolResultMiddlewareRunner(...).applyToolResultMiddleware(...)` with 60,000 `\u00e9` characters.

Observed terminal output:

```json
{
  "runtime": "openclaw",
  "serializedInputBytes": 120011,
  "middlewareObservedDetails": {
    "truncated": true,
    "originalSizeBytes": 120011
  },
  "returnedDetails": {
    "truncated": true,
    "originalSizeBytes": 120011
  }
}
```

Additional focused validation:

- Blacksmith Testbox `tbx_01kx8ge44b23czdjt1v0fah1yt`: `corepack pnpm test src/agents/harness/tool-result-middleware.test.ts` — 25 tests passed.
- `git diff --check` — clean.
- `python .agents/skills/autoreview/scripts/autoreview --mode local` — clean after one accepted availability finding; final confidence 0.91.
