### PR TITLE
fix: canonicalize disabled MCP server aliases

### DIFF
--- a/src/agents/bundle-mcp-config.test.ts
+++ b/src/agents/bundle-mcp-config.test.ts
@@ -81,6 +81,25 @@ describe("loadMergedBundleMcpConfig", () => {
     expect(merged.config.mcpServers).not.toHaveProperty("disabledDocs");
   });
 
+  it("treats disabled MCP aliases as disabled after normalization", () => {
+    const merged = loadMergedBundleMcpConfig({
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            disabledDocs: {
+              disabled: true,
+              command: "node",
+              args: ["docs.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(merged.config.mcpServers).not.toHaveProperty("disabledDocs");
+  });
+
   it("lets disabled OpenClaw MCP servers tombstone bundle defaults with the same name", () => {
     const merged = loadMergedBundleMcpConfig({
       workspaceDir: "/workspace",

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2,7 +2,9 @@
 import { describe, expect, it } from "vitest";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
+import { validateConfigObjectRaw } from "../../../config/validation.js";
 import { pruneBindingsForMissingAgents } from "./legacy-config-binding-repair.js";
+import { migrateLegacyConfig } from "./legacy-config-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
 function repairBindingsForTest(config: OpenClawConfig) {
@@ -1854,6 +1856,68 @@ describe("legacy migrate sandbox scope aliases", () => {
 
     expect(res.changes).toStrictEqual([]);
     expect(res.config).toBeNull();
+  });
+});
+
+describe("legacy migrate MCP server disabled aliases", () => {
+  it("moves disabled to enabled before raw schema validation rejects the alias", () => {
+    const raw = {
+      mcp: {
+        servers: {
+          docs: {
+            disabled: true,
+            command: "node",
+            args: ["docs.mjs"],
+          },
+        },
+      },
+    };
+
+    const rawValidation = validateConfigObjectRaw(raw);
+    expect(rawValidation.ok).toBe(false);
+    if (!rawValidation.ok) {
+      expect(rawValidation.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "mcp.servers.docs.disabled",
+            message: expect.stringContaining("use enabled: false"),
+          }),
+        ]),
+      );
+    }
+    expect(findLegacyConfigIssues(raw).map((issue) => issue.path)).toContain("mcp.servers");
+
+    const res = migrateLegacyConfig(raw);
+
+    expect(res.changes).toStrictEqual(["Moved mcp.servers.docs.disabled true → enabled false."]);
+    expect(res.partiallyValid).toBeUndefined();
+    expect(res.config?.mcp?.servers?.docs).toEqual({
+      command: "node",
+      args: ["docs.mjs"],
+      enabled: false,
+    });
+  });
+
+  it("removes disabled when canonical enabled is already set", () => {
+    const res = migrateLegacyConfigForTest({
+      mcp: {
+        servers: {
+          docs: {
+            disabled: true,
+            enabled: true,
+            command: "node",
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed mcp.servers.docs.disabled (enabled true already set).",
+    ]);
+    expect(res.config?.mcp?.servers?.docs).toEqual({
+      command: "node",
+      enabled: true,
+    });
   });
 });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -19,8 +19,45 @@ const MCP_SERVER_TYPE_RULE: LegacyConfigRule = {
     Object.values(value).some((server) => isRecord(server) && isKnownCliMcpTypeAlias(server.type)),
 };
 
+const MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
+  path: ["mcp", "servers"],
+  message: 'mcp.servers entries use enabled instead of disabled. Run "openclaw doctor --fix".',
+  match: (value) =>
+    isRecord(value) &&
+    Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
+};
+
 /** Legacy config migration specs for MCP server config compatibility. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "mcp.servers.disabled->enabled",
+    describe: "Move MCP server disabled aliases to enabled",
+    legacyRules: [MCP_SERVER_DISABLED_RULE],
+    apply: (raw, changes) => {
+      const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
+      const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
+      if (!servers) {
+        return;
+      }
+
+      for (const [serverName, rawServer] of Object.entries(servers)) {
+        if (!isRecord(rawServer) || typeof rawServer.disabled !== "boolean") {
+          continue;
+        }
+        if (typeof rawServer.enabled !== "boolean") {
+          rawServer.enabled = !rawServer.disabled;
+          changes.push(
+            `Moved mcp.servers.${serverName}.disabled ${rawServer.disabled} → enabled ${rawServer.enabled}.`,
+          );
+        } else {
+          changes.push(
+            `Removed mcp.servers.${serverName}.disabled (enabled ${rawServer.enabled} already set).`,
+          );
+        }
+        delete rawServer.disabled;
+      }
+    },
+  }),
   defineLegacyConfigMigration({
     id: "mcp.servers.type->transport",
     describe: "Move CLI-native MCP server type aliases to OpenClaw transport",

--- a/src/config/mcp-config-normalize.ts
+++ b/src/config/mcp-config-normalize.ts
@@ -46,6 +46,12 @@ export function canonicalizeConfiguredMcpServer(
   if (isKnownCliMcpTypeAlias(next.type)) {
     delete next.type;
   }
+  if (typeof next.disabled === "boolean") {
+    if (typeof next.enabled !== "boolean") {
+      next.enabled = !next.disabled;
+    }
+    delete next.disabled;
+  }
   if (typeof next.connect_timeout === "number" && typeof next.connectTimeout !== "number") {
     next.connectTimeout = next.connect_timeout;
     delete next.connect_timeout;
@@ -80,6 +86,9 @@ export function normalizeConfiguredMcpServers(value: unknown): ConfigMcpServers 
   return Object.fromEntries(
     Object.entries(value)
       .filter(([, server]) => isRecord(server))
-      .map(([name, server]) => [name, { ...(server as Record<string, unknown>) }]),
+      .map(([name, server]) => [
+        name,
+        canonicalizeConfiguredMcpServer(server as Record<string, unknown>),
+      ]),
   );
 }

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -363,4 +363,55 @@ describe("config mcp config", () => {
       });
     });
   });
+
+  it("canonicalizes disabled MCP config aliases to enabled false when saving config", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "docs",
+        server: {
+          disabled: true,
+          command: "node",
+          args: ["docs.mjs"],
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      const loaded = await listConfiguredMcpServers();
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loaded.mcpServers.docs).toEqual({
+        enabled: false,
+        command: "node",
+        args: ["docs.mjs"],
+      });
+    });
+  });
+
+  it("keeps canonical enabled values ahead of disabled aliases", async () => {
+    await withMcpConfigHome({}, async () => {
+      const setResult = await setConfiguredMcpServer({
+        name: "docs",
+        server: {
+          enabled: true,
+          disabled: true,
+          command: "node",
+          args: ["docs.mjs"],
+        },
+      });
+
+      expect(setResult.ok).toBe(true);
+      const loaded = await listConfiguredMcpServers();
+      expect(loaded.ok).toBe(true);
+      if (!loaded.ok) {
+        throw new Error("expected MCP config to load");
+      }
+      expect(loaded.mcpServers.docs).toEqual({
+        enabled: true,
+        command: "node",
+        args: ["docs.mjs"],
+      });
+    });
+  });
 });

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -187,6 +187,32 @@ describe("config schema", () => {
     expect(serversNode?.additionalProperties?.properties).toHaveProperty("codex");
   });
 
+  it("rejects unsupported MCP disabled aliases with an actionable enabled hint", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: {
+        servers: {
+          docs: {
+            disabled: true,
+            command: "node",
+            args: ["docs.mjs"],
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["mcp", "servers", "docs", "disabled"],
+            message: expect.stringContaining("use enabled: false"),
+          }),
+        ]),
+      );
+    }
+  });
+
   it("rejects empty Codex MCP agent scopes", () => {
     expect(() =>
       OpenClawSchema.parse({

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -466,6 +466,13 @@ const McpServerSchema = z
         path: ["transport"],
       });
     }
+    if (Object.hasOwn(data, "disabled")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'mcp.servers entries do not support "disabled"; use enabled: false instead',
+        path: ["disabled"],
+      });
+    }
   })
   .catchall(z.unknown());
 


### PR DESCRIPTION
## Summary
- canonicalize MCP `disabled` aliases to `enabled: false` when saving/listing configured MCP servers
- keep explicit `enabled` values authoritative and remove the unsupported `disabled` key from normalized config
- add `openclaw doctor --fix` migration coverage so raw legacy `disabled` config is repaired before schema validation blocks startup
- reject raw config-schema `disabled` entries with an actionable `use enabled: false` hint

Fixes #103954.

## What Problem This Solves
Some MCP setup flows and CLI-native config snippets use `disabled: true`, while OpenClaw's canonical schema only supports `enabled: false`. Before this change, raw config files containing `mcp.servers.*.disabled` fail schema validation, so runtime helper normalization alone is not enough to protect upgrades. This PR makes authored/configure-time MCP records canonical and gives `openclaw doctor --fix` a migration path for existing raw config files.

## Evidence
- Raw schema behavior is covered: `src/config/schema.test.ts` rejects `mcp.servers.docs.disabled` with a `use enabled: false` hint.
- Runtime/configure helper behavior is covered: `src/config/mcp-config.test.ts` verifies `disabled` is canonicalized to `enabled` and explicit `enabled` wins.
- Bundle behavior is covered: `src/agents/bundle-mcp-config.test.ts` verifies disabled servers are filtered after canonicalization.
- Doctor migration behavior is covered: `src/commands/doctor/shared/legacy-config-migrate.test.ts` proves raw validation rejects `disabled`, legacy issue detection catches it, and `migrateLegacyConfig` repairs it to `enabled` before validation succeeds.

## Tests
- `pnpm test src/config/mcp-config.test.ts src/config/schema.test.ts src/agents/bundle-mcp-config.test.ts`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 pnpm check:changed`
- `pnpm vitest run src/commands/doctor/shared/legacy-config-migrate.test.ts src/config/schema.test.ts`
