### PR TITLE
Fix OpenAI GPT-5.6 model availability

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -50,7 +50,12 @@ const PROVIDER_ID = "openai";
 const OPENAI_CODEX_BASE_URL = OPENAI_CODEX_RESPONSES_BASE_URL;
 const OPENAI_CODEX_LOGIN_ASSISTANT_PRIORITY = -30;
 const OPENAI_CODEX_DEVICE_PAIRING_ASSISTANT_PRIORITY = -10;
-const OPENAI_CODEX_GPT_56_MODEL_IDS = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
+const OPENAI_CODEX_GPT_56_MODEL_IDS = [
+  "gpt-5.6",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+] as const;
 const OPENAI_CODEX_GPT_56_THINKING_LEVEL_MAP = {
   off: null,
   xhigh: "xhigh",

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -196,6 +196,7 @@ describe("buildOpenAIProvider", () => {
       throw new Error("expected OpenAI static provider catalog");
     }
     const gpt55 = result.providers.openai?.models.find((model) => model.id === "gpt-5.5");
+    const gpt56 = result.providers.openai?.models.find((model) => model.id === "gpt-5.6");
     const gpt56Models = result.providers.openai?.models.filter((model) =>
       model.id.startsWith("gpt-5.6-"),
     );
@@ -207,6 +208,7 @@ describe("buildOpenAIProvider", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
     ]);
+    expect(gpt56?.thinkingLevelMap?.off).toBeNull();
     expect(gpt56Models?.map((model) => model.thinkingLevelMap?.off)).toEqual([null, null, null]);
     expect(OPENAI_DEFAULT_MODEL).toBe("openai/gpt-5.5");
   });
@@ -525,7 +527,10 @@ describe("buildOpenAIProvider", () => {
       });
       expect(result.providers.openai?.api).toBe("openai-chatgpt-responses");
       expect(result.providers.openai?.auth).toBe("oauth");
-      expect(result.providers.openai?.models.map((model) => model.id)).toEqual(["gpt-5.5"]);
+      expect(result.providers.openai?.models.map((model) => model.id)).toEqual([
+        "gpt-5.5",
+        "gpt-5.6",
+      ]);
       expect(fetchSpy).toHaveBeenCalledOnce();
     } finally {
       fetchSpy.mockRestore();
@@ -573,7 +578,7 @@ describe("buildOpenAIProvider", () => {
 
     expect(provider?.api).toBe("openai-chatgpt-responses");
     expect(provider?.auth).toBe("oauth");
-    expect(provider?.models.map((model) => model.id)).toEqual(["gpt-5.4"]);
+    expect(provider?.models.map((model) => model.id)).toEqual(["gpt-5.4", "gpt-5.6", "gpt-5.5"]);
     expect(provider?.models[0]).toMatchObject({
       baseUrl: "https://chatgpt.com/backend-api/codex",
       input: ["text", "image"],
@@ -619,6 +624,45 @@ describe("buildOpenAIProvider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("supplements sparse Codex model discovery with supported OpenAI OAuth fallbacks", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
+      response: Response.json({
+        models: [
+          {
+            slug: "gpt-5.4",
+            display_name: "GPT-5.4",
+            visibility: "list",
+            supported_reasoning_levels: [
+              { effort: "medium", description: "medium" },
+              { effort: "high", description: "high" },
+            ],
+            context_window: 272_000,
+            max_context_window: 1_050_000,
+            max_output_tokens: 128_000,
+          },
+        ],
+      }),
+      finalUrl: "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
+      release,
+    }));
+
+    const provider = await buildOpenAICodexLiveProviderConfig({
+      discoveryApiKey: "oauth-token",
+      accountId: "acct-openai-workspace",
+      fetchGuard,
+    });
+
+    expect(provider.models.map((model) => model.id)).toEqual(["gpt-5.4", "gpt-5.6", "gpt-5.5"]);
+    expect(provider.models.find((model) => model.id === "gpt-5.6")).toMatchObject({
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+      input: ["text", "image"],
+      reasoning: true,
+    });
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("keeps the deprecated Codex provider builder on the public API barrel", async () => {
     const { buildOpenAICodexProviderPlugin } = await import("./api.js");
     const provider = buildOpenAICodexProviderPlugin();
@@ -627,7 +671,7 @@ describe("buildOpenAIProvider", () => {
     expect(provider.hookAliases).toEqual(["azure-openai", "azure-openai-responses"]);
   });
 
-  it.each(["gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
+  it.each(["gpt-5.5", "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
     "prefers auth-aware Codex runtime metadata for %s over static OpenAI catalog rows",
     (modelId) => {
       const provider = buildOpenAIProvider();
@@ -1029,6 +1073,11 @@ describe("buildOpenAIProvider", () => {
   });
 
   it.each([
+    {
+      id: "gpt-5.6",
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+      thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
+    },
     {
       id: "gpt-5.6-sol",
       cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -50,6 +50,7 @@ const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CHAT_LATEST_MODEL_ID = "chat-latest";
+const OPENAI_GPT_56_MODEL_ID = "gpt-5.6";
 const OPENAI_GPT_56_SOL_MODEL_ID = "gpt-5.6-sol";
 const OPENAI_GPT_56_TERRA_MODEL_ID = "gpt-5.6-terra";
 const OPENAI_GPT_56_LUNA_MODEL_ID = "gpt-5.6-luna";
@@ -70,6 +71,12 @@ const OPENAI_GPT_54_MINI_CONTEXT_TOKENS = 400_000;
 const OPENAI_GPT_54_NANO_CONTEXT_TOKENS = 400_000;
 const OPENAI_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CHAT_LATEST_COST = { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 } as const;
+const OPENAI_GPT_56_COST = {
+  input: 5,
+  output: 30,
+  cacheRead: 0.5,
+  cacheWrite: 6.25,
+} as const;
 const OPENAI_GPT_56_SOL_COST = {
   input: 5,
   output: 30,
@@ -127,6 +134,7 @@ const OPENAI_GPT_56_THINKING_LEVEL_MAP = {
 } as const;
 const OPENAI_MODERN_MODEL_IDS = [
   OPENAI_CHAT_LATEST_MODEL_ID,
+  OPENAI_GPT_56_MODEL_ID,
   OPENAI_GPT_56_SOL_MODEL_ID,
   OPENAI_GPT_56_TERRA_MODEL_ID,
   OPENAI_GPT_56_LUNA_MODEL_ID,
@@ -390,6 +398,18 @@ function buildOpenAICodexStaticProviderConfig(): ModelProviderConfig {
   };
 }
 
+function buildOpenAICodexFallbackModel(modelId: string): ModelDefinitionConfig | undefined {
+  const fallback = resolveCodexModelFallback(modelId);
+  if (!fallback) {
+    return undefined;
+  }
+  return {
+    ...fallback,
+    api: "openai-chatgpt-responses",
+    baseUrl: OPENAI_CODEX_RESPONSES_BASE_URL,
+  };
+}
+
 export async function buildOpenAICodexLiveProviderConfig(params: {
   discoveryApiKey: string;
   accountId?: string;
@@ -423,6 +443,22 @@ export async function buildOpenAICodexLiveProviderConfig(params: {
       .map(buildOpenAICodexModelFromLiveRow)
       .filter((model): model is ModelDefinitionConfig => Boolean(model));
     if (models.length > 0) {
+      const present = new Set(models.map((model) => normalizeLowercaseStringOrEmpty(model.id)));
+      for (const modelId of [
+        OPENAI_GPT_56_MODEL_ID,
+        OPENAI_GPT_55_MODEL_ID,
+        OPENAI_GPT_53_CODEX_SPARK_MODEL_ID,
+      ] as const) {
+        if (present.has(modelId)) {
+          continue;
+        }
+        const fallback = buildOpenAICodexFallbackModel(modelId);
+        if (!fallback) {
+          continue;
+        }
+        models.push(fallback);
+        present.add(modelId);
+      }
       return {
         baseUrl: OPENAI_CODEX_RESPONSES_BASE_URL,
         api: "openai-chatgpt-responses",
@@ -593,17 +629,20 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
       maxTokens: OPENAI_GPT_54_MAX_TOKENS,
     };
   } else if (
+    lower === OPENAI_GPT_56_MODEL_ID ||
     lower === OPENAI_GPT_56_SOL_MODEL_ID ||
     lower === OPENAI_GPT_56_TERRA_MODEL_ID ||
     lower === OPENAI_GPT_56_LUNA_MODEL_ID
   ) {
     templateIds = OPENAI_GPT_56_TEMPLATE_MODEL_IDS;
     const cost =
-      lower === OPENAI_GPT_56_SOL_MODEL_ID
-        ? OPENAI_GPT_56_SOL_COST
-        : lower === OPENAI_GPT_56_TERRA_MODEL_ID
-          ? OPENAI_GPT_56_TERRA_COST
-          : OPENAI_GPT_56_LUNA_COST;
+      lower === OPENAI_GPT_56_MODEL_ID
+        ? OPENAI_GPT_56_COST
+        : lower === OPENAI_GPT_56_SOL_MODEL_ID
+          ? OPENAI_GPT_56_SOL_COST
+          : lower === OPENAI_GPT_56_TERRA_MODEL_ID
+            ? OPENAI_GPT_56_TERRA_COST
+            : OPENAI_GPT_56_LUNA_COST;
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -103,6 +103,20 @@
             "cost": { "input": 30, "output": 180, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
+            "id": "gpt-5.6",
+            "name": "GPT-5.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 372000,
+            "maxTokens": 128000,
+            "cost": { "input": 5, "output": 30, "cacheRead": 0.5, "cacheWrite": 6.25 },
+            "thinkingLevelMap": { "off": null, "xhigh": "xhigh", "max": "max" },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "medium", "high", "xhigh", "max"]
+            }
+          },
+          {
             "id": "gpt-5.6-sol",
             "name": "GPT-5.6 Sol",
             "reasoning": true,


### PR DESCRIPTION
Problem\n\nOpenClaw reported GPT-5.6 support through the OpenAI/Codex path, but the plain  model could disappear from runtime discovery and picker state. That left users seeing support messaging without actually being able to select or use the model. GPT-5.5 needed to remain consistently available in the same flow.\n\nRoot cause\n\nThe static OpenAI manifest only treated the preview family variants (, , ) as first-class catalog rows. Runtime Codex discovery also returned sparse model lists in some cases, and the provider did not supplement those responses with the supported fallback rows users actually needed.\n\nFix\n\n- Add first-class manifest support for plain .\n- Treat plain  as part of the modern OpenAI/Codex model family in runtime resolution.\n- Supplement sparse Codex OAuth discovery with supported fallback rows so  and  remain available.\n- Update OpenAI provider tests to cover the new static, runtime, and fallback behavior.\n\nValidation\n\n- [test-extension] Running 30 test files for openai

 RUN  v4.1.8 /private/tmp/openclaw-gpt56-picker


 Test Files  27 passed (27)
      Tests  350 passed (350)
   Start at  09:07:20
   Duration  12.50s (transform 3.44s, setup 284ms, import 7.90s, tests 4.09s, environment 0ms)\n\nProduction expectation\n\nUsers using the OpenAI/Codex integration should consistently see and be able to select  and , even when live Codex model discovery returns an incomplete list.