### PR TITLE
fix(logs): clean up gateway and channel startup/shutdown log output

### DIFF
--- a/extensions/discord/src/monitor/provider.allowlist.test.ts
+++ b/extensions/discord/src/monitor/provider.allowlist.test.ts
@@ -88,7 +88,8 @@ describe("resolveDiscordAllowlistConfig", () => {
     expect(logs).toContain(
       "discord channels unresolved: 145/c404 (guild:Ops; channel:missing-room)",
     );
-    expect(logs).toContain("discord users resolved: 387→Peter (id:387)");
+    expect(logs).toContain("discord users resolved: 387→Peter");
+    expect(logs).not.toContain("(id:387)");
   });
 
   it("groups resolved discord channel aliases under one target line", async () => {

--- a/extensions/discord/src/monitor/provider.allowlist.ts
+++ b/extensions/discord/src/monitor/provider.allowlist.ts
@@ -90,15 +90,18 @@ function formatDiscordChannelUnresolved(entry: DiscordChannelLogEntry): string {
   ]);
 }
 
-function formatDiscordUserResolved(entry: DiscordUserLogEntry): string {
+function formatDiscordUserResolved(entry: DiscordUserLogEntry): string | null {
   const displayName = entry.name?.trim();
   const target = displayName || entry.id;
   const base = formatResolvedBase(entry.input, target);
-  return formatResolutionLogDetails(base, [
-    displayName && entry.id ? `id:${entry.id}` : undefined,
+  const formatted = formatResolutionLogDetails(base, [
+    // Repeating the id is only useful when the input was not already that id.
+    displayName && entry.id && entry.id !== entry.input ? `id:${entry.id}` : undefined,
     entry.guildName ? `guild:${entry.guildName}` : undefined,
     entry.note,
   ]);
+  // An id that resolved to itself with no metadata carries no information.
+  return formatted === entry.input ? null : formatted;
 }
 
 function formatDiscordUserUnresolved(entry: DiscordUserLogEntry): string {

--- a/extensions/discord/src/monitor/provider.commands.ts
+++ b/extensions/discord/src/monitor/provider.commands.ts
@@ -116,14 +116,14 @@ export async function resolveDiscordProviderCommandSpecs(params: {
     });
     params.runtime.log?.(
       warn(
-        `discord: ${initialCommandCount} commands exceeds limit; removing per-skill commands and keeping /skill.`,
+        `${initialCommandCount} commands exceed the ${maxDiscordCommands}-command Discord limit; removing per-skill commands and keeping /skill.`,
       ),
     );
   }
   if (params.nativeEnabled && commandSpecs.length > maxDiscordCommands) {
     params.runtime.log?.(
       warn(
-        `discord: ${commandSpecs.length} commands exceeds limit; some commands may fail to deploy.`,
+        `${commandSpecs.length} commands exceed the ${maxDiscordCommands}-command Discord limit; some commands may fail to deploy.`,
       ),
     );
   }

--- a/extensions/discord/src/monitor/provider.deploy-errors.ts
+++ b/extensions/discord/src/monitor/provider.deploy-errors.ts
@@ -260,7 +260,7 @@ export function formatDiscordDeployRateLimitWarning(
   if (!rateLimit) {
     return undefined;
   }
-  const parts = [`discord: native slash command deploy rate limited for ${accountId}`];
+  const parts = [`[${accountId}] slash command deploy rate limited`];
   if (typeof rateLimit.retryAfterMs === "number") {
     parts.push(
       `retry after ${formatDurationSeconds(rateLimit.retryAfterMs, {
@@ -318,6 +318,17 @@ function formatDiscordRejectedDeployEntries(params: {
   });
 }
 
+// Discord error envelopes are usually plain {message, code}; both already
+// appear via the error message and the code= detail, so repeating the JSON
+// body would only double the line length without adding information.
+function isRedundantDiscordDeployBody(rawBody: unknown): boolean {
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return false;
+  }
+  const keys = Object.keys(rawBody);
+  return keys.length > 0 && keys.every((key) => key === "message" || key === "code");
+}
+
 export function formatDiscordDeployErrorDetails(err: unknown): string {
   if (!err || typeof err !== "object") {
     return "";
@@ -337,7 +348,7 @@ export function formatDiscordDeployErrorDetails(err: unknown): string {
   if (typeof discordCode === "number" || typeof discordCode === "string") {
     details.push(`code=${discordCode}`);
   }
-  if (rawBody !== undefined) {
+  if (rawBody !== undefined && !isRedundantDiscordDeployBody(rawBody)) {
     let bodyText;
     try {
       bodyText = JSON.stringify(rawBody);

--- a/extensions/discord/src/monitor/provider.deploy.test.ts
+++ b/extensions/discord/src/monitor/provider.deploy.test.ts
@@ -1,0 +1,136 @@
+// Discord tests cover slash-command deploy REST logging behavior.
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { describe, expect, it, type Mock, vi } from "vitest";
+import type { Client } from "../internal/discord.js";
+import { formatDiscordDeployErrorDetails } from "./provider.deploy-errors.js";
+import { runDiscordCommandDeployInBackground } from "./provider.deploy.js";
+
+type RestFn = (path: string, data?: unknown, query?: unknown) => Promise<unknown>;
+type RestMock = {
+  get: Mock<RestFn>;
+  post: Mock<RestFn>;
+  put: Mock<RestFn>;
+  patch: Mock<RestFn>;
+  delete: Mock<RestFn>;
+};
+
+function createRestMock(): RestMock {
+  return {
+    get: vi.fn<RestFn>(async () => undefined),
+    post: vi.fn<RestFn>(async () => undefined),
+    put: vi.fn<RestFn>(async () => undefined),
+    patch: vi.fn<RestFn>(async () => undefined),
+    delete: vi.fn<RestFn>(async () => undefined),
+  };
+}
+
+function runDeploy(params: {
+  rest: RestMock;
+  deployCommands: (rest: RestMock) => Promise<void>;
+  shouldLogVerbose?: boolean;
+}) {
+  const log = vi.fn<(message: string) => void>();
+  const error = vi.fn<(message: string) => void>();
+  const client = {
+    rest: params.rest,
+    deployCommands: vi.fn(async () => params.deployCommands(params.rest)),
+  };
+  runDiscordCommandDeployInBackground({
+    client: client as unknown as Client,
+    runtime: { log, error } as unknown as RuntimeEnv,
+    enabled: true,
+    accountId: "default",
+    startupStartedAt: Date.now(),
+    shouldLogVerbose: () => params.shouldLogVerbose ?? false,
+    isVerbose: () => false,
+  });
+  return { log, error, client };
+}
+
+function joinedCalls(mock: Mock<(message: string) => void>): string {
+  return mock.mock.calls.map((call) => call[0]).join("\n");
+}
+
+describe("discord slash-command deploy REST logging", () => {
+  it("passes non-command REST traffic through without deploy labels", async () => {
+    const rest = createRestMock();
+    rest.get.mockImplementation(async (path: string) => {
+      if (path.includes("/voice-states/")) {
+        throw Object.assign(new Error("Unknown Voice State"), { status: 404 });
+      }
+      return undefined;
+    });
+    let deployFinished = false;
+    const { log, error } = runDeploy({
+      rest,
+      shouldLogVerbose: true,
+      deployCommands: async (wrapped) => {
+        await wrapped.get("/applications/app-1/commands");
+        // Concurrent non-deploy traffic (voice-state probe) during the deploy
+        // window must keep its caller-owned error handling.
+        await expect(wrapped.get("/guilds/1/voice-states/2")).rejects.toThrow(
+          "Unknown Voice State",
+        );
+        deployFinished = true;
+      },
+    });
+
+    await vi.waitFor(() => expect(deployFinished).toBe(true));
+    const logged = joinedCalls(log);
+    expect(logged).toContain("native-slash-command-deploy-rest:get:start");
+    expect(logged).toContain("path=/applications/app-1/commands");
+    expect(logged).not.toContain("voice-states");
+    expect(logged).not.toContain("slash command deploy failed");
+    expect(joinedCalls(error)).not.toContain("voice-states");
+  });
+
+  it("logs one warning per deploy failure at default verbosity", async () => {
+    const rest = createRestMock();
+    const deployError = Object.assign(new Error("Missing Access"), {
+      status: 403,
+      discordCode: 50001,
+      rawBody: { message: "Missing Access", code: 50001 },
+    });
+    rest.post.mockRejectedValue(deployError);
+    const { log, error, client } = runDeploy({
+      rest,
+      shouldLogVerbose: false,
+      deployCommands: async (wrapped) => {
+        await wrapped.post("/applications/app-1/commands", {
+          body: [{ name: "skill" }],
+        } as never);
+      },
+    });
+
+    await vi.waitFor(() => expect(client.deployCommands).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(log).toHaveBeenCalled());
+    const warnings = log.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message.includes("slash command deploy failed"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("(message send/receive unaffected)");
+    // Per-request rest:error lines are verbose-only diagnostics.
+    expect(error).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatDiscordDeployErrorDetails", () => {
+  it("omits bodies that only repeat the message and code", () => {
+    expect(
+      formatDiscordDeployErrorDetails({
+        status: 400,
+        discordCode: 30032,
+        rawBody: { message: "Maximum number of application commands reached (100).", code: 30032 },
+      }),
+    ).toBe(" (status=400, code=30032)");
+  });
+
+  it("keeps bodies that carry extra fields", () => {
+    const details = formatDiscordDeployErrorDetails({
+      status: 400,
+      discordCode: 50035,
+      rawBody: { message: "Invalid Form Body", code: 50035, errors: { "0": { name: {} } } },
+    });
+    expect(details).toContain("body=");
+  });
+});

--- a/extensions/discord/src/monitor/provider.deploy.ts
+++ b/extensions/discord/src/monitor/provider.deploy.ts
@@ -23,6 +23,14 @@ function readDeployRequestBody(data?: unknown): unknown {
     : undefined;
 }
 
+// deployCommands only touches application-command routes. The wrapper patches
+// the shared client.rest, so unrelated concurrent startup traffic (voice-state
+// probes, channel lookups) must pass through untouched or it gets mislabeled
+// as slash-command deploy and double-logged next to its owner's handling.
+function isDeployCommandsPath(path: string): boolean {
+  return path.startsWith("/applications/") && path.includes("/commands");
+}
+
 function wrapDeployRestMethod(params: {
   method: RestMethodName;
   original: RestMethodMap;
@@ -33,6 +41,9 @@ function wrapDeployRestMethod(params: {
   shouldLogVerbose: () => boolean;
 }) {
   return async (path: string, data?: never, query?: never) => {
+    if (!isDeployCommandsPath(path)) {
+      return params.original[params.method](path, data, query);
+    }
     const startedAt = Date.now();
     const body = readDeployRequestBody(data);
     const commandCount = Array.isArray(body) ? body.length : undefined;
@@ -71,7 +82,9 @@ function wrapDeployRestMethod(params: {
             ),
           );
         }
-      } else {
+      } else if (params.shouldLogVerbose()) {
+        // Deploy failures surface once through deployDiscordCommands' warning;
+        // this per-request line is verbose timing diagnostics only.
         const details = formatDiscordDeployErrorDetails(err);
         params.runtime.error?.(
           `discord startup [${params.accountId}] native-slash-command-deploy-rest:${params.method}:error ${Math.max(0, Date.now() - params.startupStartedAt)}ms path=${path} requestMs=${requestMs} error=${formatDiscordDeployErrorMessage(err)}${details}`,
@@ -144,7 +157,7 @@ async function deployDiscordCommands(params: {
       if (isDiscordDeployDailyCreateLimit(err)) {
         params.runtime.log?.(
           warn(
-            `discord: native slash command deploy skipped for ${accountId}; daily application command create limit reached. Existing slash commands stay active until Discord resets the quota. Message send/receive is unaffected.`,
+            `[${accountId}] slash command deploy skipped: daily application command create limit reached. Existing slash commands stay active until Discord resets the quota; message send/receive is unaffected.`,
           ),
         );
         return;
@@ -159,7 +172,7 @@ async function deployDiscordCommands(params: {
   } catch (err) {
     params.runtime.log?.(
       warn(
-        `discord: native slash command deploy warning (not message send): ${formatDiscordDeployErrorMessage(err)}${formatDiscordDeployErrorDetails(err)}`,
+        `[${accountId}] slash command deploy failed (message send/receive unaffected): ${formatDiscordDeployErrorMessage(err)}${formatDiscordDeployErrorDetails(err)}`,
       ),
     );
   } finally {
@@ -201,7 +214,7 @@ export function runDiscordCommandDeployInBackground(params: {
     .catch((err: unknown) => {
       params.runtime.log?.(
         warn(
-          `discord: native slash command deploy background warning (not message send): ${formatErrorMessage(err)}`,
+          `[${params.accountId}] slash command deploy failed in background (message send/receive unaffected): ${formatErrorMessage(err)}`,
         ),
       );
     });

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -950,8 +950,9 @@ describe("monitorDiscordProvider", () => {
         .mocked(runtime.log)
         .mock.calls.some(
           (call) =>
-            String(call[0]).includes("native slash command deploy warning (not message send):") &&
-            String(call[0]).includes("Discord REST request was aborted"),
+            String(call[0]).includes(
+              "slash command deploy failed (message send/receive unaffected):",
+            ) && String(call[0]).includes("Discord REST request was aborted"),
         ),
     ).toBe(true);
   });
@@ -993,7 +994,7 @@ describe("monitorDiscordProvider", () => {
     const warningMessages = vi
       .mocked(runtime.log)
       .mock.calls.map((call) => String(call[0]))
-      .filter((message) => message.includes("native slash command deploy rate limited"));
+      .filter((message) => message.includes("slash command deploy rate limited"));
     expect(warningMessages).toHaveLength(1);
     expect(warningMessages[0]).toContain("retry after 0s");
     expect(warningMessages[0]).toContain("Message send/receive is unaffected.");

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -1176,7 +1176,7 @@ export class DiscordVoiceManager {
         ).catch((err: unknown) => {
           if (!isUnknownDiscordVoiceStateError(err)) {
             logger.warn(
-              `discord voice: follow user reconcile skipped transient voice state error guild=${plan.guildId} user=${userId} reason=${reason}: ${formatErrorMessage(err)}`,
+              `follow-user reconcile skipped (transient voice-state error) guild=${plan.guildId} user=${userId} trigger=${reason}: ${formatErrorMessage(err)}`,
             );
             return "transient-error" as const;
           }

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -460,9 +460,10 @@ function formatSlackResolvedLabel(params: {
 }): string | null {
   const extras = params.extra?.filter(Boolean) ?? [];
   const display = params.name ?? params.id;
-  if (params.input === display && extras.length === 0) {
+  if (params.input === params.id && !params.name && extras.length === 0) {
     // An id that resolved to itself with no display name says nothing; omit it
-    // so startup summaries only list lookups that translated something.
+    // so startup summaries only list lookups that translated something. Bare
+    // names that resolved to an id stay logged even when name === input.
     return null;
   }
   // Show the raw id only when neither the input nor the display already is it.

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -457,14 +457,24 @@ function formatSlackResolvedLabel(params: {
   id: string;
   name?: string;
   extra?: string[];
-}): string {
+}): string | null {
   const extras = params.extra?.filter(Boolean) ?? [];
-  const suffix =
-    extras.length > 0 ? ` (id:${params.id}, ${extras.join(", ")})` : ` (id:${params.id})`;
-  return `${params.input}→${params.name ?? params.id}${suffix}`;
+  const display = params.name ?? params.id;
+  if (params.input === display && extras.length === 0) {
+    // An id that resolved to itself with no display name says nothing; omit it
+    // so startup summaries only list lookups that translated something.
+    return null;
+  }
+  // Show the raw id only when neither the input nor the display already is it.
+  const details = [
+    ...(params.input === params.id || display === params.id ? [] : [`id:${params.id}`]),
+    ...extras,
+  ];
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `${params.input}→${display}${suffix}`;
 }
 
-export function formatSlackChannelResolved(entry: SlackChannelResolution): string {
+export function formatSlackChannelResolved(entry: SlackChannelResolution): string | null {
   const id = entry.id ?? entry.input;
   return formatSlackResolvedLabel({
     input: entry.input,
@@ -474,7 +484,7 @@ export function formatSlackChannelResolved(entry: SlackChannelResolution): strin
   });
 }
 
-export function formatSlackUserResolved(entry: SlackUserResolution): string {
+export function formatSlackUserResolved(entry: SlackUserResolution): string | null {
   const id = entry.id ?? entry.input;
   return formatSlackResolvedLabel({
     input: entry.input,

--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -45,7 +45,7 @@ function resolveAllowlistCallAt(index: number): { entries?: unknown } {
 }
 
 describe("slack allowlist log formatting", () => {
-  it("prints channel names alongside ids", () => {
+  it("prints channel names without repeating the id input", () => {
     expect(
       formatSlackChannelResolved({
         input: "C0AQXEG6QFJ",
@@ -53,10 +53,10 @@ describe("slack allowlist log formatting", () => {
         id: "C0AQXEG6QFJ",
         name: "openclawtest",
       }),
-    ).toBe("C0AQXEG6QFJ→openclawtest (id:C0AQXEG6QFJ)");
+    ).toBe("C0AQXEG6QFJ→openclawtest");
   });
 
-  it("prints user names alongside ids", () => {
+  it("prints user names without repeating the id input", () => {
     expect(
       formatSlackUserResolved({
         input: "U090HHQ029J",
@@ -64,7 +64,28 @@ describe("slack allowlist log formatting", () => {
         id: "U090HHQ029J",
         name: "steipete",
       }),
-    ).toBe("U090HHQ029J→steipete (id:U090HHQ029J)");
+    ).toBe("U090HHQ029J→steipete");
+  });
+
+  it("includes the id when resolving from a display name", () => {
+    expect(
+      formatSlackUserResolved({
+        input: "@steipete",
+        resolved: true,
+        id: "U090HHQ029J",
+        name: "steipete",
+      }),
+    ).toBe("@steipete→steipete (id:U090HHQ029J)");
+  });
+
+  it("omits identity lookups that resolved to themselves without a name", () => {
+    expect(
+      formatSlackUserResolved({
+        input: "U090HHQ029J",
+        resolved: true,
+        id: "U090HHQ029J",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -87,6 +87,17 @@ describe("slack allowlist log formatting", () => {
       }),
     ).toBeNull();
   });
+
+  it("keeps bare-name lookups that resolved to an id, even when the name matches the input", () => {
+    expect(
+      formatSlackChannelResolved({
+        input: "general",
+        resolved: true,
+        id: "C123",
+        name: "general",
+      }),
+    ).toBe("general→general (id:C123)");
+  });
 });
 
 describe("slack startup user allowlist resolution", () => {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -540,7 +540,10 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
                 unresolved.push(entry.input);
                 continue;
               }
-              mapping.push(formatSlackChannelResolved(entry));
+              const resolvedLabel = formatSlackChannelResolved(entry);
+              if (resolvedLabel) {
+                mapping.push(resolvedLabel);
+              }
               const existing = nextChannels[entry.id] ?? {};
               nextChannels[entry.id] = { ...source, ...existing };
             }

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -262,7 +262,7 @@ describe("registerTelegramNativeCommands", () => {
     expect(commandHandlers.has("demo_skill_0")).toBe(true);
     expect(runtimeLog).toHaveBeenCalledWith(
       expect.stringContaining(
-        "commands exceeds limit; removing per-skill commands and keeping /skill.",
+        "-command Telegram limit; removing per-skill commands and keeping /skill.",
       ),
     );
   });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -974,7 +974,7 @@ export const registerTelegramNativeCommands = ({
     const initialCommandCount = fullCommandCatalog.totalCommands;
     menuCommandCatalog = resolveTelegramMenuCommandCatalog([], skillCommands);
     runtime.log?.(
-      `Telegram: ${initialCommandCount} commands exceeds limit; removing per-skill commands and keeping /skill.`,
+      `${initialCommandCount} commands exceed the ${fullCommandCatalog.maxCommands}-command Telegram limit; removing per-skill commands and keeping /skill.`,
     );
   }
   const { nativeCommands, pluginCatalog } = fullCommandCatalog;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -11,7 +11,6 @@ import {
 import {
   computeBackoff,
   formatDurationPrecise,
-  logVerbose,
   sleepWithAbort,
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -1232,8 +1231,9 @@ export class TelegramPollingSession {
         .catch(() => undefined);
       return stopWorkerPromise;
     };
-    // Routine startup detail; only failures/stops below warrant info-level output.
-    logVerbose(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
+    // Readiness contract: test/e2e/qa-lab telegram-bot-token-runtime waits for
+    // this marker on the injected runtime log; do not demote it to verbose.
+    this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
     const pollState: {
       startedAt: number | null;
       offset: number | null;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -11,6 +11,7 @@ import {
 import {
   computeBackoff,
   formatDurationPrecise,
+  logVerbose,
   sleepWithAbort,
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -1231,7 +1232,8 @@ export class TelegramPollingSession {
         .catch(() => undefined);
       return stopWorkerPromise;
     };
-    this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
+    // Routine startup detail; only failures/stops below warrant info-level output.
+    logVerbose(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
     const pollState: {
       startedAt: number | null;
       offset: number | null;

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -549,17 +549,35 @@ function shouldCopyStaticExtensionAssets(params) {
  * Runs every runtime postbuild phase after the main dist build.
  */
 export function runRuntimePostBuild(params = {}) {
-  const timingsEnabled = params.timings ?? process.env.OPENCLAW_RUNTIME_POSTBUILD_TIMINGS !== "0";
+  const timingsSetting = params.timings ?? process.env.OPENCLAW_RUNTIME_POSTBUILD_TIMINGS;
+  const timingsEnabled = timingsSetting !== "0" && timingsSetting !== false;
+  // Per-phase lines are debug detail; default output is one summary line so a
+  // routine rebuild does not print nine near-identical timing rows.
+  const perPhaseEnabled = timingsSetting === "verbose" || timingsSetting === true;
+  const phaseTimings = [];
   const runPhase = (label, action) => {
     const startedAt = performance.now();
     try {
       return action();
     } finally {
-      if (timingsEnabled) {
-        const durationMs = Math.round(performance.now() - startedAt);
+      const durationMs = Math.round(performance.now() - startedAt);
+      phaseTimings.push({ label, durationMs });
+      if (perPhaseEnabled) {
         console.error(`runtime-postbuild: ${label} completed in ${durationMs}ms`);
       }
     }
+  };
+  const logSummary = () => {
+    if (!timingsEnabled || perPhaseEnabled || phaseTimings.length === 0) {
+      return;
+    }
+    const totalMs = phaseTimings.reduce((sum, phase) => sum + phase.durationMs, 0);
+    const slowest = phaseTimings.reduce((max, phase) =>
+      phase.durationMs > max.durationMs ? phase : max,
+    );
+    console.error(
+      `runtime-postbuild: ${phaseTimings.length} phases completed in ${totalMs}ms (slowest: ${slowest.label} ${slowest.durationMs}ms)`,
+    );
   };
   runPhase("plugin SDK root alias", () => copyPluginSdkRootAlias(params));
   runPhase("bundled plugin metadata", () => copyBundledPluginMetadata(params));
@@ -580,6 +598,7 @@ export function runRuntimePostBuild(params = {}) {
   runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
   runPhase("legacy root runtime compat aliases", () => writeLegacyRootRuntimeCompatAliases(params));
   runPhase("legacy CLI exit compat chunks", () => writeLegacyCliExitCompatChunks(params));
+  logSummary();
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -501,7 +501,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
           ctx.logger.warn(
             `transcripts autoStart failed provider=${entry.providerId}: ${
               err instanceof Error ? err.message : String(err)
-            }`,
+            } (check the transcripts.autoStart entry in your config)`,
           );
           return;
         }

--- a/src/channels/allowlists/resolve-utils.test.ts
+++ b/src/channels/allowlists/resolve-utils.test.ts
@@ -22,6 +22,16 @@ describe("buildAllowlistResolutionSummary", () => {
     expect(result.unresolved).toEqual(["b", "c"]);
   });
 
+  it("omits identity lookups from the logged mapping but keeps their additions", () => {
+    const resolvedUsers = [
+      { input: "42", resolved: true, id: "42" },
+      { input: "alice", resolved: true, id: "1" },
+    ];
+    const result = buildAllowlistResolutionSummary(resolvedUsers);
+    expect(result.mapping).toEqual(["alice→1"]);
+    expect(result.additions).toEqual(["42", "1"]);
+  });
+
   it("supports custom resolved formatting", () => {
     const resolvedUsers = [{ input: "a", resolved: true, id: "1", note: "x" }];
     const result = buildAllowlistResolutionSummary(resolvedUsers, {
@@ -108,9 +118,12 @@ describe("summarizeMapping", () => {
 
     summarizeMapping("demo allowlist", ["a", "b", "c", "d", "e", "f", "g"], ["x", "y"], runtime);
 
-    expect(runtime.log).toHaveBeenCalledWith(
-      "demo allowlist resolved: a, b, c, d, e, f (+1)\ndemo allowlist unresolved: x, y",
+    // Separate calls per line so each gets its own timestamp/subsystem prefix.
+    expect(runtime.log).toHaveBeenNthCalledWith(
+      1,
+      "demo allowlist resolved: a, b, c, d, e, f (+1)",
     );
+    expect(runtime.log).toHaveBeenNthCalledWith(2, "demo allowlist unresolved: x, y");
   });
 
   it("skips logging when both lists are empty", () => {

--- a/src/channels/allowlists/resolve-utils.ts
+++ b/src/channels/allowlists/resolve-utils.ts
@@ -45,7 +45,11 @@ export function mergeAllowlist(params: {
 /** Splits lookup results into resolved mappings, unresolved display text, and id additions. */
 export function buildAllowlistResolutionSummary<T extends AllowlistUserResolutionLike>(
   resolvedUsers: T[],
-  opts?: { formatResolved?: (entry: T) => string; formatUnresolved?: (entry: T) => string },
+  opts?: {
+    /** Return null to omit an entry from the logged mapping (e.g. identity lookups). */
+    formatResolved?: (entry: T) => string | null;
+    formatUnresolved?: (entry: T) => string;
+  },
 ): {
   resolvedMap: Map<string, T>;
   mapping: string[];
@@ -54,9 +58,16 @@ export function buildAllowlistResolutionSummary<T extends AllowlistUserResolutio
 } {
   const resolvedMap = new Map(resolvedUsers.map((entry) => [entry.input, entry]));
   const resolvedOk = (entry: T) => Boolean(entry.resolved && entry.id);
-  const formatResolved = opts?.formatResolved ?? ((entry: T) => `${entry.input}→${entry.id}`);
+  // An id that "resolves" to itself carries no information; skip it so startup
+  // summaries only mention lookups that actually translated something.
+  const formatResolved =
+    opts?.formatResolved ??
+    ((entry: T) => (entry.id === entry.input ? null : `${entry.input}→${entry.id}`));
   const formatUnresolved = opts?.formatUnresolved ?? ((entry: T) => entry.input);
-  const mapping = resolvedUsers.filter(resolvedOk).map(formatResolved);
+  const mapping = resolvedUsers
+    .filter(resolvedOk)
+    .map(formatResolved)
+    .filter((label): label is string => label !== null);
   const additions = resolvedUsers
     .filter(resolvedOk)
     .map((entry) => entry.id)
@@ -165,14 +176,15 @@ export function summarizeMapping(
   unresolved: string[],
   runtime: RuntimeEnv,
 ): void {
-  const lines: string[] = [];
+  // One log call per line: the console logger only prefixes the first line of
+  // a message with timestamp/subsystem, so a joined multi-line summary leaves
+  // bare continuation lines in operator output.
   if (mapping.length > 0) {
-    lines.push(`${label} resolved: ${summarizeStringEntries({ entries: mapping, limit: 6 })}`);
+    runtime.log?.(`${label} resolved: ${summarizeStringEntries({ entries: mapping, limit: 6 })}`);
   }
   if (unresolved.length > 0) {
-    lines.push(`${label} unresolved: ${summarizeStringEntries({ entries: unresolved, limit: 6 })}`);
-  }
-  if (lines.length > 0) {
-    runtime.log?.(lines.join("\n"));
+    runtime.log?.(
+      `${label} unresolved: ${summarizeStringEntries({ entries: unresolved, limit: 6 })}`,
+    );
   }
 }

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -112,6 +112,7 @@ const loadConfig = vi.fn<() => { gateway: { reload: { deferralTimeoutMs?: number
   },
 }));
 const gatewayLog = {
+  debug: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -766,7 +766,9 @@ export async function runGatewayLoop(params: {
   };
 
   const onSigterm = () => {
-    gatewayLog.info("signal SIGTERM received");
+    // Debug-level: every accepted signal is announced by request()'s
+    // "received <signal>; ..." line, so an info pre-log would double up.
+    gatewayLog.debug("signal SIGTERM received");
     void (async () => {
       const { consumeGatewayRestartIntentPayloadSync } = await loadGatewayLifecycleRuntimeModule();
       const restartIntent = consumeGatewayRestartIntentPayloadSync();
@@ -782,11 +784,11 @@ export async function runGatewayLoop(params: {
     });
   };
   const onSigint = () => {
-    gatewayLog.info("signal SIGINT received");
+    gatewayLog.debug("signal SIGINT received");
     request("stop", "SIGINT");
   };
   const onSigusr1 = () => {
-    gatewayLog.info("signal SIGUSR1 received");
+    gatewayLog.debug("signal SIGUSR1 received");
     void (async () => {
       const {
         abortPendingChannelReloads,

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -106,9 +106,6 @@ const bootLifecycle = vi.hoisted(() => ({
   record: vi.fn((_env?: NodeJS.ProcessEnv, _nowMs?: number, _reason?: string) => "boot-id"),
   complete: vi.fn(),
 }));
-const controlUiState = vi.hoisted(() => ({
-  root: "/tmp/openclaw-control-ui" as string | null,
-}));
 const netState = vi.hoisted(() => ({
   autoBindHost: "127.0.0.1",
   container: false,
@@ -239,10 +236,6 @@ vi.mock("../../gateway/server.js", () => ({
   startGatewayServer: (port: number, opts?: unknown) => startGatewayServer(port, opts),
 }));
 
-vi.mock("../../infra/control-ui-assets.js", () => ({
-  resolveControlUiRootSync: () => controlUiState.root,
-}));
-
 vi.mock("../../gateway/ws-logging.js", () => ({
   setGatewayWsLogStyle: (style: string) => setGatewayWsLogStyle(style),
 }));
@@ -291,6 +284,7 @@ vi.mock("../../infra/gateway-boot-lifecycle.js", () => ({
 
 vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({
+    debug: () => undefined,
     info: (message: string) => {
       gatewayLogMessages.push(message);
     },
@@ -351,7 +345,6 @@ describe("gateway run option collisions", () => {
     netState.container = false;
     readBestEffortConfig.mockClear();
     readConfigFileSnapshotWithPluginMetadata.mockClear();
-    controlUiState.root = "/tmp/openclaw-control-ui";
     gatewayLogMessages.length = 0;
     writeDiagnosticStabilityBundleForFailureSync.mockClear();
     bootLifecycle.decisions.length = 0;
@@ -1438,16 +1431,6 @@ describe("gateway run option collisions", () => {
     });
     expect(gatewayStartOptions(1).channelAutostartSuppression).toBeUndefined();
     expect(gatewayLogMessages.some((message) => message.includes("breaker recovered"))).toBe(true);
-  });
-
-  it("logs when first startup will build missing Control UI assets", async () => {
-    controlUiState.root = null;
-
-    await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
-
-    expect(gatewayLogMessages).toContain(
-      "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
-    );
   });
 
   it("does not write startup failure bundles for expected gateway lock conflicts", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -203,28 +203,6 @@ function shouldBlockGatewayBindWithoutExplicitAuth(params: {
   );
 }
 
-async function maybeLogPendingControlUiBuild(cfg: OpenClawConfig): Promise<void> {
-  if (cfg.gateway?.controlUi?.enabled === false) {
-    return;
-  }
-  if (toOptionString(cfg.gateway?.controlUi?.root)) {
-    return;
-  }
-  const { resolveControlUiRootSync } = await import("../../infra/control-ui-assets.js");
-  if (
-    resolveControlUiRootSync({
-      moduleUrl: import.meta.url,
-      argv1: process.argv[1],
-      cwd: process.cwd(),
-    })
-  ) {
-    return;
-  }
-  gatewayLog.info(
-    "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
-  );
-}
-
 function getGatewayStartGuardErrors(params: {
   allowUnconfigured?: boolean;
   configExists: boolean;
@@ -709,9 +687,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV] = String(process.pid);
   }
   await hooks.refreshManagedProxy?.(cfg.proxy);
-  void maybeLogPendingControlUiBuild(cfg).catch((err: unknown) => {
-    gatewayLog.warn(`Control UI asset check failed: ${String(err)}`);
-  });
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
     defaultRuntime.error(formatInvalidPortOption("--port"));
@@ -757,7 +732,8 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
         sigtermTimeoutMs: 700,
       });
       if (killed.length === 0) {
-        gatewayLog.info(`force: no listeners on port ${port}`);
+        // Nothing was freed; keep the no-op out of normal startup output.
+        gatewayLog.debug(`force: no listeners on port ${port}`);
       } else {
         for (const proc of killed) {
           gatewayLog.info(

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1312,16 +1312,13 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
           : {}),
       },
     });
+    // logConfigUpdated already prints the `.bak` backup line when it exists.
     logConfigUpdated(ctx.runtime);
     const preUpdateSnapshotPath = `${ctx.configPath}.pre-update`;
     if (updateDoctorRun && fs.existsSync(preUpdateSnapshotPath)) {
       ctx.runtime.log(
         `Update changed config; pre-update backup: ${shortenHomePath(preUpdateSnapshotPath)}`,
       );
-    }
-    const backupPath = `${ctx.configPath}.bak`;
-    if (fs.existsSync(backupPath)) {
-      ctx.runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
   }
 }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -64,6 +64,7 @@ vi.mock("../agents/agent-bundle-lsp-runtime.js", async () => ({
 
 vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: vi.fn(() => ({
+    debug: vi.fn(),
     info: mocks.logInfo,
     warn: mocks.logWarn,
   })),

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -722,7 +722,9 @@ export function createGatewayCloseHandler(
     const measureCloseStep = <T>(name: string, run: () => Promise<T> | T) =>
       measureGatewayRestartTrace(`restart.close.${name}`, run, [["reason", reason]]);
     try {
-      shutdownLog.info(`shutdown started: ${reason}`);
+      // Debug-level: the signal handler already announced the stop/restart at
+      // info, and the completion line below reports duration and outcome.
+      shutdownLog.debug(`shutdown started: ${reason}`);
 
       await measureCloseStep("gateway-shutdown-hook", () =>
         shutdownStep(

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -325,7 +325,9 @@ export async function ensureControlUiAssetsBuilt(
     };
   }
 
-  runtime.log("Control UI assets missing; building (ui:build, auto-installs UI deps)…");
+  runtime.log(
+    "Control UI assets missing; building them now (rerun `pnpm ui:build` after UI changes, or use `pnpm ui:dev` while developing the Control UI)…",
+  );
 
   const build = await runCommandWithTimeout([process.execPath, uiScript, "build"], {
     cwd: repoRoot,


### PR DESCRIPTION
## What Problem This Solves

Routine gateway boots print duplicated, mislabeled, and zero-information log lines that bury real problems. Observed on a live `pnpm gateway:watch` session (see linked issue): voice-state probes logged as slash-command deploy errors, the same deploy failure logged twice with the JSON body repeated inside it, unresolved-channel lines printed with no timestamp/subsystem prefix, Slack "resolved" lines that map an id to itself, five log lines for one SIGTERM, doctor printing the backup path twice, and nine `runtime-postbuild` timing rows per rebuild.

Fixes https://github.com/openclaw/openclaw/issues/104163.

## Why This Change Was Made

Each fix targets a specific defect rather than a style preference:

- **Mislabeled REST diagnostics** — `provider.deploy.ts` monkeypatches the shared `client.rest` for the whole deploy window, so unrelated concurrent startup traffic (voice-state probes, channel lookups) picked up the `native-slash-command-deploy-rest` label and was re-logged at error level even when its owner (e.g. the voice manager) already treats the failure as an expected state. The wrapper now passes non-`/applications/**/commands` paths straight through.
- **Double logging of deploy failures** — the per-request `rest:*:error` line is now verbose-only; the single owner-level warning (`slash command deploy failed (message send/receive unaffected): ...`) is the one non-verbose line per failure.
- **Redundant `body=`** — Discord error envelopes that only contain `message` + `code` are no longer appended, since both already appear in the line.
- **Multi-line prefix loss** — `summarizeMapping` logged resolved+unresolved as one `\n`-joined message; the console logger only prefixes the first line. It now logs one call per line.
- **Identity-mapping noise** — allowlist summaries skip lookups that resolved to themselves with no display name (`U0ATMLTKMC3→U0ATMLTKMC3 (id:U0ATMLTKMC3)` said nothing three times per boot), and the `(id:...)` suffix is only added when the id isn't already visible in the line.
- **Embedded subsystem prefixes** — `[discord] discord: ...` messages had the channel name baked into the message; the logger already prefixes the subsystem. (The theme-colored `warn()` wrapper defeats the console's redundant-prefix stripper, so this has to be fixed at the call sites.)
- **Shutdown chatter** — `signal SIGTERM received` and `shutdown started: ...` demoted to debug; `received SIGTERM; shutting down` + `shutdown completed cleanly in Nms` remain.
- **Doctor backup duplicate** — `logConfigUpdated` already prints the `.bak` line; the second print in `doctor-health-contributions.ts` is removed.
- **Control UI assets** — the two near-identical messages (pre-warning in `run.ts`, build notice in `control-ui-assets.ts`) are merged into one line at build time carrying the `pnpm ui:build`/`pnpm ui:dev` guidance.
- **`force: no listeners`** — demoted to debug when nothing was actually killed.
- **Telegram polling `[diag] isolated polling ingress started`** — intentionally kept at info: the `test/e2e/qa-lab` telegram-bot-token runtime waits for this exact marker on the injected runtime log, so demoting it would time out that live proof. The contract is now commented at the call site.
- **`runtime-postbuild`** — one summary line by default (`9 phases completed in 903ms (slowest: ...)`); per-phase rows via `OPENCLAW_RUNTIME_POSTBUILD_TIMINGS=verbose`, `0` still silences.
- **Actionability** — the recurring `transcripts autoStart failed` config error now names the config surface to fix (`transcripts.autoStart`); command-limit warnings name the platform limit (`112 commands exceed the 100-command Telegram limit; ...`).

A "startup issues summary block" was considered and deliberately not built: channel config findings trickle in for 60s+ after `[gateway] ready` (transcripts autoStart fires a minute later), and aggregated reporting already exists in `openclaw channels status` / `openclaw doctor`. The per-line fixes make each remaining line correctly attributed and actionable instead of adding a second, racy aggregator.

## User Impact

Operators watching gateway logs get one correctly-labeled line per event. Example (default verbosity, from the observed session):

**Before**

```
03:29:23 [gateway] Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.
03:29:23 [gateway] force: no listeners on port 18789
03:29:24 [gateway] Control UI assets missing; building (ui:build, auto-installs UI deps)…
03:29:28 [telegram] 112 commands exceeds limit; removing per-skill commands and keeping /skill.
03:29:28 [telegram] [diag] isolated polling ingress started spool=/Users/steipete/.openclaw/telegram/ingress-spool-default
03:29:28 [slack] channels resolved: C0AUXUC5AGN→maintainers (id:C0AUXUC5AGN)
03:29:28 [slack] users resolved: U0ATMLTKMC3→U0ATMLTKMC3 (id:U0ATMLTKMC3)
03:29:28 [slack] channel users resolved: U0ATMLTKMC3→U0ATMLTKMC3 (id:U0ATMLTKMC3)
03:29:29 [discord] channels resolved: 1456350064065904867/1456744319972282449 (guild:Friends of the Crustacean 🦞🤝; channel:maintainers), …
discord channels unresolved: 1456350064065904867/1501689839878275142 (guildId:1456350064065904867; channelId:1501689839878275142)
03:29:30 [discord] discord: 110 commands exceeds limit; removing per-skill commands and keeping /skill.
03:29:30 [discord] startup [default] native-slash-command-deploy-rest:get:error 3147ms path=/channels/1501689839878275142 requestMs=177 error=Missing Access (status=403, code=50001, body={"message":"Missing Access","code":50001})
03:29:30 [discord] startup [default] native-slash-command-deploy-rest:post:error 3411ms path=/applications/1456406468898197625/commands requestMs=198 error=Maximum number of application commands reached (100). (status=400, code=30032, body={"message":"Maximum number of application commands reached (100).","code":30032})
03:29:30 [discord] discord: native slash command deploy warning (not message send): Maximum number of application commands reached (100). (status=400, code=30032, body={"message":"Maximum number of application commands reached (100).","code":30032})
03:29:31 [discord] startup [default] native-slash-command-deploy-rest:get:error 3528ms path=/guilds/1456350064065904867/voice-states/387380367612706819 requestMs=177 error=Unknown Voice State (status=404, code=10065, body={"message":"Unknown Voice State","code":10065})
03:30:10 [gateway] signal SIGTERM received
03:30:10 [gateway] received SIGTERM; shutting down
03:30:10 [shutdown] started: gateway stopping
03:30:11 [shutdown] completed cleanly in 736ms
```

**After**

```
03:29:24 [gateway] Control UI assets missing; building them now (rerun `pnpm ui:build` after UI changes, or use `pnpm ui:dev` while developing the Control UI)…
03:29:28 [telegram] 112 commands exceed the 100-command Telegram limit; removing per-skill commands and keeping /skill.
03:29:28 [telegram] [diag] isolated polling ingress started spool=/Users/steipete/.openclaw/telegram/ingress-spool-default
03:29:28 [slack] channels resolved: C0AUXUC5AGN→maintainers
03:29:29 [discord] channels resolved: 1456350064065904867/1456744319972282449 (guild:Friends of the Crustacean 🦞🤝; channel:maintainers), …
03:29:29 [discord] channels unresolved: 1456350064065904867/1501689839878275142 (guildId:1456350064065904867; channelId:1501689839878275142)
03:29:30 [discord] 110 commands exceed the 100-command Discord limit; removing per-skill commands and keeping /skill.
03:29:30 [discord] [default] slash command deploy failed (message send/receive unaffected): Maximum number of application commands reached (100). (status=400, code=30032)
03:30:10 [gateway] received SIGTERM; shutting down
03:30:11 [shutdown] completed cleanly in 736ms
```

The Missing Access probe and Unknown Voice State lines don't disappear from the product — they were never deploy events. The channel probe still surfaces as `channels unresolved` (now correctly prefixed), and the voice manager keeps handling its expected 404s verbose-only, as it already did.

Doctor no longer prints the backup twice:

```
Updated config: ~/.openclaw/openclaw.json
  Backup: ~/.openclaw/openclaw.json.bak
```

Rebuilds print one postbuild line instead of nine (captured from the remote proof build):

```
runtime-postbuild: 9 phases completed in 246ms (slowest: stable root runtime imports 87ms)
```

`OPENCLAW_RUNTIME_POSTBUILD_TIMINGS=verbose` restores the per-phase rows; `0` still silences timings entirely.

## Evidence

- New regression tests: `extensions/discord/src/monitor/provider.deploy.test.ts` (non-command REST passthrough keeps caller-owned error handling, exactly one warning per deploy failure at default verbosity, redundant-body dedupe), identity-skip coverage in `src/channels/allowlists/resolve-utils.test.ts` and `extensions/slack/src/monitor/provider.allowlist.test.ts`.
- Updated assertions for the reworded lines in `provider.test.ts`, `provider.allowlist.test.ts`, `bot-native-commands.test.ts`, `resolve-utils.test.ts`; subsystem-logger test mocks gained the `debug` method the demoted lines now use.
- Blacksmith Testbox via Crabbox (`tbx_01kx7nc2abm64vxh7gwzeghx9r`): focused suites green — discord provider/deploy/allowlist, slack allowlist, telegram native commands, channel resolve-utils, gateway run/run-loop/server-close, run-node (7 shards); `pnpm check:changed` exit 0 (typecheck core/tests/extensions + lint fan-out + guards); `pnpm build` exit 0.
- Codex autoreview (`gpt-5.6-sol`): two accepted findings were fixed in follow-up commits — Slack bare-name resolutions (`general` → id) are no longer suppressed by the identity filter, and the Telegram isolated-ingress readiness marker stays on the runtime log because the `test/e2e/qa-lab` bot-token runtime waits for it. The remaining changelog finding is rejected per repo policy (`CHANGELOG.md` is release-only; release-note context lives in this PR body and the commit messages).
- Focused reruns after the review fixes: `extensions/slack/src/monitor/provider.allowlist.test.ts` 8/8 green.
