### PR TITLE
fix(gateway): avoid stealing live startup locks

### DIFF
--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -248,9 +248,10 @@ describe("gateway lock", () => {
           readProcessCmdline: () => ["openclaw-gateway"],
         }),
       ).rejects.toBeInstanceOf(GatewayLockError);
-      expect(connectSpy).toHaveBeenCalled();
+      expect(connectSpy).not.toHaveBeenCalled();
     } finally {
       await lock.release();
+      connectSpy.mockRestore();
     }
   });
 
@@ -328,21 +329,99 @@ describe("gateway lock", () => {
     statSpy.mockRestore();
   });
 
-  it("treats lock as stale when owner pid is alive but configured port is free", async () => {
-    vi.useRealTimers();
+  it("keeps a stale startup lock while its verified owner has not bound the port", async () => {
     const env = await makeEnv();
-    await writeRecentLockFile(env);
+    let now = Date.parse("2026-07-11T00:00:00.000Z");
+    const { lockPath } = await writeLockFile(env, {
+      startTime: 111,
+      createdAt: new Date(now - 10_001).toISOString(),
+    });
+    await fs.utimes(lockPath, new Date(now - 10_001), new Date(now - 10_001));
     const connectSpy = createPortProbeConnectionSpy("refused");
 
-    const lock = await acquireForTest(env, {
-      timeoutMs: 80,
-      pollIntervalMs: 5,
+    const result = await acquireForTest(env, {
+      timeoutMs: 5,
+      pollIntervalMs: 2,
       staleMs: 10_000,
       platform: "darwin",
       port: 18789,
+      now: () => now,
+      sleep: async (ms) => {
+        now += ms;
+      },
+      readProcessCmdline: () => ["/usr/local/bin/openclaw", "gateway", "run"],
+    }).then(
+      (lock) => ({ lock, error: null }),
+      (error: unknown) => ({ lock: null, error }),
+    );
+
+    try {
+      expect(result.error).toBeInstanceOf(GatewayLockError);
+      expect(connectSpy).not.toHaveBeenCalled();
+    } finally {
+      await result.lock?.release();
+      connectSpy.mockRestore();
+    }
+  });
+
+  it("reclaims a stale lock when owner identity is unknown and the port is free", async () => {
+    const env = await makeEnv();
+    const now = Date.parse("2026-07-11T00:00:00.000Z");
+    const { lockPath, configPath } = resolveLockPath(env);
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date(now - 10_001).toISOString(),
+        configPath,
+      }),
+      "utf8",
+    );
+    const connectSpy = createPortProbeConnectionSpy("refused");
+
+    try {
+      const lock = await acquireForTest(env, {
+        timeoutMs: 80,
+        pollIntervalMs: 5,
+        staleMs: 10_000,
+        platform: "linux",
+        port: 18789,
+        now: () => now,
+        sleep: async () => {},
+        readProcessCmdline: () => null,
+      });
+      expect(connectSpy).toHaveBeenCalled();
+      await expectGatewayLock(lock).release();
+    } finally {
+      connectSpy.mockRestore();
+    }
+  });
+
+  it("reclaims a stale darwin lock when cmdline is unavailable and the port is free", async () => {
+    const env = await makeEnv();
+    const now = Date.parse("2026-07-11T00:00:00.000Z");
+    await writeLockFile(env, {
+      startTime: 111,
+      createdAt: new Date(now - 10_001).toISOString(),
     });
-    await expectGatewayLock(lock).release();
-    connectSpy.mockRestore();
+    const connectSpy = createPortProbeConnectionSpy("refused");
+
+    try {
+      const lock = await acquireForTest(env, {
+        timeoutMs: 80,
+        pollIntervalMs: 5,
+        staleMs: 10_000,
+        platform: "darwin",
+        port: 18789,
+        now: () => now,
+        sleep: async () => {},
+        readProcessCmdline: () => null,
+      });
+      expect(connectSpy).toHaveBeenCalled();
+      await expectGatewayLock(lock).release();
+    } finally {
+      connectSpy.mockRestore();
+    }
   });
 
   it("keeps lock when configured port is busy and owner pid is alive", async () => {
@@ -476,6 +555,35 @@ describe("gateway lock", () => {
     await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
 
     openSpy.mockRestore();
+  });
+
+  it("leaves a successor lock intact when an old handle releases", async () => {
+    const env = await makeEnv();
+    const lock = expectGatewayLock(await acquireForTest(env));
+    const successorOwnerId = "00000000-0000-4000-8000-000000000001";
+
+    try {
+      const firstPayload = JSON.parse(await fs.readFile(lock.lockPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      await fs.rm(lock.lockPath);
+      await fs.writeFile(
+        lock.lockPath,
+        JSON.stringify({ ...firstPayload, ownerId: successorOwnerId }),
+        { encoding: "utf8", flag: "wx" },
+      );
+
+      await lock.release();
+
+      const successorPayload = JSON.parse(await fs.readFile(lock.lockPath, "utf8")) as {
+        ownerId?: string;
+      };
+      expect(successorPayload.ownerId).toBe(successorOwnerId);
+    } finally {
+      await lock.release();
+      await fs.rm(lock.lockPath, { force: true });
+    }
   });
 
   it("clears stale lock on win32 when process cmdline is not a gateway", async () => {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -1,5 +1,6 @@
 // Coordinates gateway lock files, ports, and stale owner detection.
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -23,6 +24,7 @@ const DEFAULT_STALE_MS = 30_000;
 const DEFAULT_PORT_PROBE_TIMEOUT_MS = 1000;
 
 type LockPayload = {
+  ownerId?: string;
   pid: number;
   createdAt: string;
   configPath: string;
@@ -31,6 +33,7 @@ type LockPayload = {
 };
 
 const LockPayloadSchema = z.object({
+  ownerId: z.string().uuid().optional(),
   pid: z.number(),
   createdAt: z.string(),
   configPath: z.string(),
@@ -176,17 +179,11 @@ async function resolveGatewayOwnerStatus(
   readCmdline?: (pid: number) => string[] | null,
   opts: { trustUnknownCmdlineOwner?: boolean } = {},
 ): Promise<LockOwnerStatus> {
-  if (port != null) {
-    const portFree = await checkPortFree(port);
-    if (portFree) {
-      return "dead";
-    }
-  }
-
   if (!isPidAlive(pid)) {
     return "dead";
   }
 
+  let ownerStatus: LockOwnerStatus;
   // On Linux, an extra start-time comparison catches PID recycling even when
   // the replacement process also looks like a gateway (same argv shape).
   if (platform === "linux") {
@@ -196,22 +193,39 @@ async function resolveGatewayOwnerStatus(
       if (currentStartTime == null) {
         return "unknown";
       }
-      return currentStartTime === payloadStartTime ? "alive" : "dead";
+      ownerStatus = currentStartTime === payloadStartTime ? "alive" : "dead";
+    } else {
+      ownerStatus = "unknown";
+    }
+  } else {
+    ownerStatus = "unknown";
+  }
+
+  if (ownerStatus === "unknown") {
+    const readFn = readCmdline ?? ((p: number) => defaultReadProcessCmdline(p, platform));
+    const args = readFn(pid);
+    if (!args) {
+      // Cmdline reader unavailable or failed. On Linux legacy locks (no
+      // start-time), "unknown" lets the stale-lock heuristic eventually reclaim
+      // very old locks. A configured port supplies the same conservative fallback
+      // on other platforms: busy means alive, free remains unknown until stale.
+      ownerStatus =
+        platform === "linux" || opts.trustUnknownCmdlineOwner === false || port != null
+          ? "unknown"
+          : "alive";
+    } else {
+      // Long-running gateways retitle themselves so macOS/BSD process inspection
+      // can identify the owner after the original argv is no longer available.
+      ownerStatus = isGatewayArgv(args, { allowGatewayBinary: true }) ? "alive" : "dead";
     }
   }
 
-  const readFn = readCmdline ?? ((p: number) => defaultReadProcessCmdline(p, platform));
-  const args = readFn(pid);
-  if (!args) {
-    // Cmdline reader unavailable or failed. On Linux legacy locks (no
-    // start-time), "unknown" lets the stale-lock heuristic eventually reclaim
-    // very old locks. On win32/darwin/other, conservatively assume "alive" to
-    // preserve single-instance guarantees when wmic/ps is unavailable.
-    return platform === "linux" || opts.trustUnknownCmdlineOwner === false ? "unknown" : "alive";
+  if (ownerStatus !== "unknown" || port == null) {
+    return ownerStatus;
   }
-  // Long-running gateways retitle themselves so macOS/BSD process inspection
-  // can identify the owner after the original argv is no longer available.
-  return isGatewayArgv(args, { allowGatewayBinary: true }) ? "alive" : "dead";
+  // A busy configured port is conservative evidence for an owner whose process
+  // identity cannot be read. A free port never overrides a verified live owner.
+  return (await checkPortFree(port)) ? "unknown" : "alive";
 }
 
 async function readLockPayload(lockPath: string): Promise<LockPayload | null> {
@@ -287,9 +301,11 @@ export async function acquireGatewayLock(
   while (now() - startedAt < timeoutMs) {
     try {
       const handle = await fs.open(lockPath, "wx");
+      const ownerId = randomUUID();
       try {
         const startTime = platform === "linux" ? readLinuxStartTime(process.pid) : null;
         const payload: LockPayload = {
+          ownerId,
           pid: process.pid,
           createdAt: resolveTimestampMsToIsoString(now()),
           configPath,
@@ -313,6 +329,11 @@ export async function acquireGatewayLock(
         configPath,
         release: async () => {
           await handle.close().catch(() => undefined);
+          const currentPayload = await readLockPayload(lockPath);
+          // A stale handle must not unlink a successor that reclaimed the same path.
+          if (currentPayload?.ownerId !== ownerId) {
+            return;
+          }
           await fs.rm(lockPath, { force: true });
         },
       };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a second Gateway startup could treat a verified live lock owner as dead merely because that owner had not begun listening on the configured port yet. After the stale-age threshold, the second process could unlink the first process's startup lock and allow overlapping Gateway initialization.

## Why This Change Was Made

Lock ownership is now decided from PID identity, process start time, and command line before port state. A verified live owner cannot be downgraded by a temporarily free port. For owners whose identity cannot be verified, a busy port remains conservative evidence of liveness while a stale lock plus a free configured port remains recoverable. Each new lock also carries an ownership token, and release removes the file only when the token still matches, preventing an old handle from unlinking a successor lock.

Legacy lock payloads remain readable; no config or protocol surface changes.

## User Impact

Concurrent Gateway starts no longer steal the lock from a healthy process during its pre-listen startup window. Truly stale unverifiable locks can still recover, including on platforms where command-line inspection is unavailable.

## Evidence

AI-assisted change. I reviewed the cross-platform identity and release-fencing behavior.

Focused regressions cover:

- a stale-aged, verified live owner while the configured port is still free;
- stale legacy / unverifiable Linux locks with a free port;
- macOS command-line lookup unavailable with stale/free-port recovery;
- an old lock handle attempting to release a successor's lock.

Commands run locally on the final branch head (Testbox unavailable for this contributor):

```text
node scripts/run-vitest.mjs src/infra/gateway-lock.test.ts
# 1 file, 23 tests passed

node scripts/run-oxlint.mjs src/infra/gateway-lock.ts src/infra/gateway-lock.test.ts
node_modules/.bin/oxfmt --check src/infra/gateway-lock.ts src/infra/gateway-lock.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

The unit tests drive the real lock acquisition/release code with controlled process and port probes. No live multi-process Gateway scenario or Testbox run was available.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript: Gateway startup lock ownership</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated turns omitted

[user excerpt]
[P1] Gateway 启动锁把“尚未开始监听”误判为 owner 已死亡

[assistant]
首轮 autoreview 对 Gateway 锁提出了一个有效回归：macOS/Windows 无法读取 cmdline 时，当前代码会直接把 owner 当 alive，导致“PID 已复用 + 锁已陈旧 + 端口空闲”永远不能回收。我会把这种情况保留为 unknown（仅在有端口证据时），让“已验证 owner 永不被端口降级”和“无法验证的陈旧锁仍可恢复”同时成立。

[tool summary]
The final suite passed 23 lock tests, including verified pre-listen ownership, stale unknown-owner recovery, and successor-token release fencing. Branch autoreview reported no actionable findings.
````

</details>
<!-- agent-transcript:end -->
