### PR TITLE
fix(android): restore sticky node service

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -179,7 +179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 116,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connected",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 116,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Talk mode active",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 278,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 278,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 649,
+      "line": 666,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1512,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1512,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1556,
+      "line": 1573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
@@ -243,7 +243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1556,
+      "line": 1573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
@@ -251,7 +251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3149,
+      "line": 3169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3151,
+      "line": 3171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3153,
+      "line": 3173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
@@ -7,6 +7,10 @@ import ai.openclaw.app.gateway.DeviceIdentityStore
 import android.app.Application
 import android.os.StrictMode
 import androidx.room.withTransaction
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -15,6 +19,7 @@ import kotlinx.coroutines.runBlocking
 class NodeApp : Application() {
   val prefs: SecurePrefs by lazy { SecurePrefs(this) }
 
+  private val runtimeScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
   private val runtimeLock = Any()
   private var runtimeInstance: NodeRuntime? = null
 
@@ -24,6 +29,13 @@ class NodeApp : Application() {
   fun ensureRuntime(): NodeRuntime =
     synchronized(runtimeLock) {
       runtimeInstance ?: NodeRuntime(this, prefs).also { runtimeInstance = it }
+    }
+
+  /** Creates a cold-process runtime with foreground-only capabilities disabled before publication. */
+  internal fun ensureBackgroundRuntime(): NodeRuntime =
+    synchronized(runtimeLock) {
+      runtimeInstance
+        ?: NodeRuntime(this, prefs, initialForeground = false).also { runtimeInstance = it }
     }
 
   internal fun ensureScreenshotFixtureRuntime(): NodeRuntime =
@@ -40,6 +52,13 @@ class NodeApp : Application() {
    * Reads the runtime without forcing startup, used by lifecycle probes and services.
    */
   fun peekRuntime(): NodeRuntime? = synchronized(runtimeLock) { runtimeInstance }
+
+  /** Disconnects the current or concurrently constructing runtime without blocking the caller. */
+  internal fun disconnectRuntimeAsync() {
+    // The process-owned scope outlives a stopping service, so cancellation cannot
+    // strand an Activity-created runtime that the service has not observed yet.
+    runtimeScope.launch { peekRuntime()?.disconnect() }
+  }
 
   /** Clears pairing auth without racing lazy process-runtime construction. */
   suspend fun resetGatewaySetupAuth(stableId: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -10,9 +10,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -20,24 +22,63 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** Foreground service that keeps the Android node connection and voice capture visible to the OS. */
 class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
+  private var runtimeRestoreJob: Job? = null
+  private var activeRuntime: NodeRuntime? = null
+  private var latestStartId = 0
   private var voiceCaptureMode = VoiceCaptureMode.Off
+
+  @Volatile private var disconnectRequested = false
 
   override fun onCreate() {
     super.onCreate()
     ensureChannel()
     val initial = buildNotification(title = "OpenClaw Node", text = "Starting…")
     startForegroundWithTypes(notification = initial)
+  }
 
-    val runtime = (application as NodeApp).peekRuntime()
-    if (runtime == null) {
-      stopSelf()
-      return
-    }
+  private fun startRuntimeIfNeeded(startId: Int) {
+    if (activeRuntime != null || runtimeRestoreJob?.isActive == true || disconnectRequested) return
+    val app = application as NodeApp
+    runtimeRestoreJob =
+      scope.launch(Dispatchers.Default) {
+        try {
+          restoreStickyRuntime(
+            createRuntime = app::ensureBackgroundRuntime,
+            disconnectRequested = { disconnectRequested },
+            disconnectRuntime = NodeRuntime::disconnect,
+          ) { restoredRuntime ->
+            withContext(Dispatchers.Main) {
+              runtimeRestoreJob = null
+              if (disconnectRequested) {
+                false
+              } else {
+                activeRuntime = restoredRuntime
+                observeRuntime(restoredRuntime)
+                true
+              }
+            }
+          }
+        } catch (err: CancellationException) {
+          throw err
+        } catch (err: Throwable) {
+          Log.e("OpenClawNodeService", "Failed to restore node runtime", err)
+          withContext(Dispatchers.Main) {
+            runtimeRestoreJob = null
+            if (!disconnectRequested && !stopSelfResult(startId)) {
+              startRuntimeIfNeeded(latestStartId)
+            }
+          }
+        }
+      }
+  }
+
+  private fun observeRuntime(runtime: NodeRuntime) {
     // Keep the connection tuple atomic, then split connection and capture work so notification text
     // can update without restarting runtime-owned connection work.
     notificationJob =
@@ -101,10 +142,16 @@ class NodeForegroundService : Service() {
     flags: Int,
     startId: Int,
   ): Int {
+    latestStartId = maxOf(latestStartId, startId)
     when (intent?.action) {
       ACTION_STOP -> {
-        (application as NodeApp).peekRuntime()?.disconnect()
-        stopSelf()
+        disconnectRequested = true
+        runtimeRestoreJob?.cancel()
+        runtimeRestoreJob = null
+        activeRuntime?.disconnect()
+        activeRuntime = null
+        (application as NodeApp).disconnectRuntimeAsync()
+        stopSelfResult(startId)
         return START_NOT_STICKY
       }
       ACTION_SET_VOICE_CAPTURE_MODE -> {
@@ -118,6 +165,14 @@ class NodeForegroundService : Service() {
         )
       }
     }
+    if (disconnectRequested) {
+      // A STOP can lose stopSelfResult to a newer queued start. Let the newest
+      // start id close the service instead of leaving a disconnected FGS alive.
+      stopSelfResult(startId)
+      return START_NOT_STICKY
+    }
+    // START_STICKY recreates the service in a fresh process and calls this with a null intent.
+    startRuntimeIfNeeded(startId)
     // Keep running; connection is managed by NodeRuntime (auto-reconnect + manual).
     return START_STICKY
   }
@@ -229,6 +284,31 @@ class NodeForegroundService : Service() {
       } else {
         context.startService(intent)
       }
+    }
+  }
+}
+
+/** Restores process-local state after Android recreates a sticky service in a fresh process. */
+internal suspend fun <T> restoreStickyRuntime(
+  createRuntime: () -> T,
+  disconnectRequested: () -> Boolean,
+  disconnectRuntime: (T) -> Unit,
+  activateRuntime: suspend (T) -> Boolean,
+) {
+  // A queued recovery may begin after STOP; do not construct process state once
+  // disconnect has already won. The post-create check still closes the race during construction.
+  if (disconnectRequested()) return
+  val runtime = createRuntime()
+  var activated = false
+  try {
+    if (!disconnectRequested()) {
+      activated = activateRuntime(runtime)
+    }
+  } finally {
+    // Ownership transfers only after activation. Stop/cancellation during the
+    // dispatcher hop must disconnect the recovered runtime instead of leaking it.
+    if (!activated) {
+      disconnectRuntime(runtime)
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -357,6 +357,7 @@ class NodeRuntime private constructor(
   private val tlsFingerprintProbe: suspend (String, Int) -> GatewayTlsProbeResult,
   chatStores: AndroidChatStores,
   internal val mode: NodeRuntimeMode,
+  initialForeground: Boolean,
 ) {
   private val chatTranscriptCache = chatStores.transcriptCache
   private val chatCommandOutbox = chatStores.commandOutbox
@@ -394,6 +395,20 @@ class NodeRuntime private constructor(
     tlsFingerprintProbe = tlsFingerprintProbe,
     chatStores = openAndroidChatStores(context),
     mode = NodeRuntimeMode.Live,
+    initialForeground = true,
+  )
+
+  internal constructor(
+    context: Context,
+    prefs: SecurePrefs,
+    initialForeground: Boolean,
+  ) : this(
+    context = context,
+    prefs = prefs,
+    tlsFingerprintProbe = ::probeGatewayTlsFingerprint,
+    chatStores = openAndroidChatStores(context),
+    mode = NodeRuntimeMode.Live,
+    initialForeground = initialForeground,
   )
 
   internal constructor(
@@ -406,6 +421,7 @@ class NodeRuntime private constructor(
     tlsFingerprintProbe = ::probeGatewayTlsFingerprint,
     chatStores = openAndroidChatStores(context),
     mode = mode,
+    initialForeground = true,
   )
 
   internal constructor(
@@ -422,6 +438,7 @@ class NodeRuntime private constructor(
         commandOutbox = RoomChatCommandOutbox(ChatCacheDatabase.open(context.applicationContext)),
       ),
     mode = NodeRuntimeMode.Live,
+    initialForeground = true,
   )
 
   /**
@@ -805,7 +822,7 @@ class NodeRuntime private constructor(
   private val _healthLogsErrorText = MutableStateFlow<String?>(null)
   val healthLogsErrorText: StateFlow<String?> = _healthLogsErrorText.asStateFlow()
 
-  private val _isForeground = MutableStateFlow(true)
+  private val _isForeground = MutableStateFlow(initialForeground)
   val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
 
   private data class TalkPttOwnership(
@@ -1978,8 +1995,11 @@ class NodeRuntime private constructor(
         prefs.setVoiceWakeMode(VoiceWakeMode.Off)
       }
 
-      if (prefs.voiceMicEnabled.value) {
+      if (initialForeground && prefs.voiceMicEnabled.value) {
         setVoiceCaptureMode(VoiceCaptureMode.ManualMic, persistManualMic = false)
+      } else if (!initialForeground && prefs.voiceMicEnabled.value) {
+        // Process recovery without an Activity must not revive microphone capture.
+        prefs.setVoiceMicEnabled(false)
       }
 
       scope.launch(Dispatchers.Default) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -1,20 +1,158 @@
 package ai.openclaw.app
 
 import android.app.Notification
+import android.app.Service
+import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class NodeForegroundServiceTest {
+  @Test
+  fun restoreStickyRuntimeCreatesAndActivatesMissingProcessRuntime() =
+    runBlocking {
+      val restoredRuntime = Any()
+      var created = false
+      var activated: Any? = null
+
+      restoreStickyRuntime(
+        createRuntime = {
+          created = true
+          restoredRuntime
+        },
+        disconnectRequested = { false },
+        disconnectRuntime = {},
+        activateRuntime = {
+          activated = it
+          true
+        },
+      )
+
+      assertTrue(created)
+      assertSame(restoredRuntime, activated)
+    }
+
+  @Test
+  fun restoreStickyRuntimeDoesNotCreateAfterDisconnectAlreadyWon() =
+    runBlocking {
+      var created = false
+
+      restoreStickyRuntime(
+        createRuntime = {
+          created = true
+          Any()
+        },
+        disconnectRequested = { true },
+        disconnectRuntime = {},
+        activateRuntime = { true },
+      )
+
+      assertFalse(created)
+    }
+
+  @Test
+  fun restoreStickyRuntimeHonorsDisconnectRequestedDuringCreation() =
+    runBlocking {
+      val restoredRuntime = Any()
+      var disconnectRequested = false
+      var disconnected: Any? = null
+      var activated = false
+
+      restoreStickyRuntime(
+        createRuntime = {
+          disconnectRequested = true
+          restoredRuntime
+        },
+        disconnectRequested = { disconnectRequested },
+        disconnectRuntime = { disconnected = it },
+        activateRuntime = {
+          activated = true
+          true
+        },
+      )
+
+      assertSame(restoredRuntime, disconnected)
+      assertFalse(activated)
+    }
+
+  @Test
+  fun restoreStickyRuntimeDisconnectsWhenActivationDeclinesOwnership() =
+    runBlocking {
+      val restoredRuntime = Any()
+      var disconnected: Any? = null
+
+      restoreStickyRuntime(
+        createRuntime = { restoredRuntime },
+        disconnectRequested = { false },
+        disconnectRuntime = { disconnected = it },
+        activateRuntime = { false },
+      )
+
+      assertSame(restoredRuntime, disconnected)
+    }
+
+  @Test
+  fun coldStopDoesNotCreateRuntime() {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    assertNull(app.peekRuntime())
+    val controller = Robolectric.buildService(NodeForegroundService::class.java).create()
+
+    try {
+      val result =
+        controller
+          .get()
+          .onStartCommand(
+            Intent(app, NodeForegroundService::class.java)
+              .setAction("ai.openclaw.app.action.STOP"),
+            0,
+            1,
+          )
+
+      assertEquals(Service.START_NOT_STICKY, result)
+      assertNull(app.peekRuntime())
+
+      val secondResult = controller.get().onStartCommand(Intent(app, NodeForegroundService::class.java), 0, 2)
+      assertEquals(Service.START_NOT_STICKY, secondResult)
+      assertEquals(2, Shadows.shadowOf(controller.get()).stopSelfResultId)
+      assertNull(app.peekRuntime())
+    } finally {
+      controller.destroy()
+    }
+  }
+
+  @Test
+  fun backgroundRuntimeStartsWithoutForegroundCapabilitiesOrMicRestore() {
+    val app = RuntimeEnvironment.getApplication()
+    val securePrefs =
+      app.getSharedPreferences("node-service-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    prefs.setVoiceMicEnabled(true)
+    val runtime = NodeRuntime(app, prefs, initialForeground = false)
+
+    try {
+      assertFalse(runtime.isForeground.value)
+      assertFalse(prefs.voiceMicEnabled.value)
+    } finally {
+      runtime.disconnect()
+    }
+  }
+
   @Test
   fun buildNotificationSetsLaunchIntent() {
     val service = Robolectric.buildService(NodeForegroundService::class.java).get()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android declared the node foreground service `START_STICKY`, but a process-death restart always stopped because `onCreate()` only accepted an already-existing process-local `NodeRuntime`. The OS restart therefore could not restore the node connection it was intended to keep alive.

## Why This Change Was Made

`onCreate()` now establishes foreground notification state only. Every non-STOP `onStartCommand()` (including Android's null-intent sticky restart) starts one off-main recovery and atomically publishes a background-safe runtime. Ownership transfers to the service only after activation; cancellation, STOP, or activation failure disconnects an unowned runtime.

A cold STOP never constructs a runtime. STOP also uses a process-owned disconnect fallback so an Activity-created or concurrently constructing runtime is not stranded after the service scope ends. Newer start IDs are stopped again after a STOP so a queued start cannot leave a disconnected foreground service alive.

Cold recovery initializes `NodeRuntime` as background before publication and clears persisted microphone capture instead of briefly reviving foreground-only capabilities without an Activity.

## User Impact

When Android recreates the sticky foreground service in a fresh process, OpenClaw can reconstruct the node runtime and resume its normal Gateway reconnect loop. Explicit STOP remains terminal and does not create or leak a runtime.

## Evidence

AI-assisted change. I reviewed the service/process ownership races and background capability boundary.

Focused Robolectric coverage verifies:

- null-intent sticky recovery creates and activates one runtime;
- cold STOP does not create a runtime;
- a queued recovery performs zero construction when STOP already won;
- STOP racing recovery disconnects before ownership transfer;
- a later start ID after STOP calls `stopSelfResult` again;
- background runtime construction starts non-foreground and does not restore microphone capture.

Final local verification used both Android product flavors (Testbox unavailable for this contributor):

```text
apps/android/gradlew -p apps/android --no-daemon \
  :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest \
  --tests ai.openclaw.app.NodeForegroundServiceTest \
  :app:runKtlintCheckOverMainSourceSet :app:runKtlintCheckOverTestSourceSet
# Play: 10 passed
# ThirdParty: 10 passed
# failures/errors/skipped: 0

git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

The repository native-i18n generator was also run and this PR commits the Android inventory line shifts caused by the service/runtime changes. The current base independently has two uncommitted `MenuBar.swift` inventory line shifts (`321 -> 322`); a non-Android branch reproduces that same remaining `native:i18n:check` failure, so this PR does not duplicate the unrelated macOS baseline update.

No physical-device process-kill test was run; the proof is deterministic service/runtime lifecycle coverage under Robolectric.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript: Android sticky service recovery</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, system/developer prompts, and unrelated turns omitted

[user excerpt]
[P1] Android sticky 前台服务在进程回收后必然停止，无法恢复节点连接

[assistant]
Android sticky 分支的复核暴露了两个更隐蔽的稳定性问题：冷恢复 runtime 会短暂被当成“Activity 前台”，而冷 STOP 还可能在主线程等待 runtime 构造锁。我正在把恢复入口移到非 STOP 的 onStartCommand，让 STOP 不创建 runtime、不阻塞主线程，并把“初始前后台状态”作为 NodeRuntime 构造事实传入。

[tool summary]
Play and ThirdParty each passed all 10 NodeForegroundService tests, ktlint, and diff checks. The final branch review reported no actionable findings after the STOP-before-construction race was fixed.
````

</details>
<!-- agent-transcript:end -->
