### PR TITLE
fix: avoid duplicate set-profile message action

### DIFF
--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -56,7 +56,6 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "ban",
   "set-profile",
   "set-presence",
-  "set-profile",
   "download-file",
   "upload-file",
 ] as const;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where message-action consumers could receive `set-profile` twice when iterating the canonical action list, including the default tool schema enum and CLI error guidance.

## Why This Change Was Made

Removes the duplicate canonical entry while retaining the supported action and its existing ordering.

## User Impact

Tool schemas and CLI action lists now advertise `set-profile` once. Runtime action validation remains unchanged.

## Evidence

- `pnpm test src/agents/tools/message-tool.test.ts src/commands/message.test.ts` on Blacksmith Testbox: 128 tests passed across 2 shards.
- `pnpm check:changed` on Blacksmith Testbox: passed core/extension typechecks, lint, and policy guards.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.
