### PR TITLE
feat(gateway): report redacted startup outcomes

### DIFF
--- a/src/gateway/server-startup-outcomes.test.ts
+++ b/src/gateway/server-startup-outcomes.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  createGatewayStartupOutcomeRecorder,
+  formatGatewayStartupOutcomes,
+  type GatewayStartupOutcome,
+  type GatewayStartupOutcomeRecorderParams,
+} from "./server-startup-outcomes.js";
+
+const inactiveParams: GatewayStartupOutcomeRecorderParams = {
+  cfg: {},
+  gatewayStartHooks: false,
+  memoryStartupMode: "off",
+  env: {},
+};
+
+describe("gateway startup outcomes", () => {
+  it("formats reverse input in canonical subsystem order", () => {
+    const outcomes: GatewayStartupOutcome[] = [
+      { subsystem: "gmail-model", status: "scheduled" },
+      { subsystem: "gmail-watcher", status: "skipped", reason: "no-gmail-account" },
+      { subsystem: "memory-qmd", status: "skipped", reason: "startup-disabled" },
+      { subsystem: "gateway-start-hooks", status: "scheduled" },
+      { subsystem: "internal-startup-hook", status: "scheduled" },
+      { subsystem: "internal-hooks", status: "loaded" },
+    ];
+
+    expect(formatGatewayStartupOutcomes(outcomes)).toBe(
+      "gateway startup outcomes: internal-hooks=loaded; " +
+        "internal-startup-hook=scheduled; gateway-start-hooks=scheduled; " +
+        "memory-qmd=skipped (startup-disabled); " +
+        "gmail-watcher=skipped (no-gmail-account); gmail-model=scheduled",
+    );
+  });
+
+  it.each([
+    {
+      name: "unconfigured",
+      params: inactiveParams,
+      expected: [
+        "internal-hooks=skipped (not-configured)",
+        "internal-startup-hook=skipped (no-handlers-loaded)",
+        "gateway-start-hooks=skipped (no-handlers-loaded)",
+        "memory-qmd=skipped (not-configured)",
+        "gmail-watcher=skipped (hooks-disabled)",
+        "gmail-model=skipped (not-configured)",
+      ],
+    },
+    {
+      name: "explicitly disabled and default-off qmd",
+      params: {
+        ...inactiveParams,
+        cfg: { hooks: { internal: { enabled: false } }, memory: { backend: "qmd" } },
+      } satisfies GatewayStartupOutcomeRecorderParams,
+      expected: [
+        "internal-hooks=skipped (hooks-disabled)",
+        "internal-startup-hook=skipped (hooks-disabled)",
+        "memory-qmd=skipped (startup-disabled)",
+      ],
+    },
+    {
+      name: "scheduled",
+      params: {
+        cfg: {
+          hooks: {
+            enabled: true,
+            internal: { enabled: true },
+            gmail: { account: "operator@example.com", model: "openai/gpt-5.5" },
+          },
+          memory: { backend: "qmd", qmd: { update: { startup: "immediate" } } },
+        },
+        gatewayStartHooks: true,
+        memoryStartupMode: "immediate",
+        env: {},
+      } satisfies GatewayStartupOutcomeRecorderParams,
+      expected: [
+        "internal-hooks=skipped (no-handlers-loaded)",
+        "internal-startup-hook=skipped (no-handlers-loaded)",
+        "gateway-start-hooks=scheduled",
+        "memory-qmd=scheduled",
+        "gmail-watcher=scheduled",
+        "gmail-model=scheduled",
+      ],
+    },
+    {
+      name: "gmail skip reasons",
+      params: {
+        ...inactiveParams,
+        cfg: { hooks: { enabled: true, gmail: { account: "operator@example.com" } } },
+        env: { OPENCLAW_SKIP_GMAIL_WATCHER: "1" },
+      } satisfies GatewayStartupOutcomeRecorderParams,
+      expected: ["gmail-watcher=skipped (disabled-by-environment)"],
+    },
+    {
+      name: "missing gmail account",
+      params: {
+        ...inactiveParams,
+        cfg: { hooks: { enabled: true } },
+      } satisfies GatewayStartupOutcomeRecorderParams,
+      expected: ["gmail-watcher=skipped (no-gmail-account)"],
+    },
+  ])("uses the fixed vocabulary for $name", ({ params, expected }) => {
+    const summary = formatGatewayStartupOutcomes(
+      createGatewayStartupOutcomeRecorder(params).snapshot(),
+    );
+
+    for (const entry of expected) {
+      expect(summary).toContain(entry);
+    }
+  });
+
+  it("records awaited internal hook outcomes without logging raw error fields", () => {
+    const recorder = createGatewayStartupOutcomeRecorder({
+      ...inactiveParams,
+      cfg: {
+        hooks: {
+          enabled: true,
+          internal: { enabled: true },
+          gmail: { account: "private-account", model: "private-provider/private-model" },
+        },
+      },
+    });
+    const failedOutcome: GatewayStartupOutcome & { error: string; value: string } = {
+      subsystem: "internal-hooks",
+      status: "failed",
+      reason: "see earlier log",
+      error: "secret startup error",
+      value: "private config value",
+    };
+
+    recorder.record(failedOutcome);
+    let summary = formatGatewayStartupOutcomes(recorder.snapshot());
+    expect(summary).toContain("internal-hooks=failed (see earlier log)");
+    expect(summary).not.toContain("secret startup error");
+    expect(summary).not.toContain("private config value");
+    expect(summary).not.toContain("private-account");
+    expect(summary).not.toContain("private-provider/private-model");
+
+    recorder.record({ subsystem: "internal-hooks", status: "loaded" });
+    recorder.record({ subsystem: "internal-startup-hook", status: "scheduled" });
+    summary = formatGatewayStartupOutcomes(recorder.snapshot());
+    expect(summary).toContain("internal-hooks=loaded");
+    expect(summary).toContain("internal-startup-hook=scheduled");
+  });
+});

--- a/src/gateway/server-startup-outcomes.ts
+++ b/src/gateway/server-startup-outcomes.ts
@@ -1,0 +1,160 @@
+// Fixed-vocabulary Gateway startup outcomes keep normal boot logs useful
+// without exposing configuration values, paths, or startup errors.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasConfiguredInternalHooks } from "../hooks/configured.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+
+export const GATEWAY_STARTUP_SUBSYSTEMS = [
+  "internal-hooks",
+  "internal-startup-hook",
+  "gateway-start-hooks",
+  "memory-qmd",
+  "gmail-watcher",
+  "gmail-model",
+] as const;
+
+export type GatewayStartupSubsystem = (typeof GATEWAY_STARTUP_SUBSYSTEMS)[number];
+
+export type GatewayStartupSkippedReason =
+  | "not-configured"
+  | "no-handlers-loaded"
+  | "disabled-by-environment"
+  | "hooks-disabled"
+  | "no-gmail-account"
+  | "startup-disabled";
+
+export type GatewayStartupOutcome =
+  | { subsystem: GatewayStartupSubsystem; status: "loaded" | "scheduled" }
+  | { subsystem: GatewayStartupSubsystem; status: "failed"; reason: "see earlier log" }
+  | {
+      subsystem: GatewayStartupSubsystem;
+      status: "skipped";
+      reason: GatewayStartupSkippedReason;
+    };
+
+type GatewayStartupOutcomePlan = {
+  internalHooks: "configured" | "not-configured" | "hooks-disabled";
+  gatewayStartHooks: boolean;
+  memoryQmd: "scheduled" | "not-configured" | "startup-disabled";
+  gmailWatcher: "scheduled" | "disabled-by-environment" | "hooks-disabled" | "no-gmail-account";
+  gmailModel: "scheduled" | "not-configured";
+};
+
+export type GatewayStartupOutcomeRecorder = {
+  record: (outcome: GatewayStartupOutcome) => void;
+  snapshot: () => GatewayStartupOutcome[];
+};
+
+export type GatewayStartupOutcomeRecorderParams = {
+  cfg: OpenClawConfig;
+  gatewayStartHooks: boolean;
+  memoryStartupMode: "off" | "immediate" | "idle";
+  env?: NodeJS.ProcessEnv;
+};
+
+function skipped(
+  subsystem: GatewayStartupSubsystem,
+  reason: GatewayStartupSkippedReason,
+): GatewayStartupOutcome {
+  return { subsystem, status: "skipped", reason };
+}
+
+function resolveOutcomePlan(
+  params: GatewayStartupOutcomeRecorderParams,
+): GatewayStartupOutcomePlan {
+  const internalHooks: GatewayStartupOutcomePlan["internalHooks"] =
+    params.cfg.hooks?.internal?.enabled === false
+      ? "hooks-disabled"
+      : hasConfiguredInternalHooks(params.cfg)
+        ? "configured"
+        : "not-configured";
+  const memoryQmd: GatewayStartupOutcomePlan["memoryQmd"] =
+    params.cfg.memory?.backend !== "qmd"
+      ? "not-configured"
+      : params.memoryStartupMode === "off"
+        ? "startup-disabled"
+        : "scheduled";
+  const gmailWatcher: GatewayStartupOutcomePlan["gmailWatcher"] = !params.cfg.hooks?.enabled
+    ? "hooks-disabled"
+    : !params.cfg.hooks.gmail?.account
+      ? "no-gmail-account"
+      : isTruthyEnvValue((params.env ?? process.env).OPENCLAW_SKIP_GMAIL_WATCHER)
+        ? "disabled-by-environment"
+        : "scheduled";
+
+  return {
+    internalHooks,
+    gatewayStartHooks: params.gatewayStartHooks,
+    memoryQmd,
+    gmailWatcher,
+    gmailModel: params.cfg.hooks?.gmail?.model ? "scheduled" : "not-configured",
+  };
+}
+
+/** Create the complete initial outcome set; awaited startup work may replace entries later. */
+export function createGatewayStartupOutcomeRecorder(
+  params: GatewayStartupOutcomeRecorderParams,
+): GatewayStartupOutcomeRecorder {
+  const plan = resolveOutcomePlan(params);
+  const internalHooks =
+    plan.internalHooks === "configured"
+      ? skipped("internal-hooks", "no-handlers-loaded")
+      : skipped("internal-hooks", plan.internalHooks);
+  const internalStartupHook =
+    plan.internalHooks === "hooks-disabled"
+      ? skipped("internal-startup-hook", "hooks-disabled")
+      : skipped("internal-startup-hook", "no-handlers-loaded");
+  const outcomes = new Map<GatewayStartupSubsystem, GatewayStartupOutcome>([
+    ["internal-hooks", internalHooks],
+    ["internal-startup-hook", internalStartupHook],
+    [
+      "gateway-start-hooks",
+      plan.gatewayStartHooks
+        ? { subsystem: "gateway-start-hooks", status: "scheduled" }
+        : skipped("gateway-start-hooks", "no-handlers-loaded"),
+    ],
+    [
+      "memory-qmd",
+      plan.memoryQmd === "scheduled"
+        ? { subsystem: "memory-qmd", status: "scheduled" }
+        : skipped("memory-qmd", plan.memoryQmd),
+    ],
+    [
+      "gmail-watcher",
+      plan.gmailWatcher === "scheduled"
+        ? { subsystem: "gmail-watcher", status: "scheduled" }
+        : skipped("gmail-watcher", plan.gmailWatcher),
+    ],
+    [
+      "gmail-model",
+      plan.gmailModel === "scheduled"
+        ? { subsystem: "gmail-model", status: "scheduled" }
+        : skipped("gmail-model", "not-configured"),
+    ],
+  ]);
+
+  return {
+    record: (outcome) => {
+      outcomes.set(outcome.subsystem, outcome);
+    },
+    snapshot: () =>
+      GATEWAY_STARTUP_SUBSYSTEMS.flatMap((subsystem) => {
+        const outcome = outcomes.get(subsystem);
+        return outcome ? [outcome] : [];
+      }),
+  };
+}
+
+/** Format outcomes in canonical order regardless of collection order. */
+export function formatGatewayStartupOutcomes(outcomes: readonly GatewayStartupOutcome[]): string {
+  const bySubsystem = new Map(outcomes.map((outcome) => [outcome.subsystem, outcome]));
+  const entries = GATEWAY_STARTUP_SUBSYSTEMS.flatMap((subsystem) => {
+    const outcome = bySubsystem.get(subsystem);
+    if (!outcome) {
+      return [];
+    }
+    const detail = "reason" in outcome ? ` (${outcome.reason})` : "";
+    return `${outcome.subsystem}=${outcome.status}${detail}`;
+  });
+  return `gateway startup outcomes: ${entries.join("; ")}`;
+}

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -414,6 +414,73 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
   });
 
+  it("logs one startup outcome summary after sidecar registration and before readiness", async () => {
+    const events: string[] = [];
+    const outcomeMessages: string[] = [];
+    const log = {
+      info: vi.fn((message: string) => {
+        if (message.startsWith("gateway startup outcomes:")) {
+          outcomeMessages.push(message);
+          events.push("outcomes");
+        } else if (message === "gateway ready") {
+          events.push("ready-log");
+        }
+      }),
+      warn: vi.fn(),
+    };
+
+    await startGatewayPostAttachRuntime({
+      ...createPostAttachParams(),
+      log,
+      agentRuntimePluginPrewarm: { enabled: false },
+      onPostReadySidecars: () => {
+        events.push("post-ready-registered");
+      },
+      onGatewayLifetimeSidecars: () => {
+        events.push("lifetime-registered");
+      },
+      onSidecarsReady: () => {
+        events.push("sidecars-ready");
+      },
+    });
+
+    expect(outcomeMessages).toHaveLength(1);
+    expect(outcomeMessages[0]).toBe(
+      "gateway startup outcomes: internal-hooks=skipped (hooks-disabled); " +
+        "internal-startup-hook=skipped (hooks-disabled); " +
+        "gateway-start-hooks=skipped (no-handlers-loaded); " +
+        "memory-qmd=skipped (not-configured); " +
+        "gmail-watcher=skipped (hooks-disabled); gmail-model=skipped (not-configured)",
+    );
+    expect(events).toEqual([
+      "post-ready-registered",
+      "lifetime-registered",
+      "outcomes",
+      "sidecars-ready",
+      "ready-log",
+    ]);
+  });
+
+  it("reports internal hook load failures without copying the error into the summary", async () => {
+    const log = { info: vi.fn<(message: string) => void>(), warn: vi.fn() };
+    const logHooks = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    hoisted.loadInternalHooks.mockRejectedValueOnce(new Error("private hook path"));
+
+    await startGatewayPostAttachRuntime({
+      ...createPostAttachParams(),
+      log,
+      logHooks,
+      gatewayPluginConfigAtStart: { hooks: { internal: { enabled: true } } } as never,
+    });
+
+    expect(logHooks.error).toHaveBeenCalledWith("failed to load hooks: Error: private hook path");
+    const outcomeMessage = log.info.mock.calls
+      .map(([message]) => message)
+      .find((message) => message.startsWith("gateway startup outcomes:"));
+    expect(outcomeMessage).toContain("internal-hooks=failed (see earlier log)");
+    expect(outcomeMessage).not.toContain("private hook path");
+  });
+
   it("refreshes the restart sentinel after sidecars without blocking post-attach", async () => {
     const events: string[] = [];
     const refreshLatestUpdateRestartSentinel = vi.fn(async () => {
@@ -826,8 +893,10 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("keeps the qmd memory backend lazy by default", async () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
     await startGatewayPostAttachRuntime({
       ...createPostAttachParams(),
+      log,
       gatewayPluginConfigAtStart: {
         hooks: { internal: { enabled: false } },
         memory: { backend: "qmd" },
@@ -835,6 +904,9 @@ describe("startGatewayPostAttachRuntime", () => {
     });
 
     expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("memory-qmd=skipped (startup-disabled)"),
+    );
     expect(
       testing.resolveGatewayMemoryStartupPolicy({ memory: { backend: "qmd" } } as never),
     ).toEqual({ mode: "off" });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -26,6 +26,11 @@ import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
+import {
+  createGatewayStartupOutcomeRecorder,
+  formatGatewayStartupOutcomes,
+  type GatewayStartupOutcomeRecorder,
+} from "./server-startup-outcomes.js";
 import type { startGatewayTailscaleExposure } from "./server-tailscale.js";
 
 const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
@@ -700,6 +705,7 @@ export async function startGatewaySidecars(params: {
   };
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   startupTrace?: GatewayStartupTrace;
+  startupOutcomes?: GatewayStartupOutcomeRecorder;
 }) {
   const postReadySidecars: GatewayPostReadySidecarHandle[] = [];
 
@@ -714,12 +720,24 @@ export async function startGatewaySidecars(params: {
         setInternalHooksEnabled(params.cfg.hooks?.internal?.enabled !== false);
         const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
         if (loadedCount > 0) {
+          params.startupOutcomes?.record({ subsystem: "internal-hooks", status: "loaded" });
           params.logHooks.info(
             `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,
           );
+        } else {
+          params.startupOutcomes?.record({
+            subsystem: "internal-hooks",
+            status: "skipped",
+            reason: "no-handlers-loaded",
+          });
         }
       }
     } catch (err) {
+      params.startupOutcomes?.record({
+        subsystem: "internal-hooks",
+        status: "failed",
+        reason: "see earlier log",
+      });
       params.logHooks.error(`failed to load hooks: ${String(err)}`);
     }
   });
@@ -794,6 +812,10 @@ export async function startGatewaySidecars(params: {
   const shouldDispatchGatewayStartupInternalHook =
     internalHooksConfigured || (await hasGatewayStartupInternalHookListeners());
   if (shouldDispatchGatewayStartupInternalHook) {
+    params.startupOutcomes?.record({
+      subsystem: "internal-startup-hook",
+      status: "scheduled",
+    });
     // Run startup hooks after sidecar startup has yielded once so gateway bind
     // and channel startup are not delayed by hook handlers.
     setTimeout(() => {
@@ -1176,6 +1198,13 @@ export async function startGatewayPostAttachRuntime(
   };
   await loadStartupPluginsIfNeeded();
 
+  const memoryStartupPolicy = resolveGatewayMemoryStartupPolicy(params.gatewayPluginConfigAtStart);
+  const startupOutcomes = createGatewayStartupOutcomeRecorder({
+    cfg: params.gatewayPluginConfigAtStart,
+    gatewayStartHooks: hasGatewayStartHooks(pluginRegistry),
+    memoryStartupMode: memoryStartupPolicy.mode,
+  });
+
   const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () =>
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
@@ -1259,6 +1288,7 @@ export async function startGatewayPostAttachRuntime(
             onChannelsStarted: params.onChannelsStarted,
             onPluginServices: reportPluginServices,
             shouldStartPluginServices: () => params.isClosing?.() !== true,
+            startupOutcomes,
           }),
         );
         const loaderStatsAfter = getPluginModuleLoaderStats();
@@ -1327,6 +1357,7 @@ export async function startGatewayPostAttachRuntime(
         }
         params.onPostReadySidecars?.(postReadySidecars);
         params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
+        params.log.info(formatGatewayStartupOutcomes(startupOutcomes.snapshot()));
         params.onSidecarsReady?.();
         params.startupTrace?.detail("sidecars.ready", [
           [


### PR DESCRIPTION
Fixes #14861

## What Problem This Solves

Fixes an issue where operators restarting the Gateway could not tell whether key startup hooks and sidecars were loaded, scheduled, skipped, or failed. In particular, enabling hooks without a Gmail account silently omitted the Gmail watcher from normal startup diagnostics.

## Why This Change Was Made

The Gateway now emits one concise outcome line after sidecars register and immediately before readiness. The line covers six stable Gateway-owned subsystems in canonical order and uses only a closed, redacted status/reason vocabulary; it does not include config values, paths, account names, model names, or raw errors, and it does not change startup scheduling or readiness behavior.

#86710 by @ferminquant was a useful prior attempt at this operator-facing diagnostic, but its branch drifted and closed unmerged. This is an independent current-main implementation with a narrower fixed-vocabulary contract.

AI-assisted change; I reviewed the complete startup path, caller, hook/Gmail siblings, and tests, and ran a fresh Codex autoreview with no actionable findings.

## User Impact

Operators get an immediate, safe answer for the most important optional startup paths, including the previously silent `gmail-watcher=skipped (no-gmail-account)` case. Existing startup timing, hook execution, sidecar scheduling, and failure tolerance remain unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kx7p43e7pghcgfzxwcyxbm5g`: `pnpm test src/gateway/server-startup-outcomes.test.ts src/gateway/server-startup-post-attach.test.ts src/hooks/gmail-watcher-lifecycle.test.ts src/gateway/server-startup-log.test.ts` — 154 tests passed across gateway and hooks shards on rebased head `ced14ba542bd2fa6b6aaf7ebb37a8785c65e8696`.
- Same Testbox, isolated foreground Gateway via `node openclaw.mjs gateway --port 19881 --bind loopback --allow-unconfigured`: exactly one outcome line; it appeared at log line 11 immediately before ready at line 12; it reported `gmail-watcher=skipped (no-gmail-account)`; a configured private model marker was absent from the outcome line.
- Same Testbox: path-scoped `pnpm check:changed` passed for all four touched files, including core and test typechecks, changed-file lint, database-first guard, runtime sidecar loader guard, and import-cycle check.
- Same Testbox: `pnpm build` passed.
- Targeted `oxfmt --check`, `git diff --check`, and fresh local autoreview passed; autoreview reported no accepted/actionable findings (confidence 0.94).
