### PR TITLE
fix(secrets): resolve active exec refs locally

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -621,9 +621,8 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
   });
 
-  it("keeps local exec SecretRef fallback enabled by default", async () => {
+  it("resolves active exec SecretRefs locally without calling the gateway", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -632,10 +631,151 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       mode: "read_only_status",
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(true);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
-    expectGatewayUnavailableLocalFallbackDiagnostics(result);
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          `memory status: resolved exec SecretRefs locally without gateway secrets.resolve at ${TALK_TEST_PROVIDER_API_KEY_PATH}`,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to gateway resolution when a local exec provider fails", async () => {
+    const { config } = await createExecProviderConfig("talk/providers/failing-api-key");
+    const provider = config.secrets?.providers?.default;
+    if (!provider || provider.source !== "exec") {
+      throw new Error("expected exec provider");
+    }
+    (provider as { args?: string[] }).args = ["-e", "process.exit(7)"];
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: TALK_TEST_PROVIDER_API_KEY_PATH,
+          pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
+          value: "gateway-exec-key",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("gateway-exec-key");
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_gateway");
+    expect(result.hadUnresolvedTargets).toBe(false);
+    expect(result.diagnostics.some((entry) => entry.includes("continuing with degraded"))).toBe(
+      false,
+    );
+    expect(
+      result.diagnostics.some(
+        (entry) => entry.includes("failed to resolve") && entry.includes("locally"),
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves the local exec failure when gateway recovery also leaves the path unresolved", async () => {
+    const { config } = await createExecProviderConfig("talk/providers/failing-api-key");
+    const provider = config.secrets?.providers?.default;
+    if (!provider || provider.source !== "exec") {
+      throw new Error("expected exec provider");
+    }
+    (provider as { args?: string[] }).args = ["-e", "process.exit(7)"];
+    callGateway.mockResolvedValueOnce({
+      assignments: [],
+      diagnostics: ["gateway did not resolve the exec-backed path"],
+    });
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
+    expect(result.hadUnresolvedTargets).toBe(true);
+    expect(result.diagnostics).toContain("gateway did not resolve the exec-backed path");
+    expect(
+      result.diagnostics.some(
+        (entry) =>
+          entry.includes(`failed to resolve ${TALK_TEST_PROVIDER_API_KEY_PATH} locally`) &&
+          entry.includes("exited with code 7"),
+      ),
+    ).toBe(true);
+    expect(
+      result.diagnostics.filter((entry) =>
+        entry.includes(`failed to resolve ${TALK_TEST_PROVIDER_API_KEY_PATH} locally`),
+      ),
+    ).toHaveLength(1);
+    expect(
+      result.diagnostics.some((entry) => entry.includes("skipped local exec SecretRef resolution")),
+    ).toBe(false);
+    expect(result.diagnostics.some((entry) => entry.includes("rerun with --allow-exec"))).toBe(
+      false,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("keeps non-exec targets on gateway resolution when the command also uses exec refs", async () => {
+    const { config: execConfig, markerPath } =
+      await createExecProviderConfig("talk/providers/api-key");
+    const gatewayPath = "talk.providers.gateway-speech.apiKey";
+    const config = {
+      ...execConfig,
+      talk: {
+        ...execConfig.talk,
+        providers: {
+          ...execConfig.talk?.providers,
+          "gateway-speech": {
+            apiKey: { source: "env", provider: "env", id: "GATEWAY_SPEECH_API_KEY" },
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          ...execConfig.secrets?.providers,
+          env: { source: "env" },
+        },
+      },
+    } as OpenClawConfig;
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: gatewayPath,
+          pathSegments: ["talk", "providers", "gateway-speech", "apiKey"],
+          value: "gateway-only-key",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(await markerExists(markerPath)).toBe(true);
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
+    expect(result.resolvedConfig.talk?.providers?.["gateway-speech"]?.apiKey).toBe(
+      "gateway-only-key",
+    );
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+    expect(result.targetStatesByPath[gatewayPath]).toBe("resolved_gateway");
   });
 
   it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -358,12 +358,14 @@ function classifyConfiguredTargetRefs(params: {
 }): {
   hasActiveConfiguredRef: boolean;
   hasUnknownConfiguredRef: boolean;
+  activeOrUnknownRefPaths: Set<string>;
   diagnostics: string[];
 } {
   if (params.configuredTargetRefPaths.size === 0) {
     return {
       hasActiveConfiguredRef: false,
       hasUnknownConfiguredRef: false,
+      activeOrUnknownRefPaths: new Set(),
       diagnostics: [],
     };
   }
@@ -388,6 +390,7 @@ function classifyConfiguredTargetRefs(params: {
   const diagnostics = new Set<string>();
   let hasActiveConfiguredRef = false;
   let hasUnknownConfiguredRef = false;
+  const activeOrUnknownRefPaths = new Set<string>();
 
   for (const path of params.configuredTargetRefPaths) {
     if (
@@ -396,6 +399,7 @@ function classifyConfiguredTargetRefs(params: {
       params.optionalActivePaths?.has(path)
     ) {
       hasActiveConfiguredRef = true;
+      activeOrUnknownRefPaths.add(path);
       continue;
     }
     const inactiveWarning = inactiveWarningsByPath.get(path);
@@ -404,13 +408,35 @@ function classifyConfiguredTargetRefs(params: {
       continue;
     }
     hasUnknownConfiguredRef = true;
+    activeOrUnknownRefPaths.add(path);
   }
 
   return {
     hasActiveConfiguredRef,
     hasUnknownConfiguredRef,
+    activeOrUnknownRefPaths,
     diagnostics: [...diagnostics],
   };
+}
+
+function collectExecSecretRefPaths(params: {
+  config: OpenClawConfig;
+  targetIds: Set<string>;
+  paths: ReadonlySet<string>;
+}): string[] {
+  const defaults = params.config.secrets?.defaults;
+  return commandSecretGatewayDeps
+    .discoverConfigSecretTargetsByIds(params.config, params.targetIds)
+    .filter((target) => params.paths.has(target.path))
+    .filter((target) => {
+      const { ref } = resolveSecretInputRef({
+        value: target.value,
+        refValue: target.refValue,
+        defaults,
+      });
+      return ref?.source === "exec";
+    })
+    .map((target) => target.path);
 }
 
 function parseGatewaySecretsResolveResult(payload: unknown): {
@@ -933,6 +959,82 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       diagnostics: preflight.diagnostics,
       targetStatesByPath: {},
       hadUnresolvedTargets: false,
+    };
+  }
+  const commandExecSecretRefPaths = resolutionPolicy.allowExecSecretRefs
+    ? collectExecSecretRefPaths({
+        config: params.config,
+        targetIds: params.targetIds,
+        paths: preflight.activeOrUnknownRefPaths,
+      })
+    : [];
+  if (commandExecSecretRefPaths.length > 0) {
+    const execPaths = new Set(commandExecSecretRefPaths);
+    const localExec = await resolveCommandSecretRefsLocally({
+      config: params.config,
+      commandName: params.commandName,
+      targetIds: params.targetIds,
+      preflightDiagnostics: preflight.diagnostics,
+      mode: "read_only_operational",
+      allowedPaths: execPaths,
+      forcedActivePaths: params.forcedActivePaths,
+      optionalActivePaths: params.optionalActivePaths,
+      resolutionPolicy: {
+        ...resolutionPolicy,
+        scrubUnresolvedSecretRefs: false,
+      },
+    });
+    const resolvedExecPaths = new Set(
+      commandExecSecretRefPaths.filter(
+        (path) => localExec.targetStatesByPath[path] === "resolved_local",
+      ),
+    );
+    const remainingPaths = new Set(
+      [...preflight.activeOrUnknownRefPaths].filter((path) => !resolvedExecPaths.has(path)),
+    );
+    const remaining =
+      remainingPaths.size > 0
+        ? await resolveCommandSecretRefsViaGateway({
+            ...params,
+            config: localExec.resolvedConfig,
+            allowedPaths: remainingPaths,
+            allowLocalExecSecretRefs: false,
+          })
+        : undefined;
+    const targetStatesByPath = {
+      ...localExec.targetStatesByPath,
+      ...remaining?.targetStatesByPath,
+    };
+    const unrecoveredExecDiagnostics = localExec.diagnostics.filter((diagnostic) =>
+      commandExecSecretRefPaths.some(
+        (path) =>
+          targetStatesByPath[path] === "unresolved" &&
+          diagnostic.startsWith(`${params.commandName}: failed to resolve ${path} locally (`),
+      ),
+    );
+    const attemptedExecSkipDiagnostics = new Set(
+      commandExecSecretRefPaths.map(
+        (path) =>
+          `${params.commandName}: skipped local exec SecretRef resolution for ${path}; rerun with --allow-exec to execute configured exec providers.`,
+      ),
+    );
+    const remainingDiagnostics = (remaining?.diagnostics ?? []).filter(
+      (diagnostic) => !attemptedExecSkipDiagnostics.has(diagnostic),
+    );
+    return {
+      resolvedConfig: remaining?.resolvedConfig ?? localExec.resolvedConfig,
+      diagnostics: dedupeDiagnostics([
+        ...preflight.diagnostics,
+        ...(resolvedExecPaths.size > 0
+          ? [
+              `${params.commandName}: resolved exec SecretRefs locally without gateway secrets.resolve at ${[...resolvedExecPaths].join(", ")}.`,
+            ]
+          : []),
+        ...unrecoveredExecDiagnostics,
+        ...remainingDiagnostics,
+      ]),
+      targetStatesByPath,
+      hadUnresolvedTargets: Object.values(targetStatesByPath).includes("unresolved"),
     };
   }
   const gatewayExecSecretRefCredentialPaths = resolutionPolicy.allowExecSecretRefs


### PR DESCRIPTION
## Summary

- resolve active command-scoped `exec` SecretRefs locally before calling `gateway secrets.resolve`
- preserve gateway snapshot ownership for all remaining non-exec targets
- fall back to gateway resolution when a local exec provider fails
- preserve the path-specific local exec error only when gateway recovery also fails
- preserve inactive-surface diagnostics and merge per-path resolution state

This prevents `reply` from producing noisy `gateway secrets.resolve unavailable` errors when agent-runtime model/provider credentials use locally executable SecretRefs.

Fixes #96653

## What Problem This Solves

Queued reply turns currently send active model/provider `exec` SecretRefs to `gateway secrets.resolve`. The gateway cannot execute those local providers, so it returns `UNAVAILABLE`; the reply process then resolves the same ref locally and succeeds. That produces a misleading gateway error and needless round trip on every turn. Mixed-source commands additionally need a stable ownership boundary: resolving an exec path locally must not move unrelated env or other snapshot-backed credentials out of the gateway.

## Resolution boundary

This PR intentionally uses **split per-path resolution**:

1. Active and allowed `exec` paths resolve locally.
2. Successfully resolved exec paths are removed from the unresolved target set.
3. Remaining env/file/keychain/plugin-backed paths continue through the active gateway snapshot.
4. If local exec fails, that path remains unresolved and is included in the gateway request.
5. Successful gateway recovery removes the stale local error; dual failure retains the actionable local provider diagnostic.

This keeps configured exec execution narrowly scoped while preserving the gateway as the source of truth for non-exec credentials.

## Evidence

Tested after rebasing onto current `main`.

Environment:

- Linux x64
- Node `v22.22.2`
- production bundle built with `pnpm build cliStartup`
- temporary real gateway process with a temporary config/state directory
- real child process for the exec provider
- no production credentials; all values were synthetic and redacted from output

Command:

```bash
node /root/cad/reports/pr-104192-live-proof.mjs
```

Redacted output:

```console
LIVE BUILT-CODE PROOF — PR #104192
Node: v22.22.2
Dist: command-secret-gateway-B6pWjwzk.js

exec-only:
  markerRan: true
  talk.providers.local-exec.apiKey: resolved_local
  unresolved: false
  diagnostic: resolved exec SecretRefs locally without gateway secrets.resolve

mixed-exec-and-gateway:
  markerRan: true
  talk.providers.local-exec.apiKey: resolved_local
  talk.providers.gateway-env.apiKey: resolved_gateway
  unresolved: false

local-exec-failure-gateway-recovery:
  markerRan: false
  talk.providers.failing-exec.apiKey: resolved_gateway
  unresolved: false

local-exec-and-gateway-dual-failure:
  markerRan: false
  talk.providers.missing-exec.apiKey: unresolved
  unresolved: true
  diagnostic: failed to resolve talk.providers.missing-exec.apiKey locally (Exec provider "failing" exited with code 7.)
  misleading rerun-with-allow-exec diagnostic: absent

Gateway secrets.resolve failures in log: 0
ALL SCENARIOS PASS
```

What this demonstrates:

| Scenario | Local exec | Gateway | Result |
|---|---:|---:|---|
| Exec-only | Runs | Not needed | Path is `resolved_local`; no gateway error |
| Mixed exec + env | Runs for exec path | Resolves env path | Split ownership is preserved |
| Local exec failure | Fails before producing a value | Recovers failed path | Path is `resolved_gateway`; no stale failure diagnostic |
| Local exec + gateway dual failure | Fails before producing a value | Leaves path unresolved | Path-specific exit-code diagnostic is retained |

## Tests

Focused suites after the exact-head rebase:

```console
$ pnpm test src/cli/command-secret-gateway.test.ts \
  src/auto-reply/reply/agent-runner-utils.test.ts \
  src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts

Test Files  3 passed (3)
Tests       60 passed (60)
```

Changed-file quality gate:

```console
$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 \
  pnpm check:changed -- \
  src/cli/command-secret-gateway.ts \
  src/cli/command-secret-gateway.test.ts

exit 0
```

The gate includes production and test typechecks, changed-file lint, dependency/package guards, database-first guards, and runtime import-cycle checks.

## Relationship to #96661

PR #96661 is a useful candidate for the same canonical issue and supplied earlier live proof for active exec detection. The permanent boundary differs:

- **#96661:** when an active target uses exec, skip gateway resolution for the command target set and use local resolution.
- **This PR:** resolve only active exec-backed paths locally, then send every remaining path through the gateway snapshot; if local exec fails, send that path through the gateway too.

Useful coverage retained or expanded here:

- active exec refs execute locally
- inactive exec refs do not affect unrelated active targets
- callers that disallow local exec keep gateway-first behavior
- mixed exec/non-exec targets preserve separate resolution owners
- failed local exec falls back to gateway resolution
- successful gateway recovery removes stale local-failure diagnostics
- dual failure preserves the path-specific local exec failure
- recursive gateway fallback does not claim exec was skipped when it was already attempted

The split boundary is narrower: it moves only configured active exec execution into the local reply process and does not move env or other gateway-resolvable credentials out of the gateway snapshot.

## Security impact

- no credential values are added to gateway RPC metadata
- only active, command-scoped, allowed exec paths execute locally
- non-exec credentials remain gateway-owned
- failed local exec does not force degraded operation when the gateway can recover
- no config schema or protocol changes

## Compatibility

Backward compatible. Resolution outcomes remain the same for successful setups; the change removes avoidable gateway failures and preserves gateway resolution for mixed-source targets.
