### PR TITLE
fix: macOS node install fails to load LaunchAgent

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1046,6 +1046,33 @@ describe("launchctl list detection", () => {
 });
 
 describe("launchd bootstrap repair", () => {
+  it("migrates inline secrets before making an existing plist readable", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const warn = vi.fn();
+    const secret = "legacy-secret";
+    state.files.set(wrapperPath, "custom wrapper");
+    state.files.set(
+      plistPath,
+      createTestLaunchAgentPlist({
+        label: "ai.openclaw.gateway",
+        programArguments: defaultProgramArguments,
+        environment: { OPENAI_API_KEY: secret },
+      }),
+    );
+    state.fileModes.set(plistPath, 0o600);
+
+    await repairLaunchAgentBootstrap({ env, warn });
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("custom behavior"));
+    expect(state.files.get(plistPath)).not.toContain(secret);
+    expect(state.fileModes.get(plistPath)).toBe(0o644);
+    expect(state.files.get("/Users/test/.openclaw/service-env/ai.openclaw.gateway.env")).toContain(
+      secret,
+    );
+  });
+
   it("enables and bootstraps the resolved label without kickstarting the fresh agent", async () => {
     const env = createDefaultLaunchdEnv();
     const repair = await repairLaunchAgentBootstrap({ env });
@@ -1486,7 +1513,7 @@ describe("launchd install", () => {
     expect(state.dirModes.get(env.HOME!)).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
-    expect(state.fileModes.get(plistPath)).toBe(0o600);
+    expect(state.fileModes.get(plistPath)).toBe(0o644);
   });
 
   it("stops LaunchAgent via bootout by default, preserving KeepAlive for future crashes", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -45,7 +45,9 @@ import type {
 } from "./service-types.js";
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
-const LAUNCH_AGENT_PLIST_MODE = 0o600;
+// launchd rejects user LaunchAgent plists without group/other read access on
+// current macOS. Secrets stay in the separate 0600 environment file.
+const LAUNCH_AGENT_PLIST_MODE = 0o644;
 const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
@@ -658,6 +660,10 @@ async function bootstrapLaunchAgentOrThrow(params: {
   throw new Error(`launchctl bootstrap failed: ${detail}`);
 }
 
+async function ensureLaunchAgentPlistReadable(plistPath: string): Promise<void> {
+  await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+}
+
 async function ensureSecureDirectory(
   targetPath: string,
   dirMode = LAUNCH_AGENT_DIR_MODE,
@@ -785,12 +791,18 @@ function isLaunchctlAlreadyLoaded(res: { stdout: string; stderr: string; code: n
 
 export async function repairLaunchAgentBootstrap(args: {
   env?: Record<string, string | undefined>;
+  warn?: (message: string) => void;
 }): Promise<LaunchAgentBootstrapRepairResult> {
   const env = args.env ?? (process.env as Record<string, string | undefined>);
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
   const serviceTarget = `${domain}/${label}`;
+  // Rewrite first so legacy inline environment secrets move into the private
+  // env file before the plist becomes world-readable for launchd.
+  const warn =
+    args.warn ?? ((message: string) => process.stderr.write(`${formatLine("Warning", message)}\n`));
+  await rewriteLaunchAgentPlistForRestart({ env, label, plistPath, warn });
   await execLaunchctl(["enable", serviceTarget]);
   const boot = await execLaunchctl(["bootstrap", domain, plistPath]);
   let repairStatus: "repaired" | "already-loaded" = "repaired";
@@ -1116,7 +1128,7 @@ async function writeLaunchAgentPlist({
     environment: prepared.inlineEnvironment,
   });
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
-  await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+  await ensureLaunchAgentPlistReadable(plistPath);
   return { plistPath, stdoutPath };
 }
 
@@ -1217,10 +1229,11 @@ async function rewriteLaunchAgentPlistForRestart({
   });
   const previousPlist = await fs.readFile(plistPath, "utf8").catch(() => "");
   if (previousPlist === plist) {
+    await ensureLaunchAgentPlistReadable(plistPath);
     return false;
   }
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
-  await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);
+  await ensureLaunchAgentPlistReadable(plistPath);
   return true;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing or recovering a macOS node LaunchAgent could get `Bootstrap failed: 5: Input/output error` because current launchd rejects a user LaunchAgent plist written with mode `0600`.

## Why This Change Was Made

Write secret-free LaunchAgent plists as `0644`, while retaining service environment values in the existing owner-only `0600` env file. Recovery rewrites legacy inline environments before widening plist permissions, and still warns before replacing customized generated wrappers.

## User Impact

`openclaw node install`, Gateway installs, and bootstrap repair can load successfully on current macOS. Existing installs are repaired without exposing legacy inline credentials.

## Evidence

- Live macOS 26.5.2 reproduction: the generated node plist at `0600` failed `launchctl bootstrap` with exit 5; changing only the plist to `0644` loaded the service and left it running.
- Testbox: `corepack pnpm test src/daemon/launchd.test.ts` — 78 passed, 24 skipped.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29142662108
- Fresh autoreview: clean, no accepted/actionable findings.
