### PR TITLE
fix(ci): preserve QA package intent boundaries

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -3,6 +3,11 @@ name: Install Smoke (Reusable)
 on:
   workflow_call:
     inputs:
+      allow_unreleased_changelog:
+        description: Allow Unreleased changelog notes when packaging the current tree
+        required: false
+        default: false
+        type: boolean
       ref:
         description: Git ref to validate
         required: false
@@ -705,6 +710,7 @@ jobs:
 
       - name: Run installer docker tests
         env:
+          OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
           OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
           OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
           OPENCLAW_NO_ONBOARD: "1"
@@ -862,6 +868,7 @@ jobs:
 
       - name: Run Bun global install image-provider smoke
         env:
+          OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
           OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0"
         run: bash scripts/e2e/bun-global-install-smoke.sh

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -33,6 +33,7 @@ jobs:
       packages: read
     uses: ./.github/workflows/install-smoke-reusable.yml
     with:
+      allow_unreleased_changelog: true
       ref: ${{ github.sha }}
       run_bun_global_install_smoke: ${{ github.event_name == 'schedule' || inputs.run_bun_global_install_smoke }}
       update_baseline_version: ${{ inputs.update_baseline_version || 'latest' }}

--- a/scripts/docker-e2e-rerun.mjs
+++ b/scripts/docker-e2e-rerun.mjs
@@ -140,7 +140,9 @@ function trustedReuseInputsFromCommand(command) {
 function reuseInputsFromJson(parsed) {
   const bareImage = maybeGhcrImage(parsed.images?.bare);
   const functionalImage = maybeGhcrImage(parsed.images?.functional);
+  const allowUnreleasedChangelog = parsed.allowUnreleasedChangelog === true ? "true" : undefined;
   return {
+    ...(allowUnreleasedChangelog ? { allowUnreleasedChangelog } : {}),
     ...(bareImage ? { bareImage } : {}),
     ...(functionalImage ? { functionalImage } : {}),
   };

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -79,6 +79,7 @@ run_with_timeout() {
 }
 
 resolve_package_tgz() {
+  local -a package_args
   if [ -n "$PACKAGE_TGZ" ]; then
     if [ ! -f "$PACKAGE_TGZ" ]; then
       echo "OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ does not exist: $PACKAGE_TGZ" >&2
@@ -105,12 +106,16 @@ resolve_package_tgz() {
   PACK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-bun-pack.XXXXXX")"
 
   echo "==> Pack OpenClaw tarball"
+  package_args=(
+    --skip-build
+    --output-dir "$PACK_DIR"
+    --output-name openclaw-current.tgz
+  )
+  if [[ "${OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:-true}" == "true" ]]; then
+    package_args+=(--allow-unreleased-changelog)
+  fi
   PACKAGE_TGZ="$(
-    node scripts/package-openclaw-for-docker.mjs \
-      --allow-unreleased-changelog \
-      --skip-build \
-      --output-dir "$PACK_DIR" \
-      --output-name openclaw-current.tgz
+    node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"
   )"
   if [ -z "$PACKAGE_TGZ" ] || [ ! -f "$PACKAGE_TGZ" ]; then
     echo "missing packed OpenClaw tarball" >&2

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -425,6 +425,9 @@ export async function writeRunSummary(logDir, summary, env = process.env) {
   const file = path.join(logDir, "summary.json");
   const payload = {
     ...summary,
+    // Summary reruns do not carry failure-index commands, so preserve this exact package intent.
+    allowUnreleasedChangelog:
+      env.OPENCLAW_DOCKER_E2E_ALLOW_UNRELEASED_CHANGELOG === "true" ? true : undefined,
     packageArtifactName: env.OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME || undefined,
     finishedAt: new Date().toISOString(),
     github: {

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -303,7 +303,7 @@ process.stdout.write(packageJson.version);
 prepare_update_tarball() {
   local pack_json_file
   local baseline_pack_json_file
-  local package_args
+  local -a package_args
   local package_tgz
   local packed_update_version
   pack_json_file="${UPDATE_DIR}/pack.json"
@@ -324,12 +324,14 @@ prepare_update_tarball() {
     fi
     UPDATE_EXPECT_VERSION="$(read_candidate_version)"
     package_args=(
-      --allow-unreleased-changelog
       --source-dir "$ROOT_DIR"
       --output-dir "$UPDATE_DIR"
       --pack-json "$pack_json_file"
       --skip-build
     )
+    if [[ "${OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:-true}" == "true" ]]; then
+      package_args+=(--allow-unreleased-changelog)
+    fi
     package_tgz="$(
       node "$HARNESS_ROOT/scripts/package-openclaw-for-docker.mjs" "${package_args[@]}"
     )"

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -201,9 +201,10 @@ describe("scripts/test-docker-all scheduler", () => {
     expectDeclaredDispatchInputs(registryCommand);
   });
 
-  it("preserves ephemeral package intent in generated failure reruns", async () => {
+  it("preserves ephemeral package intent in generated summary and failure reruns", async () => {
     const logDir = createTempDir("openclaw-docker-all-rerun-intent-");
     try {
+      const selectedSha = "c".repeat(40);
       await writeRunSummary(
         logDir,
         {
@@ -213,13 +214,29 @@ describe("scripts/test-docker-all scheduler", () => {
         },
         {
           ...process.env,
-          GITHUB_SHA: "c".repeat(40),
           OPENCLAW_DOCKER_E2E_ALLOW_UNRELEASED_CHANGELOG: "true",
+          OPENCLAW_DOCKER_E2E_SELECTED_SHA: selectedSha,
         },
       );
 
-      const failureIndex = JSON.parse(readFileSync(path.join(logDir, "failures.json"), "utf8"));
+      const summaryFile = path.join(logDir, "summary.json");
+      const summary = JSON.parse(readFileSync(summaryFile, "utf8"));
+      expect(summary.allowUnreleasedChangelog).toBe(true);
+
+      const failureIndexFile = path.join(logDir, "failures.json");
+      const failureIndex = JSON.parse(readFileSync(failureIndexFile, "utf8"));
       expect(failureIndex.combinedGhWorkflowCommand).toContain("allow_unreleased_changelog=true");
+
+      for (const artifact of [summaryFile, failureIndexFile]) {
+        const rerun = spawnSync(process.execPath, ["scripts/docker-e2e-rerun.mjs", artifact], {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: process.env,
+        });
+        expect(rerun.status, rerun.stderr).toBe(0);
+        expect(rerun.stdout).toContain(`-f ref='${selectedSha}'`);
+        expect(rerun.stdout).toContain("allow_unreleased_changelog=true");
+      }
     } finally {
       rmSync(logDir, { force: true, recursive: true });
     }

--- a/test/scripts/docker-e2e-helper-cli.test.ts
+++ b/test/scripts/docker-e2e-helper-cli.test.ts
@@ -493,6 +493,30 @@ describe("Docker E2E helper CLIs", () => {
     }
   });
 
+  it("rejects non-boolean unreleased changelog intent from summary artifacts", () => {
+    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-e2e-rerun-inputs-`);
+    try {
+      const file = path.join(root, "summary.json");
+      writeFileSync(
+        file,
+        `${JSON.stringify({
+          allowUnreleasedChangelog: "true",
+          failures: [{ name: "install-e2e", status: 1 }],
+          github: { selectedSha: EXACT_TARGET_REF },
+          status: "failed",
+        })}\n`,
+        "utf8",
+      );
+
+      const result = runHelper("scripts/docker-e2e-rerun.mjs", file);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).not.toContain("allow_unreleased_changelog");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("groups combined reruns by recovered workflow inputs", () => {
     const root = mkdtempSync(`${tmpdir()}/openclaw-docker-e2e-rerun-groups-`);
     try {

--- a/test/scripts/docker-e2e-helper-cli.test.ts
+++ b/test/scripts/docker-e2e-helper-cli.test.ts
@@ -11,11 +11,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const LIVE_E2E_WORKFLOW = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
 const EXACT_TARGET_REF = "1".repeat(40);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runHelper(script: string, ...args: Array<string | Record<string, string>>) {
   const maybeEnv = args.at(-1);
@@ -494,27 +496,23 @@ describe("Docker E2E helper CLIs", () => {
   });
 
   it("rejects non-boolean unreleased changelog intent from summary artifacts", () => {
-    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-e2e-rerun-inputs-`);
-    try {
-      const file = path.join(root, "summary.json");
-      writeFileSync(
-        file,
-        `${JSON.stringify({
-          allowUnreleasedChangelog: "true",
-          failures: [{ name: "install-e2e", status: 1 }],
-          github: { selectedSha: EXACT_TARGET_REF },
-          status: "failed",
-        })}\n`,
-        "utf8",
-      );
+    const root = tempDirs.make("openclaw-docker-e2e-rerun-inputs-");
+    const file = path.join(root, "summary.json");
+    writeFileSync(
+      file,
+      `${JSON.stringify({
+        allowUnreleasedChangelog: "true",
+        failures: [{ name: "install-e2e", status: 1 }],
+        github: { selectedSha: EXACT_TARGET_REF },
+        status: "failed",
+      })}\n`,
+      "utf8",
+    );
 
-      const result = runHelper("scripts/docker-e2e-rerun.mjs", file);
+    const result = runHelper("scripts/docker-e2e-rerun.mjs", file);
 
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).not.toContain("allow_unreleased_changelog");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).not.toContain("allow_unreleased_changelog");
   });
 
   it("groups combined reruns by recovered workflow inputs", () => {

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -76,6 +76,7 @@ describe("install smoke no-push root image transport", () => {
     });
     expect(delegated.uses).toBe("./.github/workflows/install-smoke-reusable.yml");
     expect(delegated.with).toMatchObject({
+      allow_unreleased_changelog: true,
       ref: "${{ github.sha }}",
       run_bun_global_install_smoke:
         "${{ github.event_name == 'schedule' || inputs.run_bun_global_install_smoke }}",
@@ -88,6 +89,10 @@ describe("install smoke no-push root image transport", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     expect(workflow.on?.schedule).toBeUndefined();
     expect(workflow.on?.workflow_dispatch).toBeUndefined();
+    expect(workflow.on?.workflow_call?.inputs?.allow_unreleased_changelog).toMatchObject({
+      default: false,
+      type: "boolean",
+    });
     expect(workflow.on?.workflow_call?.inputs?.root_image_transport).toBeUndefined();
     expect(workflow.permissions).toEqual({
       actions: "read",
@@ -266,6 +271,21 @@ describe("install smoke no-push root image transport", () => {
     expect(caller.with).toMatchObject({
       ref: "${{ needs.resolve_target.outputs.revision }}",
       run_bun_global_install_smoke: true,
+    });
+    expect(caller.with).not.toHaveProperty("allow_unreleased_changelog");
+  });
+
+  it("passes package changelog intent only to current-tree smoke scripts", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
+    expect(step(job(workflow, "installer_smoke"), "Run installer docker tests").env).toMatchObject({
+      OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
+    });
+    expect(
+      step(job(workflow, "bun_global_install_smoke"), "Run Bun global install image-provider smoke")
+        .env,
+    ).toMatchObject({
+      OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:
+        "${{ inputs.allow_unreleased_changelog }}",
     });
   });
 });

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -873,6 +873,11 @@ printf 'status=%s\\n' "$status"
 
     expect(script).toContain('node "$HARNESS_ROOT/scripts/package-openclaw-for-docker.mjs"');
     expect(script).toContain("--allow-unreleased-changelog");
+    expect(script).toContain("OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG");
+    expect(script).toContain(
+      'if [[ "${OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:-true}" == "true" ]]',
+    );
+    expect(script).toContain("package_args+=(--allow-unreleased-changelog)");
     expect(script).toContain('--source-dir "$ROOT_DIR"');
     expect(script).toContain('--pack-json "$pack_json_file"');
     expect(script).toContain("--skip-build");
@@ -1173,6 +1178,11 @@ describe("bun global install smoke", () => {
 
     expect(script).toContain("node scripts/package-openclaw-for-docker.mjs");
     expect(script).toContain("--allow-unreleased-changelog");
+    expect(script).toContain("OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG");
+    expect(script).toContain(
+      'if [[ "${OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:-true}" == "true" ]]',
+    );
+    expect(script).toContain("package_args+=(--allow-unreleased-changelog)");
     expect(script).toContain("--skip-build");
     expect(script).toContain("--output-name openclaw-current.tgz");
     expect(script).not.toContain("npm pack --ignore-scripts --json --pack-destination");
@@ -1578,6 +1588,7 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
       "./.github/actions/setup-node-env",
     );
     expect(step("Run installer docker tests").env).toMatchObject({
+      OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
       OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
     });
     expect(step("Run installer docker tests").run).toBe("bash scripts/test-install-sh-docker.sh");


### PR DESCRIPTION
## What Problem This Solves

PR #104186 made current-tree QA packaging accept `Unreleased` changelog notes, but two intent boundaries remained inconsistent:

- `failures.json` reruns retained the opt-in while supported `summary.json` reruns silently dropped it and failed before the selected Docker lane.
- Focused release install-smoke reused scripts that unconditionally accepted `Unreleased`, weakening exact-version changelog validation for that release gate.

## Why This Change Was Made

- Persist the current-tree package intent as an optional boolean in `summary.json` and recover only literal JSON `true` when regenerating workflow commands.
- Add one false-default reusable install-smoke input. The scheduled/current-tree caller opts in; the release caller remains strict by omission.
- Pass the workflow decision explicitly to both package scripts while preserving their documented standalone current-tree default.

This keeps one packaging contract and makes the caller own whether `Unreleased` notes are valid. It also addresses the post-merge finding on #104186 without inferring intent from refs, profiles, or changelog contents.

## User Impact

Maintainer QA reruns generated from either Docker artifact retain the same package intent. Focused release install-smoke once again fails when the selected stable version lacks exact changelog notes. End-user runtime behavior is unchanged.

## Evidence

- AWS Crabbox run `run_8dbc73ee206e`: 5 focused files / 145 tests passed after the final base rebase across summary and failure reruns, hostile summary input, install-smoke workflow routing, both package scripts, and release no-push boundaries.
- AWS Crabbox run `run_d838acb47760`: all 8 formatter-supported changed files passed `oxfmt --check`.
- AWS Crabbox run `run_eb15135ef2ac`: `pnpm check:changed` passed, including type, core/script lint, workflow guards, shell syntax, and Docker scheduler dry-run lanes.
- AWS Crabbox run `run_2bf7d88dbf03`: rerun-helper and temp-creation guard suites passed, 2 files / 40 tests.
- Hosted exact-head [CI run 29142215926](https://github.com/openclaw/openclaw/actions/runs/29142215926): both QA Smoke profiles, Testbox, workflow, lint, type, build, and relevant test jobs passed. The only failures are deterministic current-main regressions from #104210; that PR's own jobs failed identically, and this PR touches neither `docs/**` nor `src/flows/**`.
- `bash -n` passed for both changed shell scripts; both changed JavaScript files passed `node --check`; `git diff --check` passed.
- Fresh structured Codex autoreview: full patch clean at 0.87; final cleanup clean at 0.88, with no accepted/actionable findings.
- Independent sibling audit found no other concrete intent-propagation gaps across Docker, plugin prerelease, Parallels, cross-OS, package-candidate, or release/package acceptance paths.

Refs #104186.
