### PR TITLE
fix(onboard): wait for gateway warnings before installing service

### DIFF
--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -960,6 +960,20 @@ describe("finalizeSetupWizard", () => {
     expect(gatewayServiceInstall).toHaveBeenCalledTimes(1);
   });
 
+  it("shows gateway install warnings when planning fails", async () => {
+    const prompter = createLaterPrompter();
+    buildGatewayInstallPlan.mockImplementationOnce(async (params) => {
+      params?.warn?.("Gateway install warning", "Gateway service");
+      throw new Error("plan failed");
+    });
+
+    await finalizeSetupWizard(createAdvancedFinalizeArgs({ installDaemon: true, prompter }));
+
+    expect(prompter.note).toHaveBeenCalledWith("Gateway install warning", "Gateway service");
+    expectNoteContains(prompter, "plan failed", "Gateway");
+    expect(gatewayServiceInstall).not.toHaveBeenCalled();
+  });
+
   it("suppresses token-bearing onboarding output when requested", async () => {
     const prompter = createLaterPrompter();
 

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -32,7 +32,7 @@ const resolveDefaultModelAuthStatus = vi.hoisted(() =>
   vi.fn(() => ({ provider: "anthropic", model: "claude-opus-4-8", hasAuth: true })),
 );
 const buildGatewayInstallPlan = vi.hoisted(() =>
-  vi.fn(async () => ({
+  vi.fn(async (_params?: { warn?: (message: string, title?: string) => void }) => ({
     programArguments: [],
     workingDirectory: "/tmp",
     environment: {},
@@ -920,6 +920,44 @@ describe("finalizeSetupWizard", () => {
         },
       }),
     );
+  });
+
+  it("waits for gateway install warnings before installing the service", async () => {
+    let acknowledgeWarning: (() => void) | undefined;
+    const warningAcknowledged = new Promise<void>((resolve) => {
+      acknowledgeWarning = resolve;
+    });
+    const prompter = buildWizardPrompter({
+      select: vi.fn(async () => "later") as never,
+      confirm: vi.fn(async () => false),
+      note: vi.fn(async (message: string) => {
+        if (message === "Gateway install warning") {
+          await warningAcknowledged;
+        }
+      }),
+    });
+    buildGatewayInstallPlan.mockImplementationOnce(async (params) => {
+      params?.warn?.("Gateway install warning", "Gateway service");
+      return {
+        programArguments: [],
+        workingDirectory: "/tmp",
+        environment: {},
+        environmentValueSources: {},
+      };
+    });
+
+    const finalizePromise = finalizeSetupWizard(
+      createAdvancedFinalizeArgs({ installDaemon: true, prompter }),
+    );
+    await vi.waitFor(() => {
+      expect(prompter.note).toHaveBeenCalledWith("Gateway install warning", "Gateway service");
+    });
+    expect(gatewayServiceInstall).not.toHaveBeenCalled();
+
+    acknowledgeWarning?.();
+    await finalizePromise;
+
+    expect(gatewayServiceInstall).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses token-bearing onboarding output when requested", async () => {

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -339,6 +339,15 @@ export async function ensureGatewayServiceForOnboarding(params: {
     ) {
       const progress = prompter.progress(t("wizard.finalize.gatewayService"));
       let installError: string | null = null;
+      const installWarnings: Array<{ message: string; title?: string }> = [];
+      let nextInstallWarning = 0;
+      const flushInstallWarnings = async () => {
+        while (nextInstallWarning < installWarnings.length) {
+          const warning = installWarnings[nextInstallWarning];
+          nextInstallWarning += 1;
+          await prompter.note(warning.message, warning.title);
+        }
+      };
       try {
         progress.update(t("wizard.finalize.gatewayServicePreparing"));
         const tokenResolution = await resolveGatewayInstallToken({
@@ -355,7 +364,6 @@ export async function ensureGatewayServiceForOnboarding(params: {
             t("wizard.finalize.gatewayInstallFixAuth"),
           ].join(" ");
         } else {
-          const installWarnings: Array<{ message: string; title?: string }> = [];
           const { programArguments, workingDirectory, environment, environmentValueSources } =
             await buildGatewayInstallPlan({
               env: process.env,
@@ -366,9 +374,7 @@ export async function ensureGatewayServiceForOnboarding(params: {
               },
               config: nextConfig,
             });
-          for (const warning of installWarnings) {
-            await prompter.note(warning.message, warning.title);
-          }
+          await flushInstallWarnings();
 
           progress.update(t("wizard.finalize.gatewayServiceInstalling"));
           await service.install({
@@ -381,6 +387,7 @@ export async function ensureGatewayServiceForOnboarding(params: {
           });
         }
       } catch (err) {
+        await flushInstallWarnings();
         installError = formatErrorMessage(err);
       } finally {
         progress.stop(

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -340,11 +340,11 @@ export async function ensureGatewayServiceForOnboarding(params: {
       const progress = prompter.progress(t("wizard.finalize.gatewayService"));
       let installError: string | null = null;
       const installWarnings: Array<{ message: string; title?: string }> = [];
-      let nextInstallWarning = 0;
       const flushInstallWarnings = async () => {
-        while (nextInstallWarning < installWarnings.length) {
-          const warning = installWarnings[nextInstallWarning];
-          nextInstallWarning += 1;
+        let warning: (typeof installWarnings)[number] | undefined;
+        // Remove before awaiting so a rejected note is not replayed when the
+        // outer catch drains warnings that remain in the planner's queue.
+        while ((warning = installWarnings.shift()) !== undefined) {
           await prompter.note(warning.message, warning.title);
         }
       };

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -355,16 +355,20 @@ export async function ensureGatewayServiceForOnboarding(params: {
             t("wizard.finalize.gatewayInstallFixAuth"),
           ].join(" ");
         } else {
+          const installWarnings: Array<{ message: string; title?: string }> = [];
           const { programArguments, workingDirectory, environment, environmentValueSources } =
             await buildGatewayInstallPlan({
               env: process.env,
               port: settings.port,
               runtime: daemonRuntime,
               warn: (message, title) => {
-                void prompter.note(message, title);
+                installWarnings.push({ message, title });
               },
               config: nextConfig,
             });
+          for (const warning of installWarnings) {
+            await prompter.note(warning.message, warning.title);
+          }
 
           progress.update(t("wizard.finalize.gatewayServiceInstalling"));
           await service.install({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users completing onboarding through the remote wizard could have Gateway service installation begin before they acknowledged an installation warning.

## Why This Change Was Made

Gateway install-plan warnings are collected synchronously, then drained and awaited in order before service installation starts. The queue removes each warning before awaiting it, so a rejected remote note cannot replay itself when the error path drains any remaining warnings. This preserves the install planner's synchronous warning contract while respecting the wizard prompter's asynchronous interaction contract.

## User Impact

Onboarding users now see and acknowledge Gateway installation warnings before OpenClaw installs the service, including when the wizard is driven through the Gateway API.

## Evidence

- Exact head: `6d6a9971daea26eab020b537690bc480919bc48f`
- Blacksmith Testbox `tbx_01kx8ge44b23czdjt1v0fah1yt`: `corepack pnpm test src/wizard/setup.finalize.test.ts` — 27 passed.
- Current-head remote WizardSession runtime transcript. It runs the production `WizardSession`, onboarding finalizer, and install planner; the Windows service-write and CLI-command boundaries are isolated so no system task is created:

  ```text
  wizard.step installWarning=true
  install_calls_before_ack=0
  wizard.ack installWarning=true
  service.install
  warning_acknowledged_before_service_install=true
  ```

- The planning-failure regression test emits a warning and rejects the plan, then verifies the warning is still shown and service installation is not called.
- `oxfmt --check --threads=1 src/wizard/setup.finalize.ts src/wizard/setup.finalize.test.ts` — passed.
- `git diff --check upstream/main...HEAD` — passed.
- Fresh maintainer autoreview — clean, confidence 0.98.

AI-assisted: yes. I reviewed the changed production path and regression test and understand the ordering fix.
