### PR TITLE
fix(android): return timed-out node invokes promptly

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -435,7 +435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1303,
+      "line": 1327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -443,7 +443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1303,
+      "line": 1327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
@@ -1216,16 +1217,39 @@ class GatewaySession(
           ?: payload["params"]?.let { value -> if (value is JsonNull) null else value.toString() }
       val timeoutMs = payload["timeoutMs"].asLongOrNull()
       connectionScope.launch {
-        val result =
-          try {
-            onInvoke?.invoke(InvokeRequest(id, nodeId, command, params, timeoutMs))
-              ?: InvokeResult.error("UNAVAILABLE", "invoke handler missing")
-          } catch (err: CancellationException) {
-            throw err
-          } catch (err: Throwable) {
-            invokeErrorFromThrowable(err)
-          }
+        val request = InvokeRequest(id, nodeId, command, params, timeoutMs)
+        val result = executeInvokeRequest(request)
         sendInvokeResult(id, nodeId, result, timeoutMs)
+      }
+    }
+
+    private suspend fun executeInvokeRequest(request: InvokeRequest): InvokeResult {
+      val handler = onInvoke ?: return InvokeResult.error("UNAVAILABLE", "invoke handler missing")
+      return try {
+        val timeoutMs = resolveInvokeExecutionTimeoutMs(request.timeoutMs)
+        if (timeoutMs == null) {
+          handler(request)
+        } else {
+          // Keep the deadline owner separate so a blocking handler cannot delay the timeout result.
+          // Cancellation still reaches cooperative handlers; late results are never sent.
+          val handlerTask = connectionScope.async { handler(request) }
+          try {
+            withTimeoutOrNull(timeoutMs) { handlerTask.await() }
+              ?: run {
+                handlerTask.cancel(CancellationException("node invoke timed out"))
+                InvokeResult.error("TIMEOUT", "node invoke timed out")
+              }
+          } catch (err: CancellationException) {
+            handlerTask.cancel(err)
+            throw err
+          }
+        }
+      } catch (err: TimeoutCancellationException) {
+        InvokeResult.error("TIMEOUT", err.message ?: "node invoke timed out")
+      } catch (err: CancellationException) {
+        throw err
+      } catch (err: Throwable) {
+        invokeErrorFromThrowable(err)
       }
     }
 
@@ -1687,4 +1711,11 @@ private fun parseJsonOrNull(payload: String): JsonElement? {
 internal fun resolveInvokeResultAckTimeoutMs(invokeTimeoutMs: Long?): Long {
   val normalized = invokeTimeoutMs?.takeIf { it > 0L } ?: 15_000L
   return normalized.coerceIn(15_000L, 120_000L)
+}
+
+/** Zero disables the deadline; an omitted value uses the same 30s default as Gateway/iOS. */
+internal fun resolveInvokeExecutionTimeoutMs(invokeTimeoutMs: Long?): Long? {
+  val normalized = invokeTimeoutMs ?: 30_000L
+  if (normalized <= 0L) return null
+  return normalized.coerceAtMost(Int.MAX_VALUE.toLong())
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -34,6 +35,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
@@ -817,6 +820,116 @@ class GatewaySessionInvokeTest {
     }
 
   @Test
+  fun nodeInvokeRequest_cancelsHandlerWhenExecutionTimeoutExpires() =
+    runBlocking {
+      val handlerCancelled = CompletableDeferred<Unit>()
+      val result =
+        runInvokeScenario(
+          invokeEventFrame =
+            """{"type":"event","event":"node.invoke.request","payload":{"id":"invoke-timeout","nodeId":"node-1","command":"camera.clip","timeoutMs":100}}""",
+        ) {
+          try {
+            awaitCancellation()
+          } finally {
+            handlerCancelled.complete(Unit)
+          }
+        }
+
+      withTimeout(TEST_TIMEOUT_MS) { handlerCancelled.await() }
+      assertEquals(
+        false,
+        result.resultParams["ok"]
+          ?.jsonPrimitive
+          ?.content
+          ?.toBooleanStrict(),
+      )
+      assertEquals(
+        "TIMEOUT",
+        result.resultParams["error"]
+          ?.jsonObject
+          ?.get("code")
+          ?.jsonPrimitive
+          ?.content,
+      )
+      assertEquals(
+        "node invoke timed out",
+        result.resultParams["error"]
+          ?.jsonObject
+          ?.get("message")
+          ?.jsonPrimitive
+          ?.content,
+      )
+    }
+
+  @Test
+  fun nodeInvokeRequest_sendsResultForHandlerOwnedTimeout() =
+    runBlocking {
+      val result =
+        runInvokeScenario(
+          invokeEventFrame =
+            """{"type":"event","event":"node.invoke.request","payload":{"id":"handler-timeout","nodeId":"node-1","command":"camera.snap","timeoutMs":5000}}""",
+        ) {
+          withTimeout(10) { awaitCancellation() }
+        }
+
+      assertEquals(
+        false,
+        result.resultParams["ok"]
+          ?.jsonPrimitive
+          ?.content
+          ?.toBooleanStrict(),
+      )
+      assertEquals(
+        "TIMEOUT",
+        result.resultParams["error"]
+          ?.jsonObject
+          ?.get("code")
+          ?.jsonPrimitive
+          ?.content,
+      )
+    }
+
+  @Test
+  fun nodeInvokeRequest_sendsTimeoutWhileBlockingHandlerIsStillRunning() =
+    runBlocking {
+      val releaseHandler = CountDownLatch(1)
+      val handlerFinished = CompletableDeferred<Unit>()
+      val result =
+        runInvokeScenario(
+          invokeEventFrame =
+            """{"type":"event","event":"node.invoke.request","payload":{"id":"blocking-timeout","nodeId":"node-1","command":"camera.clip","timeoutMs":100}}""",
+          afterResult = {
+            assertFalse(handlerFinished.isCompleted)
+            releaseHandler.countDown()
+            withTimeout(TEST_TIMEOUT_MS) { handlerFinished.await() }
+          },
+        ) {
+          try {
+            check(releaseHandler.await(5, TimeUnit.SECONDS)) { "blocking handler was not released" }
+            GatewaySession.InvokeResult.ok(null)
+          } finally {
+            handlerFinished.complete(Unit)
+          }
+        }
+
+      assertEquals(
+        false,
+        result.resultParams["ok"]
+          ?.jsonPrimitive
+          ?.content
+          ?.toBooleanStrict(),
+      )
+      assertEquals(
+        "TIMEOUT",
+        result.resultParams["error"]
+          ?.jsonObject
+          ?.get("code")
+          ?.jsonPrimitive
+          ?.content,
+      )
+    }
+
+  @Test
   fun nodeInvokeRequest_doesNotSendResultAfterCancellation() =
     runBlocking {
       val json = testJson()
@@ -1046,7 +1159,7 @@ class GatewaySessionInvokeTest {
     connected: CompletableDeferred<Unit>,
     lastDisconnect: AtomicReference<String>,
     onEvent: (event: String, payloadJson: String?) -> Unit = { _, _ -> },
-    onInvoke: (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
+    onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
   ): NodeHarness {
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
@@ -1141,7 +1254,8 @@ class GatewaySessionInvokeTest {
   private suspend fun runInvokeScenario(
     invokeEventFrame: String,
     onHandshake: ((RecordedRequest) -> Unit)? = null,
-    onInvoke: (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
+    afterResult: suspend (InvokeScenarioResult) -> Unit = {},
+    onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
   ): InvokeScenarioResult {
     val json = testJson()
     val connected = CompletableDeferred<Unit>()
@@ -1182,7 +1296,9 @@ class GatewaySessionInvokeTest {
       val request = withTimeout(TEST_TIMEOUT_MS) { invokeRequest.await() }
       val resultParamsJson = withTimeout(TEST_TIMEOUT_MS) { invokeResultParams.await() }
       val resultParams = json.parseToJsonElement(resultParamsJson).jsonObject
-      return InvokeScenarioResult(request = request, resultParams = resultParams)
+      val result = InvokeScenarioResult(request = request, resultParams = resultParams)
+      afterResult(result)
+      return result
     } finally {
       shutdownHarness(harness, server)
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTimeoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTimeoutTest.kt
@@ -39,4 +39,16 @@ class GatewaySessionInvokeTimeoutTest {
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(121_000L))
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(Long.MAX_VALUE))
   }
+
+  @Test
+  fun resolveInvokeExecutionTimeoutMs_defaultsAndAllowsExplicitDisable() {
+    assertEquals(30_000L, resolveInvokeExecutionTimeoutMs(null))
+    assertEquals(null, resolveInvokeExecutionTimeoutMs(0L))
+    assertEquals(null, resolveInvokeExecutionTimeoutMs(-1L))
+  }
+
+  @Test
+  fun resolveInvokeExecutionTimeoutMs_capsAtCoroutineTimerBound() {
+    assertEquals(Int.MAX_VALUE.toLong(), resolveInvokeExecutionTimeoutMs(Long.MAX_VALUE))
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android accepted `node.invoke.request.timeoutMs` but did not enforce it while running the node handler. A slow or blocked command could outlive the Gateway deadline, continue holding resources, and delay any `node.invoke.result` indefinitely.

## Why This Change Was Made

Android now normalizes the execution deadline consistently with Gateway/iOS semantics: an omitted value uses 30 seconds, a non-positive value disables the execution deadline, and oversized values are safely capped. Timed handlers run in a connection-owned sibling task so even a synchronously blocking handler cannot stop the deadline owner from sending a structured `TIMEOUT` result. The sibling is cancelled at expiry; cooperative handlers receive cancellation, and late results are discarded.

Handler-owned `TimeoutCancellationException` is mapped to `TIMEOUT`, while ordinary connection/task cancellation still propagates and does not emit a stale result.

## User Impact

Gateway callers receive a timely `TIMEOUT` result for expired Android node commands, including when a handler blocks synchronously. Cooperative camera/media handlers are cancelled and run their existing cleanup paths.

Android cannot roll back a side effect already synchronously committed to the platform or forcibly terminate a non-cooperative blocking Java/Android call. In that case this change guarantees the timeout response, requests cancellation, and ignores the late result; it does not claim transactional rollback.

## Evidence

AI-assisted change. I reviewed the coroutine ownership and the non-cooperative boundary.

The blocking-handler regression uses a latch and proves the real `node.invoke.result` with code `TIMEOUT` is observed before the handler is released. Additional coverage verifies cooperative cancellation, nested handler timeouts, normal cancellation, disabled/default/oversized timeout normalization, and no late result.

Final local verification used both Android product flavors and forced task re-execution (Testbox unavailable for this contributor):

```text
apps/android/gradlew -p apps/android --no-daemon --rerun-tasks \
  :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest \
  --tests ai.openclaw.app.gateway.GatewaySessionInvokeTimeoutTest \
  --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest \
  :app:runKtlintCheckOverMainSourceSet :app:runKtlintCheckOverTestSourceSet
# Play: 30 passed (22 + 8)
# ThirdParty: 30 passed (22 + 8)
# failures/errors/skipped: 0

git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
# clean; patch is correct (0.83)
```

The repository native-i18n generator was also run and this PR commits the two Android inventory line shifts caused by the handler extraction. The current base independently has two uncommitted `MenuBar.swift` inventory line shifts (`321 -> 322`); a non-Android branch reproduces that same remaining `native:i18n:check` failure, so this PR does not duplicate the unrelated macOS baseline update.

No physical-device or live Gateway test was run. Existing manifest-merge warnings were non-failing and unrelated.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript: Android node invoke deadlines</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated turns omitted

[user excerpt]
[P1] Android 不执行 node.invoke.request.timeoutMs，超时后副作用仍继续

[assistant]
Android invoke 超时分支的独立复核刚发现一个真实边界：handler 自己抛出的 TimeoutCancellationException 会被误当成外部取消并逃逸，导致不回 node.invoke.result。我会先补这个回归测试并区分“handler 内部超时”和“连接/任务取消”。

[assistant]
Post-rebase Android invoke 的 fresh review 提出一个更严格但合理的边界：同协程 withTimeoutOrNull 无法按时返回被同步平台调用阻塞的 handler。我会把 timed handler 放到 connection-owned sibling task 中，deadline 到达时先发结构化 TIMEOUT 并取消该 task；新增阻塞 handler 测试证明 TIMEOUT 在 handler 释放前已发送。

[tool summary]
Play and ThirdParty each passed 30 focused tests with zero failures/errors/skips. Branch autoreview reported no actionable findings.
````

</details>
<!-- agent-transcript:end -->
