### PR TITLE
feat(cli): collect live paired-node commands

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,0 +1,77 @@
+---
+summary: "List and inspect the command surfaces known to OpenClaw"
+read_when:
+  - Building command inventory, compliance, diagnostics, or documentation tooling
+  - Inspecting command provenance and effect data
+title: "Commands"
+---
+
+# `openclaw tools commands`
+
+`openclaw tools commands` provides a read-only inventory of command information OpenClaw already
+owns. It does not execute commands, grant permission, or enforce policy.
+
+## List commands
+
+```bash
+openclaw tools commands list
+openclaw tools commands list --json
+openclaw tools commands list --markdown
+openclaw tools commands list --json --plugin-descriptors
+```
+
+The inventory joins these command-owned sources:
+
+- static core and sub-CLI descriptors
+- routed command paths and their operation metadata
+- commands registered in the current CLI invocation
+- plugin CLI descriptors when `--plugin-descriptors` is supplied
+
+Human output is Markdown by default. Use `--json` for the versioned machine-readable shape.
+`--json` and `--markdown` cannot be combined.
+
+Plugin descriptor discovery is opt-in because it activates plugin registration. When requested,
+loader failures and error-level plugin diagnostics fail the command instead of returning an
+apparently complete partial inventory. Plugin warnings remain visible on stderr.
+
+## Inspect one path
+
+```bash
+openclaw tools commands inspect gateway
+openclaw tools commands inspect nodes run --json
+openclaw tools commands inspect memory --json --plugin-descriptors
+```
+
+`inspect` hydrates the requested lazy core or sub-CLI group, resolves runtime aliases, and returns
+the records that match that exact command path. The result includes `found`, the requested and
+resolved paths, and matching descriptors, routes, routed operations, runtime registrations, plugin
+registrations, and caller-supplied node records.
+
+An unknown path returns `found: false` in JSON or `No matching command was found` in Markdown.
+
+## Inventory semantics
+
+The JSON result includes `schemaVersion: 1`, source identity, discovery mode, visibility, and effect
+metadata where the owning registry provides it. Missing effect metadata is not a safety claim.
+Callers should not infer that an unannotated command is read-only or low risk.
+
+The current runtime command scope is the command tree registered for this invocation. Plugin
+commands appear only with `--plugin-descriptors`. Node command records are supported by the catalog
+model but this CLI does not fetch live paired-node commands.
+
+The existing Gateway `commands.list` RPC remains the agent-facing chat, native, skill, and plugin
+inventory. This CLI is an operator and developer view and does not replace that RPC.
+
+## Options
+
+| Flag                   | Meaning                                                      |
+| ---------------------- | ------------------------------------------------------------ |
+| `--json`               | Emit the versioned JSON inventory.                           |
+| `--markdown`           | Emit Markdown explicitly; this is the default human format.  |
+| `--plugin-descriptors` | Load plugin CLI descriptors and include their command shape. |
+
+## Related
+
+- [CLI reference](/cli)
+- [Plugin SDK](/plugins/sdk-overview)
+- [`openclaw nodes`](/cli/nodes)

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -18,6 +18,7 @@ openclaw tools commands list
 openclaw tools commands list --json
 openclaw tools commands list --markdown
 openclaw tools commands list --json --plugin-descriptors
+openclaw tools commands list --json --node <node-id>
 ```
 
 The inventory joins these command-owned sources:
@@ -26,6 +27,7 @@ The inventory joins these command-owned sources:
 - routed command paths and their operation metadata
 - commands registered in the current CLI invocation
 - plugin CLI descriptors when `--plugin-descriptors` is supplied
+- commands advertised by one connected, paired Gateway node when `--node` is supplied
 
 Human output is Markdown by default. Use `--json` for the versioned machine-readable shape.
 `--json` and `--markdown` cannot be combined.
@@ -56,19 +58,25 @@ metadata where the owning registry provides it. Missing effect metadata is not a
 Callers should not infer that an unannotated command is read-only or low risk.
 
 The current runtime command scope is the command tree registered for this invocation. Plugin
-commands appear only with `--plugin-descriptors`. Node command records are supported by the catalog
-model but this CLI does not fetch live paired-node commands.
+commands appear only with `--plugin-descriptors`. A live node query is opt-in with `--node`; the
+selected node must be connected and paired, and an empty result is still reported with
+`nodeCommandScope: "live-gateway-query"` so callers can distinguish an executed Gateway query from
+caller-supplied records.
 
 The existing Gateway `commands.list` RPC remains the agent-facing chat, native, skill, and plugin
 inventory. This CLI is an operator and developer view and does not replace that RPC.
 
 ## Options
 
-| Flag                   | Meaning                                                      |
-| ---------------------- | ------------------------------------------------------------ |
-| `--json`               | Emit the versioned JSON inventory.                           |
-| `--markdown`           | Emit Markdown explicitly; this is the default human format.  |
-| `--plugin-descriptors` | Load plugin CLI descriptors and include their command shape. |
+| Flag                   | Meaning                                                           |
+| ---------------------- | ----------------------------------------------------------------- |
+| `--json`               | Emit the versioned JSON inventory.                                |
+| `--markdown`           | Emit Markdown explicitly; this is the default human format.       |
+| `--plugin-descriptors` | Load plugin CLI descriptors and include their command shape.      |
+| `--node <node-id>`     | Query one connected, paired Gateway node for advertised commands. |
+| `--url <url>`          | Gateway WebSocket URL for the live node query.                    |
+| `--token <token>`      | Gateway token for the live node query.                            |
+| `--timeout <ms>`       | Gateway timeout in milliseconds for the live node query.          |
 
 ## Related
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -9,6 +9,8 @@ title: "CLI reference"
 `openclaw` is the main CLI entry point. Each core command has a dedicated
 reference page or is documented with the command it aliases; this index lists
 the commands, global flags, and output styling rules that apply across the CLI.
+For a machine-readable inventory of command descriptors, routes, runtime registrations, and
+opt-in plugin descriptors, see [`openclaw tools commands`](/cli/commands).
 
 Setup commands by intent:
 
@@ -126,6 +128,8 @@ openclaw [--dev] [--profile <name>] <command>
     wizard
     status
     repair
+  tools
+    commands list|inspect
   channels
     list
     status

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1852,6 +1852,7 @@
                     "pages": [
                       "cli/approvals",
                       "cli/browser",
+                      "cli/commands",
                       "cli/cron",
                       "cli/flows",
                       "cli/node",

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -254,7 +254,9 @@ CLI registration:
   `registerCli(registrar, { parentPath: ["nodes"], ... })`).
 - For other nested plugin commands, add `parentPath` and register commands
   on the `program` object passed to the registrar; OpenClaw resolves it to
-  the parent command before calling the plugin.
+  the parent command before calling the plugin. Use only documented
+  plugin-extensible parents; `openclaw tools` is core-owned inventory and is
+  not a plugin command parent.
 - For channel plugins, register CLI descriptors from `registerCliMetadata`
   and keep `registerFull` focused on runtime-only work.
 - If `registerFull` also registers gateway RPC methods, keep them on a

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -507,7 +507,7 @@ own trust.
 
 ### CLI registration metadata
 
-`api.registerCli(registrar, opts?)` accepts two kinds of command metadata:
+`api.registerCli(registrar, opts?)` accepts command ownership data:
 
 - `commands`: explicit command names owned by the registrar
 - `descriptors`: parse-time command descriptors used for CLI help,
@@ -523,6 +523,9 @@ For paired-node features, prefer
 If you want a plugin command to stay lazy-loaded in the normal root CLI path,
 provide `descriptors` that cover every top-level command root exposed by that
 registrar.
+
+Descriptors describe parse-time command shape only. They do not declare effect
+risk, grant permission, enforce policy, or hide commands from inventory.
 
 ```typescript
 api.registerCli(

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -515,6 +515,10 @@ own trust.
 - `parentPath`: optional parent command path for nested command groups, such as
   `["nodes"]`
 
+Nested plugin CLI registrations are only for extension points that core
+documents as plugin-extensible. The `tools` root is reserved for OpenClaw's
+read-only inventory commands and does not load plugin-owned child commands.
+
 For paired-node features, prefer
 `api.registerNodeCliFeature(registrar, opts?)`. It is a small wrapper around
 `api.registerCli(..., { parentPath: ["nodes"] })` and makes commands such as

--- a/src/cli-catalog-overlay/inspect.test.ts
+++ b/src/cli-catalog-overlay/inspect.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { inspectCommand, renderCommandInspectionMarkdown } from "./inspect.js";
+import { buildCatalogList } from "./list.js";
+
+describe("command inventory inspect", () => {
+  it("joins records for an exact command path", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["gateway", "status"]);
+
+    expect(inspection.found).toBe(true);
+    expect(inspection.routes.map((route) => route.commandPath)).toEqual([
+      ["gateway"],
+      ["gateway", "status"],
+    ]);
+    expect(inspection.routedOperations.map((operation) => operation.id)).toContain(
+      "gateway-status",
+    );
+  });
+
+  it("inspects supplied node commands", () => {
+    const list = buildCatalogList({
+      nodeCommands: [
+        {
+          id: "node:demo:filesystem.read",
+          command: "filesystem.read",
+          title: "Read a file",
+          description: "Read a file from the paired node",
+          argumentHints: ["path"],
+          invocationHint: "filesystem.read path=<path>",
+          availability: "approved",
+          approvalKind: "pairing",
+          risk: "low",
+          confirmationRequired: false,
+          effectMode: "read",
+          effects: ["filesystem.read"],
+          trustBoundary: "paired-node",
+          sourceKind: "node-pairing",
+          sourceId: "demo:filesystem.read",
+          discoveryMode: "paired-node-declaration",
+          visibility: ["audit", "operator"],
+        },
+      ],
+    });
+
+    expect(inspectCommand(list, ["filesystem.read"]).nodeCommands).toHaveLength(1);
+  });
+
+  it("reports unknown command paths without fuzzy matching", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(renderCommandInspectionMarkdown(inspection)).toContain("No matching command was found.");
+  });
+
+  it("does not treat an inherited route policy as command existence", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["gateway", "missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(inspection.routes.map((route) => route.commandPath)).toEqual([["gateway"]]);
+  });
+
+  it("includes inherited operations without treating them as command existence", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["tasks", "missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(inspection.routedOperations.map((operation) => operation.id)).toContain("tasks-list");
+  });
+
+  it("resolves runtime aliases before joining command records", () => {
+    const list = buildCatalogList({
+      runtimeCommands: [
+        {
+          commandPath: ["infer"],
+          parentPath: [],
+          depth: 1,
+          name: "infer",
+          aliases: ["capability"],
+          description: "Run inference",
+          hasSubcommands: false,
+          visibleSubcommandCount: 0,
+          hidden: false,
+          sourceKind: "runtime",
+          sourceId: "infer",
+          discoveryMode: "runtime-registered",
+          visibility: ["operator"],
+        },
+      ],
+    });
+
+    const inspection = inspectCommand(list, ["capability"]);
+    expect(inspection.found).toBe(true);
+    expect(inspection.resolvedCommandPath).toEqual(["infer"]);
+    expect(inspection.runtimeCommands).toHaveLength(1);
+  });
+
+  it("uses a Markdown fence longer than plugin-controlled content", () => {
+    const list = buildCatalogList({
+      pluginCommands: [
+        {
+          pluginId: "example",
+          commandPath: ["example"],
+          parentPath: [],
+          depth: 1,
+          name: "example",
+          descriptorName: "example",
+          description: "contains ``` fence",
+          hasSubcommands: false,
+          commandHints: ["example"],
+          sourceKind: "plugin",
+          sourceId: "example:example",
+          discoveryMode: "plugin-descriptor",
+        },
+      ],
+    });
+
+    expect(renderCommandInspectionMarkdown(inspectCommand(list, ["example"]))).toContain(
+      "````json",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/inspect.ts
+++ b/src/cli-catalog-overlay/inspect.ts
@@ -1,0 +1,119 @@
+import { matchesCommandPath } from "../cli/command-path-matches.js";
+import type { CliCatalogList } from "./list.js";
+
+type CliCommandInspection = {
+  readonly schemaVersion: 1;
+  readonly generatedFrom: "command-inventory-inspect";
+  readonly commandPath: readonly string[];
+  readonly resolvedCommandPath: readonly string[];
+  readonly found: boolean;
+  readonly descriptors: CliCatalogList["cli"]["descriptors"];
+  readonly routes: CliCatalogList["cli"]["commandRoutes"];
+  readonly routedOperations: CliCatalogList["cli"]["routedOperations"];
+  readonly runtimeCommands: CliCatalogList["cli"]["runtimeCommands"];
+  readonly pluginCommands: CliCatalogList["cli"]["pluginCommands"];
+  readonly nodeCommands: CliCatalogList["cli"]["nodeCommands"];
+};
+
+function samePath(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((part, index) => part === right[index]);
+}
+
+function resolveRuntimeCommandPath(
+  commands: CliCatalogList["cli"]["runtimeCommands"],
+  commandPath: readonly string[],
+): readonly string[] {
+  const resolved: string[] = [];
+  for (const segment of commandPath) {
+    const match = commands.find(
+      (command) =>
+        samePath(command.parentPath, resolved) &&
+        (command.name === segment || command.aliases.includes(segment)),
+    );
+    if (!match) {
+      return commandPath;
+    }
+    resolved.push(match.name);
+  }
+  return resolved;
+}
+
+export function inspectCommand(
+  list: CliCatalogList,
+  commandPath: readonly string[],
+): CliCommandInspection {
+  const resolvedCommandPath = resolveRuntimeCommandPath(list.cli.runtimeCommands, commandPath);
+  const descriptors =
+    resolvedCommandPath.length === 1
+      ? list.cli.descriptors.filter((descriptor) => descriptor.name === resolvedCommandPath[0])
+      : [];
+  const routes = list.cli.commandRoutes.filter((route) =>
+    matchesCommandPath([...resolvedCommandPath], route.commandPath, { exact: route.exact }),
+  );
+  const hasExactRoute = routes.some((route) => samePath(route.commandPath, resolvedCommandPath));
+  const matchedRouteIds = new Set<string>(
+    routes.flatMap((route) => (route.routeId ? [route.routeId] : [])),
+  );
+  const routedOperations = list.cli.routedOperations.filter((operation) =>
+    matchedRouteIds.has(operation.id),
+  );
+  const hasExactRoutedOperation = routedOperations.some((operation) =>
+    operation.commandPaths.some((path) => samePath(path, resolvedCommandPath)),
+  );
+  const runtimeCommands = list.cli.runtimeCommands.filter((command) =>
+    samePath(command.commandPath, resolvedCommandPath),
+  );
+  const pluginCommands = list.cli.pluginCommands.filter((command) =>
+    samePath(command.commandPath, resolvedCommandPath),
+  );
+  const nodeCommands = list.cli.nodeCommands.filter(
+    (command) => command.command === resolvedCommandPath.join(" "),
+  );
+  const found =
+    descriptors.length +
+      Number(hasExactRoute) +
+      Number(hasExactRoutedOperation) +
+      runtimeCommands.length +
+      pluginCommands.length +
+      nodeCommands.length >
+    0;
+
+  return {
+    schemaVersion: 1,
+    generatedFrom: "command-inventory-inspect",
+    commandPath,
+    resolvedCommandPath,
+    found,
+    descriptors,
+    routes,
+    routedOperations,
+    runtimeCommands,
+    pluginCommands,
+    nodeCommands,
+  };
+}
+
+export function renderCommandInspectionMarkdown(inspection: CliCommandInspection): string {
+  const path = inspection.commandPath.join(" ");
+  if (!inspection.found) {
+    return `# Command: ${path}\n\nNo matching command was found.\n`;
+  }
+  const json = JSON.stringify(inspection, null, 2);
+  const longestFence = Math.max(0, ...Array.from(json.matchAll(/`+/g), (match) => match[0].length));
+  const fence = "`".repeat(Math.max(3, longestFence + 1));
+  return [
+    `# Command: ${path}`,
+    "",
+    `- Descriptors: ${inspection.descriptors.length}`,
+    `- Routes: ${inspection.routes.length}`,
+    `- Routed operations: ${inspection.routedOperations.length}`,
+    `- Runtime registrations: ${inspection.runtimeCommands.length}`,
+    `- Plugin registrations: ${inspection.pluginCommands.length}`,
+    `- Node commands: ${inspection.nodeCommands.length}`,
+    "",
+    `${fence}json`,
+    json,
+    fence,
+    "",
+  ].join("\n");
+}

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import type { CliCatalogNodeCommand } from "./node-commands.js";
+
+const sampleNodeCommands: readonly CliCatalogNodeCommand[] = [
+  {
+    id: "node:demo-filesystem:filesystem.read",
+    command: "filesystem.read",
+    title: "Read file through paired node",
+    nodeId: "demo-filesystem",
+    nodeName: "Demo filesystem node",
+    cap: "filesystem",
+    description: "Read a file through a paired node command declaration.",
+    argumentHints: ["path"],
+    invocationHint:
+      'openclaw nodes invoke --node demo-filesystem --command filesystem.read --params {"path":"..."}',
+    availability: "approved",
+    approvalKind: "pairing",
+    risk: "medium",
+    confirmationRequired: true,
+    effectMode: "read",
+    effects: ["filesystem.read"],
+    trustBoundary: "paired-node",
+    sourceKind: "node-pairing",
+    sourceId: "demo-filesystem:filesystem.read",
+    discoveryMode: "paired-node-declaration",
+    visibility: ["docs", "audit", "operator", "policy"],
+  },
+];
+
+describe("command inventory list", () => {
+  it("builds a read-only programmatic list", () => {
+    const list = buildCatalogList();
+
+    expect(list).toMatchObject({
+      schemaVersion: 1,
+      generatedFrom: "command-inventory",
+      counts: {
+        runtimeCommands: 0,
+        nodeCommands: 0,
+      },
+    });
+    expect(list.cli.runtimeCommandScope).toBe("current-invocation-registered-tree");
+    expect(list.cli.nodeCommandScope).toBe("caller-supplied");
+    expect(list.collection).toEqual({
+      descriptors: "complete",
+      commandRoutes: "complete",
+      runtimeCommands: "not-requested",
+      pluginCommands: "not-requested",
+      nodeCommands: "not-requested",
+    });
+    expect(list.cli.descriptors.map((descriptor) => descriptor.name)).not.toContain("crestodian");
+    expect(list.cli.descriptors.find((descriptor) => descriptor.name === "gateway")).toMatchObject({
+      source: "subcli",
+      hasSubcommands: true,
+    });
+    expect(
+      list.cli.routedOperations.find((operation) => operation.id === "gateway-status"),
+    ).toMatchObject({ commandPaths: [["gateway", "status"]] });
+    expect(
+      list.cli.routedOperations.find((operation) => operation.id === "config-unset"),
+    ).toMatchObject({
+      risk: "medium",
+      confirmationRequired: true,
+      effectMode: "mutating",
+    });
+    expect(list.counts.commandDescriptors).toBeGreaterThan(50);
+    expect(list.counts.commandRoutes).toBeGreaterThan(90);
+    expect(list.counts.routedOperations).toBeGreaterThan(10);
+  });
+
+  it("preserves unknown routed-operation effects", () => {
+    const operation = buildCatalogList().cli.routedOperations.find(
+      (entry) => entry.id === "agents-list",
+    );
+
+    expect(operation).toBeDefined();
+    expect(operation).not.toHaveProperty("risk");
+    expect(operation).not.toHaveProperty("confirmationRequired");
+    expect(operation).not.toHaveProperty("effectMode");
+  });
+
+  it("carries supplied node/operator commands through the list contract", () => {
+    const list = buildCatalogList({ nodeCommands: sampleNodeCommands });
+
+    expect(list.counts.nodeCommands).toBe(1);
+    expect(list.cli.nodeCommands[0]).toMatchObject({
+      id: "node:demo-filesystem:filesystem.read",
+      command: "filesystem.read",
+      availability: "approved",
+      approvalKind: "pairing",
+      trustBoundary: "paired-node",
+    });
+  });
+
+  it("renders a Markdown command inventory", () => {
+    const markdown = renderCatalogListMarkdown();
+
+    expect(markdown).toContain("# OpenClaw Commands");
+    expect(markdown).toContain("- CLI descriptors:");
+    expect(markdown).toContain("- Command routes:");
+    expect(markdown).toContain("- Runtime command scope: current-invocation-registered-tree");
+    expect(markdown).toContain("- Supplied node commands: 0");
+    expect(markdown).toContain("- Node command scope: caller-supplied");
+    expect(markdown).toContain(
+      "| `gateway-status` | `unknown` | `unknown` | unknown | `gateway status` |",
+    );
+    expect(markdown).not.toContain("Agent/tool surfaces");
+  });
+
+  it("renders node/operator command rows when supplied", () => {
+    const markdown = renderCatalogListMarkdown({ nodeCommands: sampleNodeCommands });
+
+    expect(markdown).toContain("## Node/operator commands");
+    expect(markdown).toContain(
+      "| `filesystem.read` | Demo filesystem node | `approved` | `pairing` |",
+    );
+  });
+
+  it("keeps supplied node metadata inside its Markdown table cells", () => {
+    const command = {
+      ...sampleNodeCommands[0]!,
+      command: "filesystem.`read`|raw",
+      nodeName: "Build | prod\nprimary",
+      invocationHint: "nodes invoke `filesystem.read` | inspect\nnext",
+    };
+
+    const markdown = renderCatalogListMarkdown({ nodeCommands: [command] });
+
+    expect(markdown).toContain(
+      "| `` filesystem.`read`\\|raw `` | Build \\| prod primary | `approved` | `pairing` |",
+    );
+    expect(markdown).toContain("`` nodes invoke `filesystem.read` \\| inspect next ``");
+    expect(markdown).not.toContain("Build | prod\nprimary");
+  });
+});

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -181,4 +181,19 @@ describe("command inventory list", () => {
     expect(markdown).not.toContain(String.fromCharCode(27));
     expect(markdown).not.toContain(String.fromCharCode(7));
   });
+
+  it("sanitizes node command IDs before Markdown terminal output", () => {
+    const command = {
+      ...sampleNodeCommands[0]!,
+      command: `filesystem.${String.fromCharCode(27)}[31mread${String.fromCharCode(7)}`,
+      invocationHint: `nodes invoke ${String.fromCharCode(27)}[31mfilesystem.read`,
+    };
+
+    const markdown = renderCatalogListMarkdown({ nodeCommands: [command] });
+
+    expect(markdown).toContain("| `filesystem.read` | Demo filesystem node |");
+    expect(markdown).toContain("`nodes invoke filesystem.read`");
+    expect(markdown).not.toContain(String.fromCharCode(27));
+    expect(markdown).not.toContain(String.fromCharCode(7));
+  });
 });

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -84,6 +84,7 @@ describe("command inventory list", () => {
     const list = buildCatalogList({ nodeCommands: sampleNodeCommands });
 
     expect(list.counts.nodeCommands).toBe(1);
+    expect(list.collection.nodeCommands).toBe("caller-supplied");
     expect(list.cli.nodeCommands[0]).toMatchObject({
       id: "node:demo-filesystem:filesystem.read",
       command: "filesystem.read",
@@ -93,6 +94,29 @@ describe("command inventory list", () => {
     });
   });
 
+  it("reports live Gateway node command collection at both inventory levels", () => {
+    const list = buildCatalogList({
+      nodeCommands: [
+        {
+          ...sampleNodeCommands[0]!,
+          id: "node:live-node:device.info",
+          command: "device.info",
+          title: "device.info",
+          nodeId: "live-node",
+          sourceKind: "node-runtime",
+          sourceId: "live-node:device.info",
+          discoveryMode: "runtime-node-query",
+          metadataCompleteness: "identifier-only",
+          visibility: ["audit", "operator"],
+        },
+      ],
+    });
+
+    expect(list.counts.nodeCommands).toBe(1);
+    expect(list.collection.nodeCommands).toBe("live-gateway-query");
+    expect(list.cli.nodeCommandScope).toBe("live-gateway-query");
+  });
+
   it("renders a Markdown command inventory", () => {
     const markdown = renderCatalogListMarkdown();
 
@@ -100,7 +124,7 @@ describe("command inventory list", () => {
     expect(markdown).toContain("- CLI descriptors:");
     expect(markdown).toContain("- Command routes:");
     expect(markdown).toContain("- Runtime command scope: current-invocation-registered-tree");
-    expect(markdown).toContain("- Supplied node commands: 0");
+    expect(markdown).toContain("- Node commands: 0");
     expect(markdown).toContain("- Node command scope: caller-supplied");
     expect(markdown).toContain(
       "| `gateway-status` | `unknown` | `unknown` | unknown | `gateway status` |",

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -117,6 +117,17 @@ describe("command inventory list", () => {
     expect(list.cli.nodeCommandScope).toBe("live-gateway-query");
   });
 
+  it("keeps explicit live Gateway collection scope for empty command results", () => {
+    const list = buildCatalogList({
+      nodeCommands: [],
+      nodeCommandScope: "live-gateway-query",
+    });
+
+    expect(list.counts.nodeCommands).toBe(0);
+    expect(list.collection.nodeCommands).toBe("live-gateway-query");
+    expect(list.cli.nodeCommandScope).toBe("live-gateway-query");
+  });
+
   it("renders a Markdown command inventory", () => {
     const markdown = renderCatalogListMarkdown();
 
@@ -156,5 +167,18 @@ describe("command inventory list", () => {
     );
     expect(markdown).toContain("`` nodes invoke `filesystem.read` \\| inspect next ``");
     expect(markdown).not.toContain("Build | prod\nprimary");
+  });
+
+  it("sanitizes node labels before Markdown terminal output", () => {
+    const command = {
+      ...sampleNodeCommands[0]!,
+      nodeName: `Desk ${String.fromCharCode(27)}[31mred${String.fromCharCode(7)} node`,
+    };
+
+    const markdown = renderCatalogListMarkdown({ nodeCommands: [command] });
+
+    expect(markdown).toContain("| `filesystem.read` | Desk red node |");
+    expect(markdown).not.toContain(String.fromCharCode(27));
+    expect(markdown).not.toContain(String.fromCharCode(7));
   });
 });

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -1,0 +1,315 @@
+import {
+  normalizeCommandEffectProfile,
+  normalizeCommandExposure,
+  type CliCatalogVisibility,
+} from "../cli/catalog-metadata.js";
+import { cliCommandCatalog, type CliCommandCatalogEntry } from "../cli/command-catalog.js";
+import { getCoreCliCommandDescriptors } from "../cli/program/core-command-descriptors.js";
+import { getSubCliEntries } from "../cli/program/subcli-descriptors.js";
+import { buildNodeCommandCatalog, type CliCatalogNodeCommand } from "./node-commands.js";
+import type { CliCatalogPluginCommand } from "./plugin-commands.js";
+import type { CliCatalogRuntimeCommand } from "./runtime-commands.js";
+
+function markdownTableCell(value: string): string {
+  return value.replace(/\r\n?|\n/g, " ").replace(/\|/g, "\\|");
+}
+
+function markdownCodeCell(value: string): string {
+  const cell = markdownTableCell(value);
+  const longestFence = Math.max(0, ...Array.from(cell.matchAll(/`+/g), (match) => match[0].length));
+  const fence = "`".repeat(longestFence + 1);
+  return longestFence > 0 ? `${fence} ${cell} ${fence}` : `${fence}${cell}${fence}`;
+}
+
+type CliCatalogListDescriptor = {
+  readonly name: string;
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly parentDefaultHelp: boolean;
+  readonly source: "core" | "subcli";
+  readonly sourceKind: "core" | "subcli";
+  readonly sourceId: string;
+  readonly discoveryMode: "static-descriptor";
+  readonly visibility: readonly CliCatalogVisibility[];
+  readonly effectProfile?: {
+    readonly effectMode: string;
+    readonly confirmationRequired?: boolean;
+    readonly risk?: string;
+  };
+  readonly exposureTier?: "public" | "internal";
+};
+
+type CliCatalogListCommandRoute = {
+  readonly commandPath: readonly string[];
+  readonly exact: boolean;
+  readonly routeId?: NonNullable<CliCommandCatalogEntry["route"]>["id"];
+  readonly policyKeys: readonly string[];
+  readonly sourceKind: "route-policy";
+  readonly sourceId: string;
+  readonly discoveryMode: "route-policy";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+type CliCatalogListRoutedOperation = {
+  readonly id: string;
+  readonly commandPaths: readonly (readonly string[])[];
+  readonly risk?: string;
+  readonly confirmationRequired?: boolean;
+  readonly effectMode?: string;
+  readonly sourceKind: "route-policy";
+  readonly discoveryMode: "route-policy";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+type CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
+type CliCatalogNodeCommandScope = "caller-supplied";
+
+const RUNTIME_COMMAND_SCOPE: CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
+const NODE_COMMAND_SCOPE: CliCatalogNodeCommandScope = "caller-supplied";
+
+export type CliCatalogList = {
+  readonly schemaVersion: 1;
+  readonly generatedFrom: "command-inventory";
+  readonly counts: {
+    readonly commandDescriptors: number;
+    readonly commandRoutes: number;
+    readonly routedOperations: number;
+    readonly runtimeCommands: number;
+    readonly pluginCommands: number;
+    readonly nodeCommands: number;
+  };
+  readonly collection: {
+    readonly descriptors: "complete";
+    readonly commandRoutes: "complete";
+    readonly runtimeCommands: "collected" | "not-requested";
+    readonly pluginCommands: "collected" | "not-requested";
+    readonly nodeCommands: "caller-supplied" | "not-requested";
+  };
+  readonly cli: {
+    readonly descriptors: readonly CliCatalogListDescriptor[];
+    readonly commandRoutes: readonly CliCatalogListCommandRoute[];
+    readonly routedOperations: readonly CliCatalogListRoutedOperation[];
+    readonly runtimeCommandScope: CliCatalogRuntimeCommandScope;
+    readonly nodeCommandScope: CliCatalogNodeCommandScope;
+    readonly runtimeCommands: readonly CliCatalogRuntimeCommand[];
+    readonly pluginCommands: readonly CliCatalogPluginCommand[];
+    readonly nodeCommands: readonly CliCatalogNodeCommand[];
+  };
+};
+
+function mapDescriptor(
+  descriptor: ReturnType<typeof getCoreCliCommandDescriptors>[number],
+  source: "core" | "subcli",
+): CliCatalogListDescriptor {
+  const commandExposure = normalizeCommandExposure(descriptor.commandExposure);
+  const effectProfile = normalizeCommandEffectProfile(descriptor.effectProfile);
+  return {
+    name: descriptor.name,
+    description: descriptor.description,
+    hasSubcommands: descriptor.hasSubcommands,
+    parentDefaultHelp: Boolean(descriptor.parentDefaultHelp),
+    source,
+    sourceKind: source,
+    sourceId: descriptor.name,
+    discoveryMode: "static-descriptor",
+    visibility:
+      commandExposure?.tier === "internal"
+        ? ["audit", "operator", "policy"]
+        : ["docs", "audit", "operator", "policy"],
+    ...(effectProfile ? { effectProfile } : {}),
+    ...(commandExposure?.tier ? { exposureTier: commandExposure.tier } : {}),
+  };
+}
+
+function buildDescriptors(): readonly CliCatalogListDescriptor[] {
+  const core = getCoreCliCommandDescriptors()
+    .filter((descriptor) => descriptor.hidden !== true)
+    .map((descriptor) => mapDescriptor(descriptor, "core"));
+  const subcli = getSubCliEntries()
+    .filter((descriptor) => descriptor.hidden !== true)
+    .map((descriptor) => mapDescriptor(descriptor, "subcli"));
+  return [...core, ...subcli];
+}
+
+function buildCommandRoutes(): readonly CliCatalogListCommandRoute[] {
+  return cliCommandCatalog.map((entry) => {
+    const route: CliCatalogListCommandRoute = {
+      commandPath: entry.commandPath,
+      exact: Boolean(entry.exact),
+      policyKeys: entry.policy ? Object.keys(entry.policy).toSorted() : [],
+      sourceKind: "route-policy",
+      sourceId: entry.commandPath.join(" "),
+      discoveryMode: "route-policy",
+      visibility: ["audit", "operator", "policy"],
+    };
+    if (entry.route) {
+      Object.assign(route, { routeId: entry.route.id });
+    }
+    return route;
+  });
+}
+
+function buildRoutedOperations(
+  routes = buildCommandRoutes(),
+): readonly CliCatalogListRoutedOperation[] {
+  const effectProfiles = new Map(
+    cliCommandCatalog.flatMap((entry) => {
+      const effectProfile = normalizeCommandEffectProfile(entry.route?.effectProfile);
+      return entry.route && effectProfile ? [[entry.route.id, effectProfile] as const] : [];
+    }),
+  );
+  return [...new Set(routes.flatMap((route) => (route.routeId ? [route.routeId] : [])))]
+    .toSorted()
+    .map((id) => {
+      const effectProfile = effectProfiles.get(id);
+      const operation: CliCatalogListRoutedOperation = {
+        id,
+        sourceKind: "route-policy" as const,
+        discoveryMode: "route-policy" as const,
+        visibility: ["audit", "operator", "policy"] as const,
+        commandPaths: routes
+          .filter((route) => route.routeId === id)
+          .map((route) => route.commandPath),
+      };
+      if (effectProfile?.risk) {
+        Object.assign(operation, { risk: effectProfile.risk });
+      }
+      if (effectProfile?.confirmationRequired !== undefined) {
+        Object.assign(operation, {
+          confirmationRequired: effectProfile.confirmationRequired,
+        });
+      }
+      if (effectProfile?.effectMode) {
+        Object.assign(operation, { effectMode: effectProfile.effectMode });
+      }
+      return operation;
+    });
+}
+
+export function buildCatalogList(
+  params: {
+    runtimeCommands?: readonly CliCatalogRuntimeCommand[];
+    pluginCommands?: readonly CliCatalogPluginCommand[];
+    nodeCommands?: readonly CliCatalogNodeCommand[];
+  } = {},
+): CliCatalogList {
+  const descriptors = buildDescriptors();
+  const commandRoutes = buildCommandRoutes();
+  const routedOperations = buildRoutedOperations(commandRoutes);
+  const runtimeCommands = params.runtimeCommands ?? [];
+  const pluginCommands = params.pluginCommands ?? [];
+  const nodeCommands = buildNodeCommandCatalog(params.nodeCommands);
+  return {
+    schemaVersion: 1,
+    generatedFrom: "command-inventory",
+    counts: {
+      commandDescriptors: descriptors.length,
+      commandRoutes: commandRoutes.length,
+      routedOperations: routedOperations.length,
+      runtimeCommands: runtimeCommands.length,
+      pluginCommands: pluginCommands.length,
+      nodeCommands: nodeCommands.length,
+    },
+    collection: {
+      descriptors: "complete",
+      commandRoutes: "complete",
+      runtimeCommands: params.runtimeCommands === undefined ? "not-requested" : "collected",
+      pluginCommands: params.pluginCommands === undefined ? "not-requested" : "collected",
+      nodeCommands: params.nodeCommands === undefined ? "not-requested" : "caller-supplied",
+    },
+    cli: {
+      descriptors,
+      commandRoutes,
+      routedOperations,
+      runtimeCommandScope: RUNTIME_COMMAND_SCOPE,
+      nodeCommandScope: NODE_COMMAND_SCOPE,
+      runtimeCommands,
+      pluginCommands,
+      nodeCommands,
+    },
+  };
+}
+
+export function renderCatalogListMarkdown(
+  params: {
+    runtimeCommands?: readonly CliCatalogRuntimeCommand[];
+    pluginCommands?: readonly CliCatalogPluginCommand[];
+    nodeCommands?: readonly CliCatalogNodeCommand[];
+  } = {},
+): string {
+  const list = buildCatalogList(params);
+  const lines = [
+    "# OpenClaw Commands",
+    "",
+    "Read-only inventory of OpenClaw CLI, routed, runtime, plugin, and node commands.",
+    "",
+    "## Counts",
+    "",
+    `- CLI descriptors: ${list.counts.commandDescriptors}`,
+    `- Command routes: ${list.counts.commandRoutes}`,
+    `- Routed operations: ${list.counts.routedOperations}`,
+    `- Runtime commands: ${list.counts.runtimeCommands}`,
+    `- Runtime command scope: ${list.cli.runtimeCommandScope}`,
+    `- Plugin descriptor commands: ${list.counts.pluginCommands}`,
+    `- Supplied node commands: ${list.counts.nodeCommands}`,
+    `- Node command scope: ${list.cli.nodeCommandScope}`,
+    "",
+    "## Routed operations",
+    "",
+    "| Operation | Risk | Effect mode | Confirmation | Command paths |",
+    "| --- | --- | --- | --- | --- |",
+  ];
+  for (const operation of list.cli.routedOperations) {
+    const paths = operation.commandPaths.map((path) => markdownCodeCell(path.join(" "))).join(", ");
+    lines.push(
+      `| ${markdownCodeCell(operation.id)} | ${markdownCodeCell(operation.risk ?? "unknown")} | ${markdownCodeCell(operation.effectMode ?? "unknown")} | ${operation.confirmationRequired === undefined ? "unknown" : operation.confirmationRequired ? "yes" : "no"} | ${paths || "None"} |`,
+    );
+  }
+  if (list.cli.pluginCommands.length > 0) {
+    lines.push(
+      "",
+      "## Plugin descriptor commands",
+      "",
+      "| Command path | Parent | Depth | Plugin | Description |",
+      "| --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.pluginCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.commandPath.join(" "))} | ${command.parentPath.length > 0 ? markdownCodeCell(command.parentPath.join(" ")) : "None"} | ${command.depth} | ${markdownCodeCell(command.pluginId)} | ${markdownTableCell(command.description || "None")} |`,
+      );
+    }
+  }
+
+  if (list.cli.runtimeCommands.length > 0) {
+    lines.push(
+      "",
+      "## Runtime registered commands",
+      "",
+      "| Command path | Parent | Depth | Visible subcommands | Description |",
+      "| --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.runtimeCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.commandPath.join(" "))} | ${command.parentPath.length > 0 ? markdownCodeCell(command.parentPath.join(" ")) : "None"} | ${command.depth} | ${command.visibleSubcommandCount} | ${markdownTableCell(command.description || "None")} |`,
+      );
+    }
+  }
+
+  if (list.cli.nodeCommands.length > 0) {
+    lines.push(
+      "",
+      "## Node/operator commands",
+      "",
+      "| Command | Node | Availability | Approval | Risk | Effect mode | Invocation |",
+      "| --- | --- | --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.nodeCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.command)} | ${markdownTableCell(command.nodeName ?? command.nodeId ?? "Any")} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${command.invocationHint ? markdownCodeCell(command.invocationHint) : "None"} |`,
+      );
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import {
   normalizeCommandEffectProfile,
   normalizeCommandExposure,
@@ -201,6 +202,7 @@ export function buildCatalogList(
     runtimeCommands?: readonly CliCatalogRuntimeCommand[];
     pluginCommands?: readonly CliCatalogPluginCommand[];
     nodeCommands?: readonly CliCatalogNodeCommand[];
+    nodeCommandScope?: CliCatalogNodeCommandScope;
   } = {},
 ): CliCatalogList {
   const descriptors = buildDescriptors();
@@ -209,7 +211,7 @@ export function buildCatalogList(
   const runtimeCommands = params.runtimeCommands ?? [];
   const pluginCommands = params.pluginCommands ?? [];
   const nodeCommands = buildNodeCommandCatalog(params.nodeCommands);
-  const nodeCommandScope = resolveNodeCommandScope(nodeCommands);
+  const nodeCommandScope = params.nodeCommandScope ?? resolveNodeCommandScope(nodeCommands);
   return {
     schemaVersion: 1,
     generatedFrom: "command-inventory",
@@ -246,6 +248,7 @@ export function renderCatalogListMarkdown(
     runtimeCommands?: readonly CliCatalogRuntimeCommand[];
     pluginCommands?: readonly CliCatalogPluginCommand[];
     nodeCommands?: readonly CliCatalogNodeCommand[];
+    nodeCommandScope?: CliCatalogNodeCommandScope;
   } = {},
 ): string {
   const list = buildCatalogList(params);
@@ -315,8 +318,11 @@ export function renderCatalogListMarkdown(
       "| --- | --- | --- | --- | --- | --- | --- |",
     );
     for (const command of list.cli.nodeCommands) {
+      const nodeLabel = sanitizeTerminalText(
+        markdownTableCell(command.nodeName ?? command.nodeId ?? "Any"),
+      );
       lines.push(
-        `| ${markdownCodeCell(command.command)} | ${markdownTableCell(command.nodeName ?? command.nodeId ?? "Any")} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${command.invocationHint ? markdownCodeCell(command.invocationHint) : "None"} |`,
+        `| ${markdownCodeCell(command.command)} | ${nodeLabel} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${command.invocationHint ? markdownCodeCell(command.invocationHint) : "None"} |`,
       );
     }
   }

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -62,10 +62,20 @@ type CliCatalogListRoutedOperation = {
 };
 
 type CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
-type CliCatalogNodeCommandScope = "caller-supplied";
+type CliCatalogNodeCommandScope = "caller-supplied" | "live-gateway-query" | "mixed";
 
 const RUNTIME_COMMAND_SCOPE: CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
-const NODE_COMMAND_SCOPE: CliCatalogNodeCommandScope = "caller-supplied";
+function resolveNodeCommandScope(
+  commands: readonly CliCatalogNodeCommand[],
+): CliCatalogNodeCommandScope {
+  const liveCount = commands.filter(
+    (command) => command.discoveryMode === "runtime-node-query",
+  ).length;
+  if (liveCount === 0) {
+    return "caller-supplied";
+  }
+  return liveCount === commands.length ? "live-gateway-query" : "mixed";
+}
 
 export type CliCatalogList = {
   readonly schemaVersion: 1;
@@ -83,7 +93,7 @@ export type CliCatalogList = {
     readonly commandRoutes: "complete";
     readonly runtimeCommands: "collected" | "not-requested";
     readonly pluginCommands: "collected" | "not-requested";
-    readonly nodeCommands: "caller-supplied" | "not-requested";
+    readonly nodeCommands: CliCatalogNodeCommandScope | "not-requested";
   };
   readonly cli: {
     readonly descriptors: readonly CliCatalogListDescriptor[];
@@ -199,6 +209,7 @@ export function buildCatalogList(
   const runtimeCommands = params.runtimeCommands ?? [];
   const pluginCommands = params.pluginCommands ?? [];
   const nodeCommands = buildNodeCommandCatalog(params.nodeCommands);
+  const nodeCommandScope = resolveNodeCommandScope(nodeCommands);
   return {
     schemaVersion: 1,
     generatedFrom: "command-inventory",
@@ -215,14 +226,14 @@ export function buildCatalogList(
       commandRoutes: "complete",
       runtimeCommands: params.runtimeCommands === undefined ? "not-requested" : "collected",
       pluginCommands: params.pluginCommands === undefined ? "not-requested" : "collected",
-      nodeCommands: params.nodeCommands === undefined ? "not-requested" : "caller-supplied",
+      nodeCommands: params.nodeCommands === undefined ? "not-requested" : nodeCommandScope,
     },
     cli: {
       descriptors,
       commandRoutes,
       routedOperations,
       runtimeCommandScope: RUNTIME_COMMAND_SCOPE,
-      nodeCommandScope: NODE_COMMAND_SCOPE,
+      nodeCommandScope,
       runtimeCommands,
       pluginCommands,
       nodeCommands,
@@ -251,7 +262,7 @@ export function renderCatalogListMarkdown(
     `- Runtime commands: ${list.counts.runtimeCommands}`,
     `- Runtime command scope: ${list.cli.runtimeCommandScope}`,
     `- Plugin descriptor commands: ${list.counts.pluginCommands}`,
-    `- Supplied node commands: ${list.counts.nodeCommands}`,
+    `- Node commands: ${list.counts.nodeCommands}`,
     `- Node command scope: ${list.cli.nodeCommandScope}`,
     "",
     "## Routed operations",

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -15,6 +15,10 @@ function markdownTableCell(value: string): string {
   return value.replace(/\r\n?|\n/g, " ").replace(/\|/g, "\\|");
 }
 
+function markdownSafeSingleLineText(value: string): string {
+  return sanitizeTerminalText(value.replace(/\r\n?|\n|\t/g, " "));
+}
+
 function markdownCodeCell(value: string): string {
   const cell = markdownTableCell(value);
   const longestFence = Math.max(0, ...Array.from(cell.matchAll(/`+/g), (match) => match[0].length));
@@ -318,12 +322,12 @@ export function renderCatalogListMarkdown(
       "| --- | --- | --- | --- | --- | --- | --- |",
     );
     for (const command of list.cli.nodeCommands) {
-      const commandCell = markdownCodeCell(sanitizeTerminalText(command.command));
-      const nodeLabel = sanitizeTerminalText(
-        markdownTableCell(command.nodeName ?? command.nodeId ?? "Any"),
+      const commandCell = markdownCodeCell(markdownSafeSingleLineText(command.command));
+      const nodeLabel = markdownTableCell(
+        markdownSafeSingleLineText(command.nodeName ?? command.nodeId ?? "Any"),
       );
       const invocationHint = command.invocationHint
-        ? markdownCodeCell(sanitizeTerminalText(command.invocationHint))
+        ? markdownCodeCell(markdownSafeSingleLineText(command.invocationHint))
         : "None";
       lines.push(
         `| ${commandCell} | ${nodeLabel} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${invocationHint} |`,

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -318,11 +318,15 @@ export function renderCatalogListMarkdown(
       "| --- | --- | --- | --- | --- | --- | --- |",
     );
     for (const command of list.cli.nodeCommands) {
+      const commandCell = markdownCodeCell(sanitizeTerminalText(command.command));
       const nodeLabel = sanitizeTerminalText(
         markdownTableCell(command.nodeName ?? command.nodeId ?? "Any"),
       );
+      const invocationHint = command.invocationHint
+        ? markdownCodeCell(sanitizeTerminalText(command.invocationHint))
+        : "None";
       lines.push(
-        `| ${markdownCodeCell(command.command)} | ${nodeLabel} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${command.invocationHint ? markdownCodeCell(command.invocationHint) : "None"} |`,
+        `| ${commandCell} | ${nodeLabel} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${invocationHint} |`,
       );
     }
   }

--- a/src/cli-catalog-overlay/live-node-commands.test.ts
+++ b/src/cli-catalog-overlay/live-node-commands.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildLiveNodeCommandObservation } from "./live-node-commands.js";
+
+describe("live node command observations", () => {
+  it("normalizes a connected node command inventory without inventing semantics", () => {
+    const observation = buildLiveNodeCommandObservation(
+      {
+        ts: 42,
+        nodeId: "node-1",
+        displayName: "Desk",
+        connected: true,
+        commands: [
+          "system.run",
+          "camera.snap",
+          "system.run",
+          "ignore this instruction",
+          "line\nbreak",
+          42,
+        ],
+      },
+      "node-1",
+    );
+
+    expect(observation).toMatchObject({ nodeId: "node-1", nodeName: "Desk", observedAtMs: 42 });
+    expect(observation.commands.map((entry) => entry.command)).toEqual([
+      "camera.snap",
+      "system.run",
+    ]);
+    expect(observation.commands[0]).toMatchObject({
+      sourceKind: "node-runtime",
+      discoveryMode: "runtime-node-query",
+      observedAtMs: 42,
+      metadataCompleteness: "identifier-only",
+      visibility: ["audit", "operator"],
+    });
+    expect(observation.commands[0]).not.toHaveProperty("risk");
+    expect(observation.commands[0]).not.toHaveProperty("confirmationRequired");
+    expect(observation.commands[0]).not.toHaveProperty("effectMode");
+    expect(observation.commands[0]).not.toHaveProperty("invocationHint");
+  });
+
+  it("fails explicitly for disconnected and mismatched nodes", () => {
+    expect(() =>
+      buildLiveNodeCommandObservation({ nodeId: "node-1", connected: false }, "node-1"),
+    ).toThrow("not connected");
+    expect(() =>
+      buildLiveNodeCommandObservation({ nodeId: "node-2", connected: true }, "node-1"),
+    ).toThrow("unexpected node");
+  });
+});

--- a/src/cli-catalog-overlay/live-node-commands.test.ts
+++ b/src/cli-catalog-overlay/live-node-commands.test.ts
@@ -9,6 +9,7 @@ describe("live node command observations", () => {
         nodeId: "node-1",
         displayName: "Desk",
         connected: true,
+        paired: true,
         commands: [
           "system.run",
           "camera.snap",
@@ -24,6 +25,8 @@ describe("live node command observations", () => {
     expect(observation).toMatchObject({ nodeId: "node-1", nodeName: "Desk", observedAtMs: 42 });
     expect(observation.commands.map((entry) => entry.command)).toEqual([
       "camera.snap",
+      "ignore this instruction",
+      "line\nbreak",
       "system.run",
     ]);
     expect(observation.commands[0]).toMatchObject({
@@ -46,5 +49,14 @@ describe("live node command observations", () => {
     expect(() =>
       buildLiveNodeCommandObservation({ nodeId: "node-2", connected: true }, "node-1"),
     ).toThrow("unexpected node");
+  });
+
+  it("fails explicitly for connected nodes that are not paired", () => {
+    expect(() =>
+      buildLiveNodeCommandObservation(
+        { nodeId: "node-1", connected: true, paired: false, commands: ["system.run"] },
+        "node-1",
+      ),
+    ).toThrow("not paired");
   });
 });

--- a/src/cli-catalog-overlay/live-node-commands.ts
+++ b/src/cli-catalog-overlay/live-node-commands.ts
@@ -1,0 +1,73 @@
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { CliCatalogNodeCommand } from "./node-commands.js";
+
+type LiveNodeCommandObservation = {
+  readonly nodeId: string;
+  readonly nodeName?: string;
+  readonly observedAtMs?: number;
+  readonly commands: readonly CliCatalogNodeCommand[];
+};
+
+const NODE_COMMAND_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value
+        .map(normalizeOptionalString)
+        .filter((item): item is string => item !== undefined && NODE_COMMAND_ID_PATTERN.test(item)),
+    ),
+  ].toSorted();
+}
+
+export function buildLiveNodeCommandObservation(
+  value: unknown,
+  requestedNodeId: string,
+): LiveNodeCommandObservation {
+  const record = asRecord(value);
+  const nodeId = normalizeOptionalString(record.nodeId);
+  if (!nodeId || nodeId !== requestedNodeId) {
+    throw new Error(`node.describe returned an unexpected node for ${requestedNodeId}`);
+  }
+  if (record.connected !== true) {
+    throw new Error(`node ${nodeId} is not connected; live command inventory is unavailable`);
+  }
+
+  const nodeName = normalizeOptionalString(record.displayName);
+  const observedAtMs =
+    typeof record.ts === "number" && Number.isFinite(record.ts) ? record.ts : undefined;
+  const commands = stringList(record.commands).map((command): CliCatalogNodeCommand => {
+    const entry: CliCatalogNodeCommand = {
+      id: `node:${nodeId}:${command}`,
+      command,
+      title: command,
+      nodeId,
+      argumentHints: [],
+      effects: [],
+      trustBoundary: "paired-node",
+      sourceKind: "node-runtime",
+      sourceId: `${nodeId}:${command}`,
+      discoveryMode: "runtime-node-query",
+      metadataCompleteness: "identifier-only",
+      visibility: ["audit", "operator"],
+    };
+    if (nodeName) {
+      Object.assign(entry, { nodeName });
+    }
+    if (observedAtMs !== undefined) {
+      Object.assign(entry, { observedAtMs });
+    }
+    return entry;
+  });
+
+  return {
+    nodeId,
+    ...(nodeName ? { nodeName } : {}),
+    ...(observedAtMs !== undefined ? { observedAtMs } : {}),
+    commands,
+  };
+}

--- a/src/cli-catalog-overlay/live-node-commands.ts
+++ b/src/cli-catalog-overlay/live-node-commands.ts
@@ -9,17 +9,13 @@ type LiveNodeCommandObservation = {
   readonly commands: readonly CliCatalogNodeCommand[];
 };
 
-const NODE_COMMAND_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
-
 function stringList(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
   }
   return [
     ...new Set(
-      value
-        .map(normalizeOptionalString)
-        .filter((item): item is string => item !== undefined && NODE_COMMAND_ID_PATTERN.test(item)),
+      value.map(normalizeOptionalString).filter((item): item is string => item !== undefined),
     ),
   ].toSorted();
 }
@@ -35,6 +31,9 @@ export function buildLiveNodeCommandObservation(
   }
   if (record.connected !== true) {
     throw new Error(`node ${nodeId} is not connected; live command inventory is unavailable`);
+  }
+  if (record.paired !== true) {
+    throw new Error(`node ${nodeId} is not paired; live command inventory is unavailable`);
   }
 
   const nodeName = normalizeOptionalString(record.displayName);

--- a/src/cli-catalog-overlay/node-commands.ts
+++ b/src/cli-catalog-overlay/node-commands.ts
@@ -1,0 +1,63 @@
+import type {
+  CliCatalogEffectMode,
+  CliCatalogRisk,
+  CliCatalogVisibility,
+} from "../cli/catalog-metadata.js";
+
+type CliCatalogNodeCommandSourceKind = "node-pairing" | "node-host-command" | "node-runtime";
+
+type CliCatalogNodeCommandDiscoveryMode =
+  | "paired-node-declaration"
+  | "node-host-registry"
+  | "runtime-node-query";
+
+type CliCatalogNodeCommandAvailability =
+  | "approved"
+  | "pending-approval"
+  | "available"
+  | "unavailable";
+
+type CliCatalogNodeCommandApprovalKind =
+  | "pairing"
+  | "gateway-allowlist"
+  | "operator-confirmation"
+  | "none";
+
+export type CliCatalogNodeCommand = {
+  readonly id: string;
+  readonly command: string;
+  readonly title: string;
+  readonly nodeId?: string;
+  readonly nodeName?: string;
+  readonly cap?: string;
+  readonly description?: string;
+  readonly argumentHints: readonly string[];
+  readonly invocationHint?: string;
+  readonly availability?: CliCatalogNodeCommandAvailability;
+  readonly approvalKind?: CliCatalogNodeCommandApprovalKind;
+  readonly risk?: CliCatalogRisk;
+  readonly confirmationRequired?: boolean;
+  readonly effectMode?: CliCatalogEffectMode;
+  readonly effects: readonly string[];
+  readonly trustBoundary: "local-node-host" | "paired-node" | "remote-node";
+  readonly sourceKind: CliCatalogNodeCommandSourceKind;
+  readonly sourceId: string;
+  readonly discoveryMode: CliCatalogNodeCommandDiscoveryMode;
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+const DEFAULT_NODE_COMMAND_VISIBILITY: readonly CliCatalogVisibility[] = ["audit", "operator"];
+
+export function buildNodeCommandCatalog(
+  commands: readonly CliCatalogNodeCommand[] = [],
+): readonly CliCatalogNodeCommand[] {
+  return commands
+    .filter((command) => command.id.trim() && command.command.trim())
+    .map((command) =>
+      Object.assign({}, command, {
+        visibility:
+          command.visibility.length > 0 ? command.visibility : DEFAULT_NODE_COMMAND_VISIBILITY,
+      }),
+    )
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+}

--- a/src/cli-catalog-overlay/node-commands.ts
+++ b/src/cli-catalog-overlay/node-commands.ts
@@ -43,6 +43,8 @@ export type CliCatalogNodeCommand = {
   readonly sourceKind: CliCatalogNodeCommandSourceKind;
   readonly sourceId: string;
   readonly discoveryMode: CliCatalogNodeCommandDiscoveryMode;
+  readonly observedAtMs?: number;
+  readonly metadataCompleteness?: "identifier-only" | "enriched";
   readonly visibility: readonly CliCatalogVisibility[];
 };
 

--- a/src/cli-catalog-overlay/plugin-commands.test.ts
+++ b/src/cli-catalog-overlay/plugin-commands.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import { buildPluginCatalogCommands } from "./plugin-commands.js";
+
+describe("plugin command catalog", () => {
+  it("projects plugin CLI descriptors into source-labeled catalog entries", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "example-plugin",
+        parentPath: ["nodes"],
+        commands: ["camera"],
+        descriptors: [
+          { name: "camera", description: "Camera controls", hasSubcommands: true },
+          {
+            name: "status",
+            description: "Internal camera status",
+            hasSubcommands: false,
+          },
+        ],
+      },
+    ]);
+
+    expect(pluginCommands).toEqual([
+      expect.objectContaining({
+        pluginId: "example-plugin",
+        commandPath: ["nodes", "camera"],
+        parentPath: ["nodes"],
+        depth: 2,
+        descriptorName: "camera",
+        sourceKind: "plugin",
+        sourceId: "example-plugin:nodes camera",
+        discoveryMode: "plugin-descriptor",
+      }),
+      expect.objectContaining({
+        sourceId: "example-plugin:nodes status",
+      }),
+    ]);
+    expect(pluginCommands[0]).not.toHaveProperty("risk");
+    expect(pluginCommands[0]).not.toHaveProperty("effectMode");
+    expect(pluginCommands[0]).not.toHaveProperty("confirmationRequired");
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(2);
+  });
+
+  it("omits plugin CLI command registrations without descriptors", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "voice-plugin",
+        parentPath: [],
+        commands: ["voicecall"],
+        descriptors: [],
+      },
+    ]);
+
+    expect(pluginCommands).toEqual([]);
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(0);
+  });
+
+  it("keeps plugin descriptions inside their Markdown table cells", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "example-plugin",
+        parentPath: [],
+        commands: ["camera"],
+        descriptors: [
+          {
+            name: "camera",
+            description: "Camera | controls\nfor operators",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(renderCatalogListMarkdown({ pluginCommands })).toContain(
+      "| `camera` | None | 1 | `example-plugin` | Camera \\| controls for operators |",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/plugin-commands.test.ts
+++ b/src/cli-catalog-overlay/plugin-commands.test.ts
@@ -55,6 +55,32 @@ describe("plugin command catalog", () => {
     expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(0);
   });
 
+  it("omits plugin descriptors under reserved core command roots", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "tools-plugin",
+        parentPath: ["tools"],
+        commands: ["sync"],
+        descriptors: [{ name: "sync", description: "Sync tools", hasSubcommands: false }],
+      },
+      {
+        pluginId: "auth-plugin",
+        parentPath: [],
+        commands: ["auth"],
+        descriptors: [{ name: "auth", description: "Auth replacement", hasSubcommands: false }],
+      },
+      {
+        pluginId: "node-plugin",
+        parentPath: ["nodes"],
+        commands: ["camera"],
+        descriptors: [{ name: "camera", description: "Camera controls", hasSubcommands: false }],
+      },
+    ]);
+
+    expect(pluginCommands.map((command) => command.commandPath)).toEqual([["nodes", "camera"]]);
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(1);
+  });
+
   it("keeps plugin descriptions inside their Markdown table cells", () => {
     const pluginCommands = buildPluginCatalogCommands([
       {

--- a/src/cli-catalog-overlay/plugin-commands.ts
+++ b/src/cli-catalog-overlay/plugin-commands.ts
@@ -1,3 +1,4 @@
+import { isReservedNonPluginCommandRoot } from "../cli/command-registration-policy.js";
 import type { PluginCliDescriptorEntry } from "../plugins/cli-registry-loader.js";
 
 export type CliCatalogPluginCommand = {
@@ -19,22 +20,27 @@ export function buildPluginCatalogCommands(
   entries: readonly PluginCliDescriptorEntry[],
 ): readonly CliCatalogPluginCommand[] {
   return entries.flatMap((entry) => {
-    return entry.descriptors.map((descriptor) => {
+    return entry.descriptors.flatMap((descriptor): CliCatalogPluginCommand[] => {
       const commandPath = [...entry.parentPath, descriptor.name];
-      return {
-        pluginId: entry.pluginId,
-        commandPath,
-        parentPath: entry.parentPath,
-        depth: commandPath.length,
-        name: descriptor.name,
-        descriptorName: descriptor.name,
-        description: descriptor.description,
-        hasSubcommands: descriptor.hasSubcommands,
-        commandHints: [commandPath.join(" ")],
-        sourceKind: "plugin" as const,
-        sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
-        discoveryMode: "plugin-descriptor" as const,
-      };
+      if (isReservedNonPluginCommandRoot(commandPath[0])) {
+        return [];
+      }
+      return [
+        {
+          pluginId: entry.pluginId,
+          commandPath,
+          parentPath: entry.parentPath,
+          depth: commandPath.length,
+          name: descriptor.name,
+          descriptorName: descriptor.name,
+          description: descriptor.description,
+          hasSubcommands: descriptor.hasSubcommands,
+          commandHints: [commandPath.join(" ")],
+          sourceKind: "plugin" as const,
+          sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
+          discoveryMode: "plugin-descriptor" as const,
+        },
+      ];
     });
   });
 }

--- a/src/cli-catalog-overlay/plugin-commands.ts
+++ b/src/cli-catalog-overlay/plugin-commands.ts
@@ -1,0 +1,40 @@
+import type { PluginCliDescriptorEntry } from "../plugins/cli-registry-loader.js";
+
+export type CliCatalogPluginCommand = {
+  readonly pluginId: string;
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly depth: number;
+  readonly name: string;
+  readonly descriptorName: string;
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly commandHints: readonly string[];
+  readonly sourceKind: "plugin";
+  readonly sourceId: string;
+  readonly discoveryMode: "plugin-descriptor";
+};
+
+export function buildPluginCatalogCommands(
+  entries: readonly PluginCliDescriptorEntry[],
+): readonly CliCatalogPluginCommand[] {
+  return entries.flatMap((entry) => {
+    return entry.descriptors.map((descriptor) => {
+      const commandPath = [...entry.parentPath, descriptor.name];
+      return {
+        pluginId: entry.pluginId,
+        commandPath,
+        parentPath: entry.parentPath,
+        depth: commandPath.length,
+        name: descriptor.name,
+        descriptorName: descriptor.name,
+        description: descriptor.description,
+        hasSubcommands: descriptor.hasSubcommands,
+        commandHints: [commandPath.join(" ")],
+        sourceKind: "plugin" as const,
+        sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
+        discoveryMode: "plugin-descriptor" as const,
+      };
+    });
+  });
+}

--- a/src/cli-catalog-overlay/runtime-commands.test.ts
+++ b/src/cli-catalog-overlay/runtime-commands.test.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import { collectRuntimeCommandTree } from "./runtime-commands.js";
+
+describe("runtime command catalog", () => {
+  it("enumerates the currently registered Commander tree", () => {
+    const program = new Command();
+    program.command("alpha").description("Alpha command").alias("a");
+    program
+      .command("beta")
+      .description("Beta command")
+      .command("child")
+      .description("Nested child");
+    program
+      .command("secret", { hidden: true })
+      .description("Hidden command")
+      .command("child")
+      .description("Hidden child");
+
+    const runtimeCommands = collectRuntimeCommandTree(program);
+
+    expect(runtimeCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          commandPath: ["alpha"],
+          parentPath: [],
+          depth: 1,
+          aliases: ["a"],
+          visibleSubcommandCount: 0,
+          hidden: false,
+          discoveryMode: "runtime-registered",
+          sourceKind: "runtime",
+        }),
+        expect.objectContaining({
+          commandPath: ["beta"],
+          hasSubcommands: true,
+          visibleSubcommandCount: 1,
+        }),
+        expect.objectContaining({ commandPath: ["beta", "child"], parentPath: ["beta"], depth: 2 }),
+      ]),
+    );
+    expect(runtimeCommands.map((command) => command.commandPath)).not.toContainEqual(["secret"]);
+    expect(runtimeCommands.map((command) => command.commandPath)).not.toContainEqual([
+      "secret",
+      "child",
+    ]);
+    expect(
+      runtimeCommands.find((command) => command.commandPath[0] === "secret-visible-parent"),
+    ).toBeUndefined();
+    expect(buildCatalogList({ runtimeCommands }).counts.runtimeCommands).toBe(3);
+  });
+
+  it("keeps runtime descriptions inside their Markdown table cells", () => {
+    const program = new Command();
+    program.command("alpha").description("Alpha | command\nfor operators");
+    const runtimeCommands = collectRuntimeCommandTree(program);
+
+    expect(renderCatalogListMarkdown({ runtimeCommands })).toContain(
+      "| `alpha` | None | 1 | 0 | Alpha \\| command for operators |",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/runtime-commands.ts
+++ b/src/cli-catalog-overlay/runtime-commands.ts
@@ -1,0 +1,62 @@
+import type { Command } from "commander";
+import type { CliCatalogVisibility } from "../cli/catalog-metadata.js";
+
+export type CliCatalogRuntimeCommand = {
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly depth: number;
+  readonly name: string;
+  readonly aliases: readonly string[];
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly visibleSubcommandCount: number;
+  readonly hidden: false;
+  readonly sourceKind: "runtime";
+  readonly sourceId: string;
+  readonly discoveryMode: "runtime-registered";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+function commandDescription(command: Command): string {
+  return command.description().trim();
+}
+
+function isHiddenCommand(command: Command): boolean {
+  return Reflect.get(command, "_hidden") === true;
+}
+
+function visibleChildren(command: Command): readonly Command[] {
+  return command.commands.filter((child) => !isHiddenCommand(child));
+}
+
+function collectChildren(
+  command: Command,
+  parentPath: readonly string[],
+): CliCatalogRuntimeCommand[] {
+  const result: CliCatalogRuntimeCommand[] = [];
+  for (const child of visibleChildren(command)) {
+    const commandPath = [...parentPath, child.name()];
+    const childCommands = visibleChildren(child);
+    const entry: CliCatalogRuntimeCommand = {
+      commandPath,
+      parentPath,
+      depth: commandPath.length,
+      name: child.name(),
+      aliases: child.aliases(),
+      description: commandDescription(child),
+      hasSubcommands: childCommands.length > 0,
+      visibleSubcommandCount: childCommands.length,
+      hidden: false,
+      sourceKind: "runtime",
+      sourceId: commandPath.join(" "),
+      discoveryMode: "runtime-registered",
+      visibility: ["audit", "operator", "policy"],
+    };
+    result.push(entry, ...collectChildren(child, commandPath));
+  }
+  return result;
+}
+
+export function collectRuntimeCommandTree(program: Command): readonly CliCatalogRuntimeCommand[] {
+  return collectChildren(program, []);
+}

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -1,0 +1,219 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loggingState } from "../logging/state.js";
+import { registerCommandsCli } from "./catalog-cli.js";
+
+const loadPluginCliDescriptorEntriesMock = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/cli-registry-loader.js").loadPluginCliDescriptorEntries>(
+    async () => [],
+  ),
+);
+
+vi.mock("../plugins/cli-registry-loader.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../plugins/cli-registry-loader.js")>();
+  return {
+    ...original,
+    loadPluginCliDescriptorEntries: loadPluginCliDescriptorEntriesMock,
+  };
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (text) => process.stdout.write(text),
+    writeErr: (text) => process.stderr.write(text),
+  });
+  registerCommandsCli(program.command("tools"));
+  return program;
+}
+
+async function captureStdout(run: () => Promise<void> | void): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await run();
+    return chunks.join("");
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("tools commands cli", () => {
+  afterEach(() => {
+    loadPluginCliDescriptorEntriesMock.mockReset();
+    loadPluginCliDescriptorEntriesMock.mockResolvedValue([]);
+    loggingState.forceConsoleToStderr = false;
+    loggingState.earlyConsoleRoutingRestore = null;
+  });
+
+  it("prints parent help for a bare tools commands invocation", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync(["node", "openclaw", "tools", "commands"]);
+    });
+
+    expect(output).toContain("list");
+    expect(output).toContain("inspect");
+    expect(output).not.toContain("audit");
+  });
+
+  it("prints command inventory JSON", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync(["node", "openclaw", "tools", "commands", "list", "--json"]);
+    });
+    const parsed = JSON.parse(output) as {
+      counts: { commandDescriptors: number; routedOperations: number; runtimeCommands: number };
+    };
+
+    expect(parsed.counts.commandDescriptors).toBeGreaterThan(50);
+    expect(parsed.counts.routedOperations).toBeGreaterThan(10);
+    expect(parsed.counts.runtimeCommands).toBeGreaterThan(0);
+  });
+
+  it("inspects an exact nested command path", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "gateway",
+        "status",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as {
+      found: boolean;
+      commandPath: string[];
+      routes: unknown[];
+    };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.commandPath).toEqual(["gateway", "status"]);
+    expect(parsed.routes).toHaveLength(2);
+  });
+
+  it("loads a lazy sub-CLI before inspecting a nested command", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "models",
+        "aliases",
+        "list",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as { found: boolean; runtimeCommands: unknown[] };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it("loads a lazy core command group before inspection", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "message",
+        "send",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as { found: boolean; runtimeCommands: unknown[] };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it("loads plugin descriptors only when requested and keeps JSON clean", async () => {
+    const forceStderrSnapshots: boolean[] = [];
+    loadPluginCliDescriptorEntriesMock.mockImplementationOnce(async () => {
+      forceStderrSnapshots.push(loggingState.forceConsoleToStderr);
+      return [
+        {
+          pluginId: "example-plugin",
+          parentPath: [],
+          commands: ["example"],
+          descriptors: [
+            { name: "example", description: "Example plugin command", hasSubcommands: false },
+          ],
+        },
+      ];
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "example",
+        "--json",
+        "--plugin-descriptors",
+      ]);
+    });
+
+    expect(forceStderrSnapshots).toEqual([true]);
+    expect(JSON.parse(output).pluginCommands).toHaveLength(1);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("routes plugin logs away from Markdown output", async () => {
+    const forceStderrSnapshots: boolean[] = [];
+    loadPluginCliDescriptorEntriesMock.mockImplementationOnce(async () => {
+      forceStderrSnapshots.push(loggingState.forceConsoleToStderr);
+      return [];
+    });
+
+    await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--markdown",
+        "--plugin-descriptors",
+      ]);
+    });
+
+    expect(forceStderrSnapshots).toEqual([true]);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("fails instead of emitting an incomplete inventory when plugin loading fails", async () => {
+    loadPluginCliDescriptorEntriesMock.mockRejectedValueOnce(
+      new Error("Failed to load plugin CLI descriptor metadata: example-plugin: register failed"),
+    );
+
+    const output = await captureStdout(async () => {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "openclaw",
+          "tools",
+          "commands",
+          "list",
+          "--json",
+          "--plugin-descriptors",
+        ]),
+      ).rejects.toThrow("Failed to load plugin CLI descriptor metadata");
+    });
+
+    expect(output).toBe("");
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+});

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -187,6 +187,36 @@ describe("tools commands cli", () => {
     });
   });
 
+  it("normalizes the requested node ID before querying Gateway", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      nodeId: "node-1",
+      connected: true,
+      paired: true,
+      commands: ["system.run"],
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--json",
+        "--node",
+        " node-1 ",
+      ]);
+    });
+    const parsed = JSON.parse(output) as { cli: { nodeCommands: Array<{ nodeId: string }> } };
+
+    expect(callNodeDiagnosticsGatewayCliMock).toHaveBeenCalledWith(
+      "node.describe",
+      expect.objectContaining({ json: true }),
+      { nodeId: "node-1" },
+    );
+    expect(parsed.cli.nodeCommands[0]?.nodeId).toBe("node-1");
+  });
+
   it("preserves Gateway-valid command strings from a paired node", async () => {
     callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
       nodeId: "node-1",

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -150,6 +150,7 @@ describe("tools commands cli", () => {
       nodeId: "node-1",
       displayName: "Desk",
       connected: true,
+      paired: true,
       commands: ["system.run"],
     });
 
@@ -186,10 +187,71 @@ describe("tools commands cli", () => {
     });
   });
 
+  it("preserves Gateway-valid command strings from a paired node", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      nodeId: "node-1",
+      connected: true,
+      paired: true,
+      commands: ["vendor/foo", "system.run"],
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--json",
+        "--node",
+        "node-1",
+      ]);
+    });
+    const parsed = JSON.parse(output) as {
+      cli: { nodeCommands: Array<{ command: string }> };
+    };
+
+    expect(parsed.cli.nodeCommands.map((command) => command.command)).toEqual([
+      "system.run",
+      "vendor/foo",
+    ]);
+  });
+
+  it("keeps live Gateway provenance when the paired node has no commands", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      nodeId: "node-1",
+      connected: true,
+      paired: true,
+      commands: [],
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--json",
+        "--node",
+        "node-1",
+      ]);
+    });
+    const parsed = JSON.parse(output) as {
+      collection: { nodeCommands: string };
+      cli: { nodeCommandScope: string; nodeCommands: unknown[] };
+    };
+
+    expect(parsed.collection.nodeCommands).toBe("live-gateway-query");
+    expect(parsed.cli.nodeCommandScope).toBe("live-gateway-query");
+    expect(parsed.cli.nodeCommands).toHaveLength(0);
+  });
+
   it("fails without JSON output when the selected node is disconnected", async () => {
     callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
       nodeId: "node-1",
       connected: false,
+      paired: true,
       commands: ["system.run"],
     });
 
@@ -206,6 +268,32 @@ describe("tools commands cli", () => {
           "node-1",
         ]),
       ).rejects.toThrow("not connected");
+    });
+
+    expect(output).toBe("");
+  });
+
+  it("fails without JSON output when the selected node is not paired", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      nodeId: "node-1",
+      connected: true,
+      paired: false,
+      commands: ["system.run"],
+    });
+
+    const output = await captureStdout(async () => {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "openclaw",
+          "tools",
+          "commands",
+          "list",
+          "--json",
+          "--node",
+          "node-1",
+        ]),
+      ).rejects.toThrow("not paired");
     });
 
     expect(output).toBe("");

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -3,6 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../logging/state.js";
 import { registerCommandsCli } from "./catalog-cli.js";
 
+const callNodeDiagnosticsGatewayCliMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./nodes-cli/rpc.js", () => ({
+  callNodeDiagnosticsGatewayCli: callNodeDiagnosticsGatewayCliMock,
+}));
+
 const loadPluginCliDescriptorEntriesMock = vi.hoisted(() =>
   vi.fn<typeof import("../plugins/cli-registry-loader.js").loadPluginCliDescriptorEntries>(
     async () => [],
@@ -45,6 +51,7 @@ async function captureStdout(run: () => Promise<void> | void): Promise<string> {
 
 describe("tools commands cli", () => {
   afterEach(() => {
+    callNodeDiagnosticsGatewayCliMock.mockReset();
     loadPluginCliDescriptorEntriesMock.mockReset();
     loadPluginCliDescriptorEntriesMock.mockResolvedValue([]);
     loggingState.forceConsoleToStderr = false;
@@ -135,6 +142,73 @@ describe("tools commands cli", () => {
 
     expect(parsed.found).toBe(true);
     expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it("includes commands from one connected paired node when requested", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      ts: 42,
+      nodeId: "node-1",
+      displayName: "Desk",
+      connected: true,
+      commands: ["system.run"],
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--json",
+        "--node",
+        "node-1",
+      ]);
+    });
+    const parsed = JSON.parse(output) as {
+      counts: { nodeCommands: number };
+      cli: {
+        nodeCommandScope: string;
+        nodeCommands: Array<{ command: string; discoveryMode: string }>;
+      };
+    };
+
+    expect(callNodeDiagnosticsGatewayCliMock).toHaveBeenCalledWith(
+      "node.describe",
+      expect.objectContaining({ json: true }),
+      { nodeId: "node-1" },
+    );
+    expect(parsed.counts.nodeCommands).toBe(1);
+    expect(parsed.cli.nodeCommandScope).toBe("live-gateway-query");
+    expect(parsed.cli.nodeCommands[0]).toMatchObject({
+      command: "system.run",
+      discoveryMode: "runtime-node-query",
+    });
+  });
+
+  it("fails without JSON output when the selected node is disconnected", async () => {
+    callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
+      nodeId: "node-1",
+      connected: false,
+      commands: ["system.run"],
+    });
+
+    const output = await captureStdout(async () => {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "openclaw",
+          "tools",
+          "commands",
+          "list",
+          "--json",
+          "--node",
+          "node-1",
+        ]),
+      ).rejects.toThrow("not connected");
+    });
+
+    expect(output).toBe("");
   });
 
   it("loads plugin descriptors only when requested and keeps JSON clean", async () => {

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -217,6 +217,26 @@ describe("tools commands cli", () => {
     expect(parsed.cli.nodeCommands[0]?.nodeId).toBe("node-1");
   });
 
+  it("fails without JSON output when --node is blank", async () => {
+    const output = await captureStdout(async () => {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "openclaw",
+          "tools",
+          "commands",
+          "list",
+          "--json",
+          "--node",
+          " ",
+        ]),
+      ).rejects.toThrow("--node must be a non-empty node id");
+    });
+
+    expect(callNodeDiagnosticsGatewayCliMock).not.toHaveBeenCalled();
+    expect(output).toBe("");
+  });
+
   it("preserves Gateway-valid command strings from a paired node", async () => {
     callNodeDiagnosticsGatewayCliMock.mockResolvedValue({
       nodeId: "node-1",

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -1,0 +1,111 @@
+import type { Command } from "commander";
+import { inspectCommand, renderCommandInspectionMarkdown } from "../cli-catalog-overlay/inspect.js";
+import { buildCatalogList, renderCatalogListMarkdown } from "../cli-catalog-overlay/list.js";
+import { buildPluginCatalogCommands } from "../cli-catalog-overlay/plugin-commands.js";
+import { collectRuntimeCommandTree } from "../cli-catalog-overlay/runtime-commands.js";
+import { loadPluginCliDescriptorEntries } from "../plugins/cli-registry-loader.js";
+import { withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+async function loadPluginCommands() {
+  const entries = await withConsoleLogsRoutedToStderrForJson(
+    ["--json"],
+    async () => await loadPluginCliDescriptorEntries({}),
+  );
+  return buildPluginCatalogCommands(entries);
+}
+
+function validateOutputOptions(
+  opts: { json?: boolean; markdown?: boolean },
+  command: Command,
+): void {
+  if (opts.json && opts.markdown) {
+    command.error("error: --json and --markdown cannot be combined");
+  }
+}
+
+async function loadInspectedCommandGroup(
+  program: Command,
+  commandPath: readonly string[],
+): Promise<void> {
+  const root = commandPath[0];
+  if (!root || root === "tools") {
+    return;
+  }
+  const argv = ["node", "openclaw", ...commandPath];
+  const [{ registerCoreCliByName }, { createProgramContext }, { registerSubCliByName }] =
+    await Promise.all([
+      import("./program/command-registry-core.js"),
+      import("./program/context.js"),
+      import("./program/register.subclis.js"),
+    ]);
+  if (await registerCoreCliByName(program, createProgramContext(), root, argv)) {
+    return;
+  }
+  await registerSubCliByName(program, root, argv);
+}
+
+export function registerCommandsCli(program: Command): void {
+  const inventoryRoot = program.parent ?? program;
+  const commands = program.command("commands").description("List and inspect OpenClaw commands");
+
+  commands
+    .command("list")
+    .description("List CLI, routed, runtime, and opt-in plugin commands")
+    .option("--json", "Output JSON", false)
+    .option("--markdown", "Output Markdown", false)
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
+    .action(
+      async (
+        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+        command: Command,
+      ) => {
+        validateOutputOptions(opts, command);
+        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+        if (opts.json) {
+          process.stdout.write(
+            `${JSON.stringify(buildCatalogList({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) }), null, 2)}\n`,
+          );
+          return;
+        }
+        process.stdout.write(
+          `${renderCatalogListMarkdown({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) })}\n`,
+        );
+      },
+    );
+
+  commands
+    .command("inspect")
+    .description("Inspect one exact command path")
+    .argument("<command-path...>", "Command path to inspect")
+    .option("--json", "Output JSON", false)
+    .option("--markdown", "Output Markdown", false)
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
+    .action(
+      async (
+        commandPath: string[],
+        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+        command: Command,
+      ) => {
+        validateOutputOptions(opts, command);
+        await loadInspectedCommandGroup(inventoryRoot, commandPath);
+        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+        const inspection = inspectCommand(
+          buildCatalogList({
+            runtimeCommands,
+            ...(pluginCommands ? { pluginCommands } : {}),
+          }),
+          commandPath,
+        );
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(inspection, null, 2)}\n`);
+          return;
+        }
+        process.stdout.write(`${renderCommandInspectionMarkdown(inspection)}\n`);
+      },
+    );
+
+  applyParentDefaultHelpAction(commands);
+}

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { inspectCommand, renderCommandInspectionMarkdown } from "../cli-catalog-overlay/inspect.js";
 import { buildCatalogList, renderCatalogListMarkdown } from "../cli-catalog-overlay/list.js";
@@ -32,12 +33,16 @@ async function loadNodeCommandObservation(opts: NodeInventoryOpts) {
   if (!opts.node) {
     return undefined;
   }
+  const nodeId = normalizeOptionalString(opts.node);
+  if (!nodeId) {
+    throw new Error("--node must be a non-empty node id");
+  }
   const result = await callNodeDiagnosticsGatewayCli(
     "node.describe",
     { ...opts, json: true },
-    { nodeId: opts.node },
+    { nodeId },
   );
-  return buildLiveNodeCommandObservation(result, opts.node);
+  return buildLiveNodeCommandObservation(result, nodeId);
 }
 
 function validateOutputOptions(

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -1,10 +1,13 @@
 import type { Command } from "commander";
 import { inspectCommand, renderCommandInspectionMarkdown } from "../cli-catalog-overlay/inspect.js";
 import { buildCatalogList, renderCatalogListMarkdown } from "../cli-catalog-overlay/list.js";
+import { buildLiveNodeCommandObservation } from "../cli-catalog-overlay/live-node-commands.js";
 import { buildPluginCatalogCommands } from "../cli-catalog-overlay/plugin-commands.js";
 import { collectRuntimeCommandTree } from "../cli-catalog-overlay/runtime-commands.js";
 import { loadPluginCliDescriptorEntries } from "../plugins/cli-registry-loader.js";
 import { withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
+import { callNodeDiagnosticsGatewayCli } from "./nodes-cli/rpc.js";
+import type { NodesRpcOpts } from "./nodes-cli/types.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
 async function loadPluginCommands() {
@@ -13,6 +16,28 @@ async function loadPluginCommands() {
     async () => await loadPluginCliDescriptorEntries({}),
   );
   return buildPluginCatalogCommands(entries);
+}
+
+type NodeInventoryOpts = NodesRpcOpts & { node?: string };
+
+function addNodeInventoryOptions(command: Command): Command {
+  return command
+    .option("--node <node-id>", "Include commands advertised by one connected paired node")
+    .option("--url <url>", "Gateway WebSocket URL")
+    .option("--token <token>", "Gateway token")
+    .option("--timeout <ms>", "Gateway timeout in ms", "10000");
+}
+
+async function loadNodeCommands(opts: NodeInventoryOpts) {
+  if (!opts.node) {
+    return undefined;
+  }
+  const result = await callNodeDiagnosticsGatewayCli(
+    "node.describe",
+    { ...opts, json: true },
+    { nodeId: opts.node },
+  );
+  return buildLiveNodeCommandObservation(result, opts.node).commands;
 }
 
 function validateOutputOptions(
@@ -49,63 +74,67 @@ export function registerCommandsCli(program: Command): void {
   const inventoryRoot = program.parent ?? program;
   const commands = program.command("commands").description("List and inspect OpenClaw commands");
 
-  commands
+  const listCommand = commands
     .command("list")
     .description("List CLI, routed, runtime, and opt-in plugin commands")
     .option("--json", "Output JSON", false)
     .option("--markdown", "Output Markdown", false)
-    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
-    .action(
-      async (
-        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
-        command: Command,
-      ) => {
-        validateOutputOptions(opts, command);
-        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
-        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
-        if (opts.json) {
-          process.stdout.write(
-            `${JSON.stringify(buildCatalogList({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) }), null, 2)}\n`,
-          );
-          return;
-        }
-        process.stdout.write(
-          `${renderCatalogListMarkdown({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) })}\n`,
-        );
-      },
-    );
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false);
+  addNodeInventoryOptions(listCommand).action(
+    async (
+      opts: NodeInventoryOpts & { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+      command: Command,
+    ) => {
+      validateOutputOptions(opts, command);
+      const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+      const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+      const nodeCommands = await loadNodeCommands(opts);
+      const catalogParams = {
+        runtimeCommands,
+        ...(pluginCommands ? { pluginCommands } : {}),
+        ...(nodeCommands ? { nodeCommands } : {}),
+      };
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(buildCatalogList(catalogParams), null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(`${renderCatalogListMarkdown(catalogParams)}\n`);
+    },
+  );
 
-  commands
+  const inspectCommandCli = commands
     .command("inspect")
     .description("Inspect one exact command path")
     .argument("<command-path...>", "Command path to inspect")
     .option("--json", "Output JSON", false)
     .option("--markdown", "Output Markdown", false)
-    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
-    .action(
-      async (
-        commandPath: string[],
-        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
-        command: Command,
-      ) => {
-        validateOutputOptions(opts, command);
-        await loadInspectedCommandGroup(inventoryRoot, commandPath);
-        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
-        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
-        const inspection = inspectCommand(
-          buildCatalogList({
-            runtimeCommands,
-            ...(pluginCommands ? { pluginCommands } : {}),
-          }),
-          commandPath,
-        );
-        if (opts.json) {
-          process.stdout.write(`${JSON.stringify(inspection, null, 2)}\n`);
-          return;
-        }
-        process.stdout.write(`${renderCommandInspectionMarkdown(inspection)}\n`);
-      },
-    );
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false);
+  addNodeInventoryOptions(inspectCommandCli).action(
+    async (
+      commandPath: string[],
+      opts: NodeInventoryOpts & { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+      command: Command,
+    ) => {
+      validateOutputOptions(opts, command);
+      await loadInspectedCommandGroup(inventoryRoot, commandPath);
+      const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+      const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+      const nodeCommands = await loadNodeCommands(opts);
+      const inspection = inspectCommand(
+        buildCatalogList({
+          runtimeCommands,
+          ...(pluginCommands ? { pluginCommands } : {}),
+          ...(nodeCommands ? { nodeCommands } : {}),
+        }),
+        commandPath,
+      );
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(inspection, null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(`${renderCommandInspectionMarkdown(inspection)}\n`);
+    },
+  );
 
   applyParentDefaultHelpAction(commands);
 }

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -28,7 +28,7 @@ function addNodeInventoryOptions(command: Command): Command {
     .option("--timeout <ms>", "Gateway timeout in ms", "10000");
 }
 
-async function loadNodeCommands(opts: NodeInventoryOpts) {
+async function loadNodeCommandObservation(opts: NodeInventoryOpts) {
   if (!opts.node) {
     return undefined;
   }
@@ -37,7 +37,7 @@ async function loadNodeCommands(opts: NodeInventoryOpts) {
     { ...opts, json: true },
     { nodeId: opts.node },
   );
-  return buildLiveNodeCommandObservation(result, opts.node).commands;
+  return buildLiveNodeCommandObservation(result, opts.node);
 }
 
 function validateOutputOptions(
@@ -88,11 +88,16 @@ export function registerCommandsCli(program: Command): void {
       validateOutputOptions(opts, command);
       const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
       const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
-      const nodeCommands = await loadNodeCommands(opts);
+      const nodeObservation = await loadNodeCommandObservation(opts);
       const catalogParams = {
         runtimeCommands,
         ...(pluginCommands ? { pluginCommands } : {}),
-        ...(nodeCommands ? { nodeCommands } : {}),
+        ...(nodeObservation
+          ? {
+              nodeCommands: nodeObservation.commands,
+              nodeCommandScope: "live-gateway-query" as const,
+            }
+          : {}),
       };
       if (opts.json) {
         process.stdout.write(`${JSON.stringify(buildCatalogList(catalogParams), null, 2)}\n`);
@@ -119,12 +124,17 @@ export function registerCommandsCli(program: Command): void {
       await loadInspectedCommandGroup(inventoryRoot, commandPath);
       const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
       const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
-      const nodeCommands = await loadNodeCommands(opts);
+      const nodeObservation = await loadNodeCommandObservation(opts);
       const inspection = inspectCommand(
         buildCatalogList({
           runtimeCommands,
           ...(pluginCommands ? { pluginCommands } : {}),
-          ...(nodeCommands ? { nodeCommands } : {}),
+          ...(nodeObservation
+            ? {
+                nodeCommands: nodeObservation.commands,
+                nodeCommandScope: "live-gateway-query" as const,
+              }
+            : {}),
         }),
         commandPath,
       );

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -30,7 +30,7 @@ function addNodeInventoryOptions(command: Command): Command {
 }
 
 async function loadNodeCommandObservation(opts: NodeInventoryOpts) {
-  if (!opts.node) {
+  if (opts.node === undefined) {
     return undefined;
   }
   const nodeId = normalizeOptionalString(opts.node);

--- a/src/cli/catalog-metadata.test.ts
+++ b/src/cli/catalog-metadata.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCommandEffectProfile, normalizeCommandExposure } from "./catalog-metadata.js";
+
+describe("catalog metadata normalization", () => {
+  it("preserves valid source-owned metadata", () => {
+    expect(
+      normalizeCommandEffectProfile({
+        effectMode: "mutating",
+        risk: "medium",
+        confirmationRequired: true,
+      }),
+    ).toEqual({
+      effectMode: "mutating",
+      risk: "medium",
+      confirmationRequired: true,
+    });
+    expect(normalizeCommandExposure({ tier: "internal" })).toEqual({ tier: "internal" });
+  });
+
+  it("drops malformed or expanded metadata shapes", () => {
+    expect(normalizeCommandEffectProfile({ effectMode: "write" })).toBeUndefined();
+    expect(
+      normalizeCommandEffectProfile({ effectMode: "read", commandHints: ["not source-owned"] }),
+    ).toBeUndefined();
+    expect(normalizeCommandExposure({ tier: "private" })).toBeUndefined();
+  });
+});

--- a/src/cli/catalog-metadata.ts
+++ b/src/cli/catalog-metadata.ts
@@ -1,0 +1,62 @@
+export type CliCatalogRisk = "low" | "medium" | "high";
+export type CliCatalogEffectMode = "read" | "mutating" | "mixed";
+export type CliCatalogVisibility = "docs" | "audit" | "operator" | "policy";
+type CliCommandExposureTier = "public" | "internal";
+
+export type CommandEffectProfile = {
+  readonly effectMode: CliCatalogEffectMode;
+  readonly confirmationRequired?: boolean;
+  readonly risk?: CliCatalogRisk;
+};
+
+export type CommandExposure = {
+  readonly tier?: CliCommandExposureTier;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function normalizeCommandEffectProfile(value: unknown): CommandEffectProfile | undefined {
+  const record = asRecord(value);
+  if (
+    !record ||
+    Object.keys(record).some(
+      (key) => key !== "effectMode" && key !== "confirmationRequired" && key !== "risk",
+    ) ||
+    (record.effectMode !== "read" &&
+      record.effectMode !== "mutating" &&
+      record.effectMode !== "mixed") ||
+    (record.confirmationRequired !== undefined &&
+      typeof record.confirmationRequired !== "boolean") ||
+    (record.risk !== undefined &&
+      record.risk !== "low" &&
+      record.risk !== "medium" &&
+      record.risk !== "high")
+  ) {
+    return undefined;
+  }
+  return {
+    effectMode: record.effectMode,
+    ...(typeof record.confirmationRequired === "boolean"
+      ? { confirmationRequired: record.confirmationRequired }
+      : {}),
+    ...(record.risk === "low" || record.risk === "medium" || record.risk === "high"
+      ? { risk: record.risk }
+      : {}),
+  };
+}
+
+export function normalizeCommandExposure(value: unknown): CommandExposure | undefined {
+  const record = asRecord(value);
+  if (
+    !record ||
+    Object.keys(record).some((key) => key !== "tier") ||
+    (record.tier !== undefined && record.tier !== "public" && record.tier !== "internal")
+  ) {
+    return undefined;
+  }
+  return record.tier === "public" || record.tier === "internal" ? { tier: record.tier } : {};
+}

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,5 +1,6 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
 import { getCommandPositionalsWithRootOptions, hasFlag } from "./argv.js";
+import type { CommandEffectProfile } from "./catalog-metadata.js";
 
 export type CliCommandPluginLoadPolicy =
   | "never"
@@ -52,6 +53,7 @@ export type CliCommandCatalogEntry = {
   route?: {
     id: CliRoutedCommandId;
     preloadPlugins?: boolean;
+    effectProfile?: CommandEffectProfile;
   };
 };
 
@@ -296,7 +298,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["config", "unset"],
     exact: true,
     policy: { configGuard: "run", ensureCliPath: false, networkProxy: "bypass" },
-    route: { id: "config-unset" },
+    route: {
+      id: "config-unset",
+      effectProfile: {
+        risk: "medium",
+        confirmationRequired: true,
+        effectMode: "mutating",
+      },
+    },
   },
   {
     commandPath: ["models", "list"],
@@ -314,6 +323,15 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       networkProxy: ({ argv }) => (hasFlag(argv, "--probe") ? "default" : "bypass"),
     },
     route: { id: "models-status" },
+  },
+  {
+    commandPath: ["tools", "commands"],
+    policy: {
+      configGuard: "skip",
+      ensureCliPath: false,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    },
   },
   {
     commandPath: ["tasks", "list"],
@@ -354,8 +372,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   {
-    // This unregistered root is reserved so plugin registration cannot claim it;
-    // the catalog entry preserves its startup policy.
     commandPath: ["tools"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },

--- a/src/cli/command-registration-policy.test.ts
+++ b/src/cli/command-registration-policy.test.ts
@@ -74,6 +74,13 @@ describe("command-registration-policy", () => {
     ).toBe(true);
     expect(
       shouldSkipPluginCommandRegistration({
+        argv: ["node", "openclaw", "tools", "commands", "list"],
+        primary: "tools",
+        hasBuiltinPrimary: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipPluginCommandRegistration({
         argv: ["node", "openclaw", "googlemeet", "login"],
         primary: "googlemeet",
         hasBuiltinPrimary: false,

--- a/src/cli/command-registration-policy.test.ts
+++ b/src/cli/command-registration-policy.test.ts
@@ -67,9 +67,9 @@ describe("command-registration-policy", () => {
     ).toBe(true);
     expect(
       shouldSkipPluginCommandRegistration({
-        argv: ["node", "openclaw", "tools", "effective"],
+        argv: ["node", "openclaw", "tools", "commands"],
         primary: "tools",
-        hasBuiltinPrimary: false,
+        hasBuiltinPrimary: true,
       }),
     ).toBe(true);
     expect(

--- a/src/cli/command-registration-policy.ts
+++ b/src/cli/command-registration-policy.ts
@@ -2,7 +2,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 
-const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool", "tools"]);
+const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool"]);
 
 export function isReservedNonPluginCommandRoot(primary: string | null | undefined): boolean {
   return typeof primary === "string" && RESERVED_NON_PLUGIN_COMMAND_ROOTS.has(primary);

--- a/src/cli/command-registration-policy.ts
+++ b/src/cli/command-registration-policy.ts
@@ -2,7 +2,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 
-const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool"]);
+const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool", "tools"]);
 
 export function isReservedNonPluginCommandRoot(primary: string | null | undefined): boolean {
   return typeof primary === "string" && RESERVED_NON_PLUGIN_COMMAND_ROOTS.has(primary);

--- a/src/cli/program/command-group-descriptors.ts
+++ b/src/cli/program/command-group-descriptors.ts
@@ -1,5 +1,6 @@
 // Descriptor-to-lazy-command-group adapters used by core and sub-CLI registration.
 import type { Command } from "commander";
+import type { CommandEffectProfile, CommandExposure } from "../catalog-metadata.js";
 import type { MachineOutputResolver } from "../machine-output-argv.js";
 
 /** Descriptor for one root command placeholder. */
@@ -10,6 +11,8 @@ export type NamedCommandDescriptor = {
   machineOutput?: MachineOutputResolver;
   hidden?: boolean;
   parentDefaultHelp?: boolean;
+  effectProfile?: CommandEffectProfile;
+  commandExposure?: CommandExposure;
 };
 
 /** Group spec that names the placeholders owned by one registrar. */

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -305,6 +305,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       loadModule: () => import("../update-cli.js"),
       exportName: "registerUpdateCli",
     },
+    {
+      commandNames: ["tools"],
+      loadModule: () => import("../tools-cli.js"),
+      exportName: "registerToolsCli",
+    },
   ]),
 ];
 

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -13,7 +13,6 @@ import { getSubCliEntries } from "./subcli-descriptors.js";
 
 const RESERVED_CATALOG_ROOTS = {
   tool: "reserved so plugin registration cannot claim this unregistered root",
-  tools: "reserved so plugin registration cannot claim this unregistered root",
 } as const;
 
 const PLUGIN_CATALOG_PATHS = {
@@ -90,6 +89,8 @@ const JSON_NOT_APPLICABLE = {
       "models auth order",
       "tasks flow",
       "skills workshop",
+      "tools",
+      "tools commands",
     ],
   },
   interactive: {

--- a/src/cli/program/subcli-descriptors.test.ts
+++ b/src/cli/program/subcli-descriptors.test.ts
@@ -67,6 +67,12 @@ describe("sub-cli descriptors", () => {
     expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
   });
 
+  it("does not reserve the commands root for the catalog", async () => {
+    const { SUB_CLI_DESCRIPTORS } = await importSubCliDescriptors();
+
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("commands");
+  });
+
   it("includes qa in the exported descriptor list when private QA is enabled", async () => {
     process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
 

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -21,6 +21,14 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Run, inspect, and query the WebSocket Gateway",
     hasSubcommands: true,
     machineOutput: ({ argv }) => isGatewayMachineOutput(argv),
+    commandExposure: {
+      tier: "public",
+    },
+    effectProfile: {
+      risk: "medium",
+      confirmationRequired: true,
+      effectMode: "mixed",
+    },
   },
   {
     name: "daemon",
@@ -233,6 +241,12 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     name: "update",
     description: "Update OpenClaw and inspect update channel status",
     hasSubcommands: true,
+  },
+  {
+    name: "tools",
+    description: "Inspect OpenClaw tool and command metadata",
+    hasSubcommands: true,
+    parentDefaultHelp: true,
   },
   {
     name: "completion",

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2807,7 +2807,6 @@ describe("runCli exit behavior", () => {
   it.each([
     ["auth", ["node", "openclaw", "auth", "--help"]],
     ["tool", ["node", "openclaw", "tool", "image_generate"]],
-    ["tools", ["node", "openclaw", "tools", "effective"]],
   ])("keeps reserved %s command roots out of plugin command discovery", async (_name, argv) => {
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
@@ -2821,6 +2820,28 @@ describe("runCli exit behavior", () => {
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, argv[2], argv]]);
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+    expect(parseAsync).toHaveBeenCalledWith(argv);
+  });
+
+  it("keeps tools available to plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "effective"];
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    const program = {
+      commands: [],
+      parseAsync,
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+
+    await runCli(argv);
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
+    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
+      program,
+      undefined,
+      undefined,
+      { mode: "lazy", primary: "tools", skipPluginValidation: false },
+    );
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2823,8 +2823,8 @@ describe("runCli exit behavior", () => {
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 
-  it("keeps tools available to plugin command discovery", async () => {
-    const argv = ["node", "openclaw", "tools", "effective"];
+  it("keeps tools commands out of plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "commands", "list"];
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
       commands: [],
@@ -2836,12 +2836,7 @@ describe("runCli exit behavior", () => {
 
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
-    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
-      program,
-      undefined,
-      undefined,
-      { mode: "lazy", primary: "tools", skipPluginValidation: false },
-    );
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/tools-cli.ts
+++ b/src/cli/tools-cli.ts
@@ -1,0 +1,10 @@
+import type { Command } from "commander";
+import { registerCommandsCli } from "./catalog-cli.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+export function registerToolsCli(program: Command): void {
+  const tools = program.command("tools").description("Inspect OpenClaw tool and command metadata");
+
+  registerCommandsCli(tools);
+  applyParentDefaultHelpAction(tools);
+}

--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -131,6 +131,15 @@ describe("captured plugin registration", () => {
           description: "Captured command",
           handler: async () => ({ text: "ok" }),
         });
+        api.registerCli(() => {}, {
+          descriptors: [
+            {
+              name: "captured-cli",
+              description: "Captured CLI",
+              hasSubcommands: false,
+            },
+          ],
+        });
         api.registerAgentToolResultMiddleware(() => undefined, {
           runtimes: ["codex"],
         });
@@ -154,6 +163,13 @@ describe("captured plugin registration", () => {
     expect(captured.textTransforms[0]?.input).toHaveLength(1);
     expect(captured.agentToolResultMiddlewares).toHaveLength(1);
     expect(captured.agentToolResultMiddlewares[0]?.runtimes).toEqual(["codex"]);
+    expect(captured.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({
+        name: "captured-cli",
+        description: "Captured CLI",
+        hasSubcommands: false,
+      }),
+    );
     expect(captured.api.registerMemoryEmbeddingProvider).toBeTypeOf("function");
   });
 

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -46,6 +46,13 @@ export type PluginCliCommandGroupEntry = {
   register: (program: OpenClawPluginCliContext["program"]) => Promise<void>;
 };
 
+export type PluginCliDescriptorEntry = {
+  pluginId: string;
+  parentPath: readonly string[];
+  commands: readonly string[];
+  descriptors: readonly OpenClawPluginCliRootCommandDescriptor[];
+};
+
 /** Creates the default plugin CLI logger shared with runtime loading. */
 export function createPluginCliLogger(): PluginLogger {
   return createPluginRuntimeLoaderLogger();
@@ -241,7 +248,38 @@ export async function loadPluginCliDescriptors(
   }
 }
 
-async function loadPluginCliRegistrationEntries(params: {
+export async function loadPluginCliDescriptorEntries(
+  params: PluginCliPublicLoadParams,
+): Promise<PluginCliDescriptorEntry[]> {
+  const logger = resolvePluginCliLogger(params.logger);
+  const context = resolvePluginCliLoadContext({
+    cfg: params.cfg,
+    env: params.env,
+    logger,
+  });
+  const { registry } = await loadPluginCliMetadataRegistryWithContext(
+    context,
+    { primaryCommand: params.primaryCommand },
+    params.loaderOptions,
+  );
+  const loadErrors = registry.diagnostics.filter((diagnostic) => diagnostic.level === "error");
+  if (loadErrors.length > 0) {
+    const details = loadErrors
+      .map((diagnostic) =>
+        diagnostic.pluginId ? `${diagnostic.pluginId}: ${diagnostic.message}` : diagnostic.message,
+      )
+      .join("; ");
+    throw new Error(`Failed to load plugin CLI descriptor metadata: ${details}`);
+  }
+  return registry.cliRegistrars.map((entry) => ({
+    pluginId: entry.pluginId,
+    parentPath: entry.parentPath ?? [],
+    commands: entry.commands,
+    descriptors: entry.descriptors,
+  }));
+}
+
+export async function loadPluginCliRegistrationEntries(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   loaderOptions?: PluginCliLoaderOptions;

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -98,6 +98,11 @@ describe("plugin loader CLI metadata", () => {
           description: "Rogue CLI metadata",
           hasSubcommands: true,
         },
+        {
+          name: "other-rogue",
+          description: "Other rogue CLI metadata",
+          hasSubcommands: false,
+        },
       ],
     });
   },
@@ -122,6 +127,9 @@ describe("plugin loader CLI metadata", () => {
 
     expect(warnings).toStrictEqual([]);
     expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("rogue");
+    expect(registry.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({ name: "other-rogue" }),
+    );
   });
 
   it("passes validated plugin config into non-activating CLI metadata loads", async () => {

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -79,12 +79,12 @@ export type OpenClawPluginCliContext = {
 export type OpenClawPluginCliRegistrar = (ctx: OpenClawPluginCliContext) => void | Promise<void>;
 
 /**
- * Top-level CLI metadata for plugin-owned commands.
+ * CLI descriptor data for plugin-owned commands.
  *
  * Descriptors are the parse-time contract for lazy plugin CLI registration.
  * If you want OpenClaw to keep a plugin command lazy-loaded while still
- * advertising it at the root CLI level, provide descriptors that cover every
- * top-level command root registered by that plugin CLI surface.
+ * advertising it at parse time, provide descriptors that cover every command
+ * root registered by that plugin CLI surface.
  */
 type OpenClawPluginCliCommandDescriptor = {
   name: string;


### PR DESCRIPTION
## Summary

Adds opt-in live paired-node command observation to the `openclaw tools commands`
inventory from [#100960](https://github.com/openclaw/openclaw/pull/100960).

## Contract

- Live node collection runs only when the caller supplies `--node`.
- The selected node must be connected and paired through Gateway diagnostics.
- Node command records are observation-only and do not grant invoke authority.
- Unknown node command semantics remain unknown; the inventory does not infer
  effect, risk, or confirmation policy.
- Collection status is reported at both the overall inventory level and the CLI
  node-command scope.
- CLI failures for missing, disconnected, unpaired, or mismatched nodes fail
  without emitting partial JSON.

## Scope

This PR adds live Gateway node command collection for the command inventory only.
It does not change node invocation, pairing policy, authorization, or agent
prompt behavior.

## Validation

Current head: `a7ce8e8aaefa3da34b8396c6fd4ed691798241fe`.
Parent stack: #100960 current repaired head
`8e72d20247b3adbd447fd738338ab3a93319ca5f`; this child branch now carries the
same `tools` core-owned namespace repair content plus only the live-node
inventory commits.

Windows worktree `C:\src\openclaw-pr104158-node-rebuild`:

1. Repaired the two exact-head ClawSweeper findings from the August 5 review:
   `tools` remains a reserved/core-owned CLI root, and explicit blank `--node`
   values now fail before Gateway query or JSON output.
2. Restacked the child branch on the exact #100960 parent head after the
   reserved plugin-root filtering repair and dropped duplicate parent repair
   commits already present in #100960.
3. `oxfmt --check src/cli-catalog-overlay/live-node-commands.ts src/cli-catalog-overlay/live-node-commands.test.ts src/cli-catalog-overlay/list.ts src/cli-catalog-overlay/list.test.ts src/cli/catalog-cli.ts src/cli/catalog-cli.test.ts docs/cli/commands.md`
   passed after the parent restack.
4. `git diff --check origin/user/giodl/cli-catalog-review-hardening..HEAD`
   passed.
5. Focused Vitest in this Windows-mounted worktree is still blocked before
   tests execute by existing local dependency skew:
   `TypeError: configureFsSafeNative is not a function` from
   `src/infra/fs-safe-defaults.ts`.

WSL Ubuntu hydrated checkout at `/tmp/openclaw-pr100960-tools-validate`:

1. `node scripts/run-vitest.mjs run src/cli/catalog-cli.test.ts src/cli-catalog-overlay/list.test.ts src/cli-catalog-overlay/live-node-commands.test.ts --reporter=verbose --maxWorkers=1`
   passed: 28 focused catalog/list/live-node/CLI tests across 2 Vitest shards.
2. `node scripts/run-vitest.mjs run src/cli/catalog-cli.test.ts src/cli-catalog-overlay/list.test.ts src/cli-catalog-overlay/inspect.test.ts src/cli-catalog-overlay/plugin-commands.test.ts src/cli-catalog-overlay/live-node-commands.test.ts --reporter=verbose --maxWorkers=1`
   passed: 39 catalog, CLI, plugin descriptor, inspect, and live-node tests
   across 2 Vitest shards.
3. `pnpm deadcode:exports` passed with 0 entries.
4. `pnpm exec oxfmt --check docs/cli/commands.md src/cli-catalog-overlay/list.test.ts src/cli-catalog-overlay/list.ts src/cli-catalog-overlay/live-node-commands.test.ts src/cli-catalog-overlay/live-node-commands.ts src/cli-catalog-overlay/node-commands.ts src/cli/catalog-cli.test.ts src/cli/catalog-cli.ts`
   passed.
5. `git diff --check 8e72d20247b3adbd447fd738338ab3a93319ca5f..HEAD` passed.

## Real behavior proof

Behavior or issue addressed:
`openclaw tools commands list --json --node <node-id>` can observe command
identifiers from a selected connected paired Gateway node and expose them as
audit/operator catalog entries without granting invoke authority or inventing
effect metadata.

Real environment tested:
WSL Ubuntu source harness in hydrated checkout
`/tmp/openclaw-pr100960-tools-validate` at exact head
`a7ce8e8aaefa3da34b8396c6fd4ed691798241fe`, represented locally as temporary
validation commit `2d09cc413440cab02d8aaef032f9f09ab488376c` on top of #100960
`8e72d20247b3adbd447fd738338ab3a93319ca5f`, with the same tree
`2ad8553f0b11796c4707aa4eb6ffe705f88be747`, using the repository Gateway and
CLI catalog test harnesses.

Exact steps or command run after this patch:

1. `node scripts/run-vitest.mjs run src/cli/catalog-cli.test.ts src/cli-catalog-overlay/list.test.ts src/cli-catalog-overlay/live-node-commands.test.ts --reporter=verbose --maxWorkers=1`
2. `node scripts/run-vitest.mjs run src/cli/catalog-cli.test.ts src/cli-catalog-overlay/list.test.ts src/cli-catalog-overlay/inspect.test.ts src/cli-catalog-overlay/plugin-commands.test.ts src/cli-catalog-overlay/live-node-commands.test.ts --reporter=verbose --maxWorkers=1`
3. `pnpm deadcode:exports`

Evidence after fix:
Step 1 passed 28 focused CLI/list/live-node tests proving the repaired review
findings: Gateway-valid strings such as `vendor/foo` are preserved, connected
but unpaired nodes fail before JSON output, blank `--node` fails before Gateway
query or JSON output, empty live Gateway results keep `nodeCommandScope:
"live-gateway-query"`, and node labels, command IDs, and invocation hints are
kept inside Markdown table cells before terminal output. The main CLI
projection still asserts
`callNodeDiagnosticsGatewayCli("node.describe", ..., { nodeId: "node-1" })`,
`counts.nodeCommands === 1`, `cli.nodeCommandScope === "live-gateway-query"`,
and a projected node command with `command: "system.run"` and `discoveryMode:
"runtime-node-query"`.

Step 2 passed 39 catalog, CLI, plugin descriptor, inspect, and live-node tests
across 2 Vitest shards. Step 3 passed with 0 unused-export entries.

Observed result after fix:
The exact restacked head still proves the two runtime halves required by this
slice: Gateway diagnostics responses from a selected paired node are projected
into the command inventory's live node-command collection without granting
invoke authority, and Markdown output no longer lets node-supplied metadata
break table rows.

What was not tested:
A spawned child-process CLI proof against the in-process Gateway server was
attempted in the hydrated WSL checkout, but the temporary one-off gateway test
harness hung before setup markers printed. No diagnostic harness code is
included in this PR. Maintainers should treat the proof above as exact-head
source-harness proof, not as an exact spawned-process CLI transcript.
