### PR TITLE
docs(plugins): document safe external cron projection

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4680,6 +4680,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Provider-only (SenseAudio)
   - H3: Echo transcript to chat (opt-in)
   - H2: Notes and limits
+  - H3: Resident local STT
   - H3: Proxy environment support
   - H2: Mention detection in groups
   - H2: Gotchas

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5564,6 +5564,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Message hooks
   - H2: Install hooks
   - H2: Gateway lifecycle
+  - H3: Safe external cron projection
   - H2: Upcoming deprecations
   - H2: Related
 

--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -6,6 +6,7 @@ read_when:
   - You are building an external app, script, dashboard, CI job, or IDE extension that talks to OpenClaw
   - You are choosing between Gateway RPC and the Plugin SDK
   - You are integrating with Gateway agent runs, sessions, events, approvals, models, or tools
+  - You are pairing a hosting controller with an external wake scheduler
 ---
 
 External apps talk to OpenClaw through the Gateway protocol: WebSocket
@@ -142,6 +143,14 @@ remain active.
 The hosting platform must freeze or snapshot the full process tree and its
 filesystem consistently; unregistered work cannot be proven idle by this first
 contract.
+
+<Tip>
+  For host wake scheduling, keep the OpenClaw-facing part in an in-process
+  plugin and project idempotent full snapshots to the external host adapter.
+  The hosting controller should not import the Plugin SDK or reconstruct cron
+  state from event deltas. See [Safe external cron
+  projection](/plugins/hooks#safe-external-cron-projection).
+</Tip>
 
 ## App code vs plugin code
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -626,11 +626,14 @@ Keep OpenClaw as the source of truth for due checks and execution.
 Project a complete wake snapshot instead of forwarding cron event deltas. The
 external adapter's `replaceAll` operation must be atomic and idempotent, and it
 must resolve only after the host has durably accepted the snapshot. It must
-also honor the supplied abort signal so Gateway shutdown can drain cleanly.
+also honor the supplied abort signal: if the signal aborts before durable
+acceptance, the adapter must not accept that snapshot.
 
 This pattern keeps one latest-state worker in flight. Only `cron_reconciled`
 adopts a scheduler instance; `cron_changed` merely asks that worker to reread
 the authoritative instance, so a late hint cannot restore an older scheduler.
+A newer revision aborts the active host attempt before it can accept a stale
+snapshot.
 
 ```typescript
 import { setTimeout as sleep } from "node:timers/promises";
@@ -661,15 +664,22 @@ export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWak
   let requestedRevision = 0;
   let appliedRevision = 0;
   let worker = Promise.resolve();
+  let activeAttempt: AbortController | undefined;
 
   const projectLatest = async () => {
     let retryMs = 1_000;
 
     while (!lifecycle.signal.aborted && appliedRevision < requestedRevision) {
       const targetRevision = requestedRevision;
+      const attempt = new AbortController();
+      const signal = AbortSignal.any([lifecycle.signal, attempt.signal]);
+      activeAttempt = attempt;
 
       try {
         const jobs = enabled && cron ? await cron.list({ includeDisabled: true }) : [];
+        if (signal.aborted || targetRevision !== requestedRevision) {
+          continue;
+        }
         const wakes = jobs
           .flatMap((job): ExternalWake[] => {
             const runAtMs = job.enabled === false ? undefined : job.state?.nextRunAtMs;
@@ -677,26 +687,42 @@ export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWak
           })
           .sort((a, b) => a.runAtMs - b.runAtMs || a.jobId.localeCompare(b.jobId));
 
-        await host.replaceAll(wakes, { signal: lifecycle.signal });
+        await host.replaceAll(wakes, { signal });
+        if (signal.aborted || targetRevision !== requestedRevision) {
+          continue;
+        }
         appliedRevision = targetRevision;
         retryMs = 1_000;
       } catch {
         if (lifecycle.signal.aborted) {
           return;
         }
+        if (attempt.signal.aborted) {
+          continue;
+        }
         api.logger.warn(`external cron projection failed; retrying in ${retryMs}ms`);
         try {
-          await sleep(retryMs, undefined, { signal: lifecycle.signal });
+          await sleep(retryMs, undefined, { signal });
         } catch {
-          return;
+          if (lifecycle.signal.aborted) {
+            return;
+          }
+          if (attempt.signal.aborted) {
+            continue;
+          }
         }
         retryMs = Math.min(retryMs * 2, 30_000);
+      } finally {
+        if (activeAttempt === attempt) {
+          activeAttempt = undefined;
+        }
       }
     }
   };
 
   const requestProjection = () => {
     const targetRevision = ++requestedRevision;
+    activeAttempt?.abort();
     worker = worker.then(async () => {
       if (!lifecycle.signal.aborted && appliedRevision < targetRevision) {
         await projectLatest();

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -658,15 +658,15 @@ export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWak
   let cron: CronReader | undefined;
   let enabled = false;
   let hasBaseline = false;
-  let revision = 0;
+  let requestedRevision = 0;
   let appliedRevision = 0;
-  let worker: Promise<void> | undefined;
+  let worker = Promise.resolve();
 
   const projectLatest = async () => {
     let retryMs = 1_000;
 
-    while (!lifecycle.signal.aborted) {
-      const targetRevision = revision;
+    while (!lifecycle.signal.aborted && appliedRevision < requestedRevision) {
+      const targetRevision = requestedRevision;
 
       try {
         const jobs = enabled && cron ? await cron.list({ includeDisabled: true }) : [];
@@ -680,10 +680,6 @@ export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWak
         await host.replaceAll(wakes, { signal: lifecycle.signal });
         appliedRevision = targetRevision;
         retryMs = 1_000;
-
-        if (appliedRevision === revision) {
-          return;
-        }
       } catch {
         if (lifecycle.signal.aborted) {
           return;
@@ -700,22 +696,12 @@ export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWak
   };
 
   const requestProjection = () => {
-    revision += 1;
-    if (!worker) {
-      const running = projectLatest();
-      worker = running;
-      void running
-        .finally(() => {
-          if (worker !== running) {
-            return;
-          }
-          worker = undefined;
-          if (!lifecycle.signal.aborted && appliedRevision !== revision) {
-            requestProjection();
-          }
-        })
-        .catch(() => undefined);
-    }
+    const targetRevision = ++requestedRevision;
+    worker = worker.then(async () => {
+      if (!lifecycle.signal.aborted && appliedRevision < targetRevision) {
+        await projectLatest();
+      }
+    });
     return worker;
   };
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -5,6 +5,7 @@ read_when:
   - You are building a plugin that needs before_tool_call, before_agent_reply, message hooks, or lifecycle hooks
   - You need to block, rewrite, or require approval for tool calls from a plugin
   - You are deciding between internal hooks and plugin hooks
+  - You are projecting OpenClaw cron wakes into an external host scheduler
 ---
 
 Plugin hooks are in-process extension points for OpenClaw plugins: inspect or
@@ -57,10 +58,10 @@ observation side effects.
 
 `api.on(name, handler, opts?)` accepts:
 
-| Option      | Effect                                                                                                                                                                                          |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `priority`  | Ordering; higher runs first.                                                                                                                                                                    |
-| `timeoutMs` | Per-hook budget. When set, the runner aborts that handler after the budget and moves on instead of blocking on the configured model timeout. Omit to use the runner's default per-hook timeout. |
+| Option      | Effect                                                                                                                                                                                            |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `priority`  | Ordering; higher runs first.                                                                                                                                                                      |
+| `timeoutMs` | Per-hook await budget. When it expires, OpenClaw stops awaiting that handler and moves on. It does not cancel the handler or its side effects. Omit to use the runner's default per-hook timeout. |
 
 Operators can set hook budgets without patching plugin code:
 
@@ -86,6 +87,11 @@ Operators can set hook budgets without patching plugin code:
 plugin-authored `api.on(..., { timeoutMs })` value. Each value must be a
 positive integer up to 600000 ms. Prefer per-hook overrides for known-slow
 hooks so one plugin does not get a longer budget everywhere.
+
+A timed-out handler promise continues running because hook callbacks do not
+receive a cancellation signal. The hook dispatch can release its Gateway
+admission while that plugin work is still in progress. Plugins that own
+long-running work must provide their own cancellation and shutdown lifecycle.
 
 Each hook receives `event.context.pluginConfig`, the resolved config for the
 plugin that registered that handler. OpenClaw injects it per handler without
@@ -611,8 +617,142 @@ write changes an existing job's effective `nextRunAtMs`, excluding that job's
 explicit `added`, `updated`, or `removed` lifecycle event. The top-level
 `event.nextRunAtMs` is the committed next wake; when it is absent, the job has
 no next wake. Treat these events as reconciliation hints, not an ordered delta
-log. Use these events as coalescible hints between `cron_reconciled` snapshots,
-and keep OpenClaw as the source of truth for due checks and execution.
+log. Use them as coalescible hints to reread the scheduler last captured by
+`cron_reconciled`; do not adopt the scheduler from a `cron_changed` context.
+Keep OpenClaw as the source of truth for due checks and execution.
+
+### Safe external cron projection
+
+Project a complete wake snapshot instead of forwarding cron event deltas. The
+external adapter's `replaceAll` operation must be atomic and idempotent, and it
+must resolve only after the host has durably accepted the snapshot. It must
+also honor the supplied abort signal so Gateway shutdown can drain cleanly.
+
+This pattern keeps one latest-state worker in flight. Only `cron_reconciled`
+adopts a scheduler instance; `cron_changed` merely asks that worker to reread
+the authoritative instance, so a late hint cannot restore an older scheduler.
+
+```typescript
+import { setTimeout as sleep } from "node:timers/promises";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+type ExternalWake = { jobId: string; runAtMs: number };
+
+type ExternalWakeHost = {
+  replaceAll(wakes: readonly ExternalWake[], options: { signal: AbortSignal }): Promise<void>;
+  close(): Promise<void>;
+};
+
+type CronReader = {
+  list(options: { includeDisabled: true }): Promise<
+    Array<{
+      id: string;
+      enabled?: boolean;
+      state?: { nextRunAtMs?: number };
+    }>
+  >;
+};
+
+export function registerCronProjection(api: OpenClawPluginApi, host: ExternalWakeHost) {
+  const lifecycle = new AbortController();
+  let cron: CronReader | undefined;
+  let enabled = false;
+  let hasBaseline = false;
+  let revision = 0;
+  let appliedRevision = 0;
+  let worker: Promise<void> | undefined;
+
+  const projectLatest = async () => {
+    let retryMs = 1_000;
+
+    while (!lifecycle.signal.aborted) {
+      const targetRevision = revision;
+
+      try {
+        const jobs = enabled && cron ? await cron.list({ includeDisabled: true }) : [];
+        const wakes = jobs
+          .flatMap((job): ExternalWake[] => {
+            const runAtMs = job.enabled === false ? undefined : job.state?.nextRunAtMs;
+            return runAtMs === undefined ? [] : [{ jobId: job.id, runAtMs }];
+          })
+          .sort((a, b) => a.runAtMs - b.runAtMs || a.jobId.localeCompare(b.jobId));
+
+        await host.replaceAll(wakes, { signal: lifecycle.signal });
+        appliedRevision = targetRevision;
+        retryMs = 1_000;
+
+        if (appliedRevision === revision) {
+          return;
+        }
+      } catch {
+        if (lifecycle.signal.aborted) {
+          return;
+        }
+        api.logger.warn(`external cron projection failed; retrying in ${retryMs}ms`);
+        try {
+          await sleep(retryMs, undefined, { signal: lifecycle.signal });
+        } catch {
+          return;
+        }
+        retryMs = Math.min(retryMs * 2, 30_000);
+      }
+    }
+  };
+
+  const requestProjection = () => {
+    revision += 1;
+    if (!worker) {
+      const running = projectLatest();
+      worker = running;
+      void running
+        .finally(() => {
+          if (worker !== running) {
+            return;
+          }
+          worker = undefined;
+          if (!lifecycle.signal.aborted && appliedRevision !== revision) {
+            requestProjection();
+          }
+        })
+        .catch(() => undefined);
+    }
+    return worker;
+  };
+
+  api.on("cron_reconciled", (event, ctx) => {
+    const reconciledCron = ctx.getCron?.();
+    if (event.enabled && !reconciledCron) {
+      api.logger.warn("cron reconciliation did not expose a scheduler");
+      return;
+    }
+    cron = reconciledCron;
+    enabled = event.enabled;
+    hasBaseline = true;
+    return requestProjection();
+  });
+
+  api.on("cron_changed", () => {
+    if (hasBaseline) {
+      return requestProjection();
+    }
+  });
+
+  api.on("gateway_stop", async () => {
+    lifecycle.abort();
+    await worker;
+    await host.close();
+  });
+}
+```
+
+When `cron_reconciled` reports `enabled: false`, the same path calls
+`replaceAll([])` and clears stale external wakes. Retry/backoff in this example
+is process-local and treats runtime adapter failures as transient; validate
+non-retryable configuration before registration. OpenClaw does not provide an
+outbox for plugin hook effects. If the process exits before durable acceptance,
+the next Gateway start emits a new authoritative `cron_reconciled` snapshot.
+`gateway_stop` aborts in-flight host work, waits for the worker to settle, then
+closes the adapter.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -496,18 +496,19 @@ cover CLI and Gateway-backed install or update paths.
 - `cron_reconciled`: rebuild a full external cron projection after startup or scheduler reload. It includes `reason` and the effective `enabled` state, including `enabled: false`, while `ctx.getCron?.()` returns the exact reconciled scheduler.
 - `cron_changed`: observe gateway-owned cron lifecycle changes. `scheduled` and `removed` events are post-commit reconciliation hints, not an ordered delta log. A scheduled event's `event.nextRunAtMs` is absent when the job has no next wake; a removed event still carries the deleted job snapshot.
 
-External wake schedulers should debounce or coalesce `cron_changed` events by
-`jobId`, then reconcile the full durable view:
-
-```typescript
-const jobs = await ctx.getCron?.()?.list({ includeDisabled: true });
-```
+External wake schedulers should debounce or coalesce `cron_changed` events,
+then reread the full durable view from the scheduler last captured by
+`cron_reconciled`. Do not adopt the scheduler from a `cron_changed` context: a
+detached hint from an older scheduler can overlap a later reload.
 
 Use `cron_reconciled` as the full-snapshot trigger for durable state loaded at
 Gateway startup or scheduler replacement. It is not replayed for a plugin-only
 hot reload. Observation handlers run in parallel, and fire-and-forget
 dispatches can overlap, so consumers must not depend on event completion order.
 Keep OpenClaw as the source of truth for due checks and execution.
+
+For a single-flight adapter with durable replacement, retry/backoff, and clean
+shutdown, see [Safe external cron projection](/plugins/hooks#safe-external-cron-projection).
 
 ### API object fields
 


### PR DESCRIPTION
Closes #104083

## What Problem This Solves

Fixes an issue where plugin authors could mistake a hook `timeoutMs` for cancellation and allow external scheduler writes to outlive the lifecycle they thought they were bounded by. The cron lifecycle docs also lacked a complete safe pattern for projecting wakes to a hosting platform.

## Why This Change Was Made

The docs now state the actual await-only timeout contract and provide one vendor-neutral, full-snapshot cron projection pattern. The example keeps scheduler ownership at `cron_reconciled`, treats `cron_changed` as a coalescible hint, serializes replacement, waits for durable host acceptance, retries with bounded backoff, and aborts/drains/closes on `gateway_stop` without adding a core outbox.

## User Impact

Plugin and hosting-integration authors can implement wake scheduling without relying on lossy event ordering, adopting a stale scheduler after reload, or assuming OpenClaw cancels timed-out plugin work. The SDK and external-app guides now route readers to the same canonical contract.

## Evidence

- `pnpm docs:list`
- `pnpm format:docs:check` — clean across 689 files
- `pnpm docs:check-mdx` — 705 files passed
- `pnpm docs:check-links` — 5,812 internal links checked, 0 broken
- `pnpm docs:check-i18n-glossary` — passed against the fetched `main` merge base
- `pnpm docs:map:check` — generated map current; adds the new section and refreshes one existing current-main heading
- Extracted TypeScript example checked with `tsgo` against the repository config
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.5 --thinking high` — clean, no accepted/actionable findings
