### PR TITLE
feat: add live updater maintainer skill

### DIFF
--- a/.agents/skills/openclaw-live-updater/SKILL.md
+++ b/.agents/skills/openclaw-live-updater/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: openclaw-live-updater
+description: "Maintain the canonical live OpenClaw main checkout, managed Gateway, local macOS app, exact-head main CI, and recurring full release validation. Use for fast-forward update heartbeats, post-update runtime verification, attributable CI repair and repo-native landing, or non-publishing Full Release Validation of current main."
+---
+
+# OpenClaw Live Updater
+
+Keep `/Users/steipete/openclaw` a read-only-to-the-agent deployment mirror: clean, standalone, full, on `main`, and fast-forwarded only. Make every repair in the controlling Codex project worktree.
+
+## Boundaries
+
+- Report only in the controlling Codex thread. Never send Slack, Discord, email, or other external messages.
+- Never release, tag, bump versions, publish npm, create a GitHub Release, rotate credentials, or weaken a gate.
+- Escalate only irreversible or materially risky security, privacy, auth, destructive migration/data-loss, protocol-version, credential-rotation, dependency patch/override, or product choices.
+- Diagnose ordinary update, runtime, app, CI, test, and release-validation failures; fix them through a focused PR; prove exact head; land with `scripts/pr`.
+- Never edit, stash, reset, clean, or create a branch in the live mirror.
+
+## Fast Update And Maintenance
+
+1. Run the deterministic updater and retain its JSON:
+
+   ```bash
+   node .agents/skills/openclaw-live-updater/scripts/update-main.mjs
+   ```
+
+   Stop on any failed invariant. Do not repair the mirror destructively. The helper holds one checkout-scoped lock across update, build, Gateway proof, and Mac work. A concurrent heartbeat returns `reason: "overlap"`; it must not start another build. A dead owner lock may be recovered, but unreadable or unsafe lock state fails closed.
+
+2. The helper verifies one unrewritten expected origin, an owned non-symlinked standalone/full clone, single worktree, clean `main`, fetches `origin/main`, rechecks for concurrent changes, and merges `--ff-only`. It then uses the source runner's canonical local-build metadata contract and parser: both `dist/.buildstamp` and `dist/.runtime-postbuildstamp` heads, required runtime-postbuild outputs, `dist/entry.js`, Control UI index plus referenced local assets, and `dist/build-info.json` must all match exact `afterSha`.
+
+   - Every successful update sets `actions.gatewayBuild` and rebuilds exact new `main` before any restart.
+   - Missing, invalid, or stale build output also forces a build, even when Git did not move.
+   - A dependency-input change, absent `node_modules`, or missing/invalid build provenance first runs `pnpm install --frozen-lockfile`.
+   - `pnpm build` must leave both canonical stamp heads and `dist/build-info.json.commit` equal to post-update `afterSha`; any missing/mismatched stamp or required artifact blocks restart.
+   - Only after exact-SHA build proof may it restart the managed Gateway and require `gateway status --deep --require-rpc --json` plus `health --verbose --json`.
+
+   Treat supervisor state alone as insufficient. If build or proof fails, leave the new mirror head intact and retry the stale/missing build on the next heartbeat; never run the old `dist` against new source.
+
+   Re-run the canonical freshness check immediately before every `pnpm openclaw` restart or probe so the source runner cannot hide stale output with an implicit auto-build. Every pass, including a no-update/current-build pass, must run deep RPC status and verbose health. If that first probe fails while the build is already exact-current, perform one managed Gateway restart and repeat both probes once. Do not rebuild a current exact-SHA artifact merely to self-heal the managed process; fail and diagnose if the one restart does not recover it.
+
+3. If changed paths can affect macOS, the helper runs `scripts/restart-mac.sh --sign --wait --target-only` only after the exact-SHA JS/UI build completes. Target-only mode may stop the canonical `/Applications/OpenClaw.app` process and this checkout's exact `dist` process before launching the rebuilt `dist` app. It defers when another worktree, temporary bundle, test, or agent-owned OpenClaw process is active; it never kills that process. The script's immediate `OK` is not proof. The helper waits and requires the exact executable `/Users/steipete/openclaw/dist/OpenClaw.app/Contents/MacOS/OpenClaw`, then repeats Gateway RPC and health proof.
+
+   Never kill another worktree, temporary bundle, test, or agent-owned OpenClaw process. If a foreign app prevents the exact target from staying alive, record the pending Mac attempt, report it, and retry on the next heartbeat. Escalate only after the conflict persists across repeated heartbeats; never claim Mac proof from another bundle or the short launch check. If `actions.macUiVerification` is true, exercise the changed behavior with the existing macOS/UI automation workflow after delayed exact-bundle proof.
+
+4. Load `$openclaw-testing`. Resolve exact current `origin/main`, then inspect only relevant required checks and workflow jobs whose `headSha` equals it. Ignore skipped jobs and routine noise such as Auto response, Labeler, docs agents, performance advisory jobs, and stale/cancelled runs superseded by a newer run for the same SHA.
+
+5. For an attributable failure, leave the mirror untouched. Use the controlling Codex worktree, trace the failed surface, add focused proof, run `$autoreview`, open a focused PR, and land through `$openclaw-pr-maintainer`'s exact `scripts/pr` sequence. Never weaken or bypass the failing gate. After landing, begin again at step 1 so the mirror, Gateway, app classification, and exact-head checks all converge on new `main`.
+
+If no update, build repair, pending Mac retry, or exact-head failure exists, report a terse no-op with the SHA and proof checked.
+
+## Full Release Validation
+
+Load `$release-openclaw-ci` and `$openclaw-testing`. This is validation only, never release preparation or publication.
+
+1. Treat 12 hours as wall-clock cadence, not per-SHA cadence. Inspect Full Release Validation runs from the last 12 hours and verify effective `release_profile=full`, `rerun_group=all`, and expected child-job shape. Any valid active or successful full/all umbrella in that window satisfies the cadence even if `main` advanced afterward. Never duplicate an active full/all run.
+2. Only when the cadence is due, confirm no full/all run is active, then snapshot exact current `origin/main` after checking mirror invariants. Run the provider-secret preflight without printing secrets and dispatch the trusted workflow once:
+
+   ```bash
+   gh workflow run full-release-validation.yml \
+     --repo openclaw/openclaw \
+     --ref main \
+     -f ref=<exact-main-sha> \
+     -f provider=openai \
+     -f mode=both \
+     -f release_profile=full \
+     -f rerun_group=all
+   ```
+
+3. Watch the parent with `release-ci-summary.mjs`; require its recorded target SHA and children to match the dispatch snapshot. Fetch logs only for failed or blocking jobs. Do not cancel unrelated release checks.
+4. For a code or harness failure, repair and land from the Codex worktree as above. Then target new exact `main` with the narrowest supported `rerun_group` that covers the failed child; use `live_suite_filter` for one live/E2E shard. A targeted recovery run does not create a second full/all cadence dispatch.
+5. Report exact SHA, parent and child run URLs/IDs, conclusions, repairs and landed PRs, targeted reruns, and any genuine proof gap. Do not write release evidence or publish artifacts unless separately authorized.
+
+## Failure Discipline
+
+- Recheck live mirror invariants before every mutation and after every fetch.
+- Attribute failures from exact SHA, job, logs, and current source. Provider or infrastructure flakes need independent proof before code edits.
+- Keep the task branch focused. No `CHANGELOG.md` change.
+- Finish with the mirror clean/on `main`, the Codex worktree clean on the expected branch, remote Testbox stopped, and every public GitHub write linked in the controlling thread.

--- a/.agents/skills/openclaw-live-updater/agents/openai.yaml
+++ b/.agents/skills/openclaw-live-updater/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OpenClaw Live Updater"
+  short_description: "Maintain live main, CI, gateway, and Mac app"
+  default_prompt: "Use $openclaw-live-updater to fast-forward the canonical OpenClaw main mirror, verify the managed runtime and exact-head CI, repair failures through a PR, or run full release validation without publishing."

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -128,7 +128,7 @@ export function classifyActions(
   );
   return {
     dependencyInstall:
-      buildRequired && (dependencyInputsChanged || !nodeModulesPresent || !buildProvenanceKnown),
+      !nodeModulesPresent || (buildRequired && (dependencyInputsChanged || !buildProvenanceKnown)),
     gatewayBuild: buildRequired,
     gatewayProbe: true,
     gatewayRestart: buildRequired,

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1,0 +1,708 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { detectChangedScope } from "../../../../scripts/ci-changed-scope.mjs";
+import { isDirectRunUrl } from "../../../../scripts/lib/direct-run.mjs";
+import {
+  BUILD_STAMP_FILE,
+  RUNTIME_POSTBUILD_STAMP_FILE,
+} from "../../../../scripts/lib/local-build-metadata.mjs";
+import {
+  runNodeConfigFiles,
+  runNodeSourceRoots,
+} from "../../../../scripts/run-node-watch-paths.mjs";
+import {
+  resolveBuildRequirement,
+  resolveRuntimePostBuildRequirement,
+} from "../../../../scripts/run-node.mjs";
+
+const DEFAULT_CHECKOUT = "/Users/steipete/openclaw";
+const DEFAULT_EXPECTED_ORIGIN = "openclaw/openclaw";
+const FULL_SHA_RE = /^[0-9a-f]{40}$/u;
+const DEPENDENCY_INPUT_RE =
+  /^(?:\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|patches\/)|(?:^|\/)package\.json$/u;
+
+export class UpdateInvariantError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = "UpdateInvariantError";
+    this.code = code;
+  }
+}
+
+function git(checkout, args, options = {}) {
+  return execFileSync("git", ["-C", checkout, ...args], {
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+  });
+}
+
+function gitText(checkout, args) {
+  return git(checkout, args).trim();
+}
+
+function configValue(checkout, key, bool = false) {
+  try {
+    return gitText(checkout, ["config", ...(bool ? ["--bool"] : ["--get"]), key]);
+  } catch {
+    return "";
+  }
+}
+
+function githubSlug(remoteUrl) {
+  const match = remoteUrl.match(
+    /^(?:https:\/\/github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+\/[^/]+?)(?:\.git)?\/?$/iu,
+  );
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function applicableUrlRewrite(checkout, remoteUrl) {
+  let output;
+  try {
+    output = gitText(checkout, ["config", "--get-regexp", "^url\\..*\\.insteadOf$"]);
+  } catch {
+    return null;
+  }
+  return (
+    output
+      .split("\n")
+      .map((line) => line.match(/^\S+\s+(.+)$/u)?.[1]?.trim())
+      .filter(Boolean)
+      .filter((prefix) => remoteUrl.startsWith(prefix))
+      .toSorted((left, right) => right.length - left.length)[0] ?? null
+  );
+}
+
+export function originMatches(remoteUrl) {
+  return githubSlug(remoteUrl) === DEFAULT_EXPECTED_ORIGIN;
+}
+
+function changedPathsBetween(checkout, beforeSha, afterSha) {
+  return git(checkout, ["diff", "--name-only", "-z", beforeSha, afterSha], {
+    encoding: "buffer",
+  })
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+}
+
+function commitExists(checkout, sha) {
+  try {
+    git(checkout, ["cat-file", "-e", `${sha}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function classifyActions(
+  changedPaths,
+  { buildProvenanceKnown, buildRequired, nodeModulesPresent },
+) {
+  const runMacos = changedPaths.length > 0 && detectChangedScope(changedPaths).runMacos;
+  const macUiVerification =
+    runMacos &&
+    changedPaths.some((changedPath) =>
+      /^(?:apps\/macos\/Sources\/|apps\/shared\/OpenClawKit\/Sources\/|apps\/swabble\/Sources\/)/u.test(
+        changedPath,
+      ),
+    );
+  const dependencyInputsChanged = changedPaths.some((changedPath) =>
+    DEPENDENCY_INPUT_RE.test(changedPath),
+  );
+  return {
+    dependencyInstall:
+      buildRequired && (dependencyInputsChanged || !nodeModulesPresent || !buildProvenanceKnown),
+    gatewayBuild: buildRequired,
+    gatewayProbe: true,
+    gatewayRestart: buildRequired,
+    gatewaySelfHeal: false,
+    macAppRebuild: runMacos,
+    macUiVerification,
+  };
+}
+
+function readStampHead(checkout, stampFile) {
+  try {
+    const parsed = JSON.parse(readFileSync(path.join(checkout, "dist", stampFile), "utf8"));
+    return typeof parsed.head === "string" && FULL_SHA_RE.test(parsed.head.toLowerCase())
+      ? parsed.head.toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalBuildRequirements(checkout) {
+  const distRoot = path.join(checkout, "dist");
+  const fsImpl = { existsSync, readFileSync, readdirSync, statSync };
+  const deps = {
+    cwd: checkout,
+    env: process.env,
+    fs: fsImpl,
+    spawnSync,
+    distRoot,
+    distEntry: path.join(distRoot, "entry.js"),
+    buildStampPath: path.join(distRoot, BUILD_STAMP_FILE),
+    runtimePostBuildStampPath: path.join(distRoot, RUNTIME_POSTBUILD_STAMP_FILE),
+    sourceRoots: runNodeSourceRoots.map((sourceRoot) => ({
+      name: sourceRoot,
+      path: path.join(checkout, sourceRoot),
+    })),
+    configFiles: runNodeConfigFiles.map((filePath) => path.join(checkout, filePath)),
+  };
+  return {
+    build: resolveBuildRequirement(deps),
+    runtimePostBuild: resolveRuntimePostBuildRequirement(deps),
+  };
+}
+
+function missingControlUiAssets(checkout) {
+  const root = path.join(checkout, "dist/control-ui");
+  const indexPath = path.join(root, "index.html");
+  let html;
+  try {
+    html = readFileSync(indexPath, "utf8");
+  } catch {
+    return ["index.html"];
+  }
+  const references = [...html.matchAll(/\b(?:href|src)=["']([^"']+)["']/giu)]
+    .map((match) => match[1].split(/[?#]/u, 1)[0])
+    .filter(
+      (reference) => reference && reference !== "/" && !/^(?:[a-z]+:|\/\/|#)/iu.test(reference),
+    )
+    .map((reference) => reference.replace(/^\.\//u, ""));
+  const missing = references.filter((reference) => {
+    const candidate = path.resolve(root, reference.replace(/^\//u, ""));
+    return (
+      !candidate.startsWith(`${root}${path.sep}`) ||
+      !statSync(candidate, { throwIfNoEntry: false })?.isFile()
+    );
+  });
+  const assetsDir = path.join(root, "assets");
+  let hasAssetPayload = false;
+  try {
+    hasAssetPayload = readdirSync(assetsDir, { withFileTypes: true }).some((entry) =>
+      entry.isFile(),
+    );
+  } catch {
+    // Report the missing payload below.
+  }
+  if (!hasAssetPayload) {
+    missing.push("assets/*");
+  }
+  return [...new Set(missing)].toSorted();
+}
+
+export function inspectBuildState(checkout, expectedSha) {
+  const buildInfoPath = path.join(checkout, "dist/build-info.json");
+  const uiPath = path.join(checkout, "dist/control-ui/index.html");
+  let commit = null;
+  try {
+    const parsed = JSON.parse(readFileSync(buildInfoPath, "utf8"));
+    commit = typeof parsed.commit === "string" ? parsed.commit.toLowerCase() : null;
+    if (!commit || !FULL_SHA_RE.test(commit)) {
+      commit = null;
+    }
+  } catch {
+    // Missing or invalid provenance is handled below.
+  }
+  const buildStampHead = readStampHead(checkout, BUILD_STAMP_FILE);
+  const runtimePostBuildStampHead = readStampHead(checkout, RUNTIME_POSTBUILD_STAMP_FILE);
+  const requirements = canonicalBuildRequirements(checkout);
+  const missingUiAssets = missingControlUiAssets(checkout);
+  const requiredFilesPresent =
+    existsSync(buildInfoPath) && existsSync(uiPath) && missingUiAssets.length === 0;
+  const current =
+    requiredFilesPresent &&
+    commit === expectedSha &&
+    buildStampHead === expectedSha &&
+    runtimePostBuildStampHead === expectedSha &&
+    !requirements.build.shouldBuild &&
+    !requirements.runtimePostBuild.shouldSync;
+  const missingCanonicalOutput =
+    !requiredFilesPresent ||
+    requirements.build.reason.startsWith("missing_") ||
+    requirements.runtimePostBuild.reason.startsWith("missing_");
+  return {
+    current,
+    state: current ? "current" : missingCanonicalOutput ? "missing" : commit ? "stale" : "invalid",
+    commit,
+    buildStampHead,
+    runtimePostBuildStampHead,
+    missingUiAssets,
+    requirements,
+  };
+}
+
+export function verifyCheckout(checkout, { remote }) {
+  let resolvedCheckout;
+  try {
+    resolvedCheckout = realpathSync(checkout);
+  } catch {
+    throw new UpdateInvariantError("checkout_missing", `checkout does not exist: ${checkout}`);
+  }
+
+  const gitDir = path.join(resolvedCheckout, ".git");
+  const gitDirStat = lstatSync(gitDir, { throwIfNoEntry: false });
+  if (!gitDirStat?.isDirectory() || gitDirStat.isSymbolicLink()) {
+    throw new UpdateInvariantError(
+      "not_standalone_clone",
+      `checkout must contain its own .git directory: ${resolvedCheckout}`,
+    );
+  }
+  if (
+    realpathSync(gitText(resolvedCheckout, ["rev-parse", "--show-toplevel"])) !== resolvedCheckout
+  ) {
+    throw new UpdateInvariantError(
+      "checkout_not_root",
+      "checkout path must be the repository root",
+    );
+  }
+
+  const commonDir = realpathSync(
+    path.resolve(resolvedCheckout, gitText(resolvedCheckout, ["rev-parse", "--git-common-dir"])),
+  );
+  if (commonDir !== realpathSync(gitDir)) {
+    throw new UpdateInvariantError("linked_worktree", "checkout uses a shared Git directory");
+  }
+  if (gitText(resolvedCheckout, ["rev-parse", "--is-shallow-repository"]) !== "false") {
+    throw new UpdateInvariantError("shallow_clone", "checkout must be a full clone");
+  }
+  if (configValue(resolvedCheckout, "core.sparseCheckout", true) === "true") {
+    throw new UpdateInvariantError("sparse_checkout", "checkout must not use sparse checkout");
+  }
+  if (
+    configValue(resolvedCheckout, `remote.${remote}.promisor`, true) === "true" ||
+    configValue(resolvedCheckout, "extensions.partialClone")
+  ) {
+    throw new UpdateInvariantError("partial_clone", "checkout must not use partial clone filters");
+  }
+  if (existsSync(path.join(gitDir, "objects/info/alternates"))) {
+    throw new UpdateInvariantError("borrowed_objects", "checkout must own its Git objects");
+  }
+
+  const worktreeCount = gitText(resolvedCheckout, ["worktree", "list", "--porcelain"])
+    .split("\n")
+    .filter((line) => line.startsWith("worktree ")).length;
+  if (worktreeCount !== 1) {
+    throw new UpdateInvariantError(
+      "multiple_worktrees",
+      `checkout must own exactly one worktree; found ${worktreeCount}`,
+    );
+  }
+
+  const branch = gitText(resolvedCheckout, ["symbolic-ref", "--short", "HEAD"]);
+  if (branch !== "main") {
+    throw new UpdateInvariantError("wrong_branch", `checkout must be on main; found ${branch}`);
+  }
+  if (gitText(resolvedCheckout, ["status", "--porcelain=v1", "--untracked-files=all"])) {
+    throw new UpdateInvariantError("dirty_checkout", "checkout has tracked or untracked changes");
+  }
+
+  const remoteUrl = configValue(resolvedCheckout, `remote.${remote}.url`);
+  if (!originMatches(remoteUrl)) {
+    throw new UpdateInvariantError(
+      "unexpected_origin",
+      `${remote} points to ${remoteUrl}; expected ${DEFAULT_EXPECTED_ORIGIN}`,
+    );
+  }
+  const rewrite = applicableUrlRewrite(resolvedCheckout, remoteUrl);
+  if (rewrite) {
+    throw new UpdateInvariantError(
+      "rewritten_origin",
+      `${remote} URL is affected by a Git insteadOf rewrite for ${rewrite}`,
+    );
+  }
+  return {
+    checkout: resolvedCheckout,
+    branch,
+    headSha: gitText(resolvedCheckout, ["rev-parse", "HEAD"]),
+    remoteUrl,
+  };
+}
+
+export function updateMain({ checkout, remote }, dependencies = {}) {
+  const before = verifyCheckout(checkout, { remote });
+  const fetchMain =
+    dependencies.fetchMain ??
+    ((target, remoteName) =>
+      git(
+        target,
+        ["fetch", "--prune", remoteName, `refs/heads/main:refs/remotes/${remoteName}/main`],
+        {
+          stdio: ["ignore", "ignore", "inherit"],
+        },
+      ));
+  fetchMain(before.checkout, remote);
+  const afterFetch = verifyCheckout(before.checkout, { remote });
+  if (afterFetch.headSha !== before.headSha) {
+    throw new UpdateInvariantError(
+      "concurrent_head_change",
+      `HEAD changed during fetch: ${before.headSha} -> ${afterFetch.headSha}`,
+    );
+  }
+
+  const remoteSha = gitText(before.checkout, ["rev-parse", `${remote}/main`]);
+  git(before.checkout, ["merge", "--ff-only", `${remote}/main`], {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  const after = verifyCheckout(before.checkout, { remote });
+  if (after.headSha !== remoteSha) {
+    throw new UpdateInvariantError(
+      "local_main_diverged",
+      `local main ${after.headSha} does not equal ${remote}/main ${remoteSha}`,
+    );
+  }
+  const updated = before.headSha !== after.headSha;
+  return {
+    checkout: before.checkout,
+    remote,
+    branch: after.branch,
+    beforeSha: before.headSha,
+    afterSha: after.headSha,
+    remoteSha,
+    updated,
+    changedPaths: updated
+      ? changedPathsBetween(before.checkout, before.headSha, after.headSha)
+      : [],
+  };
+}
+
+function defaultLockPath(checkout) {
+  const key = createHash("sha256").update(path.resolve(checkout)).digest("hex").slice(0, 12);
+  return path.join(tmpdir(), `openclaw-live-updater-${key}.lock`);
+}
+
+function defaultStatePath(checkout) {
+  return path.join(realpathSync(checkout), ".git", "openclaw-live-updater-state.json");
+}
+
+function readMaintenanceState(statePath) {
+  if (!existsSync(statePath)) {
+    return {};
+  }
+  try {
+    const stat = lstatSync(statePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error("unsafe state file");
+    }
+    const state = JSON.parse(readFileSync(statePath, "utf8"));
+    return state && typeof state === "object" ? state : {};
+  } catch {
+    throw new UpdateInvariantError(
+      "invalid_state",
+      `maintenance state is unreadable: ${statePath}`,
+    );
+  }
+}
+
+function writeMaintenanceState(statePath, state) {
+  const directory = path.dirname(statePath);
+  const temporary = path.join(directory, `.openclaw-live-updater-${process.pid}-${randomUUID()}`);
+  writeFileSync(temporary, `${JSON.stringify(state)}\n`, { flag: "wx", mode: 0o600 });
+  try {
+    renameSync(temporary, statePath);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function acquireMaintenanceLock(checkout, requestedPath) {
+  const lockPath = requestedPath ?? defaultLockPath(checkout);
+  let incompleteLockRetries = 0;
+  while (true) {
+    try {
+      mkdirSync(lockPath);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      let stat;
+      try {
+        stat = lstatSync(lockPath);
+      } catch (statError) {
+        if (statError?.code === "ENOENT") {
+          continue;
+        }
+        throw statError;
+      }
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new UpdateInvariantError("unsafe_lock", `refusing unsafe lock path: ${lockPath}`);
+      }
+      let owner;
+      try {
+        owner = JSON.parse(readFileSync(path.join(lockPath, "owner.json"), "utf8"));
+      } catch (ownerError) {
+        if (ownerError?.code === "ENOENT" && incompleteLockRetries < 20) {
+          incompleteLockRetries += 1;
+          spawnSync("sleep", ["0.01"]);
+          continue;
+        }
+        throw new UpdateInvariantError("invalid_lock", `lock owner is unreadable: ${lockPath}`);
+      }
+      incompleteLockRetries = 0;
+      if (Number.isInteger(owner.pid) && processAlive(owner.pid)) {
+        return { acquired: false, lockPath, owner };
+      }
+      const staleClaim = `${lockPath}.stale-${process.pid}-${randomUUID()}`;
+      try {
+        renameSync(lockPath, staleClaim);
+      } catch (renameError) {
+        if (renameError?.code === "ENOENT") {
+          continue;
+        }
+        throw renameError;
+      }
+      rmSync(staleClaim, { recursive: true });
+    }
+  }
+
+  const owner = {
+    pid: process.pid,
+    checkout: path.resolve(checkout),
+    startedAt: new Date().toISOString(),
+  };
+  writeFileSync(path.join(lockPath, "owner.json"), `${JSON.stringify(owner)}\n`, { flag: "wx" });
+  return {
+    acquired: true,
+    lockPath,
+    owner,
+    release() {
+      const current = JSON.parse(readFileSync(path.join(lockPath, "owner.json"), "utf8"));
+      if (current.pid !== process.pid) {
+        throw new UpdateInvariantError("lock_owner_changed", "maintenance lock ownership changed");
+      }
+      rmSync(lockPath, { recursive: true });
+    },
+  };
+}
+
+function defaultRunCommand(command, args, checkout) {
+  execFileSync(command, args, {
+    cwd: checkout,
+    stdio: ["ignore", process.stderr, process.stderr],
+  });
+}
+
+function assertExactBuild(checkout, expectedSha) {
+  const state = inspectBuildState(checkout, expectedSha);
+  if (!state.current) {
+    throw new UpdateInvariantError(
+      "build_sha_mismatch",
+      `build output does not match ${expectedSha}; state=${state.state}`,
+    );
+  }
+  return state;
+}
+
+function restartGateway(runCommand, checkout, expectedSha) {
+  assertExactBuild(checkout, expectedSha);
+  runCommand("pnpm", ["openclaw", "gateway", "restart"], checkout);
+}
+
+function verifyGateway(runCommand, checkout, expectedSha) {
+  assertExactBuild(checkout, expectedSha);
+  runCommand(
+    "pnpm",
+    ["openclaw", "gateway", "status", "--deep", "--require-rpc", "--json"],
+    checkout,
+  );
+  runCommand("pnpm", ["openclaw", "health", "--verbose", "--json"], checkout);
+}
+
+export function findExactMacTarget(processes, executable) {
+  const target = processes
+    .split("\n")
+    .map((line) => line.trim().match(/^(\d+)\s+(.+)$/u))
+    .find((match) => match && (match[2] === executable || match[2].startsWith(`${executable} `)));
+  return target ? { executable, pid: Number(target[1]) } : null;
+}
+
+function defaultVerifyMacTarget(checkout) {
+  execFileSync("sleep", ["10"]);
+  const executable = path.join(checkout, "dist/OpenClaw.app/Contents/MacOS/OpenClaw");
+  const processes = execFileSync("ps", ["axww", "-o", "pid=,command="], {
+    encoding: "utf8",
+  });
+  const target = findExactMacTarget(processes, executable);
+  if (!target) {
+    throw new UpdateInvariantError(
+      "mac_target_not_alive",
+      `exact target bundle exited after delayed verification: ${executable}`,
+    );
+  }
+  return target;
+}
+
+export function maintainMain(options, dependencies = {}) {
+  const lock = acquireMaintenanceLock(options.checkout, options.lockPath);
+  if (!lock.acquired) {
+    return {
+      schemaVersion: 1,
+      ok: true,
+      skipped: true,
+      reason: "overlap",
+      lock: { path: lock.lockPath, ownerPid: lock.owner.pid, startedAt: lock.owner.startedAt },
+    };
+  }
+
+  try {
+    const update = updateMain(options, dependencies);
+    const statePath = options.statePath ?? defaultStatePath(update.checkout);
+    const maintenanceState = readMaintenanceState(statePath);
+    const buildBefore = inspectBuildState(update.checkout, update.afterSha);
+    const buildRequired = update.updated || !buildBefore.current;
+    let buildChangedPaths = update.changedPaths;
+    const buildBaseExists =
+      Boolean(buildBefore.commit) && commitExists(update.checkout, buildBefore.commit);
+    if (
+      buildRequired &&
+      buildBefore.commit &&
+      buildBefore.commit !== update.afterSha &&
+      buildBaseExists
+    ) {
+      buildChangedPaths = changedPathsBetween(update.checkout, buildBefore.commit, update.afterSha);
+    }
+    const actions = classifyActions(buildChangedPaths, {
+      buildProvenanceKnown: buildBefore.current || buildBaseExists,
+      buildRequired,
+      nodeModulesPresent: existsSync(path.join(update.checkout, "node_modules")),
+    });
+    if (maintenanceState.macPending) {
+      actions.macAppRebuild = true;
+      actions.macUiVerification ||= maintenanceState.macUiVerification === true;
+    }
+    const runCommand = dependencies.runCommand ?? defaultRunCommand;
+    const verifyMacTarget = dependencies.verifyMacTarget ?? defaultVerifyMacTarget;
+    let queuedMacState = null;
+    if (actions.macAppRebuild) {
+      queuedMacState = {
+        macPending: true,
+        macUiVerification: actions.macUiVerification,
+        sinceSha: maintenanceState.sinceSha ?? update.afterSha,
+        attempts: Number(maintenanceState.attempts ?? 0),
+        queuedAt: maintenanceState.queuedAt ?? new Date().toISOString(),
+      };
+      writeMaintenanceState(statePath, queuedMacState);
+    }
+
+    if (actions.dependencyInstall) {
+      runCommand("pnpm", ["install", "--frozen-lockfile"], update.checkout);
+    }
+    if (actions.gatewayBuild) {
+      runCommand("pnpm", ["build"], update.checkout);
+      assertExactBuild(update.checkout, update.afterSha);
+      restartGateway(runCommand, update.checkout, update.afterSha);
+      verifyGateway(runCommand, update.checkout, update.afterSha);
+    } else {
+      try {
+        verifyGateway(runCommand, update.checkout, update.afterSha);
+      } catch {
+        actions.gatewayRestart = true;
+        actions.gatewaySelfHeal = true;
+        restartGateway(runCommand, update.checkout, update.afterSha);
+        verifyGateway(runCommand, update.checkout, update.afterSha);
+      }
+    }
+    if (actions.macAppRebuild) {
+      const pendingState = {
+        ...queuedMacState,
+        attempts: Number(queuedMacState?.attempts ?? 0) + 1,
+        lastAttemptAt: new Date().toISOString(),
+      };
+      writeMaintenanceState(statePath, pendingState);
+      try {
+        runCommand(
+          "bash",
+          ["scripts/restart-mac.sh", "--sign", "--wait", "--target-only"],
+          update.checkout,
+        );
+        const macTarget = verifyMacTarget(update.checkout);
+        verifyGateway(runCommand, update.checkout, update.afterSha);
+        rmSync(statePath, { force: true });
+        maintenanceState.macTarget = macTarget;
+      } catch (error) {
+        writeMaintenanceState(statePath, {
+          ...pendingState,
+          lastFailure: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    }
+
+    return {
+      schemaVersion: 1,
+      ok: true,
+      ...update,
+      buildBefore,
+      buildChangedPaths,
+      actions,
+      ...(maintenanceState.macTarget ? { macTarget: maintenanceState.macTarget } : {}),
+    };
+  } finally {
+    lock.release();
+  }
+}
+
+function parseArgs(argv) {
+  const options = { checkout: DEFAULT_CHECKOUT, remote: "origin" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--checkout") {
+      options.checkout = argv[++index];
+    } else if (arg === "--remote") {
+      options.remote = argv[++index];
+    } else if (arg === "--help" || arg === "-h") {
+      console.log("Usage: update-main.mjs [--checkout PATH] [--remote NAME]");
+      process.exit(0);
+    } else {
+      throw new UpdateInvariantError("invalid_argument", `unknown argument: ${arg}`);
+    }
+  }
+  if (!options.checkout || !options.remote) {
+    throw new UpdateInvariantError("invalid_argument", "option values must be non-empty");
+  }
+  return options;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  try {
+    console.log(JSON.stringify(maintainMain(parseArgs(argv))));
+  } catch (error) {
+    const code = error instanceof UpdateInvariantError ? error.code : "update_failed";
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(JSON.stringify({ schemaVersion: 1, ok: false, error: { code, message } }));
+    process.exitCode = 1;
+  }
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  main();
+}

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ USER.md
 !.agents/skills/openclaw-ghsa-maintainer/**
 !.agents/skills/openclaw-landable-bug-sweep/
 !.agents/skills/openclaw-landable-bug-sweep/**
+!.agents/skills/openclaw-live-updater/
+!.agents/skills/openclaw-live-updater/**
 !.agents/skills/openclaw-parallels-smoke/
 !.agents/skills/openclaw-parallels-smoke/**
 !.agents/skills/openclaw-pr-maintainer/

--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -23,6 +23,10 @@ AUTO_DETECT_SIGNING=1
 GATEWAY_WAIT_SECONDS="${OPENCLAW_GATEWAY_WAIT_SECONDS:-0}"
 LAUNCHAGENT_DISABLE_MARKER="${HOME}/.openclaw/disable-launchagent"
 ATTACH_ONLY=1
+TARGET_ONLY=0
+TARGET_APP_BUNDLE="${ROOT_DIR}/dist/OpenClaw.app"
+TARGET_EXECUTABLE="${TARGET_APP_BUNDLE}/${APP_EXECUTABLE_RELATIVE_PATH}"
+INSTALLED_EXECUTABLE="/Applications/OpenClaw.app/${APP_EXECUTABLE_RELATIVE_PATH}"
 
 log()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -104,13 +108,15 @@ for arg in "$@"; do
     --sign) SIGN=1; AUTO_DETECT_SIGNING=0 ;;
     --attach-only) ATTACH_ONLY=1 ;;
     --no-attach-only) ATTACH_ONLY=0 ;;
+    --target-only) TARGET_ONLY=1 ;;
     --help|-h)
-      log "Usage: $(basename "$0") [--wait] [--no-sign] [--sign] [--attach-only|--no-attach-only]"
+      log "Usage: $(basename "$0") [--wait] [--no-sign] [--sign] [--attach-only|--no-attach-only] [--target-only]"
       log "  --wait    Wait for other restart to complete instead of exiting"
       log "  --no-sign Force no code signing (fastest for development)"
       log "  --sign    Force code signing (will fail if no signing key available)"
       log "  --attach-only    Launch app with --attach-only (skip launchd install)"
       log "  --no-attach-only Launch app without attach-only override"
+      log "  --target-only    Restart only this checkout's dist app; fail if another OpenClaw app is active"
       log ""
       log "Env:"
       log "  OPENCLAW_GATEWAY_WAIT_SECONDS=0  Wait time before gateway port check (unsigned only)"
@@ -132,6 +138,12 @@ done
 
 if [[ "$NO_SIGN" -eq 1 && "$SIGN" -eq 1 ]]; then
   fail "Cannot use --sign and --no-sign together"
+fi
+if [[ "$TARGET_ONLY" -eq 1 && "$ATTACH_ONLY" -ne 1 ]]; then
+  fail "--target-only requires --attach-only"
+fi
+if [[ "$TARGET_ONLY" -eq 1 && -n "$APP_BUNDLE" ]]; then
+  fail "--target-only does not accept OPENCLAW_APP_BUNDLE"
 fi
 canonicalize_app_bundle
 
@@ -194,15 +206,75 @@ process_pids_matching() {
       done
 }
 
+foreign_openclaw_process_pids() {
+  ps axww -o pid=,command= 2>/dev/null \
+    | while read -r pid command_line; do
+        [[ "${pid}" =~ ^[0-9]+$ ]] || continue
+        [[ "${pid}" != "$$" ]] || continue
+        local executable="${command_line%% *}"
+        [[ "${executable}" == "${TARGET_EXECUTABLE}" ]] && continue
+        [[ "${executable}" == "${INSTALLED_EXECUTABLE}" ]] && continue
+        if [[ "${executable}" == *"/OpenClaw.app/${APP_EXECUTABLE_RELATIVE_PATH}" \
+          || "${executable}" == *"/apps/macos/.build/debug/OpenClaw" \
+          || "${executable}" == *"/apps/macos/.build-local/debug/OpenClaw" \
+          || "${executable}" == *"/apps/macos/.build/release/OpenClaw" ]]; then
+          printf '%s\n' "${pid}"
+        fi
+      done
+}
+
+process_pids_for_executable() {
+  local executable="$1"
+  ps axww -o pid=,command= 2>/dev/null \
+    | while read -r pid command_line; do
+        [[ "${pid}" =~ ^[0-9]+$ ]] || continue
+        [[ "${pid}" != "$$" ]] || continue
+        [[ "${command_line}" == "${executable}" || "${command_line}" == "${executable} "* ]] || continue
+        printf '%s\n' "${pid}"
+      done
+}
+
+managed_openclaw_process_pids() {
+  {
+    process_pids_for_executable "${TARGET_EXECUTABLE}"
+    process_pids_for_executable "${INSTALLED_EXECUTABLE}"
+  } | sort -u
+}
+
+kill_managed_openclaw() {
+  for _ in {1..10}; do
+    local pids=""
+    pids="$(managed_openclaw_process_pids)"
+    if [[ -z "${pids}" ]]; then
+      return 0
+    fi
+    while IFS= read -r pid; do
+      kill "${pid}" 2>/dev/null || true
+    done <<< "${pids}"
+    sleep 0.3
+  done
+  [[ -z "$(managed_openclaw_process_pids)" ]]
+}
+
 stop_launch_agent() {
   launchctl bootout gui/"$UID"/ai.openclaw.mac 2>/dev/null || true
 }
 
-# 1) Stop launchd supervision, then kill all running instances.
-stop_launch_agent
-log "==> Killing existing OpenClaw instances"
-if ! kill_all_openclaw; then
-  fail "OpenClaw instances did not exit after cleanup attempts"
+# 1) Stop only the process set selected by the requested mode.
+if [[ "$TARGET_ONLY" -eq 1 ]]; then
+  if [[ -n "$(foreign_openclaw_process_pids)" ]]; then
+    fail "Another OpenClaw app or test process is active; target-only restart deferred"
+  fi
+  log "==> Killing managed installed and exact target OpenClaw instances"
+  if ! kill_managed_openclaw; then
+    fail "Managed OpenClaw instances did not exit after cleanup attempts"
+  fi
+else
+  stop_launch_agent
+  log "==> Killing existing OpenClaw instances"
+  if ! kill_all_openclaw; then
+    fail "OpenClaw instances did not exit after cleanup attempts"
+  fi
 fi
 
 # Bundle Gateway-hosted plugin assets.

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -354,6 +354,28 @@ describe("openclaw live updater", () => {
     ]);
   });
 
+  test("restores missing dependencies before probing a current build", () => {
+    const { root, mirror } = makeFixture();
+    writeBuild(mirror);
+    const commands = fakeCommands(mirror);
+
+    const output = maintainFixture(
+      { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+      { runCommand: commands.runCommand },
+    );
+
+    expect(output.actions).toMatchObject({
+      dependencyInstall: true,
+      gatewayBuild: false,
+      gatewayProbe: true,
+    });
+    expect(commands.calls).toEqual([
+      "pnpm install --frozen-lockfile",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
+  });
+
   test("restarts once when a current exact-SHA Gateway probe fails", () => {
     const { root, mirror } = makeFixture();
     mkdirSync(path.join(mirror, "node_modules"));

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -1,0 +1,605 @@
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import {
+  acquireMaintenanceLock,
+  classifyActions,
+  findExactMacTarget,
+  inspectBuildState,
+  maintainMain,
+  originMatches,
+} from "../../.agents/skills/openclaw-live-updater/scripts/update-main.mjs";
+import {
+  BUILD_STAMP_FILE,
+  RUNTIME_POSTBUILD_STAMP_FILE,
+} from "../../scripts/lib/local-build-metadata.mjs";
+import { listCoreRuntimePostBuildOutputs } from "../../scripts/runtime-postbuild.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const script = path.join(repoRoot, ".agents/skills/openclaw-live-updater/scripts/update-main.mjs");
+const fixtureOrigins = new Map<string, string>();
+
+function git(cwd: string, ...args: string[]) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function fetchFixtureMain(checkout: string, remote: string) {
+  const origin = fixtureOrigins.get(checkout);
+  if (!origin) {
+    throw new Error(`missing fixture origin for ${checkout}`);
+  }
+  git(checkout, "fetch", origin, `main:refs/remotes/${remote}/main`);
+}
+
+function maintainFixture(
+  options: Record<string, unknown>,
+  dependencies: Record<string, unknown> = {},
+) {
+  return maintainMain(options, { fetchMain: fetchFixtureMain, ...dependencies });
+}
+
+function makeFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-live-updater-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+  const mirror = path.join(root, "mirror");
+  mkdirSync(seed);
+  git(root, "init", "--bare", origin);
+  git(seed, "init", "-b", "main");
+  git(seed, "config", "user.name", "Test");
+  git(seed, "config", "user.email", "test@example.com");
+  writeFileSync(path.join(seed, "README.md"), "one\n");
+  writeFileSync(path.join(seed, ".gitignore"), "dist/\nnode_modules/\n");
+  git(seed, "add", "README.md", ".gitignore");
+  git(seed, "commit", "-m", "initial");
+  git(seed, "remote", "add", "origin", origin);
+  git(seed, "push", "-u", "origin", "main");
+  git(root, "--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main");
+  git(root, "clone", origin, mirror);
+  const canonicalOrigin = "https://github.com/openclaw/openclaw.git";
+  git(mirror, "remote", "set-url", "origin", canonicalOrigin);
+  fixtureOrigins.set(mirror, origin);
+  return { root, mirror, origin, seed };
+}
+
+function writeBuild(mirror: string) {
+  mkdirSync(path.join(mirror, "dist/control-ui"), { recursive: true });
+  const head = git(mirror, "rev-parse", "HEAD");
+  writeFileSync(path.join(mirror, "dist/build-info.json"), `${JSON.stringify({ commit: head })}\n`);
+  writeFileSync(path.join(mirror, "dist/index.js"), "// built\n");
+  writeFileSync(path.join(mirror, "dist/entry.js"), "// built\n");
+  mkdirSync(path.join(mirror, "dist/control-ui/assets"), { recursive: true });
+  writeFileSync(
+    path.join(mirror, "dist/control-ui/index.html"),
+    '<script type="module" src="./assets/app.js"></script>\n',
+  );
+  writeFileSync(path.join(mirror, "dist/control-ui/assets/app.js"), "// ui\n");
+  writeFileSync(path.join(mirror, "dist", BUILD_STAMP_FILE), `${JSON.stringify({ head })}\n`);
+  writeFileSync(
+    path.join(mirror, "dist", RUNTIME_POSTBUILD_STAMP_FILE),
+    `${JSON.stringify({ head })}\n`,
+  );
+  for (const relativePath of listCoreRuntimePostBuildOutputs({ rootDir: mirror })) {
+    const outputPath = path.join(mirror, relativePath);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, "// runtime postbuild\n");
+  }
+}
+
+function fakeCommands(mirror: string) {
+  const calls: string[] = [];
+  return {
+    calls,
+    runCommand(command: string, args: string[]) {
+      calls.push([command, ...args].join(" "));
+      if (command === "pnpm" && args[0] === "install") {
+        mkdirSync(path.join(mirror, "node_modules"), { recursive: true });
+      }
+      if (command === "pnpm" && args[0] === "build") {
+        writeBuild(mirror);
+      }
+    },
+  };
+}
+
+describe("openclaw live updater", () => {
+  test("accepts supported OpenClaw GitHub origins", () => {
+    expect(originMatches("https://github.com/openclaw/openclaw.git")).toBe(true);
+    expect(originMatches("git@github.com:openclaw/openclaw.git")).toBe(true);
+    expect(originMatches("https://github.com/example/openclaw.git")).toBe(false);
+  });
+
+  test("production fetch refreshes the remote-tracking main ref", () => {
+    const source = readFileSync(script, "utf8");
+    expect(source).toContain("refs/heads/main:refs/remotes/${remoteName}/main");
+    expect(source).not.toContain('["fetch", "--prune", remoteName, "main"]');
+  });
+
+  test("rejects Git URL rewrites that change the effective fetch source", () => {
+    const { mirror, origin } = makeFixture();
+    git(mirror, "config", `url.${origin}.insteadOf`, "https://github.com/openclaw/openclaw.git");
+
+    const result = spawnSync(process.execPath, [script, "--checkout", mirror], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      error: { code: "rewritten_origin" },
+    });
+  });
+
+  test("rejects a symlinked Git directory", () => {
+    const { root, mirror } = makeFixture();
+    const externalGitDir = path.join(root, "external-git-dir");
+    renameSync(path.join(mirror, ".git"), externalGitDir);
+    symlinkSync(externalGitDir, path.join(mirror, ".git"), "dir");
+
+    const result = spawnSync(process.execPath, [script, "--checkout", mirror], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      error: { code: "not_standalone_clone" },
+    });
+  });
+
+  test("classifies exact-head build, install, macOS rebuild, and native UI proof", () => {
+    expect(
+      classifyActions(["docs/index.md"], {
+        buildProvenanceKnown: true,
+        buildRequired: true,
+        nodeModulesPresent: true,
+      }),
+    ).toEqual({
+      dependencyInstall: false,
+      gatewayBuild: true,
+      gatewayProbe: true,
+      gatewayRestart: true,
+      gatewaySelfHeal: false,
+      macAppRebuild: false,
+      macUiVerification: false,
+    });
+    expect(
+      classifyActions(["package.json", "apps/macos/Sources/OpenClaw/AppDelegate.swift"], {
+        buildProvenanceKnown: true,
+        buildRequired: true,
+        nodeModulesPresent: true,
+      }),
+    ).toEqual({
+      dependencyInstall: true,
+      gatewayBuild: true,
+      gatewayProbe: true,
+      gatewayRestart: true,
+      gatewaySelfHeal: false,
+      macAppRebuild: true,
+      macUiVerification: true,
+    });
+  });
+
+  test("accepts only the delayed exact target bundle process", () => {
+    const executable = "/Users/steipete/openclaw/dist/OpenClaw.app/Contents/MacOS/OpenClaw";
+    const foreign = "41 /tmp/agent/OpenClaw.app/Contents/MacOS/OpenClaw";
+    expect(findExactMacTarget(foreign, executable)).toBeNull();
+    expect(findExactMacTarget(`${foreign}\n42 ${executable} --attach-only`, executable)).toEqual({
+      executable,
+      pid: 42,
+    });
+  });
+
+  test("rejects missing or mismatched canonical build stamps", () => {
+    const { mirror } = makeFixture();
+    writeBuild(mirror);
+    const head = git(mirror, "rev-parse", "HEAD");
+    const buildStamp = path.join(mirror, "dist", BUILD_STAMP_FILE);
+    const runtimeStamp = path.join(mirror, "dist", RUNTIME_POSTBUILD_STAMP_FILE);
+
+    writeFileSync(buildStamp, `${JSON.stringify({ head: "0".repeat(40) })}\n`);
+    expect(inspectBuildState(mirror, head)).toMatchObject({
+      current: false,
+      buildStampHead: "0".repeat(40),
+      requirements: { build: { shouldBuild: true, reason: "git_head_changed" } },
+    });
+
+    writeFileSync(buildStamp, `${JSON.stringify({ head })}\n`);
+    rmSync(runtimeStamp);
+    expect(inspectBuildState(mirror, head)).toMatchObject({
+      current: false,
+      runtimePostBuildStampHead: null,
+      requirements: {
+        runtimePostBuild: { shouldSync: true, reason: "missing_runtime_postbuild_stamp" },
+      },
+    });
+  });
+
+  test("rejects a missing Control UI asset referenced by index", () => {
+    const { mirror } = makeFixture();
+    writeBuild(mirror);
+    const head = git(mirror, "rev-parse", "HEAD");
+    rmSync(path.join(mirror, "dist/control-ui/assets/app.js"));
+
+    expect(inspectBuildState(mirror, head)).toMatchObject({
+      current: false,
+      missingUiAssets: ["assets/*", "assets/app.js"],
+    });
+  });
+
+  test("fast-forwards, builds exact SHA, restarts Gateway, then proves exact Mac target", () => {
+    const { root, mirror, seed } = makeFixture();
+    mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
+    writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
+    git(seed, "add", ".");
+    git(seed, "commit", "-m", "mac change");
+    git(seed, "push");
+    const commands = fakeCommands(mirror);
+
+    const output = maintainFixture(
+      {
+        checkout: mirror,
+        remote: "origin",
+        lockPath: path.join(root, "maintenance.lock"),
+        statePath: path.join(root, "maintenance-state.json"),
+      },
+      {
+        runCommand: commands.runCommand,
+        verifyMacTarget: () => ({
+          executable: path.join(mirror, "dist/OpenClaw.app/Contents/MacOS/OpenClaw"),
+          pid: 123,
+        }),
+      },
+    );
+
+    expect(output.updated).toBe(true);
+    expect(output.afterSha).toBe(git(seed, "rev-parse", "HEAD"));
+    expect(output.buildChangedPaths).toEqual(["apps/macos/Sources/OpenClaw/App.swift"]);
+    expect(output.actions).toEqual({
+      dependencyInstall: true,
+      gatewayBuild: true,
+      gatewayProbe: true,
+      gatewayRestart: true,
+      gatewaySelfHeal: false,
+      macAppRebuild: true,
+      macUiVerification: true,
+    });
+    expect(commands.calls).toEqual([
+      "pnpm install --frozen-lockfile",
+      "pnpm build",
+      "pnpm openclaw gateway restart",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+      "bash scripts/restart-mac.sh --sign --wait --target-only",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
+    expect(output.macTarget?.executable).toBe(
+      path.join(mirror, "dist/OpenClaw.app/Contents/MacOS/OpenClaw"),
+    );
+  });
+
+  test("rejects a local main that is ahead of origin main", () => {
+    const { root, mirror } = makeFixture();
+    git(mirror, "config", "user.name", "Test");
+    git(mirror, "config", "user.email", "test@example.com");
+    writeFileSync(path.join(mirror, "local-commit.txt"), "local\n");
+    git(mirror, "add", "local-commit.txt");
+    git(mirror, "commit", "-m", "local commit");
+
+    expect(() =>
+      maintainFixture({
+        checkout: mirror,
+        remote: "origin",
+        lockPath: path.join(root, "maintenance.lock"),
+      }),
+    ).toThrow(/does not equal origin\/main/u);
+  });
+
+  test("builds and restarts when build output is missing without a new commit", () => {
+    const { root, mirror } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    const commands = fakeCommands(mirror);
+
+    const output = maintainFixture(
+      { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+      { runCommand: commands.runCommand },
+    );
+
+    expect(output.updated).toBe(false);
+    expect(output.buildBefore.state).toBe("missing");
+    expect(output.actions.gatewayBuild).toBe(true);
+    expect(output.actions.dependencyInstall).toBe(true);
+    expect(commands.calls).toEqual([
+      "pnpm install --frozen-lockfile",
+      "pnpm build",
+      "pnpm openclaw gateway restart",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
+  });
+
+  test("proves a current exact-SHA Gateway on a no-op heartbeat", () => {
+    const { root, mirror } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    writeBuild(mirror);
+    const commands = fakeCommands(mirror);
+
+    const output = maintainFixture(
+      { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+      { runCommand: commands.runCommand },
+    );
+
+    expect(output.updated).toBe(false);
+    expect(output.actions).toMatchObject({
+      gatewayBuild: false,
+      gatewayProbe: true,
+      gatewayRestart: false,
+      gatewaySelfHeal: false,
+    });
+    expect(commands.calls).toEqual([
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
+  });
+
+  test("restarts once when a current exact-SHA Gateway probe fails", () => {
+    const { root, mirror } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    writeBuild(mirror);
+    const calls: string[] = [];
+    let failed = false;
+
+    const output = maintainFixture(
+      { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+      {
+        runCommand(command: string, args: string[]) {
+          const call = [command, ...args].join(" ");
+          calls.push(call);
+          if (!failed && call.includes("gateway status")) {
+            failed = true;
+            throw new Error("RPC unavailable");
+          }
+        },
+      },
+    );
+
+    expect(output.actions).toMatchObject({
+      gatewayBuild: false,
+      gatewayRestart: true,
+      gatewaySelfHeal: true,
+    });
+    expect(calls).toEqual([
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway restart",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
+  });
+
+  test("keeps successful CLI stdout as one machine-readable JSON object", () => {
+    const { root, mirror, origin } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    writeBuild(mirror);
+    const binDir = path.join(root, "bin");
+    const pnpm = path.join(binDir, "pnpm");
+    const gitShim = path.join(binDir, "git");
+    const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+    mkdirSync(binDir);
+    writeFileSync(pnpm, "#!/bin/sh\necho child-output\n");
+    writeFileSync(
+      gitShim,
+      `#!/bin/sh\nif [ "$3" = "fetch" ]; then\n  exec "${realGit}" -C "$2" fetch "${origin}" "main:refs/remotes/origin/main"\nfi\nexec "${realGit}" "$@"\n`,
+    );
+    chmodSync(pnpm, 0o755);
+    chmodSync(gitShim, 0o755);
+
+    const result = spawnSync(process.execPath, [script, "--checkout", mirror], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({ ok: true, updated: false });
+    expect(result.stderr).toContain("child-output");
+  });
+
+  test("does not restart Gateway when build provenance misses the exact SHA", () => {
+    const { root, mirror } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    const calls: string[] = [];
+
+    expect(() =>
+      maintainFixture(
+        { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+        {
+          runCommand: (command: string, args: string[]) => calls.push([command, ...args].join(" ")),
+        },
+      ),
+    ).toThrow(/build output does not match/u);
+    expect(calls).toEqual(["pnpm install --frozen-lockfile", "pnpm build"]);
+  });
+
+  test("retains failed exact-bundle Mac proof for the next heartbeat", () => {
+    const { root, mirror, seed } = makeFixture();
+    mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
+    writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
+    git(seed, "add", ".");
+    git(seed, "commit", "-m", "mac change");
+    git(seed, "push");
+    const lockPath = path.join(root, "maintenance.lock");
+    const statePath = path.join(root, "maintenance-state.json");
+    const firstCommands = fakeCommands(mirror);
+
+    expect(() =>
+      maintainFixture(
+        { checkout: mirror, remote: "origin", lockPath, statePath },
+        {
+          runCommand: firstCommands.runCommand,
+          verifyMacTarget: () => {
+            throw new Error("exact target exited");
+          },
+        },
+      ),
+    ).toThrow("exact target exited");
+    expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
+      macPending: true,
+      attempts: 1,
+      lastFailure: "exact target exited",
+    });
+
+    const retryCommands = fakeCommands(mirror);
+    const retry = maintainFixture(
+      { checkout: mirror, remote: "origin", lockPath, statePath },
+      {
+        runCommand: retryCommands.runCommand,
+        verifyMacTarget: () => ({ executable: "exact", pid: 456 }),
+      },
+    );
+    expect(retry.updated).toBe(false);
+    expect(retry.actions.gatewayBuild).toBe(false);
+    expect(retry.actions.macAppRebuild).toBe(true);
+    expect(retryCommands.calls.slice(0, 3)).toEqual([
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+      "bash scripts/restart-mac.sh --sign --wait --target-only",
+    ]);
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  test("records pending Mac work before Gateway maintenance can fail", () => {
+    const { root, mirror, seed } = makeFixture();
+    mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
+    writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
+    git(seed, "add", ".");
+    git(seed, "commit", "-m", "mac change");
+    git(seed, "push");
+    const statePath = path.join(root, "maintenance-state.json");
+    const commands = fakeCommands(mirror);
+
+    expect(() =>
+      maintainFixture(
+        {
+          checkout: mirror,
+          remote: "origin",
+          lockPath: path.join(root, "maintenance.lock"),
+          statePath,
+        },
+        {
+          runCommand(command: string, args: string[]) {
+            commands.runCommand(command, args);
+            if (command === "pnpm" && args.includes("status")) {
+              throw new Error("Gateway failed");
+            }
+          },
+        },
+      ),
+    ).toThrow("Gateway failed");
+    expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
+      macPending: true,
+      attempts: 0,
+    });
+  });
+
+  test("refuses a symlinked maintenance state file without touching its target", () => {
+    const { root, mirror } = makeFixture();
+    const statePath = path.join(root, "maintenance-state.json");
+    const victimPath = path.join(root, "victim.txt");
+    writeFileSync(victimPath, "untouched\n");
+    symlinkSync(victimPath, statePath);
+
+    expect(() =>
+      maintainFixture({
+        checkout: mirror,
+        remote: "origin",
+        lockPath: path.join(root, "maintenance.lock"),
+        statePath,
+      }),
+    ).toThrow(/maintenance state is unreadable/u);
+    expect(readFileSync(victimPath, "utf8")).toBe("untouched\n");
+  });
+
+  test("skips an overlapping heartbeat while the owner process is alive", () => {
+    const { root, mirror } = makeFixture();
+    const lockPath = path.join(root, "maintenance.lock");
+    const held = acquireMaintenanceLock(mirror, lockPath);
+    try {
+      const output = maintainFixture({ checkout: mirror, remote: "origin", lockPath });
+      expect(output).toMatchObject({ ok: true, skipped: true, reason: "overlap" });
+    } finally {
+      held.release?.();
+    }
+  });
+
+  test("atomically recovers a dead maintenance lock", () => {
+    const { root, mirror } = makeFixture();
+    const lockPath = path.join(root, "maintenance.lock");
+    mkdirSync(lockPath);
+    writeFileSync(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: 999_999_999, checkout: mirror, startedAt: "stale" })}\n`,
+    );
+
+    const held = acquireMaintenanceLock(mirror, lockPath);
+    try {
+      expect(held.acquired).toBe(true);
+      expect(held.owner.pid).toBe(process.pid);
+      expect(existsSync(`${lockPath}.stale-${process.pid}`)).toBe(false);
+    } finally {
+      held.release?.();
+    }
+  });
+
+  test("treats an owner file creation race as a normal overlap", () => {
+    const { root, mirror } = makeFixture();
+    const lockPath = path.join(root, "maintenance.lock");
+    mkdirSync(lockPath);
+    const owner = { pid: process.pid, checkout: mirror, startedAt: "racing" };
+    const writer = spawn(
+      "sh",
+      ["-c", 'sleep 0.03; printf "%s\\n" "$OWNER_JSON" > "$LOCK_PATH/owner.json"'],
+      {
+        env: { ...process.env, LOCK_PATH: lockPath, OWNER_JSON: JSON.stringify(owner) },
+        stdio: "ignore",
+      },
+    );
+
+    try {
+      expect(acquireMaintenanceLock(mirror, lockPath)).toMatchObject({
+        acquired: false,
+        owner,
+      });
+    } finally {
+      writer.kill();
+    }
+  });
+
+  test("refuses dirty work without moving HEAD", () => {
+    const { mirror } = makeFixture();
+    const before = git(mirror, "rev-parse", "HEAD");
+    writeFileSync(path.join(mirror, "local.txt"), "do not destroy\n");
+
+    const result = spawnSync(process.execPath, [script, "--checkout", mirror], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout.trim())).toMatchObject({
+      ok: false,
+      error: { code: "dirty_checkout" },
+    });
+    expect(git(mirror, "rev-parse", "HEAD")).toBe(before);
+    expect(git(mirror, "status", "--porcelain")).toContain("?? local.txt");
+  });
+});

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -152,10 +152,11 @@ function runRestartArgParser(...args: string[]) {
       "SIGN=0",
       "AUTO_DETECT_SIGNING=1",
       "ATTACH_ONLY=1",
+      "TARGET_ONLY=0",
       'log() { printf "%s\\n" "$*"; }',
       'fail() { printf "ERROR: %s\\n" "$*" >&2; exit 1; }',
       parserBlock,
-      'printf "wait=%s no_sign=%s sign=%s attach_only=%s\\n" "$WAIT_FOR_LOCK" "$NO_SIGN" "$SIGN" "$ATTACH_ONLY"',
+      'printf "wait=%s no_sign=%s sign=%s attach_only=%s target_only=%s\\n" "$WAIT_FOR_LOCK" "$NO_SIGN" "$SIGN" "$ATTACH_ONLY" "$TARGET_ONLY"',
     ].join("\n"),
   );
   chmodSync(harnessPath, 0o755);
@@ -193,6 +194,39 @@ function runRestartLockHarness(lockDir: string) {
   return spawnSync("bash", [harnessPath], { encoding: "utf8" });
 }
 
+function runForeignProcessClassifier(fakePs: string) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-test-"));
+  tempRoots.push(root);
+  const binDir = join(root, "bin");
+  mkdirSync(binDir);
+  const psPath = join(binDir, "ps");
+  writeFileSync(psPath, fakePs);
+  chmodSync(psPath, 0o755);
+
+  const script = readFileSync(restartScriptPath, "utf8");
+  const functions = script.slice(
+    script.indexOf("process_pids_matching()"),
+    script.indexOf("stop_launch_agent()"),
+  );
+  const harnessPath = join(root, "foreign-process-harness.sh");
+  writeFileSync(
+    harnessPath,
+    [
+      "#!/usr/bin/env bash",
+      functions,
+      'APP_EXECUTABLE_RELATIVE_PATH="Contents/MacOS/OpenClaw"',
+      'TARGET_EXECUTABLE="/Users/steipete/openclaw/dist/OpenClaw.app/Contents/MacOS/OpenClaw"',
+      'INSTALLED_EXECUTABLE="/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"',
+      "foreign_openclaw_process_pids",
+    ].join("\n"),
+  );
+  chmodSync(harnessPath, 0o755);
+  return spawnSync("bash", [harnessPath], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+  });
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { force: true, recursive: true });
@@ -209,10 +243,10 @@ describe("scripts/restart-mac.sh", () => {
   });
 
   it("parses restart mode flags before side effects", () => {
-    const result = runRestartArgParser("--wait", "--no-sign", "--no-attach-only");
+    const result = runRestartArgParser("--wait", "--no-sign", "--target-only");
 
     expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("wait=1 no_sign=1 sign=0 attach_only=0");
+    expect(result.stdout.trim()).toBe("wait=1 no_sign=1 sign=0 attach_only=1 target_only=1");
     expect(result.stderr).toBe("");
   });
 
@@ -267,7 +301,9 @@ describe("scripts/restart-mac.sh", () => {
     const result = runRestartLockHarness(lockDir);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain(`Another restart is running (pid ${process.pid}); re-run with --wait.`);
+    expect(result.stdout).toContain(
+      `Another restart is running (pid ${process.pid}); re-run with --wait.`,
+    );
     expect(result.stderr).toBe("");
     expect(existsSync(lockDir)).toBe(true);
     expect(readFileSync(join(lockDir, "pid"), "utf8")).toBe(String(process.pid));
@@ -326,12 +362,44 @@ describe("scripts/restart-mac.sh", () => {
 
   it("stops launchd supervision before killing app processes", () => {
     const script = readFileSync(restartScriptPath, "utf8");
-    const stopIndex = script.indexOf("stop_launch_agent\nlog");
+    const stopIndex = script.indexOf("stop_launch_agent\n  log");
     const killIndex = script.indexOf("if ! kill_all_openclaw");
 
     expect(stopIndex).toBeGreaterThan(-1);
     expect(killIndex).toBeGreaterThan(-1);
     expect(stopIndex).toBeLessThan(killIndex);
+  });
+
+  it("target-only mode refuses foreign app processes without broad cleanup", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+    const targetBlock = script.slice(
+      script.indexOf('if [[ "$TARGET_ONLY" -eq 1 ]]; then', script.indexOf("# 1)")),
+      script.indexOf("else", script.indexOf("# 1)")),
+    );
+
+    expect(targetBlock).toContain("foreign_openclaw_process_pids");
+    expect(targetBlock).toContain("kill_managed_openclaw");
+    expect(targetBlock).not.toContain("stop_launch_agent");
+    expect(targetBlock).not.toContain("kill_all_openclaw");
+    expect(script).toContain('[[ "${executable}" == "${TARGET_EXECUTABLE}" ]] && continue');
+    expect(script).toContain('process_pids_for_executable "${TARGET_EXECUTABLE}"');
+    expect(script).toContain("target-only restart deferred");
+  });
+
+  it("treats the canonical installed app as managed but temp bundles as foreign", () => {
+    const result = runForeignProcessClassifier(
+      [
+        "#!/usr/bin/env bash",
+        "printf '%s\\n' '  101 /Applications/OpenClaw.app/Contents/MacOS/OpenClaw --attach-only'",
+        "printf '%s\\n' '  102 /Users/steipete/openclaw/dist/OpenClaw.app/Contents/MacOS/OpenClaw --attach-only'",
+        "printf '%s\\n' '  103 /tmp/agent/OpenClaw.app/Contents/MacOS/OpenClaw --attach-only'",
+        "printf '%s\\n' '  104 /bin/sh test.sh /Applications/OpenClaw.app/Contents/MacOS/OpenClaw'",
+      ].join("\n"),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("103");
+    expect(result.stderr).toBe("");
   });
 
   it("verifies the launched app through the chosen bundle executable", () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's live `main` checkout, managed Gateway, local Mac app, exact-head CI repair, and non-publishing Full Release Validation need one repo-native maintainer contract. Existing primitives cover each operation, but not their fail-closed sequencing, overlap handling, exact-build provenance, or reporting boundary.

Closes #104170.

## Why This Change Was Made

- Adds the concise `openclaw-live-updater` skill and OpenAI agent metadata.
- Adds a deterministic updater that verifies a clean standalone full clone on `main`, refreshes and fast-forwards only to exact `origin/main`, classifies changed paths, and emits one JSON result.
- Reuses canonical build stamps and runtime-postbuild metadata before every Gateway command; restores dependencies, builds exact head, restarts, and requires deep RPC plus verbose health.
- Adds overlap locking, atomic pending-Mac state, and target-only Mac restart semantics: the canonical installed app and exact live `dist` app are managed, while temp/worktree/test bundles defer and are never killed.
- Documents 12-hour wall-clock Full Release Validation cadence with exact-SHA proof and targeted repair reruns, without any release publication.

## User Impact

Maintainer automation can update and prove the live checkout without destroying local work, silently running stale build output, duplicating long builds, or claiming health from the wrong Mac app bundle. No user-facing product behavior, release artifact, version, or changelog changes.

## Evidence

- Blacksmith Testbox focused proof: 43 tests passed across `test/scripts/openclaw-live-updater.test.ts` and `test/scripts/restart-mac.test.ts` (tree-equivalent proof before final base refresh).
- Blacksmith Testbox `check:changed`: all fail-safe lanes passed, including typecheck, all oxlint shards, dependency/patch guards, and runtime import-cycle checks.
- Fresh Codex autoreview converged clean after fixes for fetch ref freshness, process signal scope, state-file safety, lock races, and missing dependency recovery.
- `bash -n scripts/restart-mac.sh`
- YAML/frontmatter parsed with Ruby Psych; `git diff --check` clean.
- Exact PR-head hosted CI will be required by `scripts/pr prepare-run` before merge.

## AI Assistance

Implemented and reviewed with Codex. No transcript attached.
