### PR TITLE
feat(plugins): add cron reconciliation lifecycle hook

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4159cf7a45b5af031a57f23c7a5ab357bb433dfe5221a4116ec50ce6c877678c  plugin-sdk-api-baseline.json
-84f72e8fc201c7c269b7f687b0182ba48774a34b4e70c99253688a2b5f440b53  plugin-sdk-api-baseline.jsonl
+3ed9d161dede01958afa24aef325ea2f5662b3cc005b42580ad6906cab3f71ad  plugin-sdk-api-baseline.json
+d87feb7503532fd395e66da415f794aa8866d4ae97ae8201934eab0ceafafa71  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -164,6 +164,7 @@ observation-only.
 | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `gateway_start` / `gateway_stop` | Start or stop plugin-owned services with the Gateway                                                 |
 | `deactivate`                     | Deprecated compatibility alias for `gateway_stop`; use `gateway_stop` in new plugins                 |
+| `cron_reconciled`                | Reconcile against the complete Gateway cron state after startup or reload                            |
 | `cron_changed`                   | Observe Gateway-owned cron lifecycle changes (added, updated, removed, started, finished, scheduled) |
 | **`before_install`**             | Inspect staged skill or plugin install material from a loaded plugin runtime                         |
 
@@ -573,13 +574,28 @@ failures block the install fail-closed.
 
 ## Gateway lifecycle
 
-Use `gateway_start` for plugin services that need Gateway-owned state. The
-context exposes `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for
-cron inspection and updates. Use `gateway_stop` to clean up long-running
-resources.
+Use `gateway_start` to start general plugin services and `gateway_stop` to
+clean up long-running resources. The cron scheduler can still be loading when
+`gateway_start` runs, so do not use it as the baseline signal for an external
+cron projection.
 
 Do not rely on the internal `gateway:startup` hook for plugin-owned runtime
 services.
+
+`cron_reconciled` fires after the Gateway cron scheduler and its on-exit
+watchers have reconciled their durable state. It fires for both initial
+startup and scheduler replacement during config reload. The event reports
+`reason` (`startup` or `reload`) and the effective `enabled` state. Disabled
+cron still emits with `enabled: false`, allowing an external projection to
+clear stale wakes. Use `ctx.getCron?.()` for the exact scheduler instance that
+completed reconciliation; a later reload does not retarget that callback.
+This is a scheduler lifecycle signal, not a plugin-activation signal: a
+plugin-only hot reload does not replay it. A newly enabled consumer receives
+its first baseline on the next scheduler replacement or Gateway start.
+
+Like other observation hooks, `gateway_start` and `cron_reconciled` callbacks
+can overlap. If both handlers share plugin initialization, coordinate them
+with a plugin-local readiness promise rather than depending on callback order.
 
 `cron_changed` fires for Gateway-owned cron lifecycle events with a typed
 event payload covering `added`, `updated`, `removed`, `started`, `finished`,
@@ -595,9 +611,8 @@ write changes an existing job's effective `nextRunAtMs`, excluding that job's
 explicit `added`, `updated`, or `removed` lifecycle event. The top-level
 `event.nextRunAtMs` is the committed next wake; when it is absent, the job has
 no next wake. Treat these events as reconciliation hints, not an ordered delta
-log. Use `ctx.getCron?.()` and `ctx.config` from the runtime context when
-syncing external wake schedulers, and keep OpenClaw as the source of truth for
-due checks and execution.
+log. Use these events as coalescible hints between `cron_reconciled` snapshots,
+and keep OpenClaw as the source of truth for due checks and execution.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -492,7 +492,8 @@ cover CLI and Gateway-backed install or update paths.
 - `message_sending`: returning `{ cancel: false }` is treated as no decision (same as omitting `cancel`), not as an override.
 - `message_received`: use the typed `threadId` field when you need inbound thread/topic routing. Keep `metadata` for channel-specific extras.
 - `message_sending`: use typed `replyToId` / `threadId` routing fields before falling back to channel-specific `metadata`.
-- `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks.
+- `gateway_start`: use `ctx.config`, `ctx.workspaceDir`, and `ctx.getCron?.()` for gateway-owned startup state instead of relying on internal `gateway:startup` hooks. Cron may still be loading at this point.
+- `cron_reconciled`: rebuild a full external cron projection after startup or scheduler reload. It includes `reason` and the effective `enabled` state, including `enabled: false`, while `ctx.getCron?.()` returns the exact reconciled scheduler.
 - `cron_changed`: observe gateway-owned cron lifecycle changes. `scheduled` and `removed` events are post-commit reconciliation hints, not an ordered delta log. A scheduled event's `event.nextRunAtMs` is absent when the job has no next wake; a removed event still carries the deleted job snapshot.
 
 External wake schedulers should debounce or coalesce `cron_changed` events by
@@ -502,11 +503,11 @@ External wake schedulers should debounce or coalesce `cron_changed` events by
 const jobs = await ctx.getCron?.()?.list({ includeDisabled: true });
 ```
 
-Perform the same full reconciliation from `gateway_start` to recover changes
-made while the plugin was offline. Observation handlers run in parallel, and
-fire-and-forget dispatches can overlap, so consumers must not depend on event
-completion order. Keep OpenClaw as the source of truth for due checks and
-execution.
+Use `cron_reconciled` as the full-snapshot trigger for durable state loaded at
+Gateway startup or scheduler replacement. It is not replayed for a plugin-only
+hot reload. Observation handlers run in parallel, and fire-and-forget
+dispatches can overlap, so consumers must not depend on event completion order.
+Keep OpenClaw as the source of truth for due checks and execution.
 
 ### API object fields
 

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,7 +195,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10497,
+      10499,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/server-cron-reconciled.test.ts
+++ b/src/gateway/server-cron-reconciled.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createGatewayCronReconciliation } from "./server-cron-reconciled.js";
+
+type RunHook = Parameters<typeof createGatewayCronReconciliation>[0]["runHook"];
+
+describe("gateway cron reconciliation lifecycle", () => {
+  it("emits only the public snapshot fields and captures the reconciled service", async () => {
+    const runHook = vi.fn<RunHook>(async () => undefined);
+    const cron = { id: "startup-cron" };
+    const config = { cron: { enabled: true } } as OpenClawConfig;
+    const reconciliation = createGatewayCronReconciliation({
+      port: 18789,
+      workspaceDir: "/tmp/openclaw-workspace",
+      isClosing: () => false,
+      runHook,
+    });
+    const cronState = {
+      cron,
+      storePath: "/private/cron.json",
+      cronEnabled: false,
+    };
+    const armed = reconciliation.arm({
+      reason: "startup",
+      config,
+      cronState: cronState as never,
+    });
+    cronState.cron = { id: "replacement-cron" };
+    await armed.complete();
+    await armed.complete();
+
+    expect(runHook).toHaveBeenCalledTimes(1);
+    const [event, ctx] = runHook.mock.calls[0] ?? [];
+    expect(event).toEqual({ reason: "startup", enabled: false });
+    expect(Object.keys(event ?? {}).toSorted()).toEqual(["enabled", "reason"]);
+    expect(ctx).toMatchObject({
+      port: 18789,
+      workspaceDir: "/tmp/openclaw-workspace",
+      config,
+    });
+    expect(ctx?.getCron?.()).toBe(cron);
+  });
+
+  it("suppresses a startup completion superseded by reload", async () => {
+    const runHook = vi.fn<RunHook>(async () => undefined);
+    const reconciliation = createGatewayCronReconciliation({
+      port: 18789,
+      workspaceDir: "/tmp/openclaw-workspace",
+      isClosing: () => false,
+      runHook,
+    });
+    const startup = reconciliation.arm({
+      reason: "startup",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("startup", true),
+    });
+    const reload = reconciliation.arm({
+      reason: "reload",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("reload", true),
+    });
+
+    await startup.complete();
+    await reload.complete();
+
+    expect(runHook).toHaveBeenCalledTimes(1);
+    expect(runHook.mock.calls[0]?.[0]).toEqual({ reason: "reload", enabled: true });
+  });
+
+  it("suppresses invalidated and shutdown completions", async () => {
+    let closing = false;
+    const runHook = vi.fn<RunHook>(async () => undefined);
+    const reconciliation = createGatewayCronReconciliation({
+      port: 18789,
+      workspaceDir: "/tmp/openclaw-workspace",
+      isClosing: () => closing,
+      runHook,
+    });
+    const invalidated = reconciliation.arm({
+      reason: "reload",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("invalidated", true),
+    });
+    reconciliation.invalidate();
+    await invalidated.complete();
+
+    const shutdown = reconciliation.arm({
+      reason: "reload",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("shutdown", false),
+    });
+    closing = true;
+    await shutdown.complete();
+
+    expect(runHook).not.toHaveBeenCalled();
+  });
+
+  it("serializes snapshots so a reload cannot settle before startup", async () => {
+    let releaseStartup: (() => void) | undefined;
+    const order: string[] = [];
+    const runHook = vi.fn<RunHook>(async (event) => {
+      order.push(`${event.reason}:start`);
+      if (event.reason === "startup") {
+        await new Promise<void>((resolve) => {
+          releaseStartup = resolve;
+        });
+      }
+      order.push(`${event.reason}:end`);
+    });
+    const reconciliation = createGatewayCronReconciliation({
+      port: 18789,
+      workspaceDir: "/tmp/openclaw-workspace",
+      isClosing: () => false,
+      runHook,
+    });
+    const startup = reconciliation.arm({
+      reason: "startup",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("startup", true),
+    });
+    const startupCompletion = startup.complete();
+    await vi.waitFor(() => expect(order).toEqual(["startup:start"]));
+    const reload = reconciliation.arm({
+      reason: "reload",
+      config: {} as OpenClawConfig,
+      cronState: createCronState("reload", true),
+    });
+    const reloadCompletion = reload.complete();
+
+    await Promise.resolve();
+    expect(order).toEqual(["startup:start"]);
+    if (!releaseStartup) {
+      throw new Error("Expected startup hook to be pending");
+    }
+    releaseStartup();
+    await Promise.all([startupCompletion, reloadCompletion]);
+
+    expect(order).toEqual(["startup:start", "startup:end", "reload:start", "reload:end"]);
+  });
+});
+
+function createCronState(id: string, cronEnabled: boolean) {
+  return {
+    cron: { id },
+    storePath: `/tmp/${id}.json`,
+    cronEnabled,
+  } as never;
+}

--- a/src/gateway/server-cron-reconciled.ts
+++ b/src/gateway/server-cron-reconciled.ts
@@ -1,0 +1,72 @@
+// Gateway cron reconciliation lifecycle.
+// Suppresses stale scheduler completions across reload and shutdown boundaries.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type {
+  PluginHookCronReconciledEvent,
+  PluginHookGatewayContext,
+  PluginHookGatewayCronService,
+} from "../plugins/hook-types.js";
+import type { GatewayCronState } from "./server-cron.js";
+
+type GatewayCronReconciliationArmParams = {
+  reason: PluginHookCronReconciledEvent["reason"];
+  config: OpenClawConfig;
+  cronState: GatewayCronState;
+};
+
+export type GatewayCronReconciliation = {
+  arm: (params: GatewayCronReconciliationArmParams) => {
+    complete: () => Promise<void>;
+  };
+  invalidate: () => void;
+};
+
+export function createGatewayCronReconciliation(params: {
+  port: number;
+  workspaceDir: string;
+  isClosing: () => boolean;
+  runHook: (event: PluginHookCronReconciledEvent, ctx: PluginHookGatewayContext) => Promise<void>;
+}): GatewayCronReconciliation {
+  let lifecycleGeneration = 0;
+  let dispatchTail = Promise.resolve();
+
+  return {
+    arm: ({ reason, config, cronState }) => {
+      const generation = ++lifecycleGeneration;
+      const cron = cronState.cron as PluginHookGatewayCronService;
+      const event: PluginHookCronReconciledEvent = {
+        reason,
+        enabled: cronState.cronEnabled,
+      };
+      let completed = false;
+
+      return {
+        complete: async () => {
+          if (completed) {
+            return;
+          }
+          completed = true;
+          const dispatch = dispatchTail.then(async () => {
+            // A newer scheduler or shutdown owns reconciliation now. Dispatching
+            // this completion would let plugins replace current state with stale data.
+            if (params.isClosing() || generation !== lifecycleGeneration) {
+              return;
+            }
+            await params.runHook(event, {
+              port: params.port,
+              config,
+              workspaceDir: params.workspaceDir,
+              getCron: () => cron,
+            });
+          });
+          // Preserve lifecycle order even when one plugin callback is slow or fails.
+          dispatchTail = dispatch.catch(() => {});
+          await dispatch;
+        },
+      };
+    },
+    invalidate: () => {
+      lifecycleGeneration += 1;
+    },
+  };
+}

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -75,6 +75,9 @@ describe("gateway startup import boundaries", () => {
     expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
       "clearPostReadyMaintenanceTimer();",
     );
+    expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
+      "cronReconciliation.invalidate();",
+    );
     expect(postReadyStart).toBeGreaterThan(-1);
     expect(postReadyBlock).toContain("isClosing: () => closePreludeStarted");
     expect(postReadyBlock).toContain("if (closePreludeStarted)");

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -64,6 +64,10 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
       logChannels: { info: vi.fn(), error: vi.fn() },
       logCron: { error: vi.fn() },
       logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      cronReconciliation: {
+        arm: () => ({ complete: async () => {} }),
+        invalidate: vi.fn(),
+      },
       channelManager: {} as never,
       activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
         sourceConfig: config,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -30,9 +30,34 @@ import {
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import {
   abortPendingChannelReloads,
-  createGatewayReloadHandlers,
-  startManagedGatewayConfigReloader,
+  createGatewayReloadHandlers as createGatewayReloadHandlersImpl,
+  startManagedGatewayConfigReloader as startManagedGatewayConfigReloaderImpl,
 } from "./server-reload-handlers.js";
+
+type ReloadHandlerParams = Parameters<typeof createGatewayReloadHandlersImpl>[0];
+type ManagedReloaderParams = Parameters<typeof startManagedGatewayConfigReloaderImpl>[0];
+
+function createGatewayReloadHandlers(
+  params: Omit<ReloadHandlerParams, "cronReconciliation"> & {
+    cronReconciliation?: ReloadHandlerParams["cronReconciliation"];
+  },
+) {
+  return createGatewayReloadHandlersImpl({
+    ...params,
+    cronReconciliation: params.cronReconciliation ?? createTestCronReconciliation(),
+  });
+}
+
+function startManagedGatewayConfigReloader(
+  params: Omit<ManagedReloaderParams, "cronReconciliation"> & {
+    cronReconciliation?: ManagedReloaderParams["cronReconciliation"];
+  },
+) {
+  return startManagedGatewayConfigReloaderImpl({
+    ...params,
+    cronReconciliation: params.cronReconciliation ?? createTestCronReconciliation(),
+  });
+}
 
 type GmailWatcherRestartParams = {
   cfg: OpenClawConfig;
@@ -181,6 +206,33 @@ vi.mock("./server-cron.js", async () => {
   };
 });
 
+function createTestCronReconciliation() {
+  const complete = vi.fn<() => Promise<void>>(async () => {});
+  return {
+    arm: vi.fn<() => { complete: () => Promise<void> }>(() => ({ complete })),
+    complete,
+    invalidate: vi.fn(),
+  };
+}
+
+function createCronRestartPlan(): GatewayReloadPlan {
+  return {
+    changedPaths: ["cron"],
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: ["cron"],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartCron: true,
+    restartHeartbeat: false,
+    restartHealthMonitor: false,
+    reloadPlugins: false,
+    restartChannels: new Set(),
+    disposeMcpRuntimes: false,
+    noopPaths: [],
+  };
+}
+
 function createReloadHandlersForTest(
   logReload = { info: vi.fn(), warn: vi.fn() },
   channels?: {
@@ -195,6 +247,7 @@ function createReloadHandlersForTest(
     updateConfig: vi.fn(),
   };
   const setState = vi.fn();
+  const cronReconciliation = createTestCronReconciliation();
   const handlers = createGatewayReloadHandlers({
     deps: {} as never,
     broadcast: vi.fn(),
@@ -224,9 +277,17 @@ function createReloadHandlersForTest(
     logChannels: { info: vi.fn(), error: vi.fn() },
     logCron: { error: vi.fn() },
     logReload,
+    cronReconciliation,
     createHealthMonitor: () => null,
   });
-  return { ...handlers, cron, heartbeatRunner, setState, stopExitWatchers };
+  return {
+    ...handlers,
+    cron,
+    cronReconciliation,
+    heartbeatRunner,
+    setState,
+    stopExitWatchers,
+  };
 }
 
 // Other gateway test helpers (test-helpers.mocks.ts, test-helpers.server.ts)
@@ -263,8 +324,16 @@ afterEach(() => {
 
 describe("gateway hot reload model state", () => {
   it("stops old cron exit watchers and reconciles rebuilt ones after cron restart", async () => {
-    const newCron = { start: vi.fn(async () => {}), stop: vi.fn() };
-    const newReconcileExitWatchers = vi.fn(async () => {});
+    const order: string[] = [];
+    const newCron = {
+      start: vi.fn(async () => {
+        order.push("start-new");
+      }),
+      stop: vi.fn(),
+    };
+    const newReconcileExitWatchers = vi.fn(async () => {
+      order.push("reconcile-watchers");
+    });
     const rebuiltCronState = {
       cron: newCron,
       storePath: "/tmp/rebuilt-cron.json",
@@ -272,37 +341,76 @@ describe("gateway hot reload model state", () => {
       reconcileExitWatchers: newReconcileExitWatchers,
       stopExitWatchers: vi.fn(),
     };
-    hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
-    const { applyHotReload, cron, setState, stopExitWatchers } = createReloadHandlersForTest();
-
-    await applyHotReload(
-      {
-        changedPaths: ["cron"],
-        restartGateway: false,
-        restartReasons: [],
-        hotReasons: ["cron"],
-        reloadHooks: false,
-        restartGmailWatcher: false,
-        restartCron: true,
-        restartHeartbeat: false,
-        restartHealthMonitor: false,
-        reloadPlugins: false,
-        restartChannels: new Set(),
-        disposeMcpRuntimes: false,
-        noopPaths: [],
+    hoisted.buildGatewayCronService.mockImplementationOnce(() => {
+      order.push("build-new");
+      return rebuiltCronState;
+    });
+    const { applyHotReload, cron, cronReconciliation, setState, stopExitWatchers } =
+      createReloadHandlersForTest();
+    cron.stop.mockImplementation(() => {
+      order.push("stop-old");
+    });
+    stopExitWatchers.mockImplementation(() => {
+      order.push("stop-old-watchers");
+    });
+    cronReconciliation.invalidate.mockImplementation(() => {
+      order.push("invalidate-old");
+    });
+    cronReconciliation.arm.mockImplementation(() => ({
+      complete: async () => {
+        order.push("hook");
       },
-      {} as OpenClawConfig,
-    );
+    }));
+    const nextConfig = { cron: { enabled: true } } as OpenClawConfig;
+
+    await applyHotReload(createCronRestartPlan(), nextConfig);
 
     expect(cron.stop).toHaveBeenCalledTimes(1);
     expect(stopExitWatchers).toHaveBeenCalledTimes(1);
     expect(newCron.start).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => expect(newReconcileExitWatchers).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(order.at(-1)).toBe("hook"));
+    expect(order).toEqual([
+      "invalidate-old",
+      "stop-old",
+      "stop-old-watchers",
+      "build-new",
+      "start-new",
+      "reconcile-watchers",
+      "hook",
+    ]);
+    expect(cronReconciliation.arm).toHaveBeenCalledWith({
+      reason: "reload",
+      config: nextConfig,
+      cronState: rebuiltCronState,
+    });
     expect(setState).toHaveBeenCalledWith(
       expect.objectContaining({
         cronState: rebuiltCronState,
       }),
     );
+  });
+
+  it("completes reload reconciliation when the replacement scheduler is disabled", async () => {
+    const rebuiltCronState = {
+      cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+      storePath: "/tmp/rebuilt-cron.json",
+      cronEnabled: false,
+      reconcileExitWatchers: vi.fn(async () => {}),
+      stopExitWatchers: vi.fn(),
+    };
+    hoisted.buildGatewayCronService.mockReturnValueOnce(rebuiltCronState);
+    const { applyHotReload, cronReconciliation } = createReloadHandlersForTest();
+    const nextConfig = { cron: { enabled: false } } as OpenClawConfig;
+
+    await applyHotReload(createCronRestartPlan(), nextConfig);
+
+    await vi.waitFor(() => expect(cronReconciliation.complete).toHaveBeenCalledTimes(1));
+    expect(cronReconciliation.arm).toHaveBeenCalledWith({
+      reason: "reload",
+      config: nextConfig,
+      cronState: rebuiltCronState,
+    });
   });
 
   it("resets prepared model runtime state for every hot reload and rewarms after plugin reload", async () => {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -40,6 +40,7 @@ import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind } from "./config-reload-plan.js";
 import { startGatewayConfigReloader, type GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
+import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { markGatewayModelCatalogStaleForReload } from "./server-model-catalog.js";
@@ -197,6 +198,7 @@ type GatewayReloadHandlerParams = {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: GatewayReloadLog;
+  cronReconciliation: GatewayCronReconciliation;
   createHealthMonitor: (config: OpenClawConfig) => ChannelHealthMonitor | null;
   createGmailRestartAbortController?: () => GatewayGmailRestartAbortController;
   clearGmailRestartAbortController?: (controller: GatewayGmailRestartAbortController) => void;
@@ -468,6 +470,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       }
     }
     if (plan.restartCron) {
+      params.cronReconciliation.invalidate();
       params.onCronRestart?.();
       state.cronState.cron.stop();
       state.cronState.stopExitWatchers?.();
@@ -477,7 +480,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         broadcast: params.broadcast,
       });
       startGatewayCronWithLogging({
-        cron: nextState.cronState.cron,
+        cronState: nextState.cronState,
+        cronReconciliation: params.cronReconciliation,
+        reason: "reload",
+        config: nextConfig,
         afterStart: nextState.cronState.reconcileExitWatchers,
         logCron: params.logCron,
       });
@@ -764,6 +770,7 @@ export function startManagedGatewayConfigReloader(
     logChannels: params.logChannels,
     logCron: params.logCron,
     logReload: params.logReload,
+    cronReconciliation: params.cronReconciliation,
     createGmailRestartAbortController,
     clearGmailRestartAbortController: (abortController) => {
       if (activeGmailRestartAbortController === abortController) {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -2,6 +2,10 @@
  * Gateway runtime service lifecycle tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -67,6 +71,7 @@ const {
 describe("server-runtime-services", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    resetGatewayWorkAdmission();
     hoisted.heartbeatRunner.stop.mockClear();
     hoisted.heartbeatRunner.updateConfig.mockClear();
     hoisted.startHeartbeatRunner.mockClear();
@@ -82,6 +87,7 @@ describe("server-runtime-services", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    resetGatewayWorkAdmission();
   });
 
   it("skips model pricing bootstrap import when pricing is disabled", async () => {
@@ -90,7 +96,8 @@ describe("server-runtime-services", () => {
       cfgAtStart: { models: { pricing: { enabled: false } } } as never,
       deps: {} as never,
       sessionDeliveryRecoveryMaxEnqueuedAt: 123,
-      cron: { start: vi.fn(async () => undefined) },
+      cronState: createTestCronState(),
+      cronReconciliation: createTestCronReconciliation(),
       logCron: { error: vi.fn() },
       log: createLog(),
     });
@@ -128,12 +135,12 @@ describe("server-runtime-services", () => {
       index: { plugins: [] },
       manifestRegistry: { plugins: [], diagnostics: [] },
     };
-    const { cron, services } = activateScheduledServicesForTest({
+    const { cronStart, services } = activateScheduledServicesForTest({
       pluginLookUpTable: pluginLookUpTable as never,
     });
 
     expect(hoisted.startHeartbeatRunner).toHaveBeenCalledTimes(1);
-    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(cronStart).toHaveBeenCalledTimes(1);
     await vi.dynamicImportSettled();
     expect(hoisted.startGatewayModelPricingRefresh).toHaveBeenCalledWith({
       config: {},
@@ -143,7 +150,7 @@ describe("server-runtime-services", () => {
     expect(hoisted.stopModelPricingRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it("runs cron afterStart after startup succeeds", async () => {
+  it("runs cron start, watcher reconciliation, and hook completion in order", async () => {
     const order: string[] = [];
     const cron = {
       start: vi.fn(async () => {
@@ -153,12 +160,101 @@ describe("server-runtime-services", () => {
     const afterStart = vi.fn(async () => {
       order.push("after-start");
     });
+    const cronReconciliation = createTestCronReconciliation(async () => {
+      order.push("hook");
+    });
+    const cronState = createTestCronState(cron);
+    const config = { cron: { enabled: true } } as never;
     const logCron = { error: vi.fn() };
 
-    startGatewayCronWithLogging({ cron, afterStart, logCron });
+    startGatewayCronWithLogging({
+      cronState,
+      cronReconciliation,
+      reason: "startup",
+      config,
+      afterStart,
+      logCron,
+    });
 
-    await vi.waitFor(() => expect(order).toEqual(["start", "after-start"]));
+    await vi.waitFor(() => expect(order).toEqual(["start", "after-start", "hook"]));
+    expect(cronReconciliation.arm).toHaveBeenCalledWith({
+      reason: "startup",
+      config,
+      cronState,
+    });
     expect(logCron.error).not.toHaveBeenCalled();
+  });
+
+  it("does not complete cron reconciliation when scheduler startup rejects", async () => {
+    const cron = {
+      start: vi.fn(async () => {
+        throw new Error("store unavailable");
+      }),
+    };
+    const cronReconciliation = createTestCronReconciliation();
+    const logCron = { error: vi.fn() };
+
+    startGatewayCronWithLogging({
+      cronState: createTestCronState(cron),
+      cronReconciliation,
+      reason: "startup",
+      config: {} as never,
+      logCron,
+    });
+
+    await vi.waitFor(() =>
+      expect(logCron.error).toHaveBeenCalledWith("failed to start: Error: store unavailable"),
+    );
+    expect(cronReconciliation.complete).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("does not complete cron reconciliation when exit-watcher reconciliation rejects", async () => {
+    const cronReconciliation = createTestCronReconciliation();
+    const logCron = { error: vi.fn() };
+
+    startGatewayCronWithLogging({
+      cronState: createTestCronState(),
+      cronReconciliation,
+      reason: "reload",
+      config: {} as never,
+      afterStart: async () => {
+        throw new Error("watcher unavailable");
+      },
+      logCron,
+    });
+
+    await vi.waitFor(() =>
+      expect(logCron.error).toHaveBeenCalledWith("failed to start: Error: watcher unavailable"),
+    );
+    expect(cronReconciliation.complete).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("keeps one independent root admitted until the reconciliation hook settles", async () => {
+    let releaseHook: (() => void) | undefined;
+    const cronReconciliation = createTestCronReconciliation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHook = resolve;
+        }),
+    );
+
+    startGatewayCronWithLogging({
+      cronState: createTestCronState(),
+      cronReconciliation,
+      reason: "startup",
+      config: {} as never,
+      logCron: { error: vi.fn() },
+    });
+
+    await vi.waitFor(() => expect(cronReconciliation.complete).toHaveBeenCalledTimes(1));
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    if (!releaseHook) {
+      throw new Error("Expected cron reconciliation hook to be pending");
+    }
+    releaseHook();
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
   it("does not start model pricing refresh after scheduled services stop before import settles", async () => {
@@ -174,10 +270,10 @@ describe("server-runtime-services", () => {
   it("activates heartbeat, cron, and delivery recovery after sidecars are ready", async () => {
     vi.useFakeTimers();
     const log = createLog();
-    const { cron, services } = activateScheduledServicesForTest({ log });
+    const { cronStart, services } = activateScheduledServicesForTest({ log });
 
     expect(hoisted.startHeartbeatRunner).toHaveBeenCalledTimes(1);
-    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(cronStart).toHaveBeenCalledTimes(1);
     expect(services.heartbeatRunner).toBe(hoisted.heartbeatRunner);
     await vi.advanceTimersByTimeAsync(1_250);
     await vi.dynamicImportSettled();
@@ -210,7 +306,8 @@ describe("server-runtime-services", () => {
       cfgAtStart: {} as never,
       deps: {} as never,
       sessionDeliveryRecoveryMaxEnqueuedAt: 123,
-      cron,
+      cronState: createTestCronState(cron),
+      cronReconciliation: createTestCronReconciliation(),
       startCron: false,
       logCron: { error: vi.fn() },
       log,
@@ -235,7 +332,9 @@ describe("server-runtime-services", () => {
       applyMaintenance: vi.fn(),
       shouldStartCron: () => true,
       markCronStartHandled: vi.fn(),
-      cron,
+      cronState: createTestCronState(cron),
+      cronReconciliation: createTestCronReconciliation(),
+      cronConfig: {} as never,
       logCron: { error: vi.fn() },
       log,
       recordPostReadyMemory,
@@ -290,7 +389,7 @@ describe("server-runtime-services", () => {
         isClosing: () => closing,
         startMaintenance,
         applyMaintenance,
-        cron,
+        cronState: createTestCronState(cron),
         recordPostReadyMemory,
       }),
     );
@@ -325,7 +424,8 @@ describe("server-runtime-services", () => {
       cfgAtStart: {} as never,
       deps: {} as never,
       sessionDeliveryRecoveryMaxEnqueuedAt: 123,
-      cron,
+      cronState: createTestCronState(cron),
+      cronReconciliation: createTestCronReconciliation(),
       logCron: { error: vi.fn() },
       log: createLog(),
     });
@@ -353,25 +453,51 @@ function createLog() {
 }
 
 function createTestCron() {
-  return { start: vi.fn(async () => undefined) };
+  return { start: vi.fn<() => Promise<void>>(async () => {}) };
+}
+
+function createTestCronState(
+  cron: { start: () => Promise<void> } = createTestCron(),
+  cronEnabled = true,
+) {
+  return {
+    cron,
+    storePath: "/tmp/cron.json",
+    cronEnabled,
+  } as never;
+}
+
+function createTestCronReconciliation(complete: () => Promise<void> = async () => {}) {
+  const completeMock = vi.fn<() => Promise<void>>(complete);
+  return {
+    arm: vi.fn<() => { complete: () => Promise<void> }>(() => ({ complete: completeMock })),
+    complete: completeMock,
+    invalidate: vi.fn(),
+  };
 }
 
 function activateScheduledServicesForTest(
-  overrides: Partial<Parameters<typeof activateGatewayScheduledServices>[0]> = {},
+  overrides: Omit<
+    Partial<Parameters<typeof activateGatewayScheduledServices>[0]>,
+    "cronState"
+  > = {},
 ) {
-  const cron = overrides.cron ?? createTestCron();
+  const cron = createTestCron();
+  const cronState = createTestCronState(cron);
+  const cronStart = cron.start;
   const log = overrides.log ?? createLog();
   const services = activateGatewayScheduledServices({
     minimalTestGateway: false,
     cfgAtStart: {} as never,
     deps: {} as never,
     sessionDeliveryRecoveryMaxEnqueuedAt: 123,
+    cronReconciliation: createTestCronReconciliation(),
     logCron: { error: vi.fn() },
     ...overrides,
-    cron,
+    cronState,
     log,
   });
-  return { cron, log, services };
+  return { cron, cronStart, log, services };
 }
 
 function createPostReadyMaintenanceScheduleParams(
@@ -384,7 +510,9 @@ function createPostReadyMaintenanceScheduleParams(
     applyMaintenance: vi.fn(),
     shouldStartCron: () => true,
     markCronStartHandled: vi.fn(),
-    cron: { start: vi.fn(async () => undefined) },
+    cronState: createTestCronState(),
+    cronReconciliation: createTestCronReconciliation(),
+    cronConfig: {} as never,
     logCron: { error: vi.fn() },
     log: createLog(),
     recordPostReadyMemory: vi.fn(),

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -7,6 +7,8 @@ import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-r
 import type { PluginMetadataRegistryView } from "../plugins/plugin-metadata-snapshot.types.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { isGatewayModelPricingEnabled } from "./model-pricing-config.js";
+import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
+import type { GatewayCronState } from "./server-cron.js";
 import type { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import {
   createNoopHeartbeatRunner,
@@ -25,15 +27,24 @@ export type GatewayMaintenanceHandles = NonNullable<
   Awaited<ReturnType<typeof startGatewayMaintenanceTimers>>
 >;
 
-/** Starts cron without making gateway startup wait for cron initialization. */
+/** Starts cron without making the surrounding startup or reload transaction wait. */
 export function startGatewayCronWithLogging(params: {
-  cron: { start: () => Promise<void> };
+  cronState: GatewayCronState;
+  cronReconciliation: GatewayCronReconciliation;
+  reason: "startup" | "reload";
+  config: OpenClawConfig;
   afterStart?: () => Promise<void>;
   logCron: { error: (message: string) => void };
 }): void {
+  const reconciliation = params.cronReconciliation.arm({
+    reason: params.reason,
+    config: params.config,
+    cronState: params.cronState,
+  });
   void runWithGatewayIndependentRootWorkAdmission(async () => {
-    await params.cron.start();
+    await params.cronState.cron.start();
     await params.afterStart?.();
+    await reconciliation.complete();
   }).catch((err: unknown) => params.logCron.error(`failed to start: ${String(err)}`));
 }
 
@@ -59,7 +70,9 @@ export async function runGatewayPostReadyMaintenance(params: {
   applyMaintenance: (maintenance: GatewayMaintenanceHandles) => void;
   shouldStartCron: () => boolean;
   markCronStartHandled: () => void;
-  cron: { start: () => Promise<void> };
+  cronState: GatewayCronState;
+  cronReconciliation: GatewayCronReconciliation;
+  cronConfig: OpenClawConfig;
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
@@ -75,7 +88,10 @@ export async function runGatewayPostReadyMaintenance(params: {
   if (params.shouldStartCron()) {
     params.markCronStartHandled();
     startGatewayCronWithLogging({
-      cron: params.cron,
+      cronState: params.cronState,
+      cronReconciliation: params.cronReconciliation,
+      reason: "startup",
+      config: params.cronConfig,
       logCron: params.logCron,
     });
   }
@@ -91,7 +107,9 @@ export function scheduleGatewayPostReadyMaintenance(params: {
   applyMaintenance: (maintenance: GatewayMaintenanceHandles) => void;
   shouldStartCron: () => boolean;
   markCronStartHandled: () => void;
-  cron: { start: () => Promise<void> };
+  cronState: GatewayCronState;
+  cronReconciliation: GatewayCronReconciliation;
+  cronConfig: OpenClawConfig;
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
@@ -125,7 +143,9 @@ export function scheduleGatewayPostReadyMaintenance(params: {
         },
         shouldStartCron: () => !params.isClosing() && params.shouldStartCron(),
         markCronStartHandled: params.markCronStartHandled,
-        cron: params.cron,
+        cronState: params.cronState,
+        cronReconciliation: params.cronReconciliation,
+        cronConfig: params.cronConfig,
         logCron: params.logCron,
         log: params.log,
         recordPostReadyMemory: () => {
@@ -225,7 +245,8 @@ export function activateGatewayScheduledServices(params: {
   cfgAtStart: OpenClawConfig;
   deps: import("../cli/deps.types.js").CliDeps;
   sessionDeliveryRecoveryMaxEnqueuedAt: number;
-  cron: { start: () => Promise<void> };
+  cronState: GatewayCronState;
+  cronReconciliation: GatewayCronReconciliation;
   startCron?: boolean;
   logCron: { error: (message: string) => void };
   log: GatewayRuntimeServiceLogger;
@@ -242,7 +263,10 @@ export function activateGatewayScheduledServices(params: {
   });
   if (params.startCron !== false) {
     startGatewayCronWithLogging({
-      cron: params.cron,
+      cronState: params.cronState,
+      cronReconciliation: params.cronReconciliation,
+      reason: "startup",
+      config: params.cfgAtStart,
       logCron: params.logCron,
     });
   }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -99,6 +99,7 @@ import { resolveGatewayPluginConfig } from "./runtime-plugin-config.js";
 import type { ChannelAutostartSuppression } from "./server-channels.js";
 import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
+import { createGatewayCronReconciliation } from "./server-cron-reconciled.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayServerLiveState, type GatewayServerLiveState } from "./server-live-state.js";
 import { GATEWAY_EVENTS } from "./server-methods-list.js";
@@ -1032,6 +1033,21 @@ export async function startGatewayServer(
   };
 
   let closePreludeStarted = false;
+  const cronReconciliation = createGatewayCronReconciliation({
+    port,
+    workspaceDir: defaultWorkspaceDir,
+    isClosing: () => closePreludeStarted,
+    runHook: async (event, ctx) => {
+      try {
+        const hookRunner = (await import("../plugins/hook-runner-global.js")).getGlobalHookRunner();
+        if (hookRunner?.hasHooks("cron_reconciled")) {
+          await hookRunner.runCronReconciled(event, ctx);
+        }
+      } catch (err) {
+        logCron.error(`cron_reconciled hook failed: ${String(err)}`);
+      }
+    },
+  });
   let postReadyMaintenanceTimer: ReturnType<typeof setTimeout> | null = null;
   const clearPostReadyMaintenanceTimer = () => {
     if (!postReadyMaintenanceTimer) {
@@ -1042,6 +1058,7 @@ export async function startGatewayServer(
   };
   const markClosePreludeStarted = () => {
     closePreludeStarted = true;
+    cronReconciliation.invalidate();
     clearPostReadyMaintenanceTimer();
   };
   const runClosePrelude = async () => {
@@ -1671,7 +1688,8 @@ export async function startGatewayServer(
           cfgAtStart,
           deps,
           sessionDeliveryRecoveryMaxEnqueuedAt,
-          cron: runtimeState.cronState.cron,
+          cronState: runtimeState.cronState,
+          cronReconciliation,
           startCron: false,
           logCron,
           log,
@@ -1829,6 +1847,7 @@ export async function startGatewayServer(
       logChannels,
       logCron,
       logReload,
+      cronReconciliation,
       onCronRestart: () => {
         gatewayCronStartHandled = true;
       },
@@ -1885,7 +1904,9 @@ export async function startGatewayServer(
         markCronStartHandled: () => {
           gatewayCronStartHandled = true;
         },
-        cron: runtimeState.cronState.cron,
+        cronState: runtimeState.cronState,
+        cronReconciliation,
+        cronConfig: cfgAtStart,
         logCron,
         log,
         recordPostReadyMemory: () => {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -119,6 +119,7 @@ export type PluginHookName =
   | "gateway_start"
   | "gateway_stop"
   | "heartbeat_prompt_contribution"
+  | "cron_reconciled"
   | "cron_changed"
   | "before_dispatch"
   | "reply_dispatch"
@@ -161,6 +162,7 @@ export const PLUGIN_HOOK_NAMES = [
   "gateway_start",
   "gateway_stop",
   "heartbeat_prompt_contribution",
+  "cron_reconciled",
   "cron_changed",
   "before_dispatch",
   "reply_dispatch",
@@ -868,6 +870,11 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+export type PluginHookCronReconciledEvent = {
+  reason: "startup" | "reload";
+  enabled: boolean;
+};
+
 export type PluginHookGatewayCronRunStatus = "ok" | "error" | "skipped";
 
 export type PluginHookGatewayCronDeliveryStatus =
@@ -1274,6 +1281,10 @@ export type PluginHookHandlerMap = {
     | Promise<PluginHeartbeatPromptContributionResult | void>
     | PluginHeartbeatPromptContributionResult
     | void;
+  cron_reconciled: (
+    event: PluginHookCronReconciledEvent,
+    ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
   cron_changed: (
     event: PluginHookCronChangedEvent,
     ctx: PluginHookGatewayContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -58,6 +58,7 @@ import type {
   PluginHeartbeatPromptContributionEvent,
   PluginHeartbeatPromptContributionResult,
   PluginHookBeforeAgentRunEvent,
+  PluginHookCronReconciledEvent,
   PluginHookCronChangedEvent,
   PluginHookGatewayCronDeliveryStatus,
   PluginHookGatewayCronJobState,
@@ -138,6 +139,7 @@ export type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookBeforeAgentRunEvent,
+  PluginHookCronReconciledEvent,
   PluginHookAfterToolCallEvent,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
@@ -1564,6 +1566,16 @@ export function createHookRunner(
   }
 
   /**
+   * Run cron_reconciled after the Gateway scheduler reaches a complete state.
+   */
+  async function runCronReconciled(
+    event: PluginHookCronReconciledEvent,
+    ctx: PluginHookGatewayContext,
+  ): Promise<void> {
+    return runVoidHook("cron_reconciled", event, ctx);
+  }
+
+  /**
    * Run cron_changed hook for gateway-owned cron lifecycle changes.
    */
   async function runCronChanged(
@@ -1684,6 +1696,7 @@ export function createHookRunner(
     runGatewayStart,
     runGatewayStop,
     runHeartbeatPromptContribution,
+    runCronReconciled,
     runCronChanged,
     // Install hooks
     runBeforeInstall,

--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -1,5 +1,5 @@
 /**
- * Test: gateway_start & gateway_stop hook wiring (server.impl.ts)
+ * Test: Gateway and cron lifecycle hook wiring.
  *
  * Since startGatewayServer is heavily integrated, we test the hook runner
  * calls at the unit level by verifying the hook runner functions exist
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createHookRunnerWithRegistry } from "./hooks.test-helpers.js";
 import type {
   PluginHookCronChangedEvent,
+  PluginHookCronReconciledEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -80,6 +81,19 @@ describe("gateway hook runner methods", () => {
     };
 
     await runner.runCronChanged(event, gatewayCtx);
+
+    expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
+  });
+
+  it.each([
+    { reason: "startup", enabled: true },
+    { reason: "reload", enabled: false },
+  ] as const)("runCronReconciled forwards $reason state", async ({ reason, enabled }) => {
+    const handler = vi.fn();
+    const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_reconciled", handler }]);
+    const event: PluginHookCronReconciledEvent = { reason, enabled };
+
+    await runner.runCronReconciled(event, gatewayCtx);
 
     expect(handler).toHaveBeenCalledWith(event, gatewayCtx);
   });
@@ -162,10 +176,12 @@ describe("gateway hook runner methods", () => {
   it("hasHooks returns true for registered gateway hooks", () => {
     const { runner } = createHookRunnerWithRegistry([
       { hookName: "gateway_start", handler: vi.fn() },
+      { hookName: "cron_reconciled", handler: vi.fn() },
       { hookName: "cron_changed", handler: vi.fn() },
     ]);
 
     expect(runner.hasHooks("gateway_start")).toBe(true);
+    expect(runner.hasHooks("cron_reconciled")).toBe(true);
     expect(runner.hasHooks("cron_changed")).toBe(true);
     expect(runner.hasHooks("gateway_stop")).toBe(false);
   });


### PR DESCRIPTION
Closes #104082

Related: #103736 (the separate hot-reload publication/atomicity issue is not changed by this PR).

## What Problem This Solves

Plugins that project OpenClaw cron jobs into an external scheduler have no authoritative lifecycle point after the Gateway has loaded durable cron state and reconciled exit watchers. `gateway_start` can run too early, while `cron_changed` is a coalescible change hint rather than a complete-state baseline.

## Why This Change Was Made

This adds a typed `cron_reconciled` observation hook after scheduler startup and every scheduler replacement on config reload. The event exposes only the reconciliation reason and effective enabled state; plugins read the exact reconciled scheduler through `ctx.getCron()`. Generation guards, serialized delivery, and shutdown invalidation suppress stale callbacks without introducing retries, durability, or plugin-only replay.

## User Impact

Plugin authors can reliably rebuild a complete external cron projection after Gateway startup or scheduler replacement. Disabled cron emits `enabled: false`, allowing adapters to clear stale external wakes, while `cron_changed` remains available for low-latency incremental hints.

## Evidence

- Runtime hook head `f2976f273c9648010fcde3ed5ff7161c409bfe36`: 141 focused gateway/plugin test executions and `pnpm plugin-sdk:api:check` passed on Blacksmith Testbox `tbx_01kx7tqqvxah2ms4g68ek1d7pp` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29141439667)).
- SDK export-budget fix: all 10 `plugin-sdk-surface-report` tests and `pnpm plugin-sdk:api:check` passed on Blacksmith Testbox `tbx_01kx7vcdpjxe3w3vdc5j8g1wk1` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29141737063)).
- Final rebased head `30fdbfa92b1c630f393a000e2cc7bfd2823abac2`; the intervening `origin/main` files are outside this PR's gateway/plugin/SDK surface. Exact-head hosted CI is the landing gate.
- Pre-rebase full proof on the same patch: `pnpm check:changed`, `pnpm check:docs`, and `pnpm build` passed; the build included the Plugin SDK export check.
- Exact rebased head docs formatting, Markdown lint, and MDX validation passed. The global link audit currently reports six missing `IDENTITY`/`USER` template routes introduced on `origin/main`; those paths are outside this PR diff.
- `git diff --check` passed.
- Fresh GPT-5.5 autoreview: no accepted or actionable findings.

AI-assisted: yes; maintainer-directed and manually audited.
