### PR TITLE
fix(signal): flush accepted debounced inbound once after monitor abort

### DIFF
--- a/extensions/signal/src/monitor.debounce-drain.test.ts
+++ b/extensions/signal/src/monitor.debounce-drain.test.ts
@@ -1,0 +1,111 @@
+// Signal monitor drains accepted debounce work before daemon stop on abort.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  config,
+  createMockSignalDaemonHandle,
+  createSignalToolResultConfig,
+  getSignalToolResultTestMocks,
+  installSignalToolResultTestHooks,
+  setSignalToolResultTestConfig,
+} from "./monitor.tool-result.test-harness.js";
+
+installSignalToolResultTestHooks();
+
+const { monitorSignalProvider } = await import("./monitor.js");
+
+const { streamMock, spawnSignalDaemonMock, replyMock, waitForTransportReadyMock } =
+  getSignalToolResultTestMocks();
+
+const SIGNAL_BASE_URL = "http://127.0.0.1:8080";
+
+function createMonitorRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never,
+  };
+}
+
+describe("monitorSignalProvider debounce drain", () => {
+  it("drains accepted debounced inbound before stopping the Signal daemon", async () => {
+    const runtime = createMonitorRuntime();
+    const order: string[] = [];
+    const abortController = new AbortController();
+
+    setSignalToolResultTestConfig(
+      createSignalToolResultConfig({
+        // Keep dm open so the synthetic receive event is accepted.
+        dmPolicy: "open",
+        allowFrom: ["*"],
+      }),
+    );
+    // Long debounce so the timer alone cannot flush before teardown.
+    (config as { messages?: Record<string, unknown> }).messages = {
+      ...(config.messages as Record<string, unknown> | undefined),
+      responsePrefix: "PFX",
+      inbound: { debounceMs: 60_000 },
+    };
+
+    const stop = vi.fn(() => {
+      order.push("daemon-stop");
+    });
+    spawnSignalDaemonMock.mockReturnValue(
+      createMockSignalDaemonHandle({
+        stop: stop as unknown as ReturnType<typeof vi.fn>,
+      }),
+    );
+    waitForTransportReadyMock.mockResolvedValue(undefined);
+
+    replyMock.mockImplementation(async () => {
+      order.push("dispatch");
+      return { text: "ok" };
+    });
+
+    streamMock.mockImplementation(
+      async (params: {
+        onEvent: (event: { event: string; data: string }) => void;
+        abortSignal?: AbortSignal;
+      }) => {
+        params.onEvent({
+          event: "receive",
+          data: JSON.stringify({
+            envelope: {
+              sourceNumber: "+15550001111",
+              sourceName: "Alice",
+              timestamp: 1_700_000_000_000,
+              dataMessage: {
+                message: "accepted before monitor abort",
+                attachments: [],
+              },
+            },
+          }),
+        });
+        // Let the tracked handleEvent task finish enqueue (timer scheduled).
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(order).not.toContain("dispatch");
+        abortController.abort(new Error("monitor stopped"));
+        if (params.abortSignal?.aborted) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          params.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    );
+
+    await monitorSignalProvider({
+      config: config as OpenClawConfig,
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      abortSignal: abortController.signal,
+      runtime,
+      waitForTransportReady: waitForTransportReadyMock as never,
+    });
+
+    expect(order).toEqual(["dispatch", "daemon-stop"]);
+    expect(stop).toHaveBeenCalled();
+  });
+});

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -640,10 +640,10 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     daemonLifecycle.attach(daemonHandle);
   }
 
-  const onAbort = () => {
-    daemonLifecycle.stop();
-  };
-  opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
+  // Do not stop the daemon on abort here. SSE/readiness already observe the
+  // merged abort signal; finally drains accepted debounce work first, then
+  // stops the daemon so timer-backed initial flushes stay lifecycle-owned.
+  let drainAcceptedInbound: (() => Promise<void>) | undefined;
 
   try {
     if (daemonHandle) {
@@ -711,6 +711,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       shouldEmitSignalReactionNotification,
       buildSignalReactionSystemEventText,
     });
+    drainAcceptedInbound = handleEvent.drainAcceptedInbound;
 
     await runSignalSseLoop({
       baseUrl,
@@ -731,16 +732,24 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
   } catch (err) {
     const daemonExitError = daemonLifecycle.getExitError();
+    // Abort without a daemon crash is a clean shutdown; finally still drains
+    // accepted debounce work before stopping the daemon.
     if (opts.abortSignal?.aborted && !daemonExitError) {
       return;
     }
     throw err;
   } finally {
-    // Stop first: pending retry delays observe abort, while retries that already
-    // started remain in the task runner and drain before monitor teardown.
+    // 1) Force-flush accepted timer-backed debounce batches while the daemon
+    //    is still up (initial attempt only; retries stay abort-aware).
+    // 2) Stop the daemon so retry backoff observes abort and exits.
+    // 3) Wait for tracked tasks (including in-flight flushes/retries) to idle.
+    try {
+      await drainAcceptedInbound?.();
+    } catch (err) {
+      runtime.error?.(`signal accepted inbound drain failed: ${String(err)}`);
+    }
     daemonLifecycle.stop();
     await monitorTaskRunner.waitForIdle();
     daemonLifecycle.dispose();
-    opts.abortSignal?.removeEventListener("abort", onAbort);
   }
 }

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -180,6 +180,44 @@ describe("signal reply session init conflict retry", () => {
     }
   });
 
+  it("still performs the initial debounced flush after monitor abort", async () => {
+    // Accepted inbound work must get one initial flush even when shutdown aborts
+    // the lifecycle before the debounce timer fires (timer-backed flush is not
+    // owned by the active enqueue() awaiter).
+    dispatchInboundMessageMock.mockResolvedValue({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    const abort = new AbortController();
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 10 } } },
+        abortSignal: abort.signal,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const handled = handler(
+        createSignalReceiveEvent({
+          dataMessage: { message: "accepted before shutdown", attachments: [] },
+        }),
+      );
+      // Abort after acceptance / enqueue scheduling, before the debounce flush.
+      abort.abort(new Error("monitor stopped"));
+      await vi.advanceTimersByTimeAsync(10);
+      await handled;
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      const payload = dispatchInboundMessageMock.mock.calls[0]?.[0] as
+        | { ctx?: { Body?: string } }
+        | undefined;
+      expect(payload?.ctx?.Body ?? "").toContain("accepted before shutdown");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps a retry that crossed the timer boundary in the monitor task runner", async () => {
     let resolveRetry: (() => void) | undefined;
     const retryDispatch = new Promise<{ queuedFinal: boolean; counts: Record<string, number> }>(

--- a/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
+++ b/extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts
@@ -218,6 +218,44 @@ describe("signal reply session init conflict retry", () => {
     }
   });
 
+  it("drainAcceptedInbound flushes accepted batches without waiting for the timer", async () => {
+    // Monitor teardown calls drainAcceptedInbound() before daemon stop so the
+    // accepted initial flush is lifecycle-owned, not a free-running timer race.
+    dispatchInboundMessageMock.mockResolvedValue({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    const abort = new AbortController();
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 60_000 } } },
+        abortSignal: abort.signal,
+      }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const handled = handler(
+        createSignalReceiveEvent({
+          dataMessage: { message: "drain before daemon stop", attachments: [] },
+        }),
+      );
+      await handled;
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(0);
+
+      abort.abort(new Error("monitor stopped"));
+      await handler.drainAcceptedInbound();
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      const payload = dispatchInboundMessageMock.mock.calls[0]?.[0] as
+        | { ctx?: { Body?: string } }
+        | undefined;
+      expect(payload?.ctx?.Body ?? "").toContain("drain before daemon stop");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps a retry that crossed the timer boundary in the monitor task runner", async () => {
     let resolveRetry: (() => void) | undefined;
     const retryDispatch = new Promise<{ queuedFinal: boolean; counts: Record<string, number> }>(

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -236,7 +236,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     replyToSender?: string;
     replyToIsQuote?: boolean;
   };
-  const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
     const fromLabel = formatInboundFromLabel({
@@ -757,12 +756,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
-      // enqueue() awaits inline and overflow flushes, but not timer-backed work.
-      // Drain tracked inline work on shutdown; stop delayed work with no owner.
-      const hasActiveEnqueue = entries.some((entry) => activeEnqueueEntries.has(entry));
-      if (!hasActiveEnqueue && deps.abortSignal?.aborted) {
-        return;
-      }
+      // Events accepted before monitor abort still get one initial flush attempt.
+      // Abort only cancels reply-session conflict retry backoff / later attempts
+      // (see retrySignalInboundFlush), so shutdown does not drop already-accepted
+      // debounced batches that fire after the lifecycle signal is aborted.
       try {
         await flushSignalInboundEntries(entries);
       } catch (err) {
@@ -1288,11 +1285,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
     };
-    activeEnqueueEntries.add(entry);
-    try {
-      await debouncer.enqueue(entry);
-    } finally {
-      activeEnqueueEntries.delete(entry);
-    }
+    await debouncer.enqueue(entry);
   };
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -756,10 +756,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
-      // Events accepted before monitor abort still get one initial flush attempt.
-      // Abort only cancels reply-session conflict retry backoff / later attempts
-      // (see retrySignalInboundFlush), so shutdown does not drop already-accepted
-      // debounced batches that fire after the lifecycle signal is aborted.
+      // Accepted work always gets one initial flush. Abort only cancels
+      // reply-session conflict retry backoff / later attempts (see
+      // retrySignalInboundFlush). The monitor awaits drainAcceptedInbound()
+      // before daemon stop so timer-backed batches stay lifecycle-owned.
       try {
         await flushSignalInboundEntries(entries);
       } catch (err) {
@@ -876,7 +876,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     return true;
   }
 
-  return async (event: { event?: string; data?: string }) => {
+  const handleEvent = async (event: { event?: string; data?: string }) => {
     if (event.event !== "receive" || !event.data) {
       return;
     }
@@ -1287,4 +1287,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     };
     await debouncer.enqueue(entry);
   };
+
+  // Monitor teardown awaits this before daemon stop so accepted timer-backed
+  // batches complete one initial flush while the Signal daemon is still up.
+  const drainAcceptedInbound = async () => {
+    await debouncer.flushAll();
+  };
+
+  return Object.assign(handleEvent, { drainAcceptedInbound });
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -172,6 +172,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     await flushBuffer(key, buffer);
   };
 
+  /** Force-flush every timer-backed buffer and await its onFlush work. */
+  const flushAll = async () => {
+    // Snapshot keys: flushBuffer removes entries while we iterate.
+    const keys = [...buffers.keys()];
+    await Promise.all(keys.map((key) => flushKey(key)));
+  };
+
   const cancelKey = (key: string): boolean => {
     const buffer = buffers.get(key);
     if (!buffer) {
@@ -286,5 +293,5 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey, cancelKey };
+  return { enqueue, flushKey, flushAll, cancelKey };
 }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -534,6 +534,32 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
+  it("flushAll force-flushes every timer-backed buffer without waiting for timers", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 10_000,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    await debouncer.enqueue({ key: "b", id: "2" });
+    expect(calls).toStrictEqual([]);
+
+    await debouncer.flushAll();
+
+    expect(calls).toEqual([["1"], ["2"]]);
+    // Timer advance must not re-flush drained buffers.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls).toEqual([["1"], ["2"]]);
+
+    vi.useRealTimers();
+  });
+
   it("flushes buffered items before non-debounced item", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -675,6 +675,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
               await params.onFlush([item]);
             },
             flushKey: vi.fn(),
+            flushAll: vi.fn(async () => {}),
             cancelKey: vi.fn(() => false),
           }),
         ) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"],


### PR DESCRIPTION
Closes #103881

## What Problem This Solves

Fixes an issue where Signal users could lose an already-accepted inbound message when the monitor shut down (or reconnected) before a debounced flush ran. The accepted event never produced a reply even though the SSE callback had already taken the work.

## Why This Change Was Made

Signal’s debouncer schedules timer-backed flushes that outlive the `enqueue()` await. The tracked SSE task can finish after scheduling the timer, so monitor finalization could stop the Signal daemon before the initial flush ran. ClawSweeper correctly required lifecycle ownership: await an accepted debounce drain **before** daemon stop, while keeping conflict-retry backoff abortable.

This PR:

1. Adds `flushAll()` on the shared inbound debouncer.
2. Exposes `drainAcceptedInbound()` from the Signal event handler.
3. Monitor teardown awaits that drain, then stops the daemon, then waits for tracked tasks.
4. Keeps abort-aware cancellation for reply-session conflict retries only.

## User Impact

Inbound Signal messages accepted before monitor teardown or reconnect complete one initial delivery attempt while the daemon is still up. Conflict retries still stop promptly on shutdown.

## Evidence

Verification host: local macOS (Crabbox bypass)

Commands:

```text
node scripts/run-vitest.mjs \
  extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts \
  extensions/signal/src/monitor.debounce-drain.test.ts
# 10/10 passed

node scripts/run-vitest.mjs src/auto-reply/inbound.test.ts -t "flushAll"
# flushAll force-flush unit test passed

git diff --check  # clean
```

Focused suite result:

```text
✓ extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts (9 tests)
✓ extensions/signal/src/monitor.debounce-drain.test.ts (1 test)
Test Files  2 passed (2)
Tests  10 passed (10)
```

## Real behavior proof

- Behavior addressed: Accepted Signal debounced inbound is force-drained and dispatched **before** monitor daemon stop on abort; conflict retries remain abortable after the initial attempt.
- Environment: local macOS + openclaw checkout on branch `fix/103881-signal-initial-flush-after-abort` @ `ab3b5aa23`; Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast (handler-level): Pre-fix `onFlush` early-return when aborted dropped timer-backed batches (`expected 1 dispatch, got 0`).
- Monitor teardown proof: `monitor.debounce-drain.test.ts` delivers a receive event with `debounceMs=60_000`, aborts before the timer, and asserts order `["dispatch", "daemon-stop"]` — dispatch completes during `drainAcceptedInbound()` before `daemonLifecycle.stop()`.
- Handler drain proof: `drainAcceptedInbound flushes accepted batches without waiting for the timer` force-flushes after abort with a 60s debounce window and no timer advance.
- Retry control: `cancels a pending retry when the Signal monitor aborts` still proves post-initial conflict backoff stops on abort.
- Exact commands: see Evidence above.
- What was not tested: Live Signal device/SSE tenant; full suite / full `pnpm check:changed` (CI owns broad lanes).

## AI disclosure

This PR was authored with AI assistance (Grok / process-openclaw-pr-reviews follow-up). Human/reviewer should treat code and proof as the source of truth.
