### PR TITLE
feat(ui): overlay hover meta and even out chat thread rhythm

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -614,6 +614,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       });
       expect(await context.isVisible()).toBe(false);
 
+      // Travel like a real pointer: the footer overlay is pointer-gated until
+      // the group is hovered, so enter through the message body first.
+      await page.locator(".chat-text").first().hover();
       await page.locator(".msg-meta__summary").hover();
       expect(await context.isVisible()).toBe(true);
       const hoverLayout = await page.evaluate(() => {
@@ -635,6 +638,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.mouse.move(0, 0);
       expect(await context.isVisible()).toBe(false);
 
+      await page.locator(".chat-text").first().hover();
       await page.locator(".msg-meta__summary").click();
       await page.mouse.move(0, 0);
       expect(await details.getAttribute("open")).toBe("");

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -619,8 +619,10 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
         ${footerStartedAt !== null
           ? html`
               <div class="chat-group-footer">
-                <span class="chat-sender-name">${name}</span>
-                ${renderChatTimestamp(footerStartedAt)}
+                <div class="chat-group-footer__meta">
+                  <span class="chat-sender-name">${name}</span>
+                  ${renderChatTimestamp(footerStartedAt)}
+                </div>
               </div>
             `
           : nothing}

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -58,12 +58,17 @@
   right: 0;
   z-index: 1; /* revealed overlay paints above the next group's leading edge */
   display: flex;
-  flex-wrap: nowrap;
+  /* Wrap instead of clipping in narrow lanes (extreme chatMessageMaxWidth,
+     slim split panes): a wrapped revealed footer may transiently overlap the
+     next group, but every control stays reachable. Hidden overlays must not
+     intercept pointer input, so hit-testing is gated on the reveal. */
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
   min-width: 0;
   margin-top: 1px;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 120ms ease-out;
 }
 
@@ -71,6 +76,7 @@
 .chat-group:focus-within .chat-group-footer,
 .chat-group-footer:has(details.msg-meta[open]) {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .chat-group-footer__meta {
@@ -368,6 +374,7 @@ img.chat-avatar {
     width: 100%;
     margin-top: 4px;
     opacity: 1;
+    pointer-events: auto;
   }
 
   .chat-group-footer-actions button,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -99,10 +99,16 @@
   margin-top: 4px;
 }
 
+/* Single line, ellipsized: the footer overlays a fixed 26px rhythm gap, so
+   long configurable sender names must never wrap it taller than the gap. */
 .chat-sender-name {
   font-weight: 500;
   font-size: 12px;
   color: var(--muted);
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-group-timestamp {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -2,12 +2,16 @@
    GROUPED CHAT LAYOUT (Slack-style)
    ============================================= */
 
-/* Chat Group Layout - default (assistant/other on left) */
+/* Chat Group Layout - default (assistant/other on left). The bottom PADDING
+   is the thread's rhythm unit and doubles as the reveal zone for the
+   overlaid hover footer: padding (not margin) keeps the gap inside the
+   group's hover box so the pointer can travel to the footer without it
+   vanishing mid-way. */
 .chat-group {
   display: flex;
   gap: 10px;
   align-items: flex-start;
-  margin-bottom: 14px;
+  padding-bottom: 26px;
   margin-left: 4px;
   margin-right: 16px;
 }
@@ -19,6 +23,7 @@
 }
 
 .chat-group-messages {
+  position: relative; /* anchors the overlaid hover footer */
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -43,16 +48,21 @@
 }
 
 /* Footer at bottom of message group (role + time). Hidden until the group is
-   hovered/focused so the thread reads as a clean stream; opacity (not
-   display) keeps the height reserved and avoids layout shift on reveal. */
+   hovered/focused so the thread reads as a clean stream; overlaid into the
+   group's bottom margin (no reserved flow height) so message rhythm stays
+   even. Touch devices restore the in-flow always-visible footer below. */
 .chat-group-footer {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1; /* revealed overlay paints above the next group's leading edge */
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
   align-items: center;
-  width: 100%;
   min-width: 0;
-  margin-top: 4px;
+  margin-top: 1px;
   opacity: 0;
   transition: opacity 120ms ease-out;
 }
@@ -339,7 +349,18 @@ img.chat-avatar {
 @media (hover: none),
   (max-width: 768px),
   (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  /* No hover to reveal an overlay: restore the in-flow always-visible footer
+     and the tighter rhythm that accounts for its height. */
+  .chat-group {
+    padding-bottom: 0;
+    margin-bottom: 14px;
+  }
+
   .chat-group-footer {
+    position: static;
+    flex-wrap: wrap;
+    width: 100%;
+    margin-top: 4px;
     opacity: 1;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #104016/#104035/#104092: the flat chat stream still reserved in-flow space under every message group for the hover-only footer, producing uneven vertical rhythm — large empty bands between assistant text, tool rows, and user bubbles (most visible between consecutive user messages), while intra-message spacing stayed tight.

## Why This Change Was Made

The hover footer no longer reserves flow height: it overlays the group's bottom rhythm gap as an absolutely-positioned row. The gap itself is the group's bottom **padding** (26px), not margin — padding keeps the gap inside the group's hover box, so the pointer can travel from the message down to the revealed footer without it vanishing mid-way. The hidden overlay is pointer-gated (`pointer-events: none` until revealed) so it never swallows clicks in the gap. Sender names are single-line ellipsized so configurable names can't wrap the overlay past the gap; in genuinely narrow lanes (extreme `chatMessageMaxWidth`, slim split panes) the revealed footer wraps instead of clipping its action buttons, transiently overlapping the next group rather than hiding controls. The streaming footer's sender+time join the same shrinkable `__meta` row regular footers use. Touch devices (no hover) restore the previous in-flow always-visible footer and tighter rhythm. A container-query fallback was evaluated and deliberately rejected: `container-type` layout containment would re-anchor the `position: fixed` delete-confirmation popover and misplace it everywhere. Web (Control UI) only.

## User Impact

The thread reads with an even, calm rhythm — uniform gaps between every message, tool row, and reply, with no dead bands. Hovering a message reveals its sender/time/actions in the gap without anything shifting; all controls stay reachable in narrow layouts; mobile is unchanged.

## Evidence

| Even rhythm (light) | Hover reveal into the gap |
|---|---|
| ![rhythm](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-spacing-redesign/desktop-light.png) | ![hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-spacing-redesign/hover-footer-final.png) |

Dark/narrow: [desktop-dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-spacing-redesign/desktop-dark.png), [narrow-dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-spacing-redesign/narrow-dark.png). Before (reserved footers, uneven bands): [previous state](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/direct-thread-avatars/direct-kind-light.png). The hover shot is captured with real pointer travel (message body → footer), proving the pointer-gated overlay is reachable.

- Chat suites (`chat-view`, `chat-message`, `chat-responsive.browser`) 300/300 on Blacksmith Testbox after every fix cycle; the timestamp-hover regression test now travels through the group first, matching real pointer behavior.
- `pnpm check:changed` green at head. Codex autoreview, four rounds → final clean ("patch is correct 0.95"); fixed along the way: overlay fit guard (ellipsis), narrow-lane wrap + hidden-overlay hit-test gating, streaming footer row structure.
