### PR TITLE
fix(release): Telegram QA survives runner path masks

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1016,6 +1016,7 @@ jobs:
           candidate_extract_root="$(dirname "$CANDIDATE_ROOT")"
           candidate_runtime_root="/opt/openclaw-telegram-sut-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           runtime_root="/var/lib/openclaw-telegram-sut-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          node_bin="${runtime_root}/node"
           launcher="/usr/local/bin/openclaw-telegram-sut-launcher"
           config="/etc/openclaw-telegram-sut.conf"
           preload="${runtime_root}/openclaw-telegram-preentry.mjs"
@@ -1023,7 +1024,7 @@ jobs:
           runner_gid="$(id -g)"
           runner_home="$(realpath -e "$HOME")"
           runner_temp="$(realpath -e "$RUNNER_TEMP")"
-          node_bin="$(realpath -e "$(command -v node)")"
+          source_node_bin="$(realpath -e "$(command -v node)")"
           [[ "$candidate_extract_root" == "${RUNNER_TEMP}/openclaw-telegram-executor-extract" ]]
           case "$runner_temp/" in
             "$runner_home"/*) ;;
@@ -1045,6 +1046,9 @@ jobs:
           sudo mv "$CANDIDATE_ROOT" "$candidate_runtime_root"
           CANDIDATE_ROOT="$candidate_runtime_root"
           sudo install -d -o root -g root -m 0755 "$runtime_root"
+          sudo install -o root -g root -m 0555 "$source_node_bin" "$node_bin"
+          [[ "$(stat -c '%F:%a:%u:%g' "$node_bin")" == "regular file:555:0:0" ]]
+          "$node_bin" --version >/dev/null
           sudo install -d -o "$runner_uid" -g "$runner_gid" -m 0711 "$runtime_root/tmp"
           # Frozen candidates prefer /tmp/openclaw before TMPDIR. Make that shared path
           # unavailable to the runner so they use the isolated runtime fallback instead.

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -514,6 +514,19 @@ describe("release Telegram QA workflow", () => {
     expect(source).toMatch(/launcher_stage=enter-mount-namespace\n\s+\/usr\/bin\/unshare/u);
     expect(source).not.toContain("exec /usr/bin/unshare");
     expect(source).not.toContain("set -x");
+    expect(source).toContain('source_node_bin="$(realpath -e "$(command -v node)")"');
+    expect(source).toContain('node_bin="${runtime_root}/node"');
+    expect(source).toContain(
+      'sudo install -o root -g root -m 0555 "$source_node_bin" "$node_bin"',
+    );
+    expect(source).toContain(
+      '[[ "$(stat -c \'%F:%a:%u:%g\' "$node_bin")" == "regular file:555:0:0" ]]',
+    );
+    expect(source).toContain('"$node_bin" --version >/dev/null');
+    expect(source).toContain("for masked_path in \"$RUNNER_HOME\" /tmp /var/tmp /dev/shm");
+    expect(source).not.toMatch(
+      /^\s+node_bin="\$\(realpath -e "\$\(command -v node\)"\)"$/mu,
+    );
     expect(source).toContain('temp_root="$(realpath -e "${OPENCLAW_QA_TEMP_ROOT:?}")"');
     expect(source).toContain("sudo install -d -o root -g root -m 0700 /tmp/openclaw");
     expect(source).toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the trusted Telegram release QA workflow could not start the candidate gateway after masking runner-owned paths. The setup-node executable lived below the masked runner home, so every scenario failed with `Permission denied` before exercising the release candidate.

Related: https://github.com/openclaw/openclaw/actions/runs/29138787990

## Why This Change Was Made

The workflow now copies the resolved Node executable into the existing root-owned SUT runtime root before entering the masked mount namespace. The runner-home and temporary-directory masks remain unchanged, and the copied executable is verified as a root-owned regular file with mode `0555` before use.

## User Impact

Release maintainers can run the hardened Telegram beta validation without weakening its host-path isolation. This changes release infrastructure only; product runtime behavior is unchanged.

## Evidence

- Focused Testbox workflow contract: 12/12 passed
- Testbox: `tbx_01kx7q847j1crcheshxm8bfmtm`
- Run: https://github.com/openclaw/openclaw/actions/runs/29139811270
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Autoreview: no accepted/actionable findings
