### PR TITLE
fix(memory-wiki): prevent source ingest content loss during concurrent vault writes

### DIFF
--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -93,7 +93,10 @@ hello from source
     await lockEntered.promise;
 
     const ingestQueued = deferred();
-    const originalEnqueue = KeyedAsyncQueue.prototype.enqueue;
+    const originalEnqueue = Object.getOwnPropertyDescriptor(
+      KeyedAsyncQueue.prototype,
+      "enqueue",
+    )?.value as KeyedAsyncQueue["enqueue"];
     const enqueueSpy = vi
       .spyOn(KeyedAsyncQueue.prototype, "enqueue")
       .mockImplementation(function (this: KeyedAsyncQueue, key, task, hooks) {

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -93,10 +93,8 @@ hello from source
     await lockEntered.promise;
 
     const ingestQueued = deferred();
-    const originalEnqueue = Object.getOwnPropertyDescriptor(
-      KeyedAsyncQueue.prototype,
-      "enqueue",
-    )?.value as KeyedAsyncQueue["enqueue"];
+    const originalEnqueue = Object.getOwnPropertyDescriptor(KeyedAsyncQueue.prototype, "enqueue")
+      ?.value as KeyedAsyncQueue["enqueue"];
     const enqueueSpy = vi
       .spyOn(KeyedAsyncQueue.prototype, "enqueue")
       .mockImplementation(function (this: KeyedAsyncQueue, key, task, hooks) {

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -1,7 +1,8 @@
 // Memory Wiki tests cover ingest plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { describe, expect, it, vi } from "vitest";
 import { ingestMemoryWikiSource } from "./ingest.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -91,23 +92,38 @@ hello from source
     });
     await lockEntered.promise;
 
-    const ingest = ingestMemoryWikiSource({
-      config,
-      inputPath,
-      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
-    });
-    // Give an unserialized ingest enough real turns to reach its page write.
-    await new Promise((done) => {
-      setTimeout(done, 50);
-    });
-    await expect(fs.access(pagePath)).rejects.toThrow();
+    const ingestQueued = deferred();
+    const originalEnqueue = KeyedAsyncQueue.prototype.enqueue;
+    const enqueueSpy = vi
+      .spyOn(KeyedAsyncQueue.prototype, "enqueue")
+      .mockImplementation(function (key, task, hooks) {
+        ingestQueued.resolve();
+        return originalEnqueue.call(this, key, task, hooks);
+      });
+    let ingest: ReturnType<typeof ingestMemoryWikiSource> | undefined;
+    try {
+      ingest = ingestMemoryWikiSource({
+        config,
+        inputPath,
+        nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+      });
+      // On fixed code this observes ingest joining the held queue before any
+      // filesystem work. On unfixed code it observes nested compile only after
+      // the source page was already written, so the assertion fails.
+      await ingestQueued.promise;
+      await expect(fs.access(pagePath)).rejects.toThrow();
 
-    releaseLock.resolve();
-    // Completion also proves the nested compile re-enters the held vault
-    // lock reentrantly instead of deadlocking.
-    const result = await ingest;
-    await holder;
-    expect(result.created).toBe(true);
-    await expect(fs.readFile(pagePath, "utf8")).resolves.toContain("hello from source");
+      releaseLock.resolve();
+      // Completion also proves the nested compile re-enters the held vault
+      // lock reentrantly instead of deadlocking.
+      const result = await ingest;
+      await holder;
+      expect(result.created).toBe(true);
+      await expect(fs.readFile(pagePath, "utf8")).resolves.toContain("hello from source");
+    } finally {
+      releaseLock.resolve();
+      enqueueSpy.mockRestore();
+      await Promise.allSettled([holder, ...(ingest ? [ingest] : [])]);
+    }
   });
 });

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -3,9 +3,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { ingestMemoryWikiSource } from "./ingest.js";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createTempDir, createVault } = createMemoryWikiTestHarness();
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 describe("ingestMemoryWikiSource", () => {
   it("copies a local text file into sources markdown", async () => {
@@ -63,5 +72,42 @@ hello from source
     await expect(fs.readFile(path.join(config.vault.path, "index.md"), "utf8")).resolves.toContain(
       "[meeting notes](sources/meeting-notes.md)",
     );
+  });
+
+  it("queues behind a held vault mutation instead of writing mid-transaction", async () => {
+    const rootDir = await createTempDir("memory-wiki-ingest-lock-");
+    const inputPath = path.join(rootDir, "meeting-notes.txt");
+    await fs.writeFile(inputPath, "hello from source\n", "utf8");
+    const { config } = await createVault({
+      rootDir: path.join(rootDir, "vault"),
+    });
+    const pagePath = path.join(config.vault.path, "sources", "meeting-notes.md");
+
+    const lockEntered = deferred();
+    const releaseLock = deferred();
+    const holder = withMemoryWikiVaultMutation(config.vault.path, async () => {
+      lockEntered.resolve();
+      await releaseLock.promise;
+    });
+    await lockEntered.promise;
+
+    const ingest = ingestMemoryWikiSource({
+      config,
+      inputPath,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+    // Give an unserialized ingest enough real turns to reach its page write.
+    await new Promise((done) => {
+      setTimeout(done, 50);
+    });
+    await expect(fs.access(pagePath)).rejects.toThrow();
+
+    releaseLock.resolve();
+    // Completion also proves the nested compile re-enters the held vault
+    // lock reentrantly instead of deadlocking.
+    const result = await ingest;
+    await holder;
+    expect(result.created).toBe(true);
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toContain("hello from source");
   });
 });

--- a/extensions/memory-wiki/src/ingest.test.ts
+++ b/extensions/memory-wiki/src/ingest.test.ts
@@ -96,7 +96,7 @@ hello from source
     const originalEnqueue = KeyedAsyncQueue.prototype.enqueue;
     const enqueueSpy = vi
       .spyOn(KeyedAsyncQueue.prototype, "enqueue")
-      .mockImplementation(function (key, task, hooks) {
+      .mockImplementation(function (this: KeyedAsyncQueue, key, task, hooks) {
         ingestQueued.resolve();
         return originalEnqueue.call(this, key, task, hooks);
       });

--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -12,6 +12,7 @@ import {
   slugifyWikiPageStem,
   slugifyWikiSegment,
 } from "./markdown.js";
+import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { resolveMemoryWikiTimestamp } from "./time.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
@@ -64,7 +65,7 @@ async function readExistingSourcePage(pagePath: string): Promise<string> {
   throw readError;
 }
 
-export async function ingestMemoryWikiSource(params: {
+async function ingestMemoryWikiSourceUnlocked(params: {
   config: ResolvedMemoryWikiConfig;
   inputPath: string;
   title?: string;
@@ -141,4 +142,18 @@ export async function ingestMemoryWikiSource(params: {
     created,
     indexUpdatedFiles: compile.updatedFiles,
   };
+}
+
+export async function ingestMemoryWikiSource(params: {
+  config: ResolvedMemoryWikiConfig;
+  inputPath: string;
+  title?: string;
+  nowMs?: number;
+}): Promise<IngestMemoryWikiSourceResult> {
+  // Ingest read-modify-writes the source page and recompiles the vault; hold
+  // the vault mutation lock across the whole span so it cannot interleave
+  // with the other serialized vault mutators (apply/compile/source-sync).
+  return await withMemoryWikiVaultMutation(params.config.vault.path, () =>
+    ingestMemoryWikiSourceUnlocked(params),
+  );
 }


### PR DESCRIPTION
Related: #103408

## What Problem This Solves

Memory Wiki source ingest read, merged, and rewrote a source page outside the established per-vault mutation transaction. A concurrent locked mutation could therefore write stale page state after ingest, silently discarding content even though ingest reported success.

## Why This Change Was Made

`ingestMemoryWikiSource` now uses the same reentrant `withMemoryWikiVaultMutation` boundary as apply, compile, and source sync. The lock covers vault initialization, existence/read decisions, page write, log append, and compile. Nested compile re-enters the same-vault lease; unrelated vaults remain parallel.

Maintainer follow-up replaced the original 50 ms timing assertion with deterministic queue-boundary proof. The test observes the real `KeyedAsyncQueue.enqueue` call: fixed code reaches the outer ingest queue before filesystem work, while unfixed code first reaches the queue from nested compile after the page write, making the same page-absence assertion fail deterministically.

## User Impact

Concurrent same-process source ingest and Memory Wiki mutations no longer lose ingested content through stale write-back. Single-caller behavior and public APIs remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/ingest.test.ts extensions/memory-wiki/src/mutation-coordinator.test.ts extensions/memory-wiki/src/source-sync.test.ts` — 3 files, 18 tests passed.
- `node scripts/check-changed.mjs -- extensions/memory-wiki/src/ingest.ts extensions/memory-wiki/src/ingest.test.ts` — delegated extension/test typechecks, lint, formatting, boundaries, and guards passed on Testbox `tbx_01kxs9d6x4f62xbtgdbfkpsyty`: https://github.com/openclaw/openclaw/actions/runs/29622791656
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean after each maintainer edit; final confidence 0.99.
- `git diff --check` — passed.
