### PR TITLE
fix(webchat): model picker tooltip repeats the fully visible model name

### DIFF
--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -13,11 +13,11 @@ type TooltipProviderElement = HTMLElement & {
   skipDelay: number;
 };
 
-function createTooltip(content: string) {
+function createTooltip(content: string, triggerText = "trigger") {
   const tooltip = document.createElement("openclaw-tooltip") as TooltipElement;
   tooltip.content = content;
   const trigger = document.createElement("button");
-  trigger.textContent = content;
+  trigger.textContent = triggerText;
   tooltip.append(trigger);
   return { tooltip, trigger };
 }
@@ -103,6 +103,33 @@ describe("openclaw-tooltip", () => {
     vi.advanceTimersByTime(39);
     expectPortalCount(0);
     vi.advanceTimersByTime(1);
+    expectPortalCount(1);
+  });
+
+  it("suppresses a tooltip that repeats fully visible trigger text", async () => {
+    const provider = createProvider();
+    const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "Claude Opus 4.7 Anthropic");
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+
+    focusTrigger(trigger);
+    expectPortalCount(0);
+    hoverTrigger(trigger);
+    vi.runAllTimers();
+    expectPortalCount(0);
+  });
+
+  it("keeps a repeated-label tooltip when the trigger clips its text", async () => {
+    const provider = createProvider();
+    const { tooltip, trigger } = createTooltip("Claude Opus 4.7", "Claude Opus 4.7 Anthropic");
+    Object.defineProperty(trigger, "scrollWidth", { value: 160, configurable: true });
+    Object.defineProperty(trigger, "clientWidth", { value: 80, configurable: true });
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+
+    focusTrigger(trigger);
     expectPortalCount(1);
   });
 

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -17,6 +17,10 @@ function createTooltipId() {
   return `openclaw-tooltip-${nextTooltipId}`;
 }
 
+function normalizeTooltipText(text: string) {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
 class TooltipProvider extends OpenClawLitElement {
   @property({ type: Number }) delay = HOVER_DELAY;
   @property({ type: Number }) skipDelay = SKIP_DELAY;
@@ -305,6 +309,24 @@ class Tooltip extends OpenClawLitElement {
     }, delay);
   }
 
+  // Tooltips that merely repeat text the trigger already shows in full are
+  // noise (e.g. a model row echoing its own visible label); suppress those
+  // opens, but keep the tooltip when any trigger element clips its content so
+  // ellipsized labels still reveal the full text on hover.
+  private isRedundantContent() {
+    const trigger = this.trigger;
+    if (!trigger) {
+      return false;
+    }
+    const content = normalizeTooltipText(this.content);
+    if (!content || !normalizeTooltipText(trigger.textContent ?? "").includes(content)) {
+      return false;
+    }
+    return [trigger, ...trigger.querySelectorAll("*")].every(
+      (element) => !(element instanceof HTMLElement) || element.scrollWidth <= element.clientWidth,
+    );
+  }
+
   private show() {
     const trigger = this.trigger;
     if (!trigger || !this.content.trim()) {
@@ -316,6 +338,9 @@ class Tooltip extends OpenClawLitElement {
         this.portal.textContent = this.content;
         this.positionTooltip();
       }
+      return;
+    }
+    if (this.isRedundantContent()) {
       return;
     }
     const provider = this.provider;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where hovering a model row in the chat model picker would show a tooltip that just repeats the row's own fully visible label (e.g. hovering "Claude Opus 4.7" shows a "Claude Opus 4.7" tooltip). The same redundant-hover pattern exists on other label-repeating tooltips such as background-task titles, attachment filenames, and the workspace path.

## Why This Change Was Made

The tooltip on those rows exists so ellipsized labels can reveal their full text on hover. Instead of special-casing the model picker, the shared `openclaw-tooltip` now suppresses opens whose content is already fully visible in the trigger: if the normalized tooltip text is contained in the trigger's text and no element inside the trigger clips its content horizontally, the tooltip stays closed. Truncated labels (scrollWidth > clientWidth) still get the full-text tooltip, and icon-only buttons are unaffected because their tooltip text is not present in the trigger.

## User Impact

Hovering a fully visible model name (or task title, attachment name, workspace path) no longer pops a tooltip that duplicates the text under the cursor. Tooltips still appear when the label is truncated or when they add information.

## Evidence

- `pnpm test ui/src/components/tooltip.test.ts` on Blacksmith Testbox through Crabbox (`tbx_01kx7t9b1fpzy2vrwa9er34ec4`): 6/6 passed, including two new regression tests — one asserting suppression for a repeated fully visible label, one asserting the tooltip still opens when the trigger clips its text.
- `pnpm check:changed` on the same Testbox: exit 0 (format, lint, tsgo lanes, import cycles, and repo guards all green).
- Codex autoreview (`gpt-5.5`) on the diff: clean, no accepted/actionable findings.
