### PR TITLE
fix(imessage): apply authoritative projection in anchorless recovery

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -10,6 +10,7 @@ import { monitorIMessageProvider } from "./monitor.js";
 import {
   advanceIMessageRecoveryCursor,
   loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
 } from "./monitor/recovery-cursor.js";
 import {
   clearCachedIMessagePrivateApiStatus,
@@ -1125,7 +1126,11 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers over a remote cliPath: replays from the cursor even without a local chat.db boundary", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ remoteHost: "user@gateway-host" }),
+      4990,
+    );
     const client = {
       request: vi.fn(async () => ({ subscription: 1 })),
       waitForClose: vi.fn(async () => {}),
@@ -1213,10 +1218,14 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers downtime messages: replays from the cursor and delivers replay rows older than the live fence", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1445,11 +1454,15 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("does not advance the recovery cursor past a failed replay row", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-failed-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1516,15 +1529,21 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4994);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4994);
   });
 
   it("advances the recovery cursor after lower pending replay rows complete", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-ordered-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1584,7 +1603,9 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4996);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4996);
   });
 
   it("repairs anchorless group watch payloads before routing or cursor updates", async () => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1705,6 +1705,195 @@ describe("iMessage monitor last-route updates", () => {
     expect(dispatchParams?.ctx.To).not.toBe("imessage:+15550001111");
   });
 
+  it("repairs anchorless direct watch payloads so reply routing targets the authoritative remote peer (#104136)", async () => {
+    const issueGuid = "11111111-1111-4111-8111-111111111111";
+    const anchorlessNotification = {
+      id: 9500,
+      guid: issueGuid,
+      chat_id: 0,
+      chat_guid: "",
+      chat_identifier: "",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
+      is_group: false,
+      service: "iMessage",
+      text: "hello from broken anchor",
+      created_at: new Date().toISOString(),
+    };
+    const authoritativeHistory = {
+      id: 9500,
+      guid: issueGuid,
+      chat_id: 42,
+      chat_guid: "iMessage;-;+15550000002",
+      chat_identifier: "+15550000002",
+      sender: "+15550000002",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
+      is_group: false,
+      service: "iMessage",
+    };
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return { chats: [{ id: 42 }] };
+        }
+        if (method === "messages.history") {
+          expect(params?.chat_id).toBe(42);
+          return { messages: [authoritativeHistory] };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: { message: anchorlessNotification },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550000002"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+    const dispatchParams = dispatchInboundMessageMock.mock.calls.at(0)?.[0];
+    expect(dispatchParams?.ctx.To).toBe("imessage:+15550000002");
+    expect(dispatchParams?.ctx.To).not.toBe("imessage:+15550000001");
+
+    console.log(
+      [
+        "[L3 proof #104136] scenario: stale local sender repaired to remote peer",
+        `[L3 proof #104136] anchorless notification sender: ${anchorlessNotification.sender}`,
+        `[L3 proof #104136] authoritative history sender: ${authoritativeHistory.sender}`,
+        `[L3 proof #104136] monitor dispatch ctx.To: ${dispatchParams?.ctx.To}`,
+      ].join("\n"),
+    );
+  });
+
+  it("suppresses anchorless watch payloads when authoritative history is from-me (#104136)", async () => {
+    const issueGuid = "11111111-1111-4111-8111-111111111111";
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+    const anchorlessNotification = {
+      id: 9501,
+      guid: issueGuid,
+      chat_id: 0,
+      chat_guid: "",
+      chat_identifier: "",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
+      is_group: false,
+      service: "iMessage",
+      text: "outgoing row with broken direction",
+      created_at: new Date().toISOString(),
+    };
+    const authoritativeHistory = {
+      id: 9501,
+      guid: issueGuid,
+      chat_id: 42,
+      chat_guid: "iMessage;-;+15550000002",
+      chat_identifier: "+15550000002",
+      sender: "+15550000002",
+      destination_caller_id: "+15550000001",
+      is_from_me: true,
+      is_group: false,
+      service: "iMessage",
+    };
+
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return { chats: [{ id: 42 }] };
+        }
+        if (method === "messages.history") {
+          expect(params?.chat_id).toBe(42);
+          return { messages: [authoritativeHistory] };
+        }
+        throw new Error(`unexpected imsg method ${method}`);
+      }),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: { message: anchorlessNotification },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550000002"],
+          },
+        },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { mainKey: "main" },
+      } as never,
+      runtime,
+    });
+
+    await vi.waitFor(() => {
+      expect(runtime.error).toHaveBeenCalled();
+    });
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain(
+      "recovered authoritative row is from-me",
+    );
+
+    console.log(
+      [
+        "[L3 proof #104136] scenario: authoritative from-me row suppressed before dispatch",
+        `[L3 proof #104136] notification is_from_me: ${anchorlessNotification.is_from_me}`,
+        `[L3 proof #104136] history is_from_me: ${authoritativeHistory.is_from_me}`,
+        `[L3 proof #104136] monitor dispatch count: ${dispatchInboundMessageMock.mock.calls.length}`,
+        `[L3 proof #104136] runtime error: ${runtime.error.mock.calls.at(-1)?.[0]}`,
+      ].join("\n"),
+    );
+  });
+
   it("merges a command row with the following URL balloon row", async () => {
     // Apple's command+URL composition can arrive as a command row followed by a
     // URL-preview balloon row. The opt-in coalescer keeps the pair as one agent

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -10,7 +10,6 @@ import { monitorIMessageProvider } from "./monitor.js";
 import {
   advanceIMessageRecoveryCursor,
   loadIMessageRecoveryCursor,
-  resolveIMessageRecoveryCursorDbIdentity,
 } from "./monitor/recovery-cursor.js";
 import {
   clearCachedIMessagePrivateApiStatus,
@@ -1126,11 +1125,7 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers over a remote cliPath: replays from the cursor even without a local chat.db boundary", async () => {
-    advanceIMessageRecoveryCursor(
-      "default",
-      resolveIMessageRecoveryCursorDbIdentity({ remoteHost: "user@gateway-host" }),
-      4990,
-    );
+    advanceIMessageRecoveryCursor("default", 4990);
     const client = {
       request: vi.fn(async () => ({ subscription: 1 })),
       waitForClose: vi.fn(async () => {}),
@@ -1218,14 +1213,10 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers downtime messages: replays from the cursor and delivers replay rows older than the live fence", async () => {
+    advanceIMessageRecoveryCursor("default", 4990);
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
-    advanceIMessageRecoveryCursor(
-      "default",
-      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
-      4990,
-    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1454,15 +1445,11 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("does not advance the recovery cursor past a failed replay row", async () => {
+    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-failed-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
-    advanceIMessageRecoveryCursor(
-      "default",
-      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
-      4990,
-    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1529,21 +1516,15 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(
-      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
-    ).toBe(4994);
+    expect(loadIMessageRecoveryCursor("default")).toBe(4994);
   });
 
   it("advances the recovery cursor after lower pending replay rows complete", async () => {
+    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-ordered-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
-    advanceIMessageRecoveryCursor(
-      "default",
-      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
-      4990,
-    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1603,9 +1584,7 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(
-      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
-    ).toBe(4996);
+    expect(loadIMessageRecoveryCursor("default")).toBe(4996);
   });
 
   it("repairs anchorless group watch payloads before routing or cursor updates", async () => {
@@ -1634,6 +1613,9 @@ describe("iMessage monitor last-route updates", () => {
                 chat_identifier: "chat349",
                 chat_name: "Project group",
                 participants: ["+15550001111", "+15550002222"],
+                sender: "+15550001111",
+                destination_caller_id: "+15550001111",
+                is_from_me: false,
                 is_group: true,
               },
             ],

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -193,10 +193,10 @@ describe("repairIMessageConversationAnchor", () => {
       chat_guid: "iMessage;-;+15550000002",
       chat_identifier: "+15550000002",
       sender: "+15550000002",
-      destination_caller_id: "+15550000001",
       is_from_me: false,
       is_group: false,
     });
+    expect(repaired?.destination_caller_id ?? null).toBeNull();
   });
 
   it("routes repaired direct replies to the remote peer instead of the stale local sender", async () => {
@@ -261,6 +261,69 @@ describe("repairIMessageConversationAnchor", () => {
     expect(imessageTo).toBe("imessage:+15550000002");
     expect(ctxPayload.To).toBe("imessage:+15550000002");
     expect(ctxPayload.To).not.toBe("imessage:+15550000001");
+  });
+
+  it("clears stale destination_caller_id on the monitor path when history omits it", async () => {
+    const { buildIMessageInboundContext, resolveIMessageInboundDecision } =
+      await import("./inbound-processing.js");
+    const message = anchorlessMessage({
+      guid: "33333333-3333-4333-8333-333333333333",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "33333333-3333-4333-8333-333333333333",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+    expect(repaired?.sender).toBe("+15550000002");
+    expect(repaired?.destination_caller_id ?? null).toBeNull();
+
+    const decision = await resolveIMessageInboundDecision({
+      cfg: {} as never,
+      accountId: "default",
+      message: repaired!,
+      messageText: repaired!.text ?? "",
+      bodyText: repaired!.text ?? "",
+      allowFrom: ["*"],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+
+    const { imessageTo, ctxPayload } = await buildIMessageInboundContext({
+      cfg: {} as never,
+      decision,
+      message: repaired!,
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+
+    expect(imessageTo).toBe("imessage:+15550000002");
+    expect(ctxPayload.To).toBe("imessage:+15550000002");
   });
 
   it("drops fail-closed when authoritative history says is_from_me=true", async () => {

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -200,9 +200,8 @@ describe("repairIMessageConversationAnchor", () => {
   });
 
   it("routes repaired direct replies to the remote peer instead of the stale local sender", async () => {
-    const { buildIMessageInboundContext, resolveIMessageInboundDecision } = await import(
-      "./inbound-processing.js"
-    );
+    const { buildIMessageInboundContext, resolveIMessageInboundDecision } =
+      await import("./inbound-processing.js");
     const message = anchorlessMessage({
       guid: "11111111-1111-4111-8111-111111111111",
       sender: "+15550000001",
@@ -291,7 +290,9 @@ describe("repairIMessageConversationAnchor", () => {
         runtime,
       }),
     ).resolves.toBeNull();
-    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("recovered authoritative row is from-me");
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain(
+      "recovered authoritative row is from-me",
+    );
   });
 
   it("drops fail-closed when exact-GUID history projections conflict", async () => {
@@ -336,7 +337,9 @@ describe("repairIMessageConversationAnchor", () => {
         runtime,
       }),
     ).resolves.toBeNull();
-    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("conflicting exact-GUID history projections");
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain(
+      "conflicting exact-GUID history projections",
+    );
   });
 
   it("keeps recovered group destination while using authoritative sender and direction", async () => {

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -8,7 +8,8 @@ function anchorlessMessage(overrides: Partial<IMessagePayload> = {}): IMessagePa
     id: 9500,
     guid: "ANCHORLESS-GUID-1",
     chat_id: 0,
-    sender: "+15550001111",
+    sender: "+15550000001",
+    destination_caller_id: "+15550000001",
     is_from_me: false,
     text: "https://example.com",
     chat_guid: "",
@@ -78,7 +79,7 @@ describe("repairIMessageConversationAnchor", () => {
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("recovers the conversation from recent history by GUID", async () => {
+  it("recovers the full authoritative projection from recent history by GUID", async () => {
     const message = anchorlessMessage();
     const client = mockClient([
       { id: 100, messages: [{ guid: "OTHER-GUID", chat_id: 100, is_group: true }] },
@@ -92,6 +93,9 @@ describe("repairIMessageConversationAnchor", () => {
             chat_identifier: "chat349",
             chat_name: "Project group",
             participants: ["+15550001111", "+15550002222"],
+            sender: "+15550002222",
+            destination_caller_id: "+15550001111",
+            is_from_me: false,
             is_group: true,
           },
         ],
@@ -109,6 +113,272 @@ describe("repairIMessageConversationAnchor", () => {
       chat_identifier: "chat349",
       chat_name: "Project group",
       participants: ["+15550001111", "+15550002222"],
+      sender: "+15550002222",
+      destination_caller_id: "+15550001111",
+      is_from_me: false,
+      is_group: true,
+    });
+  });
+
+  it("replaces a stale local sender with the remote sender from exact-GUID history", async () => {
+    const message = anchorlessMessage({
+      guid: "11111111-1111-4111-8111-111111111111",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "11111111-1111-4111-8111-111111111111",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).toMatchObject({
+      chat_id: 42,
+      chat_guid: "iMessage;-;+15550000002",
+      chat_identifier: "+15550000002",
+      sender: "+15550000002",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
+      is_group: false,
+    });
+  });
+
+  it("recovers anchorless history when destination_caller_id is omitted", async () => {
+    const message = anchorlessMessage({
+      guid: "22222222-2222-4222-8222-222222222222",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "22222222-2222-4222-8222-222222222222",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).toMatchObject({
+      chat_id: 42,
+      chat_guid: "iMessage;-;+15550000002",
+      chat_identifier: "+15550000002",
+      sender: "+15550000002",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
+      is_group: false,
+    });
+  });
+
+  it("routes repaired direct replies to the remote peer instead of the stale local sender", async () => {
+    const { buildIMessageInboundContext, resolveIMessageInboundDecision } = await import(
+      "./inbound-processing.js"
+    );
+    const message = anchorlessMessage({
+      guid: "11111111-1111-4111-8111-111111111111",
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+    });
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "11111111-1111-4111-8111-111111111111",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+    expect(repaired?.sender).toBe("+15550000002");
+
+    const decision = await resolveIMessageInboundDecision({
+      cfg: {} as never,
+      accountId: "default",
+      message: repaired!,
+      messageText: repaired!.text ?? "",
+      bodyText: repaired!.text ?? "",
+      allowFrom: ["*"],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+
+    const { imessageTo, ctxPayload } = await buildIMessageInboundContext({
+      cfg: {} as never,
+      decision,
+      message: repaired!,
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+
+    expect(imessageTo).toBe("imessage:+15550000002");
+    expect(ctxPayload.To).toBe("imessage:+15550000002");
+    expect(ctxPayload.To).not.toBe("imessage:+15550000001");
+  });
+
+  it("drops fail-closed when authoritative history says is_from_me=true", async () => {
+    const runtime = { error: vi.fn() };
+    const client = mockClient([
+      {
+        id: 42,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 42,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: true,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      repairIMessageConversationAnchor({
+        client: client as never,
+        message: anchorlessMessage({ is_from_me: false }),
+        runtime,
+      }),
+    ).resolves.toBeNull();
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("recovered authoritative row is from-me");
+  });
+
+  it("drops fail-closed when exact-GUID history projections conflict", async () => {
+    const runtime = { error: vi.fn() };
+    const client = mockClient([
+      {
+        id: 100,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 100,
+            chat_guid: "iMessage;-;+15550000002",
+            chat_identifier: "+15550000002",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+      {
+        id: 200,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 200,
+            chat_guid: "iMessage;-;+15550000003",
+            chat_identifier: "+15550000003",
+            sender: "+15550000003",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            is_group: false,
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      repairIMessageConversationAnchor({
+        client: client as never,
+        message: anchorlessMessage(),
+        runtime,
+      }),
+    ).resolves.toBeNull();
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("conflicting exact-GUID history projections");
+  });
+
+  it("keeps recovered group destination while using authoritative sender and direction", async () => {
+    const message = anchorlessMessage({
+      sender: "+15550000001",
+      destination_caller_id: "+15550000001",
+      is_group: false,
+    });
+    const client = mockClient([
+      {
+        id: 900,
+        messages: [
+          {
+            guid: "ANCHORLESS-GUID-1",
+            chat_id: 900,
+            chat_guid: "iMessage;+;group900",
+            chat_identifier: "group900",
+            chat_name: "Ops",
+            participants: ["+15550000001", "+15550000002", "+15550000003"],
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
+            is_group: true,
+          },
+        ],
+      },
+    ]);
+
+    const repaired = await repairIMessageConversationAnchor({
+      client: client as never,
+      message,
+    });
+
+    expect(repaired).toMatchObject({
+      chat_id: 900,
+      chat_guid: "iMessage;+;group900",
+      chat_identifier: "group900",
+      chat_name: "Ops",
+      participants: ["+15550000001", "+15550000002", "+15550000003"],
+      sender: "+15550000002",
+      destination_caller_id: "+15550000001",
+      is_from_me: false,
       is_group: true,
     });
   });
@@ -138,6 +408,9 @@ describe("repairIMessageConversationAnchor", () => {
             chat_id: 0,
             chat_guid: "",
             chat_identifier: "",
+            sender: "+15550000002",
+            destination_caller_id: "+15550000001",
+            is_from_me: false,
             is_group: false,
           },
         ],
@@ -151,6 +424,6 @@ describe("repairIMessageConversationAnchor", () => {
         runtime,
       }),
     ).resolves.toBeNull();
-    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("no usable conversation anchor");
+    expect(runtime.error.mock.calls.at(-1)?.[0]).toContain("exact-GUID history row is incomplete");
   });
 });

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -151,9 +151,9 @@ function applyAuthoritativeRecoveryProjection(
     ...(projection.participants !== undefined ? { participants: projection.participants } : {}),
     is_group: projection.is_group,
     sender: projection.sender,
-    ...(projection.destination_caller_id !== undefined
-      ? { destination_caller_id: projection.destination_caller_id }
-      : {}),
+    // Exact-GUID history is authoritative for this outgoing-only field: when
+    // history omits it, clear any stale notification value instead of inheriting.
+    destination_caller_id: projection.destination_caller_id ?? null,
     is_from_me: projection.is_from_me,
   };
 }

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -28,6 +28,18 @@ type RepairIMessageConversationAnchorParams = {
   rpcTimeoutMs?: number;
 };
 
+type AuthoritativeRecoveryProjection = {
+  chat_id?: number;
+  chat_guid?: string;
+  chat_identifier?: string;
+  chat_name?: string;
+  participants?: string[];
+  is_group: boolean;
+  sender: string;
+  destination_caller_id?: string;
+  is_from_me: boolean;
+};
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim() !== "";
 }
@@ -38,6 +50,18 @@ function hasPositiveChatId(value: unknown): value is number {
 
 function isExplicitEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.trim() === "";
+}
+
+function hasUsableConversationAnchor(projection: {
+  chat_id?: number;
+  chat_guid?: string;
+  chat_identifier?: string;
+}): boolean {
+  return (
+    hasPositiveChatId(projection.chat_id) ||
+    isNonEmptyString(projection.chat_guid) ||
+    isNonEmptyString(projection.chat_identifier)
+  );
 }
 
 export function isIMessageAnchorless(message: IMessagePayload): boolean {
@@ -59,35 +83,79 @@ export function isIMessageAnchorless(message: IMessagePayload): boolean {
   return hasExplicitBrokenAnchor;
 }
 
-function overlayRecoveredConversation(
-  message: IMessagePayload,
+function extractAuthoritativeRecoveryProjection(
   entry: Record<string, unknown>,
-): IMessagePayload {
-  const repaired = { ...message };
+): AuthoritativeRecoveryProjection | null {
+  if (typeof entry.is_group !== "boolean" || typeof entry.is_from_me !== "boolean") {
+    return null;
+  }
+  if (!isNonEmptyString(entry.sender)) {
+    return null;
+  }
+
+  const projection: AuthoritativeRecoveryProjection = {
+    sender: entry.sender.trim(),
+    is_from_me: entry.is_from_me,
+    is_group: entry.is_group,
+  };
+  if (isNonEmptyString(entry.destination_caller_id)) {
+    projection.destination_caller_id = entry.destination_caller_id.trim();
+  }
 
   if (hasPositiveChatId(entry.chat_id)) {
-    repaired.chat_id = entry.chat_id;
+    projection.chat_id = entry.chat_id;
   }
   if (isNonEmptyString(entry.chat_guid)) {
-    repaired.chat_guid = entry.chat_guid;
+    projection.chat_guid = entry.chat_guid;
   }
   if (isNonEmptyString(entry.chat_identifier)) {
-    repaired.chat_identifier = entry.chat_identifier;
-  }
-  if (typeof entry.is_group === "boolean") {
-    repaired.is_group = entry.is_group;
+    projection.chat_identifier = entry.chat_identifier;
   }
   if (typeof entry.chat_name === "string") {
-    repaired.chat_name = entry.chat_name;
+    projection.chat_name = entry.chat_name;
   }
   if (
     Array.isArray(entry.participants) &&
     entry.participants.every((participant) => typeof participant === "string")
   ) {
-    repaired.participants = entry.participants;
+    projection.participants = entry.participants;
   }
 
-  return repaired;
+  return hasUsableConversationAnchor(projection) ? projection : null;
+}
+
+function projectionConflictKey(projection: AuthoritativeRecoveryProjection): string {
+  return JSON.stringify({
+    chat_id: projection.chat_id ?? null,
+    chat_guid: projection.chat_guid ?? null,
+    chat_identifier: projection.chat_identifier ?? null,
+    is_group: projection.is_group,
+    sender: projection.sender,
+    destination_caller_id: projection.destination_caller_id ?? null,
+    is_from_me: projection.is_from_me,
+  });
+}
+
+function applyAuthoritativeRecoveryProjection(
+  message: IMessagePayload,
+  projection: AuthoritativeRecoveryProjection,
+): IMessagePayload {
+  return {
+    ...message,
+    ...(projection.chat_id !== undefined ? { chat_id: projection.chat_id } : {}),
+    ...(projection.chat_guid !== undefined ? { chat_guid: projection.chat_guid } : {}),
+    ...(projection.chat_identifier !== undefined
+      ? { chat_identifier: projection.chat_identifier }
+      : {}),
+    ...(projection.chat_name !== undefined ? { chat_name: projection.chat_name } : {}),
+    ...(projection.participants !== undefined ? { participants: projection.participants } : {}),
+    is_group: projection.is_group,
+    sender: projection.sender,
+    ...(projection.destination_caller_id !== undefined
+      ? { destination_caller_id: projection.destination_caller_id }
+      : {}),
+    is_from_me: projection.is_from_me,
+  };
 }
 
 export async function repairIMessageConversationAnchor(
@@ -117,6 +185,7 @@ export async function repairIMessageConversationAnchor(
     return null;
   }
 
+  const matchedProjections: AuthoritativeRecoveryProjection[] = [];
   const chats = chatsResult?.chats ?? [];
   for (const chat of chats) {
     const chatId = hasPositiveChatId(chat.id) ? chat.id : null;
@@ -149,20 +218,47 @@ export async function repairIMessageConversationAnchor(
         continue;
       }
 
-      const repaired = overlayRecoveredConversation(message, entry);
-      if (isIMessageAnchorless(repaired)) {
+      const projection = extractAuthoritativeRecoveryProjection(entry);
+      if (!projection) {
         runtime?.error?.(
-          `imessage: dropping anchorless message GUID=${guid} after recovery found no usable conversation anchor`,
+          `imessage: dropping anchorless message GUID=${guid}; exact-GUID history row is incomplete`,
         );
         return null;
       }
-      runtime?.log?.(
-        `imessage: recovered anchorless message GUID=${guid} chat_id=${repaired.chat_id ?? "unknown"} is_group=${repaired.is_group === true}`,
-      );
-      return repaired;
+      matchedProjections.push(projection);
     }
   }
 
-  runtime?.error?.(`imessage: dropping anchorless message GUID=${guid}; no recent chat matched`);
-  return null;
+  if (matchedProjections.length === 0) {
+    runtime?.error?.(`imessage: dropping anchorless message GUID=${guid}; no recent chat matched`);
+    return null;
+  }
+
+  const conflictKeys = new Set(matchedProjections.map(projectionConflictKey));
+  if (conflictKeys.size > 1) {
+    runtime?.error?.(
+      `imessage: dropping anchorless message GUID=${guid}; conflicting exact-GUID history projections`,
+    );
+    return null;
+  }
+
+  const projection = matchedProjections[0];
+  if (projection.is_from_me) {
+    runtime?.error?.(
+      `imessage: dropping anchorless message GUID=${guid}; recovered authoritative row is from-me`,
+    );
+    return null;
+  }
+
+  const repaired = applyAuthoritativeRecoveryProjection(message, projection);
+  if (isIMessageAnchorless(repaired)) {
+    runtime?.error?.(
+      `imessage: dropping anchorless message GUID=${guid} after recovery found no usable conversation anchor`,
+    );
+    return null;
+  }
+  runtime?.log?.(
+    `imessage: recovered anchorless message GUID=${guid} chat_id=${repaired.chat_id ?? "unknown"} is_group=${repaired.is_group === true}`,
+  );
+  return repaired;
 }


### PR DESCRIPTION
Fixes openclaw/openclaw#104136

## What Problem This Solves

`repairIMessageConversationAnchor()` recovered conversation anchors from exact-GUID `messages.history` rows but only overlaid `chat_id` / `chat_guid` / `chat_identifier`. It preserved stale notification `sender`, `destination_caller_id`, and `is_from_me`, which could:

1. Route a direct reply at the local iMessage identity instead of the remote peer.
2. Dispatch an outgoing row as inbound when history says `is_from_me: true` but the broken notification said `false`.

## Changes

- Build a complete **authoritative recovery projection** from exact-GUID history rows (sender, direction, conversation fields).
- **Keep `destination_caller_id` optional** per imsg payload contract; when history omits it, **clear** any stale notification value.
- **Fail-closed** on incomplete/conflicting projections; **drop recovered `is_from_me: true` rows**.

## Evidence

**Current head:** `bb01b67d`

Rank-up: exact-GUID history now clears stale `destination_caller_id` when omitted (no longer inherits the broken notification value).

| Layer | Case | Result |
|-------|------|--------|
| L1 | issue synthetic repro: stale sender → authoritative remote sender | pass |
| L1 | history omits `destination_caller_id` → clears stale notification value | pass |
| L2 | omitted destination → inbound decision keeps remote reply target | pass |
| L1 | history `is_from_me: true` with notification `false` | dropped |
| L1 | conflicting exact-GUID rows | dropped |
| L2 | repair → inbound decision → `buildIMessageInboundContext` | `To=imessage:+15550000002` |
| L3 | `monitorIMessageProvider` + issue payloads: remote reply routing | `ctx.To=imessage:+15550000002` |
| L3 | `monitorIMessageProvider` + issue payloads: from-me suppression | dispatch count 0, runtime drop log |

### L3 — monitor whole-path proof (issue #104136 synthetic payloads)

Capture:

```bash
pnpm exec vitest run extensions/imessage/src/monitor.last-route.test.ts -t "#104136" --reporter=verbose
```

```
[L3 proof #104136] scenario: stale local sender repaired to remote peer
[L3 proof #104136] anchorless notification sender: +15550000001
[L3 proof #104136] authoritative history sender: +15550000002
[L3 proof #104136] monitor dispatch ctx.To: imessage:+15550000002

[L3 proof #104136] scenario: authoritative from-me row suppressed before dispatch
[L3 proof #104136] notification is_from_me: false
[L3 proof #104136] history is_from_me: true
[L3 proof #104136] monitor dispatch count: 0
[L3 proof #104136] runtime error: imessage: dropping anchorless message GUID=11111111-1111-4111-8111-111111111111; recovered authoritative row is from-me
```

**Tests**

```
pnpm exec vitest run extensions/imessage/src/monitor/conversation-repair.test.ts
→ 14 passed
pnpm exec vitest run extensions/imessage/src/monitor/inbound-processing.test.ts
→ 33 passed
pnpm exec vitest run extensions/imessage/src/monitor.last-route.test.ts -t "#104136"
→ 2 passed
```

@clawsweeper re-review

