### PR TITLE
fix(diagnostics-otel): classify model calls as client spans

### DIFF
--- a/extensions/diagnostics-otel/src/service-genai-attributes.ts
+++ b/extensions/diagnostics-otel/src/service-genai-attributes.ts
@@ -210,7 +210,7 @@ export function modelCallSpanName(evt: {
 }
 
 export function modelCallSpanKind(): SpanKind | undefined {
-  return emitLatestGenAiSemconv() ? SpanKind.CLIENT : undefined;
+  return SpanKind.CLIENT;
 }
 
 export function addUpstreamRequestIdSpanEvent(

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2881,7 +2881,7 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(modelOptions?.attributes ?? {}, "openclaw.runId")).toBe(false);
     expect(Object.hasOwn(modelOptions?.attributes ?? {}, "openclaw.sessionKey")).toBe(false);
     expect(modelOptions?.startTime).toBeTypeOf("number");
-    expect(Object.hasOwn(modelOptions ?? {}, "kind")).toBe(false);
+    expect(modelOptions?.kind).toBe(2);
     expect(modelCall?.[2]).toBeUndefined();
 
     const harnessCall = startedSpanCall("openclaw.harness.run");
@@ -2918,6 +2918,7 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(toolOptions?.attributes ?? {}, "openclaw.runId")).toBe(false);
     expect(Object.hasOwn(toolOptions?.attributes ?? {}, "openclaw.sessionKey")).toBe(false);
     expect(toolOptions?.startTime).toBeTypeOf("number");
+    expect(Object.hasOwn(toolOptions ?? {}, "kind")).toBe(false);
     expect(toolCall?.[2]).toBeUndefined();
 
     const modelCallDuration = lastHistogramRecord("openclaw.model_call.duration_ms");


### PR DESCRIPTION
Closes #102017

## What Problem This Solves

Model-provider calls are outbound remote requests, but legacy-named diagnostics spans omitted `kind`. OpenTelemetry defaults an omitted kind to `INTERNAL`, so dependency graphs and span-kind dashboards could not reliably distinguish provider latency from in-process work.

## What Changed

- `modelCallSpanKind()` now returns `SpanKind.CLIENT` independently of the optional GenAI semantic-convention naming mode.
- The default-path regression test now requires `CLIENT`.
- A sibling assertion preserves generic tool spans without an explicit kind because the shared event can represent local filesystem or process work as well as remote tools.

This is deliberately limited to the one-line semantic fix and test updates. It adds no config, environment variable, dependency, or documentation surface.

## Dependency Contract

The [OpenTelemetry tracing specification](https://opentelemetry.io/docs/specs/otel/trace/api/#spankind) defines `CLIENT` for the client-side wrapper around a remote request and `INTERNAL` as the default when kind is omitted. The installed `@opentelemetry/api` 1.9.1 types define `SpanKind.CLIENT` as numeric value `2`, matching the focused assertions.

## Operator Impact

Operators filtering dashboards or alerts on span kind will see model-call spans move from `INTERNAL` to `CLIENT`. Span names, attributes, configuration, and generic tool-span classification are otherwise unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` — 110 tests passed on the final current-main branch.
- `node scripts/check-changed.mjs -- extensions/diagnostics-otel/src/service-genai-attributes.ts extensions/diagnostics-otel/src/service.test.ts` — all selected format, dependency/API-contract, boundary, production/test tsgo, lint, database-first, and import-cycle lanes passed on [Blacksmith Testbox run 29668199596](https://github.com/openclaw/openclaw/actions/runs/29668199596).
- Maintainer autoreview against current `origin/main` — clean, no accepted/actionable findings (0.98 confidence).
- `git diff --check origin/main...HEAD` — clean.

## AI Assistance

AI-assisted: yes. The implementation, surrounding model/tool recorder paths, tests, OpenTelemetry specification, and installed dependency types were reviewed before landing.
