### PR TITLE
fix(imessage): overlay sender/direction from history in anchorless repair

### DIFF
--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -153,4 +153,112 @@ describe("repairIMessageConversationAnchor", () => {
     ).resolves.toBeNull();
     expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("no usable conversation anchor");
   });
+
+  // #104136: the exact-GUID history row is authoritative for routing/direction
+  // fields — the raw notification may carry incorrect sender or direction.
+  it("overlays sender and destination from the history entry", async () => {
+    // Notification has local identity as sender; history has the remote peer.
+    const message = anchorlessMessage({
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            service: "iMessage",
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).not.toBeNull();
+    expect(repaired!.sender).toBe("+15550000002");
+    expect(repaired!.destination_caller_id).toBe("+15550000001");
+  });
+
+  it("overlays is_from_me and service from the history entry", async () => {
+    const message = anchorlessMessage({
+      sender: "+15550000001",
+      destination_caller_id: "+15550000002",
+      is_from_me: false,
+      service: "SMS",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            service: "iMessage",
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).not.toBeNull();
+    expect(repaired!.service).toBe("iMessage");
+    expect(repaired!.is_from_me).toBe(false);
+  });
+
+  it("drops fail-closed when recovered history row has is_from_me=true", async () => {
+    const runtime = { error: vi.fn() };
+    const message = anchorlessMessage({
+      sender: "+15550000001",
+      is_from_me: false,
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000001",
+            destination_caller_id: "+15550000002",
+            is_from_me: true,
+            service: "iMessage",
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      repairIMessageConversationAnchor({
+        client: client as never,
+        message,
+        runtime,
+      }),
+    ).resolves.toBeNull();
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("is_from_me=true");
+  });
 });

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -87,6 +87,22 @@ function overlayRecoveredConversation(
     repaired.participants = entry.participants;
   }
 
+  // The exact-GUID history row is authoritative for routing/direction fields;
+  // the raw notification may carry stale or incorrect sender/direction values
+  // (#104136).
+  if (isNonEmptyString(entry.sender)) {
+    repaired.sender = entry.sender;
+  }
+  if (isNonEmptyString(entry.destination_caller_id)) {
+    repaired.destination_caller_id = entry.destination_caller_id;
+  }
+  if (typeof entry.is_from_me === "boolean") {
+    repaired.is_from_me = entry.is_from_me;
+  }
+  if (isNonEmptyString(entry.service)) {
+    repaired.service = entry.service;
+  }
+
   return repaired;
 }
 
@@ -150,6 +166,14 @@ export async function repairIMessageConversationAnchor(
       }
 
       const repaired = overlayRecoveredConversation(message, entry);
+      // A recovered outgoing message (is_from_me: true) must not dispatch
+      // to the agent — it was sent by the local identity, not a remote peer (#104136).
+      if (repaired.is_from_me === true) {
+        runtime?.error?.(
+          `imessage: dropping recovered anchorless message GUID=${guid} with is_from_me=true`,
+        );
+        return null;
+      }
       if (isIMessageAnchorless(repaired)) {
         runtime?.error?.(
           `imessage: dropping anchorless message GUID=${guid} after recovery found no usable conversation anchor`,

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -66,6 +66,7 @@ export type IMessagePayload = {
   chat_name?: string | null;
   participants?: string[] | null;
   is_group?: boolean | null;
+  service?: string | null;
 };
 
 export type MonitorIMessageOpts = {


### PR DESCRIPTION
## What Problem This Solves

When an iMessage notification arrives without a conversation anchor, the repair logic uses the raw notification's `sender` and `direction` fields. However, the exact-GUID history row is authoritative for these routing fields — the raw notification may carry incorrect sender or direction information.

## Fix

Overlay `sender` and `destination_caller_id` from the history entry during anchorless repair. Reject repaired outgoing rows where the history contradicts the notification's `is_from_me` flag.

## Evidence

### Before fix: notification sender used even when history differs

```
Notification: sender="+15550000001" (local identity)
History row:  sender="+15550000002" (remote peer, authoritative)

Before fix: local identity used as sender → message routed incorrectly
```

### After fix: history row is authoritative

```
After fix: exact-GUID history row overlays sender/direction fields
Message correctly attributed to the remote peer
Outgoing rows with contradictory is_from_me are rejected
```

## Test plan

- [x] New test: sender/direction overlaid from history entry
- [x] New test: repaired outgoing rows rejected when history contradicts
- [x] Existing repair tests pass