### PR TITLE
fix(tasks): deliver corrected terminal outcomes

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { registerActiveCronTaskRun, resetActiveCronTaskRunsForTests } from "./cron-task-cancel.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
@@ -2398,12 +2399,10 @@ describe("task-registry", () => {
 
       expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1);
       const message = sentMessageCall();
-      expectRecordFields(message, {
-        idempotencyKey: `task-terminal:${task.taskId}:succeeded:blocked`,
-      });
-      expectRecordFields(message.mirror, {
-        idempotencyKey: `task-terminal:${task.taskId}:succeeded:blocked`,
-      });
+      expect(message.idempotencyKey).toMatch(
+        new RegExp(`^task-terminal:${task.taskId}:succeeded:blocked:[0-9a-f]{16}$`),
+      );
+      expectRecordFields(message.mirror, { idempotencyKey: message.idempotencyKey });
       expectRecordFields(requireTaskByRunId("run-racing-delivery"), {
         deliveryStatus: "delivered",
       });
@@ -2440,6 +2439,255 @@ describe("task-registry", () => {
       releaseSend();
       await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       expectRecordFields(requireTaskByRunId("run-held-delivery"), {
+        deliveryStatus: "delivered",
+      });
+    });
+  });
+
+  it.each(["resolves", "rejects"] as const)(
+    "delivers a newer terminal outcome when the replaced send %s",
+    async (settlement) => {
+      await withTaskRegistryTempDir(async () => {
+        resetTaskRegistryMemoryForTest();
+        const firstSendPending = createDeferred();
+        hoisted.sendMessageMock
+          .mockImplementationOnce(async () => {
+            await firstSendPending.promise;
+            return {
+              channel: "notifychat",
+              to: "notifychat:123",
+              via: "direct",
+            };
+          })
+          .mockResolvedValue({
+            channel: "notifychat",
+            to: "notifychat:123",
+            via: "direct",
+          });
+
+        const task = createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          requesterOrigin: {
+            channel: "notifychat",
+            to: "notifychat:123",
+          },
+          childSessionKey: "agent:main:acp:terminal-replacement",
+          runId: "run-terminal-replacement",
+          task: "Resolve the terminal outcome",
+          status: "running",
+          deliveryStatus: "pending",
+        });
+
+        finalizeTaskRunByRunId({
+          runId: task.runId!,
+          runtime: "acp",
+          status: "succeeded",
+          endedAt: 200,
+          terminalOutcome: "blocked",
+          terminalSummary: "Waiting for external access.",
+        });
+        await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
+
+        finalizeTaskRunByRunId({
+          runId: task.runId!,
+          runtime: "acp",
+          status: "failed",
+          endedAt: 201,
+          error: "External access was denied.",
+          terminalOutcome: null,
+          terminalSummary: "The task cannot continue.",
+        });
+        if (settlement === "resolves") {
+          firstSendPending.resolve();
+        } else {
+          firstSendPending.reject(new Error("first terminal send failed"));
+        }
+
+        await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(2));
+        expect(sentMessageCall(0)).toMatchObject({
+          content:
+            "Background task blocked: ACP background task (run run-term). Waiting for external access.",
+        });
+        expect(sentMessageCall(1)).toMatchObject({
+          content:
+            "Background task failed: ACP background task (run run-term). External access was denied.",
+        });
+        expect(sentMessageCall(0).idempotencyKey).toMatch(
+          new RegExp(`^task-terminal:${task.taskId}:succeeded:blocked:[0-9a-f]{16}$`),
+        );
+        expect(sentMessageCall(1).idempotencyKey).toMatch(
+          new RegExp(`^task-terminal:${task.taskId}:failed:default:[0-9a-f]{16}$`),
+        );
+        expect(sentMessageCall(1).idempotencyKey).not.toBe(sentMessageCall(0).idempotencyKey);
+        expectRecordFields(requireTaskById(task.taskId), {
+          status: "failed",
+          deliveryStatus: "delivered",
+        });
+        expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      });
+    },
+  );
+
+  it("delivers a revised terminal payload with the same status and outcome", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      const firstSendPending = createDeferred();
+      hoisted.sendMessageMock
+        .mockImplementationOnce(async () => {
+          await firstSendPending.promise;
+          return {
+            channel: "notifychat",
+            to: "notifychat:123",
+            via: "direct",
+          };
+        })
+        .mockResolvedValue({
+          channel: "notifychat",
+          to: "notifychat:123",
+          via: "direct",
+        });
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        childSessionKey: "agent:main:acp:terminal-revision",
+        runId: "run-terminal-revision",
+        task: "Report the terminal result",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      finalizeTaskRunByRunId({
+        runId: task.runId!,
+        runtime: "acp",
+        status: "failed",
+        endedAt: 200,
+        error: "Initial failure detail.",
+      });
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
+
+      finalizeTaskRunByRunId({
+        runId: task.runId!,
+        runtime: "acp",
+        status: "failed",
+        endedAt: 201,
+        error: "Corrected failure detail.",
+      });
+      firstSendPending.resolve();
+
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(2));
+      expect(sentMessageCall(0).content).toContain("Initial failure detail.");
+      expect(sentMessageCall(1).content).toContain("Corrected failure detail.");
+      expect(sentMessageCall(1).idempotencyKey).not.toBe(sentMessageCall(0).idempotencyKey);
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "failed",
+        deliveryStatus: "delivered",
+      });
+    });
+  });
+
+  it("delivers a terminal correction after the previous payload was delivered", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "notifychat",
+        to: "notifychat:123",
+        via: "direct",
+      });
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        childSessionKey: "agent:main:acp:terminal-correction",
+        runId: "run-terminal-correction",
+        task: "Correct the terminal result",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      finalizeTaskRunByRunId({
+        runId: task.runId!,
+        runtime: "acp",
+        status: "succeeded",
+        endedAt: 200,
+        terminalOutcome: "blocked",
+        terminalSummary: "Waiting for access.",
+      });
+      await waitForAssertion(() =>
+        expect(requireTaskById(task.taskId).deliveryStatus).toBe("delivered"),
+      );
+
+      finalizeTaskRunByRunId({
+        runId: task.runId!,
+        runtime: "acp",
+        status: "failed",
+        endedAt: 201,
+        error: "Access was denied.",
+        terminalOutcome: null,
+      });
+
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(2));
+      expect(sentMessageCall(0).content).toContain("Waiting for access.");
+      expect(sentMessageCall(1).content).toContain("Access was denied.");
+      expect(sentMessageCall(1).idempotencyKey).not.toBe(sentMessageCall(0).idempotencyKey);
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "failed",
+        deliveryStatus: "delivered",
+      });
+    });
+  });
+
+  it("does not redeliver an unchanged terminal payload", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "notifychat",
+        to: "notifychat:123",
+        via: "direct",
+      });
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        childSessionKey: "agent:main:acp:terminal-duplicate",
+        runId: "run-terminal-duplicate",
+        task: "Report once",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const finalize = (endedAt: number) =>
+        finalizeTaskRunByRunId({
+          runId: task.runId!,
+          runtime: "acp",
+          status: "failed",
+          endedAt,
+          error: "Stable failure detail.",
+        });
+      finalize(200);
+      await waitForAssertion(() =>
+        expect(requireTaskById(task.taskId).deliveryStatus).toBe("delivered"),
+      );
+
+      finalize(201);
+
+      expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1);
+      expectRecordFields(requireTaskById(task.taskId), {
         deliveryStatus: "delivered",
       });
     });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1042,13 +1042,67 @@ function resolveTaskStateChangeIdempotencyKey(params: {
   return `task-event:${params.task.taskId}:${params.latestEvent.at}:${params.latestEvent.kind}`;
 }
 
-function resolveTaskTerminalIdempotencyKey(task: TaskRecord): string {
+type TaskTerminalDeliveryProjection = {
+  owner: TaskDeliveryOwner;
+  ownerSessionKey?: string;
+  shouldRouteParentReview: boolean;
+  shouldDeliverParentReviewDirect: boolean;
+  canDeliverDirect: boolean;
+  directEventText: string;
+  sessionEventText: string;
+  idempotencyKey: string;
+};
+
+function resolveTaskTerminalDeliveryProjection(task: TaskRecord): TaskTerminalDeliveryProjection {
   const owner = resolveTaskDeliveryOwner(task);
-  if (owner.flowId) {
-    const outcome = task.status === "succeeded" ? (task.terminalOutcome ?? "default") : "default";
-    return `flow-terminal:${owner.flowId}:${task.taskId}:${task.status}:${outcome}`;
-  }
-  return taskTerminalDeliveryIdempotencyKey(task);
+  const ownerSessionKey = owner.sessionKey?.trim() || undefined;
+  const shouldRouteParentReview = shouldUseParentReviewTaskTerminalMessage(task);
+  const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToBoundDiscordThread(task);
+  const canDeliverDirect = canDeliverTaskToRequesterOrigin(task) || shouldDeliverParentReviewDirect;
+  const directEventText = formatTaskTerminalMessage(task);
+  const sessionEventText = formatTaskTerminalMessage(
+    task,
+    shouldRouteParentReview ? { surface: "parent_session" } : undefined,
+  );
+  const directContent = shouldDeliverParentReviewDirect ? sessionEventText : directEventText;
+  const origin = owner.requesterOrigin;
+  const payloadHash = crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify([
+        owner.sessionKey ?? null,
+        origin?.channel ?? null,
+        origin?.to ?? null,
+        origin?.accountId ?? null,
+        origin?.threadId ?? null,
+        directContent,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 16);
+  const idempotencyKey = owner.flowId
+    ? `flow-terminal:${owner.flowId}:${task.taskId}:${task.status}:${task.status === "succeeded" ? (task.terminalOutcome ?? "default") : "default"}:${payloadHash}`
+    : `${taskTerminalDeliveryIdempotencyKey(task)}:${payloadHash}`;
+  return {
+    owner,
+    ownerSessionKey,
+    shouldRouteParentReview,
+    shouldDeliverParentReviewDirect,
+    canDeliverDirect,
+    directEventText,
+    sessionEventText,
+    idempotencyKey,
+  };
+}
+
+function resolveTaskTerminalIdempotencyKey(task: TaskRecord): string {
+  return resolveTaskTerminalDeliveryProjection(task).idempotencyKey;
+}
+
+function isSameTaskTerminalDeliveryGeneration(task: TaskRecord, idempotencyKey: string): boolean {
+  // The key fingerprints destination and rendered payload. A revised terminal
+  // projection must get its own send before it can be marked delivered.
+  return resolveTaskTerminalIdempotencyKey(task) === idempotencyKey;
 }
 
 function getLinkedFlowForDelivery(task: TaskRecord) {
@@ -1458,6 +1512,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
     return cloneTaskRecord(current);
   }
   tasksWithPendingDelivery.add(taskId);
+  let retrySupersededTerminalDelivery = false;
   try {
     const latest = tasks.get(taskId);
     if (!latest || !shouldAutoDeliverTaskTerminalUpdate(latest)) {
@@ -1490,23 +1545,23 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
         lastEventAt: Date.now(),
       });
     }
-    const owner = resolveTaskDeliveryOwner(latest);
-    const ownerSessionKey = owner.sessionKey?.trim();
+    const delivery = resolveTaskTerminalDeliveryProjection(latest);
+    const {
+      owner,
+      ownerSessionKey,
+      shouldRouteParentReview,
+      shouldDeliverParentReviewDirect,
+      canDeliverDirect,
+      directEventText,
+      sessionEventText,
+      idempotencyKey: terminalDeliveryIdempotencyKey,
+    } = delivery;
     if (!ownerSessionKey) {
       return updateTask(taskId, {
         deliveryStatus: resolveMissingOwnerDeliveryStatus(latest),
         lastEventAt: Date.now(),
       });
     }
-    const shouldRouteParentReview = shouldUseParentReviewTaskTerminalMessage(latest);
-    const shouldDeliverParentReviewDirect = canDeliverParentReviewTaskToBoundDiscordThread(latest);
-    const canDeliverDirect =
-      canDeliverTaskToRequesterOrigin(latest) || shouldDeliverParentReviewDirect;
-    const directEventText = formatTaskTerminalMessage(latest);
-    const sessionEventText = formatTaskTerminalMessage(
-      latest,
-      shouldRouteParentReview ? { surface: "parent_session" } : undefined,
-    );
     if ((shouldRouteParentReview && !shouldDeliverParentReviewDirect) || !canDeliverDirect) {
       try {
         queueTaskSystemEvent(latest, sessionEventText);
@@ -1536,8 +1591,11 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       if (!beforeSend || !shouldAutoDeliverTaskTerminalUpdate(beforeSend)) {
         return beforeSend ? cloneTaskRecord(beforeSend) : null;
       }
+      if (!isSameTaskTerminalDeliveryGeneration(beforeSend, terminalDeliveryIdempotencyKey)) {
+        retrySupersededTerminalDelivery = true;
+        return cloneTaskRecord(beforeSend);
+      }
       const requesterAgentId = parseAgentSessionKey(ownerSessionKey)?.agentId;
-      const idempotencyKey = resolveTaskTerminalIdempotencyKey(latest);
       await sendMessage({
         channel: owner.requesterOrigin?.channel,
         to: owner.requesterOrigin?.to ?? "",
@@ -1545,16 +1603,20 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
         threadId: owner.requesterOrigin?.threadId,
         content: shouldDeliverParentReviewDirect ? sessionEventText : directEventText,
         agentId: requesterAgentId,
-        idempotencyKey,
+        idempotencyKey: terminalDeliveryIdempotencyKey,
         mirror: {
           sessionKey: ownerSessionKey,
           agentId: requesterAgentId,
-          idempotencyKey,
+          idempotencyKey: terminalDeliveryIdempotencyKey,
         },
       });
       const afterSend = tasks.get(taskId);
       if (!afterSend || !shouldAutoDeliverTaskTerminalUpdate(afterSend)) {
         return afterSend ? cloneTaskRecord(afterSend) : null;
+      }
+      if (!isSameTaskTerminalDeliveryGeneration(afterSend, terminalDeliveryIdempotencyKey)) {
+        retrySupersededTerminalDelivery = true;
+        return cloneTaskRecord(afterSend);
       }
       if (afterSend.terminalOutcome === "blocked") {
         queueBlockedTaskFollowup(afterSend);
@@ -1573,6 +1635,10 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
       const beforeFallback = tasks.get(taskId);
       if (!beforeFallback || !shouldAutoDeliverTaskTerminalUpdate(beforeFallback)) {
         return beforeFallback ? cloneTaskRecord(beforeFallback) : null;
+      }
+      if (!isSameTaskTerminalDeliveryGeneration(beforeFallback, terminalDeliveryIdempotencyKey)) {
+        retrySupersededTerminalDelivery = true;
+        return cloneTaskRecord(beforeFallback);
       }
       try {
         queueTaskSystemEvent(beforeFallback, sessionEventText);
@@ -1593,6 +1659,9 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
     }
   } finally {
     tasksWithPendingDelivery.delete(taskId);
+    if (retrySupersededTerminalDelivery) {
+      void maybeDeliverTaskTerminalUpdate(taskId);
+    }
   }
 }
 
@@ -2075,6 +2144,25 @@ function updateTaskStateByRunId(params: {
       // Teardown suppression must survive redundant lifecycle finalizers that
       // arrive after queues are cleared, or they can repopulate the stopped session.
       patch.deliveryStatus = "not_applicable";
+    }
+    if (!params.suppressDelivery && current.deliveryStatus === "delivered") {
+      const pendingCorrection = {
+        ...current,
+        ...patch,
+        deliveryStatus: "pending" as const,
+      };
+      if (Object.hasOwn(patch, "error") && patch.error === undefined) {
+        delete pendingCorrection.error;
+      }
+      if (
+        shouldAutoDeliverTaskTerminalUpdate(pendingCorrection) &&
+        resolveTaskTerminalIdempotencyKey(current) !==
+          resolveTaskTerminalIdempotencyKey(pendingCorrection)
+      ) {
+        // This mutation path always schedules terminal delivery below, so a
+        // corrected user-visible projection can safely re-arm after an older send.
+        patch.deliveryStatus = "pending";
+      }
     }
     const eventSummary =
       normalizeTaskSummary(params.eventSummary) ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an older terminal notification could finish sending after a task had acquired a newer terminal outcome and then mark that newer outcome as already delivered. Users could receive the stale success/cancellation message while the corrected failure or summary was permanently suppressed.

## Why This Change Was Made

Terminal delivery now uses one canonical projection containing the owner, route, rendered payload, delivery capability, and an idempotency key fingerprinted from the actual destination and content. The registry revalidates that projection before sending, after a successful send, and before fallback. If a newer generation replaces an in-flight notification, the old completion cannot mutate the new delivery state and the newer notifier is scheduled immediately.

## User Impact

When a task's terminal status, error, summary, or destination changes during delivery, users receive the corrected terminal notification. Repeating an identical terminal projection remains idempotent and does not resend.

## Evidence

AI-assisted change. I reviewed the state-machine transitions and test scenarios.

Focused regressions cover:

- an old send resolving after `succeeded` / `blocked` becomes `failed`;
- an old send rejecting after the terminal generation changes;
- same status/outcome with changed error or summary while the first send is pending;
- a correction after the old payload was already delivered;
- an identical terminal repeat remaining single-delivery.

Commands run locally on the final branch head (Testbox unavailable for this contributor):

```text
node scripts/run-vitest.mjs src/tasks/task-registry.test.ts
# 1 file, 114 tests passed

node scripts/run-oxlint.mjs src/tasks/task-registry.ts src/tasks/task-registry.test.ts
node_modules/.bin/oxfmt --check src/tasks/task-registry.ts src/tasks/task-registry.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

The tests use controlled in-flight delivery promises, so they reproduce the real ordering race without relying on timing sleeps.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript: terminal delivery generation</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated turns omitted

[user excerpt]
[P1] 旧 terminal 通知发送完成后，会把较新的 terminal outcome 错标为已送达

[assistant]
我已经确认到一个比较典型的“源码看起来有防重，但状态变化时仍会错”的任务生命周期竞态：发送终态通知期间，任务可以从临时取消态变成真实成功态，旧发送完成后却会把新终态直接标成已通知。

[assistant]
Gateway 与 terminal 两个分支的 autoreview 已 clean。

[tool summary]
The final regression suite passed 114 task-registry tests, including old-send resolve/reject races, corrected payload delivery, and identical-repeat idempotency.
````

</details>
<!-- agent-transcript:end -->
