### PR TITLE
fix(ci): package unreleased QA smoke candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,6 +965,7 @@ jobs:
           node scripts/build-all.mjs qaRuntime
           pnpm ui:build
           node scripts/package-openclaw-for-docker.mjs \
+            --allow-unreleased-changelog \
             --skip-build \
             --output-dir .artifacts/qa-e2e/smoke-ci-package \
             --output-name openclaw-current.tgz

--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -2,7 +2,6 @@
 import { createServer, type Server } from "node:http";
 import { gzipSync } from "node:zlib";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
-import { fetch as undiciFetch } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { serializeRequestBody } from "./rest-body.js";
 import { DiscordError, RateLimitError, RequestClient } from "./rest.js";
@@ -845,19 +844,12 @@ describe("RequestClient", () => {
     expect(form.get("files[0]")).toBeInstanceOf(Blob);
   });
 
-  it("dispatches multipart uploads with a multipart/form-data content type", async () => {
+  it("passes multipart uploads to fetch as FormData", async () => {
+    const arrayBufferSpy = vi.spyOn(Blob.prototype, "arrayBuffer");
     const fetchSpy = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
       expect(init?.headers).toBeInstanceOf(Headers);
-      expect((init!.headers as Headers).get("Content-Type")).toMatch(
-        /^multipart\/form-data; boundary=/,
-      );
-      expect(init?.body).not.toBeInstanceOf(FormData);
-      const request = new Request("https://discord.test/upload", {
-        method: "POST",
-        headers: init?.headers,
-        body: init?.body,
-      });
-      expect(request.headers.get("Content-Type")).toMatch(/^multipart\/form-data; boundary=/);
+      expect((init!.headers as Headers).get("Content-Type")).toBeNull();
+      expect(init?.body).toBeInstanceOf(FormData);
       return new Response(JSON.stringify({ id: "msg" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -865,16 +857,21 @@ describe("RequestClient", () => {
     });
     const client = new RequestClient("test-token", { fetch: fetchSpy, queueRequests: false });
 
-    await expect(
-      client.post("/channels/c1/messages", {
-        body: {
-          content: "file",
-          files: [{ name: "a.txt", data: new Uint8Array([1]), contentType: "text/plain" }],
-        },
-      }),
-    ).resolves.toEqual({ id: "msg" });
+    try {
+      await expect(
+        client.post("/channels/c1/messages", {
+          body: {
+            content: "file",
+            files: [{ name: "a.txt", data: new Uint8Array([1]), contentType: "text/plain" }],
+          },
+        }),
+      ).resolves.toEqual({ id: "msg" });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(arrayBufferSpy).not.toHaveBeenCalled();
+    } finally {
+      arrayBufferSpy.mockRestore();
+    }
   });
 
   it("dispatches multipart uploads through undici fetch with a multipart/form-data content type", async () => {
@@ -897,7 +894,6 @@ describe("RequestClient", () => {
       const client = new RequestClient("test-token", {
         baseUrl: `http://127.0.0.1:${address.port}`,
         apiVersion: 10,
-        fetch: undiciFetch as unknown as typeof fetch,
         queueRequests: false,
       });
 

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -1,5 +1,4 @@
 // Discord plugin module implements rest behavior.
-import { randomBytes } from "node:crypto";
 import { inspect } from "node:util";
 import { gunzipSync } from "node:zlib";
 import {
@@ -151,52 +150,6 @@ function isZlibMaxOutputLengthError(err: unknown): boolean {
   );
 }
 
-function escapeMultipartQuotedValue(value: string): string {
-  return value.replace(/["\r\n]/g, (ch) => (ch === '"' ? "%22" : ch === "\r" ? "%0D" : "%0A"));
-}
-
-async function formDataToMultipartBody(body: FormData, headers: Headers): Promise<BodyInit> {
-  const boundary = `----openclaw-discord-${randomBytes(12).toString("hex")}`;
-  headers.set("Content-Type", `multipart/form-data; boundary=${boundary}`);
-  const chunks: Buffer[] = [];
-  const push = (value: string | Buffer) => {
-    chunks.push(typeof value === "string" ? Buffer.from(value) : value);
-  };
-  for (const [key, value] of body.entries()) {
-    push(`--${boundary}\r\n`);
-    const escapedKey = escapeMultipartQuotedValue(key);
-    if (typeof value === "string") {
-      push(`Content-Disposition: form-data; name="${escapedKey}"\r\n\r\n`);
-      push(value);
-      push("\r\n");
-      continue;
-    }
-    const filename = (value as Blob & { name?: unknown }).name;
-    const escapedFilename = escapeMultipartQuotedValue(
-      typeof filename === "string" && filename.length > 0 ? filename : "blob",
-    );
-    push(`Content-Disposition: form-data; name="${escapedKey}"; filename="${escapedFilename}"\r\n`);
-    if (value.type) {
-      push(`Content-Type: ${value.type}\r\n`);
-    }
-    push("\r\n");
-    push(Buffer.from(await value.arrayBuffer()));
-    push("\r\n");
-  }
-  push(`--${boundary}--\r\n`);
-  return Buffer.concat(chunks) as unknown as BodyInit;
-}
-
-async function normalizeFetchBody(
-  body: BodyInit | undefined,
-  headers: Headers,
-): Promise<BodyInit | undefined> {
-  if (body instanceof FormData) {
-    return await formDataToMultipartBody(body, headers);
-  }
-  return body;
-}
-
 export class RequestClient {
   readonly options: NormalizedRequestClientOptions;
   protected token: string;
@@ -297,7 +250,7 @@ export class RequestClient {
       const response = await (this.customFetch ?? fetch)(url, {
         method,
         headers,
-        body: await normalizeFetchBody(body, headers),
+        body,
         signal,
       });
       const text = await readResponseBodyText(response, this.options.timeout ?? 15_000);

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -14,7 +14,8 @@ import {
 import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { Agent, fetch as undiciFetch } from "undici";
+import { fetchWithRuntimeDispatcher } from "openclaw/plugin-sdk/runtime-fetch";
+import { Agent } from "undici";
 import { createDiscordDnsLookup } from "../network-config.js";
 import { withValidatedDiscordProxy } from "../proxy-fetch.js";
 
@@ -56,12 +57,7 @@ function createEnvProxyDiscordRestDispatcher(
 
 function createDiscordRestFetchWithDispatcher(dispatcher: DiscordRestDispatcher): typeof fetch {
   return wrapFetchWithAbortSignal(((input: RequestInfo | URL, init?: RequestInit) =>
-    (
-      undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
-        dispatcher,
-      }) as unknown as Promise<Response>
-    ).then((response) => {
+    fetchWithRuntimeDispatcher(input, { ...init, dispatcher }).then((response) => {
       captureHttpExchange({
         url: resolveRequestUrl(input),
         method: init?.method ?? "GET",

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -33,7 +33,6 @@ import {
   createDiscordClient,
   resolveChannelId,
   resolveDiscordChannel,
-  toDiscordFileBlob,
   stripUndefinedFields,
   SUPPRESS_NOTIFICATIONS_FLAG,
 } from "./send.shared.js";
@@ -218,8 +217,7 @@ async function buildDiscordComponentPayload(params: {
     const filenameOverride = params.opts.filename?.trim();
     resolvedFileName = filenameOverride || media.fileName || "upload";
     spec = withImplicitComponentAttachmentBlock(spec, resolvedFileName);
-    const fileData = toDiscordFileBlob(media.buffer);
-    files = [{ data: fileData, name: resolvedFileName }];
+    files = [{ data: media.buffer, name: resolvedFileName }];
   }
 
   const attachmentNames = extractComponentAttachmentNames(spec);

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -304,15 +304,6 @@ export function buildDiscordTextChunks(
   return resolveTextChunksWithFallback(text, chunks);
 }
 
-export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
-  if (data instanceof Blob) {
-    return data;
-  }
-  const arrayBuffer = new ArrayBuffer(data.byteLength);
-  new Uint8Array(arrayBuffer).set(data);
-  return new Blob([arrayBuffer]);
-}
-
 export type DiscordSendProgress = (
   result: { id: string; channel_id: string },
   kind: "text" | "media",
@@ -450,7 +441,6 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars })
     : [];
   const caption = chunks[0] ?? "";
-  const fileData = toDiscordFileBlob(media.buffer);
   const captionComponents = resolveDiscordSendComponents({
     components,
     text: caption,
@@ -470,7 +460,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     replyTo: resolveDiscordReplyMessageId(reply, true),
     files: [
       {
-        data: fileData,
+        data: media.buffer,
         name: resolvedFileName,
       },
     ],

--- a/scripts/package-changelog.mjs
+++ b/scripts/package-changelog.mjs
@@ -22,7 +22,7 @@ const PRERELEASE_VERSION_PATTERN =
 /**
  * Resolves acceptable changelog headings for a package version.
  */
-export function resolvePackageChangelogVersions(packageVersion) {
+export function resolvePackageChangelogVersions(packageVersion, options = {}) {
   const match = RELEASE_VERSION_PATTERN.exec(packageVersion);
   if (!match) {
     throw new Error(
@@ -32,7 +32,7 @@ export function resolvePackageChangelogVersions(packageVersion) {
   if (PRERELEASE_VERSION_PATTERN.test(packageVersion)) {
     return [packageVersion, match[1], UNRELEASED_HEADING];
   }
-  return [packageVersion];
+  return options.allowUnreleasedFallback ? [packageVersion, UNRELEASED_HEADING] : [packageVersion];
 }
 
 function splitLines(content) {
@@ -61,8 +61,8 @@ function extractPreamble(lines, firstHeadingIndex) {
 /**
  * Extracts the current release changelog section for package publishing.
  */
-export function extractCurrentPackageChangelog(content, packageVersion) {
-  const targetVersions = resolvePackageChangelogVersions(packageVersion);
+export function extractCurrentPackageChangelog(content, packageVersion, options = {}) {
+  const targetVersions = resolvePackageChangelogVersions(packageVersion, options);
   const lines = splitLines(content);
   const headings = findLevelTwoHeadings(lines);
   const heading = targetVersions
@@ -109,7 +109,7 @@ async function readPackageVersion(cwd) {
 /**
  * Restores the source changelog from a package-changelog backup.
  */
-export async function restorePackageChangelog(cwd = process.cwd()) {
+export async function restorePackageChangelog(cwd = process.cwd(), options = {}) {
   const backupPath = path.join(cwd, BACKUP_PATH);
   if (!existsSync(backupPath)) {
     return false;
@@ -123,7 +123,7 @@ export async function restorePackageChangelog(cwd = process.cwd()) {
     const packageVersion = await readPackageVersion(cwd);
     let expectedPackaged;
     try {
-      expectedPackaged = extractCurrentPackageChangelog(backup, packageVersion);
+      expectedPackaged = extractCurrentPackageChangelog(backup, packageVersion, options);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(
@@ -145,13 +145,13 @@ export async function restorePackageChangelog(cwd = process.cwd()) {
 /**
  * Writes packaged changelog content while preserving a restorable backup.
  */
-export async function preparePackageChangelog(cwd = process.cwd()) {
-  await restorePackageChangelog(cwd);
+export async function preparePackageChangelog(cwd = process.cwd(), options = {}) {
+  await restorePackageChangelog(cwd, options);
   const changelogPath = path.join(cwd, CHANGELOG_PATH);
   const backupPath = path.join(cwd, BACKUP_PATH);
   const original = await readFile(changelogPath, "utf8");
   const packageVersion = await readPackageVersion(cwd);
-  const packaged = extractCurrentPackageChangelog(original, packageVersion);
+  const packaged = extractCurrentPackageChangelog(original, packageVersion, options);
   if (packaged === original) {
     return false;
   }

--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -137,6 +137,7 @@ function resolvePackedOpenClawFileName(value) {
 
 export function parseArgs(argv) {
   const options = {
+    allowUnreleasedChangelog: false,
     outputDir: "",
     outputName: "",
     packJson: "",
@@ -181,6 +182,8 @@ export function parseArgs(argv) {
         "packJson",
         readEqualsOptionValue(arg.slice("--pack-json=".length), "--pack-json"),
       );
+    } else if (arg === "--allow-unreleased-changelog") {
+      setOnce(arg, "allowUnreleasedChangelog", true);
     } else if (arg === "--pnpm-pack") {
       setOnce(arg, "pnpmPack", true);
     } else if (arg === "--skip-build") {
@@ -661,7 +664,10 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
     throw new Error("packJsonPath cannot be combined with pnpmPack");
   }
   console.error("==> Packing OpenClaw package");
-  await prepareChangelog(sourceDir);
+  const changelogOptions = {
+    allowUnreleasedFallback: options.allowUnreleasedChangelog === true,
+  };
+  await prepareChangelog(sourceDir, changelogOptions);
   let packOutput;
   let cleanupBundledAiRuntime = async () => {};
   try {
@@ -689,7 +695,7 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
     try {
       await cleanupBundledAiRuntime();
     } finally {
-      await restoreChangelog(sourceDir);
+      await restoreChangelog(sourceDir, changelogOptions);
     }
   }
   // pnpm reports an absolute destination path. The directory was emptied before packing,
@@ -740,6 +746,7 @@ async function main() {
   );
 
   const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
+    allowUnreleasedChangelog: options.allowUnreleasedChangelog,
     outputName: options.outputName,
     packJsonPath: options.packJson,
     pnpmPack: options.pnpmPack,

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -84,6 +84,7 @@ describe("package-openclaw-for-docker", () => {
   it("parses package artifact output options", () => {
     expect(
       parseArgs([
+        "--allow-unreleased-changelog",
         "--output-dir",
         ".artifacts/docker",
         "--output-name=openclaw-current.tgz",
@@ -94,6 +95,7 @@ describe("package-openclaw-for-docker", () => {
         "--skip-build",
       ]),
     ).toEqual({
+      allowUnreleasedChangelog: true,
       outputDir: ".artifacts/docker",
       outputName: "openclaw-current.tgz",
       packJson: ".artifacts/docker/pack.json",
@@ -116,6 +118,10 @@ describe("package-openclaw-for-docker", () => {
   it("rejects duplicate package artifact CLI options", () => {
     const duplicateCases = [
       ["--output-dir", ["--output-dir", "one", "--output-dir=two"]],
+      [
+        "--allow-unreleased-changelog",
+        ["--allow-unreleased-changelog", "--allow-unreleased-changelog"],
+      ],
       ["--output-name", ["--output-name", "one.tgz", "--output-name=two.tgz"]],
       ["--pack-json", ["--pack-json", "one.json", "--pack-json=two.json"]],
       ["--pnpm-pack", ["--pnpm-pack", "--pnpm-pack"]],
@@ -421,6 +427,24 @@ describe("package-openclaw-for-docker", () => {
       "npm:pack --silent --ignore-scripts --pack-destination /out:/repo",
       "restore:/repo",
     ]);
+  });
+
+  it("passes the explicit Unreleased fallback through the changelog lifecycle", async () => {
+    const calls: string[] = [];
+
+    await packOpenClawPackageForDocker("/repo", "/out", {
+      allowUnreleasedChangelog: true,
+      prepareBundledAiRuntime: skipBundledAiRuntime,
+      prepareChangelog: async (cwd: string, options: { allowUnreleasedFallback?: boolean }) => {
+        calls.push(`prepare:${cwd}:${String(options.allowUnreleasedFallback)}`);
+      },
+      restoreChangelog: async (cwd: string, options: { allowUnreleasedFallback?: boolean }) => {
+        calls.push(`restore:${cwd}:${String(options.allowUnreleasedFallback)}`);
+      },
+      runCaptureImpl: async () => "openclaw-2026.5.29.tgz\n",
+    });
+
+    expect(calls).toEqual(["prepare:/repo:true", "restore:/repo:true"]);
   });
 
   it("uses pnpm pack when requested", async () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2164,6 +2164,7 @@ describe("ci workflow guards", () => {
     expect(smokeProfileJob.name).toBe("QA Smoke CI (${{ matrix.name }})");
     expect(smokeBuildStep.run).toContain("node scripts/build-all.mjs qaRuntime");
     expect(smokeBuildStep.run).toContain("pnpm ui:build");
+    expect(smokeBuildStep.run).toContain("--allow-unreleased-changelog");
     expect(smokeBuildStep.env.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
     expect(smokeBuildStep.run).toContain("--skip-build");
     expect(workflow.jobs["qa-smoke-ci-artifacts"]).toBeUndefined();

--- a/test/scripts/package-changelog.test.ts
+++ b/test/scripts/package-changelog.test.ts
@@ -21,7 +21,7 @@ const cumulativeChangelog = changelog`
 Docs: https://docs.openclaw.ai
 ## Unreleased
 ### Fixes
-- Pending note.
+- Pending beta release notes with enough detail.
 ## 2026.5.28
 ### Highlights
 - Current highlight.
@@ -48,6 +48,9 @@ describe("package-changelog", () => {
       "2026.5.28",
       "Unreleased",
     ]);
+    expect(resolvePackageChangelogVersions("2026.5.29", { allowUnreleasedFallback: true })).toEqual(
+      ["2026.5.29", "Unreleased"],
+    );
   });
 
   it("extracts only the package version stable release section", () => {
@@ -122,6 +125,21 @@ Docs: https://docs.openclaw.ai
     expect(() => extractCurrentPackageChangelog(cumulativeChangelog, "2026.5.29")).toThrow(
       "CHANGELOG.md does not contain a release section for 2026.5.29.",
     );
+  });
+
+  it("uses Unreleased for an unreleased stable-version package only when explicitly allowed", () => {
+    expect(
+      extractCurrentPackageChangelog(cumulativeChangelog, "2026.5.29", {
+        allowUnreleasedFallback: true,
+      }),
+    ).toBe(changelog`
+# Changelog
+Docs: https://docs.openclaw.ai
+
+## Unreleased
+### Fixes
+- Pending beta release notes with enough detail.
+`);
   });
 
   it("fails closed when the packaged changelog is unexpectedly large", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every CI QA smoke profile failed before running any scenario after `main` advanced to version `2026.7.2`. Packaging required an exact `2026.7.2` changelog section even though release policy intentionally keeps changelog generation as the final candidate source task.

Baseline: https://github.com/openclaw/openclaw/actions/runs/29139615832

## Why This Change Was Made

QA smoke packaging can now explicitly fall back to the existing `Unreleased` section. Normal and release packaging remain strict by default, exact version sections still win when present, and the same opt-in is carried through backup restoration so source `CHANGELOG.md` is restored safely.

## User Impact

CI can package and exercise unreleased `main` candidates without forcing premature changelog generation. Release artifacts still fail closed when their final release section is missing.

## Evidence

- Focused Testbox tests: 85/85 passed
- Testbox: `tbx_01kx7qpvtpg46ksrj7vea16t13`
- Run: https://github.com/openclaw/openclaw/actions/runs/29140027274
- `pnpm check:changed`: passed
- Testbox: `tbx_01kx7qvk0dq5mgnpbjzjtx0gsg`
- Run: https://github.com/openclaw/openclaw/actions/runs/29140092174
- `actionlint .github/workflows/ci.yml`
- Targeted `oxfmt --check`
- `git diff --check`
- Autoreview: no accepted/actionable findings
