### PR TITLE
fix(doctor): keep local audio inventory informational

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1667,6 +1667,21 @@ describe("doctor health contributions", () => {
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 
+  it("keeps local audio inventory in the lint flow", async () => {
+    const contribution = requireDoctorContribution("doctor:local-audio-acceleration");
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/local-audio-acceleration"]);
+    expect(
+      contributionChecks.find((check) => check.id === "core/doctor/local-audio-acceleration"),
+    ).toBeDefined();
+
+    await contribution.run({} as DoctorContributionRunContext);
+
+    expect(mocks.getHealthCheck).not.toHaveBeenCalled();
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
   it("keeps systemd linger opt-in and reports disabled linger when selected", async () => {
     const contributionChecks = await resolveDoctorContributionHealthChecks();
     const systemdLingerCheck = contributionChecks.find(

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1502,10 +1502,6 @@ async function runProviderCatalogProjectionHealth(ctx: DoctorHealthFlowContext):
   await runCoreHealthFindingNote(ctx, "core/doctor/provider-catalog-projection");
 }
 
-async function runLocalAudioAccelerationHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  await runCoreHealthFindingNote(ctx, "core/doctor/local-audio-acceleration");
-}
-
 async function runRuntimeToolSchemasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   await runCoreHealthFindingNote(ctx, "core/doctor/runtime-tool-schemas");
 }
@@ -2034,7 +2030,9 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:local-audio-acceleration",
       label: "Local audio acceleration",
       healthCheckIds: ["core/doctor/local-audio-acceleration"],
-      run: runLocalAudioAccelerationHealth,
+      // This informational inventory is rendered through `doctor --lint`.
+      // Keep the normal doctor flow quiet instead of presenting healthy local STT as a warning.
+      run: async () => {},
     }),
     createDoctorHealthContribution({
       id: "doctor:runtime-tool-schemas",


### PR DESCRIPTION
## What Problem This Solves

#104242 restored ordered ownership for the local STT health check, but routed its informational inventory through `runCoreHealthFindingNote`. That legacy bridge is severity-blind: whenever local STT is available, ordinary `openclaw doctor` labels the healthy `info` finding as `Doctor warnings` and sets `healthOk = false`.

## Why This Change Was Made

Keep the contribution ownership needed by the documented `doctor --lint --only core/doctor/local-audio-acceleration` path, but make its normal-doctor runner intentionally quiet. Structured lint remains the owner of this informational capability inventory.

The regression test verifies both halves of that boundary: lint resolves the check, while normal doctor does not load or render it as a warning.

## User Impact

The documented local-audio lint check continues to work. Ordinary `openclaw doctor` no longer reports healthy local STT selection as a warning or marks health unsuccessful.

## Evidence

- AWS Crabbox `run_76c31abdfef5`: 113 focused doctor tests passed; both touched file blobs are byte-identical on the current rebased head.
- Canonical `oxfmt --check` for both changed TypeScript files: passed.
- `git diff --check`: passed.
- Fresh branch autoreview after rebasing onto #104242: no actionable findings; patch correct at 0.86 confidence.
- Hosted exact-head CI will rerun on `4c5ca2b4c44`.

Related: #104210, #104242, #104207
