### PR TITLE
fix(agents): honor aborts during context preflight

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -414,6 +414,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(bootstrapParams.sessionId).toBe("session-1");
     expect(bootstrapParams.sessionKey).toBe("agent:main:session-1");
     expect(bootstrapParams.sessionFile).toBe(sessionFile);
+    expect(bootstrapParams.abortSignal).toBeInstanceOf(AbortSignal);
     expect(bootstrapParams.runtimeSettings).toMatchObject({
       runtime: { mode: "degraded" },
       model: {
@@ -447,6 +448,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       },
     });
     expect(assembleParams.prompt).toBe("hello");
+    expect(assembleParams.abortSignal).toBe(bootstrapParams.abortSignal);
     expect(assembleParams.messages.map((message) => message.role)).toEqual(["assistant"]);
     expect(assembleParams.availableTools).toEqual(new Set());
 
@@ -459,6 +461,47 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     await harness.completeTurn();
     await run;
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("aborts pending context bootstrap before starting Codex", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("existing context", Date.now()) as never,
+    );
+    const bootstrap = vi.fn<NonNullable<ContextEngine["bootstrap"]>>(async ({ abortSignal }) => {
+      if (!abortSignal) {
+        throw new Error("missing context bootstrap abort signal");
+      }
+      await new Promise<never>((_resolve, reject) => {
+        const rejectForAbort = () =>
+          reject(
+            abortSignal.reason instanceof Error
+              ? abortSignal.reason
+              : new Error("context bootstrap aborted"),
+          );
+        if (abortSignal.aborted) {
+          rejectForAbort();
+          return;
+        }
+        abortSignal.addEventListener("abort", rejectForAbort, { once: true });
+      });
+      throw new Error("unreachable");
+    });
+    const contextEngine = createContextEngine({ bootstrap });
+    const harness = createStartedThreadHarness();
+    const abortController = new AbortController();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.abortSignal = abortController.signal;
+
+    const run = runCodexAppServerAttempt(params);
+    const rejection = expect(run).rejects.toThrow("context bootstrap cancelled");
+    await vi.waitFor(() => expect(bootstrap).toHaveBeenCalledTimes(1));
+    abortController.abort(new Error("context bootstrap cancelled"));
+
+    await rejection;
+    expect(harness.requests).toEqual([]);
   });
 
   it("keeps context-engine history bound to the run session when sandbox key differs", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -459,25 +459,76 @@ async function runCodexAgentEndHook(
   runAgentEndSideEffects(sideEffectParams);
 }
 
+type RunCodexAppServerAttemptOptions = {
+  bindingStore: CodexAppServerBindingStore;
+  pluginConfig?: unknown;
+  startupTimeoutFloorMs?: number;
+  nativeHookRelay?: {
+    enabled?: boolean;
+    events?: readonly NativeHookRelayEvent[];
+    ttlMs?: number;
+    gatewayTimeoutMs?: number;
+    hookTimeoutSec?: number;
+  };
+  turnCompletionIdleTimeoutMs?: number;
+  turnAssistantCompletionIdleTimeoutMs?: number;
+  postToolRawAssistantCompletionIdleTimeoutMs?: number;
+  turnTerminalIdleTimeoutMs?: number;
+  clientFactory?: CodexAppServerClientFactory;
+};
+
+function createCodexRunDeadlineScope(params: EmbeddedRunAttemptParams): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const timeoutReason = new Error("Codex agent run timed out");
+  timeoutReason.name = "TimeoutError";
+  const onCallerAbort = () => controller.abort(params.abortSignal?.reason);
+  if (params.abortSignal?.aborted) {
+    onCallerAbort();
+  } else {
+    params.abortSignal?.addEventListener("abort", onCallerAbort, { once: true });
+    if (params.abortSignal?.aborted) {
+      onCallerAbort();
+    }
+  }
+  const timer = setTimeout(() => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    params.onAttemptTimeout?.(timeoutReason);
+    controller.abort(timeoutReason);
+  }, Math.max(1, params.timeoutMs));
+  timer.unref?.();
+  params.onAttemptTimeoutArmed?.();
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      params.abortSignal?.removeEventListener("abort", onCallerAbort);
+    },
+  };
+}
+
 export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
-  options: {
-    bindingStore: CodexAppServerBindingStore;
-    pluginConfig?: unknown;
-    startupTimeoutFloorMs?: number;
-    nativeHookRelay?: {
-      enabled?: boolean;
-      events?: readonly NativeHookRelayEvent[];
-      ttlMs?: number;
-      gatewayTimeoutMs?: number;
-      hookTimeoutSec?: number;
-    };
-    turnCompletionIdleTimeoutMs?: number;
-    turnAssistantCompletionIdleTimeoutMs?: number;
-    postToolRawAssistantCompletionIdleTimeoutMs?: number;
-    turnTerminalIdleTimeoutMs?: number;
-    clientFactory?: CodexAppServerClientFactory;
-  },
+  options: RunCodexAppServerAttemptOptions,
+): Promise<EmbeddedRunAttemptResult> {
+  const deadline = createCodexRunDeadlineScope(params);
+  try {
+    return await runCodexAppServerAttemptWithinDeadline(
+      { ...params, abortSignal: deadline.signal },
+      options,
+    );
+  } finally {
+    deadline.dispose();
+  }
+}
+
+async function runCodexAppServerAttemptWithinDeadline(
+  params: EmbeddedRunAttemptParams,
+  options: RunCodexAppServerAttemptOptions,
 ): Promise<EmbeddedRunAttemptResult> {
   const attemptStartedAt = Date.now();
   const profilerEnabled = isCodexAppServerProfilerEnabled(params.config);
@@ -680,6 +731,7 @@ export async function runCodexAppServerAttempt(
   preDynamicStartupStages.mark("native-hook-relay");
 
   const runAbortController = new AbortController();
+  let timedOut = false;
   // AbortController preserves its first reason, so retain explicit cancellation
   // that can arrive after the timeout abort while cleanup is still draining.
   let explicitCancellationObserved = false;
@@ -707,7 +759,11 @@ export async function runCodexAppServerAttempt(
     runAbortController.abort(reason);
   };
   const abortFromUpstream = () => {
-    abortExplicitly(params.abortSignal?.reason ?? "upstream_abort");
+    const reason = params.abortSignal?.reason ?? "upstream_abort";
+    if (reason instanceof Error && reason.name === "TimeoutError") {
+      timedOut = true;
+    }
+    abortExplicitly(reason);
   };
   if (params.abortSignal?.aborted) {
     abortFromUpstream();
@@ -1099,6 +1155,7 @@ export async function runCodexAppServerAttempt(
       modelId: effectiveRuntimeModelId,
       fallbackReason: usesSupervisionConnection ? undefined : params.fallbackReason,
       degradedReason: usesSupervisionConnection ? undefined : params.degradedReason,
+      abortSignal: runAbortController.signal,
       runMaintenance: runHarnessContextEngineMaintenance,
       config: params.config,
       warn: (message) => embeddedAgentLog.warn(message),
@@ -1180,6 +1237,7 @@ export async function runCodexAppServerAttempt(
       fallbackReason: usesSupervisionConnection ? undefined : params.fallbackReason,
       degradedReason: usesSupervisionConnection ? undefined : params.degradedReason,
       prompt: params.prompt,
+      abortSignal: runAbortController.signal,
     });
     if (!assembled) {
       throw new Error("context engine assemble returned no result");
@@ -1237,6 +1295,9 @@ export async function runCodexAppServerAttempt(
         !nativeToolSurfaceEnabled ? undefined : startupBinding,
       );
     } catch (assembleErr) {
+      if (runAbortController.signal.aborted) {
+        throw assembleErr;
+      }
       embeddedAgentLog.warn("context engine assemble failed; using Codex baseline prompt", {
         error: formatErrorMessage(assembleErr),
       });
@@ -1838,7 +1899,6 @@ export async function runCodexAppServerAttempt(
   let rateLimitsRevisionBeforeLastTurnStart: number | undefined;
   let completed = false;
   let terminalTurnNotificationQueued = false;
-  let timedOut = false;
   let turnCompletionIdleTimedOut = false;
   let turnWatchTimeoutKind: CodexAttemptTurnWatchTimeoutKind | undefined;
   let turnWatchTimeoutIdleMs: number | undefined;

--- a/src/agents/cli-runner.context-engine.test.ts
+++ b/src/agents/cli-runner.context-engine.test.ts
@@ -176,6 +176,8 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
     const dispose = vi.fn(async () => {});
     const contextEngine = createContextEngine({ bootstrap, afterTurn, maintain, dispose });
     const context = buildPreparedContext(contextEngine);
+    const abortController = new AbortController();
+    context.params.abortSignal = abortController.signal;
     context.params.bootstrapContextRunKind = "commitment-only";
     const result = await runPreparedCliAgent(context);
 
@@ -212,6 +214,7 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
         },
       },
     });
+    expect(bootstrapParams?.abortSignal).toBe(abortController.signal);
     expect(afterTurn).toHaveBeenCalledTimes(1);
     const afterTurnParams = afterTurn.mock.calls[0]?.[0];
     expect(afterTurnParams).toMatchObject({
@@ -332,6 +335,40 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
     const afterTurnParams = afterTurn.mock.calls[0]?.[0];
     expect(afterTurnParams?.prePromptMessageCount).toBe(1);
     expect(afterTurnParams?.messages[0]).toEqual(postBootstrapHistory[0]);
+  });
+
+  it("aborts pending context bootstrap before starting the CLI backend", async () => {
+    const bootstrap = vi.fn<NonNullable<ContextEngine["bootstrap"]>>(async ({ abortSignal }) => {
+      if (!abortSignal) {
+        throw new Error("missing context bootstrap abort signal");
+      }
+      await new Promise<never>((_resolve, reject) => {
+        const rejectForAbort = () =>
+          reject(
+            abortSignal.reason instanceof Error
+              ? abortSignal.reason
+              : new Error("context bootstrap aborted"),
+          );
+        if (abortSignal.aborted) {
+          rejectForAbort();
+          return;
+        }
+        abortSignal.addEventListener("abort", rejectForAbort, { once: true });
+      });
+      throw new Error("unreachable");
+    });
+    const contextEngine = createContextEngine({ bootstrap });
+    const context = buildPreparedContext(contextEngine);
+    const abortController = new AbortController();
+    context.params.abortSignal = abortController.signal;
+
+    const run = runPreparedCliAgent(context);
+    const rejection = expect(run).rejects.toThrow("context bootstrap cancelled");
+    await vi.waitFor(() => expect(bootstrap).toHaveBeenCalledTimes(1));
+    abortController.abort(new Error("context bootstrap cancelled"));
+
+    await rejection;
+    expect(executePreparedCliRunMock).not.toHaveBeenCalled();
   });
 
   it("falls back to ingestBatch and still runs turn maintenance", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1096,6 +1096,7 @@ export async function runPreparedCliAgent(
       }),
       providerId: params.provider,
       modelId: context.modelId,
+      abortSignal: params.abortSignal,
       warn: (message) => log.warn(message),
     });
     const contextEngineHistoryMessages = context.contextEngine

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -339,6 +339,7 @@ async function executeContextEngineMaintenance(params: {
   agentId?: string;
   executionMode: "foreground" | "background";
   config?: OpenClawConfig;
+  abortSignal?: AbortSignal;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
   if (typeof params.contextEngine.maintain !== "function") {
     return undefined;
@@ -362,6 +363,7 @@ async function executeContextEngineMaintenance(params: {
       purpose: `context-engine.${params.reason}.maintenance`,
       contextEnginePluginId: resolveContextEngineOwnerPluginId(params.contextEngine),
     }),
+    abortSignal: params.abortSignal,
   });
   if (result.changed) {
     log.info(
@@ -658,6 +660,7 @@ export async function runContextEngineMaintenance(params: {
   onDeferredMaintenanceFailure?: (error: unknown) => void;
   config?: OpenClawConfig;
   disposeDeferredContextEngineAfterMaintenance?: boolean;
+  abortSignal?: AbortSignal;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
   if (typeof params.contextEngine?.maintain !== "function") {
     return undefined;
@@ -707,8 +710,12 @@ export async function runContextEngineMaintenance(params: {
       agentId: params.agentId,
       executionMode,
       config: params.config,
+      abortSignal: params.abortSignal,
     });
   } catch (err) {
+    if (params.abortSignal?.aborted) {
+      throw err;
+    }
     log.warn(`context engine maintain failed (${params.reason}): ${String(err)}`);
     return undefined;
   }

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -60,6 +60,10 @@ describe("runEmbeddedAttempt abort races", () => {
 
     expect(hoisted.createAgentSessionMock).not.toHaveBeenCalled();
     expect(prompt).not.toHaveBeenCalled();
-    expect(observedSignal).toBe(abortController.signal);
+    // The lock follows the attempt-owned signal so both the run deadline and
+    // caller cancellation can stop eager acquisition without losing the reason.
+    expect(observedSignal).not.toBe(abortController.signal);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(observedSignal?.reason).toBe(abortError);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -180,6 +180,52 @@ function createTestContextEngine(params: Partial<AttemptContextEngine>): Attempt
   } as AttemptContextEngine;
 }
 
+function createPendingContextEngineCall() {
+  let release: (() => void) | undefined;
+  let notifyStarted: (() => void) | undefined;
+  let settled = false;
+  const started = new Promise<void>((resolve) => {
+    notifyStarted = resolve;
+  });
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    wait: async (abortSignal?: AbortSignal) => {
+      notifyStarted?.();
+      try {
+        if (!abortSignal) {
+          await pending;
+          return;
+        }
+        await new Promise<void>((resolve, reject) => {
+          const onAbort = () => {
+            reject(
+              abortSignal.reason instanceof Error
+                ? abortSignal.reason
+                : new Error("context engine call aborted"),
+            );
+          };
+          if (abortSignal.aborted) {
+            onAbort();
+            return;
+          }
+          abortSignal.addEventListener("abort", onAbort, { once: true });
+          void pending.then(() => {
+            abortSignal.removeEventListener("abort", onAbort);
+            resolve();
+          });
+        });
+      } finally {
+        settled = true;
+      }
+    },
+    started,
+    isSettled: () => settled,
+    release: () => release?.(),
+  };
+}
+
 async function runBootstrap(
   sessionKey: string,
   contextEngine: AttemptContextEngine,
@@ -292,11 +338,208 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     await cleanupTempPaths(tempPaths);
     clearMemoryPluginState();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("enables Tool Search controls for embedded OpenClaw runs when configured", async () => {
     expect(toolSearchControlsCase.includeToolSearchControls).toBe(true);
     expect(toolSearchControlsCase.toolSearchCatalogRef).toEqual({});
+  });
+
+  it("honors caller abort while context-engine assembly is pending", async () => {
+    const abortController = new AbortController();
+    const pendingAssembly = createPendingContextEngineCall();
+    const releaseSessionLock = vi.fn(async () => {});
+    hoisted.acquireSessionWriteLockMock.mockResolvedValue({ release: releaseSessionLock });
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages, abortSignal }) => {
+          await pendingAssembly.wait(abortSignal);
+          return { messages, estimatedTokens: 1 };
+        },
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: { abortSignal: abortController.signal },
+    });
+
+    await pendingAssembly.started;
+    abortController.abort();
+    const outcome = await Promise.race([
+      attempt.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+      ),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    pendingAssembly.release();
+    await attempt.catch(() => {});
+
+    expect(outcome).toBe("AbortError");
+    expect(pendingAssembly.isSettled()).toBe(true);
+    expect(releaseSessionLock).toHaveBeenCalled();
+  });
+
+  it("applies the attempt timeout while context-engine assembly is pending", async () => {
+    vi.useFakeTimers();
+    const pendingAssembly = createPendingContextEngineCall();
+    const onAttemptTimeout = vi.fn();
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages, abortSignal }) => {
+          await pendingAssembly.wait(abortSignal);
+          return { messages, estimatedTokens: 1 };
+        },
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: { timeoutMs: 25, onAttemptTimeout },
+    });
+
+    await pendingAssembly.started;
+    const outcomePromise = Promise.race([
+      attempt.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+      ),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    await vi.advanceTimersByTimeAsync(100);
+    const outcome = await outcomePromise;
+    pendingAssembly.release();
+    await attempt.catch(() => {});
+    vi.useRealTimers();
+
+    expect(outcome).toBe("TimeoutError");
+    expect(pendingAssembly.isSettled()).toBe(true);
+    expect(onAttemptTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "TimeoutError" }),
+    );
+  });
+
+  it("honors caller abort while context-engine bootstrap is pending", async () => {
+    const abortController = new AbortController();
+    const pendingBootstrap = createPendingContextEngineCall();
+    const releaseSessionLock = vi.fn(async () => {});
+    hoisted.acquireSessionWriteLockMock.mockResolvedValue({ release: releaseSessionLock });
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: {
+        bootstrap: async ({ abortSignal }) => {
+          await pendingBootstrap.wait(abortSignal);
+          return { bootstrapped: true };
+        },
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: { abortSignal: abortController.signal },
+    });
+
+    await pendingBootstrap.started;
+    abortController.abort();
+    const outcome = await Promise.race([
+      attempt.then(
+        () => "resolved",
+        (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+      ),
+      new Promise<"pending">((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    pendingBootstrap.release();
+    await attempt.catch(() => {});
+
+    expect(outcome).toBe("AbortError");
+    expect(pendingBootstrap.isSettled()).toBe(true);
+    expect(releaseSessionLock).toHaveBeenCalled();
+  });
+
+  it("applies the attempt timeout while context-engine bootstrap is pending", async () => {
+    vi.useFakeTimers();
+    const pendingBootstrap = createPendingContextEngineCall();
+    const releaseSessionLock = vi.fn(async () => {});
+    hoisted.acquireSessionWriteLockMock.mockResolvedValue({ release: releaseSessionLock });
+    const onAttemptTimeout = vi.fn();
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: {
+        bootstrap: async ({ abortSignal }) => {
+          await pendingBootstrap.wait(abortSignal);
+          return { bootstrapped: true };
+        },
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: { timeoutMs: 25, onAttemptTimeout },
+    });
+
+    await pendingBootstrap.started;
+    const outcomePromise = attempt.then(
+      () => "resolved",
+      (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+    );
+    await vi.advanceTimersByTimeAsync(25);
+    const outcome = await outcomePromise;
+    pendingBootstrap.release();
+    await attempt.catch(() => {});
+    vi.useRealTimers();
+
+    expect(outcome).toBe("TimeoutError");
+    expect(pendingBootstrap.isSettled()).toBe(true);
+    expect(onAttemptTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "TimeoutError" }),
+    );
+    expect(releaseSessionLock).toHaveBeenCalled();
+  });
+
+  it("applies the attempt timeout while the initial session write lock is pending", async () => {
+    vi.useFakeTimers();
+    let notifyLockStarted: (() => void) | undefined;
+    const lockStarted = new Promise<void>((resolve) => {
+      notifyLockStarted = resolve;
+    });
+    hoisted.acquireSessionWriteLockMock.mockImplementation(async ({ signal }) => {
+      notifyLockStarted?.();
+      await new Promise<never>((_resolve, reject) => {
+        const onAbort = () =>
+          reject(
+            signal?.reason instanceof Error ? signal.reason : new Error("session lock aborted"),
+          );
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+      throw new Error("unreachable");
+    });
+    const onAttemptTimeout = vi.fn();
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: { timeoutMs: 25, onAttemptTimeout },
+    });
+    const outcomePromise = attempt.then(
+      () => "resolved",
+      (error: unknown) => (error instanceof Error ? error.name : "rejected"),
+    );
+
+    await lockStarted;
+    await vi.advanceTimersByTimeAsync(25);
+    const outcome = await outcomePromise;
+    vi.useRealTimers();
+
+    expect(outcome).toBe("TimeoutError");
+    expect(onAttemptTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "TimeoutError" }),
+    );
   });
 
   it("keeps client tool names out of context engine capability guidance", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -1208,6 +1208,7 @@ export async function createContextEngineAttemptRunner(params: {
       sessionId: string;
       sessionKey?: string;
       sessionFile: string;
+      abortSignal?: AbortSignal;
     }) => Promise<BootstrapResult>;
     maintain?:
       | boolean
@@ -1228,6 +1229,7 @@ export async function createContextEngineAttemptRunner(params: {
       messages: AgentMessage[];
       tokenBudget?: number;
       model?: string;
+      abortSignal?: AbortSignal;
     }) => Promise<AssembleResult>;
     afterTurn?: (params: {
       sessionId: string;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -991,6 +991,9 @@ export async function runEmbeddedAttempt(
 ): Promise<EmbeddedRunAttemptResult> {
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const runAbortController = new AbortController();
+  // Preparation and streaming share one attempt budget. The active watchdog
+  // inherits this deadline so slow assembly cannot reset the caller's timeout.
+  const initialRunDeadlineAtMs = Date.now() + Math.max(1, params.timeoutMs);
   // Ultra is a logical orchestration mode, not a provider effort. Preserve it for
   // prompt/status surfaces, then lower only at agent-core and provider boundaries.
   const agentCoreThinkingLevel = mapThinkingLevel(params.thinkLevel);
@@ -1142,6 +1145,7 @@ export async function runEmbeddedAttempt(
   let isCompactionPendingForExternalSignal: (() => boolean) | undefined;
   let isCompactionInFlightForExternalSignal: (() => boolean) | undefined;
   let removeExternalAbortSignalListener: (() => void) | undefined;
+  let preflightAbortTimer: NodeJS.Timeout | undefined;
   const createAttemptAbortError = (signal: AbortSignal): Error => {
     if (signal.reason instanceof Error) {
       return signal.reason;
@@ -1156,6 +1160,12 @@ export async function runEmbeddedAttempt(
     const err = new Error("request timed out");
     err.name = "TimeoutError";
     return err;
+  };
+  const clearPreflightAbortTimer = () => {
+    if (preflightAbortTimer) {
+      clearTimeout(preflightAbortTimer);
+      preflightAbortTimer = undefined;
+    }
   };
   const cleanupEmbeddedPrepResourcesAfterEarlyExit = async () => {
     if (toolSearchCatalogApplied) {
@@ -1188,6 +1198,7 @@ export async function runEmbeddedAttempt(
     if (!signal) {
       return;
     }
+    clearPreflightAbortTimer();
     externalAbort = true;
     const reason = getAbortReason(signal);
     const timeout = reason ? isSignalTimeoutReason(reason) : false;
@@ -1233,15 +1244,34 @@ export async function runEmbeddedAttempt(
     };
   };
   const throwIfAttemptAbortSignalFiredAfterPrepCleanup = async () => {
-    if (params.abortSignal?.aborted === true) {
-      const abortError = createAttemptAbortError(params.abortSignal);
-      aborted = true;
-      externalAbort = true;
-      promptError = abortError;
-      await cleanupEmbeddedPrepResourcesAfterEarlyExit();
-      throw abortError;
+    const firedSignal = params.abortSignal?.aborted
+      ? params.abortSignal
+      : runAbortController.signal;
+    if (!firedSignal.aborted) {
+      return;
     }
+    const abortError = createAttemptAbortError(firedSignal);
+    aborted = true;
+    externalAbort ||= params.abortSignal?.aborted === true;
+    promptError = abortError;
+    await cleanupEmbeddedPrepResourcesAfterEarlyExit();
+    throw abortError;
   };
+  const preflightTimeoutMs = Math.max(1, initialRunDeadlineAtMs - Date.now());
+  preflightAbortTimer = setTimeout(() => {
+    const timeoutReason = makeTimeoutAbortReason();
+    aborted = true;
+    timedOut = true;
+    timedOutByRunBudget = true;
+    promptError = timeoutReason;
+    params.onAttemptTimeout?.(timeoutReason);
+    if (!runAbortController.signal.aborted) {
+      runAbortController.abort(timeoutReason);
+    }
+    void abortActiveSessionForExternalSignal?.();
+  }, preflightTimeoutMs);
+  params.onAttemptTimeoutArmed?.();
+  armExternalAbortSignal();
   try {
     const {
       skillsEligibility,
@@ -2320,12 +2350,12 @@ export async function runEmbeddedAttempt(
     retainedSessionFileOwner = await acquireEmbeddedAttemptSessionFileOwner({
       sessionFile: params.sessionFile,
       timeoutMs: sessionWriteLockOptions.maxHoldMs,
-      signal: params.abortSignal,
+      signal: runAbortController.signal,
     });
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     const sessionLockController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
-      initialAcquireSignal: params.abortSignal,
+      initialAcquireSignal: runAbortController.signal,
       lockOptions: {
         sessionFile: params.sessionFile,
         ...sessionWriteLockOptions,
@@ -2444,7 +2474,7 @@ export async function runEmbeddedAttempt(
       trackSessionManagerAccess(params.sessionFile);
 
       await withOwnedSessionWriteLock(async () => {
-        await runAttemptContextEngineBootstrap({
+        const contextEngineBootstrap = runAttemptContextEngineBootstrap({
           hadSessionFile,
           contextEngine: activeContextEngine,
           sessionId: params.sessionId,
@@ -2466,8 +2496,12 @@ export async function runEmbeddedAttempt(
           modelId: params.modelId,
           fallbackReason: params.fallbackReason,
           degradedReason: params.degradedReason,
-          runMaintenance: async (contextParams) =>
-            await runContextEngineMaintenance({
+          abortSignal: runAbortController.signal,
+          runMaintenance: async (contextParams) => {
+            if (runAbortController.signal.aborted) {
+              throw createAttemptAbortError(runAbortController.signal);
+            }
+            return await runContextEngineMaintenance({
               contextEngine: contextParams.contextEngine as never,
               sessionId: contextParams.sessionId,
               sessionKey: contextParams.sessionKey,
@@ -2478,9 +2512,24 @@ export async function runEmbeddedAttempt(
               runtimeSettings: contextParams.runtimeSettings,
               config: params.config,
               agentId: sessionAgentId,
-            }),
+              abortSignal: runAbortController.signal,
+            });
+          },
           warn: (message) => log.warn(message),
         });
+        try {
+          // Bootstrap can mutate the session file. It receives the abort signal,
+          // but the write lock stays held until the operation actually settles.
+          await contextEngineBootstrap;
+        } catch (bootstrapErr) {
+          if (runAbortController.signal.aborted) {
+            throw createAttemptAbortError(runAbortController.signal);
+          }
+          throw bootstrapErr;
+        }
+        if (runAbortController.signal.aborted) {
+          throw createAttemptAbortError(runAbortController.signal);
+        }
 
         await prepareSessionManagerForRun({
           sessionManager,
@@ -3648,7 +3697,7 @@ export async function runEmbeddedAttempt(
               1,
               contextEngineAssemblePromptBudget - contextEngineAssembleRenderedPromptTokens,
             );
-            const assembled = await assembleAttemptContextEngine({
+            const contextEngineAssembly = assembleAttemptContextEngine({
               contextEngine: activeContextEngine,
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
@@ -3664,7 +3713,12 @@ export async function runEmbeddedAttempt(
               fallbackReason: params.fallbackReason,
               degradedReason: params.degradedReason,
               ...(params.prompt !== undefined ? { prompt: contextEngineAssemblePrompt } : {}),
+              abortSignal: runAbortController.signal,
             });
+            const assembled = await abortableWithSignal(
+              runAbortController.signal,
+              contextEngineAssembly,
+            );
             if (!assembled) {
               throw new Error("context engine assemble returned no result");
             }
@@ -3692,6 +3746,11 @@ export async function runEmbeddedAttempt(
               );
             }
           } catch (assembleErr) {
+            // Caller cancellation is terminal for the attempt, not an engine failure
+            // eligible for the normal pipeline-message fallback below.
+            if (runAbortController.signal.aborted) {
+              throw createAttemptAbortError(runAbortController.signal);
+            }
             log.warn(
               `context engine assemble failed, using pipeline messages: ${String(assembleErr)}`,
             );
@@ -3704,7 +3763,7 @@ export async function runEmbeddedAttempt(
           // PERF: If the run was aborted during the setup,
           // skip the idle wait and flush pending results synchronously so we can
           // immediately dispose the session without orphaning tool calls.
-          ...(params.abortSignal?.aborted ? { timeoutMs: 0 } : {}),
+          ...(runAbortController.signal.aborted ? { timeoutMs: 0 } : {}),
         });
         activeSession.dispose();
         throw err;
@@ -4101,7 +4160,7 @@ export async function runEmbeddedAttempt(
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
       let abortTimer: NodeJS.Timeout | undefined;
-      let runAbortDeadlineAtMs = Date.now() + params.timeoutMs;
+      let runAbortDeadlineAtMs = initialRunDeadlineAtMs;
       let compactionGraceUsed = false;
       const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
         runAbortDeadlineAtMs = Date.now() + Math.max(1, delayMs);
@@ -4158,36 +4217,12 @@ export async function runEmbeddedAttempt(
           Math.max(1, delayMs),
         );
       };
-      scheduleAbortTimer(params.timeoutMs, "initial");
-      params.onAttemptTimeoutArmed?.();
+      clearPreflightAbortTimer();
+      scheduleAbortTimer(Math.max(1, initialRunDeadlineAtMs - Date.now()), "initial");
 
       let messagesSnapshot: AgentMessage[] = [];
       let sessionIdUsed = activeSession.sessionId;
       let sessionFileUsed: string | undefined = params.sessionFile;
-      const onAbort = () => {
-        externalAbort = true;
-        const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
-        const timeout = reason ? isSignalTimeoutReason(reason) : false;
-        if (
-          shouldFlagCompactionTimeout({
-            isTimeout: timeout,
-            isCompactionPendingOrRetrying: subscription.isCompacting(),
-            isCompactionInFlight: activeSession.isCompacting,
-          })
-        ) {
-          timedOutDuringCompaction = true;
-        }
-        abortRun(timeout, reason);
-      };
-      if (params.abortSignal) {
-        if (params.abortSignal.aborted) {
-          onAbort();
-        } else {
-          params.abortSignal.addEventListener("abort", onAbort, {
-            once: true,
-          });
-        }
-      }
 
       const activeSessionManager = sessionManager;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
@@ -5772,7 +5807,6 @@ export async function runEmbeddedAttempt(
           params.sessionKey,
           params.sessionFile,
         );
-        params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
       const toolMetasNormalized = toolMetas
@@ -6286,6 +6320,7 @@ export async function runEmbeddedAttempt(
       }
     }
   } finally {
+    clearPreflightAbortTimer();
     removeExternalAbortSignalListener?.();
     if (!sessionCleanupOwnsEmbeddedResources) {
       try {

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -91,6 +91,7 @@ export async function bootstrapHarnessContextEngine(params: {
   maxOutputTokens?: number | null;
   fallbackReason?: string | null;
   degradedReason?: string | null;
+  abortSignal?: AbortSignal;
   runMaintenance?: typeof runHarnessContextEngineMaintenance;
   config?: SessionWriteLockAcquireTimeoutConfig;
   warn: (message: string) => void;
@@ -109,7 +110,13 @@ export async function bootstrapHarnessContextEngine(params: {
         sessionKey: params.sessionKey,
         sessionFile: params.sessionFile,
         runtimeSettings,
+        abortSignal: params.abortSignal,
       });
+    }
+    if (params.abortSignal?.aborted) {
+      throw params.abortSignal.reason instanceof Error
+        ? params.abortSignal.reason
+        : new Error("context engine bootstrap aborted");
     }
     await (params.runMaintenance ?? runHarnessContextEngineMaintenance)({
       contextEngine: params.contextEngine,
@@ -121,8 +128,12 @@ export async function bootstrapHarnessContextEngine(params: {
       runtimeContext: params.runtimeContext,
       runtimeSettings,
       config: params.config,
+      abortSignal: params.abortSignal,
     });
   } catch (bootstrapErr) {
+    if (params.abortSignal?.aborted) {
+      throw bootstrapErr;
+    }
     params.warn(`context engine bootstrap failed: ${String(bootstrapErr)}`);
   }
 }
@@ -150,6 +161,7 @@ export async function assembleHarnessContextEngine(params: {
   maxOutputTokens?: number | null;
   fallbackReason?: string | null;
   degradedReason?: string | null;
+  abortSignal?: AbortSignal;
 }) {
   if (!params.contextEngine) {
     return undefined;
@@ -165,6 +177,7 @@ export async function assembleHarnessContextEngine(params: {
     ...(params.citationsMode ? { citationsMode: params.citationsMode } : {}),
     model: params.modelId,
     runtimeSettings,
+    abortSignal: params.abortSignal,
     ...(params.prompt !== undefined ? { prompt: params.prompt } : {}),
   });
   return ensureAssembleResultShape(result, params.contextEngine.info.id);
@@ -381,6 +394,7 @@ export async function runHarnessContextEngineMaintenance(params: {
   executionMode?: "foreground" | "background";
   onDeferredMaintenance?: (promise: Promise<void>) => void;
   config?: SessionWriteLockAcquireTimeoutConfig;
+  abortSignal?: AbortSignal;
 }) {
   const runtimeSettings = buildHarnessContextEngineRuntimeSettings(params);
   return await runContextEngineMaintenance({
@@ -397,6 +411,7 @@ export async function runHarnessContextEngineMaintenance(params: {
     executionMode: params.executionMode,
     onDeferredMaintenance: params.onDeferredMaintenance,
     config: params.config,
+    abortSignal: params.abortSignal,
   });
 }
 

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -358,6 +358,8 @@ export interface ContextEngine {
     sessionKey?: string;
     sessionFile: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
+    /** Run-level cancellation; engines should stop session work before rejecting. */
+    abortSignal?: AbortSignal;
   }): Promise<BootstrapResult>;
 
   /**
@@ -372,6 +374,8 @@ export interface ContextEngine {
     sessionFile: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
     runtimeContext?: ContextEngineRuntimeContext;
+    /** Run-level cancellation for foreground maintenance. */
+    abortSignal?: AbortSignal;
   }): Promise<ContextEngineMaintenanceResult>;
 
   /**
@@ -438,6 +442,8 @@ export interface ContextEngine {
     /** The incoming user prompt for this turn (useful for retrieval-oriented engines). */
     prompt?: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
+    /** Run-level cancellation; engines should stop assembly work before rejecting. */
+    abortSignal?: AbortSignal;
   }): Promise<AssembleResult>;
 
   /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent run could remain stuck in Context Engine bootstrap, maintenance, session-lock acquisition, or assembly after the caller cancelled the run or its attempt deadline expired. In the embedded runner this could also consume the whole run budget before the active watchdog was armed.

## Why This Change Was Made

The embedded attempt now establishes one deadline before Context Engine preflight and carries the remaining budget into the active-run watchdog. The same run abort signal is passed through the public Context Engine bootstrap, maintenance, and assembly contracts, including the CLI and Codex harnesses. Abort is terminal instead of falling through to baseline context, and session-mutating bootstrap keeps the write lock until the engine has actually settled.

Assembly can be abandoned promptly by the host. Bootstrap and maintenance are deliberately cooperative: an engine must observe the new optional `abortSignal`, while OpenClaw keeps the write lock until an uncooperative operation really settles so late writes cannot escape lock ownership.

## User Impact

Cancelled or timed-out runs no longer continue into a model call after Context Engine preflight. Cooperative engines stop bootstrap and maintenance at the run boundary, pending assembly stops blocking the attempt, and the active model phase cannot receive a fresh timeout budget after slow preflight.

## Evidence

AI-assisted change. I reviewed the implementation, its lock/cancellation invariants, and the generated tests.

- Deterministic embedded-run regressions hold bootstrap, assembly, and initial session-lock acquisition pending, then trigger caller abort or the run deadline. They prove the attempt settles and that the write lock is not released before cooperative bootstrap settlement.
- CLI and Codex regressions hold Context Engine bootstrap pending, abort the run, and prove the CLI backend / Codex `thread/start` is never started.
- Direct dependency inspection: current sibling Codex handles model work only after `thread/start`; `turn/interrupt` targets startup or an existing turn. Context Engine projection happens before that protocol boundary, so OpenClaw must own preflight cancellation.

Commands run locally on the final branch head (Testbox unavailable for this contributor):

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/harness/context-engine-lifecycle.test.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts src/agents/cli-runner.context-engine.test.ts
# 5 files, 127 tests passed

node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts
# 1 file, 30 tests passed

node scripts/run-oxlint.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/run-attempt.ts src/agents/cli-runner.context-engine.test.ts src/agents/cli-runner.ts src/agents/embedded-agent-runner/context-engine-maintenance.ts src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/harness/context-engine-lifecycle.ts src/context-engine/types.ts
node_modules/.bin/oxfmt --check extensions/codex/src/app-server/run-attempt.context-engine.test.ts extensions/codex/src/app-server/run-attempt.ts src/agents/cli-runner.context-engine.test.ts src/agents/cli-runner.ts src/agents/embedded-agent-runner/context-engine-maintenance.ts src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/harness/context-engine-lifecycle.ts src/context-engine/types.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
# clean; patch is correct (0.82)
```

No Testbox, live provider call, or external Context Engine plugin was used. The focused tests exercise the real host lifecycle with deterministic cooperative test engines.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript: Context Engine preflight cancellation</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated turns omitted

[user excerpt]
[P1] Context Engine 预处理阶段完全不受 abort/timeout 控制

[assistant]
核心分支复核也抓到一个不完整点：Context Engine 的 assemble 已可中断，但更早的 bootstrap/maintenance 仍可能挂住并长期占有 session lock。我会把同一 run deadline/abort 边界覆盖到 bootstrap，并加入“挂起 bootstrap + 主动 abort/超时 + 锁释放”的确定性测试，避免只修半条链路。

[assistant]
Context 的 sibling 补齐后，核心 4 个测试文件共 126 项、Codex context-engine 测试 30 项都已通过；外部取消现在会在 CLI/Codex 启动模型进程或 thread/start 之前终止 pending bootstrap，Codex 的 assemble fallback 也不会再吞掉取消。

[tool summary]
Focused tests: 127 core/CLI assertions and 30 Codex assertions passed. The CI-discovered eager-lock signal ownership assertion was updated to verify relayed abort state and reason. Branch autoreview reported no actionable findings.
````

</details>
<!-- agent-transcript:end -->
