### PR TITLE
fix(release): preserve canonical main PR provenance

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -26,6 +26,10 @@ every human `Thanks @...` attribution.
   an explicit shipped/main-closeout SHA only when it is also reachable from the
   target.
 - Target ref: exact branch/SHA being released.
+- Canonical main ref: current `origin/main`, fetched before verification. Release
+  notes cite the original merged main PR when the same work is carried by a
+  backport. A release-branch PR is used only while no forward-port exists on
+  main by the release target cutoff.
 
 ## Workflow
 
@@ -44,6 +48,7 @@ every human `Thanks @...` attribution.
    node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
      --base <base-tag> \
      --target <target-ref> \
+     --main-ref origin/main \
      --version <YYYY.M.PATCH> \
      --manifest /tmp/openclaw-release-<YYYY.M.PATCH>.json \
      --write-ledger
@@ -53,9 +58,8 @@ every human `Thanks @...` attribution.
    exact base/target SHA snapshot under the worktree's git metadata. Iterative
    rewrites at the same target avoid repeated network discovery. Use
    `--refresh-github-snapshot` after suspect API data, `--github-snapshot
-   <path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
+<path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
    audit. GitHub release bodies are always read live.
-
    - the manifest is the required input to the rewrite, not an after-the-fact
      audit; it contains every referenced PR, eligible contributor credit,
      inline issue context, every direct commit, and an editorial-eligibility
@@ -78,6 +82,11 @@ every human `Thanks @...` attribution.
      PR references explicitly present in active commit subjects/bodies so
      cherry-picks and squash commits remain accounted for. Resolve every
      association page and exclude PRs merged after the target release commit
+   - canonicalize backports to the original merged PR on `main`: explicit
+     cherry-pick origins win, then a unique normalized-subject match requires
+     the same author and an overlapping changed path. Suppress the backport PR
+     when that main PR exists by the target cutoff. Keep the release-branch PR
+     only when the change has not yet been forward-ported
    - read the manifest before editing `### Highlights`, `### Changes`, or
      `### Fixes`; do not carry old grouped prose forward without re-auditing it
    - inspect linked PRs/issues or diffs for ambiguous commits. Direct commits
@@ -175,6 +184,7 @@ every human `Thanks @...` attribution.
   node .agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs \
     --base <base-tag> \
     --target <target-ref> \
+    --main-ref origin/main \
     --version <YYYY.M.PATCH> \
     --manifest /tmp/openclaw-release-<YYYY.M.PATCH>.json \
     --write-ledger

--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -58,7 +58,7 @@ every human `Thanks @...` attribution.
    exact base/target SHA snapshot under the worktree's git metadata. Iterative
    rewrites at the same target avoid repeated network discovery. Use
    `--refresh-github-snapshot` after suspect API data, `--github-snapshot
-<path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
+   <path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
    audit. GitHub release bodies are always read live.
    - the manifest is the required input to the rewrite, not an after-the-fact
      audit; it contains every referenced PR, eligible contributor credit,
@@ -84,9 +84,10 @@ every human `Thanks @...` attribution.
      association page and exclude PRs merged after the target release commit
    - canonicalize backports to the original merged PR on `main`: explicit
      cherry-pick origins win, then a unique normalized-subject match requires
-     the same author and an overlapping changed path. Suppress the backport PR
-     when that main PR exists by the target cutoff. Keep the release-branch PR
-     only when the change has not yet been forward-ported
+     the same author and an overlapping changed path. Suppress release/backport
+     PRs whenever the corresponding main PR exists by the target cutoff. Keep a
+     release-branch PR only when that change landed there first and has not yet
+     been forward-ported to `main`
    - read the manifest before editing `### Highlights`, `### Changes`, or
      `### Fixes`; do not carry old grouped prose forward without re-auditing it
    - inspect linked PRs/issues or diffs for ambiguous commits. Direct commits

--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -29,7 +29,7 @@ every human `Thanks @...` attribution.
 - Canonical main ref: current `origin/main`, fetched before verification. Release
   notes cite the original merged main PR when the same work is carried by a
   backport. A release-branch PR is used only while no forward-port exists on
-  main by the release target cutoff.
+  current main.
 
 ## Workflow
 
@@ -58,7 +58,7 @@ every human `Thanks @...` attribution.
    exact base/target SHA snapshot under the worktree's git metadata. Iterative
    rewrites at the same target avoid repeated network discovery. Use
    `--refresh-github-snapshot` after suspect API data, `--github-snapshot
-   <path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
+<path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
    audit. GitHub release bodies are always read live.
    - the manifest is the required input to the rewrite, not an after-the-fact
      audit; it contains every referenced PR, eligible contributor credit,
@@ -85,9 +85,9 @@ every human `Thanks @...` attribution.
    - canonicalize backports to the original merged PR on `main`: explicit
      cherry-pick origins win, then a unique normalized-subject match requires
      the same author and an overlapping changed path. Suppress release/backport
-     PRs whenever the corresponding main PR exists by the target cutoff. Keep a
-     release-branch PR only when that change landed there first and has not yet
-     been forward-ported to `main`
+     PRs whenever the corresponding main PR exists on current `origin/main`.
+     Keep a release-branch PR only when that change landed there first and has
+     not yet been forward-ported to `main`
    - read the manifest before editing `### Highlights`, `### Changes`, or
      `### Fixes`; do not carry old grouped prose forward without re-auditing it
    - inspect linked PRs/issues or diffs for ambiguous commits. Direct commits

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -1101,7 +1101,7 @@ function sourceCommits(base, target, mainRef) {
   }
   const canonicalMainPullRequests = resolveAssociatedPullRequests(
     [...canonicalMainHashes],
-    targetTimestamp,
+    Number.POSITIVE_INFINITY,
   );
   const resolvedCoauthors = resolveCommitCoauthors(activeCommits);
   const pullRequests = new Set();

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -74,6 +74,7 @@ Options:
   --no-github-snapshot  Disable GitHub GraphQL snapshot reuse.
   --refresh-github-snapshot
                         Ignore an existing exact-range snapshot and rebuild it.
+  --main-ref <ref>      Canonical mainline used to replace backport PRs.
   --seed-ref <ref>      Use an existing release section as editorial input.
   --shipped-ref <tag>   Exclude PRs already recorded by this shipped tag; repeatable.
   --write-ledger        Write the verified ledger back into CHANGELOG.md.
@@ -91,6 +92,7 @@ function parseArgs(argv) {
     json: false,
     manifestPath: undefined,
     githubSnapshotPath: undefined,
+    mainRef: undefined,
     noGithubSnapshot: false,
     refreshGithubSnapshot: false,
     seedRef: undefined,
@@ -131,6 +133,7 @@ function parseArgs(argv) {
       arg === "--release-tag" ||
       arg === "--shipped-ref" ||
       arg === "--github-snapshot" ||
+      arg === "--main-ref" ||
       arg === "--manifest" ||
       arg === "--seed-ref"
     ) {
@@ -146,6 +149,8 @@ function parseArgs(argv) {
         options.manifestPath = value;
       } else if (arg === "--github-snapshot") {
         options.githubSnapshotPath = value;
+      } else if (arg === "--main-ref") {
+        options.mainRef = value;
       } else if (arg === "--seed-ref") {
         options.seedRef = value;
       } else {
@@ -217,6 +222,21 @@ function gitIsAncestor(base, target) {
       result.stderr?.trim() || result.signal || result.status
     }`,
   );
+}
+
+function gitCommit(ref, required = false) {
+  const result = spawnSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status === 0) {
+    return result.stdout.trim();
+  }
+  if (!required) {
+    return undefined;
+  }
+  fail(`could not resolve canonical main ref ${ref}: ${result.stderr?.trim() || result.status}`);
 }
 
 function fetchGithubApi(args) {
@@ -759,7 +779,111 @@ function appendReferences(references, additions) {
   }
 }
 
-function sourceCommits(base, target) {
+function normalizedCommitSubject(subject) {
+  return subject
+    .replace(/\s+\(#\d+\)\s*$/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function cherryPickOrigins(message) {
+  return [...message.matchAll(/^\(cherry picked from commit ([0-9a-f]{40})\)$/gim)].map((match) =>
+    match[1].toLowerCase(),
+  );
+}
+
+function changedPathsForCommit(hash) {
+  return new Set(
+    git(["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", hash, "--"])
+      .split("\n")
+      .filter(Boolean),
+  );
+}
+
+function authorsMatch(left, right) {
+  const leftEmail = left.authorEmail?.trim().toLowerCase();
+  const rightEmail = right.authorEmail?.trim().toLowerCase();
+  if (leftEmail && rightEmail && leftEmail === rightEmail) {
+    return true;
+  }
+  return (
+    left.authorName?.trim().toLowerCase() === right.authorName?.trim().toLowerCase() &&
+    Boolean(left.authorName?.trim())
+  );
+}
+
+function pathsOverlap(left, right) {
+  for (const path of left) {
+    if (right.has(path)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function canonicalMainCommitMatches(commit, candidates) {
+  const exact = candidates.find((candidate) => candidate.hash === commit.hash);
+  if (exact) {
+    return [exact.hash];
+  }
+
+  const origins = new Set(cherryPickOrigins(commit.body));
+  const explicit = candidates
+    .filter((candidate) => origins.has(candidate.hash))
+    .map((candidate) => candidate.hash);
+  if (explicit.length > 0) {
+    return [...new Set(explicit)];
+  }
+
+  const subject = normalizedCommitSubject(commit.subject);
+  const matches = candidates.filter(
+    (candidate) =>
+      normalizedCommitSubject(candidate.subject) === subject &&
+      authorsMatch(commit, candidate) &&
+      pathsOverlap(commit.changedPaths, candidate.changedPaths),
+  );
+  return matches.length === 1 ? [matches[0].hash] : [];
+}
+
+export function canonicalPullRequests(currentPullRequests, mainPullRequests) {
+  return mainPullRequests.length > 0
+    ? [...new Set(mainPullRequests)].toSorted((left, right) => left - right)
+    : [...new Set(currentPullRequests)].toSorted((left, right) => left - right);
+}
+
+function canonicalMainCommits(base, mainRef) {
+  if (!mainRef) {
+    return [];
+  }
+  const mainCommit = gitCommit(mainRef, true);
+  if (!gitIsAncestor(base, mainCommit)) {
+    fail(`release range base ${base} must be an ancestor of canonical main ref ${mainRef}`);
+  }
+  const output = git([
+    "log",
+    "--reverse",
+    "--format=%H%x1f%s%x1f%an%x1f%ae%x1e",
+    `${base}..${mainCommit}`,
+  ]);
+  const commits = [];
+  for (const record of output.split("\x1e")) {
+    if (!record) {
+      continue;
+    }
+    const [rawHash, subject, authorName, authorEmail] = record.split("\x1f");
+    const hash = rawHash.trim();
+    commits.push({
+      authorEmail,
+      authorName,
+      hash,
+      subject,
+    });
+  }
+  return commits;
+}
+
+function sourceCommits(base, target, mainRef) {
   const targetCommit = git(["rev-parse", `${target}^{commit}`]);
   if (!gitIsAncestor(base, targetCommit)) {
     fail(`release range base ${base} must be an ancestor of target ${target}`);
@@ -931,12 +1055,67 @@ function sourceCommits(base, target) {
     activeCommits.map((commit) => commit.hash),
     targetTimestamp,
   );
+  const mainCommits = canonicalMainCommits(base, mainRef);
+  const mainCommitsByHash = new Map(mainCommits.map((commit) => [commit.hash, commit]));
+  const mainCommitsBySubject = new Map();
+  for (const commit of mainCommits) {
+    const subject = normalizedCommitSubject(commit.subject);
+    const matches = mainCommitsBySubject.get(subject) ?? [];
+    matches.push(commit);
+    mainCommitsBySubject.set(subject, matches);
+  }
+  const canonicalMainCommitsByReleaseCommit = new Map();
+  const canonicalMainHashes = new Set();
+  const changedPathsByCommit = new Map();
+  const withChangedPaths = (commit) => {
+    if (!changedPathsByCommit.has(commit.hash)) {
+      changedPathsByCommit.set(commit.hash, changedPathsForCommit(commit.hash));
+    }
+    return { ...commit, changedPaths: changedPathsByCommit.get(commit.hash) };
+  };
+  for (const commit of activeCommits) {
+    const exact = mainCommitsByHash.get(commit.hash);
+    if (exact) {
+      canonicalMainCommitsByReleaseCommit.set(commit.hash, []);
+      continue;
+    }
+    const explicit = cherryPickOrigins(commit.body)
+      .map((origin) => mainCommitsByHash.get(origin))
+      .filter(Boolean);
+    const matches =
+      explicit.length > 0
+        ? [...new Set(explicit.map((candidate) => candidate.hash))]
+        : canonicalMainCommitMatches(
+            withChangedPaths(commit),
+            (mainCommitsBySubject.get(normalizedCommitSubject(commit.subject)) ?? []).map(
+              withChangedPaths,
+            ),
+          );
+    canonicalMainCommitsByReleaseCommit.set(commit.hash, matches);
+    for (const hash of matches) {
+      canonicalMainHashes.add(hash);
+    }
+  }
+  const canonicalMainPullRequests = resolveAssociatedPullRequests(
+    [...canonicalMainHashes],
+    targetTimestamp,
+  );
   const resolvedCoauthors = resolveCommitCoauthors(activeCommits);
   const pullRequests = new Set();
   const nonRevertPullRequests = new Set();
   for (const commit of activeCommits) {
-    const associatedPullRequests = activePullRequests.get(commit.hash) ?? [];
+    const currentPullRequests = activePullRequests.get(commit.hash) ?? [];
+    const mainPullRequests = (canonicalMainCommitsByReleaseCommit.get(commit.hash) ?? []).flatMap(
+      (hash) => canonicalMainPullRequests.get(hash) ?? [],
+    );
+    const associatedPullRequests = canonicalPullRequests(currentPullRequests, mainPullRequests);
     commit.pullRequests = associatedPullRequests;
+    const suppressedBackportPullRequests = new Set(
+      currentPullRequests.filter((number) => !associatedPullRequests.includes(number)),
+    );
+    commit.references = commit.references.filter(
+      (number) => !suppressedBackportPullRequests.has(number),
+    );
     addHandles(commit.coauthors, resolvedCoauthors.get(commit.hash) ?? []);
     appendReferences(commit.references, associatedPullRequests);
     for (const number of associatedPullRequests) {
@@ -1900,7 +2079,8 @@ function main() {
   githubSnapshotState = initializeGithubSnapshot(options);
   let changelog = readFileSync("CHANGELOG.md", "utf8");
   let section = sectionFor(changelog, options.version);
-  const source = sourceCommits(options.base, options.target);
+  const defaultMainRef = options.mainRef ?? (gitCommit("origin/main") ? "origin/main" : undefined);
+  const source = sourceCommits(options.base, options.target, defaultMainRef);
   const shippedBaselineRecords = options.shippedRefs.map(shippedBaselineFor);
   const shippedExclusions = subtractShippedPullRequests(source, shippedBaselineRecords);
   source.shippedBaselines = shippedExclusions.baselines;

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -846,10 +846,13 @@ export function canonicalMainCommitMatches(commit, candidates) {
   return matches.length === 1 ? [matches[0].hash] : [];
 }
 
-export function canonicalPullRequests(currentPullRequests, mainPullRequests) {
-  return mainPullRequests.length > 0
-    ? [...new Set(mainPullRequests)].toSorted((left, right) => left - right)
-    : [...new Set(currentPullRequests)].toSorted((left, right) => left - right);
+export function canonicalPullRequests(
+  currentPullRequests,
+  mainPullRequests,
+  hasCanonicalMainCommit = mainPullRequests.length > 0,
+) {
+  const pullRequests = hasCanonicalMainCommit ? mainPullRequests : currentPullRequests;
+  return [...new Set(pullRequests)].toSorted((left, right) => left - right);
 }
 
 function canonicalMainCommits(base, mainRef) {
@@ -1108,7 +1111,12 @@ function sourceCommits(base, target, mainRef) {
     const mainPullRequests = (canonicalMainCommitsByReleaseCommit.get(commit.hash) ?? []).flatMap(
       (hash) => canonicalMainPullRequests.get(hash) ?? [],
     );
-    const associatedPullRequests = canonicalPullRequests(currentPullRequests, mainPullRequests);
+    const matchedMainCommits = canonicalMainCommitsByReleaseCommit.get(commit.hash) ?? [];
+    const associatedPullRequests = canonicalPullRequests(
+      currentPullRequests,
+      mainPullRequests,
+      matchedMainCommits.length > 0,
+    );
     commit.pullRequests = associatedPullRequests;
     const suppressedBackportPullRequests = new Set(
       currentPullRequests.filter((number) => !associatedPullRequests.includes(number)),
@@ -2079,8 +2087,7 @@ function main() {
   githubSnapshotState = initializeGithubSnapshot(options);
   let changelog = readFileSync("CHANGELOG.md", "utf8");
   let section = sectionFor(changelog, options.version);
-  const defaultMainRef = options.mainRef ?? (gitCommit("origin/main") ? "origin/main" : undefined);
-  const source = sourceCommits(options.base, options.target, defaultMainRef);
+  const source = sourceCommits(options.base, options.target, options.mainRef ?? "origin/main");
   const shippedBaselineRecords = options.shippedRefs.map(shippedBaselineFor);
   const shippedExclusions = subtractShippedPullRequests(source, shippedBaselineRecords);
   source.shippedBaselines = shippedExclusions.baselines;

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -860,14 +860,12 @@ function canonicalMainCommits(base, mainRef) {
     return [];
   }
   const mainCommit = gitCommit(mainRef, true);
-  if (!gitIsAncestor(base, mainCommit)) {
-    fail(`release range base ${base} must be an ancestor of canonical main ref ${mainRef}`);
-  }
+  const mainBase = git(["merge-base", base, mainCommit]);
   const output = git([
     "log",
     "--reverse",
     "--format=%H%x1f%s%x1f%an%x1f%ae%x1e",
-    `${base}..${mainCommit}`,
+    `${mainBase}..${mainCommit}`,
   ]);
   const commits = [];
   for (const record of output.split("\x1e")) {

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -38,9 +38,11 @@ GHSA-specific advisory work outside this skill.
   green. Then branch from that commit so regular development can continue on
   `main` while release validation runs.
 - Before release branching, commit any dirty files in coherent groups, push,
-  pull/rebase, then generate `CHANGELOG.md` on `main` from merged PRs and all
-  direct commits since the last reachable release tag. Commit/push/pull that
-  changelog rewrite immediately before creating the release branch.
+  pull/rebase, and create the release branch from the intended `main` head.
+  Finish version preparation, backports, release-only fixes, and their required
+  forward-ports before generating `CHANGELOG.md`. The changelog rewrite is the
+  final candidate source mutation; freeze the candidate SHA immediately after
+  it and do not restart completed evidence for metadata-only reruns.
 - During release planning, inspect both `src/plugins/compat/registry.ts` and
   `src/commands/doctor/shared/deprecation-compat.ts` before branching and again
   before final publish. For every deprecated or removal-pending compatibility
@@ -127,12 +129,16 @@ target_ref=<full-pr-sha> -f include_android=true -f release_gate=true`.
   cancelled, or been skipped. Then rerun `OPENCLAW_TESTBOX=1 scripts/pr
 prepare-run <PR>`.
 - Generate the changelog before every beta, beta rerun, stable release, or
-  stable rerun, before version/tag preparation. Use
+  stable rerun, after version preparation and all source/backport work. Use
   `$openclaw-changelog-update` for the rewrite. Do not continue release prep if
   the target `CHANGELOG.md` section does not have `### Highlights`,
   `### Changes`, and `### Fixes`, grouped by user-facing surface while
   preserving every relevant PR/issue ref and every human `Thanks @...`
   attribution in the grouped bullet.
+- Changelog PR provenance follows `origin/main`, not the release integration
+  PR. Cite the original merged main PR for equivalent backports. Keep a
+  release-branch PR only when the change landed there first and has not yet
+  been forward-ported to `main`.
 - Do not create beta-specific `CHANGELOG.md` headings. Beta releases use the
   stable base version section, for example `v2026.4.20-beta.1` uses
   `## 2026.4.20` release notes.
@@ -324,10 +330,11 @@ HEAD/worktree-bound manifest under git metadata for cutover review.
 
 - `CHANGELOG.md` is release-owned. Normal PRs and direct `main` fixes should
   not edit it.
-- Before release branching or tagging, rewrite the target `CHANGELOG.md`
-  section from history, not existing notes. Use the last reachable stable or
-  beta release tag as the base, then inspect every commit through the target
-  release SHA.
+- After release preparation and all intended backports/fixes are complete,
+  rewrite the target `CHANGELOG.md` section from history, not existing notes.
+  Use the last reachable stable or beta release tag as the base, then inspect
+  every commit through the target release SHA. This rewrite is the final source
+  task before freezing the candidate SHA and starting or reusing evidence.
 - Generate `$openclaw-changelog-update`'s full contribution manifest before
   the editorial rewrite. It is the required source for `### Highlights`,
   `### Changes`, and `### Fixes`; do not preserve old grouped prose without
@@ -335,7 +342,10 @@ HEAD/worktree-bound manifest under git metadata for cutover review.
   unlinked commits.
 - The changelog rewrite is not optional for beta reruns: any `beta.N` after a
   rebase or backport must refresh the same stable-base `## YYYY.M.PATCH` section
-  before the new version/tag commit.
+  after the new version/backport work and before the candidate SHA freezes.
+- Always fetch and pass current `origin/main` as the canonical main ref.
+  Equivalent release/backport PRs are omitted in favor of the original merged
+  main PR. A release-branch PR remains only until that change is forward-ported.
 - Include both merged PR commits and direct commits on `main`. Direct commits
   matter: infer notes from their subject, body, touched files, linked issues,
   tests, and nearby code when no PR body exists.
@@ -896,12 +906,16 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
 3. Commit any dirty files in coherent groups, push, pull/rebase, and verify the
    worktree is clean.
 4. Pull latest `main` and confirm current `main` CI is green.
-5. Run `/changelog` for the stable base target version on `main`, commit the
-   changelog rewrite immediately, push, and pull/rebase. For beta releases,
-   keep the changelog heading as `## YYYY.M.PATCH`, not `## YYYY.M.PATCH-beta.N`.
-6. Create `release/YYYY.M.PATCH` from that post-changelog `main` commit.
-7. Make every repo version location match the beta tag before creating it.
-8. Commit release preparation changes on the release branch and push the branch.
+5. Create `release/YYYY.M.PATCH` from the intended `main` commit.
+6. Make every repo version location match the beta tag and finish all intended
+   backports or release-only fixes. Forward-port fixes to `main` where required.
+7. Run `/changelog` for the stable base target version on the release branch as
+   the final candidate source task, using current `origin/main` for canonical PR
+   provenance. Keep the heading as `## YYYY.M.PATCH`, not
+   `## YYYY.M.PATCH-beta.N`.
+8. Commit the changelog rewrite, push the release branch, and freeze that exact
+   candidate SHA. Any later source change must finish first, then rerun only
+   this final changelog step before freezing the replacement candidate.
 9. Immediately dispatch Actions > `OpenClaw Performance` from `main` with
    `target_ref=<release-sha>`, `profile=release`, `repeat=3`, deep profiling
    off, live OpenAI off, and regression failure off. Let it run in parallel

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -480,6 +480,69 @@ describe("release-note verification", () => {
     }
   });
 
+  it("accepts a release-only base that shares history with canonical main", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-"));
+    try {
+      git(cwd, ["init", "-q"]);
+      writeFileSync(
+        join(cwd, "CHANGELOG.md"),
+        [
+          "# Changelog",
+          "",
+          "## 2026.7.1",
+          "",
+          "### Highlights",
+          "",
+          "- One.",
+          "- Two.",
+          "- Three.",
+          "- Four.",
+          "- Five.",
+          "",
+          "### Changes",
+          "",
+          "### Fixes",
+        ].join("\n"),
+      );
+      git(cwd, ["add", "CHANGELOG.md"]);
+      git(cwd, ["commit", "-qm", "initial"]);
+      const root = git(cwd, ["rev-parse", "HEAD"]);
+
+      writeFileSync(join(cwd, "main.txt"), "main\n");
+      git(cwd, ["add", "main.txt"]);
+      git(cwd, ["commit", "-qm", "main"]);
+      git(cwd, ["branch", "main-ref"]);
+
+      git(cwd, ["checkout", "-qb", "release", root]);
+      writeFileSync(join(cwd, "release.txt"), "release\n");
+      git(cwd, ["add", "release.txt"]);
+      git(cwd, ["commit", "-qm", "release"]);
+      git(cwd, ["tag", "beta-base"]);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          verifier,
+          "--base",
+          "beta-base",
+          "--target",
+          "HEAD",
+          "--main-ref",
+          "main-ref",
+          "--version",
+          "2026.7.1",
+          "--write-ledger",
+        ],
+        { cwd, encoding: "utf8" },
+      );
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a release base that is not an ancestor of the target", () => {
     const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-"));
     try {

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  canonicalMainCommitMatches,
+  canonicalPullRequests,
   contaminatingPullRequestReferences,
   countTopLevelSectionBullets,
   createGithubSnapshotState,
@@ -46,6 +48,57 @@ describe("release-note verification", () => {
         `verify-release-notes-${"a".repeat(40)}-${"b".repeat(40)}.json`,
       ),
     );
+  });
+
+  it("uses the original main PR for explicit and uniquely matched backports", () => {
+    const mainCommit = {
+      authorEmail: "maintainer@example.com",
+      authorName: "Maintainer",
+      changedPaths: new Set(["src/channel.ts"]),
+      hash: "a".repeat(40),
+      subject: "fix(channel): preserve durable replies (#123)",
+    };
+    const explicitBackport = {
+      authorEmail: "other@example.com",
+      authorName: "Other",
+      body: `(cherry picked from commit ${mainCommit.hash})`,
+      changedPaths: new Set(["src/channel.ts"]),
+      hash: "b".repeat(40),
+      subject: "fix(channel): preserve durable replies",
+    };
+    const integratedBackport = {
+      authorEmail: mainCommit.authorEmail,
+      authorName: mainCommit.authorName,
+      body: "",
+      changedPaths: new Set(["src/channel.ts", "src/release.ts"]),
+      hash: "c".repeat(40),
+      subject: "fix(channel): preserve durable replies",
+    };
+
+    expect(canonicalMainCommitMatches(explicitBackport, [mainCommit])).toEqual([mainCommit.hash]);
+    expect(canonicalMainCommitMatches(integratedBackport, [mainCommit])).toEqual([mainCommit.hash]);
+    expect(canonicalPullRequests([456], [123])).toEqual([123]);
+  });
+
+  it("keeps the release PR without an unambiguous main forward-port", () => {
+    const releaseCommit = {
+      authorEmail: "maintainer@example.com",
+      authorName: "Maintainer",
+      body: "",
+      changedPaths: new Set(["src/channel.ts"]),
+      hash: "c".repeat(40),
+      subject: "fix(channel): preserve durable replies",
+    };
+    const ambiguousMainCommits = ["a", "b"].map((prefix) => ({
+      authorEmail: releaseCommit.authorEmail,
+      authorName: releaseCommit.authorName,
+      changedPaths: new Set(["src/channel.ts"]),
+      hash: prefix.repeat(40),
+      subject: "fix(channel): preserve durable replies (#123)",
+    }));
+
+    expect(canonicalMainCommitMatches(releaseCommit, ambiguousMainCommits)).toEqual([]);
+    expect(canonicalPullRequests([456], [])).toEqual([456]);
   });
 
   it("reuses exact-range GitHub GraphQL snapshots without caching REST reads", () => {

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -101,6 +101,10 @@ describe("release-note verification", () => {
     expect(canonicalPullRequests([456], [])).toEqual([456]);
   });
 
+  it("drops the release PR when the matching main forward-port is a direct commit", () => {
+    expect(canonicalPullRequests([456], [], true)).toEqual([]);
+  });
+
   it("reuses exact-range GitHub GraphQL snapshots without caching REST reads", () => {
     const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-snapshot-"));
     try {
@@ -455,6 +459,8 @@ describe("release-note verification", () => {
           "HEAD",
           "--target",
           "HEAD",
+          "--main-ref",
+          "HEAD",
           "--version",
           "2026.7.1",
           "--write-ledger",
@@ -509,7 +515,17 @@ describe("release-note verification", () => {
 
       const result = spawnSync(
         process.execPath,
-        [verifier, "--base", "base-ref", "--target", "HEAD", "--version", "2026.7.1"],
+        [
+          verifier,
+          "--base",
+          "base-ref",
+          "--target",
+          "HEAD",
+          "--main-ref",
+          "HEAD",
+          "--version",
+          "2026.7.1",
+        ],
         { cwd, encoding: "utf8" },
       );
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-note provenance problem where backport PRs could replace the original merged PR from `main`, making changelogs point at integration mechanics instead of the canonical contribution.

## Why This Change Was Made

The release-note verifier now resolves equivalent release commits against current `origin/main`, preferring explicit cherry-pick origins and then unique same-author, same-subject, overlapping-path matches. The release process also makes changelog generation the final candidate source mutation, after version preparation and backports.

## User Impact

Release notes consistently credit and link the original merged `main` PR. A release-branch PR remains only when the change has not yet been forward-ported; direct main forward-ports suppress the backport PR without inventing a replacement PR.

## Evidence

- `pnpm test:serial test/scripts/verify-release-notes.test.ts`: 15/15 passed on Blacksmith Testbox.
- `pnpm check:changed`: passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29139464071.
- Autoreview: clean, no accepted or actionable findings.
- `git diff --check`: passed.
